### PR TITLE
apachetop: update to 0.23.2

### DIFF
--- a/sysutils/apachetop/Portfile
+++ b/sysutils/apachetop/Portfile
@@ -3,8 +3,8 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    tessus apachetop 0.18.4
-revision        1
+github.setup    tessus apachetop 0.23.2
+revision        0
 
 categories      sysutils www
 maintainers     {evermeet.cx:tessarek @tessus}
@@ -16,10 +16,12 @@ long_description \
 platforms       darwin freebsd
 license         BSD
 
-depends_lib     port:readline port:pcre port:adns
+depends_build   port:pkgconfig
+depends_lib     port:readline port:pcre2 port:adns port:ncurses
 
 github.tarball_from     releases
-checksums               rmd160  e776e8ebd07d338e2be9f549ce39f364816772ef \
-                        sha256  34ee3ad380f1f7c055a96296420f15011b522781691137ea4e3a36f6bd195568
+checksums               rmd160  2a8c80f7d0fc8150b4d1ae2aad0e39a567a0dd22 \
+                        sha256  f94a34180808c3edb24c1779f72363246dd4143a89f579ef2ac168a45b04443f \
+                        size    169381
 
 configure.args  --with-logfile=/private/var/log/apache2/access_log


### PR DESCRIPTION
#### Description

apachetop: update to 0.23.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] update

###### Tested on
macOS 10.14.6 18G9323
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
