### PR TITLE
gocryptfs: Update to version 2.3.1

### DIFF
--- a/fuse/gocryptfs/Portfile
+++ b/fuse/gocryptfs/Portfile
@@ -13,7 +13,7 @@ maintainers         {bochtler.io:macports @MarcelBochtler} \
 license             MIT
 platforms           darwin
 description         Encrypted overlay filesystem written in Go
-long_description    ${description}
+long_description    {*}${description}
 homepage            https://nuetzlich.net/gocryptfs/
 
 checksums           ${distname}${extract.suffix} \

--- a/fuse/gocryptfs/Portfile
+++ b/fuse/gocryptfs/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 PortGroup           fuse 1.0
 
-go.setup            github.com/rfjakob/gocryptfs 2.3 v
+go.setup            github.com/rfjakob/gocryptfs 2.3.1 v
 revision            0
 
 categories          fuse
@@ -17,11 +17,11 @@ long_description    ${description}
 homepage            https://nuetzlich.net/gocryptfs/
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  21bdcc50c47ed3a3377cdce08a074842f8576b42 \
-                        sha256  43609caf2ef8e8401c25281569e40cdaac8eb438717e3bd3f49112d7436659d2 \
-                        size    1370318
+                        rmd160  b3ae8b01ad4219bc027378f6475b7f417a2c9647 \
+                        sha256  0e440c66abe923792d11e9890fc893096f54a32347776589b25f9edb9e3eb8c2 \
+                        size    1371916
 
-set gitversionfuse "934a183ed914"
+set gitversionfuse "915cf5413cde"
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
                         rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
@@ -33,15 +33,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  3f372803b6ee7e65988d483eaf3696ec479b2cc3e42873e8d8e147c9600e40e2 \
                         size    14845 \
                     golang.org/x/sys \
-                        lock    bfb29a6856f2 \
-                        rmd160  8532b0affbd8046f1ba8197e58d7074cf7c4dd66 \
-                        sha256  c84221f35a3f3cfea0e8895d5f347614e9f1f73ad62ae96f8f83fb6ea76e1b67 \
-                        size    1209170 \
+                        lock    bc2c85ada10a \
+                        rmd160  c4b2c26618cd3f02fe04653b3a4fbe6707de5716 \
+                        sha256  b2526b52942c803a1687e16f87942bd0f0701b5d260fbaa35d53231e0a520577 \
+                        size    1303117 \
                     golang.org/x/net \
-                        lock    60bc85c4be6d \
-                        rmd160  6a1bf501fae3881bd457e46d247c367c7c2b2346 \
-                        sha256  f1afa9c0e0e64fb09daf3555848517d902a0612da836d04c49fa01b5960e5b2e \
-                        size    1253009 \
+                        lock    1185a9018129 \
+                        rmd160  06766c092ba6050f64d884ea7319c7ba9225891d \
+                        sha256  157ec6672ba40db471b1e5c4b9d08c9637388bafd475c93e3acf50b6bf2d2208 \
+                        size    1228139 \
                     golang.org/x/crypto \
                         lock    32db794688a5 \
                         rmd160  02ab581de5510ce94205e0fe5a58aacd2cd375b8 \
@@ -102,21 +102,21 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  5c5dd8416ee4a236632eaa4fc1a1e5ce737eee45 \
                         sha256  4a45ac5d5b5c15af45761f15e3e14f4739b1cd79cd9493ddcd4744f65edc4b52 \
                         size    43827 \
-                    github.com/jacobsa/crypto \
-                        lock    9f44e2d11115 \
-                        rmd160  0cbf3ba64ed7e4a65ad9e5083efe103deb2137f7 \
-                        sha256  8c230508b648a74dfecf86015965bd89c78b98a2e5988ee7ab538940db078390 \
-                        size    3653945 \
                     github.com/hanwen/go-fuse \
                         lock    ${gitversionfuse} \
-                        rmd160  ef96daf52bfd6534bae6819d138df4c6300aa88e \
-                        sha256  624b97c80e5fea8188dfbbab06b933da4518e4773c85fd9306fb25928ee8c1df \
-                        size    207375 \
+                        rmd160  02f4d3a41fe763097ac9f1b88f8b0cdad1ae4c4b \
+                        sha256  d466c51b50238497708f40214587a06ee539f868c7c20833128b1f92d577abd9 \
+                        size    187382 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.0 \
                         rmd160  0303eae19a01f38fe314921fd965e4d09b9ef3ad \
                         sha256  810a597004388d68bb92d8aa612375419ba1080dd5fc2c66dd41b58f0ba4442c \
-                        size    42348
+                        size    42348 \
+                    github.com/aperturerobotics/jacobsa-crypto \
+                        lock    v1.0.0 \
+                        rmd160  6d34d0b1b4779666f969c1df6cb8934ed6468e6b \
+                        sha256  f75a386f00a96aaf95975036513c3b837a601a66eb631e2d159c7f9322f33f60 \
+                        size    3654688
 
 # Build date should not be set to a variable value as this would prevent reproducible builds.
 # Not setting it results in defaulting to '0000-00-00' when using the --version flag.


### PR DESCRIPTION
###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2.1 22D68 arm64
Xcode 14.1 14B47b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -v install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
