### PR TITLE
openjdk17-openj9: update to 17.0.6

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      17.0.5
+version      17.0.6
 revision     0
 
-set build    8
-set openj9_version 0.35.0
+set build    10
+set openj9_version 0.36.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 17
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru17-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  99e6c3aae742194651c8e564778dad4d1dfbb7a2 \
-                 sha256  a8b5aefd73cfee2f46ece159728b3d22af10e841e4a7bb55aaef6dba3aa09e2c \
-                 size    209390651
+    checksums    rmd160  59b9db90c679c8c92a5cf7f57f9d06f88bb485e1 \
+                 sha256  37baae44a266c53a90e494be208564c690ed36b7b590f0d75e257efe9173e6c9 \
+                 size    209759398
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  8aa3c776576406ae46dcb1e514894a975a52a625 \
-                 sha256  094281b40696e31fe54dc6aa3a59387d4bc50208209195de735d0c3c56eafd70 \
-                 size    202728941
+    checksums    rmd160  ad16c3c9a8c49fe3cf5de1d48cb0d3b2b6cfe5e9 \
+                 sha256  56637c78f0855ab727e4372955b3bb56b5fe342bd0c7ff6b1a346a0d92daaf56 \
+                 size    202962673
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.6.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?