### PR TITLE
nethack: update to 3.6.7

### DIFF
--- a/games/nethack/Portfile
+++ b/games/nethack/Portfile
@@ -3,7 +3,7 @@
 PortSystem         1.0
 
 name               nethack
-version            3.6.6
+version            3.6.7
 categories         games
 license            Copyleft
 maintainers        {@jflude hotmail.com:justin_flude} \
@@ -22,17 +22,17 @@ master_sites       sourceforge \
                    ${homepage}download/${version}/
 distname           ${name}-[string map {{.} {}} ${version}]-src
 extract.suffix     .tgz
-checksums          sha256 cfde0c3ab6dd7c22ae82e1e5a59ab80152304eb23fb06e3129439271e5643ed2 \
-                   rmd160 de937e31c2046900ef8c6f2eb0da0da09f8e136f \
-                   size 5577633
+checksums          sha256 98cf67df6debf9668a61745aa84c09bcab362e5d33f5b944ec5155d44d2aacb2 \
+                   rmd160 d840125094bbd67e11fa2c6fb640fab97c679994 \
+                   size 5577415
 
 depends_lib        port:ncurses
-worksrcdir         NetHack-NetHack-${version}_Released
+worksrcdir         NetHack-${version}
 
 patch.pre_args     -p1
 patchfiles         patch-gamestate-dir.diff \
                    patch-manpage-dir.diff
-                   
+
 patchfiles-append  patch-nethack-warn-unused-result.diff
 
 post-patch {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
