### PR TITLE
R PG: implement testing; select R packages: add support for tests

### DIFF
--- a/R/R-Rcpp/Portfile
+++ b/R/R-Rcpp/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran RcppCore Rcpp 1.0.9
+R.setup             cran RcppCore Rcpp 1.0.10
 revision            0
 categories-append   devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -11,6 +11,6 @@ license             {GPL-2 GPL-3}
 description         Seamless R and C++ Integration
 long_description    {*}${description}
 homepage            https://www.rcpp.org
-checksums           rmd160  6660524e74f9024a0fa4952292d366e816d02ffc \
-                    sha256  807cec06dc4a96d54904360f6144466f084a7ed411ce5d2eea486a9b3c229176 \
-                    size    2957812
+checksums           rmd160  8bcb98cd68da1789f5a2a4161543d621bd05291a \
+                    sha256  1e65e24a9981251ab5fc4f9fd65fe4eab4ba0255be3400a8c5abe20b62b5d546 \
+                    size    2936173

--- a/R/R-Rcpp/Portfile
+++ b/R/R-Rcpp/Portfile
@@ -14,3 +14,10 @@ homepage            https://www.rcpp.org
 checksums           rmd160  8bcb98cd68da1789f5a2a4161543d621bd05291a \
                     sha256  1e65e24a9981251ab5fc4f9fd65fe4eab4ba0255be3400a8c5abe20b62b5d546 \
                     size    2936173
+
+depends_test-append port:R-inline \
+                    port:R-pkgKitten \
+                    port:R-rbenchmark \
+                    port:R-tinytest
+
+test.run            yes

--- a/R/R-arm/Portfile
+++ b/R/R-arm/Portfile
@@ -19,3 +19,5 @@ supported_archs     noarch
 depends_lib-append  port:R-abind \
                     port:R-coda \
                     port:R-lme4
+
+test.run            yes

--- a/R/R-cli/Portfile
+++ b/R/R-cli/Portfile
@@ -15,3 +15,25 @@ homepage            https://cli.r-lib.org
 checksums           rmd160  dace634b226ebd5289c614a4e8f5c9896cfbd032 \
                     sha256  ca9ce8d00998ee15b331a38cdda5d20607eeeda4dc442f15ef508cc791550133 \
                     size    562186
+
+depends_test-append port:R-callr \
+                    port:R-covr \
+                    port:R-crayon \
+                    port:R-digest \
+                    port:R-glue \
+                    port:R-htmltools \
+                    port:R-htmlwidgets \
+                    port:R-knitr \
+                    port:R-mockery \
+                    port:R-processx \
+                    port:R-ps \
+                    port:R-rlang \
+                    port:R-rmarkdown \
+                    port:R-rprojroot \
+                    port:R-rstudioapi \
+                    port:R-testthat \
+                    port:R-tibble \
+                    port:R-whoami \
+                    port:R-withr
+
+test.run            yes

--- a/R/R-debugme/Portfile
+++ b/R/R-debugme/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran r-lib debugme 1.1.0
+revision            0
+categories-append   devel
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             MIT
+description         Debug R packages
+long_description    {*}${description}
+checksums           rmd160  756952cfad51235946a38ed3be9e7a631f675186 \
+                    sha256  4dae0e2450d6689a6eab560e36f8a7c63853abbab64994028220b8fd4b793ab1 \
+                    size    997266
+supported_archs     noarch
+
+depends_lib-append  port:R-crayon
+
+depends_test-append port:R-covr \
+                    port:R-mockery \
+                    port:R-R6 \
+                    port:R-testthat \
+                    port:R-withr
+
+test.run            yes

--- a/R/R-later/Portfile
+++ b/R/R-later/Portfile
@@ -30,3 +30,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 16} {
         reinplace "s|@PREFIX@|${prefix}|" ${worksrcpath}/configure
     }
 }
