### PR TITLE
libvpx: explicitly require c++11 and fix link

### DIFF
--- a/multimedia/libvpx/Portfile
+++ b/multimedia/libvpx/Portfile
@@ -43,6 +43,11 @@ supported_archs     x86_64 i386 arm64 ppc ppc64
 patchfiles-append   patch-Makefile.diff
 patchfiles-append   patch-configure.sh.diff
 
+# requires c++11 https://trac.macports.org/ticket/67038
+compiler.cxx_standard 2011
+# requires MacPorts c++11 flags explicitly added to ldflags https://trac.macports.org/ticket/67038
+configure.ldflags-append {*}${configure.cxxflags}
+
 # Uses newer assembly features on Intel.
 # Also blacklist clang 8, due to issues like:
 #   error: use of undeclared identifier 'abs'


### PR DESCRIPTION
and also ensure MacPorts c++11 flags make it to the link lines

closes: https://trac.macports.org/ticket/67038

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
