### PR TITLE
upx: update to 4.0.2

### DIFF
--- a/archivers/upx/Portfile
+++ b/archivers/upx/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           cmake   1.1
+PortGroup           github  1.0
 
 name                upx
 categories          archivers
-platforms           darwin
 license             GPL-2+
 maintainers         {l2dy @l2dy} openmaintainer
 
@@ -15,20 +15,20 @@ long_description    UPX is a free, portable, extendable, high-performance \
 homepage            https://upx.github.io/
 
 if {${name} eq ${subport}} {
-    github.setup    upx upx 3.96 v
+    github.setup    upx upx 4.0.2 v
     github.tarball_from releases
 
     distname        upx-${version}-src
     use_xz          yes
-    checksums       rmd160  ca7267db80cff02d50ecbf259906b64f119dfb56 \
-                    sha256  47774df5c958f2868ef550fb258b97c73272cb1f44fe776b798e393465993714 \
-                    size    792524
+    checksums       rmd160  bcb90077d03b0422e7ee70679f6b497df22df6f5 \
+                    sha256  1221e725b1a89e06739df27fae394d6bc88aedbe12f137c630ec772522cbc76f \
+                    size    1191960
 
     conflicts       upx-devel
 }
 
 subport upx-devel {
-    github.setup    upx upx b4558e2049653c832cfde6c9a23d28455743853e
+    github.setup    upx upx 163377d1a0c008759222569d5e1152ef878adfd1
     github.livecheck.branch devel
     version         20211127
 
@@ -44,9 +44,8 @@ subport upx-devel {
                     2014
 }
 
-use_configure       no
-
-depends_lib         port:ucl port:zlib
+depends_lib-append  port:zlib \
+                    port:ucl
 
 post-configure {
     reinplace "s|CXXFLAGS += -fno-delete-null-pointer-checks||" ${worksrcpath}/src/Makefile
@@ -55,21 +54,3 @@ post-configure {
 }
 
 variant universal {}
-
-build.env           CXX=${configure.cxx} \
-                    "CXXFLAGS_OPTIMIZE=${configure.cxxflags} [get_canonical_archflags cxx]" \
-                    CXXFLAGS_WERROR=
-
-destroot {
-    xinstall -m 755 ${worksrcpath}/src/upx.out ${destroot}${prefix}/bin/upx
-
-    xinstall -m 644 ${worksrcpath}/doc/upx.1 ${destroot}${prefix}/share/man/man1
-
-    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 -W ${worksrcpath}/doc upx.doc upx.html ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 -W ${worksrcpath} BUGS COPYING LICENSE NEWS README README.1ST README.SRC THANKS ${destroot}${prefix}/share/doc/${name}
-
-    if {${name} eq ${subport}} {
-        xinstall -m 644 -W ${worksrcpath} PROJECTS ${destroot}${prefix}/share/doc/${name}
-    }
-}


### PR DESCRIPTION
- switch to the `cmake` portgroup
- update to upx-devel to 163377d1a0c008759222569d5e1152ef878adfd1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -d install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
