### PR TITLE
mariadb: fix build for Ventura and arm64

### DIFF
--- a/databases/mariadb/Portfile
+++ b/databases/mariadb/Portfile
@@ -45,7 +45,8 @@ if {$subport eq $name} {
 
     patch.pre_args      -p1
     patchfiles          patch-cmake-install_layout.cmake.diff \
-                        patch-CMakeLists.txt.diff
+                        patch-CMakeLists.txt.diff \
+                        patch-mariadb-Ventura-and-arm64.diff
 
     checksums           rmd160 c1df56d5c9ae118693e721aefb18fb19277bf5c0 \
                         sha256 23ff96db2215d3d2eb8697488719153c83ac4d131f504ae397f43c14c6d91ba3 \

--- a/databases/mariadb/files/patch-mariadb-Ventura-and-arm64.diff
+++ b/databases/mariadb/files/patch-mariadb-Ventura-and-arm64.diff
@@ -1,0 +1,27 @@
+diff --git a/include/my_global.h b/include/my_global.h
+index 01a1dca..04c487e 100644
+--- a/include/my_global.h
++++ b/include/my_global.h
+@@ -174,7 +174,7 @@
+ #  if defined(__i386__) || defined(__ppc__)
+ #    define SIZEOF_CHARP 4
+ #    define SIZEOF_LONG 4
+-#  elif defined(__x86_64__) || defined(__ppc64__)
++#  elif defined(__x86_64__) || defined(__ppc64__) || defined(__aarch64__) || defined(__arm64__)
+ #    define SIZEOF_CHARP 8
+ #    define SIZEOF_LONG 8
+ #  else
+diff --git a/storage/perfschema/CMakeLists.txt b/storage/perfschema/CMakeLists.txt
+index f8ee1ca..3445c40 100644
+--- a/storage/perfschema/CMakeLists.txt
++++ b/storage/perfschema/CMakeLists.txt
+@@ -13,8 +13,7 @@
+ # along with this program; if not, write to the Free Software Foundation,
+ # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA
+ 
+-INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}
+-                    ${CMAKE_SOURCE_DIR}/include
++INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include
+                     ${CMAKE_SOURCE_DIR}/sql
+                     ${CMAKE_SOURCE_DIR}/regex
+                     ${CMAKE_SOURCE_DIR}/extra/yassl/include)


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/66143
closes: https://trac.macports.org/ticket/66169
closes: https://trac.macports.org/ticket/63471

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.1 22C65 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

universal arm64/x86_64 also confirmed to build