### PR TITLE
istioctl: update to 1.17.1; add @ajhall as maintainer

### DIFF
--- a/sysutils/istioctl/Portfile
+++ b/sysutils/istioctl/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 name                istioctl
 revision            0
 
-go.setup            github.com/istio/istio 1.16.1
+go.setup            github.com/istio/istio 1.17.1
 categories          sysutils
 supported_archs     x86_64 arm64
 license             Apache-2
@@ -30,9 +30,9 @@ github.livecheck.regex \
 
 go.package          istio.io/istio
 
-checksums           rmd160  bdd68fc9e19227b0d2b77115aeefa7b09cee5638 \
-                    sha256  357b147578a00b0da5148a53963d1a086c79cbda345b4607f9cbe8d9f4b50220 \
-                    size    4909940
+checksums           rmd160  c99ff2cf9e276ae02350010a4c99567e779083b6 \
+                    sha256  509e1b9ad4d78b6349c69d86da31f11f5739e1e6318d0a0ddc25c1e074884dc6 \
+                    size    4595273
 
 build.cmd           make
 build.target        ${name}

--- a/sysutils/istioctl/Portfile
+++ b/sysutils/istioctl/Portfile
@@ -11,7 +11,9 @@ categories          sysutils
 supported_archs     x86_64 arm64
 license             Apache-2
 
-maintainers         {vmware.com:nnikolay @nickolaev} openmaintainer
+maintainers         {vmware.com:nnikolay @nickolaev} \
+                    {ajhall.us:macports @ajhall} \
+                    openmaintainer
 
 description         Istio command line configuration utility
 long_description    Istio is an open, platform-independent service mesh designed \


### PR DESCRIPTION
#### Description
istioctl: update to 1.17.1

I also added myself as a co-maintainer since I've been updating this port for a few months and the main maintainer hasn't been responsive recently.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.2.1 22D68 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
