### PR TITLE
R packages: more support for tests

### DIFF
--- a/R/R-Biobase/Portfile
+++ b/R/R-Biobase/Portfile
@@ -1,0 +1,16 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             bioconductor Bioconductor Biobase 2.58.0
+revision            0
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             Artistic-2
+description         Base functions for Bioconductor
+long_description    {*}${description}
+checksums           rmd160  ed70b3740f8c9dad6c66a644ef16188989da47d1 \
+                    sha256  db798af54eb18d83242b1ffbb1fa35b5bc0256cedf86b9a6519e2d786d20e566 \
+                    size    1792896
+
+depends_lib-append  port:R-BiocGenerics

--- a/R/R-MEMSS/Portfile
+++ b/R/R-MEMSS/Portfile
@@ -1,0 +1,19 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran cran MEMSS 0.9-3
+revision            0
+maintainers         nomaintainer
+license             {GPL-2 GPL-3}
+description         Datasets from Mixed-Effects Models in S
+long_description    {*}${description}
+checksums           rmd160  3ec7983f914a5c633cf16f77e2805baea142a152 \
+                    sha256  eda9bc1c9c04387012df82ff5104e3a7303b61ea82ebed04de8a3ba9b22c083b \
+                    size    126951
+supported_archs     noarch
+
+depends_lib-append  port:R-lme4
+
+test.run            yes

--- a/R/R-ape/Portfile
+++ b/R/R-ape/Portfile
@@ -18,3 +18,10 @@ depends_lib-append  port:R-digest \
                     port:R-Rcpp
 
 compilers.setup     require_fortran
+
+depends_test-append port:R-gee \
+                    port:R-expm \
+                    port:R-igraph \
+                    port:R-phangorn
+
+test.run            yes

--- a/R/R-assertthat/Portfile
+++ b/R/R-assertthat/Portfile
@@ -13,3 +13,8 @@ checksums           rmd160  1f405695d747b62c59cb2c8e1043897cc9d79e9e \
                     sha256  85cf7fcc4753a8c86da9a6f454e46c2a58ffc70c4f47cac4d3e3bcefda2a9e9f \
                     size    12742
 supported_archs     noarch
+
+depends_test-append port:R-covr \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-dcurver/Portfile
+++ b/R/R-dcurver/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+# GitHub version lags behind.
+R.setup             cran oguzhanogreden dcurver 0.9.2
+revision            0
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-3
+description         Davidian curves in R
+long_description    {*}${description}
+checksums           rmd160  21bbb868d2cebc0e5472e3bbe34e2ea73ba05afa \
+                    sha256  cc6c55090d3607910515981ea0c7221e40e7a29e0da0c5a5f42c3847012290ec \
+                    size    11409
+
+depends_lib-append  port:R-Rcpp \
+                    port:R-RcppArmadillo
+
+compilers.setup     require_fortran
+
+depends_test-append port:R-testthat
+
+test.run            yes

--- a/R/R-deSolve/Portfile
+++ b/R/R-deSolve/Portfile
@@ -16,3 +16,8 @@ checksums           rmd160  09690d4237290b354827409dd1e4b332e94141f4 \
                     size    2005914
 
 compilers.setup     require_fortran
+
+depends_test-append port:R-FME \
+                    port:R-scatterplot3d
+
+test.run            yes

--- a/R/R-fido/Portfile
+++ b/R/R-fido/Portfile
@@ -26,3 +26,14 @@ depends_lib-append  port:R-BH \
                     port:R-rlang \
                     port:R-tidybayes \
                     port:R-tidyr \
