### PR TITLE
libretroshare: new port in net

### DIFF
--- a/devel/restbed/Portfile
+++ b/devel/restbed/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+github.setup        Corvusoft restbed 4.8
+revision            0
+categories          devel
+license             AGPL-3
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Framework that brings asynchronous RESTful functionality to C++14 applications.
+long_description    Restbed is a comprehensive and consistent programming model for building applications \
+                    that require seamless and secure communication over HTTP, with the ability to model \
+                    a range of business processes, designed to target mobile, tablet, desktop \
+                    and embedded production environments.
+homepage            https://www.corvusoft.co.uk
+checksums           rmd160  45f056be2a4f79f51b95c035bcf594468ff5bec7 \
+                    sha256  8d2959b8a4b14a5c4f15364220b9b4be203b9af9ba46c439fa68084e2910f27f \
+                    size    145776
+
+depends_lib-append  port:asio
+
+patchfiles          patch-CMakeLists.diff
+
+compiler.cxx_standard 2014
+
+configure.args-append \
+                    -DBUILD_IPC=OFF \
+                    -DBUILD_SSL=OFF \
+                    -DBUILD_TESTS=OFF
+
+pre-destroot {
+    xinstall -d ${destroot}${prefix}/include/${name}
+}
+
+post-destroot {
+    # Fix permissions; setting to 0644 does not have a needed effect.
+    file attributes ${destroot}${prefix}/include/${name} -permissions 0755
+    # Remove unneeded subprefix; we install headers in ${prefix}/include/restbed:
+    fs-traverse h ${destroot}${prefix}/include/${name} {
+        if {[file isfile ${h}]} {
+            reinplace -q "s,corvusoft/,,g" ${h}
+        }
+    }
+}

