### PR TITLE
caddy: update to 2.6.3

### DIFF
--- a/www/caddy/Portfile
+++ b/www/caddy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/caddyserver/caddy 2.6.1 v
+go.setup            github.com/caddyserver/caddy 2.6.3 v
 revision            0
 categories          www
 license             Apache-2
@@ -17,9 +17,9 @@ long_description    Caddy 2 is a powerful, enterprise-ready, open source web \
 homepage            https://caddyserver.com/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  71c1f4c9f887246460330da635e867f932a14cea \
-                        sha256  cf6ade31e77a865ed4e25f6e27e5fe8df8c50586f852e75b71e7940edb16eeaf \
-                        size    560109
+                        rmd160  e82926da5a23f032536d3d1dbd7ab2ebb72aa429 \
+                        sha256  da8bdcb84bbd38c12bd279e1de551ad097f35a0cbed51ba1acaf7a09f05e9b86 \
+                        size    567493
 
 go.vendors          howett.net/plist \
                         repo    github.com/DHowett/go-plist \
@@ -37,21 +37,16 @@ go.vendors          howett.net/plist \
                         rmd160  66e9feb7944b3804efa63155ed9b618717b8955c \
                         sha256  72812077e7f20278003de6ab0d85053d89131d64c443f39115a022114fd032b6 \
                         size    73231 \
-                    gopkg.in/tomb.v1 \
-                        lock    dd632973f1e7 \
-                        rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
-                        sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
-                        size    3636 \
                     gopkg.in/square/go-jose.v2 \
                         lock    v2.6.0 \
                         rmd160  56e581a46f0364551657e2b7698bd022973e9d7c \
                         sha256  565d45760f1ee44d3c076b9f5ee46e14e046c00304ddfab345fc48443fd6031c \
                         size    310376 \
                     gopkg.in/natefinch/lumberjack.v2 \
-                        lock    v2.0.0 \
-                        rmd160  931b7db0e3893f0f6515a8113e7c35aa3e45c9da \
-                        sha256  1f7796430424a4dd4c74f73929e7e82384672f6c2c311c5b671e6c36353780f3 \
-                        size    12640 \
+                        lock    v2.2.1 \
+                        rmd160  8c8f0fe65acca516cbc84ba6c61a9b02e470df64 \
+                        sha256  32f0b88971fbfef73e416def181ef5320c225c59ea2b2446c05a46ac1d7f3ff6 \
+                        size    12570 \
                     gopkg.in/check.v1 \
                         lock    10cb98267c6c \
                         rmd160  465dcadb97762c84da6fb5f6d8352abe10445817 \
@@ -59,22 +54,22 @@ go.vendors          howett.net/plist \
                         size    32368 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.28.0 \
-                        rmd160  076cb79b7651b0fdc12168a43cdc613d111fb371 \
-                        sha256  7efea04ee3dd363a74c04a25473bcc2361d669011086c85a8b04e0c0639ad432 \
-                        size    1280082 \
+                        lock    v1.28.1 \
+                        rmd160  b6e8eb6d53889424dd6b451c20ac9b72de99a639 \
+                        sha256  0bf41d25ed04a6a4ac9d9cb33031b50718a64ca76b0e9853dabdade80ee34f3b \
+                        size    1281110 \
                     google.golang.org/grpc \
                         repo    github.com/grpc/grpc-go \
-                        lock    v1.46.0 \
-                        rmd160  d5cf0e9fe6ca060a3a757b9af38a6cb6401cb1ba \
-                        sha256  bc4e9681e87f1d7742d20fcf0972c11a5400e4dc4b236d11ee22bda77dca90e5 \
-                        size    1520498 \
+                        lock    v1.52.3 \
+                        rmd160  c134d61f4402db9a3610d181451ed05040d0ec6c \
+                        sha256  4c5c0d1e8f086915d5948afea6ce27927795afc37aa4a4c8a4e3edbb6cf8a72b \
+                        size    1765169 \
                     google.golang.org/genproto \
                         repo    github.com/googleapis/go-genproto \
-                        lock    c8bf987b8c21 \
-                        rmd160  486221f2e9ce351f9cce2ca6dce78a604b04a1c9 \
-                        sha256  19bec8f036710c27707fda8e6f4844fc0227698ad09e1915df65915154c5d6d9 \
-                        size    13386722 \
+                        lock    008b39050e57 \
+                        rmd160  f5cdf94a93f270df5d42de3cf6ecf8032df62fb9 \
+                        sha256  8ba1c289ba3a1a4bc3bf0906a2192fc1d4bc4fcfc122fb7da6071754c5611b13 \
+                        size    6399542 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
                         lock    v1.6.7 \
@@ -83,71 +78,66 @@ go.vendors          howett.net/plist \
                         size    333026 \
                     google.golang.org/api \
                         repo    github.com/googleapis/google-api-go-client \
-                        lock    v0.70.0 \
-                        rmd160  c54a796e980a398e52e169389d0fc908604ab1ae \
-                        sha256  9d61191ea5784cc27992d7b92aa85d500edfa882103fa947134000470509a24b \
-                        size    23873826 \
-                    golang.org/x/xerrors \
-                        lock    5ec99f83aff1 \
-                        rmd160  6e8267f353e153297f205e4be219236d6ae43880 \
-                        sha256  9a500a49d83a09e7de6c71b215d1c14b81e315d26884530ef327c95ddf1f2d28 \
-                        size    13667 \
+                        lock    v0.108.0 \
+                        rmd160  b92fae96489e579bef2d7eb675ed37beaef197f4 \
+                        sha256  52483447a58b863f739e20d42a79ea429a453ae843b2969a353a461c97b2d806 \
+                        size    30737892 \
                     golang.org/x/tools \
-                        lock    v0.1.10 \
-                        rmd160  48d39865b0ef19c85818eea7d38c891ad7fdab7b \
-                        sha256  e3fb60b954bc56991f1fcd67cd09b68e58e5fdc62933846ee082b0f54f2a25fd \
-                        size    3014613 \
+                        lock    v0.2.0 \
+                        rmd160  ce43be4eaa12ec1664cd00a5dee9bea113fe3688 \
+                        sha256  56465575d7c91e0c4999d66fa327a469245828f360bc406e242f54a8cace1900 \
+                        size    3210050 \
                     golang.org/x/text \
-                        lock    5bd84dd9b33b \
-                        rmd160  04b1ef275c8ad672175b805f587385082b0b1f00 \
-                        sha256  156741908e4afc594e7de5b52678c64151baf300c4274e71863b743267395123 \
-                        size    8353754 \
+                        lock    v0.6.0 \
+                        rmd160  41b7bda7df46797457b47aa00e5d745345b684bc \
+                        sha256  6172a6091f616a9fb644ed71ee61e3a69529f95f357abd9ce521599a1e57e2b9 \
+                        size    8361557 \
                     golang.org/x/term \
-                        lock    03fcf44c2211 \
-                        rmd160  a1b9592e95373ba617ef579a2f7015cfdc871343 \
-                        sha256  3673415a6d3d106d49b487715e151fc64245502ef547c16e8e13edb6b8f2f492 \
-                        size    14975 \
+                        lock    v0.5.0 \
+                        rmd160  1617c36e9e3791aeaf34ac074ee964d90029b49c \
+                        sha256  68d83a239f4a52763874891ebda16e86813793fc4cfd13d3624f47f3a76788fe \
+                        size    14807 \
                     golang.org/x/sys \
