### PR TITLE
safeclib: fix livecheck

### DIFF
--- a/devel/safeclib/Portfile
+++ b/devel/safeclib/Portfile
@@ -6,6 +6,7 @@ PortGroup           muniversal 1.0
 
 github.setup        rurban safeclib 3.7.1 v
 github.tarball_from releases
+github.livecheck.regex  (\[0-9]+\\.\[0-9]+(\\.\[0-9]+)?)
 
 categories          devel
 license             MIT


### PR DESCRIPTION
###### Type(s)

- [x] bugfix

###### Tested on
macOS 12.6.2 21G320 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?