### PR TITLE
argyll: update to 2.3.1

### DIFF
--- a/graphics/argyll/Portfile
+++ b/graphics/argyll/Portfile
@@ -3,11 +3,11 @@
 PortSystem              1.0
 
 name                    argyll
-version                 2.3.0
-revision                1
-checksums               rmd160  fcd8d70e14bea0758946270f8cfa748469c247a0 \
-                        sha256  daa21b6de8e20b5319a10ea8f72829d32eadae14c6581b50972f2f8dd5cde924 \
-                        size    14042268
+version                 2.3.1
+revision                0
+checksums               rmd160  08a703814507e6c4b6821d97ddd5506540ab3106 \
+                        sha256  bd0bcf58cec284824b79ff55baa242903ed361e12b1b37e12228679f9754961c \
+                        size    14098636
 
 categories              graphics
 maintainers             nomaintainer
@@ -33,6 +33,8 @@ depends_lib-append      port:libpng
 depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb
 depends_lib-append      port:tiff
 depends_lib-append      port:zlib
+
+patchfiles-append       patch-ppc.diff
 
 post-extract {
     # To make sure that in case of problems the build will fail instead

--- a/graphics/argyll/files/patch-ppc.diff
+++ b/graphics/argyll/files/patch-ppc.diff
@@ -1,0 +1,95 @@
+--- spectro/dispwin.c.orig	2022-06-28 16:42:04.000000000 +0800
++++ spectro/dispwin.c	2023-02-24 00:22:41.000000000 +0800
+@@ -1620,7 +1620,7 @@
+ #ifdef UNIX_APPLE
+ 	/* Various support functions */
+ 
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED < 1060
++#if __MAC_OS_X_VERSION_MAX_ALLOWED < 1060 || defined(__POWERPC__)
+ 
+ /* Given a location, return a string for it's path */
+ static char *plocpath(CMProfileLocation *ploc) {
+@@ -1659,7 +1659,7 @@
+ 
+ #endif /* < 10.6 */
+ 
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__ppc__)
+ 
+ /* There doesn't seem to be any means of determining the locations */
+ /* of profiles using current OS X API's, so we simply hard code them. */
+@@ -1836,7 +1836,7 @@
+ static void *cur_colorsync_ref(dispwin *p) {
+ 	void *cspr = NULL;
+  
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__ppc__)
+ 	CFURLRef url;
+ 	ColorSyncProfileRef ref;
+ 	CFErrorRef ev;
+@@ -1968,7 +1968,7 @@
+ 	/* to rename the currently selected profile file, ie. because it is a system profile. */
+ 	/* [ Would a workaround be to use a link, or copy of the system file ? ] */
+ 	if (persist)
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__ppc__)
+ 	if (persist) {					/* Persistent */
+ 		int rv = 0;
+ 		CFStringRef id;
+@@ -2838,7 +2838,7 @@
+ 
+ #ifdef UNIX_APPLE
+ 
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__ppc__)
+ 	{
+ 		char *dpath;		/* Install file path */
+ 		CFUUIDRef dispuuid;
+@@ -3361,7 +3361,7 @@
+ #endif /* NT */
+ 
+ #ifdef UNIX_APPLE
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__ppc__)
+ 	{
+ 		char *dpath; 			/* Read file path */
+ 		struct stat sbuf;
+@@ -4030,7 +4030,7 @@
+ 		}
+ 
+ 		if (cspr != NULL) {
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__ppc__)
+ 			CFRelease((ColorSyncProfileRef)cspr);
+ #else
+ 			CMCloseProfile((CMProfileRef)cspr);
+@@ -4039,7 +4039,7 @@
+ 	}
+ #endif /* >= 10.6 */
+ 
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1040
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__ppc__)
+ 	/* >= 10.6+ device colors don't work on secondary displays and need a null transform. */
+ 	/*  < 10.6 null transform doesn't work, but isn't needed. */
+ 
+@@ -5080,7 +5080,7 @@
+ 	}
+ 	p->ddid = disp->ddid;		/* Display we're working on */
+ 
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__ppc__)
+ 	{
+ 		CGDisplayModeRef dispmode;
+ 		CFStringRef pixenc;
+
+--- spectro/dispcal.c.orig	2022-06-28 16:42:00.000000000 +0800
++++ spectro/dispcal.c	2023-02-24 00:30:57.000000000 +0800
+@@ -1770,7 +1770,7 @@
+ 		/* Hmm. Maybe this should actually be 1.72 ?? */
+ 		g_def_gamma = 1.8;
+ 
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1040
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__ppc__)
+ 		/* "Gestalt(gestaltSystemVersion, &MacVers)" is supported for early */
+ 		/* systems, but was deprecated in 10.8 and causes warnings in 10.10. */
+ 		/* gestaltSystemVersionMajor etc. isn't supported on older systems. */


### PR DESCRIPTION
#### Description

Update plus some minor fixes for PPC.

P. S. Current 2.3.0 fails for new systems (Big Sur up), but it is unclear why: https://ports.macports.org/port/argyll/details
If 2.3.1 also gonna fail, I will try to fix it.

UPD. Okay, this version builds fine on new macOS.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
