### PR TITLE
R-igraph: add support for tests

### DIFF
--- a/R/R-igraph/Portfile
+++ b/R/R-igraph/Portfile
@@ -25,3 +25,20 @@ depends_lib-append  port:glpk \
                     port:R-rlang
 
 compilers.setup     require_fortran
+
+variant tests description "Enable tests" {
+    require_active_variants R tcltk
+    depends_test-append \
+                    port:R-ape \
+                    port:R-digest \
+                    port:R-graph \
+                    port:R-igraphdata \
+                    port:R-knitr \
+                    port:R-rgl \
+                    port:R-scales \
+                    port:R-testthat \
+                    port:R-withr \
+                    port:R-vdiffr \
+                    port:R-rmarkdown
+    test.run        yes
+}

--- a/R/R-igraphdata/Portfile
+++ b/R/R-igraphdata/Portfile
@@ -1,0 +1,19 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran RobinHankin igraphdata 1.0.1
+revision            0
+maintainers         nomaintainer
+license             public-domain
+description         Collection of network data sets for the igraph package
+long_description    {*}${description}
+checksums           rmd160  01b953f881370ce443d0bd5b3e832238403e7532 \
+                    sha256  7466426fdc1fdda90dd26d495409864e3c08ab3d997692362980a145d4b585a7 \
+                    size    953158
+supported_archs     noarch
+
+depends_lib-append  port:R-igraph
+
+test.run            yes


### PR DESCRIPTION
#### Description

Wrapped in a `tests` variant due to dependency on `tcltk`, which is not a port, but a non-default variant for `R`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
