### PR TITLE
mpich: unbreak 4.1.0 for older OSs, fix flags in native variant for ppc

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -47,19 +47,9 @@ long_description    MPICH is a high-performance and widely portable\
 homepage            https://www.mpich.org/
 master_sites        ${homepage}static/downloads/${version}
 
-if {${os.platform} eq "darwin" && ${os.major} > 16 } {
-    # 4.1+ expects os/lock.h; added in 10.13
-    checksums \
-        rmd160  c4e46f2edfbe4dd617b359597203d448856fc569 \
-        sha256  8b1ec63bc44c7caa2afbb457bc5b3cd4a70dbe46baba700123d67c48dc5ab6a0 \
-        size    38511339
-} else {
-    version     4.0.3
-    checksums \
-        rmd160  7a65f2a1d080c2b7812295a8fc0b77ec1609b166 \
-        sha256  17406ea90a6ed4ecd5be39c9ddcbfac9343e6ab4f77ac4e8c5ebe4a3e3b6c501 \
-        size    38135700
-}
+checksums           rmd160  c4e46f2edfbe4dd617b359597203d448856fc569 \
+                    sha256  8b1ec63bc44c7caa2afbb457bc5b3cd4a70dbe46baba700123d67c48dc5ab6a0 \
+                    size    38511339
 
 livecheck.type      regex
 livecheck.regex     {href=.([0-9.p]+)/}
@@ -198,7 +188,8 @@ if {${subport_enabled}} {
                     patch-no_qmkshrobj.diff \
                     patch-ch4-ipv6.diff \
                     patch-mpich-darwin-powerpc.diff \
-                    patch-pingpong.diff
+                    patch-pingpong.diff \
+                    patch-spinlocks.diff
 
     platform darwin powerpc {
         # libfabric calls for atomicops, on PPC at least

--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -401,8 +401,13 @@ if {${subport_enabled}} {
         configure.args-replace      --enable-fast=O2 \
                                     --enable-fast=all
         # Note these need to be above the following foreach
-        configure.cflags-append     -march=native
-        configure.cxxflags-append   -march=native
+        if {${build_arch} in [list ppc ppc64]} {
+            configure.cflags-append     -mtune=native
+            configure.cxxflags-append   -mtune=native
+        } else {
+            configure.cflags-append     -march=native
+            configure.cxxflags-append   -march=native
+        }
     }
 
     #---------------------------------------------------------------------------

--- a/science/mpich/files/patch-spinlocks.diff
+++ b/science/mpich/files/patch-spinlocks.diff
@@ -1,0 +1,78 @@
+From 304e91bff06c60922bb46a31b2745d3b65661bdf Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 15 Feb 2023 20:20:17 +0800
+Subject: [PATCH] osd.h: fix spinlocks for macOS
+
+---
+ include/osx/osd.h | 43 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 43 insertions(+)
+
+diff --git a/include/osx/osd.h b/include/osx/osd.h
+index a7eace242..b88074b82 100644
+--- modules/libfabric/include/osx/osd.h
++++ modules/libfabric/include/osx/osd.h
+@@ -50,6 +50,8 @@
+ 
+ #include <limits.h>
+ 
++#include <AvailabilityMacros.h>
++
+ #include "unix/osd.h"
+ #include "rdma/fi_errno.h"
+ #include "config.h"
+@@ -171,7 +173,12 @@ ssize_t ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags);
+  * used os_unfair_lock to implement pthread_spinlock.
+  * os_unfair_lock does not enforce fairness or lock ordering (hence
+  * the name unfair), which is similar to pthread_spinlock.
++ * New code supported only on 10.12+: https://developer.apple.com/documentation/os/os_unfair_lock
++ * Fallback: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/spinlock.3.html
+  */
++
++#if __MAC_OS_X_VERSION_MIN_REQUIRED > 101100
++
+ #include <os/lock.h>
+ 
+ typedef os_unfair_lock pthread_spinlock_t;
+@@ -204,6 +211,42 @@ static inline int pthread_spin_destroy(pthread_spinlock_t *lock)
+ 	return 0;
+ }
+ 
++#else
++
++#include <libkern/OSAtomic.h>
++
++typedef OSSpinLock pthread_spinlock_t;
++
++static inline int pthread_spin_init(pthread_spinlock_t *lock, int type)
++{
++	*lock = OS_SPINLOCK_INIT;
++	return 0;
++}
++
++static inline int pthread_spin_lock(pthread_spinlock_t *lock)
++{
++	OSSpinLockLock(lock);
++	return 0;
++}
++
++static inline int pthread_spin_unlock(pthread_spinlock_t *lock)
++{
++	OSSpinLockUnlock(lock);
++	return 0;
++}
++
++static inline int pthread_spin_trylock(pthread_spinlock_t *lock)
++{
++	return OSSpinLockTry(lock) ? 0 : EBUSY;
++}
++
++static inline int pthread_spin_destroy(pthread_spinlock_t *lock)
++{
++	return 0;
++}
++
++#endif
++
+ #ifdef __cplusplus
+ }
+ #endif


### PR DESCRIPTION
#### Description

1. Commit in upstream: https://github.com/ofiwg/libfabric/commit/4ff6e66fd6f2ab23eae3f9e689d88d61e2742eb72. 
2. `-march=` is invalid flag on PPC, `-mtune=` should be used.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
