### PR TITLE
git-cola: update to 4.1.0

### DIFF
--- a/devel/git-cola/Portfile
+++ b/devel/git-cola/Portfile
@@ -1,11 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           python 1.0
 
-github.setup        git-cola git-cola 3.1 v
-platforms           darwin
-categories          devel
+name                git-cola
+version             4.1.0
+revision            0
+
+supported_archs     noarch
+platforms           {darwin any}
+categories-prepend  devel
 maintainers         {raimue @raimue} \
                     openmaintainer
 license             GPL-2+
@@ -14,36 +18,30 @@ description         The highly caffeinated Git GUI
 long_description    git-cola is a powerful Git GUI with a slick and \
                     intuitive user interface.
 
-checksums           rmd160  0ea666f81054289dc0e98c7a38547b73143e96da \
-                    sha256  d8a5ee637aea00965121cd4f2388319983bcd05ae7149069a6d553268149350b \
-                    size    1180032
+checksums           rmd160  effbd5a8d4ce0ddafdbd1fe1604ec88f58d35612 \
+                    sha256  d77ba2eb1d1240f47cc44f5fcb9230cc65681834e7e27edf17c5ada462d3fb07 \
+                    size    1140358
 
-depends_build       port:py36-sphinx
-depends_lib         port:git \
-                    port:python36 \
-                    port:py36-pyqt4 \
-                    port:py36-qtpy
+homepage            https://git-cola.github.io/
+
+python.default_version 311
+python.pep517       yes
 
 patchfiles          patch-pyqt-version.diff
 
+# now default to Qt5, Qt6 and/or PySide2 are other options, for which one could add
+# variants if deemed useful
 post-patch {
-    set pyqt "pyqt4"
-    if {[variant_isset qt5]} {
-        set pyqt "pyqt5"
-    }
-    reinplace -W ${worksrcpath} -E "s/@@pyqt@@/${pyqt}/" cola/app.py
+    reinplace -W ${worksrcpath} -E "s/@@pyqt@@/pyqt5/" cola/app.py
 }
 
-use_configure no
+depends_build-append \
+                    port:py${python.version}-setuptools_scm \
+                    port:py${python.version}-toml
 
-build.args          prefix=${prefix} \
-                    PYTHON=${prefix}/bin/python3.6 \
-                    SPHINXBUILD=${prefix}/bin/sphinx-build-3.6 \
-                    NO_VENDOR_LIBS=1
-build.target        all man
-
-destroot.args       ${build.args}
-destroot.target     install install-man
+depends_lib-append  port:git \
+                    port:py${python.version}-pyqt5 \
+                    port:py${python.version}-qtpy
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/bash-completion/completions
@@ -58,11 +56,3 @@ notes "\
       source ${prefix}/share/bash-completion/completions/git
       source ${prefix}/share/bash-completion/completions/git-cola
 "
-
-variant qt5 description (Use qt5 instead of qt4} {
-    # This variant is meant to match py36-qtpy +qt5, which also depends on
-    # py36-qtpy5. However, all variants of py36-qtpy support all Qt versions.
-    # Always add the dependency in this port to ensure the selected Qt version
-    # is available.
-    depends_lib-replace port:py36-pyqt4 port:py36-pyqt5
-}

--- a/devel/git-cola/files/patch-pyqt-version.diff
+++ b/devel/git-cola/files/patch-pyqt-version.diff
@@ -1,12 +1,12 @@
---- cola/app.py.orig	2017-04-10 05:20:15.000000000 +0200
-+++ cola/app.py	2017-05-09 17:35:11.000000000 +0200
-@@ -9,6 +9,9 @@
- Copyright (C) 2009-2016 David Aguilar and contributors
+--- cola/app.py.orig	2023-03-04 09:22:38
++++ cola/app.py	2023-03-04 09:23:15
+@@ -12,6 +12,9 @@
+ Copyright (C) 2007-2022 David Aguilar and contributors
  """
  
 +# Use this specific version of Qt
 +os.environ['QT_API'] = '@@pyqt@@'
 +
- from . import core
  try:
      from qtpy import QtCore
+ except ImportError:


### PR DESCRIPTION
#### Description
- update to latest upstream version
- switch to PyPI, to avoid build errors due to `setuptools_scm`
- use Python 3.11

Closes: https://trac.macports.org/ticket/65541

###### Tested on
macOS 13.2.1 22D68 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
