### PR TITLE
datree: updated to version 1.8.26

### DIFF
--- a/devel/datree/Portfile
+++ b/devel/datree/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/datreeio/datree 1.8.24
+go.setup            github.com/datreeio/datree 1.8.26
 revision            0
 
 categories          devel
@@ -14,9 +14,9 @@ description         CLI tool to run policies against Kubernetes manifests YAML f
 long_description    Datree automatically validates Kubernetes objects for rule violations, ensuring no misconfigurations reach production
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  86efa7f46c7ba779038fce7e9f727614ca8611de \
-                    sha256  2a0bf0831a55bb91144679bce28c53efb15fb64a9974668c1680837150df8719 \
-                    size    5638173
+                    rmd160  4b59884976d7df531096e3bf25593c69edaada87 \
+                    sha256  a2e5d6b3fe8560985bfa179e2787798f19adf8229a7ee65788b74e7bdedfb06d \
+                    size    5638199
 
 set go_ldflags      "-s -w -X ${go.package}/cmd.CliVersion=${version}"
 build.args          -tags main -ldflags \"${go_ldflags}\"


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Command Line Tools 14.0.0.0.1.1661618636

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
