### PR TITLE
apr-util: use the right compiler

### DIFF
--- a/devel/apr-util/Portfile
+++ b/devel/apr-util/Portfile
@@ -26,6 +26,10 @@ depends_lib	port:apr port:expat \
 		port:libiconv port:db48 \
 		port:sqlite3
 
+# https://trac.macports.org/wiki/UsingTheRightCompiler
+patchfiles-append \
+        patch-using_the_right_compiler.diff
+
 use_parallel_build	yes
 configure.ccache	no
 configure.args	--with-apr=${prefix}/bin/apr-1-config --with-expat=${prefix} \

--- a/devel/apr-util/files/patch-using_the_right_compiler.diff
+++ b/devel/apr-util/files/patch-using_the_right_compiler.diff
@@ -1,0 +1,10 @@
+--- Makefile.in.orig	2021-08-11 03:52:26
++++ Makefile.in	2023-02-17 06:53:58
+@@ -2,6 +2,7 @@
+ # Top-level Makefile for APRUTIL
+ #
+ CPP = @CPP@
++CC = @CC@
+ 
+ # gets substituted into some targets
+ APRUTIL_MAJOR_VERSION=@APRUTIL_MAJOR_VERSION@


### PR DESCRIPTION
See https://trac.macports.org/wiki/UsingTheRightCompiler

No revbump since installed files do not change.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
