### PR TITLE
linear_algebra: fix logic of choosing default variant

### DIFF
--- a/_resources/port1.0/group/linear_algebra-1.0.tcl
+++ b/_resources/port1.0/group/linear_algebra-1.0.tcl
@@ -51,11 +51,11 @@ proc linalg.setup {args} {
 }
 
 if {![variant_isset accelerate] && ![variant_isset atlas] && ![variant_isset openblas]} {
-    if { ${os.platform} eq "darwin" && ${os.major} > 20 } {
+    if {${os.platform} eq "darwin" && ${os.major} < 21} {
         # see https://trac.macports.org/ticket/65260
-        default_variants-append +openblas
-    } else {
         default_variants-append +accelerate
+    } else {
+        default_variants-append +openblas
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Sergey Fedorov <vital.had@gmail.com>

#### Description

Existing logic is wrong: it chooses `+openblas` for `${os.platform} eq "darwin" && ${os.major} > 20` and `+accelerate` for everything else; however, `Accelerate` _does not exist on everything else_ – it is an Apple framework. Obviously, it should be reverse: choose `Accelerate` for Darwin < 21, and choose `OpenBLAS` for everything else.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
