### PR TITLE
postgresql14: version bump to 14.7

### DIFF
--- a/databases/postgresql14-doc/Portfile
+++ b/databases/postgresql14-doc/Portfile
@@ -5,7 +5,7 @@ PortSystem 1.0
 name                postgresql14-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc postgresql12-doc \
     postgresql13-doc
-version             14.6
+version             14.7
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -22,9 +22,9 @@ master_sites        postgresql:source/v${version}
 distname            postgresql-${version}
 set rname           postgresql14
 
-checksums           rmd160  f2b1ebf2f622cc38b4f39ff65cf31ce2f610805d \
-                    sha256  508840fc1809d39ab72274d5f137dabb9fd7fb4f933da4168aeebb20069edf22 \
-                    size    22177474
+checksums           rmd160  c6cd207d162ef94106c41ba5ec2d088f4b63c1aa \
+                    sha256  cef60f0098fa8101c1546f4254e45b722af5431337945b37af207007630db331 \
+                    size    22182073
 
 use_bzip2           yes
 dist_subdir         ${rname}

--- a/databases/postgresql14-server/Portfile
+++ b/databases/postgresql14-server/Portfile
@@ -3,7 +3,7 @@
 PortSystem 1.0
 
 name                postgresql14-server
-version             14.6
+version             14.7
 categories          databases
 platforms           {darwin any}
 maintainers         {jwa @jyrkiwahlstedt}

--- a/databases/postgresql14/Portfile
+++ b/databases/postgresql14/Portfile
@@ -8,7 +8,7 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql14
-version             14.6
+version             14.7
 revision            0
 
 categories          databases
@@ -27,9 +27,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  f2b1ebf2f622cc38b4f39ff65cf31ce2f610805d \
-                    sha256  508840fc1809d39ab72274d5f137dabb9fd7fb4f933da4168aeebb20069edf22 \
-                    size    22177474
+checksums           rmd160  c6cd207d162ef94106c41ba5ec2d088f4b63c1aa \
+                    sha256  cef60f0098fa8101c1546f4254e45b722af5431337945b37af207007630db331 \
+                    size    22182073
 
 use_bzip2           yes
 


### PR DESCRIPTION
Upgrade ro 14.7

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.7.3 20G1116 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