+
+patchfiles          patch-no-phyloseq-MicrobeDS.diff
+
+depends_test-append port:R-ape \
+                    port:R-knitr \
+                    port:R-MCMCpack \
+                    port:R-numDeriv \
+                    port:R-rmarkdown \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-fido/files/patch-no-phyloseq-MicrobeDS.diff
+++ b/R/R-fido/files/patch-no-phyloseq-MicrobeDS.diff
@@ -1,0 +1,12 @@
+--- DESCRIPTION.orig	2022-08-23 15:00:02.000000000 +0800
++++ DESCRIPTION	2023-03-04 05:36:13.000000000 +0800
+@@ -22,8 +22,7 @@
+ LinkingTo: Rcpp, RcppEigen, RcppNumerical, RcppZiggurat, BH
+ RoxygenNote: 7.2.1
+ Additional_repositories: https://michellepistner.github.io/fidoRepo
+-Suggests: testthat (>= 2.1.0), knitr, rmarkdown, ape, numDeriv,
+-        MCMCpack, MicrobeDS, phyloseq
++Suggests: testthat (>= 2.1.0), knitr, rmarkdown, ape, numDeriv, MCMCpack
+ VignetteBuilder: knitr
+ LazyData: true
+ BugReports: https://github.com/jsilve24/fido/issues

--- a/R/R-gee/Portfile
+++ b/R/R-gee/Portfile
@@ -1,0 +1,19 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran cran gee 4.13-25
+revision            0
+categories-append   math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-2
+description         Generalized Estimation Equation Solver
+long_description    {*}${description}
+checksums           rmd160  059640466b196a87642b23cdd242c20941c94039 \
+                    sha256  e140881e2febe793a24086a2d179062b9995db901257d678f85d220441400e89 \
+                    size    53765
+
+compilers.setup     require_fortran
+
+test.run            yes

--- a/R/R-hsstan/Portfile
+++ b/R/R-hsstan/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             github mcol hsstan 0.8.1 hsstan_
+revision            0
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-3
+description         Hierarchical shrinkage Stan models for biomarker selection
+long_description    {*}${description}
+checksums           rmd160  8ea0fb317bd17acf8dfd06c7b94f983a0ac3db73 \
+                    sha256  3d6be78d8b69131c852e908fac35c6de2fdb24000aed0b0f9d30a6d3de62d2a7 \
+                    size    220997
+
+depends_lib-append  port:R-BH \
+                    port:R-ggplot2 \
+                    port:R-loo \
+                    port:R-pROC \
+                    port:R-Rcpp \
+                    port:R-RcppEigen \
+                    port:R-RcppParallel \
+                    port:R-rstan \
+                    port:R-rstantools \
+                    port:R-StanHeaders
+
+depends_test-append port:R-testthat
+
+test.run            yes

--- a/R/R-latticeExtra/Portfile
+++ b/R/R-latticeExtra/Portfile
@@ -19,3 +19,11 @@ depends_lib-append  port:R-interp \
                     port:R-jpeg \
                     port:R-png \
                     port:R-RColorBrewer
+
+depends_test-append port:R-deldir \
+                    port:R-maps \
+                    port:R-mapproj \
+                    port:R-quantreg \
+                    port:R-zoo
+
+test.run            yes

--- a/R/R-lme4/Portfile
+++ b/R/R-lme4/Portfile
@@ -18,3 +18,24 @@ depends_lib-append  port:R-minqa \
                     port:R-nloptr \
                     port:R-Rcpp \
                     port:R-RcppEigen
+
+depends_test-append port:R-car \
+                    port:R-dfoptim \
+                    port:R-HSAUR3 \
+                    port:R-gamm4 \
+                    port:R-ggplot2 \
+                    port:R-knitr \
+                    port:R-MEMSS \
+                    port:R-merDeriv \
+                    port:R-mlmRev \
+                    port:R-numDeriv \
+                    port:R-optimx \
+                    port:R-pbkrtest \
+                    port:R-rmarkdown \
+                    port:R-rr2 \
+                    port:R-semEff \
+                    port:R-statmod \
+                    port:R-testthat \
+                    port:R-tibble
+
+test.run            yes

