### PR TITLE
caddy: update to 2.6.4

### DIFF
--- a/www/caddy/Portfile
+++ b/www/caddy/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/caddyserver/caddy 2.6.3 v
+go.setup            github.com/caddyserver/caddy 2.6.4 v
 revision            0
 categories          www
 license             Apache-2
@@ -17,9 +17,9 @@ long_description    Caddy 2 is a powerful, enterprise-ready, open source web \
 homepage            https://caddyserver.com/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  e82926da5a23f032536d3d1dbd7ab2ebb72aa429 \
-                        sha256  da8bdcb84bbd38c12bd279e1de551ad097f35a0cbed51ba1acaf7a09f05e9b86 \
-                        size    567493
+                        rmd160  ac4977b545c1f3ef623a1eecf3ce62e1ab1670a9 \
+                        sha256  4ae8033ff236a70b4c9d3606822382c0a48931244687612d45412201c864ff0c \
+                        size    568241
 
 go.vendors          howett.net/plist \
                         repo    github.com/DHowett/go-plist \
@@ -88,10 +88,10 @@ go.vendors          howett.net/plist \
                         sha256  56465575d7c91e0c4999d66fa327a469245828f360bc406e242f54a8cace1900 \
                         size    3210050 \
                     golang.org/x/text \
-                        lock    v0.6.0 \
-                        rmd160  41b7bda7df46797457b47aa00e5d745345b684bc \
-                        sha256  6172a6091f616a9fb644ed71ee61e3a69529f95f357abd9ce521599a1e57e2b9 \
-                        size    8361557 \
+                        lock    v0.7.0 \
+                        rmd160  bd2aafec6ceb2ea04c3904d2f7308916ca2b7a87 \
+                        sha256  9f3c2fc2967a7a81586f0af894f2a60ddcad5e7acda9713cd6b9cf2b39df010d \
+                        size    8361394 \
                     golang.org/x/term \
                         lock    v0.5.0 \
                         rmd160  1617c36e9e3791aeaf34ac074ee964d90029b49c \
@@ -113,10 +113,10 @@ go.vendors          howett.net/plist \
                         sha256  3434d7197de3a8ff5329a33fcbba99d4576b1f4c2d3372f0cedd90ebdd3a599b \
                         size    104520 \
                     golang.org/x/net \
-                        lock    v0.5.0 \
-                        rmd160  5c6bd81ab31a211f0e6f520dbec3c02c506d9ea6 \
-                        sha256  34827849fc6295d493c21df54fea819dae369bc37ff7d7e283030fe140118c0e \
-                        size    1238525 \
+                        lock    v0.7.0 \
+                        rmd160  e2907c7257546564c6b2eb97189d65da022bc6dc \
+                        sha256  aa9701a779a24fa615009ab3f177145c2a39a0e5366de39a08b84a0f952587b6 \
+                        size    1241181 \
                     golang.org/x/mod \
                         lock    v0.6.0 \
                         rmd160  203d707f99d76e5ce3a332eca02b4430fc2082fa \
@@ -411,10 +411,10 @@ go.vendors          howett.net/plist \
                         sha256  0120218fb1bdbadb6559516169f8281dc457806b7784793c572356575069c25a \
                         size    64304 \
                     github.com/mholt/acmez \
-                        lock    v1.0.4 \
-                        rmd160  78dcb7f7743e61c522e1da2dfba76978f7d203fd \
-                        sha256  04292a82f33b2ffb8c2cc6cc9b1af0bc4bf4b45022dd697caabd1a71848a5476 \
-                        size    52083 \
+                        lock    v1.1.0 \
+                        rmd160  86fc5cd29b77fd9067df48e4cbaf4f2bd79f6786 \
+                        sha256  7d604ca9a6145909e3a932f92f7cc734c3602a7c3aedfd488f22daea324edd76 \
+                        size    54010 \
                     github.com/mgutz/ansi \
                         lock    d51e80ef957d \
                         rmd160  a32d3fd46ae68cfd82f31fadc3dfe551966f6a5b \


### PR DESCRIPTION
###### Tested on
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?