### PR TITLE
pika: fix build on < 10.15

### DIFF
--- a/devel/pika/Portfile
+++ b/devel/pika/Portfile
@@ -78,6 +78,20 @@ platform powerpc {
     }
 }
 
+# https://github.com/pika-org/pika/issues/584
+if {${os.platform} eq "darwin" && ${os.major} <= 19 && ${cxx_stdlib} eq "libc++"} {
+    configure.ldflags-append -lc++fs
+} elseif {${cxx_stdlib} eq "libstdc++" && [string match macports-gcc* ${configure.compiler}]} {
+    set gcc_v [
+        string range ${configure.compiler} [
+            string length macports-gcc-
+        ] end
+    ]
+    if {${gcc_v} < 9} {
+        configure.ldflags-append -lstdc++fs
+    }
+}
+
 variant jemalloc conflicts tbb description "Use jemalloc instead of system malloc" {
     depends_lib-append \
                     port:jemalloc


### PR DESCRIPTION
#### Description

`pika` fails on < 10.15 currently, see: https://ports.macports.org/port/pika/details/
Upstream recommended linking to `-lc++fs`: https://github.com/pika-org/pika/issues/584
Let’s try that.

Also apparently GCC <9 should link to `-lstdc++fs`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