--- a/R/R-lmeInfo/Portfile
+++ b/R/R-lmeInfo/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+# GitHub version lags behind.
+R.setup             cran jepusto lmeInfo 0.3.1
+revision            0
+categories-append   math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-3
+description         Information matrices for lmestruct and glsstruct objects
+long_description    {*}${description}
+homepage            https://jepusto.github.io/lmeInfo
+checksums           rmd160  20832203b4aaf252e7c9cc64166be1fee1e480bd \
+                    sha256  9d94cbf678a226877c83d0e68ad273c6eb181dd27f46a5c06492ec90be8e6641 \
+                    size    65117
+supported_archs     noarch
+
+depends_test-append port:R-carData \
+                    port:R-covr \
+                    port:R-knitr \
+                    port:R-lme4 \
+                    port:R-merDeriv \
+                    port:R-mlmRev \
+                    port:R-rmarkdown \
+                    port:R-scdhlm \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-mapproj/Portfile
+++ b/R/R-mapproj/Portfile
@@ -1,0 +1,18 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran cran mapproj 1.2.11
+revision            0
+maintainers         nomaintainer
+license             LPL
+description         Map Projections
+long_description    {*}${description}
+checksums           rmd160  9517d3c1d1ff3d351e982a879f9a0166c82555bf \
+                    sha256  db2d201cc939de26717566066bf44225a967ccde6fc34731af845f03c086347d \
+                    size    25544
+
+depends_lib-append  port:R-maps
+
+test.run            yes

--- a/R/R-maxLik/Portfile
+++ b/R/R-maxLik/Portfile
@@ -18,3 +18,12 @@ supported_archs     noarch
 depends_lib-append  port:R-generics \
                     port:R-miscTools \
                     port:R-sandwich
+
+patchfiles          patch-no-plot3D.diff
+
+depends_test-append port:R-clue \
+                    port:R-dlm \
+                    port:R-tibble \
+                    port:R-tinytest
+
+test.run            yes

--- a/R/R-maxLik/files/patch-no-plot3D.diff
+++ b/R/R-maxLik/files/patch-no-plot3D.diff
@@ -1,0 +1,11 @@
+--- DESCRIPTION.orig	2021-07-27 01:30:02.000000000 +0800
++++ DESCRIPTION	2023-03-04 06:05:49.000000000 +0800
+@@ -11,7 +11,7 @@
+ 	   )
+ Depends: R (>= 2.4.0), miscTools (>= 0.6-8), methods
+ Imports: sandwich, generics
+-Suggests: MASS, clue, dlm, plot3D, tibble, tinytest
++Suggests: MASS, clue, dlm, tibble, tinytest
+ Description: Functions for Maximum Likelihood (ML) estimation, non-linear
+    optimization, and related tools.  It includes a unified way to call
+    different optimizers, and classes and methods to handle the results from

--- a/R/R-merDeriv/Portfile
+++ b/R/R-merDeriv/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran nctingwang merDeriv 0.2-4
+revision            0
+categories-append   math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             {GPL-2 GPL-3}
+description         Case-wise and cluster-wise derivatives for mixed effects models
+long_description    {*}${description}
+checksums           rmd160  a68cb207feb8d714dc480d224c20fc98f1914d63 \
+                    sha256  8c256a829ce6e8501568580670de475cd71b9f875655a8431123e64349e43ade \
+                    size    33835
+supported_archs     noarch
+
+depends_lib-append  port:R-lavaan \
+                    port:R-lme4 \
+                    port:R-nonnest2 \
+                    port:R-numDeriv \
+                    port:R-sandwich
+
+depends_test-append port:R-lmeInfo \
+                    port:R-mirt \
+                    port:R-tinytest
+
+test.run            yes

--- a/R/R-miniUI/Portfile
+++ b/R/R-miniUI/Portfile
@@ -17,3 +17,5 @@ supported_archs     noarch
 
 depends_lib-append  port:R-htmltools \
                     port:R-shiny
+
+test.run            yes

