### PR TITLE
stern: update to 1.23.0

### DIFF
--- a/sysutils/stern/Portfile
+++ b/sysutils/stern/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/stern/stern 1.22.0 v
+go.setup            github.com/stern/stern 1.23.0 v
 maintainers         {breun.nl:nils @breun} openmaintainer
 platforms           darwin
 categories          sysutils
@@ -15,9 +15,9 @@ long_description    Stern allows you to tail multiple pods on Kubernetes and \
                     multiple containers within the pod. Each result is color \
                     coded for quicker debugging.
 
-checksums           rmd160  a304d8293ca58b5f8c03f9d87ab6bfebd1b2e016 \
-                    sha256  89b6c809d5a4e4b69d8a8373367f5275134df8e132a16f2dc96bfef7f05added \
-                    size    40726
+checksums           rmd160  08665570febb5b66b28660649565b46199118579 \
+                    sha256  d5bc459956fc123408c57a383c40ab23a821dde7ea3615733c04151b838e2c74 \
+                    size    46849
 
 set go_ldflags      "-s -w -X ${go.package}/cmd.version=${version}"
 build.args          -ldflags \"${go_ldflags}\" -o bin/${name}


### PR DESCRIPTION
#### Description

Update to Stern 1.23.0.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?