### PR TITLE
bsd-games: new port

### DIFF
--- a/games/bsd-games/Portfile
+++ b/games/bsd-games/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                bsd-games
+version             3.2
+revision            0
+categories          games
+license             BSD
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         Classic text mode games from UNIX folklore
+
+long_description    {*}${description}
+
+homepage            https://bsd-games.sourceforge.net
+
+master_sites        sourceforge
+
+checksums           rmd160  0376a397f516720f3ad2dd4ff113603e74b6429b \
+                    sha256  31e9725b3a12648bed06723deef2da0d22a104570d9134ca3c30341a0d722afd \
+                    size    268327
+
+depends_build       port:pkgconfig
+
+depends_lib         port:ncurses
+
+patchfiles          patch-gomoku.diff
+
+post-patch {
+    reinplace \
+        "s|snprintf\[\[:space:]]*(ArrayBlock\[\[:space:]]*(\\(\[^)]*\\))|snprintf(\\1, ArraySize(\\1)|g" \
+        {*}[glob ${worksrcpath}/*/*.c]
+}
+
+configure.args      --localstatedir=${prefix}/var
+
+destroot.args       INSTALL_SCORE='\${INSTALL} -m 664 -g everyone /dev/null'

--- a/games/bsd-games/files/patch-gomoku.diff
+++ b/games/bsd-games/files/patch-gomoku.diff
@@ -1,0 +1,11 @@
+--- gomoku/gomoku.h.orig	2023-02-02 18:51:24.000000000 +0400
++++ gomoku/gomoku.h	2023-02-02 18:51:38.000000000 +0400
+@@ -5,7 +5,7 @@
+ #if __has_include(<sys/endian.h>)
+     #include <sys/endian.h>
+ #else
+-    #include <endian.h>
++    #include <machine/endian.h>
+ #endif
+ 
+ enum {


### PR DESCRIPTION
#### Description

[Classic text mode games from UNIX folklore](http://bsd-games.sourceforge.net/)

###### Tested on
macOS 12.6.2 21G320 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?