-                        lock    3c1f35247d10 \
-                        rmd160  9128b74566b92dbfa971dba1cf861722abd06807 \
-                        sha256  78465a4d4db5424b9cbc10c644fa1707a27c62cf110a0fe9156bd98e078a717b \
-                        size    1336890 \
+                        lock    v0.5.0 \
+                        rmd160  36adb4fe0fa6365d24736bde06750f8f272769a8 \
+                        sha256  4f36d34b34167dde799a2a865701f0d8a2f61c812dcb45d2cba6e3fd86e82d91 \
+                        size    1430348 \
                     golang.org/x/sync \
-                        lock    036812b2e83c \
-                        rmd160  f42be6eb3565d2ed3d1066ea1a7f69437c8bb1e6 \
-                        sha256  6f1daceb16cd75bdbf35da6c50aa352d1995d68ccd0049851d27686f451fad92 \
-                        size    18756 \
+                        lock    v0.1.0 \
+                        rmd160  bf68702d961107a225cce561701852f129f16a3d \
+                        sha256  50a67a11e715a61c022f218604adc63e61684de5f5db2330741077439c4ce68f \
+                        size    19355 \
                     golang.org/x/oauth2 \
-                        lock    d3ed0bb246c8 \
-                        rmd160  d66bbada6578d17da9208ee8c215d4e1ead6aef7 \
-                        sha256  7a0c986063c9580fed9223411152d3ea8126d54597be8184fe613097b95d7489 \
-                        size    87604 \
+                        lock    6fdb5e3db783 \
+                        rmd160  7c94d6f63436998be8fe3c145f55db37d3b5df45 \
+                        sha256  3434d7197de3a8ff5329a33fcbba99d4576b1f4c2d3372f0cedd90ebdd3a599b \
+                        size    104520 \
                     golang.org/x/net \
-                        lock    1d4ff48094d1 \
-                        rmd160  54c9e5e5bff36339f55d9f8fad936f51c212ea1a \
-                        sha256  570df9f5274dc1960c50b1b48eaf3ee58e6ff29017af42359ba269f9e9b2c38e \
-                        size    1226265 \
+                        lock    v0.5.0 \
+                        rmd160  5c6bd81ab31a211f0e6f520dbec3c02c506d9ea6 \
+                        sha256  34827849fc6295d493c21df54fea819dae369bc37ff7d7e283030fe140118c0e \
+                        size    1238525 \
                     golang.org/x/mod \
-                        lock    9b9b3d81d5e3 \
-                        rmd160  dd04a3d8842b92453a4813ea4c266fd1071efe6a \
-                        sha256  9c4e1592a4689f13dd3d61d03facf20acd41754410d516da6b4f170973f254fb \
-                        size    119487 \
+                        lock    v0.6.0 \
+                        rmd160  203d707f99d76e5ce3a332eca02b4430fc2082fa \
+                        sha256  6d8b4b8ca530e67861f5a4d77ab794d3c6ef6f464de6397f17e5d35eac74220d \
+                        size    120503 \
                     golang.org/x/exp \
-                        lock    a9213eeb770e \
-                        rmd160  22493ca7d5ce3968edbd955efc45c7611ec37477 \
-                        sha256  03cfb2ecf601c4f7d13cbc41b80e781e896f07349ae8cd710947c300c816e2ad \
-                        size    1556302 \
+                        lock    47842c84f3db \
+                        rmd160  b9ca1292f45aa137251dd52c3cc8a90c3571bf77 \
+                        sha256  b6849c2b037b72c14854454f36bf455d0f723dcc129ba3fd6fd3959a824cf22c \
+                        size    1606951 \
                     golang.org/x/crypto \
-                        lock    630584e8d5aa \
-                        rmd160  592a8bc8bab62d399ebd992b3f0a8d2f1d9ff603 \
-                        sha256  41bb49305186ca7a143b4044dc7ad0b85400f213a9ca6a5bb25e5048757430c2 \
-                        size    1631200 \
+                        lock    v0.5.0 \
+                        rmd160  d1a21b7260574f31cbc6588e1c392eb8f373a9e6 \
+                        sha256  a21df3765c9643d1fadcfb966fde4173c0c930851fb01a24bdef28abd950f13c \
+                        size    1633695 \
                     go.uber.org/zap \
                         repo    github.com/uber-go/zap \
-                        lock    v1.21.0 \
-                        rmd160  ba2ba8266dcf78e491192ea65fa7360094a66444 \
-                        sha256  c68a8d1b5b0255a5690840684f21239d7792e1bba91dcc298c66ae327d67d384 \
-                        size    183681 \
+                        lock    v1.24.0 \
+                        rmd160  16338afaf0e1337cf190307118fdfeeda62fa95b \
+                        sha256  33974afe73302d90cd2176c8e91fa0f9b983274a82228612f7be8a6b4b88d728 \
+                        size    168349 \
                     go.uber.org/multierr \
                         repo    github.com/uber-go/multierr \
                         lock    v1.6.0 \
@@ -168,46 +158,46 @@ go.vendors          howett.net/plist \
                         size    21353 \
                     go.step.sm/linkedca \
                         repo    github.com/smallstep/linkedca \
-                        lock    v0.16.1 \
-                        rmd160  d97cfadae56827ad5a9b833d9e8406b7621ac5ef \
-                        sha256  32e97ca043ae70a142d09f16873251966e5ea2b18f551e7349dfef17dd21fb48 \
-                        size    56147 \
+                        lock    v0.19.0 \
+                        rmd160  b72ba3563a77742dc1369cfbfd43ab0e453beb5a \
+                        sha256  52ed5c56e83e2328f0ad47baf817c98b2370d7d351f4cfce5ec571cf04a7dcf0 \
+                        size    58821 \
                     go.step.sm/crypto \
                         repo    github.com/smallstep/crypto \
-                        lock    v0.16.2 \
-                        rmd160  4b2aa4d0e6ae57d50fc613c2d62d1c417f5746a3 \
-                        sha256  c5c606e6cf52093f7db678b11589fdd1db420b707d7041a82931486b0736205c \
-                        size    167255 \
+                        lock    v0.23.2 \
+                        rmd160  1a777d547aa4f9f1aace98fbda7201121cec3dc1 \
+                        sha256  252f88303b807b4d49e5f797b75e9ca88258ed476b6772999746fd9cb8d76aa5 \
+                        size    271122 \
                     go.step.sm/cli-utils \
                         repo    github.com/smallstep/cli-utils \
-                        lock    v0.7.3 \
-                        rmd160  c00be7cc2f12fbcac0bc89124646a30faef549b6 \
-                        sha256  1dce862c944b50e96228d24946819edf2b1b6a24eb41484b6e4ca4022c9fc79e \
-                        size    141624 \
+                        lock    v0.7.5 \
+                        rmd160  f5e00db5b95c53f60e963df9130d53b06f525d06 \
+                        sha256  a8cbbc14ba13383c1b29f579ed580beb8c14f355d46574da9216137a415e88a5 \
+                        size    141679 \
                     go.opentelemetry.io/proto \
                         repo    github.com/open-telemetry/opentelemetry-proto-go \
-                        lock    v0.18.0 \
-                        rmd160  8348ed7d77843d4ba96773bd7e90561bc1ae684a \
-                        sha256  270ea5230c429404d04c4d6e37617dea150002f51acaa20d7f5c4f368de98ea6 \
-                        size    105132 \
+                        lock    v0.19.0 \
+                        rmd160  6b166158c5101b2e518221f5fe710913ad5ddd4e \
+                        sha256  4b3e7a1d444a57a838861ec390508fb94ec70fb88deaf17e93a74e5b0f9f0000 \
+                        size    100012 \
                     go.opentelemetry.io/otel \
                         repo    github.com/open-telemetry/opentelemetry-go \
