### PR TITLE
cppman: Update to 0.5.4, add groff dep, switch to Python 3.11

### DIFF
--- a/lang/cppman/Portfile
+++ b/lang/cppman/Portfile
@@ -4,9 +4,9 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               python 1.0
 
-github.setup            aitjcize cppman 0.5.3
-revision                1
-python.default_version  310
+github.setup            aitjcize cppman 0.5.4
+revision                0
+python.default_version  311
 
 maintainers             {eborisch @eborisch} \
                         openmaintainer
@@ -20,11 +20,12 @@ long_description        ${description} Sourced from cplusplus.com and \
 
 platforms               darwin
 
-checksums               rmd160  564c84e9ef54aa69db2217bd91d50b4b28856f85 \
-                        sha256  198387ff73ee44977c0dedf66ad8177ab984d9cb75b63c18ea941773547748d2 \
-                        size    3614820
+checksums               rmd160  00ba5fbe9e96f6da5d30568a74d364d15a99a4a4 \
+                        sha256  cf30817413505bea6c86071c987be94a8d94305db670ba8998ee535e13771ca1 \
+                        size    3561030
 
 depends_lib-append \
+    port:groff \
     port:py${python.version}-beautifulsoup4 \
     port:py${python.version}-html5lib
 


### PR DESCRIPTION
#### Description

See https://github.com/aitjcize/cppman/issues/144 and https://github.com/aitjcize/cppman/issues/146.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2.1 22D68 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
