### PR TITLE
R-igraph: update to 1.4.0

### DIFF
--- a/R/R-igraph/Portfile
+++ b/R/R-igraph/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran igraph igraph 1.3.5
+R.setup             cran igraph igraph 1.4.0
 revision            0
 maintainers         {gmail.com:szhorvat @szhorvat} {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-2+
@@ -13,12 +13,10 @@ long_description    Routines for simple graphs and network analysis. \
                     for generating random and regular graphs, graph visualization, \
                     centrality methods and much more.
 homepage            https://igraph.org/r
-checksums           rmd160  dc3bfb06c279d7b4f7735b715c19e324aafc8223 \
-                    sha256  9e615d67b6b5b57dfa54ec2bbc8c29da8f7c3fe82af1e35ab27273b1035b9bd4 \
-                    size    2499723
+checksums           rmd160  57bc50b66d2e3f540426c0333fc54578d91e7db7 \
+                    sha256  c3923e6fbb96104cabc31dc7fcb53e3956687fa2c83743c561a798c8e355fa6d \
+                    size    2911035
 
-depends_build-append \
-                    port:pkgconfig
 depends_lib-append  port:glpk \
                     port:gmp \
                     port:libxml2 \

--- a/R/R-pkgconfig/Portfile
+++ b/R/R-pkgconfig/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             github r-lib pkgconfig 2.0.3 v
-revision            0
+revision            1
 categories-append   devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
@@ -14,5 +14,3 @@ checksums           rmd160  c6360d0c6237ab56c553b3a515ca9bf452557e43 \
                     sha256  c371a82737112adcae905ddec116d1e5f8c779fb802e681cfe1f8c7027bfeacf \
                     size    6482
 supported_archs     noarch
-
-depends_lib-append  port:pkgconfig


### PR DESCRIPTION
#### Description

 - Update R-igraph to 1.4.0
 - Remove unneeded `port:pkgconfig` dependency from `R-pkgconfig` (unrelated to `pkgconfig`) and from `R-igraph`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
