### PR TITLE
ffmpeg-upstream: prevent autodetection of xlib

### DIFF
--- a/multimedia/ffmpeg-upstream/Portfile
+++ b/multimedia/ffmpeg-upstream/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg ffmpeg-devel
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             5.1.2
-revision            1
+revision            2
 epoch               0
 
 license             LGPL-2.1+
@@ -94,6 +94,7 @@ depends_lib-append \
                     path:lib/libspeex.dylib:speex \
                     port:soxr \
                     port:bzip2 \
+                    port:lzo2 \
                     port:xz \
                     port:zimg \
                     port:zlib
@@ -153,6 +154,7 @@ configure.args-append \
                     --disable-libjack \
                     --disable-libopencore-amrnb \
                     --disable-libopencore-amrwb \
+                    --disable-xlib \
                     --disable-libxcb \
                     --disable-libxcb-shm \
                     --disable-libxcb-xfixes \
@@ -316,7 +318,8 @@ variant x11 {
     depends_lib-append      port:xorg-libxcb \
                             port:xorg-libXext \
                             port:xorg-libXfixes
-    configure.args-delete   --disable-libxcb \
+    configure.args-delete   --disable-xlib \
+                            --disable-libxcb \
                             --disable-libxcb-shm \
                             --disable-libxcb-xfixes
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The packages from ffmpeg-upstream currently have an incorrect dependency on X11:

```
$ ffmpeg
dyld[51531]: Library not loaded: '/opt/local/lib/libX11.6.dylib'
  Referenced from: '/opt/local/bin/ffmpeg'
  Reason: tried: '/opt/local/lib/libX11.6.dylib' (no such file), '/usr/local/lib/libX11.6.dylib' (no such file), '/usr/lib/libX11.6.dylib' (no such file)
zsh: abort      ffmpeg
```

My best guess is that this is caused by detecting Xlib on the builder; since I don't have it installed locally, and always build in trace mode, I cannot reproduce it myself.

While at it, I added a dependency to LZO2, that tracemode prevented the configure script from picking up.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.2 21G320 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
