### PR TITLE
auto-multiple-choice: update to version 1.6.0

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -27,27 +27,28 @@ subport auto-multiple-choice-devel {}
 
 if {${subport} eq ${name}} {
     # release
-    set amc.version.main        1.5.2
-    set amc.version.secondary   20221031112254
+    set amc.version.main        1.6.0
+    set amc.version.secondary   20230206142200
+    set amc.version         ${amc.version.main}
     version                 ${amc.version.main}
-    checksums               rmd160  76a1b398c30a1f70a79fd069397af39522e8d5f9 \
-                            sha256  4087a8fefd184fa325af958980ce36d03c9a04f14912e056da12b2202c33b338 \
-                            size    13107480
+    checksums               rmd160  00788859b8619b45ee1c19f702ea1295d7d3e445 \
+                            sha256  acd9d266ebb8104543702fae52f383ed6170e7e7e1c90bc9c6abc4e83e3734ba \
+                            size    13419428
 
     conflicts               auto-multiple-choice-devel
 
 } else {
     # devel
-    set amc.version.main        1.5.2
-    set amc.version.secondary   20221108151552
-    checksums               rmd160  6531e7e6b41b3580c9e72842cacf703cae527ffd \
-                            sha256  71c2e53a343a87a1aabe4818fb9b9d1ee166fd7d046190d916915640f2d28f86 \
-                            size    13124174
+    set amc.version.main        1.6.0
+    set amc.version.secondary   20230206142200
+    set amc.version         ${amc.version.main}
+    version                 ${amc.version.main}
+    checksums               rmd160  00788859b8619b45ee1c19f702ea1295d7d3e445 \
+                            sha256  acd9d266ebb8104543702fae52f383ed6170e7e7e1c90bc9c6abc4e83e3734ba \
+                            size    13419428
 
     conflicts               auto-multiple-choice
 }
-set amc.version         ${amc.version.main}+git${amc.version.secondary}
-version                 ${amc.version.main}-git${amc.version.secondary}
 
 
 set opencv_ver          4


### PR DESCRIPTION
auto-multiple-choice: update to version 1.6.0
auto-multiple-choice-devel: update to version 1.6.0

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D49 arm64
Xcode 14.2 14C18 
MacPorts 2.8.1

macOS 13.2 22D49
Xcode 14.2 14C18 
MacPorts 2.8.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