-                        lock    v1.9.0 \
-                        rmd160  e9140530ade343f7541f3a7925d0b9b37ca41405 \
-                        sha256  7c00fcfd469a0bd984f2f041ee0a5450e8fdebdee459844373e92acfa342fb36 \
-                        size    1000838 \
+                        lock    v1.13.0 \
+                        rmd160  f1f123e88ec4f583e75c5a6c75cb88c300fdb1f6 \
+                        sha256  5159e52829b669a56bfaa7bea3c14dc0507a1359f015b46f9f19319151f6c953 \
+                        size    1164812 \
                     go.opentelemetry.io/contrib \
                         repo    github.com/open-telemetry/opentelemetry-go-contrib \
-                        lock    v1.9.0 \
-                        rmd160  757a700cc2bacc5a69d698e0486d4f964c1708df \
-                        sha256  c7b993789a3532115908060b1f820a258db0847c868230341d37812dadb0fef6 \
-                        size    602935 \
+                        lock    v1.14.0 \
+                        rmd160  a4a7ba232adb561a96a92a1c6deb23b7fa8586f6 \
+                        sha256  81667247fc167ef9f3e9617ad44f9cbcedb15beec9b9765fcad369a473841fc8 \
+                        size    555710 \
                     go.opencensus.io \
                         repo    github.com/census-instrumentation/opencensus-go \
-                        lock    v0.23.0 \
-                        rmd160  9d77906343a59654c68ceb858891e4070d663d3f \
-                        sha256  55d38d8243e32277b848b3d9ac5858ffd08e82b54c165e7bfbeaed7f4dc408ff \
-                        size    176412 \
+                        lock    v0.24.0 \
+                        rmd160  3ff78177f0e279b4c2f8aaa474fd747bbcb1e89c \
+                        sha256  7a88d68f99dd9ee8dd460e954f98b158629a44ba85ffc8239e13a60e0802e57a \
+                        size    176686 \
                     go.mozilla.org/pkcs7 \
                         repo    github.com/mozilla-services/pkcs7 \
                         lock    33d05740a352 \
@@ -221,30 +211,35 @@ go.vendors          howett.net/plist \
                         sha256  9a4df17332a1e279b44a288d33dfbdb151ecf5be825ce5075fa97d7d7e930ec6 \
                         size    98074 \
                     github.com/yuin/goldmark-highlighting \
-                        lock    594be1970594 \
-                        rmd160  01cfe701b68b7b21265dea072a8cc89069eec09c \
-                        sha256  c121c3e8258ba20e1dbfcf51e4bc31fdf351d28f419c493b52487c10e91795e3 \
-                        size    10046 \
+                        lock    151362477c87 \
+                        rmd160  871e5dadd6490568b999838e12876e9e188ff188 \
+                        sha256  d7bd642d977e919395ff0d7c4c7caf50a789293223a87a68736c4a86dec42b9b \
+                        size    10250 \
                     github.com/yuin/goldmark \
-                        lock    v1.4.13 \
-                        rmd160  bb05cad916044abcb54304c02cc88b32e89776ad \
-                        sha256  d5f917488d17192777b40d1951506c5e1395cf3b2013a0ec4018cf3d6dfc890a \
-                        size    257808 \
+                        lock    v1.5.4 \
+                        rmd160  7e428750043e781507d94e54431c488a2e07110a \
+                        sha256  125ebf860067caab104024f6b3072c86b8b94f131a9bbf8346b459724b097a54 \
+                        size    260013 \
+                    github.com/x448/float16 \
+                        lock    v0.8.4 \
+                        rmd160  21b735f1bde517216d8a47db4bd7ee450136c230 \
+                        sha256  16f51a49934264475113239764c6cfe83c7ecac550f2bd968b6e0e8c10d4c3e2 \
+                        size    13102 \
                     github.com/urfave/cli \
-                        lock    v1.22.5 \
-                        rmd160  f26fef0516efcbf556d953be02bcfb0ae60a9c22 \
-                        sha256  2122a2b193a2d096f3792e4f8d6a7bb2a504a0d5bba7b0d1bfe81707917831a3 \
-                        size    78154 \
+                        lock    v1.22.12 \
+                        rmd160  54813c4b0c2cf0b6f1ce4f97a8df5348ac4bf76e \
+                        sha256  5eef2487b1966274d837ffc53952ff844ae83eb3b6d1c69bb8e3c76520de5faa \
+                        size    80447 \
                     github.com/tailscale/tscert \
-                        lock    54bbcb9f74e2 \
-                        rmd160  dc310dfb686fb67da75dc293d2917b8ca7007a10 \
-                        sha256  215a1aa4ee65aa2acb8a24b68f9f95aa7133126da64bb5b6125aefa73ffabbd6 \
-                        size    13789 \
+                        lock    c6dc1f4049b2 \
+                        rmd160  a43fd9492c135bcc32551f5bac07e7e02b8754f8 \
+                        sha256  374fb17789b4674587b636b106957d81eb8684f87d14d1a30f9641b6ea507e57 \
+                        size    15338 \
                     github.com/stretchr/testify \
-                        lock    v1.8.0 \
-                        rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
-                        sha256  9b51f07d72fd2d88a76cd89fb8863fc69812e364d28d0a97f6eacf9cd974c71d \
-                        size    97622 \
+                        lock    v1.8.1 \
+                        rmd160  4d80635834e01b3ddb67babdd8de2eac2c5a7587 \
+                        sha256  9848272e238f98fc0555b514c4522e70c4df25331b4ee3f9cb9244a04935934e \
+                        size    97722 \
                     github.com/stoewer/go-strcase \
                         lock    v1.2.0 \
                         rmd160  b8c644b1233496ac620e667bd8578079b7dcda04 \
@@ -256,10 +251,10 @@ go.vendors          howett.net/plist \
                         sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
                         size    50815 \
                     github.com/spf13/cobra \
-                        lock    v1.1.3 \
-                        rmd160  d9647d9a480ffb4d35ef6602c05cae452dcf30f9 \
-                        sha256  433b6fbdec0dc61ab23a2be8e7f004ff5608ba0778d4b4ede438f6d1227adb77 \
-                        size    146625 \
+                        lock    v1.6.1 \
+                        rmd160  e7d60f9ffc63828e5e51446e550f3342d629928f \
+                        sha256  1bd0924138d5f2fc0b2187a4331af53dd65ad313b8c84bcea9345e42c29c08fb \
+                        size    111079 \
                     github.com/spf13/cast \
                         lock    v1.4.1 \
                         rmd160  cb1d2c13bdd8a4aafd7c4e768554bab0a65c5759 \
@@ -271,40 +266,35 @@ go.vendors          howett.net/plist \
                         sha256  54d6a3300600dd2f5e444f6d19fe1f91e1174329cdfff1d50dae837689214a68 \
                         size    7396 \
                     github.com/smallstep/truststore \
-                        lock    v0.12.0 \
-                        rmd160  357082d8d6d20671fefb7f4fffaf7ed7f9cf12e4 \
-                        sha256  0883c5547dd5bc30a7de5c343ef71cd0d7175b3d8df4d8fa459e71174257b926 \
-                        size    12990 \
+                        lock    v0.12.1 \
+                        rmd160  b65ae8fa8584f0290cc3011e182fc9899a93a32c \
+                        sha256  33bdfd981ca3ef8dfb127406dc2609145fada5e60be6322d134e45a3bceb10c8 \
+                        size    14500 \
                     github.com/smallstep/nosql \
