### PR TITLE
hwloc: enable tests

### DIFF
--- a/devel/hwloc/Portfile
+++ b/devel/hwloc/Portfile
@@ -40,6 +40,9 @@ configure.args      --without-x \
 
 configure.checks.implicit_function_declaration.whitelist-append strchr
 
+test.run            yes
+test.target         check
+
 livecheck.type      regex
 livecheck.regex     "${name} v(\[0-9.\]+) "
 


### PR DESCRIPTION
#### Description

No reason not to have `test.run` option.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

```
--->  Testing hwloc
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_hwloc/hwloc/work/hwloc-2.8.0" && /usr/bin/make check 
Making check in include
make[1]: Nothing to be done for `check'.
Making check in hwloc
/usr/bin/make  
make[2]: Nothing to be done for `all'.
Making check in utils
Making check in hwloc
Making check in .
/usr/bin/make  check-TESTS
PASS: test-hwloc-annotate.sh
PASS: test-hwloc-calc.sh
PASS: test-hwloc-compress-dir.sh
PASS: test-hwloc-diffpatch.sh
PASS: test-hwloc-distrib.sh
PASS: test-hwloc-info.sh
PASS: test-build-custom-topology.sh
PASS: test-parsing-flags.sh
============================================================================
Testsuite summary for hwloc 2.8.0
============================================================================
# TOTAL: 8
# PASS:  8
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in lstopo
/usr/bin/make  check-TESTS
PASS: test-lstopo.sh
============================================================================
Testsuite summary for hwloc 2.8.0
============================================================================
# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[2]: Nothing to be done for `check-am'.
Making check in tests
Making check in hwloc
Making check in .
/usr/bin/make  hwloc_api_version hwloc_list_components hwloc_bitmap hwloc_bitmap_string hwloc_bitmap_compare_inclusion hwloc_get_closest_objs hwloc_get_obj_covering_cpuset hwloc_get_cache_covering_cpuset hwloc_get_largest_objs_inside_cpuset hwloc_get_next_obj_covering_cpuset hwloc_get_obj_inside_cpuset hwloc_get_shared_cache_covering_obj hwloc_get_obj_below_array_by_type hwloc_get_obj_with_same_locality hwloc_bitmap_first_last_weight hwloc_bitmap_singlify hwloc_type_depth hwloc_type_sscanf hwloc_bind hwloc_get_last_cpu_location hwloc_get_area_memlocation hwloc_object_userdata hwloc_synthetic hwloc_backends hwloc_pci_backend hwloc_is_thissystem hwloc_distances hwloc_groups hwloc_insert_misc hwloc_topology_allow hwloc_topology_restrict hwloc_topology_dup hwloc_topology_diff hwloc_topology_abi hwloc_obj_infos hwloc_iodevs cpuset_nodeset memattrs memtiers cpukinds xmlbuffer gl           
  CC       hwloc_api_version.o
  CCLD     hwloc_api_version
  CC       hwloc_list_components.o
  CCLD     hwloc_list_components
  CC       hwloc_bitmap.o
  CCLD     hwloc_bitmap
  CC       hwloc_bitmap_string.o
  CCLD     hwloc_bitmap_string
  CC       hwloc_bitmap_compare_inclusion.o
  CCLD     hwloc_bitmap_compare_inclusion
  CC       hwloc_get_closest_objs.o
  CCLD     hwloc_get_closest_objs
  CC       hwloc_get_obj_covering_cpuset.o
  CCLD     hwloc_get_obj_covering_cpuset
  CC       hwloc_get_cache_covering_cpuset.o
  CCLD     hwloc_get_cache_covering_cpuset
  CC       hwloc_get_largest_objs_inside_cpuset.o
  CCLD     hwloc_get_largest_objs_inside_cpuset
  CC       hwloc_get_next_obj_covering_cpuset.o
  CCLD     hwloc_get_next_obj_covering_cpuset
  CC       hwloc_get_obj_inside_cpuset.o
  CCLD     hwloc_get_obj_inside_cpuset
  CC       hwloc_get_shared_cache_covering_obj.o
  CCLD     hwloc_get_shared_cache_covering_obj
  CC       hwloc_get_obj_below_array_by_type.o
  CCLD     hwloc_get_obj_below_array_by_type
  CC       hwloc_get_obj_with_same_locality.o
  CCLD     hwloc_get_obj_with_same_locality
  CC       hwloc_bitmap_first_last_weight.o
  CCLD     hwloc_bitmap_first_last_weight
  CC       hwloc_bitmap_singlify.o
  CCLD     hwloc_bitmap_singlify
  CC       hwloc_type_depth.o
  CCLD     hwloc_type_depth
  CC       hwloc_type_sscanf.o
  CCLD     hwloc_type_sscanf
  CC       hwloc_bind.o
  CCLD     hwloc_bind
  CC       hwloc_get_last_cpu_location.o
  CCLD     hwloc_get_last_cpu_location
  CC       hwloc_get_area_memlocation.o
  CCLD     hwloc_get_area_memlocation
  CC       hwloc_object_userdata.o
  CCLD     hwloc_object_userdata
  CC       hwloc_synthetic.o
  CCLD     hwloc_synthetic
  CC       hwloc_backends.o
  CCLD     hwloc_backends
  CC       hwloc_pci_backend.o
  CCLD     hwloc_pci_backend
  CC       hwloc_is_thissystem.o
  CCLD     hwloc_is_thissystem
  CC       hwloc_distances.o
  CCLD     hwloc_distances
  CC       hwloc_groups.o
  CCLD     hwloc_groups
  CC       hwloc_insert_misc.o
  CCLD     hwloc_insert_misc
  CC       hwloc_topology_allow.o
  CCLD     hwloc_topology_allow
  CC       hwloc_topology_restrict.o
  CCLD     hwloc_topology_restrict
  CC       hwloc_topology_dup.o
  CCLD     hwloc_topology_dup
  CC       hwloc_topology_diff.o
  CCLD     hwloc_topology_diff
  CC       hwloc_topology_abi.o
  CCLD     hwloc_topology_abi
  CC       hwloc_obj_infos.o
  CCLD     hwloc_obj_infos
  CC       hwloc_iodevs.o
  CCLD     hwloc_iodevs
  CC       cpuset_nodeset.o
  CCLD     cpuset_nodeset
  CC       memattrs.o
  CCLD     memattrs
  CC       memtiers.o
  CCLD     memtiers
  CC       cpukinds.o
  CCLD     cpukinds
  CC       xmlbuffer.o
  CCLD     xmlbuffer
  CC       gl.o
  CCLD     gl
