### PR TITLE
GPXSee: update to 12.1

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 11.12
+github.setup        tumic0 GPXSee 12.1
 revision            0
 
-checksums           rmd160  e3f40c8b4e61b0d723b265dc6d0684ec6d673289 \
-                    sha256  6d7f521286a843eb00c89a5304031b73f445d4bb1857f0fd79c4fba5e16f1f0b \
-                    size    5486541
+checksums           rmd160  5ce797d722bfb423832f2b0a3f0fc753e6c20e67 \
+                    sha256  472ae6211af5461b4b0826c82fabf589b7f1072f9ccd4bd3ce1afeed94b461bf \
+                    size    5487027
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
