### PR TITLE
prosody, lua-luasec: fix builds

### DIFF
--- a/lua/lua-luasec/Portfile
+++ b/lua/lua-luasec/Portfile
@@ -24,6 +24,8 @@ openssl.configure       env_vars
 build.args-append       OPENSSL_DIR=\$OPENSSL_DIR
 destroot.args-append    OPENSSL_DIR=\$OPENSSL_DIR
 
+patchfiles              patch-luasocket.diff
+
 luarocks.dependencies   luasocket
 
 luarocks.uploader       brunoos

--- a/lua/lua-luasec/files/patch-luasocket.diff
+++ b/lua/lua-luasec/files/patch-luasocket.diff
@@ -1,0 +1,12 @@
+--- src/luasocket/usocket.c.orig	2022-07-30 19:42:53.000000000 +0800
++++ src/luasocket/usocket.c	2022-11-26 17:38:51.000000000 +0800
+@@ -426,7 +426,9 @@
+         case EAI_MEMORY: return "memory allocation failure";
+         case EAI_NONAME: 
+             return "host or service not provided, or not known";
++#ifdef EAI_OVERFLOW
+         case EAI_OVERFLOW: return "argument buffer overflow";
++#endif
+ #ifdef EAI_PROTOCOL
+         case EAI_PROTOCOL: return "resolved protocol is unknown";
+ #endif

--- a/net/prosody/Portfile
+++ b/net/prosody/Portfile
@@ -1,8 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.1
 PortGroup           lua 1.0
 PortGroup           openssl 1.0
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 name                prosody
 version             0.12.3
@@ -47,7 +51,8 @@ post-patch {
                     ${worksrcpath}/prosodyctl
 }
 
-configure.cflags-append  -fPIC
+# It needs C99, otherwise build fails with old Apple complilers.
+configure.cflags-append  -std=c99 -fPIC
 configure.ldflags-append -bundle -undefined dynamic_lookup
 
 # using `--ostype=macosx` appends `-mmacosx-version-min=10.3` to CFLAGS


### PR DESCRIPTION
#### Description

`prosody` is broken on El Captain down: https://ports.macports.org/port/prosody/details

`lua-luasec` was broken by the recent update which threw away my patch -_- https://github.com/macports/macports-ports/pull/17988/commits/e07cc681e5a19213cdab5222b6f9489419041eac

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
