### PR TITLE
openjdk: worksrcdir fix

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -140,7 +140,7 @@ variant server \
 variant release \
     conflicts debug \
     description {OpenJDK with no debug information, all optimizations and no asserts} {
-    configure.args-append  --with-debug-level=release 
+    configure.args-append  --with-debug-level=release
 }
 
 variant debug \
@@ -191,7 +191,7 @@ if {![variant_isset core] && ![variant_isset zeroshark] && ![variant_isset zero]
 build.type          gnu
 build.target        images
 use_parallel_build  no
-worksrcdir          openjdk8
+worksrcdir          jdk8u-${distname}
 set jdkn jdk1.${major}.0_${update}.jdk
 set jren jre1.${major}.0_${update}.jre
 set jdk_bundle_dir build/openjdk8/images/j2sdk-bundle/${jdkn}/Contents
@@ -201,7 +201,7 @@ set jre_path ${tpath}/JavaVirtualMachines/${name}-jre
 
 test.run            yes
 test.cmd            ${jdk_bundle_dir}/Home/bin/java
-test.target         --version
+test.target         -version
 
 destroot {
     xinstall -m 755 -d ${destroot}${jdk_path}


### PR DESCRIPTION
#### Description

* Change `worksrcdir` to match the source distribution archive top-level directory name, or it hangs during the patch phase.
* Change `test.target` to `-version` with only a single hyphen.
* Remove trailing whitespace that `port lint --nitpick` complained about.

###### Type(s)

- [x] bugfix

###### Tested on
macOS 13.2 22D49 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
