### PR TITLE
py-nbconvert: Remove custom fetch code

### DIFF
--- a/python/py-nbconvert/Portfile
+++ b/python/py-nbconvert/Portfile
@@ -22,98 +22,54 @@ long_description    {*}${description}
 
 homepage            https://jupyter.org/
 
-checksums-append \
-                    ${python.rootname}-${version}${extract.suffix} \
+# Must remain in-sync with those in project build script.
+set style_css_ver   5.4.0
+set index_css_ver   3.1.11
+set light_css_ver   3.1.11
+set dark_css_ver    3.1.11
+
+set main_distfile   ${distfiles}
+set style_distfile  style-${style_css_ver}.css
+set index_distfile  index-${index_css_ver}.css
+set light_distfile  theme-light-${light_css_ver}.css
+set dark_distfile   theme-dark-${dark_css_ver}.css
+
+master_sites        ${master_sites}:main \
+                    https://cdn.jupyter.org/notebook/${style_css_ver}/style/style.min.css?dummy=:style \
+                    https://unpkg.com/@jupyterlab/nbconvert-css@${index_css_ver}/style/index.css?dummy=:index \
+                    https://unpkg.com/@jupyterlab/theme-light-extension@${light_css_ver}/style/variables.css?dummy=:light \
+                    https://unpkg.com/@jupyterlab/theme-dark-extension@${dark_css_ver}/style/variables.css?dummy=:dark
+
+distfiles           ${main_distfile}:main \
+                    ${style_distfile}:style \
+                    ${index_distfile}:index \
+                    ${light_distfile}:light \
+                    ${dark_distfile}:dark
+
+checksums           ${main_distfile} \
                     rmd160  d821a832ca32047becb59e7ccdf6a5f59887a33b \
                     sha256  a42c3ac137c64f70cbe4d763111bf358641ea53b37a01a5c202ed86374af5234 \
-                    size    870386
-
-set css_fetch_dir \
-    ${distpath}/css
-
-set css_dest_dir \
-    ${worksrcpath}/share/templates
-
-proc nb_css_fetch {} {
-    global prefix distpath css_fetch_dir
-
-    # Explicitly fetch CSS artifacts; must remain in-sync with those in project build script
-    set notebook_css_ver            5.4.0
-    set jupyterlab_css_ver          3.1.11
-    set jupyterlab_theme_light_ver  3.1.11
-    set jupyterlab_theme_dark_ver   3.1.11
-
-    set notebook_css_url \
-        https://cdn.jupyter.org/notebook/${notebook_css_ver}/style/style.min.css
-    set jupyterlab_css_url \
-        https://unpkg.com/@jupyterlab/nbconvert-css@${jupyterlab_css_ver}/style/index.css
-    set jupyterlab_theme_light_url \
-        https://unpkg.com/@jupyterlab/theme-light-extension@${jupyterlab_theme_light_ver}/style/variables.css
-    set jupyterlab_theme_dark_url \
-        https://unpkg.com/@jupyterlab/theme-dark-extension@${jupyterlab_theme_dark_ver}/style/variables.css
-
-    set wget_fetch_cmd \
-        "${prefix}/bin/wget --no-verbose --no-check-certificate --no-use-server-timestamps"
-
-    xinstall -d \
-        ${css_fetch_dir}/classic \
-        ${css_fetch_dir}/lab
-
-    system -W ${css_fetch_dir}/classic \
-        "${wget_fetch_cmd} ${notebook_css_url} -O style.css"
-    system -W ${css_fetch_dir}/lab \
-        "${wget_fetch_cmd} ${jupyterlab_css_url} -O index.css"
-    system -W ${css_fetch_dir}/lab \
-        "${wget_fetch_cmd} ${jupyterlab_theme_light_url} -O theme-light.css"
-    system -W ${css_fetch_dir}/lab \
-        "${wget_fetch_cmd} ${jupyterlab_theme_dark_url} -O theme-dark.css"
-}
-
-proc nb_css_copy {} {
-    global css_fetch_dir css_dest_dir
-
-    foreach d [glob -type d ${css_fetch_dir}/*] {
-        set dname [file tail ${d}]
-        set ddir ${css_dest_dir}/${dname}/static
-        ui_info "nb_css_copy: copying dir: ${dname} -> ${ddir}"
-        xinstall -d ${ddir}
-        foreach f [glob -type f ${d}/*] {
-            ui_info "nb_css_copy: copying file: ${f} -> ${ddir}"
-            copy -force ${f} ${ddir}
-        }
-    }
-}
-
-if {${name} ne ${subport}} {
-    distfiles-append \
-                    css/classic/style.css \
-                    css/lab/index.css \
-                    css/lab/theme-light.css \
-                    css/lab/theme-dark.css
-
-    checksums-append \
-                    css/classic/style.css \
+                    size    870386 \
+                    ${style_distfile} \
                     rmd160  05b48b82351654a627bb3a7815bd3808cacdc431 \
                     sha256  5865a609f4437b0464bc121cd567b619074e540a0515a3b82f222f764eb51e01 \
                     size    265101 \
-                    css/lab/index.css \
+                    ${index_distfile} \
                     rmd160  198fa6687d1d33e3a3236cb48c9c6d22ea4f48a1 \
                     sha256  0a3fc632f155c2c3f3c4a40b5adc19b94369b4ba8a780df50c33d61449d12717 \
                     size    552369 \
-                    css/lab/theme-light.css \
+                    ${light_distfile} \
                     rmd160  e13be340c00a4f72eb2f378581621102d7bccd42 \
                     sha256  f1f9c2f5232945d501c16737edece840b125eb9c256cf5a45892e4c051be06d7 \
                     size    14606 \
-                    css/lab/theme-dark.css \
+                    ${dark_distfile} \
                     rmd160  5fc75bcb18325bff34e1b8ffd9585ac6a544d618 \
                     sha256  2b194f360a7851ff4da5a6d3af8afa20c683c0e41e02a27b56ea00a912801051 \
                     size    15702
 
+if {${name} ne ${subport}} {
     patchfiles-append \
                     patch-hatch_build-disable-download.diff
-
-    depends_fetch-append \
-                    path:bin/wget:wget
 
     depends_build-append \
                     port:py${python.version}-setuptools
@@ -141,12 +97,18 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-importlib-metadata
     }
 
-    pre-fetch {
-        nb_css_fetch
-    }
-
+    extract.only    ${main_distfile}
     post-extract {
-        nb_css_copy
+        set dir_ids [list classic [list style] lab [list index light dark]]
+        foreach {dir ids} ${dir_ids} {
+            set dir ${worksrcpath}/share/templates/${dir}/static
+            foreach id ${ids} {
+                set src ${distpath}/[set ${id}_distfile]
+                set dst ${dir}/[string map [list -[set ${id}_css_ver].css/ .css] [set ${id}_distfile]/]
+                ui_info "copying file: ${src} -> ${dst}"
+                copy -force ${src} ${dst}
+            }
+        }
     }
 
     notes "


### PR DESCRIPTION
#### Description

Remove custom fetch code. Allows MacPorts to mirror the css files and prevents users from having to fetch the same files over and over.

Closes: https://trac.macports.org/ticket/66011
See: https://trac.macports.org/ticket/65809

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
