### PR TITLE
boost: combined option has been renamed to arm+x86

### DIFF
--- a/devel/boost181/Portfile
+++ b/devel/boost181/Portfile
@@ -493,11 +493,11 @@ variant universal {
     build.args-append   pch=off
 
     if {[lsearch ${configure.universal_archs} arm*] != -1} {
-        build.args-append address-model=64 architecture=combined
+        build.args-append address-model=64 architecture=arm+x86
     } else {
         if {[lsearch ${configure.universal_archs} ppc*] != -1} {
             if {[lsearch ${configure.universal_archs} *86*] != -1} {
-                build.args-append architecture=combined
+                build.args-append architecture=arm+x86
             } else {
                 build.args-append architecture=power
             }


### PR DESCRIPTION
combined options was replaced with arm+x86 and recently added to darwin toolset

For more details, please see : 
https://github.com/boostorg/build/commit/da10b56586850f6b2fbe3b6f4db65f9e6a5c639c https://github.com/boostorg/build/commit/04b562ac8b6d6de4aae78a85f9fc3e17f7aa4821 https://github.com/boostorg/build/commit/d312a161524213b7966eec440158f38fbaa497c2
https://github.com/bfgroup/b2/commit/0db9a736ba169e70dc29b9bf108495fee7243f8e

#### Description

[Trac ticket](https://trac.macports.org/ticket/66820)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5.1 21G83 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
