### PR TITLE
libstdcxx-docs: update to 12.2.0

### DIFF
--- a/lang/libstdcxx-docs/Portfile
+++ b/lang/libstdcxx-docs/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                libstdcxx-docs
-version             12.1.0
-revision            1
+version             12.2.0
+revision            0
 conflicts           stdman
 categories          lang
 supported_archs     noarch
@@ -24,9 +24,9 @@ distname            gcc-${version}
 set major           [lindex [split ${version} .] 0]
 dist_subdir         gcc${major}
 
-checksums           rmd160  6cdb114103541230492bbc6093585cb10e5e5ea6 \
-                    sha256  62fd634889f31c02b64af2c468f064b47ad1ca78411c45abe6ac4b5f8dd19c7b \
-                    size    82701928
+checksums           rmd160  76d30c411227d6c3e87dd4f0a8ea1ae5d8ab9ffd \
+                    sha256  e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff \
+                    size    84645292
 
 use_xz              yes
 


### PR DESCRIPTION
###### Tested on
macOS 12.6.2 21G320 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?