### PR TITLE
blink: new port

### DIFF
--- a/emulators/blink/Portfile
+++ b/emulators/blink/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github      1.0
+PortGroup           makefile    1.0
+
+github.setup        jart blink 60b9d7fca7d7d0b03eb1707351225ec983f2ea88
+version             20230203
+revision            0
+
+description         tiniest x86-64-linux emulator
+
+long_description    \
+    ${name} is a virtual machine that runs x86-64-linux programs on different \
+    operating systems and hardware architectures. It's designed to do the \
+    same thing as the qemu-x86_64 command, except that it is smaller, runs on \
+    any POSIX platform, runs 2x faster than qemu-x86_64 on some benchmarks, \
+    and is also faster at running ephemeral programs such as compilers.
+
+categories          emulators
+installs_libs       no
+license             ISC
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  05fbb5b863865becec8626c0255ee4b445d3d5e9 \
+                    sha256  1e679faa0581332d0a2ef4a9b20d2e7e227d43462f06fddf516600fac3e5cea6 \
+                    size    1540086
+
+depends_build-append \
+                    port:gmake
+
+build.cmd           gmake
+build.target        {}
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/o/blink/blink ${worksrcpath}/o/blink/blinkenlights \
+        ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
New port for https://github.com/jart/blink, a tiny x86-64-linux emulator.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -d install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