-                        lock    v0.4.0 \
-                        rmd160  fb1ad42540a93a1af86b7dff7c876898e81d2654 \
-                        sha256  edf3d61054a66e3c620185711042af2057c99009073e741bc42282191b0bd82f \
-                        size    33740 \
-                    github.com/smallstep/cli \
-                        lock    v0.21.0 \
-                        rmd160  b703908c74b15dbecf9b777ee4d1e53630afdba7 \
-                        sha256  8537d078920eb27bf07a4c0f9b8a2fa54ccb39886023696c0dfbc999e1a1ae2d \
-                        size    1848347 \
+                        lock    v0.5.0 \
+                        rmd160  e7096d204299bfab2000e9723ce39c7b46529fb9 \
+                        sha256  729a667c1f705c033356abe7453bf669ee47ca1b61baae61de826d4c196a1206 \
+                        size    33816 \
                     github.com/smallstep/certificates \
-                        lock    v0.21.0 \
-                        rmd160  561ffc6a6072111bc4bc8f06d771b923c0f71a72 \
-                        sha256  7985ee8a9250bb9d825315167d857cf04ed02de61c4192c4afb064b787e9a098 \
-                        size    17979703 \
+                        lock    v0.23.2 \
+                        rmd160  9a025d2c6b1b2a21eeb4ba9b620e88cbf6dc6cab \
+                        sha256  0c4a42294473ab9de013dd8c84109084609d8028bba01f8bc016622c117cfff1 \
+                        size    757288 \
                     github.com/smallstep/assert \
                         lock    82e2b9b3b262 \
                         rmd160  c53f5cc57f5f31670d4d5564ec080febd65910af \
                         sha256  63a6dc29bd27edaae8897ae15fd8dc6324c363809d690c6fd40179099cc64783 \
                         size    4080 \
                     github.com/slackhq/nebula \
-                        lock    v1.5.2 \
-                        rmd160  7d606cc6e1959423590923b197e021ddfb241245 \
-                        sha256  40e9626338aa94f1efcd24d1e9640d748c120405e6ba416f3c8dfd55f731b197 \
-                        size    946083 \
+                        lock    v1.6.1 \
+                        rmd160  76d3930eb025bc8de9add35f8646c29ef0d176c3 \
+                        sha256  910ed57643274445f570ee7ee2d87ca6512dcae46ea95e8faa3b2ed5fa7f4d23 \
+                        size    965251 \
                     github.com/sirupsen/logrus \
-                        lock    v1.8.1 \
-                        rmd160  aeb4e5f2ea8112e787a72fba611605c4c87f42b5 \
-                        sha256  931c31f624d05136760b41a63f6bc146b79ac91776b4642cbd2026c2792e3aca \
-                        size    47184 \
+                        lock    v1.9.0 \
+                        rmd160  7298932f511bd852fe27d6227e945256ac512479 \
+                        sha256  559f22c05df7f356b90074d4b19035d9a5a8119fe504882fe413105a4f3b4675 \
+                        size    49102 \
                     github.com/shurcooL/sanitized_anchor_name \
                         lock    v1.0.0 \
                         rmd160  c7e5322dba53e10db1711d65c146af5649b0c7c8 \
@@ -321,30 +311,60 @@ go.vendors          howett.net/plist \
                         sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
                         size    92950 \
                     github.com/rs/xid \
-                        lock    v1.2.1 \
-                        rmd160  2cff9628752a94fc62ab0e83436c61df7195eed1 \
-                        sha256  38881e009bacdbf91f6e586207b346eb9ec93f06335331c07a5e0b2ad41ee3f6 \
-                        size    9555 \
-                    github.com/prometheus/procfs \
-                        lock    v0.7.3 \
-                        rmd160  22af59de47369bf8ac95300e14ef8b1d370712a5 \
-                        sha256  40015c2a7a52b34e6502d2fc17458c30c3ee23f9c2246269d878ab0f96ca3177 \
-                        size    179014 \
-                    github.com/prometheus/common \
-                        lock    v0.32.1 \
-                        rmd160  a6acf4fa8fde63b73fdce283bf384bf0ef1beae8 \
-                        sha256  a6f193ddcbff86669bc3b3b88681dc45e456042b8d54bbd318a708c8761d7110 \
-                        size    146608 \
-                    github.com/prometheus/client_model \
+                        lock    v1.4.0 \
+                        rmd160  a748856fe6b5305168fbc86410fb22c5db673f36 \
+                        sha256  fdc2c0f0df267bb2c7c627ae7ae685e8e640309507c86d9b193171cbcc732560 \
+                        size    10998 \
+                    github.com/rogpeppe/go-internal \
+                        lock    v1.9.0 \
+                        rmd160  acb8f644e5634bdae632cdb61ea736422aeb88f0 \
+                        sha256  65b0852e5c78fa920fef2176fa17180bf1f7f32a1163baacb44c2aa480845a16 \
+                        size    133682 \
+                    github.com/quic-go/quic-go \
+                        lock    v0.32.0 \
+                        rmd160  2e3756a5750d17cf0a8ceb8171c3d6f794aff7b1 \
+                        sha256  001165948740e57200b86c13a456c7408bffb73700cde841c2de00bb5a4c71ea \
+                        size    545993 \
+                    github.com/quic-go/qtls-go1-20 \
+                        lock    v0.1.0 \
+                        rmd160  7a63c4effdb906d621a25d20db11e112aa79aada \
+                        sha256  8ab059df57152e71077d50051dc610c4f26b448e545c5ed70561585a071a3ea7 \
+                        size    422557 \
+                    github.com/quic-go/qtls-go1-19 \
                         lock    v0.2.0 \
-                        rmd160  9b5b538e80eeb491b02806cc1cb87a83e62a9577 \
-                        sha256  55c1223bb5d1ae7e33527bc0ce80e3ab5153c47d396a9f864feea150b301f690 \
-                        size    10985 \
+                        rmd160  d118ed52382f6d0cc9e80c15fa5686662729a40a \
+                        sha256  e0f78a34b4533d053a5a81556e0ca26c102885ba726c6542c43b75d8fe298ea1 \
+                        size    423283 \
+                    github.com/quic-go/qtls-go1-18 \
+                        lock    v0.2.0 \
+                        rmd160  cb528d3b4261b82bd61074e8f35d6921e32f55a2 \
+                        sha256  8820277943637e10c6f401197faaea9f6919bc7be90270b04c55f93d3f7aa591 \
+                        size    422856 \
+                    github.com/quic-go/qpack \
+                        lock    v0.4.0 \
+                        rmd160  6332ffe83d94fc508a7298ae176db4b2205e7c9e \
+                        sha256  7db52856f1245233d23a54de874bd2d2f79fb8f959c7af15ad07c777b2967bf0 \
+                        size    41810 \
+                    github.com/prometheus/procfs \
+                        lock    v0.8.0 \
+                        rmd160  0cd72a082087a0c3dd922a362316063f79364968 \
+                        sha256  4047304194f7f2cf99f627a1dae661ec0b3037f34aa07cd4d359e82015debc64 \
+                        size    194848 \
+                    github.com/prometheus/common \
+                        lock    v0.37.0 \
+                        rmd160  4b9ab33f6ebadf18c84de43be89633d0adf967d9 \
+                        sha256  ed4d3dbcb57018812d44094380bb26c0c331ef6d99d4df13b4ed907aa221bc47 \
+                        size    148974 \
+                    github.com/prometheus/client_model \
+                        lock    v0.3.0 \
+                        rmd160  a0b906835c5e39f188c88e71d319eac4a240567d \
+                        sha256  54817b98ddf4cde06a2f122c6d811d37ce25cc4f74d0a32bebf5620389c08c00 \
+                        size    14955 \
                     github.com/prometheus/client_golang \
