### PR TITLE
libmd: tuck away headers

### DIFF
--- a/devel/libmd/Portfile
+++ b/devel/libmd/Portfile
@@ -5,6 +5,7 @@ PortSystem 1.0
 name                libmd
 epoch               1
 version             1.0.4
+revision            1
 categories          devel
 license             BSD ISC Permissive
 platforms           darwin
@@ -27,3 +28,7 @@ checksums           rmd160  4a47a01fa2e47d3c9c9bd27ebd55780a3d82fe66 \
                     size    264472
 
 patchfiles          patch-symbol-alias.diff
+
+# hide away a bunch of generically-named header files
+# see https://trac.macports.org/ticket/66832
+configure.args      --includedir=${prefix}/include/libmd

--- a/mail/signing-party/Portfile
+++ b/mail/signing-party/Portfile
@@ -56,7 +56,7 @@ depends_run         path:bin/gpg:gnupg2 \
 build.args          DEB_VERSION_UPSTREAM=${version}
 
 variant universal   {}
-build.env-append    CC=${configure.cc} \
+build.env-append    "CC=${configure.cc} -I${prefix}/include/libmd" \
                     "CFLAGS=${configure.cflags} [get_canonical_archflags]"
 
 pre-build {


### PR DESCRIPTION
these headers are too generically named
causes build errors in other software
that has similarly named headers

closes: https://trac.macports.org/ticket/66832

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
