### PR TITLE
k9s: update to 0.27.3

### DIFF
--- a/sysutils/k9s/Portfile
+++ b/sysutils/k9s/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/derailed/k9s 0.27.2 v
+go.setup            github.com/derailed/k9s 0.27.3 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {breun.nl:nils @breun} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  a7d8bd772daeda6a0f2425f77b0b2425b97e59a1 \
-                    sha256  893b8f3059868944dc74f8c0a175fd4305a8286910c5cdab1f0d7e70719b59c1 \
-                    size    6393251
+checksums           rmd160  6ad2d8a647000fabd2e535a8494d1dfd5fd575a4 \
+                    sha256  acd00a661e5cfe9fb81cd92ecaaf9e439231cc0d93ce04481ec0dcb5c517ffac \
+                    size    6395143
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See


### PR DESCRIPTION
#### Description

Update to k9s 0.27.3.

###### Tested on

macOS 13.2 22D49 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?