### PR TITLE
cairo,cairo-devel: use -std=gnu99 with gcc-4

### DIFF
--- a/graphics/cairo-devel/Portfile
+++ b/graphics/cairo-devel/Portfile
@@ -114,6 +114,11 @@ platform macosx {
     variant_set             quartz
 }
 
+if {[string match *gcc-4.* ${configure.compiler}]} {
+    # gcc-4 defaults to gnu89 which is "ISO C90 plus GNU extensions". We need gnu99.
+    configure.cflags-append  -std=gnu99
+}
+
 variant x11 {
     depends_lib-append      port:xrender \
                             port:xorg-libXext \

--- a/graphics/cairo-devel/Portfile
+++ b/graphics/cairo-devel/Portfile
@@ -116,6 +116,7 @@ platform macosx {
 
 if {[string match *gcc-4.* ${configure.compiler}]} {
     # gcc-4 defaults to gnu89 which is "ISO C90 plus GNU extensions". We need gnu99.
+    # https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/264
     configure.cflags-append  -std=gnu99
 }
 

--- a/graphics/cairo/Portfile
+++ b/graphics/cairo/Portfile
@@ -68,9 +68,6 @@ if {${configure.build_arch} eq "x86_64" || (${universal_possible} && [variant_is
     compiler.blacklist-append gcc-4.0
 }
 
-# https://trac.macports.org/ticket/66904
-compiler.blacklist-append   {*gcc-4.*}
-
 configure.args              --disable-gl \
                             --disable-quartz \
                             --disable-quartz-font \

--- a/graphics/cairo/Portfile
+++ b/graphics/cairo/Portfile
@@ -119,6 +119,7 @@ platform macosx {
 
 if {[string match *gcc-4.* ${configure.compiler}]} {
     # gcc-4 defaults to gnu89 which is "ISO C90 plus GNU extensions". We need gnu99.
+    # https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/264
     configure.cflags-append  -std=gnu99
 }
 

--- a/graphics/cairo/Portfile
+++ b/graphics/cairo/Portfile
@@ -117,6 +117,11 @@ platform macosx {
     variant_set             quartz
 }
 
+if {[string match *gcc-4.* ${configure.compiler}]} {
+    # gcc-4 defaults to gnu89 which is "ISO C90 plus GNU extensions". We need gnu99.
+    configure.cflags-append  -std=gnu99
+}
+
 variant x11 {
     depends_lib-append      port:xrender \
                             port:xorg-libXext \


### PR DESCRIPTION
#### Description

Allow `cairo` and `cairo-devel` to be compiled on legacy platforms (10.4, 10.5, 10.6).

https://trac.macports.org/ticket/66904
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L31a Power Macintosh
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
