### PR TITLE
qBittorrent-qt5: put legacysupport lines in the right place

### DIFF
--- a/net/qBittorrent-qt5/Portfile
+++ b/net/qBittorrent-qt5/Portfile
@@ -44,14 +44,15 @@ if {${os.platform} ne "darwin" || ${os.major} >= 17} {
         # https://github.com/llvm/llvm-project/commit/7fb40e1569dd66292b647f4501b85517e9247953
         # MacPorts clang 8 and later have applied this fix.
         compiler.blacklist-append clang macports-clang-5.0 macports-clang-6.0 macports-clang-7.0
+    }
     # undefined symbols for std::filesystem on 10.14
     legacysupport.newest_darwin_requires_legacy 18
     legacysupport.use_mp_libcxx yes
-    }
 } else {
+    # qBittorrent 4.3.4 to 4.3.4.1 required Qt 5.12 then lowered to 5.11 after
     # qBittorrent 4.3.3 and later requires C++17 features and therefore won't build with
     # libc++ on Sierra and older
-    # Also 4.3.4 to 4.3.4.1 required Qt 5.12 then lowered to 5.11 after
+    # That is 4.3.3 might work here but needs testing
     github.setup    qbittorrent qBittorrent 4.3.2 release-
     revision        3
     checksums       rmd160  543c1a5b59c15912cde31d98bed55810709aef75 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
