### PR TITLE
macos-fortress: Update to version 2023.03.04

### DIFF
--- a/net/macos-fortress/Portfile
+++ b/net/macos-fortress/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 
 name                macos-fortress
-version             2021.12.26
+version             2023.03.04
 revision            0
 
 categories          net security

--- a/net/macos-fortress/files/proxy.pac
+++ b/net/macos-fortress/files/proxy.pac
@@ -18,76 +18,40 @@ if (
        See: https://discussions.apple.com/thread/250687994
    */
    ||
-   // Comcast
-   (host == "imap.comcast.net") || (host == "smtp.comcast.net") ||
-   dnsDomainIs(host, "imap.comcast.net") || dnsDomainIs(host, "smtp.comcast.net") ||
-   // Apple
-   (host == "imap.mail.me.com") || (host == "smtp.mail.me.com") ||
-   dnsDomainIs(host, "imap.mail.me.com") || dnsDomainIs(host, "smtp.mail.me.com") ||
-   (host == "p03-imap.mail.me.com") || (host == "p03-smtp.mail.me.com") ||
-   dnsDomainIs(host, "p03-imap.mail.me.com") || dnsDomainIs(host, "p03-smtp.mail.me.com") ||
-   (host == "p66-imap.mail.me.com") || (host == "p66-smtp.mail.me.com") ||
-   dnsDomainIs(host, "p66-imap.mail.me.com") || dnsDomainIs(host, "p66-smtp.mail.me.com") ||
-   // Google
-   (host == "imap.gmail.com") || (host == "smtp.gmail.com") ||
-   dnsDomainIs(host, "imap.gmail.com") || dnsDomainIs(host, "smtp.gmail.com") ||
-   // Yahoo
-   (host == "imap.mail.yahoo.com") || (host == "smtp.mail.yahoo.com") ||
-   dnsDomainIs(host, "imap.mail.yahoo.com") || dnsDomainIs(host, "smtp.mail.yahoo.com") ||
+   shExpMatch(url, "smtp:*") ||
+   shExpMatch(url, "submission:*") ||
+   shExpMatch(url, "imap:*") ||
+   shExpMatch(url, "imaps:*")
+   ||
    // Apple Enterprise Network Domains; https://support.apple.com/en-us/HT210060
-   (host == "albert.apple.com") || dnsDomainIs(host, "albert.apple.com") ||
-   (host == "captive.apple.com") || dnsDomainIs(host, "captive.apple.com") ||
-   (host == "gs.apple.com") || dnsDomainIs(host, "gs.apple.com") ||
-   (host == "humb.apple.com") || dnsDomainIs(host, "humb.apple.com") ||
-   (host == "static.ips.apple.com") || dnsDomainIs(host, "static.ips.apple.com") ||
-   (host == "tbsc.apple.com") || dnsDomainIs(host, "tbsc.apple.com") ||
-   (host == "time-ios.apple.com") || dnsDomainIs(host, "time-ios.apple.com") ||
-   (host == "time.apple.com") || dnsDomainIs(host, "time.apple.com") ||
-   (host == "time-macos.apple.com") || dnsDomainIs(host, "time-macos.apple.com") ||
-   dnsDomainIs(host, ".push.apple.com") ||
-   (host == "gdmf.apple.com") || dnsDomainIs(host, "gdmf.apple.com") ||
-   (host == "deviceenrollment.apple.com") || dnsDomainIs(host, "deviceenrollment.apple.com") ||
-   (host == "deviceservices-external.apple.com") || dnsDomainIs(host, "deviceservices-external.apple.com") ||
-   (host == "identity.apple.com") || dnsDomainIs(host, "identity.apple.com") ||
-   (host == "iprofiles.apple.com") || dnsDomainIs(host, "iprofiles.apple.com") ||
-   (host == "mdmenrollment.apple.com") || dnsDomainIs(host, "mdmenrollment.apple.com") ||
-   (host == "setup.icloud.com") || dnsDomainIs(host, "setup.icloud.com") ||
-   (host == "appldnld.apple.com") || dnsDomainIs(host, "appldnld.apple.com") ||
-   (host == "gg.apple.com") || dnsDomainIs(host, "gg.apple.com") ||
-   (host == "gnf-mdn.apple.com") || dnsDomainIs(host, "gnf-mdn.apple.com") ||
-   (host == "gnf-mr.apple.com") || dnsDomainIs(host, "gnf-mr.apple.com") ||
-   (host == "gs.apple.com") || dnsDomainIs(host, "gs.apple.com") ||
-   (host == "ig.apple.com") || dnsDomainIs(host, "ig.apple.com") ||
-   (host == "mesu.apple.com") || dnsDomainIs(host, "mesu.apple.com") ||
-   (host == "oscdn.apple.com") || dnsDomainIs(host, "oscdn.apple.com") ||
-   (host == "osrecovery.apple.com") || dnsDomainIs(host, "osrecovery.apple.com") ||
-   (host == "skl.apple.com") || dnsDomainIs(host, "skl.apple.com") ||
-   (host == "swcdn.apple.com") || dnsDomainIs(host, "swcdn.apple.com") ||
-   (host == "swdist.apple.com") || dnsDomainIs(host, "swdist.apple.com") ||
-   (host == "swdownload.apple.com") || dnsDomainIs(host, "swdownload.apple.com") ||
-   (host == "swpost.apple.com") || dnsDomainIs(host, "swpost.apple.com") ||
-   (host == "swscan.apple.com") || dnsDomainIs(host, "swscan.apple.com") ||
-   (host == "updates-http.cdn-apple.com") || dnsDomainIs(host, "updates-http.cdn-apple.com") ||
-   (host == "updates.cdn-apple.com") || dnsDomainIs(host, "updates.cdn-apple.com") ||
-   (host == "xp.apple.com") || dnsDomainIs(host, "xp.apple.com") ||
-   dnsDomainIs(host, ".itunes.apple.com") ||
-   dnsDomainIs(host, ".apps.apple.com") ||
+   dnsDomainIs(host, ".apple.com") ||
+   dnsDomainIs(host, ".cdn-apple.com") ||
+   dnsDomainIs(host, ".apple-cloudkit.com") ||
+   dnsDomainIs(host, ".apple-livephotoskit.com") ||
+   (host == "app-site-association.cdn-apple.com") ||
+   dnsDomainIs(host, ".app-site-association.cdn-apple.com") ||
+   (host == "app-site-association.networking.apple") ||
+   dnsDomainIs(host, ".app-site-association.networking.apple") ||
+   dnsDomainIs(host, ".apzones.com") ||
+   (host == "appldnld.apple.com.edgesuite.net") ||
+   (host == "icloud.com") ||
+   dnsDomainIs(host, ".icloud.com") ||
+   dnsDomainIs(host, ".icloud-content.com") ||
+   (host == "itunes.com") ||
+   dnsDomainIs(host, ".itunes.com") ||
    dnsDomainIs(host, ".mzstatic.com") ||
-   (host == "ppq.apple.com") || dnsDomainIs(host, "ppq.apple.com") ||
-   (host == "lcdn-registration.apple.com") || dnsDomainIs(host, "lcdn-registration.apple.com") ||
-   (host == "crl.apple.com") || dnsDomainIs(host, "crl.apple.com") ||
+   dnsDomainIs(host, ".vertexsmb.com") ||
    (host == "crl.entrust.net") || dnsDomainIs(host, "crl.entrust.net") ||
    (host == "crl3.digicert.com") || dnsDomainIs(host, "crl3.digicert.com") ||
    (host == "crl4.digicert.com") || dnsDomainIs(host, "crl4.digicert.com") ||
-   (host == "ocsp.apple.com") || dnsDomainIs(host, "ocsp.apple.com") ||
    (host == "ocsp.digicert.com") || dnsDomainIs(host, "ocsp.digicert.com") ||
    (host == "ocsp.entrust.net") || dnsDomainIs(host, "ocsp.entrust.net") ||
-   (host == "ocsp.verisign.net") || dnsDomainIs(host, "ocsp.verisign.net") ||
-   // Zoom
+   (host == "ocsp.verisign.net") || dnsDomainIs(host, "ocsp.verisign.net")
+   ||
    /*
        Proxy bypass hostnames
    */
-   ||
+   // Zoom
    dnsDomainIs(host, ".zoom.us")
 )
         return "DIRECT";


### PR DESCRIPTION
* Update Apple Enterprise Network domains from https://support.apple.com/en-us/HT210060
* Update iOS IMAP issue from https://forums.developer.apple.com/thread/121928

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2.1 22D68 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
