### PR TITLE
wxWidgets-3.0: minor fix for PPC (relevant on 10.6, does not change anything for other configs)

### DIFF
--- a/graphics/wxWidgets-3.0/Portfile
+++ b/graphics/wxWidgets-3.0/Portfile
@@ -90,6 +90,9 @@ configure.env-append \
 
 patchfiles-append   patch-configure.diff
 
+# 10.6-on-PPC hack; tested also on Rosetta:
+patchfiles-append   patch-ppc.diff
+
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|g" ${patch.dir}/configure
 

--- a/graphics/wxWidgets-3.0/files/patch-ppc.diff
+++ b/graphics/wxWidgets-3.0/files/patch-ppc.diff
@@ -1,0 +1,44 @@
+--- src/osx/utils_osx.cpp.orig	2020-05-02 22:03:18.000000000 +0800
++++ src/osx/utils_osx.cpp	2023-02-23 19:30:16.000000000 +0800
+@@ -71,7 +71,7 @@
+ {
+     int theDepth = 0;
+     
+-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__ppc__)
+     if ( UMAGetSystemVersion() >= 0x1060 ) 
+     {
+         CGDisplayModeRef currentMode = CGDisplayCopyDisplayMode(kCGDirectMainDisplay);
+@@ -94,7 +94,7 @@
+     else
+ #endif
+     {
+-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || (MAC_OS_X_VERSION_MIN_REQUIRED == 1060 && defined __ppc__)
+         theDepth = (int) CGDisplayBitsPerPixel(CGMainDisplayID());
+ #endif
+     }
+
+--- src/osx/webview_webkit.mm.orig	2020-05-02 22:03:18.000000000 +0800
++++ src/osx/webview_webkit.mm	2023-02-23 19:44:37.000000000 +0800
+@@ -1123,7 +1123,7 @@
+ 
+             case NSURLErrorUserAuthenticationRequired:
+             case NSURLErrorSecureConnectionFailed:
+-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6 && !defined(__ppc__)
+             case NSURLErrorClientCertificateRequired:
+ #endif
+                 *out = wxWEBVIEW_NAV_ERR_AUTH;
+
+--- src/osx/carbon/dcscreen.cpp.orig	2020-05-02 22:03:18.000000000 +0800
++++ src/osx/carbon/dcscreen.cpp	2023-02-23 20:10:50.000000000 +0800
+@@ -90,7 +90,7 @@
+ 
+     CGImageRef image = NULL;
+     
+-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6 && !defined(__ppc__)
+     if ( UMAGetSystemVersion() >= 0x1060)
+     {
+         image = CGDisplayCreateImage(kCGDirectMainDisplay);


### PR DESCRIPTION
#### Description

This is relevant only for Rosetta and 10.6 ppc. Nothing else is affected.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server (Rosetta)
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
