### PR TITLE
micronaut: update to 3.8.5

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.8.4 v
+github.setup    micronaut-projects micronaut-starter 3.8.5 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +54,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  fd9ea25266802cd6024f7516f9a9d4b7b96ebe9b \
-                sha256  a9ae9faf5afb1b3b22a56cd73095b5a2bf2f0fe0c014f3d7f42701f035292122 \
-                size    20147846
+checksums       rmd160  fa285fe9d33aa6c1851e560291d5eef150cefcf7 \
+                sha256  1c3dcc0e60508ba1ae91dd2558c9141d987db7b9c8e2a07ce8330eeafd8443d5 \
+                size    20150201
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.8.5.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?