### PR TITLE
Fortran: new packages

### DIFF
--- a/fortran/fortran-curl/Portfile
+++ b/fortran/fortran-curl/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        interkosmos fortran-curl 317f0f5c0e5045a0f3c402d4137a869cda6194fc
+version             0.3.0
+revision            0
+categories          fortran devel net
+license             ISC
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Fortran 2018 ISO_C_BINDING interfaces to Perl-compatible Regular Expressions 2
+long_description    {*}${description}
+checksums           rmd160  d8c4a4bc90b84ecc5f8b848811437bc7c82f9d6c \
+                    sha256  2d7fe13933ffe5187e1481e6d8479f098db4996c589b92fb350aeb9909f6636a \
+                    size    16951
+
+depends_lib-append  port:curl
+
+patchfiles          patch-Makefile.diff
+
+post-patch {
+    reinplace "s,@PREFIX@,${prefix}," ${worksrcpath}/Makefile
+    reinplace "s,@CC@,${configure.cc}," ${worksrcpath}/Makefile
+    reinplace "s,@FC@,${configure.fc}," ${worksrcpath}/Makefile
+    reinplace "s,@CFLAGS@,${configure.cflags} [get_canonical_archflags cc]," ${worksrcpath}/Makefile
+    reinplace "s,@FFLAGS@,${configure.fcflags}," ${worksrcpath}/Makefile
+}
+
+compilers.setup     require_fortran
+compiler.blacklist-append *gcc-4.* {clang < 500}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/include/${name}
+    copy ${worksrcpath}/libfortran-curl.a ${destroot}${prefix}/lib/
+    copy ${worksrcpath}/curl.mod ${destroot}${prefix}/include/${name}/
+}
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} LICENCE README.md ${destroot}${docdir}
+}

--- a/fortran/fortran-curl/files/patch-Makefile.diff
+++ b/fortran/fortran-curl/files/patch-Makefile.diff
@@ -1,0 +1,22 @@
+--- Makefile.orig	2022-05-14 06:05:16.000000000 +0800
++++ Makefile	2023-02-24 18:23:58.000000000 +0800
+@@ -1,14 +1,14 @@
+ .POSIX:
+ .SUFFIXES:
+ 
+-FC      = gfortran
+-CC      = gcc
++FC      = @FC@
++CC      = @CC@
+ AR      = ar
+-PREFIX  = /usr/local
++PREFIX  = @PREFIX@
+ DEBUG   = #-ggdb3 -O0
+ 
+-FFLAGS  = $(DEBUG) -Wall -Wno-unused-dummy-argument -std=f2008 -fmax-errors=1 -fcheck=all
+-CFLAGS  = $(DEBUG) -Wall
++FFLAGS  = @FFLAGS@ $(DEBUG) -Wall -Wno-unused-dummy-argument -std=f2008 -fmax-errors=1 -fcheck=all
++CFLAGS  = @CFLAGS@ $(DEBUG) -Wall
+ LDFLAGS = -I$(PREFIX)/include/ -L$(PREFIX)/lib/
+ LDLIBS  = -lcurl
+ ARFLAGS = rcs

--- a/fortran/fortran-pcre2/Portfile
+++ b/fortran/fortran-pcre2/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        interkosmos fortran-pcre2 0.1.0
+revision            0
+categories          fortran devel
+license             ISC
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Fortran 2018 ISO_C_BINDING interfaces to Perl-compatible Regular Expressions 2
+long_description    {*}${description}
+checksums           rmd160  54b0beddafc2b5ff1007dee08c1d0d38d209bb6d \
+                    sha256  5a7b32a5b533fd028d05766ffb8a81d1dd2ff391159d8b8761ae7453dbebfb86 \
+                    size    9442
+
+depends_lib-append  port:pcre2
+
+post-patch {
+    reinplace "s,@PREFIX@,${prefix}," ${worksrcpath}/Makefile
+    reinplace "s,@FC@,${configure.fc}," ${worksrcpath}/Makefile
+    reinplace "s,@FFLAGS@,${configure.fcflags}," ${worksrcpath}/Makefile
+}
+
+compilers.setup     require_fortran
+compiler.blacklist-append *gcc-4.* {clang < 500}
+
+use_parallel_build  no
+
+destroot {
+    xinstall -d ${destroot}${prefix}/include/${name}
+    copy ${worksrcpath}/libfortran-pcre2.a ${destroot}${prefix}/lib/
+    copy ${worksrcpath}/pcre2.mod ${destroot}${prefix}/include/${name}/
+}
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} LICENCE README.md ${destroot}${docdir}
+}
+
+test.run            yes
+test.cmd            ./test_pcre2
+test.target

--- a/fortran/fortran-pcre2/files/patch-Makefile.diff
+++ b/fortran/fortran-pcre2/files/patch-Makefile.diff
@@ -1,0 +1,14 @@
+--- Makefile.orig	2022-04-12 01:45:47.000000000 +0800
++++ Makefile	2023-02-24 18:37:57.000000000 +0800
+@@ -1,8 +1,8 @@
+ .POSIX:
+ 
+-FC      = gfortran
+-PREFIX  = /usr/local
+-FFLAGS  = -Wall -Wno-maybe-uninitialized -fmax-errors=1 -fcheck=all
++FC      = @FC@
++PREFIX  = @PREFIX@
++FFLAGS  = @FFLAGS@ -Wall -Wno-maybe-uninitialized -fmax-errors=1 -fcheck=all
+ LDFLAGS = -I$(PREFIX)/include/ -L$(PREFIX)/lib/
+ LDLIBS  = -lpcre2-8
+ ARFLAGS = rcs