--- a/R/R-mirt/Portfile
+++ b/R/R-mirt/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             github philchalmers mirt 1.38.1 v
+revision            0
+categories-append   math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-3+
+description         Multidimensional Item Response Theory
+long_description    {*}${description}
+homepage            https://github.com/philchalmers/mirt/wiki
+checksums           rmd160  4d817dfb7b3d34a8fb74a28ad93695bca94545f7 \
+                    sha256  83fbf6adfa66949cea9b104247083d604afbaaeb8b43afdcd592b70dc7ed2b1e \
+                    size    640142
+
+depends_lib-append  port:R-dcurver \
+                    port:R-Deriv \
+                    port:R-GPArotation \
+                    port:R-gridExtra \
+                    port:R-pbapply \
+                    port:R-Rcpp \
+                    port:R-RcppArmadillo \
+                    port:R-vegan
+
+compilers.setup     require_fortran

--- a/R/R-mlmRev/Portfile
+++ b/R/R-mlmRev/Portfile
@@ -1,0 +1,19 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran cran mlmRev 1.0-8
+revision            0
+maintainers         nomaintainer
+license             {GPL-2 GPL-3}
+description         Examples from Multilevel Modelling Software Review
+long_description    {*}${description}
+checksums           rmd160  d56d0d2443b45422629f794322547ad97d59258f \
+                    sha256  d57f3ff5d49e5f0079d4367cdbc1a273f48d8ce8f03bb82bb5f90606bfb2c452 \
+                    size    1490419
+supported_archs     noarch
+
+depends_lib-append  port:R-lme4
+
+test.run            yes

--- a/R/R-phangorn/Portfile
+++ b/R/R-phangorn/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran KlausVigo phangorn 2.11.1
+revision            0
+maintainers         nomaintainer
+license             {GPL-2 GPL-3}
+description         Phylogenetic reconstruction and analysis
+long_description    {*}${description}
+homepage            https://klausvigo.github.io/phangorn
+checksums           rmd160  53df4f94f27b7d06121827b3fb61a22022d9595a \
+                    sha256  10096ecae03e118aa4dbc60d9866175fad4849c948e004cf10c3868e3feed420 \
+                    size    1941820
+
+depends_lib-append  port:R-ape \
+                    port:R-digest \
+                    port:R-fastmatch \
+                    port:R-generics \
+                    port:R-igraph \
+                    port:R-quadprog \
+                    port:R-Rcpp
+
+compilers.setup     require_fortran

--- a/R/R-phylolm/Portfile
+++ b/R/R-phylolm/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran lamho86 phylolm 2.6.2
+revision            0
+categories-append   math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             {GPL-2 GPL-3}
+description         Phylogenetic linear regression
+long_description    {*}${description}
+checksums           rmd160  7942db7a62af0ee11f50297da0b833aec84e4c6b \
+                    sha256  d6fa45f58689cce9fe91519ab55a61c1e549e5a7f18b6989bf86234d483cff12 \
+                    size    261702
+
+depends_lib-append  port:R-ape \
+                    port:R-future.apply
+
+depends_test-append port:R-testthat
+
+test.run            yes

--- a/R/R-phyr/Portfile
+++ b/R/R-phyr/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+# GitHub version lags behind.
+R.setup             cran daijiang phyr 1.1.0
+revision            0
+categories-append   math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-3
+description         Functions for phylogenetic analyses
+long_description    {*}${description}
+homepage            https://daijiang.github.io/phyr
+checksums           rmd160  081734f76bb420b9e6b5276f9fc82419204bd4d7 \
+                    sha256  26b16effd45e4ac2918c7d33a43fa94ae4de46ad0b80bb93cae95bd1fbee724b \
+                    size    1477998
+
+depends_lib-append  port:R-ape \
+                    port:R-dplyr \
+                    port:R-gridExtra \
+                    port:R-latticeExtra \
+                    port:R-lme4 \
+                    port:R-mvtnorm \
+                    port:R-nloptr \
+                    port:R-Rcpp \
+                    port:R-RcppArmadillo \
+                    port:R-tidyr
+
+compilers.setup     require_fortran

