### PR TITLE
micronaut: update to 3.8.6

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -2,9 +2,8 @@
 
 PortSystem      1.0
 PortGroup       github 1.0
-PortGroup       java 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.8.5 v
+github.setup    micronaut-projects micronaut-starter 3.8.6 v
 revision        0
 name            micronaut
 categories      java
@@ -54,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  fa285fe9d33aa6c1851e560291d5eef150cefcf7 \
-                sha256  1c3dcc0e60508ba1ae91dd2558c9141d987db7b9c8e2a07ce8330eeafd8443d5 \
-                size    20150201
+checksums       rmd160  d48ee0b3b1f64f917bf2ea64148f0d0b0a18b1f4 \
+                sha256  09867533be966da66b1a60cc3488ed2e39e1b0cb775cf4ff3c36933cbcdebd8f \
+                size    20155683
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.8.6.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?