### PR TITLE
R: fix for malloc errors, finally

### DIFF
--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -10,7 +10,7 @@ name                        R
 # Remember to set revision to 0 when bumping version
 # And also to update Rversion in R PortGroup
 version                     4.2.2
-revision                    4
+revision                    5
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  math science
@@ -322,6 +322,38 @@ post-destroot {
         ${destroot}${resources}/bin/exec/R"
     system "install_name_tool -change ${destroot}${resources}/lib/libRblas.dylib ${resources}/lib/libRblas.dylib \
         ${destroot}${resources}/bin/exec/R"
+
+    platform darwin {
+        # LegacySupport magic does not work automatically. Re-implement it by hand:
+        set rexec ${resources}/bin/exec/R
+
+        if {${os.major} < 11} {
+            legacysupport::relink_libSystem ${destroot}${rexec}
+        }
+
+        if {${configure.cxx_stdlib} ne "libc++"} {
+            # We can’t do it in a sane way, since R build system in its wisdom assumes
+            # that R and R-orig are archs, and then package installation gets broken.
+            set rexec_orig ${resources}/bin/exec_orig/R
+
+            xinstall -d ${destroot}${resources}/bin/exec_orig
+
+            move ${destroot}${rexec} ${destroot}${rexec_orig}
+
+            set  wrapper    [open "${destroot}${rexec}" w 0755]
+            puts ${wrapper} "#!/bin/bash"
+            puts ${wrapper} ""
+            puts ${wrapper} {if [ -n "$DYLD_LIBRARY_PATH" ]; then}
+            puts ${wrapper} "   DYLD_LIBRARY_PATH=${prefix}/lib/libgcc:\${DYLD_LIBRARY_PATH}"
+            puts ${wrapper} {else}
+            puts ${wrapper} "   DYLD_LIBRARY_PATH=${prefix}/lib/libgcc"
+            puts ${wrapper} {fi}
+            puts ${wrapper} {export DYLD_LIBRARY_PATH}
+            puts ${wrapper} ""
+            puts ${wrapper} "exec ${rexec_orig} \"\$@\""
+            close $wrapper
+        }
+    }
 
     ln -s ${resources}/bin/R ${destroot}${prefix}/bin/R
     ln -s ${resources}/bin/Rscript ${destroot}${prefix}/bin/Rscript


### PR DESCRIPTION
#### Description

This basically re-implements logic of `LegacySupport` manually, since automatic does not work.
Finally, packages are loading cleanly.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