-                        lock    v1.12.2 \
-                        rmd160  6e2120fbbdd478bcbab9f1a7f014a2f85797db53 \
-                        sha256  df1e3c29b486c86bde89d01588b30c333265f8110a92c44bef38f21e147d2472 \
-                        size    197136 \
+                        lock    v1.14.0 \
+                        rmd160  9f502ae011c53f72a9cba178310ffeed13d67a4a \
+                        sha256  81e046e141f490525685ab27ce96b089ebb48640641da3e64d169611c42e2717 \
+                        size    236365 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -356,20 +376,15 @@ go.vendors          howett.net/plist \
                         sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
                         size    13422 \
                     github.com/onsi/gomega \
-                        lock    v1.13.0 \
-                        rmd160  dc92bda8de121272ba08a6fd53d305f86af161fb \
-                        sha256  84bb470e2662d0243c708df882666f82aa735376b837fa3edecea02ede08efac \
-                        size    127847 \
+                        lock    v1.20.1 \
+                        rmd160  72f4c51008a71b73a4dc24c2417e130a4152591e \
+                        sha256  a18ca2d2816774ebc09c78bb72630a63a28f24ceda33e5b14ebc4f8f2a6c3d3a \
+                        size    284889 \
                     github.com/onsi/ginkgo \
-                        lock    v1.16.4 \
-                        rmd160  e0c7145b2a5a9fa39d1883b7ceb788af8a3dd4db \
-                        sha256  1cf29213663b89b7578f41a0185b814dab82d40fb5233bf0fe951591ce32ab10 \
-                        size    164059 \
-                    github.com/nxadm/tail \
-                        lock    v1.4.8 \
-                        rmd160  bb6c5515804a1d141478074ba9a4f836fa51fb71 \
-                        sha256  a4e98c422980433e9a9830f16b4155836baba4c3e3aa387f03840e5cb608c84d \
-                        size    1256274 \
+                        lock    v2.2.0 \
+                        rmd160  62e10b7f571fa247792c33549ef1f544090dac49 \
+                        sha256  b02ac883e4d0cc4a2fa8d1bfb7f586679594ceaed92949e8b4e115eb8d5921eb \
+                        size    559231 \
                     github.com/mitchellh/reflectwalk \
                         lock    v1.0.2 \
                         rmd160  0371e346bfe14926662afff3eeda22ce6dc6d2a4 \
@@ -420,31 +435,11 @@ go.vendors          howett.net/plist \
                         rmd160  e9948731b241336e8d5aa2a2e25dff26a9dccebe \
                         sha256  7e815dc076eeb34bf44a348eea7ae9b7a432b37462543cc5b382350d0e91c5f0 \
                         size    9576 \
-                    github.com/marten-seemann/qtls-go1-19 \
-                        lock    v0.1.0 \
-                        rmd160  b9dff3d8a87608f6821790fafececbf994cb1063 \
-                        sha256  b4577afe819d720db7b7443503a637507038893eaf2eed35893bd301749c2bcd \
-                        size    422927 \
-                    github.com/marten-seemann/qtls-go1-18 \
-                        lock    v0.1.2 \
-                        rmd160  3ee741f1eeb1a14ab632c44f3021a19503b31666 \
-                        sha256  75fd40cf7f9c30e8a5b90ddcec8edd80a37b1a27dfd6584be6bb73e383b4d920 \
-                        size    422465 \
-                    github.com/marten-seemann/qpack \
-                        lock    v0.2.1 \
-                        rmd160  64b0f70c593a63c55ec82047643ab2a8bbebb26b \
-                        sha256  d95f2637db0b9dcbb2fb8c8a284d138354b249a021b2e6e3e41824b7c1697e4e \
-                        size    42753 \
                     github.com/manifoldco/promptui \
                         lock    v0.9.0 \
                         rmd160  0557a766a57005f08f096935e894bfb34a7b0e03 \
                         sha256  bb66c3deb1709d13f67a00ec2421185792f7a1efc5836e7a1607639a46ce1178 \
                         size    25927 \
-                    github.com/lucas-clemente/quic-go \
-                        lock    9957668d4301 \
-                        rmd160  9072871469cc8e4e06c6a2e495412892e12d0d2d \
-                        sha256  82d5b447823f509a1159855ef69df8cbeeb46da458f82ac2dd83aff9ce448504 \
-                        size    531959 \
                     github.com/libdns/libdns \
                         lock    v0.2.1 \
                         rmd160  7cd2eb2452f9767d17aac199550e8fd4b2076ffb \
@@ -456,50 +451,50 @@ go.vendors          howett.net/plist \
                         sha256  d832c980eb73ea08aef0bd153646cc5230995ce2c457ea55576e4b13f71afe34 \
                         size    103840 \
                     github.com/kr/text \
-                        lock    v0.2.0 \
-                        rmd160  48558c7e8ff67d510f83c66883907e95f4783163 \
-                        sha256  2f2e21ac8a9d523e88cbba4039441defc4a66bfaa78811c900a88fcf28729c4c \
-                        size    8702 \
+                        lock    v0.1.0 \
+                        rmd160  0b3c78459e227170a3b80a0103d87a3eef77ed88 \
+                        sha256  5ed970aad0da3cba3cffacdb4d154a162a8968655ee6d6f7b627e71b869efaf6 \
+                        size    8691 \
                     github.com/kr/pretty \
-                        lock    v0.2.1 \
-                        rmd160  eaf5b58a46b962079cbafddbc3ef83bdbf02b31e \
-                        sha256  253c4a190c9337800e08aba66b77ea3db0835e3ae61289d80093995a649eb7ae \
-                        size    8769 \
+                        lock    v0.3.1 \
+                        rmd160  8c08579b4c56cdc958794e77afe3413e80aa67c3 \
+                        sha256  7fcea475d6280976cf4a838e75d2b3a4105827316e588a80e49e8063d950c999 \
+                        size    10232 \
                     github.com/klauspost/cpuid \
-                        lock    v2.1.0 \
-                        rmd160  ebb554eebcae9d18e7636c80d8a4a0e615661ab7 \
-                        sha256  8e0ea9b86bc35636430584882c4f4ca6bbcac5a0f8a50268e46f5f2b96fdb4df \
-                        size    437008 \
+                        lock    v2.2.3 \
+                        rmd160  0af6a64f5f1932b47b8001536bbfe13701fff39a \
+                        sha256  a1dfc8cd24b17f9ad8d2eb9f74018eb9aa1b7f1079a8be5ed20094d3ef996dd3 \
+                        size    455284 \
                     github.com/klauspost/compress \
-                        lock    v1.15.9 \
-                        rmd160  df7cb5c89ccfe6217c5b812ee321dbe01d35d2bc \
-                        sha256  c3bf850b50e015ff27501a9767ac92088f748a2b59710091880ccc99f6e94deb \
-                        size    24209515 \
+                        lock    v1.15.15 \
+                        rmd160  39c0c8542b07c1e7debf1f5f9c71803d2814789e \
+                        sha256  0af4eff4029dbeba7423b66f9dc3d8bceafc568868a0bf36c0b2cb3ebf9f248a \
+                        size    36378530 \
                     github.com/jmespath/go-jmespath \
                         lock    v0.4.0 \
                         rmd160  ca4955ff89de514b5eff01a7a244626cecf0927e \
                         sha256  0fe6d784c9c75ae5aa25396283a07f94c06955a4ed775990149c17caee4112c4 \
                         size    128827 \
                     github.com/jackc/pgx \