+
+depends_test-append port:R-knitr \
+                    port:R-rmarkdown \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-magrittr/Portfile
+++ b/R/R-magrittr/Portfile
@@ -13,3 +13,11 @@ homepage            https://magrittr.tidyverse.org
 checksums           rmd160  5196287e02b4de6d8d112b2fbdffe81cc94681ac \
                     sha256  6f2f595a79d3d71d6414a38c72c19b5edd2fbb06e0431dfa6338966526e73695 \
                     size    350807
+
+depends_test-append port:R-covr \
+                    port:R-knitr \
+                    port:R-rlang \
+                    port:R-rmarkdown \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-mockery/Portfile
+++ b/R/R-mockery/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             github r-lib mockery 0.4.3 v
+revision            0
+categories-append   devel
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             MIT
+description         Mocking library for R
+long_description    {*}${description}
+checksums           rmd160  ba1d9a4c8715b63814737c6c35715b7fafb9102b \
+                    sha256  5e76d395c537af9828cf6f2f8b9776ff1e954e631cb5bffb77e0b79bf3df80f8 \
+                    size    14366
+supported_archs     noarch
+
+depends_lib-append  port:R-testthat
+
+depends_test-append port:R-knitr \
+                    port:R-R6 \
+                    port:R-rmarkdown
+
+test.run            yes

--- a/R/R-pingr/Portfile
+++ b/R/R-pingr/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             github r-lib pingr 2.0.2 v
+revision            0
+categories-append   net
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             MIT
+description         Check if a remote computer is up
+long_description    {*}${description}
+checksums           rmd160  fbdba25f525f2585ca0da3061be224459d246332 \
+                    sha256  656884a9f2bb2918ef0bcdce08ec27b818406281a5082832197d2f356660752c \
+                    size    16573
+
+depends_lib-append  port:R-processx
+
+depends_test-append port:R-covr \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-pkgKitten/Portfile
+++ b/R/R-pkgKitten/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran eddelbuettel pkgKitten 0.2.2 v
+revision            0
+categories-append   devel
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             {GPL-2 GPL-3}
+description         Create simple packages which pass R CMD check
+long_description    {*}${description}
+homepage            https://eddelbuettel.github.io/pkgkitten
+checksums           rmd160  20bd0773c8d794f7d49cfefec8092b6ffbb6688f \
+                    sha256  7a30efcad0f256b8b51a63cd8ab14c591017b01cd61afa776caecdcb3cbb5765 \
+                    size    9799
+supported_archs     noarch
+
+depends_test-append port:R-roxygen2 \
+                    port:R-tinytest \
+                    port:R-whoami
+
+test.run            yes

--- a/R/R-processx/Portfile
+++ b/R/R-processx/Portfile
@@ -17,3 +17,14 @@ checksums           rmd160  f0325fc7aa4c2573f8a9e94eca29547719d725b9 \
 
 depends_lib-append  port:R-ps \
                     port:R-R6
+
+depends_test-append port:R-callr \
+                    port:R-cli \
+                    port:R-covr \
+                    port:R-curl \
+                    port:R-debugme \
+                    port:R-rlang \
+                    port:R-testthat \
+                    port:R-withr
+
+test.run            yes

--- a/R/R-processx/Portfile
+++ b/R/R-processx/Portfile
@@ -8,8 +8,11 @@ revision            0
 categories-append   sysutils
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
-description         Execute and control system processes.
-long_description    {*}${description}
+description         Execute and control system processes
+long_description    Tools to run system processes in the background. It can check \
+                    if a background process is running, wait on a background process to finish, \
+                    get the exit status of finished processes, kill background processes. \
+                    It can read the standard output and error of the processes, using non-blocking connections. 
 homepage            https://processx.r-lib.org
 checksums           rmd160  f0325fc7aa4c2573f8a9e94eca29547719d725b9 \
                     sha256  a8d07f1d1430e82acd510dcd26ee51d9150a2d011dbbc58bd0121442543bc5f3 \