/usr/bin/make  check-TESTS
PASS: hwloc_api_version
PASS: hwloc_list_components
PASS: hwloc_bitmap
PASS: hwloc_bitmap_string
PASS: hwloc_bitmap_compare_inclusion
PASS: hwloc_get_closest_objs
PASS: hwloc_get_obj_covering_cpuset
PASS: hwloc_get_cache_covering_cpuset
PASS: hwloc_get_largest_objs_inside_cpuset
PASS: hwloc_get_next_obj_covering_cpuset
PASS: hwloc_get_obj_inside_cpuset
PASS: hwloc_get_shared_cache_covering_obj
PASS: hwloc_get_obj_below_array_by_type
PASS: hwloc_get_obj_with_same_locality
PASS: hwloc_bitmap_first_last_weight
PASS: hwloc_bitmap_singlify
PASS: hwloc_type_depth
PASS: hwloc_type_sscanf
PASS: hwloc_bind
PASS: hwloc_get_last_cpu_location
PASS: hwloc_get_area_memlocation
PASS: hwloc_object_userdata
PASS: hwloc_synthetic
PASS: hwloc_backends
PASS: hwloc_pci_backend
PASS: hwloc_is_thissystem
PASS: hwloc_distances
PASS: hwloc_groups
PASS: hwloc_insert_misc
PASS: hwloc_topology_allow
PASS: hwloc_topology_restrict
PASS: hwloc_topology_dup
PASS: hwloc_topology_diff
PASS: hwloc_topology_abi
PASS: hwloc_obj_infos
PASS: hwloc_iodevs
PASS: cpuset_nodeset
PASS: memattrs
PASS: memtiers
PASS: cpukinds
PASS: xmlbuffer
PASS: gl
============================================================================
Testsuite summary for hwloc 2.8.0
============================================================================
# TOTAL: 42
# PASS:  42
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
Making check in ports
/usr/bin/make   \
	  
