### PR TITLE
ghc-prebuilt, hadrian, cabal: Fix worksrcdir on MacPorts 2.8.1

### DIFF
--- a/lang/cabal/Portfile
+++ b/lang/cabal/Portfile
@@ -96,10 +96,9 @@ if {${name} eq ${subport}} {
                     sha256  d4eff9c1fcc5212360afac8d97da83b3aff79365490a449e9c47d3988c14b6bc \
                     size    2181318
 
-    worksrcdir      ${name}-install-${version}
-
     extract.only-append \
                     ${distfile_github}
+    extract.rename  yes
 
     variant prebuilt \
         description {This variant is deprecated.} {

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -323,7 +323,6 @@ subport ghc-prebuilt {
     revision        0
     supported_archs arm64 x86_64
 
-    worksrcdir      ${ghc_distname}
     distfiles       ${ghc_distname}${extract.suffix}
 
     gpg_verify.use_gpg_verification \
@@ -345,6 +344,7 @@ subport ghc-prebuilt {
     }
 
     extract.only    ${ghc_distname}${extract.suffix}
+    extract.rename  yes
 
     # Build requires C11
     compiler.c_standard 2011
@@ -353,7 +353,6 @@ subport ghc-prebuilt {
     compiler.blacklist-append {clang < 700}
 
     distname        ${name}-${ghc_version}
-    worksrcdir      ${distname}
 
     build           {}
 
@@ -396,8 +395,8 @@ subport hadrian {
     distfiles       [lindex ${ghc_source_checksums} 0]
     checksums       {*}${ghc_source_checksums}
     extract.only    [lindex ${ghc_source_checksums} 0]
+    extract.rename  yes
 
-    worksrcdir      ${distname}
     set worksrcpath ${workpath}/${worksrcdir}/${subport}
 
     variant stack \


### PR DESCRIPTION
* Fixes: https://trac.macports.org/ticket/66821
* Fixes: https://trac.macports.org/ticket/66690#comment:3

Note: no revbumps because no binaries or installation details are affected.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D49 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