-                        lock    v4.14.0 \
-                        rmd160  86df0ec5056dec8066ab6f0b53eb67a11070060b \
-                        sha256  5d8e81f196fe64f6d84207f23c959408dd3486cc74397fa1f3ecdcc23cdbc1bd \
-                        size    110550 \
+                        lock    v4.17.2 \
+                        rmd160  6ae3a7fdea8cdc8aaa8d78a2e5ed2a3bbbfdedc7 \
+                        sha256  7778d21761ef1c2bf6134a61951f623896dae77f8b31129810a0ad4100dc547e \
+                        size    114278 \
                     github.com/jackc/pgtype \
-                        lock    v1.9.0 \
-                        rmd160  9ba7ced9f2b879f3ce03da4786c50243ea06dadd \
-                        sha256  14c5b19256c77318ecae74656cc0d73d8835d52b081dd93778525a27af3d56fe \
-                        size    177370 \
+                        lock    v1.12.0 \
+                        rmd160  9e7e4e027a3a5162c22265af3467492b390a3953 \
+                        sha256  1cbd236e28e24470374b0166a8603951f0c1338fdfad18d80be1a465f49333c3 \
+                        size    187550 \
                     github.com/jackc/pgservicefile \
                         lock    2b9c44734f2b \
                         rmd160  5f6e8872c0b2e8e21f4656c545c656332a5b3d0d \
                         sha256  d40a3d40571d28db4338be116fb24ae861c960f465cf15443986d7f82336629f \
                         size    2998 \
                     github.com/jackc/pgproto3 \
-                        lock    v2.2.0 \
-                        rmd160  65c47143ae52c875ff90644de8f3a7c7b1f29d1b \
-                        sha256  48d417218bb1d2ea8a30c5586b067c9cde71da2ae82773c0bbe0a203fa7e15d3 \
-                        size    23703 \
+                        lock    v2.3.1 \
+                        rmd160  a803ad2549c9b90c12b21d934e373027b435d505 \
+                        sha256  2604e17149959f5d52444caae01d628dacfa081837f4146fc22288128d53ad5a \
+                        size    24678 \
                     github.com/jackc/pgpassfile \
                         lock    v1.0.0 \
                         rmd160  7054f5083a15e2d97da032fa1844b75f9a11c9de \
@@ -516,55 +511,70 @@ go.vendors          howett.net/plist \
                         sha256  a8e23d5f16ef8e7aade48d15768c9ea24fcd5eb2e65b1d1211966fa7acdc3ddc \
                         size    1885 \
                     github.com/jackc/pgconn \
-                        lock    v1.10.1 \
-                        rmd160  03d74af574c634287dde0ce47b98f86d4e480359 \
-                        sha256  c75e8b1cc2706f41413f83e01007e9fc528c050dc59cf72085bb0114eccf45f4 \
-                        size    54216 \
+                        lock    v1.13.0 \
+                        rmd160  c1275b068bda46a58d3e46eddf9952d1a17b5960 \
+                        sha256  1b25c9142a34378c055bcb9d35469c9b71ca4465a5dff0df213980b01563a952 \
+                        size    59144 \
                     github.com/jackc/chunkreader \
                         lock    v2.0.1 \
                         rmd160  546d596d7e2c661b8f9086a1bbae8ff4ab945280 \
                         sha256  bc2ead05f2d930b05522ee6a70378c0937994c353cbf0bd891c835e22c743adc \
                         size    3043 \
                     github.com/inconshreveable/mousetrap \
-                        lock    v1.0.0 \
-                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
-                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
-                        size    2291 \
+                        lock    v1.0.1 \
+                        rmd160  d5dd7c9ef19fef8876014ae3b08a3f6a2a813bf7 \
+                        sha256  57bdbba1b25456bc66319f0ad5ba00b92dcfddd8431df9152e046fe079ad85b2 \
+                        size    5944 \
                     github.com/imdario/mergo \
                         lock    v0.3.12 \
                         rmd160  44dbd1f58fd9ea7697f302c86f110ab796b5a041 \
                         sha256  dadb5b52d2de5fe7336eda4c331eefb0d4be716a5844cc7ab15c96b9b6e07b2d \
                         size    22341 \
                     github.com/huandu/xstrings \
-                        lock    v1.3.2 \
-                        rmd160  b92c0e29b345b7f7cbe79e773f9855375e7bcb2c \
-                        sha256  97bda2aeca4ae1b66f4113ce16d5d861c124baf8f38e22064f5dbd0accb04c57 \
-                        size    17916 \
+                        lock    v1.3.3 \
+                        rmd160  64a2e87712cb657ec7d79273ed8f81ca1d13fc03 \
+                        sha256  18632c31ddc1c88711bbb1829ade4e73ae9c40f4386fe1697847015595ae5467 \
+                        size    18417 \
+                    github.com/hexops/gotextdiff \
+                        lock    v1.0.3 \
+                        rmd160  074c0503049683deb78ab28932d83837343f4ae9 \
+                        sha256  6ff3e645743eb9831a6325dd3edcce1f1f5c2f918c4981cec89143252d5e1dac \
+                        size    23250 \
                     github.com/grpc-ecosystem/grpc-gateway \
                         lock    v2.7.0 \
                         rmd160  47986a2c3f1efb4f1f595921d090b152c2c6b531 \
                         sha256  71ebd5e1dadba850b29d37a0f170f5e1d207f85468fd39364afecc50f3798c66 \
                         size    631090 \
                     github.com/googleapis/gax-go \
-                        lock    v2.1.1 \
-                        rmd160  aeaa07a395820f1d6a94b21fb39c2abd04c832d9 \
-                        sha256  565a8ea94ce80fe38479c1c10b2f774a0b46297000748525a7e099ec1e406418 \
-                        size    70036 \
+                        lock    v2.7.0 \
+                        rmd160  fdb3982aa2036d2d7bd9eea15b61191412cc6884 \
+                        sha256  e096dcc4b35f54ba003a7950328034629b943189170814c5289488ba87a5fd00 \
+                        size    52970 \
+                    github.com/googleapis/enterprise-certificate-proxy \
+                        lock    v0.2.1 \
+                        rmd160  e0c84f78aceb9abbbb325e90926bad2c6ed6bfff \
+                        sha256  5b2a251dfaf4092917279556cbd55c19fe1ccc0555a69aef9b8371f48572edfd \
+                        size    31615 \
                     github.com/google/uuid \
                         lock    v1.3.0 \
                         rmd160  300ea34c54ab7ce9d2a4bbd84a4fb49f11db02f8 \
                         sha256  ef8b7d74d99c8abd9706909eb3bbd063460d1970fbf62619599b78092b8687db \
                         size    16215 \
+                    github.com/google/pprof \
+                        lock    94a9f03dee38 \
+                        rmd160  e728af72a4110b42a442fe29bf8cd4967386639e \
+                        sha256  7116f40c307a24d35322ac240b05232762c01b9c3488012b8f08b723f417e29c \
+                        size    1718487 \
                     github.com/google/go-cmp \
-                        lock    v0.5.8 \
-                        rmd160  8335ed233b7f0de3539ff5c88b2eb1400480a806 \
-                        sha256  a1b3d227b1d4a6c224f4597228e7380ac5dd4b886fe91644ba88ca0292b5f121 \
-                        size    104650 \
+                        lock    v0.5.9 \
+                        rmd160  9832ae80123461baed8aa20e830199c0e21e337b \
+                        sha256  3058d20d61f03aa05fca0fc07acb8c50850c68086998c542857aec7ad1529482 \
+                        size    104431 \
                     github.com/google/cel-go \
