### PR TITLE
wails: new port (version 2.3.1)

### DIFF
--- a/devel/wails/Portfile
+++ b/devel/wails/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/wailsapp/wails 2.3.1 v
+github.tarball_from archive
+revision            0
+
+homepage            https://wails.io
+
+description         Create beautiful applications using Go
+
+long_description    \
+    The traditional method of providing web interfaces to Go programs is via \
+    a built-in web server. Wails offers a different approach: it provides the \
+    ability to wrap both Go code and a web frontend into a single binary. \
+    Tools are provided to make this easy for you by handling project \
+    creation, compilation and bundling. All you have to do is get creative\!
+
+categories          devel
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  0bdd426fa4f82815472c1d045fb8c0999a7d9b5e \
+                    sha256  e50d418fae8f65e5f72f4aa2d0c4ea4e209c37c5439a2b5a168ea332745ce408 \
+                    size    14979215
+
+depends_run-append  bin:npm:npm8 \
+                    port:upx
+
+build.env-delete    GO111MODULE=off GOPROXY=off
+
+build.args-append   ./cmd/${name}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+github.livecheck.regex \
+                    {([\d.]+)}


### PR DESCRIPTION
New port for https://wails.io/

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~~`sudo port -vst install`~~ `sudo port -d install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
