### PR TITLE
wxWidgets-3.2: Fix universal build

### DIFF
--- a/graphics/wxWidgets-3.2/Portfile
+++ b/graphics/wxWidgets-3.2/Portfile
@@ -128,6 +128,12 @@ variant universal {
                             --disable-precomp-headers
 }
 
+# Remove the default universal flags, universal is handled above
+configure.universal_ldflags
+configure.universal_cflags
+configure.universal_cxxflags
+configure.universal_cppflags
+
 variant debug description {add debug info to libraries} {
     configure.args-append   --enable-debug
 }


### PR DESCRIPTION
#### Description

Fixes universal builds of wxWidgets-3.2

Fixes [#62206](https://trac.macports.org/ticket/62206)

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2.1（22D68）
Xcode 14.2 (14C18)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
