### PR TITLE
mvnd: switch master_sites to official download URL

### DIFF
--- a/java/mvnd/Portfile
+++ b/java/mvnd/Portfile
@@ -32,7 +32,7 @@ long_description mvnd aims at providing faster Maven builds using techniques kno
 homepage        https://github.com/apache/maven-mvnd
 supported_archs x86_64 arm64
 
-master_sites    https://github.com/apache/maven-mvnd/releases/download/${version}/
+master_sites    https://downloads.apache.org/maven/mvnd/${version}/
 
 use_configure   no
 


### PR DESCRIPTION
#### Description

Change `master_sites` to download URL in the [official release announcement](https://lists.apache.org/thread/kfl35my8ojqc7m11j0lddmgl154vf3fy).

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?