### PR TITLE
lagrange: update to 1.15.2

### DIFF
--- a/devel/sealcurses/Portfile
+++ b/devel/sealcurses/Portfile
@@ -5,8 +5,8 @@ PortGroup           cmake 1.1
 PortGroup           gitea 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         skyjake sealcurses d64caa13bc06b68906bb0a5cc87f1896226b0918
-version             2022-05-23
+gitea.setup         skyjake sealcurses e11026ca34b03c5ab546512f82a6f705d0c29e95
+version             2023-02-06
 revision            0
 categories          devel
 license             BSD
@@ -15,9 +15,11 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         SDL Emulation and Adaptation Layer for Curses (ncursesw)
 long_description    {*}${description}
 
-checksums           rmd160  053a2bdbab956a04dcbd69f51efea99df5b45320 \
-                    sha256  2162170d907c454c2594f764a4109e5621760a107c5d75d3692a9bca59ffdc78 \
-                    size    22284
+checksums           rmd160  cd0d2f2d9a9852ee59f582984dfec9c52eb76c8a \
+                    sha256  797efa8fcfea3d69383c493b4fc29305c72fdc5f3586063e84e89da601739d2c \
+                    size    22432
+
+worksrcdir          ${name}
 
 depends_build-append \
                     port:pkgconfig

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.15.0 v
+gitea.setup         gemini lagrange 1.15.2 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,11 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  41c91419c9e8af345ef358b599e37ca9dbefe76f \
-                    sha256  b12feb2d459bdc7791e22604052a02b580f36377ae32e49b045210c11d33d0fe \
-                    size    7470958
+checksums           rmd160  80d59b632607dbf8a8572533c827608937c3c50f \
+                    sha256  4086863a29fa56fe2b098bd5467f0ef3461da0ebb16fca108fb6a6fb6b37c6b4 \
+                    size    7485848
+
+worksrcdir          ${name}
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