--- a/R/R-piecewiseSEM/Portfile
+++ b/R/R-piecewiseSEM/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran jslefche piecewiseSEM 2.1.2 v
+revision            0
+categories-append   math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-3+
+description         Piece-wise structural equation modeling in R
+long_description    {*}${description}
+checksums           rmd160  846b5cab2b94fd8d9e0bfe2418d9cd8344350305 \
+                    sha256  66e09b9e5218b07a678e1b90ddda3bf4fa13cbabd2e5ea1f23d7889e5b60bce3 \
+                    size    213580
+supported_archs     noarch
+
+depends_lib-append  port:R-car \
+                    port:R-DiagrammeR \
+                    port:R-emmeans \
+                    port:R-igraph \
+                    port:R-lme4 \
+                    port:R-multcomp
+
+depends_test-append port:R-knitr \
+                    port:R-rmarkdown
+
+test.run            yes

--- a/R/R-pkgmaker/Portfile
+++ b/R/R-pkgmaker/Portfile
@@ -20,3 +20,16 @@ depends_lib-append  port:R-assertthat \
                     port:R-stringr \
                     port:R-withr \
                     port:R-xtable
+
+depends_test-append port:R-Biobase \
+                    port:R-devtools \
+                    port:R-knitr \
+                    port:R-markdown \
+                    port:R-rbibutils \
+                    port:R-rmarkdown \
+                    port:R-roxygen2 \
+                    port:R-RUnit \
+                    port:R-testthat \
+                    port:R-yaml
+
+test.run            yes

--- a/R/R-quadprog/Portfile
+++ b/R/R-quadprog/Portfile
@@ -15,3 +15,5 @@ checksums           rmd160  497807a279b9cdbebd4d4ebc63d046a335377f3e \
                     size    36141
 
 compilers.setup     require_fortran
+
+test.run            yes

--- a/R/R-rclipboard/Portfile
+++ b/R/R-rclipboard/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+# GitHub tarball is broken.
+R.setup             cran sbihorel rclipboard 0.1.6
+revision            0
+maintainers         nomaintainer
+license             MIT
+description         Shiny/R Wrapper for clipboard.js
+long_description    {*}${description}
+checksums           rmd160  fac2bb926eb26a67079c1f055f0e6e390749e978 \
+                    sha256  7e83f6355869eee1630849981abf930fa048cd3861407466a4ee4e07a1466269 \
+                    size    6419
+supported_archs     noarch
+
+depends_lib-append  port:R-shiny
+
+test.run            yes

--- a/R/R-rex/Portfile
+++ b/R/R-rex/Portfile
@@ -16,3 +16,17 @@ checksums           rmd160  a6328acf85dbcab138ae77b9583b6afed1289242 \
 supported_archs     noarch
 
 depends_lib-append  port:R-lazyeval