--- a/R/R-ps/Portfile
+++ b/R/R-ps/Portfile
@@ -21,3 +21,15 @@ patchfiles          0001-api-macos.c-fix-missing-stdbool.patch
 
 configure.env-append \
                     RBIN=${r.cmd}
+
+depends_test-append port:R-callr \
+                    port:R-covr \
+                    port:R-curl \
+                    port:R-pillar \
+                    port:R-pingr \
+                    port:R-processx \
+                    port:R-R6 \
+                    port:R-rlang \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-rbenchmark/Portfile
+++ b/R/R-rbenchmark/Portfile
@@ -1,0 +1,17 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran cran rbenchmark 1.0.0
+revision            0
+categories-append   devel
+maintainers         nomaintainer
+license             {GPL-2 GPL-3}
+description         Benchmarking routine for R
+long_description    rbenchmark is inspired by the Perl module Benchmark \
+                    and is intended to facilitate benchmarking of arbitrary R code.
+checksums           rmd160  ba93ce5349c17ec6883b6985f4b648e0c62edb6d \
+                    sha256  892a7189ccb13ad727aaffea41215c8389d082cadbe3c54220534ccbf1b00e04 \
+                    size    5093
+supported_archs     noarch

--- a/R/R-rlang/Portfile
+++ b/R/R-rlang/Portfile
@@ -14,3 +14,20 @@ homepage            https://rlang.r-lib.org
 checksums           rmd160  49bb02a3e1e7be441332e49b7eaa181f4dafa2db \
                     sha256  814317d4f9e02c5b7cb3bc7b865aaf3843232c65ed58f61a2e4a4d1fda6f3c0d \
                     size    787736
+
+depends_test-append port:R-cli \
+                    port:R-covr \
+                    port:R-crayon \
+                    port:R-fs \
+                    port:R-glue \
+                    port:R-knitr \
+                    port:R-magrittr \
+                    port:R-pillar \
+                    port:R-rmarkdown \
+                    port:R-testthat \
+                    port:R-tibble \
+                    port:R-usethis \
+                    port:R-vctrs \
+                    port:R-withr
+
+test.run            yes

--- a/R/R-selectr/Portfile
+++ b/R/R-selectr/Portfile
@@ -17,3 +17,9 @@ supported_archs     noarch
 
 depends_lib-append  port:R-R6 \
                     port:R-stringr
+
+depends_test-append port:R-testthat \
+                    port:R-XML \
+                    port:R-xml2
+
+test.run            yes

--- a/R/R-stringr/Portfile
+++ b/R/R-stringr/Portfile
@@ -24,3 +24,12 @@ depends_lib-append  port:R-cli \
                     port:R-rlang \
                     port:R-stringi \
                     port:R-vctrs
+
+depends_test-append port:R-covr \
+                    port:R-htmltools \
+                    port:R-htmlwidgets \
+                    port:R-knitr \
+                    port:R-rmarkdown \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-tinytest/Portfile
+++ b/R/R-tinytest/Portfile
@@ -1,0 +1,16 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran markvanderloo tinytest 1.3.1
+revision            0
+categories-append   devel
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-3
+description         Lightweight and feature-complete unit testing framework
+long_description    {*}${description}
+checksums           rmd160  3a3b7b0ed7da281f12292c7901290ad5abc0108b \
+                    sha256  9af45103cf9c2cec45eb58b27754feae2b8062a87026fadf5ce5b3bf8e0b03d7 \
+                    size    445398
+supported_archs     noarch

