### PR TITLE
iverilog: add missing dependency on bison

### DIFF
--- a/science/iverilog/Portfile
+++ b/science/iverilog/Portfile
@@ -35,6 +35,8 @@ depends_lib-append  port:bzip2 \
                     port:readline \
                     port:zlib
 
+depends_build       port:bison
+
 compiler.cxx_standard 2011
 
 if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
@@ -55,10 +57,6 @@ post-destroot {
     xinstall -m 644 {*}[glob ${worksrcpath}/vvp/*.txt] ${docdir}/vvp
     xinstall -m 644 -W ${worksrcpath} cadpli/cadpli.txt ivlpp/ivlpp.txt \
         ${docdir}
-}
-
-platform darwin 8 {
-    depends_build-append    port:bison
 }
 
 # g++-4.2: -E, -S, -save-temps and -M options are not allowed with multiple -arch flags


### PR DESCRIPTION
#### Description

This PR adds a dependency on bison to iverilog, which fixes an issue reported upstream due to the version bundled with Xcode being too old: https://github.com/steveicarus/iverilog/issues/270. This change ensures iverilog builds against a known version of bison rather than relying on whatever can be found on PATH.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5 21G72 arm64
Xcode 14.2 14C18


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
