### PR TITLE
nixpacks: updated to version 1.4.1

### DIFF
--- a/devel/nixpacks/Portfile
+++ b/devel/nixpacks/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        railwayapp nixpacks 1.3.1 v
+github.setup        railwayapp nixpacks 1.4.1 v
 github.tarball_from archive
 
 categories          devel
@@ -15,9 +15,9 @@ long_description    Nixpacks takes a source directory and produces an OCI compli
 homepage            https://nixpacks.com/
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  c3d162211f93207845bd21fa1a1ea7488dcfcff8 \
-                    sha256  d35a3253c49b744f6130a79a34cfb8d3e76a3de04bcc786b803bdce9fab8a879 \
-                    size    30668269
+                    rmd160  e51049744a0dbb2d147ddeeee50d2e60438c91ba \
+                    sha256  04a7afb21c0f7626e4bcdc1dfd4202792ee3133a1f0e26ff5e9f5375c0921455 \
+                    size    30669027
 
 destroot {
   xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/nixpacks ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 x86_64
Command Line Tools 14.0.0.0.1.1661618636

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
