### PR TITLE
fuzz: fix the build for new macOS, improve portfile

### DIFF
--- a/devel/fuzz/Portfile
+++ b/devel/fuzz/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fuzz
 version             0.6
-revision            1
+revision            2
 categories          devel security
 license             GPL-2
 maintainers         nomaintainer
@@ -21,5 +21,8 @@ master_sites        sourceforge:project/fuzz/fuzz/${version}
 checksums           rmd160  cc7e2454850d478dfc8aedd4067a10367c889729 \
                     sha256  70fcd0d5b83f211f0a6fd9a95e1772c3e3aaaf83d533ae224a57812c00c0ce1b \
                     size    54431
+
+# https://trac.macports.org/ticket/62631
+patchfiles          patch-getopt.diff
 
 configure.args      --mandir=${prefix}/share/man

--- a/devel/fuzz/Portfile
+++ b/devel/fuzz/Portfile
@@ -1,21 +1,25 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name            	fuzz
-version         	0.6
-revision		1
-categories      	devel security
-license         	GPL-2
-maintainers     	nomaintainer
-platforms       	darwin
-description     	software security checking tool
-homepage        	http://fuzz.sourceforge.net/
-master_sites    	sourceforge:project/fuzz/fuzz/${version}
-checksums     		md5 8c8e7c49729e0a98c0414faac7778ec7
-configure.args		--mandir=${prefix}/share/man
-long_description 	The fuzz generator is designed to attack certain kinds \
-			of software and expose one particular kind of bug \
-			common in software. This is the situation where the \
-			programmer implicity makes some assumtions about \
-			the data stream that the program will be parsing.  \
-			If the data stream is substantially different then \
-			the program might not be able to deal with it.
+PortSystem          1.0
+
+name                fuzz
+version             0.6
+revision            1
+categories          devel security
+license             GPL-2
+maintainers         nomaintainer
+description         Software security checking tool
+long_description    The fuzz generator is designed to attack certain kinds \
+                    of software and expose one particular kind of bug \
+                    common in software. This is the situation where \
+                    a programmer implicity makes some assumtions about \
+                    the data stream that the program will be parsing.  \
+                    If the data stream is substantially different then \
+                    the program might not be able to deal with it.
+homepage            http://fuzz.sourceforge.net/
+master_sites        sourceforge:project/fuzz/fuzz/${version}
+checksums           rmd160  cc7e2454850d478dfc8aedd4067a10367c889729 \
+                    sha256  70fcd0d5b83f211f0a6fd9a95e1772c3e3aaaf83d533ae224a57812c00c0ce1b \
+                    size    54431
+
+configure.args      --mandir=${prefix}/share/man

--- a/devel/fuzz/files/patch-getopt.diff
+++ b/devel/fuzz/files/patch-getopt.diff
@@ -1,0 +1,12 @@
+--- getopt.c.orig	1998-11-23 08:59:47.000000000 +0800
++++ getopt.c	2023-02-23 23:30:19.000000000 +0800
+@@ -62,6 +62,9 @@
+ 
+ #ifndef ELIDE_CODE
+ 
++#ifdef __APPLE__
++#include <string.h>
++#endif
+ 
+ /* This needs to come after some library #include
+    to get __GNU_LIBRARY__ defined.  */


### PR DESCRIPTION
#### Description

On 10.6 the fix is not required, only warnings show up, but on newer systems the build fails: https://trac.macports.org/ticket/62631
Hopefully this fixes the problem.

UPD. Apparently it does :)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
