### PR TITLE
dotnet: Add .NET 7 and 8 versions

### DIFF
--- a/dotnet/aspnetcore-runtime-devel/Portfile
+++ b/dotnet/aspnetcore-runtime-devel/Portfile
@@ -3,11 +3,12 @@
 PortSystem          1.0
 
 name                aspnetcore-runtime-devel
-version             7.0.0-preview.1.22109.13
-revision            1
+version             8.0.0-preview.1.23112.2
+revision            0
 categories          dotnet
 license             MIT
-maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} openmaintainer
+maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} \
+                    {@judaew judaew} openmaintainer
 
 description         ASP.NET Core is a cross-platform .NET framework for building modern \
                     cloud-based web applications on Windows, Mac, or Linux.
@@ -25,15 +26,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            aspnetcore-runtime-${version}-osx-x64
-        checksums           rmd160  a71ead97cb8a18af5fdd628e2417e6539f7bd422 \
-                            sha256  90cf2f9bbd50e9bc96299fa9f9947a48b9711908c9b37e6869de84b5001a86e3 \
-                            size    39610253
+        checksums           rmd160  9b6bf31c56550c4fa4461126e3b2f14ba4365988 \
+                            sha256  84c9f2359ee92cce7712f0ee88854533da25d62d1be4268e98fe413eae7eb317 \
+                            size    39486726
     }
     arm64 {
         distname            aspnetcore-runtime-${version}-osx-arm64
-        checksums           rmd160  eb8151ffa35136f18a838cef3409219dd8ab5b90 \
-                            sha256  efff62b35fc894fb3174ac5c173ce93528303ec16e44ff42f0ec708dae338da2 \
-                            size    37739010
+        checksums           rmd160  4aae970652528ca87b60805627e7d051820665d2 \
+                            sha256  2ca87cb060b403900ba7579168afd9fccda616090dc7821fac1280befee1114f \
+                            size    37757269
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-aspnetcore-runtime-7/Portfile
+++ b/dotnet/dotnet-aspnetcore-runtime-7/Portfile
@@ -1,0 +1,65 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                aspnetcore-runtime-7
+version             7.0.3
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} \
+                    {@judaew judaew} openmaintainer
+
+description         ASP.NET Core is a cross-platform .NET framework for building modern \
+                    cloud-based web applications on Windows, Mac, or Linux.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64 arm64
+
+switch ${build_arch} {
+    x86_64 {
+        distname            aspnetcore-runtime-${version}-osx-x64
+        checksums           rmd160  79bd82e4c02739b1734e010f70818a26560c4060 \
+                            sha256  ac58b6ace4114a73f57e471f607203e96b46b8eadab3e90c76e4a4b1df91a417 \
+                            size    40545018
+    }
+    arm64 {
+        distname            aspnetcore-runtime-${version}-osx-arm64
+        checksums           rmd160  d1b1a76eb19b2101827784b0f4e8cd7d6aa07e99 \
+                            sha256  937405b908260293a14299f47f35716f63e25be4ce84b7ea162c5e8fac783d23 \
+                            size    38619619
+    }
+    default {
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} @ ${version} only supported for architectures ${supported_archs}"
+            return -code error "Unsupported architecture: ${build_arch}"
+        }
+    }
+}
+
+master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set runtime_dir /shared/Microsoft.AspNetCore.App
+    xinstall -d ${destroot}${dotnet_home}${runtime_dir}
+
+    move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
+}

--- a/dotnet/dotnet-cli/Portfile
+++ b/dotnet/dotnet-cli/Portfile
@@ -3,11 +3,12 @@
 PortSystem          1.0
 
 name                dotnet-cli
-version             6.0.3
-revision            2
+version             7.0.3
+revision            0
 categories          dotnet
 license             MIT
-maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} openmaintainer
+maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} \
+                    {@judaew judaew} openmaintainer
 
 description         The .NET command-line interface (CLI) is a cross-platform toolchain \
                     for developing, building, running, and publishing .NET applications.
