### PR TITLE
py-requests-unixsocket: Add py310 py311 subport

### DIFF
--- a/python/py-requests-unixsocket/Portfile
+++ b/python/py-requests-unixsocket/Portfile
@@ -11,7 +11,7 @@ license             Apache-2
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 37 38 39
+python.versions     27 37 38 39 310 311
 
 maintainers         nomaintainer
 


### PR DESCRIPTION
#### Description

Add py310 and py311 subport for py-requests-unixsocket.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.

-->
macOS 12.2.1 21D62 x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
