### PR TITLE
onedpl: update to 2021.7.1

### DIFF
--- a/devel/onedpl/Portfile
+++ b/devel/onedpl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        oneapi-src oneDPL 2021.7.0 oneDPL- -release
+github.setup        oneapi-src oneDPL 2021.7.1 oneDPL- -release
 name                onedpl
 revision            0
 
@@ -23,9 +23,9 @@ long_description    oneAPI DPC++ Library (oneDPL) provides high-productivity \
 
 github.tarball_from archive
 
-checksums           rmd160  798a9f3e9852b53e5dc7dcdfe8cc51c1926feab5 \
-                    sha256  5484c6de482790206d877a4947dcef6e0a1e082dbfa5c6a5362e18072c4a3de3 \
-                    size    3688085
+checksums           rmd160  16dea7915e661ee7a37aaf48e96ab027a86795f1 \
+                    sha256  3f9aa5b23b459dc8cd818975f1dbb313e690f1976551ee1fe45cedb775c3ef7a \
+                    size    3704195
 
 depends_lib-append  port:onetbb
 


### PR DESCRIPTION
###### Tested on
macOS 12.6.2 21G320 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?