### PR TITLE
google-cloud-sdk: update to 417.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             417.0.0
+version             417.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4335b9a7ed89f0ca2a7c76f5a62e5d674764d700 \
-                    sha256  633f98481bcab104e6149e5528528c3aad5682ce6a5a1f2f1ebebbb470d7b068 \
-                    size    111079011
+    checksums       rmd160  af3bb2d222be51a9e97271fe83ffbf0126a0f3e5 \
+                    sha256  614139b305a95f2de5a5b0b264db728c91017b5e28c22141efde59e37ea74f68 \
+                    size    111079062
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  f8f2368fb4b4299aa6f43a760e8f538c152d326e \
-                    sha256  e7f3dc908b83a5152d0db0e2ab10dff954f3834e44e5fb35e1fc09225a602a6a \
-                    size    131408632
+    checksums       rmd160  8ef7903962a4073385022af3fcec21faabe5c8d5 \
+                    sha256  5510d7ca2306622a7df5bb3882a8cc515d01e62e4c841b42b3521adc992da34c \
+                    size    131408801
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  7f46a2a2ee69c15903268227e3854b03f09cdcfb \
-                    sha256  592648263419e0184581e52c5f2fda3cb163327694200e58d253926c65029f62 \
-                    size    128244581
+    checksums       rmd160  49b3bc5d1e2ad6cd57e4734bbf28859c655e2677 \
+                    sha256  571b04fd1d92574ed56134615bd60128585d667cd28d5f2f1d4f184edaabef09 \
+                    size    128244591
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 417.0.1.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?