### PR TITLE
josm: update to 18646

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18622
+version             18646
 categories          gis editors java
 license             GPL-2+
 supported_archs     i386 x86_64
@@ -18,9 +18,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  bcb007cc3245ce8b4c2d57ed2244b11737edc4ac \
-                    sha256  ab72abd1859ee899bac0eea1edf30034a2c258a7d4d330e90598d11faeb67928 \
-                    size    78118410
+checksums           rmd160  8366de7809bea9b8565bb12fc6dd93965097336e \
+                    sha256  8a10443a5e969c8680ef1e340f61d37552036f7d01627865874b10adb340fd25 \
+                    size    78143106
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2023-01-30: Stable release 18646](https://josm.openstreetmap.de/wiki/Changelog#a2023-01-30:Stablerelease1864623.01)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
