### PR TITLE
Update ruby/ruby-build to v20230222

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230208 v
+github.setup        rbenv ruby-build 20230222 v
 categories          ruby
 license             MIT
 platforms           any
@@ -14,9 +14,9 @@ maintainers         {mojca @mojca} openmaintainer
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  720cc0c4b8ee5f0e835d3b358afe04f784e7b29f \
-                    sha256  db5597e6beea530ed9b6b97f0bbdf4395ac909a04e9f552b45c05b90d172e419 \
-                    size    78320
+checksums           rmd160  22877e3ad0da65de29699906d15d4433a78ce189 \
+                    sha256  6bd49fa25de222dd2218682982dc98ecce47f5be0a0976fecd9c5ff4eb416287 \
+                    size    78338
 
 use_configure       no
 build {}

--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -9,7 +9,9 @@ license             MIT
 platforms           any
 supported_archs     noarch
 
-maintainers         {mojca @mojca} openmaintainer
+maintainers         {mojca @mojca} \
+                    {macports.halostatue.ca:austin @halostatue} \
+                    openmaintainer
 
 description         Compile and install Ruby
 long_description    {*}${description}


### PR DESCRIPTION
#### Description

* Update ruby-build to 20230222 release

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
  -  **`sudo port -vst install` does not work on macOS 13**
- [x] tested basic functionality of all binary files?