-                        lock    v0.12.4 \
-                        rmd160  aee2d8b227d5a6c36ae06e729313d567ce8655c1 \
-                        sha256  e7fae39a9b6df73a03dfd4bd6a0921873765846f09502f020ad6350cf61ac083 \
-                        size    953194 \
+                        lock    v0.13.0 \
+                        rmd160  b387f18f86d54c1f5532d77dad524d9798f98f71 \
+                        sha256  ebe62e83a44ae89d39b6bbbb278da7dfb422b7b8a0f4501d167b9843e96aca5a \
+                        size    924380 \
                     github.com/golang/snappy \
                         lock    v0.0.4 \
                         rmd160  23c095b7e2bc6f5a978d771e4ecc9f7b0f204491 \
@@ -585,6 +595,11 @@ go.vendors          howett.net/plist \
                         rmd160  dba4526dc11102f7cfc3ee7be23cb1416793e35b \
                         sha256  03b46be967afa501b74a1bf72211b08d6e8f6b2a3b42335105480b6df6e51980 \
                         size    26110 \
+                    github.com/golang/glog \
+                        lock    v1.0.0 \
+                        rmd160  1fe6280e257619a1eb920e52f4a31827377653e5 \
+                        sha256  5497750005b9fa9c48b8fe33246389c5a890cc6fcc3eaf933c1b7472ceb8bb5b \
+                        size    19764 \
                     github.com/gofrs/uuid \
                         lock    v4.0.0 \
                         rmd160  75b7040c970e33106e7b63902344935083e60ff9 \
@@ -616,10 +631,10 @@ go.vendors          howett.net/plist \
                         sha256  d0a22f8bd038fb17c0e536aca1920ac570d4a787da2e69dbbaba7ef280d71f43 \
                         size    38566 \
                     github.com/go-logfmt/logfmt \
-                        lock    v0.5.0 \
-                        rmd160  bd625ba006d96954552800120b01c9263d6e9103 \
-                        sha256  93ae91d57f7940852f5607f860d1d6286240c44abfbbc5d02882040425b7289e \
-                        size    11754 \
+                        lock    v0.5.1 \
+                        rmd160  548b5049dbabac1a827163b5e66a06da32c2c64d \
+                        sha256  4ebe8e6e970cc9a18a37e5b102931928c15a48d05849904c6cfb4e41c6db74fb \
+                        size    12118 \
                     github.com/go-kit/kit \
                         lock    v0.10.0 \
                         rmd160  0a46d29837e966a86d2e9064a86dccda428fd6d0 \
@@ -630,36 +645,36 @@ go.vendors          howett.net/plist \
                         rmd160  a77a9665c6582973304e9e9b67707a4a989b0cb3 \
                         sha256  91a9f199d25c1fe4b2ceb8efa50316073966fc147b08288c458eefe6abb2a82a \
                         size    75954 \
-                    github.com/fsnotify/fsnotify \
-                        lock    v1.5.1 \
-                        rmd160  c99fbad44a371ce38eb2bd5c6ef70fb4537952e3 \
-                        sha256  699405dfda2fe02a305bee66f58046adb43f426ac905f85d80710e36846b3768 \
-                        size    32714 \
+                    github.com/fxamacker/cbor \
+                        lock    v2.4.0 \
+                        rmd160  f83452c55c42324698e9d81f16c8e1c6d840e642 \
+                        sha256  53efb8a4bd7b9a948e8ff036cee64046afb72d26ed5d7ae40a5f01fd19093c00 \
+                        size    125474 \
                     github.com/felixge/httpsnoop \
                         lock    v1.0.3 \
                         rmd160  909ff38f048a85840543a0f9e645908ce2dd9ced \
                         sha256  cdd557fe7e45ce86f6c22c0030884e43c16f85daf2bb6e31b8bc00d03e5b8362 \
                         size    11657 \
                     github.com/dustin/go-humanize \
-                        lock    afde56e7acac \
-                        rmd160  ebea78b8985e3737bb3f84bb89cfe06e27ce5cb1 \
-                        sha256  2241c354ec975fa34ac268958ea0c5f0b9c039a5f07fb4f6955b56a377586337 \
-                        size    17280 \
+                        lock    v1.0.1 \
+                        rmd160  3c799a1cbda2e82f3d35ec20e539581fd9c24b9d \
+                        sha256  aa5a5059ebd8fffc9e9b9e3c888d85cdb1f4c8f7b73944a6c027647039a83df7 \
+                        size    17709 \
                     github.com/dlclark/regexp2 \
-                        lock    v1.4.0 \
-                        rmd160  673e956248ad25816b7c1c1b5b3d03a76d60ebc8 \
-                        sha256  8398ba62190ac9a14cc3d2f57cffbaaed0e6a4dc6773531aa1de52923d67b38d \
-                        size    205581 \
+                        lock    v1.7.0 \
+                        rmd160  a2b2a9eb644059c6122a9235b00ddeb37f506056 \
+                        sha256  f0a84042de5096a7434bda202d97f80aa1df6d7546e92325df2ac55b4d97a018 \
+                        size    207682 \
                     github.com/dgryski/go-farm \
                         lock    a6ae2369ad13 \
                         rmd160  1a5a77b41ba742aba7e2a852ff6e12ec50302b9b \
                         sha256  cb8bf024cf5a62fede2135f5c53ac4cd9ebc1357c13fd655597402af25b54a9d \
                         size    27132 \
                     github.com/dgraph-io/ristretto \
-                        lock    41ebdbffecfd \
-                        rmd160  ac7e9df14fb44c6fda2d93845175e2561b1606b2 \
-                        sha256  89d4db120fdc5cd9bf28cf46003bbc741c540a13914f6a64a5eb0e37fa03e3d0 \
-                        size    277963 \
+                        lock    v0.1.0 \
+                        rmd160  e7cc4ceac4227ccaad9b21b5f2d19afc89a0244b \
+                        sha256  38fc1990f18b1141672b6236853dd484b1a6993763b7b79376cc521a091b9e21 \
+                        size    310256 \
                     github.com/dgraph-io/badger \
                         lock    v2.2007.4 \
                         rmd160  2ce41beeef82916cfc21fe674e223fe85bdb1f69 \
@@ -671,10 +686,10 @@ go.vendors          howett.net/plist \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
                     github.com/cpuguy83/go-md2man \
-                        lock    v2.0.1 \
-                        rmd160  74c013e19d22e56a27d9a3ad61b4bd86975036d1 \
-                        sha256  d23365bceea7382b59ca41ad868a80e34f8066785fb371b85b51ee0b65be6a21 \
-                        size    64243 \
+                        lock    v2.0.2 \
+                        rmd160  23c11486c5bc6f87cb13d2cb2aa7c2c68fd28f96 \
+                        sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
+                        size    64382 \
                     github.com/cockroachdb/apd \
                         lock    v1.1.0 \
                         rmd160  3753e33b093067db91575bd174f3061662346c1e \
@@ -706,10 +721,10 @@ go.vendors          howett.net/plist \
                         sha256  9dd966323058af72dedc32d2f2da9123c5c899575b6a735cdd49d4bf963101cd \
                         size    9833 \
                     github.com/caddyserver/certmagic \
-                        lock    v0.17.1 \
-                        rmd160  8c0d83ee95aff50723a5e2e73b35801ba9b1d532 \
-                        sha256  faad44a250f49cb49e4faf4102107654d892eb0edc4b3fa23b1d347ff6cf17f8 \
-                        size    110244 \
+                        lock    v0.17.2 \
+                        rmd160  102bb14df06e4e5f5daaf0699b5a994e34519a68 \
+                        sha256  7f3ea9327f116e5ffd2ea6c290bd927355114eed0aba22b8ee929098a9f5efe6 \
+                        size    111478 \
                     github.com/beorn7/perks \
                         lock    v1.0.1 \
                         rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \
