### PR TITLE
eigenmath: new port in math

### DIFF
--- a/math/eigenmath/Portfile
+++ b/math/eigenmath/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        georgeweigt eigenmath 3889cdbe72b1371a23d5fa284e23976f517e75f7
+version             2023.02.02
+revision            0
+categories          math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             BSD
+description         Symbolic math app
+long_description    {*}${description}
+homepage            https://georgeweigt.github.io
+checksums           rmd160  98dc7ebb82df70e48e51f1e97c2d6fc05894f956 \
+                    sha256  ea6a2488dd93be63564b9cef46918a415bd83fbaa8c4529149c633ec3a7dd25a \
+                    size    701282
+
+post-patch {
+    reinplace "s,gcc,${configure.cc} [get_canonical_archflags cc]," ${worksrcpath}/Makefile
+}
+
+build.target        eigenmath
+
+destroot {
+    copy ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 644 -W ${worksrcpath} LICENSE README.md ${destroot}${docdir}
+}
+
+test.run            yes
+
+test {
+    system -W ${worksrcpath} "./eigenmath test/selftest1 && ./eigenmath test/selftest2"
+}


### PR DESCRIPTION
Signed-off-by: Sergey Fedorov <vital.had@gmail.com>

#### Description

New port: https://github.com/georgeweigt/eigenmath

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
make: Leaving directory `/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_eigenmath/eigenmath/work/eigenmath-3889cdbe72b1371a23d5fa284e23976f517e75f7'
--->  Testing eigenmath
Testing 1st
Testing abs
Testing adj
Testing arccos
Testing arccosh
Testing arcsin
Testing arcsinh
Testing arctan
Testing arctanh
Testing arg
Testing associativity
Testing bug fixes
Testing ceiling
Testing choose
Testing circexp
Testing clock
Testing cofactor
Testing complex exponentials
Testing complex numbers
Testing conj
Testing cos
Testing cosh
Testing defint
Testing denominator
Testing derivative
Testing det
Testing dim
Testing eigenvec
Testing eval
Testing exp
Testing expcos
Testing expsin
Testing exptan
Testing float
Testing floor
Testing for
Testing hadamard
Testing hermite
Testing imag
Testing imaginary unit
Testing infixform
Testing integral
Testing kronecker
Testing laguerre
Testing local variables
Testing log
Testing logical operators
Testing minor
Testing minormatrix
Testing mod
Testing noexpand
Testing nroots
Testing numerator
Testing numerics
Testing polar
Testing product
Testing radicals
Testing rationalize
Testing relational operators
Testing roots
Testing rotate
Testing simple powers
Testing simplify
Testing sin
Testing sinh
Testing sum
Testing tan
Testing tanh
Testing taylor
Testing tensor arithmetic
Testing tensor promotion
Testing transpose
Testing vector arithmetic
ok
Angular momentum
Birthday problem
Bondi metric
Casimir trick
Circular polarization
Complex numbers as real vectors
Dirac equation
Dirac hydrogen atom equation (32)
Elliptical polarization
Gordon decomposition
Green's theorem
Hydrogen atom
Laguerre function
Legendre function
Maxwell in tensor form
Muon pair production
Quantum electric field
Quantum electrodynamics
Quantum harmonic oscillator
Radial eigenfunctions
Rotation matrix
Rutherford scattering
Schwarzchild metric
Spherical harmonics
Spinor identities
Static metric
Stokes theorem
Surface area
Surface integral
Vector calculus
ok
```