--- a/R/R-whoami/Portfile
+++ b/R/R-whoami/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             github r-lib whoami 1.3.0 v
+revision            0
+categories-append   devel
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             MIT
+description         Username, full name, e-mail address, GitHub username of the current user
+long_description    {*}${description}
+checksums           rmd160  0d434111be9e27a553076f243917a2a8a05553b7 \
+                    sha256  34ccfc87ec108c3d34656a6760801a5f8eb389463e75e992964cfd2baff8f0a9 \
+                    size    7212
+supported_archs     noarch
+
+depends_lib-append  port:R-httr \
+                    port:R-jsonlite
+
+depends_test-append port:R-covr \
+                    port:R-mockery \
+                    port:R-testthat \
+                    port:R-withr
+
+test.run            yes

--- a/R/R-xml2/Portfile
+++ b/R/R-xml2/Portfile
@@ -19,3 +19,14 @@ checksums           rmd160  9ea1ff92c6783ac022d870eb4a36a06ee5edccc5 \
 depends_build-append \
                     port:pkgconfig
 depends_lib-append  port:libxml2
+
+depends_test-append port:R-covr \
+                    port:R-curl \
+                    port:R-httr \
+                    port:R-knitr \
+                    port:R-magrittr \
+                    port:R-mockery \
+                    port:R-rmarkdown \
+                    port:R-testthat
+
+test.run            yes

--- a/_resources/port1.0/group/R-1.0.tcl
+++ b/_resources/port1.0/group/R-1.0.tcl
@@ -136,3 +136,10 @@ destroot.target
 post-destroot {
     delete ${destroot}${packages}/${R.package}_${version}${suffix}
 }
+
+# Default can be changed once the majority of packages implement testing:
+default test.run    no
+
+test {
+    system -W ${worksrcpath} "${r.cmd} CMD check ./${R.package}_${version}${suffix}"
+}


### PR DESCRIPTION
#### Description

This PR adds support for running tests for R packages.

For the time-being, default will remain no test.run, since R packages often place ridiculous requirements on dependencies (see `R-cli` in this PR as an example). It is hardly justified effort to add tests for every package.

Here I add a few common packages to support testing and add tests to a few – rather random – packages. Initial motivation was to test `Rcpp` as one of the core dependencies. Despite `malloc` errors, `Rcpp` actually passed the testsuite fine. (Since `Rcpp` has been updated with upstream, I also update it here in a separate commit.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Example of running tests:
```
--->  Testing R-debugme
* using log directory ‘/opt/local/var/macports/build/_opt_PPCRosettaPorts_R_R-debugme/R-debugme/work/debugme/debugme.Rcheck’
* using R version 4.2.2 (2022-10-31)
* using platform: powerpc-apple-darwin10.8.0 (32-bit)
* using session charset: UTF-8
* checking for file ‘debugme/DESCRIPTION’ ... OK
* this is package ‘debugme’ version ‘1.1.0’
* package encoding: UTF-8
* checking package namespace information ... OK
* checking package dependencies ... OK
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for executable files ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking for sufficient/correct file permissions ... OK
* checking whether package ‘debugme’ can be installed ... OK
* checking installed package size ... OK
* checking package directory ... OK
* checking DESCRIPTION meta-information ... OK
* checking top-level files ... OK
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking R files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* checking whether the package can be loaded ... OK
* checking whether the package can be loaded with stated dependencies ... OK
* checking whether the package can be unloaded cleanly ... OK
* checking whether the namespace can be loaded with stated dependencies ... OK
* checking whether the namespace can be unloaded cleanly ... OK
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... OK
* checking Rd files ... OK
* checking Rd metadata ... OK
* checking Rd cross-references ... OK
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... OK
* checking Rd \usage sections ... OK
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking examples ... NONE
* checking for unstated dependencies in ‘tests’ ... OK
* checking tests ...
  Running ‘testthat.R’
 OK
* checking PDF version of manual ... OK
* DONE

Status: OK
```

Notice, that not all packages pass all tests on PPC: among those tested, `R-ps` and `R-processx` (both related to system processes) exhibit a number of failures. There are some errors with `R-rlang` too: `[ FAIL 6 | WARN 0 | SKIP 227 | PASS 3674 ]`.