### PR TITLE
google-cloud-sdk: update to 418.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             417.0.1
+version             418.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  af3bb2d222be51a9e97271fe83ffbf0126a0f3e5 \
-                    sha256  614139b305a95f2de5a5b0b264db728c91017b5e28c22141efde59e37ea74f68 \
-                    size    111079062
+    checksums       rmd160  7be6fb13f5620becbc47a6ca5a5569f94b61ea8b \
+                    sha256  ff8c0b6167552a4972cbff880c9f0d33328eb916fd36554bcfd635fdeb3956f8 \
+                    size    111100781
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  8ef7903962a4073385022af3fcec21faabe5c8d5 \
-                    sha256  5510d7ca2306622a7df5bb3882a8cc515d01e62e4c841b42b3521adc992da34c \
-                    size    131408801
+    checksums       rmd160  669c15b0b566dfdf3dccc478fe6c7fd0c570f78f \
+                    sha256  694df6ebff8ee3b74d954351cf65f07d8cbf2fc5c1f139d148bb05e654f4a497 \
+                    size    131423201
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  49b3bc5d1e2ad6cd57e4734bbf28859c655e2677 \
-                    sha256  571b04fd1d92574ed56134615bd60128585d667cd28d5f2f1d4f184edaabef09 \
-                    size    128244591
+    checksums       rmd160  2ce836861b9e38cff2c6a2d0c412c04e2bded08b \
+                    sha256  47804aee59b32b72bcd0a12b149abf3937c64957ea98aeb7abb41e5adde523fe \
+                    size    128267097
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 418.0.0.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?