### PR TITLE
terragrunt-0.43: update to 0.43.2; add @ajhall as maintainer

### DIFF
--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -9,10 +9,9 @@ license             MIT
 platforms           darwin linux
 homepage            https://terragrunt.gruntwork.io
 
-maintainers         {mjrc.nl:macports @mjrc} openmaintainer
-
-
-
+maintainers         {mjrc.nl:macports @mjrc} \
+                    {ajhall.us:macports @ajhall} \
+                    openmaintainer
 
 # *NOTE* Remember to update `latestVersion` on a version upgrade.
 set latestVersion       terragrunt-0.43

--- a/sysutils/terragrunt/Portfile
+++ b/sysutils/terragrunt/Portfile
@@ -19,11 +19,11 @@ set latestVersion       terragrunt-0.43
 
 subport terragrunt-0.43 {
     set dependsOn       1.2
-    set patchNumber     0
+    set patchNumber     2
 
-    checksums           rmd160  18d15317c1bf823f94dd714a53537ebd0f052334 \
-                        sha256  86affacbdc531ad8b5b36ec97bfb9bf63beeec0a6e1dabcdc93ca7e5fadb6001 \
-                        size    2311665
+    checksums           rmd160  b7b4643a3b78e7145475b7ada30eade4c9c0c80f \
+                        sha256  dcfa20ee66ce9001abdde949a2768be88ed45b551b6a4a165b9a62968b7dd61d \
+                        size    2316909
 }
 
 subport terragrunt-0.42 {


### PR DESCRIPTION
#### Description
terragrunt-0.43: update to 0.43.2
terragrunt: add @ajhall as maintainer

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.2 22D49 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?