@@ -721,50 +736,65 @@ go.vendors          howett.net/plist \
                         sha256  5831da7b061e87d30d7eb50ecc5a340af9ad0d8568ed4e741015288688d922ed \
                         size    6323 \
                     github.com/aws/aws-sdk-go \
-                        lock    v1.37.0 \
-                        rmd160  d93aacd5cd980ef704e93dc221b8c0e307a3a022 \
-                        sha256  f163ad6a1ed1947ecad5f4e3640fb2900ee791690df214e94e87665e6a1714a3 \
-                        size    18129497 \
+                        lock    v1.44.185 \
+                        rmd160  5bc384d7039960a147b549f0bd760b77d11f1d3a \
+                        sha256  90c69fd3e2d3686c86af2ee009123aa2e891674da6b8a628c0d4f673d7e2557d \
+                        size    26875159 \
                     github.com/aryann/difflib \
                         lock    ff5ff6dc229b \
                         rmd160  0fe41eb245a01a9be0f44ff5316c1aa2349ca37f \
                         sha256  d2bb2c75fc77675bfe290a2db555ba1def9cd34c86bd3d008a0c809d22d729a9 \
                         size    5315 \
                     github.com/antlr/antlr4 \
-                        lock    f25a4f6275ed \
-                        rmd160  7d4a43216c51cac22bf8f7c46b2781755a6aa4bd \
-                        sha256  ed831324b8a99a331da501e6ef3dce2f9461d9a4aa6721242d044957472fb0c0 \
-                        size    4600406 \
+                        lock    v4.10.1 \
+                        rmd160  c8ebce80ecd37fbc0fe817394dfe01b1c09af9a5 \
+                        sha256  0807eb415cb2452ebb47a479e674cc02c236f0679c31c55bb6e484a092801f18 \
+                        size    4600282 \
+                    github.com/alecthomas/repr \
+                        lock    v0.2.0 \
+                        rmd160  81f248ecbf94739480c32f954a0f8124b70869ee \
+                        sha256  b2c0f4f5a24184577800de0ad1c4056cf636be2b7cd794eb46a90d6cfe8cb7a0 \
+                        size    7488 \
                     github.com/alecthomas/chroma \
-                        lock    v0.10.0 \
-                        rmd160  41ff8340ec3b18ff636e56c5237ebb526d722150 \
-                        sha256  0f448cf1747a75f13b6cfe78d5cb3b2c5e0fd28a53d73c0bc9d6371621e333a3 \
-                        size    798426 \
+                        lock    v2.5.0 \
+                        rmd160  dbfdc2c3a58b001dc24499bf019ff709a6fb64c1 \
+                        sha256  6fbfa0091ae64fea407b439ca32302b6d9752270186ce3b00c132c62b7d11a21 \
+                        size    928196 \
+                    github.com/alecthomas/assert \
+                        lock    v2.2.1 \
+                        rmd160  c12916281402f7d3f47485aabd9948040018fd3c \
+                        sha256  1adc0e6edba3d55e2dc6210787b6b588d708104b7abf48c555b0e3a4381281af \
+                        size    7479 \
                     github.com/OneOfOne/xxhash \
                         lock    v1.2.2 \
                         rmd160  35e2c7b623c069fc08aec00990ca5c82ad831a22 \
                         sha256  e6a73b9f6acc9b361ea77edcb6f29103e96ac0c623c6d2882909698180e54694 \
                         size    13444 \
+                    github.com/microsoft/go-winio \
+                        lock    v0.6.0 \
+                        rmd160  3a4f54357a512c4b6b43ae6afcfc3326d696a33b \
+                        sha256  a54f47a730c0f3477104f9609f6bd0eeba3c530f4097f6cb2a3c1a0ef45e8363 \
+                        size    96679 \
                     github.com/Masterminds/sprig \
-                        lock    v3.2.2 \
-                        rmd160  de63d703b69d403532a78ed15c4909eed4014dbe \
-                        sha256  c3b414bbdcf56fd071a61744fb8fb2fdec8ae98f49ab04021430f45865dcdd32 \
-                        size    55510 \
+                        lock    v3.2.3 \
+                        rmd160  2b8476be3412c7fa9f5f7d6785b29daa28d002cc \
+                        sha256  d71243c7106756126794968c5eeebf84bb9e25adbabbc51b3bb53aad7ae158a2 \
+                        size    56457 \
                     github.com/Masterminds/semver \
-                        lock    v3.1.1 \
-                        rmd160  ef0a447415b81d00561b3559a38aebfbdf95b300 \
-                        sha256  e3f9518048841bde91680be27cb32cd1ac7d114fb99719855ecd5777bd221f98 \
-                        size    24515 \
+                        lock    v3.2.0 \
+                        rmd160  b11570a5fd505fa17aef12af95729ea211ec3ac8 \
+                        sha256  34848595c3da3c314b396e8e174c7755d4a9ea498df04d247d4da24b07bcb202 \
+                        size    26075 \
                     github.com/Masterminds/goutils \
                         lock    v1.1.1 \
                         rmd160  d50d8300ab7418bf2fe5bd0e7a5889f7906d082a \
                         sha256  9c750be5c0666f133c0bf8d9439a2e428b800276d4ab28dfc406fad8d66face6 \
                         size    14849 \
                     github.com/BurntSushi/toml \
-                        lock    v1.2.0 \
-                        rmd160  b6af60be88cbeac8ed5e5124d187cf5e1a98864d \
-                        sha256  7cc755999d3c804cfeee6e464cc800cee299a33877dfd901671f3574e2eb80fd \
-                        size    96599 \
+                        lock    v1.2.1 \
+                        rmd160  f28ee241d0d9ccdec5d3647c39b4921040ae8660 \
+                        sha256  8a680ca349a545a02844730b3f5701ff929f7b6ba35d07294b7794710c4c36fa \
+                        size    97017 \
                     github.com/AndreasBriese/bbloom \
                         lock    46b345b51c96 \
                         rmd160  37888ae5d833661314a5d2c0ee6ac65021e4cf85 \
@@ -772,16 +802,16 @@ go.vendors          howett.net/plist \
                         size    8009 \
                     filippo.io/edwards25519 \
                         repo    github.com/FiloSottile/edwards25519 \
-                        lock    v1.0.0-rc.1 \
-                        rmd160  a83aba34025ad1df3a443deb358c11c1239e15ac \
-                        sha256  4bdeff6fc20d81c28a18df76cc982f1fcca03f385dfcc36cf3ddff73b5b2f5fe \
-                        size    39144 \
+                        lock    v1.0.0 \
+                        rmd160  47330d4bd65ec5e115038359a989a1a3f775e130 \
+                        sha256  f9474496e781cc9985cc575fbd108a5ca1992cc9fdfd35ee0efcb2818fab928c \
+                        size    39898 \
                     cloud.google.com/go \
                         repo    github.com/googleapis/google-cloud-go \
-                        lock    v0.100.2 \
-                        rmd160  3c65edd6215509ff39dbfc45329347a0da7f650a \
-                        sha256  5b4b9ff34231611bd7276be629ab4f8f7f4a507751ba26d56724c56bff652040 \
-                        size    6906445
+                        lock    v0.107.0 \
+                        rmd160  37922a01aeb993f2508bab1a6a8d7281a8283de1 \
+                        sha256  dd990fb969237d3f26f171de101aac876cfb97de4326d401ff0b8a1de15d6899 \
+                        size    16065572
 
 post-extract {
     delete ${gopath}/src/github.com/google/cel-go/vendor


### PR DESCRIPTION
###### Tested on
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?