--- a/devel/restbed/files/patch-CMakeLists.diff
+++ b/devel/restbed/files/patch-CMakeLists.diff
@@ -1,0 +1,28 @@
+--- CMakeLists.txt.orig	2021-07-01 08:31:50.000000000 +0800
++++ CMakeLists.txt	2023-01-31 04:33:05.000000000 +0800
+@@ -28,7 +28,7 @@
+ set( SOURCE_DIR  "${PROJECT_SOURCE_DIR}/source/corvusoft/${PROJECT_NAME}" )
+ 
+ if ( NOT DEFINED CMAKE_INSTALL_LIBDIR )
+-    set( CMAKE_INSTALL_LIBDIR "library")
++    set( CMAKE_INSTALL_LIBDIR "lib")
+ endif ( )
+ 
+ if ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
+@@ -43,7 +43,7 @@
+     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Weffc++ -pedantic -Wno-unknown-pragmas -Wno-deprecated-declarations -Wno-non-virtual-dtor" )
+ endif ( )
+ 
+-if ( UNIX AND NOT APPLE )
++if ( UNIX OR APPLE )
+     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread" )
+ endif ( )
+ 
+@@ -118,6 +118,6 @@
+ file( GLOB ARTIFACTS "${SOURCE_DIR}/*.hpp" )
+ 
+ install( FILES "${INCLUDE_DIR}/${PROJECT_NAME}" DESTINATION "${CMAKE_INSTALL_PREFIX}/include" )
+-install( FILES ${ARTIFACTS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/corvusoft/${PROJECT_NAME}" )
++install( FILES ${ARTIFACTS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}" )
+ install( TARGETS ${STATIC_LIBRARY_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library )
+ install( TARGETS ${SHARED_LIBRARY_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library )

--- a/net/libretroshare/Portfile
+++ b/net/libretroshare/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+PortGroup               legacysupport 1.1
+PortGroup               openssl 1.0
+
+github.setup            RetroShare libretroshare efe09b87d3a11833e36a65e120328d6d5f26a7de
+version                 2023.01.30
+revision                0
+categories              net devel
+maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
+license                 {AGPL-3 Apache-2 GPL-3 LGPL-3 MIT}
+description             RetroShare is a decentralized, private, secure, cross-platform communication software.
+long_description        {*}${description} RetroShare functionalities (file sharing, chat, messages, forums, channels…) \
+                        are implemented under the hood by libretroshare which offer a documented C++ and JSON API. \
+                        While RetroShare is an application on it’s own, libretroshare is meant to be used as part of other programs.
+homepage                https://retroshare.cc
+checksums               rmd160  07b2cfb88a77669003cc778130ecf057e4682f7f \
+                        sha256  71bf77287d80ccee60c3f2db5cc97d6f6ff4a03c90e9dec0befe0fa90a17f247 \
+                        size    1906845
+
+# getline, strnlen
+legacysupport.newest_darwin_requires_legacy 10
+
+depends_lib-append      port:bzip2 \
+                        port:miniupnpc \
+                        port:rapidjson \
+                        port:restbed \
+                        port:sqlite3 \
+                        port:zlib
+
+set py_ver              3.11
+set py_ver_nodot        [string map {. {}} ${py_ver}]
+
+depends_build-append    path:bin/doxygen:doxygen \
+                        port:git \
+                        port:python${py_ver_nodot}
+git.cmd                 ${prefix}/bin/git
+
+patchfiles              0001-rsfile.h-fix-for-macOS-add-missing-headers.patch \
+                        0002-Fix-CMakeLists-for-MacPorts.patch
+
+post-patch {
+    reinplace "s,@PREFIX@,${prefix}," ${worksrcpath}/CMakeLists.txt
+}
+
+compiler.cxx_standard   2017
+
+configure.args-append   -DPython_EXECUTABLE=${prefix}/bin/python${py_ver} \
+                        -DRS_MINIUPNPC=ON \
+                        -DRS_JSON_API=ON \
+                        -DRS_EXPORT_JNI_ONLOAD=OFF \
+                        -DRS_SQLCIPHER=OFF \
+                        -DRS_WARN_DEPRECATED=OFF

--- a/net/libretroshare/Portfile
+++ b/net/libretroshare/Portfile
@@ -24,9 +24,9 @@ checksums               rmd160  07b2cfb88a77669003cc778130ecf057e4682f7f \
 # getline, strnlen
 legacysupport.newest_darwin_requires_legacy 10
 
-depends_lib-append      port:bzip2 \
+depends_lib-append      path:lib/pkgconfig/RapidJSON.pc:rapidjson \
+                        port:bzip2 \
                         port:miniupnpc \
-                        port:rapidjson \
                         port:restbed \
                         port:sqlite3 \
                         port:zlib
@@ -36,6 +36,7 @@ set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 depends_build-append    path:bin/doxygen:doxygen \
                         port:git \
+                        port:pkgconfig \
                         port:python${py_ver_nodot}
 git.cmd                 ${prefix}/bin/git
 

--- a/net/libretroshare/files/0001-rsfile.h-fix-for-macOS-add-missing-headers.patch
+++ b/net/libretroshare/files/0001-rsfile.h-fix-for-macOS-add-missing-headers.patch
@@ -1,0 +1,25 @@
+From f8dfe0da87656ea580f7b0e775efb9e4e4c9fd2a Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 30 Jan 2023 19:21:33 +0800
+Subject: [PATCH 1/2] rsfile.h: fix for macOS: add missing headers
+
+---
+ src/util/rsfile.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/util/rsfile.h b/src/util/rsfile.h
+index 530459d4..21055458 100644
+--- src/util/rsfile.h
++++ src/util/rsfile.h
+@@ -24,6 +24,11 @@
+ 
+ #include <stdio.h>
+ 
++#ifndef WINDOWS_SYS
++#include <sys/types.h>
++#include <sys/socket.h>
++#endif
++
+ namespace RsFileUtil {
+ 
+ int set_fd_nonblock(int fd);

--- a/net/libretroshare/files/0002-Fix-CMakeLists-for-MacPorts.patch
+++ b/net/libretroshare/files/0002-Fix-CMakeLists-for-MacPorts.patch
@@ -1,0 +1,41 @@
+From ded16fbe8d5c146ed413c8682fc67a8b8e40a3ce Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 31 Jan 2023 04:55:12 +0800
+Subject: [PATCH 2/2] Fix CMakeLists for MacPorts
+
+---
+ CMakeLists.txt | 19 +++----------------
+ 1 file changed, 3 insertions(+), 16 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7cb4f6dc..9198c575 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -405,24 +405,11 @@ if(RS_JSON_API)
+ 	if(RS_ANDROID)
+ 		target_link_libraries(${PROJECT_NAME} PRIVATE restbed)
+ 	else()
+-		FetchContent_Declare(
+-			restbed
+-			GIT_REPOSITORY "https://github.com/Corvusoft/restbed.git"
+-			GIT_TAG "4.8"
+-			GIT_SUBMODULES dependency/asio dependency/catch
+-			GIT_SHALLOW TRUE
+-			GIT_PROGRESS TRUE
+-			TIMEOUT 10
+-		)
+-		FetchContent_MakeAvailable(restbed)
+-
+-		## TODO: Temporary work around target_include_directories PUBLIC should
+-		## be added upstream
+ 		target_include_directories(
+-			${PROJECT_NAME} PRIVATE ${restbed_SOURCE_DIR}/source/ )
++			${PROJECT_NAME} PUBLIC @PREFIX@/include/restbed/ )
+ 
+-		target_link_libraries(${PROJECT_NAME} PRIVATE restbed-static)
+-	endif(RS_ANDROID)
++		target_link_libraries(${PROJECT_NAME} PUBLIC restbed)
++	endif()
+ 
+ 	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_JSONAPI)
+ endif(RS_JSON_API)


### PR DESCRIPTION
#### Description

New port: https://github.com/RetroShare/libretroshare
Its dependency: https://github.com/Corvusoft/restbed

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
