### PR TITLE
google-cloud-sdk: update to 416.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             415.0.0
+version             416.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  fdf9cc84190304b7f5d951bc70258cefc0631eba \
-                    sha256  3a62ede9386954b45e571e3295cf5ce8ea2076b4478d4d5ba1726a17a345faa9 \
-                    size    110955394
+    checksums       rmd160  b60c0de2d730d5e1ade3e55c1bf2711d4b0875a5 \
+                    sha256  f520b1a7bbf56283c7ded21c291fbcd1efc8db91ffd7dc66bfd2602fcebd04b1 \
+                    size    111022992
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  37bee03a30c17e6c28a6150b6e9033f7cdf72c01 \
-                    sha256  f05cc45ffc6c1f3ff73854989f3ea3d6bee40287d23047917e4c845aeb027f98 \
-                    size    131276439
+    checksums       rmd160  a4497c9bf18141c0d8d57c4d1a6a78530b7824fb \
+                    sha256  f36c27510130cc750210ed2ba718eb5fe3d7864235c84c8ac99f01bc25baa0be \
+                    size    131350109
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  535e423329a067d398ea17c1d25da4166376c3b4 \
-                    sha256  974ed4f37f8bde2f7a9731eba90b033f7c97d24d835ecc62b58eee87c8f29776 \
-                    size    128117291
+    checksums       rmd160  54b7861b3a84aa91c9dc3803514ae4d9c9719d6c \
+                    sha256  bc473df24d7e39ad6f24b890999154c63896d2b1b5a24355acef2deb1da6630e \
+                    size    128185794
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 416.0.0.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?