@@ -30,15 +31,15 @@ master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  f441ab8fb2762ea542de7684ad2ddac2b4a7c9a6 \
-                            sha256  7852d49ed7b6fa054efce7eade625cc56aae5265bc4f7e6f5c065da119269f44 \
-                            size    30077032
+        checksums           rmd160  8cb9736ac693d02ff8a47c178a73d2c2269755cf \
+                            sha256  befd6a557ee8a468f768f5223beb709b41f68a5488fbb0b62ff6b2cedd8fcd93 \
+                            size    30834606
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  e6944f5a32e22270b6f8feb3662447c758c82244 \
-                            sha256  eb5cc767c16c2b66c3c0bd69b3360b663920aaa1c254411cbd64b4b1081820fc \
-                            size    28169432
+        checksums           rmd160  b114134441984d1dfbd0fd1f400cc038722e74cf \
+                            sha256  e1d4a2c1931ca98bd1728a965b974cd40610c2b63f3c22021fc520d7e1b516fb \
+                            size    29156526
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-7/Portfile
+++ b/dotnet/dotnet-runtime-7/Portfile
@@ -1,0 +1,64 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-runtime-7
+version             7.0.3
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} \
+                    {@judaew judaew} openmaintainer
+
+description         .NET is a cross-platform runtime for cloud, mobile, desktop, and IoT apps.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64 arm64
+
+switch ${build_arch} {
+    x86_64 {
+        distname            dotnet-runtime-${version}-osx-x64
+        checksums           rmd160  8cb9736ac693d02ff8a47c178a73d2c2269755cf \
+                            sha256  befd6a557ee8a468f768f5223beb709b41f68a5488fbb0b62ff6b2cedd8fcd93 \
+                            size    30834606
+    }
+    arm64 {
+        distname            dotnet-runtime-${version}-osx-arm64
+        checksums           rmd160  b114134441984d1dfbd0fd1f400cc038722e74cf \
+                            sha256  e1d4a2c1931ca98bd1728a965b974cd40610c2b63f3c22021fc520d7e1b516fb \
+                            size    29156526
+    }
+    default {
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} @ ${version} only supported for architectures ${supported_archs}"
+            return -code error "Unsupported architecture: ${build_arch}"
+        }
+    }
+}
+
+master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set runtime_dir /shared/Microsoft.NETCore.App
+    xinstall -d ${destroot}${dotnet_home}${runtime_dir}
+
+    move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
+}

--- a/dotnet/dotnet-runtime-devel/Portfile
+++ b/dotnet/dotnet-runtime-devel/Portfile
@@ -3,11 +3,12 @@
 PortSystem          1.0
 
 name                dotnet-runtime-devel
-version             7.0.0-preview.1.22076.8
-revision            1
+version             8.0.0-preview.1.23110.8
+revision            0
 categories          dotnet
 license             MIT
-maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} openmaintainer
+maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} \
+                    {@judaew judaew} openmaintainer
 
 description         .NET is a cross-platform runtime for cloud, mobile, desktop, and IoT apps.
 
@@ -24,15 +25,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  8830697c90c5aa384ea47cb28367baeafb59d531 \
-                            sha256  6d8100f7dd27eb7c50a1d1625998af43d61dbdcce828b1f251c2a5656796b1f1 \
-                            size    30471110
+        checksums           rmd160  bfdf6835588c7d94789440d445b014c63ce062d5 \
+                            sha256  f470fc5f27a90e90b8825c371bf389b523876410e10787f96fab77d7d270c148 \
+                            size    29884353
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  af2db2cb2a2ec42f3a8d7d87190796927f607825 \
-                            sha256  14500e9114687919b3d1ac6aa07cb03904dffe07c04827827882c154c14ae1a2 \
-                            size    28822312
+        checksums           rmd160  f03267f4aa81173a1ff0e014e22e34ef61557222 \
+                            sha256  c9ca701e150d64a59628ae3d46fcfbe333cda8390b29b6c2aaf751177daa8354 \
+                            size    28364803
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-sdk-7/Portfile
+++ b/dotnet/dotnet-sdk-7/Portfile
@@ -1,0 +1,71 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-sdk-7
+version             7.0.200
+revision            0
+categories          dotnet devel
+license             MIT
+maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} \
+                    {@judaew judaew} openmaintainer
+
+description         Core functionality needed to create .NET Core projects, that is \
+                    shared between Visual Studio and CLI
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64 arm64
+
+switch ${build_arch} {
+    x86_64 {
+        distname            dotnet-sdk-${version}-osx-x64
+        checksums           rmd160  ca2daa03d39288b1e3ab4d62c5d20009dc5039d5 \
+                            sha256  12c9360fd0edd72a2185c621c027e38e47f57a14079fc9ebe2aa1eeba18165a8 \
+                            size    195724987 \
+    }
+    arm64 {
+        distname            dotnet-sdk-${version}-osx-arm64
+        checksums           rmd160  94248edab1063e99bb38f8fd1c05cd22f44e3cb2 \
+                            sha256  ec03313116c5dcebba25eda3d6b6977c6f22c12b78fe1c4398a38f1a491de313 \
+                            size    190904608
+    }
+    default {
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} @ ${version} only supported for architectures ${supported_archs}"
+            return -code error "Unsupported architecture: ${build_arch}"
+        }
+    }
+}
+
+master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli \
+                    port:dotnet-runtime-7 \
+                    port:aspnetcore-runtime-7
+
+build {}
+
+destroot {
+    set dotnet_manifest_version 7.0.100
+    set dotnet_home ${prefix}/share/dotnet
+
+    # Create the target directory
+    xinstall -d ${destroot}${dotnet_home}/sdk
+    xinstall -d ${destroot}${dotnet_home}/sdk-manifests
+
+    move ${worksrcpath}/sdk/${version} ${destroot}${dotnet_home}/sdk
+    move ${worksrcpath}/sdk-manifests/${dotnet_manifest_version} ${destroot}${dotnet_home}/sdk-manifests
+}

