### PR TITLE
madness: fix build with Clang on macOS <10.13

### DIFF
--- a/science/madness/Portfile
+++ b/science/madness/Portfile
@@ -5,6 +5,7 @@ PortGroup           active_variants 1.1
 PortGroup           boost 1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
 github.setup        m-a-d-n-e-s-s madness 04adab9e277c98c2e0633a3135f80f9a416b86ca
 version             2023.02.07
@@ -82,10 +83,29 @@ configure.args-append \
                     -DFORTRAN_INTEGER_SIZE=4 \
                     -DMADNESS_TASK_BACKEND="Pthreads"
 
-if {[string match *gcc* ${configure.compiler}]} {
-    # https://github.com/m-a-d-n-e-s-s/madness/issues/456
-    configure.cxxflags-append \
-                    -fpermissive
+legacysupport.newest_darwin_requires_legacy 16
+
+if {[string match *clang* ${configure.compiler}]} {
+    # Don’t use libcxx with gcc.
+    legacysupport.use_mp_libcxx yes
+}
+
+platform darwin {
+    # dqueue.h:221:17: error: aligned deallocation function
+    # of type 'void (void *, std::align_val_t) noexcept'
+    # is only available on macOS 10.13 or newer
+    if {${os.major} <= 16} {
+        # gcc does not recognize -fno-aligned-allocation
+        if {[string match *clang* ${configure.compiler}]} {
+            configure.cxxflags-append \
+                            -fno-aligned-allocation
+        }
+    }
+    if {[string match *gcc* ${configure.compiler}]} {
+        # https://github.com/m-a-d-n-e-s-s/madness/issues/456
+        configure.cxxflags-append \
+                            -fpermissive
+    }
 }
 
 variant tests description "Build and run tests" {


### PR DESCRIPTION
#### Description

[Cherry-pick](https://github.com/macports/macports-ports/blob/a3dad1ed6d0a1952ab4536b0e10dde764e887469/devel/fbthrift/Portfile#L49) the same construction that already works on fbthrift.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
