### PR TITLE
dnscontrol: update to 3.27.1

### DIFF
--- a/sysutils/dnscontrol/Portfile
+++ b/sysutils/dnscontrol/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/StackExchange/dnscontrol 3.26.0 v
+go.setup            github.com/StackExchange/dnscontrol 3.27.1 v
 
-checksums           rmd160  8adf0ee7b46df6be54513cf9774497bccbf8fa4a \
-                    sha256  907bea01973d5f62351fa79dc0627b3eb4c904567a02927ea93bc36e61ab5b86 \
-                    size    6385313
+checksums           rmd160  994e7ff33bf0a31fa347be981fffe1713e997c97 \
+                    sha256  5a53d851ea1f38e8783eb7fc16b3ccbfe399f08ffa63e30d00120c63467d3c16 \
+                    size    6387248
 
 homepage            https://stackexchange.github.io/dnscontrol/
 description         Synchronize your DNS to multiple providers from a simple DSL


### PR DESCRIPTION
#### Description
dnscontrol: update to 3.27.1
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.2.1 22D68 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?