+
+depends_test-append port:R-covr \
+                    port:R-dplyr \
+                    port:R-ggplot2 \
+                    port:R-Hmisc \
+                    port:R-knitr \
+                    port:R-magrittr \
+                    port:R-rmarkdown \
+                    port:R-roxygen2 \
+                    port:R-rvest \
+                    port:R-stringr \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-rr2/Portfile
+++ b/R/R-rr2/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+# GitHub version lags behind.
+R.setup             cran arives rr2 1.1.0
+revision            0
+categories-append   math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-3
+description         R2s for regression models
+long_description    {*}${description}
+checksums           rmd160  c369d8db90964dadd82fe4cee4a79d07e280be76 \
+                    sha256  b182c3d0dc33c73e5ac859c6900f031ebbe46c4ca58bc2932c3b7f124a5472d9 \
+                    size    31621
+supported_archs     noarch
+
+depends_lib-append  port:R-ape \
+                    port:R-lme4 \
+                    port:R-phylolm \
+                    port:R-phyr
+
+depends_test-append port:R-mvtnorm \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-scdhlm/Portfile
+++ b/R/R-scdhlm/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             github jepusto scdhlm 0.7.1
+revision            0
+categories-append   math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-3
+description         Estimating hierarchical linear models for single-case designs
+long_description    {*}${description}
+homepage            https://jepusto.github.io/scdhlm
+checksums           rmd160  0967f8d40521723d769c85e14b23d38f2e3d98d5 \
+                    sha256  0865163be86da11d203d0c27acac1e94dddcdb192c9a8d3730b7ee1e6e89af60 \
+                    size    1340687
+supported_archs     noarch
+
+depends_lib-append  port:R-dplyr \
+                    port:R-lmeInfo \
+                    port:R-magrittr \
+                    port:R-readxl \
+                    port:R-rlang \
+                    port:R-tidyselect
+
+depends_test-append port:R-glue \
+                    port:R-ggplot2 \
+                    port:R-janitor \
+                    port:R-knitr \
+                    port:R-markdown \
+                    port:R-plyr \
+                    port:R-rclipboard \
+                    port:R-rmarkdown \
+                    port:R-rvest \
+                    port:R-shiny \
+                    port:R-shinytest \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-semEff/Portfile
+++ b/R/R-semEff/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             github murphymv semEff 0.6.1 v
+revision            0
+categories-append   math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-3+
+description         Automatic calculation of effects for piecewise structural equation models
+long_description    {*}${description}
+homepage            https://murphymv.github.io/semEff
+checksums           rmd160  cb6869f7dd63c252aa0971fe3c01f64bc65ea676 \
+                    sha256  d48facda64350e1f0ecdb340b30ddb40b702c81a78c232eee7a226a52ac06930 \
+                    size    544068
+supported_archs     noarch
+
+depends_lib-append  port:R-gsl \
+                    port:R-lme4
+
+depends_test-append port:R-ggplot2 \
+                    port:R-knitr \
+                    port:R-markdown \
+                    port:R-piecewiseSEM \
+                    port:R-rmarkdown
+
+test.run            yes

--- a/R/R-statmod/Portfile
+++ b/R/R-statmod/Portfile
@@ -8,10 +8,14 @@ revision            0
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             {GPL-2 GPL-3}
-description         Statistical modeling
-long_description    Collection of algorithms and functions to aid statistical modeling.
+description         Statistical modelling
+long_description    Collection of algorithms and functions to aid statistical modelling.
 checksums           rmd160  c11835855d3cc248fb3c69a20e607f92be1c94f0 \
                     sha256  d61c3ef9b09d55b42e038f8d767fa483ebbdec2a9c7172b1b0ccda0ae0016ec9 \
                     size    92486
 
 compilers.setup     require_fortran
+
+depends_test-append port:R-tweedie
+
+test.run            yes

--- a/R/R-vegan/Portfile
+++ b/R/R-vegan/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+# What can we do about this ill-picked name…
+R.setup             cran vegandevs vegan 2.6-4
+revision            0
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-2
+description         R package for community ecologists: popular ordination methods, ecological null models & diversity analysis
+long_description    {*}${description}
+homepage            http://vegandevs.github.io/vegan
+checksums           rmd160  c1a6d935b748f77ae279b76e87ce110fc1d639a7 \
+                    sha256  5d8ad4bebe79ae2bbd840a34100cf54c62f089c66ea484a542a201afcba21d06 \
+                    size    1496110
+
+depends_lib-append  port:R-permute
+
+compilers.setup     require_fortran
+
+depends_test-append port:R-knitr \
+                    port:R-markdown
+
+test.run            yes


### PR DESCRIPTION
#### Description

A huge chunk of new ports are dependencies for tests for `lme4` and their dependencies :)

P. S. One new port is added which is not dependency for others here, `hsstan`, since it was broken earlier, turned out due to `malloc` issue that we have fixed, so now it builds and passes tests.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
