### PR TITLE
terragrunt-0.43: revert checksum

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -21,9 +21,9 @@ subport terragrunt-0.43 {
     set dependsOn       1.2
     set patchNumber     0
 
-    checksums           rmd160  18d15317c1bf823f94dd714a53537ebd0f052334 \
-                        sha256  86affacbdc531ad8b5b36ec97bfb9bf63beeec0a6e1dabcdc93ca7e5fadb6001 \
-                        size    2311665
+    checksums           rmd160 0a90fd170e5328f3ac734a04f35aa6ebb4e81d8a \
+                        sha256 051c912d7d4284485754676f3ecbe57b3bd5d22cfbe5af8713b07698fc4c4fec \
+                        size   2316601
 }
 
 subport terragrunt-0.42 {


### PR DESCRIPTION
#### Description

GitHub made a change that changed the checksum of the tarball, but the change has now been reverted.
https://github.blog/changelog/2023-01-30-git-archive-checksums-may-change/

This reverts commit 1100bde6eb3e1dc420a36675c39e46f821a2f41f.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.1 22C65 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
