### PR TITLE
openssl*: Fix for 3+ universal archs

### DIFF
--- a/devel/openssl10/Portfile
+++ b/devel/openssl10/Portfile
@@ -100,7 +100,10 @@ pre-destroot {
     if {[variant_exists universal] && [variant_isset universal]} {
         global merger_dont_diff
         if {[llength ${universal_archs_to_use}] > 2} {
-            lappend merger_dont_diff ${prefix}/include/openssl/opensslconf.h
+            lappend merger_dont_diff ${my_prefix}/include/openssl/opensslconf.h
+            # Previous version/revisions got this wrong, but this situation
+            # is too obscure to justify revbumping the dependents.
+            notes-append "Universal dependents may need to be rebuilt."
         }
     }
 }

--- a/devel/openssl11/Portfile
+++ b/devel/openssl11/Portfile
@@ -109,7 +109,10 @@ pre-destroot {
     if {[variant_exists universal] && [variant_isset universal]} {
         global merger_dont_diff
         if {[llength ${universal_archs_to_use}] > 2} {
-            lappend merger_dont_diff ${prefix}/include/openssl/opensslconf.h
+            lappend merger_dont_diff ${my_prefix}/include/openssl/opensslconf.h
+            # Previous version/revisions got this wrong, but this situation
+            # is too obscure to justify revbumping the dependents.
+            notes-append "Universal dependents may need to be rebuilt."
         }
     }
 }

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -119,7 +119,10 @@ pre-destroot {
     if {[variant_exists universal] && [variant_isset universal]} {
         global merger_dont_diff
         if {[llength ${universal_archs_to_use}] > 2} {
-            lappend merger_dont_diff ${prefix}/include/openssl/opensslconf.h
+            lappend merger_dont_diff ${my_prefix}/include/openssl/configuration.h
+            # Previous version/revisions got this wrong, but this situation
+            # is too obscure to justify revbumping the dependents.
+            notes-append "Universal dependents may need to be rebuilt."
         }
     }
 }


### PR DESCRIPTION
The merger_dont_diff setup for the >2 archs case was never updated to reflect the new prefix with the move to libexec.  It was also never updated for openssl3 to reflect the upstream naming change.  That caused a broken opensslconf.h (configuration.h for openssl3) to be created in the >2 archs case, with no reported error.

This in turn caused Python +universal to build "successfully" with the hashlib and ssl extensions missing.

Since this case is fairly rare (and not even allowed in 10.6+), it doesn't justify a revbump, even though it should technically get one.

For similar reasons, revbumping dependents isn't justifiable, though a note is provided suggesting rebuilding them (only in the relevant case).

TESTED:
Built +universal on 10.5 x86_64 with x86_64, i386, and ppc as universal_archs.  Resulting opensslconf.h (or configuration.h) setup is now reasonable.  With the openssl* updates, built python26-27 +universal and python32-35 +universal, and verified that the hashlib and ssl imports work in all three architectures.  Currently, python36-311 don't build +universal in this configuration, for unrelated reasons.
The normal builds of openssl11 and openssl3 were also tested on the full range of systems, due to the recent updates.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809 *
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H2, x86_64, Xcode 12.4 12D4e
macOS 11.7.3 20G1116, arm64, Xcode 13.2.1 13C100
macOS 12.6.3 21G419, arm64, Xcode 14.2 14C18
macOS 13.2 22D49, arm64, Xcode 14.2 14C18

* - The only case here with >2 universal_archs

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [NOTE 1] tried a full install with `sudo port -vst install`?
- [NOTE 2] tested basic functionality of all binary files?
- [NOTE 2] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

NOTE 1: Since the darwintrace library is broken for the only case affected by the change,
useful trace-mode testing was not available.

NOTE 2: The change doesn't interact with either binary files or variants.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
