### PR TITLE
openjdk11-openj9: update to 11.0.18

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      11.0.17
+version      11.0.18
 revision     0
 
-set build    8
-set openj9_version 0.35.0
+set build    10
+set openj9_version 0.36.1
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 11
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  f59d0f69cbac234e62db9bcaa06679226ccb0418 \
-                 sha256  ad1cca11ae20da23d2d0b5ee8977b8c588119f6b4877249f385736b3034e4065 \
-                 size    204538090
+    checksums    rmd160  1c0e76941d53095695903bb61415f76536f26155 \
+                 sha256  ef18ff9bcd8dc0955fc3f69a43953373d3681aed9465ec561085a034a23f866b \
+                 size    204802374
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  399b96077fede1a1ff2d60080208256464ca21e7 \
-                 sha256  c7dbae2bd708bd642245b996ce28bd4918dc3aaece3b40df4d02d3751f63aca3 \
-                 size    198855023
+    checksums    rmd160  abff799d46d78772bf0417374b110c4d13e4f939 \
+                 sha256  8f6e4ea6dbb19f605e4acae9b056779aacc2ae483ff1a724f90317da88d8a77e \
+                 size    199015288
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.18.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?