### PR TITLE
avahi: fix daemon start failure

### DIFF
--- a/net/avahi/Portfile
+++ b/net/avahi/Portfile
@@ -29,7 +29,8 @@ patchfiles          patch-avahi-daemon-Makefile.in.diff \
                     patch-avahi-dnsconfd-Makefile.in.diff \
                     patch-avahi-utils-Makefile.in.diff \
                     patch-initscript-darwin-org.freedesktop.avahi-daemon.plist.in.diff \
-                    patch-initscript-darwin-org.freedesktop.avahi-dnsconfd.plist.in.diff
+                    patch-initscript-darwin-org.freedesktop.avahi-dnsconfd.plist.in.diff \
+                    patch-configure-var-run.diff
 
 # ensure MacPorts machine-id from dbus is found
 # see https://trac.macports.org/ticket/53894 for O_CLOEXEC
@@ -168,11 +169,13 @@ variant gtk3 description {Build with GTK3} {
 
 variant qt4 description {Build with Qt4} {
     PortGroup   qt4 1.0
+
     configure.args-delete   --disable-qt4
 }
 
 variant qt5 description {Build with Qt5} {
     PortGroup   qt5 1.0
+
     # This configure script does not use CXXFLAGS variable for Qt5 compile test so I have to do this
     configure.env-append    QT5_CFLAGS=-std=c++11\ -DQT_CORE_LIB\ -F${qt_dir}/lib\ -I${qt_dir}/lib/QtCore.framework/Headers\ -I${qt_dir}/include
     compiler.cxx_standard   2011

--- a/net/avahi/files/patch-configure-var-run.diff
+++ b/net/avahi/files/patch-configure-var-run.diff
@@ -1,0 +1,11 @@
+--- configure.org	2023-02-12 21:25:53.000000000 -0500
++++ Configure	2023-02-12 21:28:21.000000000 -0500
+@@ -24638,7 +24638,7 @@
+ #
+ # Avahi runtime dir
+ #
+-avahi_runtime_dir="/run"
++avahi_runtime_dir="/var/run"
+ avahi_socket="${avahi_runtime_dir}/avahi-daemon/socket"
+ 
+ 

--- a/net/avahi/files/patch-initscript-darwin-org.freedesktop.avahi-daemon.plist.in.diff
+++ b/net/avahi/files/patch-initscript-darwin-org.freedesktop.avahi-daemon.plist.in.diff
@@ -1,5 +1,5 @@
---- initscript/darwin/org.freedesktop.avahi-daemon.plist.in.orig	2012-02-15 10:30:25.000000000 -0800
-+++ initscript/darwin/org.freedesktop.avahi-daemon.plist.in	2012-02-15 10:33:40.000000000 -0800
+--- initscript/darwin/org.freedesktop.avahi-daemon.plist.in.orig	2015-04-01 00:58:00.000000000 -0400
++++ initscript/darwin/org.freedesktop.avahi-daemon.plist.in	2023-02-13 13:09:30.000000000 -0500
 @@ -2,6 +2,8 @@
  <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
  <plist version="1.0">
@@ -9,3 +9,11 @@
  	<key>Label</key>
  	<string>org.freedesktop.avahi-daemon</string>
  	<key>OnDemand</key>
+@@ -9,6 +11,7 @@
+ 	<key>ProgramArguments</key>
+ 	<array>
+ 			<string>@sbindir@/avahi-daemon</string>
++			<string>--no-drop-root</string>
+ 	</array>
+ 	<key>ServiceIPC</key>
+ 	<false/>


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/57519

This fixes two issues that would prevent avahi-daemon from launching:

- It tries to write a socket file to `/run`, which is not allowed. This patches it to use `/var/run` as it did in previous versions
- using `setuid` is explicitly disallowed by dbus's API when a process is launched by launchd and will cause avahi-daemon to exit, so this adds `--no-drop-root` to its launch arguments

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
