### PR TITLE
virt-manager: Update to 4.1.0 and use Python 3.11

### DIFF
--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -35,7 +35,8 @@ patchfiles-append   patch-gtk-update-icon-cache.diff
 patchfiles-append   patch-no-kvm-warning.diff
 patchfiles-append   patch-not-in-usr.diff
 
-python.default_version  310
+python.default_version  311
+python.pep517           no
 
 # Note: 'gettext' only needed at build time. No need for a runtime dep on
 # 'gettext-runtime', as this port utilizes Python's built-in 'gettext' support.

--- a/python/py-libxml2/Portfile
+++ b/python/py-libxml2/Portfile
@@ -6,11 +6,11 @@ PortGroup           python 1.0
 # Please keep the version of the libxml2 and py-libxml2 ports the same.
 
 name                py-libxml2
-version             2.10.2
+version             2.10.3
 revision            0
-checksums           rmd160  c464042a3b0541c46d65332169cb8178627cefa9 \
-                    sha256  d240abe6da9c65cb1900dd9bf3a3501ccf88b3c2a1cb98317d03f272dda5b265 \
-                    size    2636304
+checksums           rmd160  baac5a5b160dba19ba48c23922b32c31ae336453 \
+                    sha256  5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c \
+                    size    2639908
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories-append   textproc
@@ -54,6 +54,9 @@ if {${name} ne ${subport}} {
     post-patch {
         reinplace "s|@LIBXML_VERSION@|${version}|g;s|@prefix@|${prefix}|g" ${worksrcpath}/setup.py
     }
+
+    # Build in PEP517 mode fails with Python 3.11
+    python.pep517 no
 
     post-destroot {
       set docdir ${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description

virt-manager tested and seems to work fine.

Depends on #17549 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D49 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