--- a/fortran/fortran-zlib/Portfile
+++ b/fortran/fortran-zlib/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        interkosmos fortran-zlib 63a69f36e3a08bbbe367fc1dc068f6b6ad91355f
+version             0.1.0
+revision            0
+categories          fortran archivers
+license             ISC
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Collection of Fortran 2018 ISO_C_BINDING interfaces to selected zlib functions
+long_description    {*}${description}
+checksums           rmd160  809a9743b03091838e0b5c4dfec32ab3fee11b93 \
+                    sha256  c6f2dc462df57118bb9ab1e4de2171ab95848ae29b2ca5410ef6087c05559c4f \
+                    size    5850
+
+depends_lib-append  port:zlib
+
+patchfiles          patch-Makefile.diff
+
+post-patch {
+    reinplace "s,@PREFIX@,${prefix}," ${worksrcpath}/Makefile
+    reinplace "s,@FC@,${configure.fc}," ${worksrcpath}/Makefile
+    reinplace "s,@FFLAGS@,${configure.fcflags}," ${worksrcpath}/Makefile
+}
+
+compilers.setup     require_fortran
+compiler.blacklist-append *gcc-4.* {clang < 500}
+
+use_parallel_build  no
+build.target        all test
+
+destroot {
+    xinstall -d ${destroot}${prefix}/include/${name}
+    copy ${worksrcpath}/libfortran-zlib.a ${destroot}${prefix}/lib/
+    copy ${worksrcpath}/zlib.mod ${destroot}${prefix}/include/${name}/
+}
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} LICENCE README.md ${destroot}${docdir}
+}
+
+test.run            yes
+test.cmd            ./test_zlib
+test.target

--- a/fortran/fortran-zlib/files/patch-Makefile.diff
+++ b/fortran/fortran-zlib/files/patch-Makefile.diff
@@ -1,0 +1,24 @@
+--- Makefile.orig	2022-12-14 03:46:34.000000000 +0800
++++ Makefile	2023-02-24 19:11:20.000000000 +0800
+@@ -1,9 +1,9 @@
+ .POSIX:
+ 
+-FC      = gfortran
++FC      = @FC@
+ AR      = ar
+-PREFIX  = /usr
+-FFLAGS  =
++PREFIX  = @PREFIX@
++FFLAGS  = @FFLAGS@
+ LDLAGS  = -I$(PREFIX)/include/ -L$(PREFIX)/lib/
+ LDLIBS  = -lz
+ ARFLAGS = rcs
+@@ -18,7 +18,7 @@
+ 	$(AR) $(ARFLAGS) $(TARGET) zlib.o
+ 
+ test: $(TARGET)
+-	$(FC) $(FFLAGS) $(LDFLAGS) -o test_zlib test/test_zlib.f90 $(TARGET) $(LDLIBS)
++	$(FC) $(FFLAGS) -fallow-argument-mismatch $(LDFLAGS) -o test_zlib test/test_zlib.f90 $(TARGET) $(LDLIBS)
+ 
+ clean:
+ 	if [ `ls -1 *.mod 2>/dev/null | wc -l` -gt 0 ]; then rm *.mod; fi

--- a/fortran/geodesic-fortran/Portfile
+++ b/fortran/geodesic-fortran/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           fortran 1.0
+
+github.setup        jacobwilliams geodesic-fortran 1.0.0
+revision            0
+categories-append   science
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Geodesic routines for modern Fortran
+long_description    This is a library to solve geodesic problems on a planetary body.
+checksums           rmd160  a35d01bceeb855c6d3d5cfb26386e99b720d7e19 \
+                    sha256  eec42b8d7eeb2a0979f984a9434d1a25fbdd75b9ce12f06d8d718b98e1b5e6c3 \
+                    size    164529
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} LICENSE.txt README.md ${destroot}${docdir}
+}
+
+# Test uses ieee_arithmetic module which is not yet in GCC.
+# See: https://github.com/iains/darwin-toolchains-start-here/discussions/40
+if {${os.arch} ne "powerpc"} {
+    test.run        yes
+}

--- a/fortran/sph/Portfile
+++ b/fortran/sph/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           fortran 1.0
+
+github.setup        zoziha sph 6d855bdd2f0fcaf0bfe1ed5e214f186e3f1f7d8c
+version             2022.01.22
+revision            0
+categories-append   science
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Smoothed Particle Hydrodynamics
+long_description    {*}${description}
+homepage            https://zoziha.github.io/SPH
+checksums           rmd160  3acac52a927199e55a009ad02e2860d3e9346898 \
+                    sha256  d156eed5444eb39ef56d410d1694fa82f7f9a610977b18c2f6d288b7c65439ea \
+                    size    299599
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} CHANGELOG.md LICENSE README.md README_CN.md ${destroot}${docdir}
+}
+
+test.run            yes


### PR DESCRIPTION
#### Description

Some new packages in Fortran.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
