### PR TITLE
wireguard-go: update to 0.0.20230223

### DIFF
--- a/net/wireguard-go/Portfile
+++ b/net/wireguard-go/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                wireguard-go
-version             0.0.20220316
+version             0.0.20230223
 revision            0
-checksums           rmd160  d5601921320010c1ec0cbd44a281feac53590b3a \
-                    sha256  fd6759c116e358d311309e049cc2dcc390bc326710f5fc175e0217b755330c2a \
-                    size    110444
+checksums           rmd160  d1634ffe84be9f2d49edc8ded00f0fb161c7215e \
+                    sha256  ed3694e808d96720e79e17ae396f89f7c2024da07f3449ff0af8fbc6dbfa7f6a \
+                    size    77552
 
 categories          net
 platforms           darwin


### PR DESCRIPTION
#### Description
wireguard-go: update to 0.0.20230223

###### Tested on
macOS 12.6.2 21G320 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?