### PR TITLE
gnutls: use muniversal-1.1

### DIFF
--- a/devel/gnutls/Portfile
+++ b/devel/gnutls/Portfile
@@ -6,7 +6,7 @@ PortGroup       active_variants 1.1
 PortGroup       compiler_blacklist_versions 1.0
 PortGroup       conflicts_build 1.0
 PortGroup       legacysupport 1.0
-PortGroup       muniversal 1.0
+PortGroup       muniversal 1.1
 
 name            gnutls
 version         3.7.9
@@ -171,32 +171,8 @@ variant guile description {Build guile bindings} {
     configure.args-replace  --disable-guile --enable-guile
 }
 
-if {${universal_possible} && [variant_isset universal]} {
-    set merger_host(x86_64) x86_64-apple-${os.platform}${os.major}
-    set merger_host(i386) i686-apple-${os.platform}${os.major}
-    set merger_configure_args(x86_64) --build=x86_64-apple-${os.platform}${os.major}
-    set merger_configure_args(i386) --build=i686-apple-${os.platform}${os.major}
-    set merger_host(ppc) powerpc-apple-${os.platform}${os.major}
-    set merger_host(ppc64) powerpc64-apple-${os.platform}${os.major}
-    set merger_configure_args(ppc) --build=powerpc-apple-${os.platform}${os.major}
-    set merger_configure_args(ppc64) --build=powerpc64-apple-${os.platform}${os.major}
-} elseif {${build_arch} eq "i386"} {
-    configure.args-append \
-        --host=i686-apple-${os.platform}${os.major} \
-        --build=i686-apple-${os.platform}${os.major}
-} elseif {${build_arch} eq "ppc"} {
-    configure.args-append \
-        --host=powerpc-apple-${os.platform}${os.major} \
-        --build=powerpc-apple-${os.platform}${os.major}
-} elseif {${build_arch} eq "ppc64"} {
-    configure.args-append \
-        --host=powerpc64-apple-${os.platform}${os.major} \
-        --build=powerpc64-apple-${os.platform}${os.major}
-} else {
-    configure.args-append \
-        --host=${build_arch}-apple-${os.platform}${os.major} \
-        --build=${build_arch}-apple-${os.platform}${os.major}
-}
+triplet.add_host    all
+triplet.add_build   all
 
 test.run        yes
 test.target     check


### PR DESCRIPTION
Using  muniversal1-1.1 reduced duplicate code

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
