### PR TITLE
jdupes: update to 1.21.3

### DIFF
--- a/sysutils/jdupes/Portfile
+++ b/sysutils/jdupes/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jbruchon jdupes 1.21.1 v
+github.setup        jbruchon jdupes 1.21.3 v
 revision            0
-checksums           rmd160  ac986fb96de8fa04dd62d922a4c82a94d88108fa \
-                    sha256  98df2f4f6740f29b609814bd294d131565cf741b1285d6d97e1d9bc580ff7b89 \
-                    size    97420
+checksums           rmd160  368fd1b563082f52458caf0979bc7474deb3bf31 \
+                    sha256  5ed8780605d9a46abc4768fc9f886f698997548c4400abe7d7983b76ea8c0bcc \
+                    size    156002
 
 platforms           darwin
 categories          sysutils


### PR DESCRIPTION
#### Description
jdupes: update to 1.21.3

###### Tested on
macOS 12.6.2 21G320 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
