### PR TITLE
cyrus-sasl-xoauth2: new: A SASL XOAUTH2 plugin

### DIFF
--- a/security/cyrus-sasl-xoauth2/Portfile
+++ b/security/cyrus-sasl-xoauth2/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github 1.0
+
+github.setup        moriyoshi cyrus-sasl-xoauth2 0.2 v
+checksums           rmd160  7ddde236a533807134bd59c52b0110583d5e8fe9 \
+                    sha256  50bb3ce7af25745dd8f771705499a3e27fe3fb862d1c0a652d634d41b0ca91f6 \
+                    size    14125
+
+maintainers         {cal @neverpanic} openmaintainer
+categories          security net
+platforms           darwin
+
+license             MIT
+description         Plugin implementation of XOAUTH2 for cyrus-sasl
+long_description    ${description}
+
+patchfiles          patch-autogen.sh-use-glibtoolize.diff
+
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+
+configure.args      --with-cyrus-sasl=${prefix}
+
+depends_build-append \
+                    port:libtool \
+                    port:automake \
+                    port:autoconf
+
+depends_lib-append \
+                    port:cyrus-sasl2
+

--- a/security/cyrus-sasl-xoauth2/files/patch-autogen.sh-use-glibtoolize.diff
+++ b/security/cyrus-sasl-xoauth2/files/patch-autogen.sh-use-glibtoolize.diff
@@ -1,0 +1,15 @@
+autogen.sh: Use glibtoolize
+
+On macOS, libtool is installed with a 'g' prefix to avoid a conflict
+with macOS' own /usr/bin/libtool; as a consequence, libtoolize becomes
+glibtoolize.
+
+Upstream-Status: Inappropriate [configuration]
+--- autogen.sh.orig	2023-02-11 11:56:43.000000000 +0100
++++ autogen.sh	2023-02-11 11:56:53.000000000 +0100
+@@ -1,4 +1,4 @@
+-libtoolize
++glibtoolize
+ install -d m4
+ aclocal -I m4
+ autoheader


### PR DESCRIPTION
#### Description

This port is useful for authentication with some mailservers, e.g. Google Mail, which now offer OAuth2 support.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 21G419 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
