### PR TITLE
google-cloud-sdk: update to 419.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             418.0.0
+version             419.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  7be6fb13f5620becbc47a6ca5a5569f94b61ea8b \
-                    sha256  ff8c0b6167552a4972cbff880c9f0d33328eb916fd36554bcfd635fdeb3956f8 \
-                    size    111100781
+    checksums       rmd160  632c2dfed2bfbe05b86cbf8a10639c6ba35b8d11 \
+                    sha256  ec4bb3923b03a8afcdf4da97f9a2740782635a0df884200bd5bd9388dcea050c \
+                    size    111278222
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  669c15b0b566dfdf3dccc478fe6c7fd0c570f78f \
-                    sha256  694df6ebff8ee3b74d954351cf65f07d8cbf2fc5c1f139d148bb05e654f4a497 \
-                    size    131423201
+    checksums       rmd160  7e58324f0e62e01c7001fc138104d04b220c65da \
+                    sha256  39890f5f541c3282931cd61b80faccb39bbb496ed7437c53a75b2915427ed53b \
+                    size    131602640
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  2ce836861b9e38cff2c6a2d0c412c04e2bded08b \
-                    sha256  47804aee59b32b72bcd0a12b149abf3937c64957ea98aeb7abb41e5adde523fe \
-                    size    128267097
+    checksums       rmd160  abd241ecdead59770af0755e67ff3b8183107e29 \
+                    sha256  40bf84e3153f8c6313009164bb6413ef4c827f3f8a5ce753b537c1e599e7e05b \
+                    size    128442219
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 419.0.0.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?