### PR TITLE
py-poppler-qt5: DO NOT MERGE

### DIFF
--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -27,7 +27,7 @@ checksums           md5     83a1c785aa3d0a0b0e82a7805492eabb \
                     sha256  add766db2c04026a6087f38f2044e66c8b053c81002f3753d8059713497d022d \
                     size    28235
 
-python.versions     37 38 39 310
+python.versions     310
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
dummy change to trigger CI on current version of Portfile: DO NOT MERGE!!!

#### Description

See https://github.com/macports/macports-ports/pull/17747#issuecomment-1445237991
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix