### PR TITLE
nim: install test runner binary

### DIFF
--- a/lang/nim/Portfile
+++ b/lang/nim/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                nim
 version             1.6.8
-revision            0
+revision            1
 license             MIT
 categories          lang
 platforms           darwin
@@ -51,9 +51,9 @@ build {
 destroot {
     system -W ${worksrcpath} "./install.sh [shellescape ${destroot}/${prefix}/lib]"
 
-    xinstall -m 755 -W ${worksrcpath}/bin nimble nimsuggest nimgrep ${destroot}/${prefix}/lib/${name}/bin
+    xinstall -m 755 -W ${worksrcpath}/bin nimble nimsuggest nimgrep testament ${destroot}/${prefix}/lib/${name}/bin
 
-    foreach b {nim nimble nimsuggest nimgrep} {
+    foreach b {nim nimble nimsuggest nimgrep testament} {
         ln -sf ${prefix}/lib/${name}/bin/${b} ${destroot}/${prefix}/bin/
     }
 


### PR DESCRIPTION
#### Description

Include the `testament` executable in the installation/linking list. [Testament is the Nim project's official test runner](https://nim-lang.org/docs/testament.html), and the executable for it is already built as part of the compiler/language suite.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6.3 21G419 arm64
Xcode 13.3.1 13E500a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
