### PR TITLE
graphene: allow SSE2 with i386 builds

### DIFF
--- a/graphics/graphene/Portfile
+++ b/graphics/graphene/Portfile
@@ -6,6 +6,7 @@ PortGroup           meson 1.0
 PortGroup           muniversal 1.0
 
 github.setup        ebassi graphene 1.10.8
+revision            1
 license             Permissive
 categories          graphics gnome
 maintainers         {devans @dbevans} openmaintainer
@@ -41,6 +42,11 @@ platform darwin {
         patchfiles-append patch-graphene-leopard.diff
     }
 }
+
+# graphene forces off SSE2 if not building for x86_64. This is based on a linux
+# issue with memory alignment. We allow SSE2 for i386 on Darwin, and this also
+# fixes universal building https://trac.macports.org/ticket/65710
+patchfiles-append   patch-graphene-allow-sse2-on-32bit.diff
 
 compiler.c_standard 1999
 

--- a/graphics/graphene/files/patch-graphene-allow-sse2-on-32bit.diff
+++ b/graphics/graphene/files/patch-graphene-allow-sse2-on-32bit.diff
@@ -1,0 +1,15 @@
+--- meson.build.orig	2023-02-07 18:04:51.000000000 -0800
++++ meson.build	2023-02-07 18:04:59.000000000 -0800
+@@ -293,11 +293,7 @@
+ sse2_cflags = []
+ if get_option('sse2')
+   sse_prog = '''
+-#if defined(__GNUC__)
+-# if !defined(__amd64__) && !defined(__x86_64__)
+-#   error "SSE2 intrinsics are only available on x86_64"
+-# endif
+-#elif defined (_MSC_VER) && !defined (_M_X64) && !defined (_M_AMD64)
++#if defined (_MSC_VER) && !defined (_M_X64) && !defined (_M_AMD64)
+ # error "SSE2 intrinsics not supported on x86 MSVC builds"
+ #endif
+ #if defined(__SSE__) || (_M_X64 > 0)


### PR DESCRIPTION
SSE2 is disabled on i386 linux due to segfaults from memory alignment issues, but these are not seen on MacOS.

allowing SSE2 on i386 fixes the universal i386/x86_64 build as then the two build trees match

closes: https://trac.macports.org/ticket/65710

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