make[4]: Nothing to be done for `all'.
Making check in xml
/usr/bin/make  check-TESTS
PASS: 8intel64-4n2t-memattrs.xml
PASS: 16amd64-8n2c-cpusets.xml
PASS: 16amd64-4distances.xml
PASS: 16amd64-4distances.console.output
PASS: 16em64t-4s2c2t.xml
PASS: 16em64t-4s2c2t-offlines.xml
PASS: 16em64t-4s2c2t.console.output
PASS: 16-2gr2gr2n2c+misc.xml
PASS: 16-2gr2gr2n2c+misc.console.output
PASS: 16intel64-manyVFs.xml
PASS: 16intel64-manyVFs.console.output
PASS: 16intel64-manyVFs.console.nocollapse.output
PASS: 24em64t-2n6c2t-pci.xml
PASS: 32em64t-2n8c2t-pci-noio.xml
PASS: 32em64t-2n8c2t-pci-normalio.xml
PASS: 32em64t-2n8c2t-pci-wholeio.xml
PASS: 64intel64-3g2n+2n-irregulargroups+pci.xml
PASS: 64intel64-3g2n+2n-irregulargroups+pci.console.output
PASS: 8intel64-fakeKNL-A2A-hybrid.rootattachednumas.xml
PASS: 64intel64-fakeKNL-SNC4-hybrid.xml
PASS: 96em64t-4n4d3ca2co-pci.xml
PASS: 192em64t-12gr2n8c2t.xml
PASS: 192em64t-24n8c2t.xml
PASS: power8gpudistances.xml
PASS: fakeheterodistances.xml
PASS: fakecpukinds.xml
PASS: 8em64t-2p2ca2co-nonodesets.v1tov2.xml
PASS: 8ia64-2n2s2c+1n.v1tov2.xml
PASS: 16amd64-4distances.v1tov2.xml
PASS: 16amd64-4distances.v2tov1.xml
PASS: 2intel64-1n2c-numaroot.v1tov2.xml
PASS: 28intel64-2p2g7c-CoDgroups.v1tov2.xml
PASS: 28intel64-2p2g7c-CoD.nogroups.v1tov2.xml
PASS: 8intel64-fakeKNL-A2A-hybrid.rootattachednumas.v1tov2.xml
PASS: 8intel64-fakeKNL-A2A-hybrid.rootattachednumas.v2tov1.xml
PASS: 64intel64-fakeKNL-SNC4-hybrid.v1tov2.xml
PASS: 64intel64-fakeKNL-SNC4-hybrid.v2tov1.xml
============================================================================
Testsuite summary for hwloc 2.8.0
============================================================================
# TOTAL: 37
# PASS:  37
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[2]: Nothing to be done for `check-am'.
Making check in contrib/systemd
make[1]: Nothing to be done for `check'.
Making check in contrib/completion
make[1]: Nothing to be done for `check'.
Making check in contrib/misc
/usr/bin/make  hwloc-tweak-osindex
  CC       hwloc-tweak-osindex.o
  CCLD     hwloc-tweak-osindex
Making check in contrib/hwloc-ps.www
make[1]: Nothing to be done for `check'.
Making check in doc
/usr/bin/make  check-recursive
Making check in examples
/usr/bin/make  hwloc-hello hwloc-hello-cpp cpuset+bitmap+cpubind nodeset+membind+policy get-knl-modes gpu sharedcaches
  CC       hwloc-hello.o
  CCLD     hwloc-hello
  CXX      hwloc-hello-cpp.o
  CXXLD    hwloc-hello-cpp
  CC       cpuset+bitmap+cpubind.o
  CCLD     cpuset+bitmap+cpubind
  CC       nodeset+membind+policy.o
  CCLD     nodeset+membind+policy
  CC       get-knl-modes.o
  CCLD     get-knl-modes
  CC       gpu.o
  CCLD     gpu
  CC       sharedcaches.o
  CCLD     sharedcaches
/usr/bin/make  check-TESTS
PASS: hwloc-hello
PASS: hwloc-hello-cpp
============================================================================
Testsuite summary for hwloc 2.8.0
============================================================================
# TOTAL: 2
# PASS:  2
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[3]: Nothing to be done for `check-am'.
make[1]: Nothing to be done for `check-am'.
```