### PR TITLE
maven3: update to 3.9.0

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.8.7
+version         3.9.0
 revision        0
 
 categories      java devel
@@ -35,11 +35,11 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  163339c8f3208e746767298802a486b4cee440d2 \
-                sha256  628b49352130d1d25d5519b1c724f0efe58b86bad55f37a694ca8f73f11e3604 \
-                size    8293440
+checksums       rmd160  672971cef66b6d042bd69dce2fc0d39e137c89e5 \
+                sha256  b118e624ec6f7abd8fc49e6cb23f134dbbab1119d88718fc09d798d33756dd72 \
+                size    9024147
 
-java.version    1.7+
+java.version    1.8+
 java.fallback   openjdk17
 
 depends_run     port:maven_select


### PR DESCRIPTION
#### Description

Update to Apache Maven 3.9.0.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?