### PR TITLE
GPXSee: update to 11.12

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 11.11
-revision            1
+github.setup        tumic0 GPXSee 11.12
+revision            0
 
-checksums           rmd160  27961b44fcb78c4653e0d5217f616d2a783457eb \
-                    sha256  7cc9f75f76cbae937a59a12bda9d46f25603a6760f6fddc512edd0edab3b7c40 \
-                    size    5484512
+checksums           rmd160  e3f40c8b4e61b0d723b265dc6d0684ec6d673289 \
+                    sha256  6d7f521286a843eb00c89a5304031b73f445d4bb1857f0fd79c4fba5e16f1f0b \
+                    size    5486541
 
 categories          gis graphics
 license             GPL-3
@@ -28,8 +28,6 @@ qt5.depends_build_component     qttools
 qt5.depends_runtime_component   qtimageformats qttranslations
 
 compiler.cxx_standard 2011
-
-use_xcode           yes
 
 depends_run-append  port:QtPBFImagePlugin
 


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

I'm not quite sure about removing `use_xcode yes`, but GPXSee build fails for me with this option (after last macOS update).

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
