### PR TITLE
groovy: update to 4.0.9

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         4.0.8
+version         4.0.9
 revision        0
 
 categories      lang java
@@ -41,9 +41,9 @@ master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zi
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  ff55b7e6bd94ca9bf7f00cd54e7d3f799a46249b \
-                sha256  20595e206bf6446b2733a078bd8d727ebc53e46bbcfcc797b8bad7c39add3544 \
-                size    29454915
+checksums       rmd160  0dd93c8766c8a70be91c47b0dda28c44c4839465 \
+                sha256  e0d26363ec798976b448857126b42823290c2007d63ecd97843a1718797131d4 \
+                size    29467411
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 4.0.9.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?