### PR TITLE
google-cloud-sdk: update to 417.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             416.0.0
+version             417.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  b60c0de2d730d5e1ade3e55c1bf2711d4b0875a5 \
-                    sha256  f520b1a7bbf56283c7ded21c291fbcd1efc8db91ffd7dc66bfd2602fcebd04b1 \
-                    size    111022992
+    checksums       rmd160  4335b9a7ed89f0ca2a7c76f5a62e5d674764d700 \
+                    sha256  633f98481bcab104e6149e5528528c3aad5682ce6a5a1f2f1ebebbb470d7b068 \
+                    size    111079011
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a4497c9bf18141c0d8d57c4d1a6a78530b7824fb \
-                    sha256  f36c27510130cc750210ed2ba718eb5fe3d7864235c84c8ac99f01bc25baa0be \
-                    size    131350109
+    checksums       rmd160  f8f2368fb4b4299aa6f43a760e8f538c152d326e \
+                    sha256  e7f3dc908b83a5152d0db0e2ab10dff954f3834e44e5fb35e1fc09225a602a6a \
+                    size    131408632
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  54b7861b3a84aa91c9dc3803514ae4d9c9719d6c \
-                    sha256  bc473df24d7e39ad6f24b890999154c63896d2b1b5a24355acef2deb1da6630e \
-                    size    128185794
+    checksums       rmd160  7f46a2a2ee69c15903268227e3854b03f09cdcfb \
+                    sha256  592648263419e0184581e52c5f2fda3cb163327694200e58d253926c65029f62 \
+                    size    128244581
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 417.0.0.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?