### PR TITLE
nim: update to 1.6.10

### DIFF
--- a/lang/nim/Portfile
+++ b/lang/nim/Portfile
@@ -3,11 +3,10 @@
 PortSystem          1.0
 
 name                nim
-version             1.6.8
-revision            1
+version             1.6.10
+revision            0
 license             MIT
 categories          lang
-platforms           darwin
 supported_archs     i386 x86_64 ppc64 arm64
 maintainers         {@esafak gmail.com:esafak} openmaintainer
 
@@ -21,9 +20,9 @@ long_description    Nim is a statically typed compiled systems programming \
 homepage            https://nim-lang.org
 
 master_sites        ${homepage}/download/
-checksums           rmd160  6f7ea248938d78851a935d717a94d47c0d0d25ea \
-                    sha256  0f5b65cdb60f78af41cb075c238983689a1e1f7e25c819f179862c18a484cf57 \
-                    size    5219880
+checksums           rmd160  1e6388cbdb349cba4b4faa504549f86701201f63 \
+                    sha256  13d7702f8b57087babe8cd051c13bc56a3171418ba867b49c6bbd09b29d24fea \
+                    size    5216284
 
 use_configure       no
 use_xz              yes
@@ -37,7 +36,8 @@ build {
         # nim looks for aarch64 and not arm/arm64
         set nim_build_arch "aarch64"
     }
-    system -W ${worksrcpath} "./build.sh --os ${os.platform} --cpu ${nim_build_arch}"
+    system -W ${worksrcpath} \
+        "./build.sh --os ${os.platform} --cpu ${nim_build_arch}"
 
     system -W ${worksrcpath} "./bin/nim c koch"
     system -W ${worksrcpath} "./koch boot -d:release"
@@ -49,14 +49,20 @@ build {
 }
 
 destroot {
-    system -W ${worksrcpath} "./install.sh [shellescape ${destroot}/${prefix}/lib]"
+    system -W \
+        ${worksrcpath} "./install.sh [shellescape ${destroot}/${prefix}/lib]"
 
-    xinstall -m 755 -W ${worksrcpath}/bin nimble nimsuggest nimgrep testament ${destroot}/${prefix}/lib/${name}/bin
+    foreach nimbin [glob ${worksrcpath}/bin/*] {
+        xinstall -m 0755 ${nimbin} ${destroot}/${prefix}/lib/${name}/bin/
 
-    foreach b {nim nimble nimsuggest nimgrep testament} {
-        ln -sf ${prefix}/lib/${name}/bin/${b} ${destroot}/${prefix}/bin/
+        ln -sf \
+            ${prefix}/lib/${name}/bin/[file tail ${nimbin}] \
+            ${destroot}/${prefix}/bin/
     }
 
     xinstall -d ${destroot}/${prefix}/share/doc/${name}
     copy {*}[glob ${worksrcpath}/doc/*] ${destroot}/${prefix}/share/doc/${name}
 }
+
+livecheck.url       ${homepage}/install.html
+livecheck.regex     ${name}-(\[0-9.\]+).tar.xz


### PR DESCRIPTION
- install all Nim binaries
- fix livecheck

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
