### PR TITLE
google-cloud-sdk: update to 420.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             419.0.0
+version             420.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  632c2dfed2bfbe05b86cbf8a10639c6ba35b8d11 \
-                    sha256  ec4bb3923b03a8afcdf4da97f9a2740782635a0df884200bd5bd9388dcea050c \
-                    size    111278222
+    checksums       rmd160  dc86a11af25edf23aef81c4fbd0772262e824092 \
+                    sha256  5779e84e97498953e3ab58228bab2186ea10837df430b140e8f9cb6ec7e780f2 \
+                    size    111350022
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  7e58324f0e62e01c7001fc138104d04b220c65da \
-                    sha256  39890f5f541c3282931cd61b80faccb39bbb496ed7437c53a75b2915427ed53b \
-                    size    131602640
+    checksums       rmd160  1840187c81eafd98c2a197177d1c2ac335d21ba5 \
+                    sha256  1ac7975a810156f533bc76522b015bb67eb6f2a372a40db84de8223282d7ca67 \
+                    size    131671377
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  abd241ecdead59770af0755e67ff3b8183107e29 \
-                    sha256  40bf84e3153f8c6313009164bb6413ef4c827f3f8a5ce753b537c1e599e7e05b \
-                    size    128442219
+    checksums       rmd160  fea72ce75e32a5a39a5df108524d8b0c8f9fb167 \
+                    sha256  375d44afb56ad1a217a0cf927b323a0d4c36ca9f87c66722db3fa02a48536986 \
+                    size    128516074
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 420.0.0.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?