### PR TITLE
terraform: fix checksum

### DIFF
--- a/sysutils/terraform/Portfile
+++ b/sysutils/terraform/Portfile
@@ -18,6 +18,7 @@ maintainers             {emcrisostomo @emcrisostomo} \
 set latestVersion       terraform-1.3
 
 set armAvailable        no
+set customDistSubDir    yes
 
 proc terraformBaseVersion {} {
     global subport
@@ -36,6 +37,7 @@ proc terraformDistBase {} {
 
 subport terraform-1.3 {
     set patchNumber     9
+    revision            0
 
     set armAvailable    yes
 
@@ -47,86 +49,96 @@ subport terraform-1.3 {
                         rmd160  28012de87d77b5f8c29da38ea4b4b2e3c07e709f \
                         sha256  9df6fc8a9264bba1058e6e9383f43af2ee816088e61925e5bc45128ad8b6e9ad \
                         size    19793375
+
+    set customDistSubDir no
 }
 
 subport terraform-1.2 {
     set patchNumber     9
+    revision            1
 
     set armAvailable    yes
 
     checksums           [terraformDistBase]_amd64.zip \
-                        rmd160  9be5fe69559e05347a3f147981c7e5299a8da27c \
-                        sha256  46206e564fdd792e709b7ec70eab1c873c9b1b17f4d33c07a1faa9d68955061b \
-                        size    21329275 \
+                        rmd160  04de8ebe3f669749633baaf8fbffbb0bd0e3af2a \
+                        sha256  2c4d2b425a0680c6a4d65601a5f42f8b5c23e4ccd3332cf649ce14eaa646b967 \
+                        size    21672801 \
                         [terraformDistBase]_arm64.zip \
-                        rmd160  a4bc3fa4815499cb8f80e27582e9986bbe6be8b4 \
-                        sha256  e61195aa7cc5caf6c86c35b8099b4a29339cd51e54518eb020bddb35cfc0737d \
-                        size    19773052
+                        rmd160  fd4c14e6069779bd37fafc555f56b741d946e03a \
+                        sha256  91f51a352027f338b7673f23ee3c438ca8575933b7f58bfd7a92ffccf552158b \
+                        size    20280537
 }
 
 subport terraform-1.1 {
     set patchNumber     9
+    revision            1
 
     set armAvailable    yes
 
     checksums           [terraformDistBase]_amd64.zip \
-                        rmd160  e6538bdf426ea5921331a486c3ac75a1b51c3146 \
-                        sha256  c902b3c12042ac1d950637c2dd72ff19139519658f69290b310f1a5924586286 \
-                        size    20709155 \
+                        rmd160  f8ccb12d1edec6cf17ea5a8f741cb993e9573253 \
+                        sha256  26afa7cda355fbf32a2b4cfd9122a49132f1b68337691b91f05caa0b1023c388 \
+                        size    20850633 \
                         [terraformDistBase]_arm64.zip \
-                        rmd160  1831a902fd94614825b5339d9aeae8411fdd187e \
-                        sha256  918a8684da5a5529285135f14b09766bd4eb0e8c6612a4db7c121174b4831739 \
-                        size    19835808
+                        rmd160  d257bc5f7d94fde348975b6b9092e928271b59e2 \
+                        sha256  80a230b56853f0fd50e12006c0d527da6a7f2e9974f25f7d372abfa2761ee3a3 \
+                        size    20093183
 }
 
 subport terraform-1.0 {
     set patchNumber     11
+    revision            1
 
     set armAvailable    yes
 
     checksums           [terraformDistBase]_amd64.zip \
-                        rmd160  a8ea8e4ec4087d753801f19c5f5625204cfcc098 \
-                        sha256  92f2e7eebb9699e23800f8accd519775a02bd25fe79e1fe4530eca123f178202 \
-                        size    19340098 \
+                        rmd160  a988402d3cd99b9d932206626b711725a9b7853b \
+                        sha256  5b6771c87f3febde756baa132d38a67fcac284291a1f88918a58a41d879d2558 \
+                        size    19422758 \
                         [terraformDistBase]_arm64.zip \
-                        rmd160  5194880e62164b3991d14e8ef39ef6f5e5a05c5c \
-                        sha256  0f38af81641b00a2cbb8d25015d917887a7b62792c74c28d59e40e56ce6f265c \
-                        size    18498208
+                        rmd160  b1c556cfaa52c9b3a4e23d0a84093f69680926ae \
+                        sha256  435cc512332c28c38c98cda11a2ef3670564cfc85ba4e6fe0a73462713799f9e \
+                        size    18467870
 }
 
 subport terraform-0.15 {
     set patchNumber     5
-    checksums           rmd160  d57fbd764112a5cc7d46b04c8d17d220eb5fddc8 \
-                        sha256  27d5ae2431240dff928e6483170b570782a8dd1a2b7c32ce1793097af1acb9bd \
-                        size    33803323
+    revision            1
+    checksums           rmd160  6cf3903793848fd2ef0180ec37b3989f1117536a \
+                        sha256  4ee2ed9b769426cc9f13bd26c133ee66c6046acffeef632ddf0ef66e3d36a981 \
+                        size    33932321
 }
 
 subport terraform-0.14 {
     set patchNumber     11
-    checksums           rmd160  9c9236549e343f402e3617cea6f5773f2695b06b \
-                        sha256  5c0110a4dc44ec01edd159c69bf60cebd18540eaf168aacd8b37d828b70e265d \
-                        size    34597577
+    revision            1
+    checksums           rmd160  658517e12bcf8457a9c3fd5eda70d3a5d49529ba \
+                        sha256  143ee31a4ae61564762ca5fe40851a0ec661698b73026e3cc0061f9867c7b67f \
+                        size    34764927
 }
 
 subport terraform-0.13 {
     set patchNumber     7
-    checksums           rmd160  aa35c4f8d1d03fb05736fb1dcabc3a243b8a72d6 \
-                        sha256  d5fbb589bc35c2655d0705c26117135cbb25e4259f120415009e0e6427ea97c8 \
-                        size    35672990
+    revision            1
+    checksums           rmd160  58d16b69ad295ff35c3b3cf971adf93d2ce7afd6 \
+                        sha256  2ee62413afc847d9771d46d73fad6c7e8670bcdf44190320b5fb6a3a38ec6480 \
+                        size    35823336
 }
 
 subport terraform-0.12 {
     set patchNumber     31
-    checksums           rmd160  3b275cfdfa5adbe8834bf3b1eaf3a9352f1e2389 \
-                        sha256  c1a6ca04026cebe7849610037ebc960609484c25f47a58344efaa7fcd5be1e56 \
-                        size    29180819
+    revision            1
+    checksums           rmd160  8d8c6842db51226e6fe01ab9c84fb91013b94be3 \
+                        sha256  794e736283b93b364d7f1c36ec8f47912ec6f6a0692b2108d0fb3908b5d3b5af \
+                        size    29365294
 }
 
 subport terraform-0.11 {
     set patchNumber     15
-    checksums           rmd160  0887b1812921fce1135170c23a9faf1775f5db5f \
-                        sha256  b0d2c9f9068be007f9b8eff211a679e1f07368b640245871bb02a6c2cdf28c07 \
-                        size    21882476
+    revision            1
+    checksums           rmd160  2a6145f60df76d1052583b5cb82e15e3865d44e0 \
+                        sha256  e98434b0d35c4ec058479148dd590d2bbf3e419fcc6db204522cc4b0bbd9ec25 \
+                        size    22024453
 }
 
 subport terraform_select {}
@@ -177,6 +189,10 @@ if {${subport} eq ${name}} {
         if {${build_arch} eq "arm64"} {
             distname    [terraformDistBase]_arm64
         }
+    }
+
+    if ${customDistSubDir} {
+        dist_subdir   ${name}/${version}_${revision}
     }
 
     depends_run         port:terraform_select


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
It seems terraform had an outage regarding checksums and changed them. It breaks the installation. I started to fix some but we still need to update all of them.

Since such a change is not expected, we must also double check those checksums are not fishy

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D49 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
