### PR TITLE
miniflux: update to 2.0.42

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.41
+go.setup            github.com/miniflux/v2 2.0.42
 go.package          miniflux.app
 name                miniflux
 revision            0
@@ -16,9 +16,9 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  96be8023542f903303c06fabfa920943cc41f546 \
-                        sha256  d0cb753298580c2736001d7a458142b1b50403549f87c07c42d6d3f4c158835d \
-                        size    576000
+                        rmd160  fdfe49e34e1e2e2851723e55d38881690fcfd845 \
+                        sha256  68617cd149578400027fc30f9bb151e30f9c4f34084dd4d5ef0debf399de9766 \
+                        size    577211
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
@@ -49,35 +49,35 @@ go.vendors          mvdan.cc/xurls \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
                     golang.org/x/text \
-                        lock    v0.5.0 \
-                        rmd160  22d952d3a5226707a3ab3575c75ad6269ab28851 \
-                        sha256  ae1308be329a9c8a939243c5f44410d5155594d3d31c274bd6daa2399784ce33 \
-                        size    8354318 \
+                        lock    v0.6.0 \
+                        rmd160  41b7bda7df46797457b47aa00e5d745345b684bc \
+                        sha256  6172a6091f616a9fb644ed71ee61e3a69529f95f357abd9ce521599a1e57e2b9 \
+                        size    8361557 \
                     golang.org/x/term \
-                        lock    v0.3.0 \
-                        rmd160  14a60f913597d05ed7df0b6d6fbca50ca672b594 \
-                        sha256  c5e084b265e4c0dfb37ef0a0e7aa5b5ff4f9afe55c71452d13789a85abcd46c9 \
+                        lock    v0.4.0 \
+                        rmd160  ab690adab1da9bf826e1e2960b3c032c9284a23e \
+                        sha256  fe08b220b0929e25392011fd72353f50b7ac64d52cffff4a868318b0f16beab0 \
                         size    14800 \
                     golang.org/x/sys \
-                        lock    v0.3.0 \
-                        rmd160  17c78e6210a6f938db21fa772584ab8c7d4e06c1 \
-                        sha256  b04ddf676ead57e0d3e367e9aa17db1b11fc20af719e479d1ca56873a2bdf06b \
-                        size    1411264 \
+                        lock    v0.4.0 \
+                        rmd160  83e9289b4e409a6a5a96cf70f6adda487c3f1170 \
+                        sha256  97f4948f84af5fe499733870e49ce277786e512787690065e3be9828d4a6c738 \
+                        size    1425728 \
                     golang.org/x/oauth2 \
-                        lock    v0.3.0 \
-                        rmd160  9feed440ae9739cf5f54b84c5a2d5d68ebe3ed92 \
-                        sha256  60061bd7d2c4b0e7744e581eea0974ae5172c506c8b087301f63a4e4c21cca36 \
-                        size    87101 \
+                        lock    v0.4.0 \
+                        rmd160  3492641d8a6a0b335f4c2ceb4cecbbcd135bfcab \
+                        sha256  bcd56fd25196c1620b9a9a3ff6facd1903db31a7a4db11fb193872dc91bb2b6f \
+                        size    87089 \
                     golang.org/x/net \
-                        lock    v0.4.0 \
-                        rmd160  c003f74a2dd1696a79f5fa52e78d12d95e58a3a2 \
-                        sha256  22ce878356e58045cc8509555dab771ac53d6a0541448d3d58fc24d9ba462cd9 \
-                        size    1237072 \
+                        lock    v0.5.0 \
+                        rmd160  5c6bd81ab31a211f0e6f520dbec3c02c506d9ea6 \
+                        sha256  34827849fc6295d493c21df54fea819dae369bc37ff7d7e283030fe140118c0e \
+                        size    1238525 \
                     golang.org/x/crypto \
-                        lock    v0.4.0 \
-                        rmd160  5669817509812aad1d04b5dc12d2217d28d954d8 \
-                        sha256  d2340a6bb7fa26df5f5e309cada4e2666652e721307fa512923f352a17b7a14e \
-                        size    1633555 \
+                        lock    v0.5.0 \
+                        rmd160  d1a21b7260574f31cbc6588e1c392eb8f373a9e6 \
+                        sha256  a21df3765c9643d1fadcfb966fde4173c0c930851fb01a24bdef28abd950f13c \
+                        size    1633695 \
                     github.com/yuin/goldmark \
                         lock    v1.5.3 \
                         rmd160  19ec5216062b33aa1442099e489ffc81fef34679 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.42)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