--- a/dotnet/dotnet-sdk-devel/Portfile
+++ b/dotnet/dotnet-sdk-devel/Portfile
@@ -3,13 +3,14 @@
 PortSystem          1.0
 
 name                dotnet-sdk-devel
-set main_version    7.0.100
-set patch_version   preview.1.22110.4
+set main_version    8.0.100
+set patch_version   preview.1.23115.2
 version             ${main_version}-${patch_version}
-revision            2
+revision            0
 categories          dotnet devel
 license             MIT
-maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} openmaintainer
+maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} \
+                    {@judaew judaew} openmaintainer
 
 description         Core functionality needed to create .NET Core projects, that is \
                     shared between Visual Studio and CLI
@@ -27,15 +28,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-sdk-${version}-osx-x64
-        checksums           rmd160  c03c97494fcaf8725abf6ef60fa6a77464008859 \
-                            sha256  d2896a0815303906154b9702783427461bfa29f316ed9440ca28519798ca4860 \
-                            size    176312921
+        checksums           rmd160  7945652b623a9ce0a7fcedd91e46df82774649b2 \
+                            sha256  ec5ef47d256d99335c423f85ab905c6d8515b2c9ab21778786bc86fbcfb35bf0 \
+                            size    188116346
     }
     arm64 {
         distname            dotnet-sdk-${version}-osx-arm64
-        checksums           rmd160  50d912f93a6cb4ed210a95d190a7861383fd0231 \
-                            sha256  98d1d357f69a71b775f9141c14f6f7133a150b8240d3b594c4012ffb190356fa \
-                            size    171842455
+        checksums           rmd160  3adf7ed378a8f888aa7cd52f4d9416053d0c10ad \
+                            sha256  4447c219724a004e83666537a6c65ed8748fa4fe942efbb7cac94e9637c3bd27 \
+                            size    183553815
     }
     default {
         known_fail yes
@@ -60,7 +61,7 @@ depends_run         port:dotnet-cli \
 build {}
 
 destroot {
-    set dotnet_manifest_version ${main_version}
+    set dotnet_manifest_version 8.0.100-preview.1
     set dotnet_home ${prefix}/share/dotnet
 
     # Create the target directory


### PR DESCRIPTION
#### Description

Motivation: The .NET 7 version is already in release, and a pre-release version of .NET 8 has also available.

Commits:

- aspnetcore-runtime-devel: Update to 8.0.0-preview.1.23112.2
- dotnet-runtime-devel: Update to 8.0.0-preview.1.23110.8
- dotnet-sdk-devel: Update to 8.0.100-preview.1.23115.2
- dotnet-cli: Update to 7.0.3
- aspnetcore-runtime-7: New port (version 7.0.3)
- dotnet-runtime-7: New port (version 7.0.3)
- dotnet-sdk-7: New port (version 7.0.200)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2.1 22D68 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
