### PR TITLE
nng: new port in devel

### DIFF
--- a/devel/nng/Portfile
+++ b/devel/nng/Portfile
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        nanomsg nng 1.5.2 v
+revision            0
+license             MIT
+categories          devel
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Light-weight brokerless messaging
+long_description    {*}${description}
+homepage            https://nng.nanomsg.org
+checksums           rmd160  1a45ce54ac8dfcc75c26b42fb39fa867947ec09b \
+                    sha256  d1ca7b0252bf9ba763989dcb7b3b6d828e12164daab3be3a9363b84e33280139 \
+                    size    713203
+cmake.generator     Ninja
+
+# https://github.com/nanomsg/nng/issues/1647
+patchfiles          patch-tests.diff \
+                    patch-posix_resolv_gai.diff
+
+# Remove unsupported pragmas:
+if {[string match *gcc-4.* ${configure.compiler}]} {
+    patchfiles-append patch-old-gcc.diff
+}
+
+configure.args-append \
+                    -DBUILD_SHARED_LIBS=OFF \
+                    -DNNG_ENABLE_COVERAGE=OFF \
+                    -DNNG_ENABLE_TLS=OFF \
+                    -DNNG_TESTS=ON
+
+compiler.c_standard 1999
+
+pre-test {
+    # Testing infrastructure uses /bin/ps, which is forbidden by sandboxing.
+    append portsandbox_profile " (allow process-exec (literal \"/bin/ps\") (with no-profile))"
+}
+
+# Not making a default due to: https://github.com/nanomsg/nng/issues/1648#issuecomment-1455046886
+variant dylib description "Build dynamic library" {
+    configure.args-replace \
+                    -DBUILD_SHARED_LIBS=OFF -DBUILD_SHARED_LIBS=ON
+}
+
+# There are a few failures on PPC: https://github.com/nanomsg/nng/issues/1648
+variant tests description "Enable testing" {
+    if {[variant_isset dylib]} {
+        configure.pre_args-replace \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+    }
+    configure.args-replace \
+                    -DNNG_TESTS=OFF -DNNG_TESTS=ON
+    test.run        yes
+}

--- a/devel/nng/files/patch-old-gcc.diff
+++ b/devel/nng/files/patch-old-gcc.diff
@@ -1,0 +1,14 @@
+--- src/platform/posix/posix_pipe.c.orig	2021-08-11 08:09:53.000000000 +0800
++++ src/platform/posix/posix_pipe.c	2023-03-05 15:08:48.000000000 +0800
+@@ -102,11 +102,7 @@
+ nni_plat_pipe_raise(int wfd)
+ {
+ 	char c = 1;
+-
+-#pragma GCC diagnostic push
+-#pragma GCC diagnostic ignored "-Wunused-result"
+ 	(void) write(wfd, &c, 1);
+-#pragma GCC diagnostic pop
+ }
+ 
+ void

--- a/devel/nng/files/patch-posix_resolv_gai.diff
+++ b/devel/nng/files/patch-posix_resolv_gai.diff
@@ -1,0 +1,13 @@
+--- src/platform/posix/posix_resolv_gai.c.orig	2021-08-11 08:09:53.000000000 +0800
++++ src/platform/posix/posix_resolv_gai.c	2023-03-05 18:33:35.000000000 +0800
+@@ -33,6 +33,10 @@
+ #define NNG_RESOLV_CONCURRENCY 4
+ #endif
+ 
++#ifndef AI_NUMERICSERV
++#define AI_NUMERICSERV	0x00001000 /* prevent service name resolution */
++#endif
++
+ static nni_mtx  resolv_mtx;
+ static nni_cv   resolv_cv;
+ static bool     resolv_fini;

--- a/devel/nng/files/patch-tests.diff
+++ b/devel/nng/files/patch-tests.diff
@@ -1,0 +1,20 @@
+--- cmake/NNGHelpers.cmake.orig	2021-08-11 08:09:53.000000000 +0800
++++ cmake/NNGHelpers.cmake	2023-03-05 15:21:14.000000000 +0800
+@@ -98,7 +98,7 @@
+                 ${PROJECT_SOURCE_DIR}/tests
+                 ${PROJECT_SOURCE_DIR}/src
+                 ${PROJECT_SOURCE_DIR}/include)
+-        add_test(NAME ${NNG_TEST_PREFIX}.${NAME} COMMAND ${NAME} -t -v)
++        add_test(NAME ${NNG_TEST_PREFIX}.${NAME} COMMAND ${NAME} -v)
+         set_tests_properties(${NNG_TEST_PREFIX}.${NAME} PROPERTIES TIMEOUT 180)
+     endif ()
+ endfunction()
+@@ -111,7 +111,7 @@
+                 ${PROJECT_SOURCE_DIR}/tests
+                 ${PROJECT_SOURCE_DIR}/src
+                 ${PROJECT_SOURCE_DIR}/include)
+-        add_test(NAME ${NNG_TEST_PREFIX}.${NAME} COMMAND ${NAME} -t -v)
++        add_test(NAME ${NNG_TEST_PREFIX}.${NAME} COMMAND ${NAME} -v)
+         set_tests_properties(${NNG_TEST_PREFIX}.${NAME} PROPERTIES TIMEOUT 180)
+     endif ()
+ endfunction()


### PR DESCRIPTION
#### Description

New port: https://github.com/nanomsg/nng

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Test results in Rosetta:
```
--->  Testing nng
Executing:  cd "/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_nng/nng/work/build" && ninja test 
[0/1] Running tests...
Test project /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_nng/nng/work/build
      Start  1: nng.core.aio_test
 1/81 Test  #1: nng.core.aio_test ...........................***Timeout 180.05 sec
      Start  2: nng.core.buf_size_test
 2/81 Test  #2: nng.core.buf_size_test ......................   Passed    0.20 sec
      Start  3: nng.core.errors_test
 3/81 Test  #3: nng.core.errors_test ........................   Passed    0.05 sec
      Start  4: nng.core.id_test
 4/81 Test  #4: nng.core.id_test ............................   Passed    0.12 sec
      Start  5: nng.core.list_test
 5/81 Test  #5: nng.core.list_test ..........................   Passed    0.07 sec
      Start  6: nng.core.message_test
 6/81 Test  #6: nng.core.message_test .......................   Passed    0.31 sec
      Start  7: nng.core.reconnect_test
 7/81 Test  #7: nng.core.reconnect_test .....................   Passed    1.37 sec
      Start  8: nng.core.sock_test
 8/81 Test  #8: nng.core.sock_test ..........................   Passed    1.69 sec
      Start  9: nng.core.url_test
 9/81 Test  #9: nng.core.url_test ...........................   Passed    0.28 sec
      Start 10: nng.platform.platform_test
10/81 Test #10: nng.platform.platform_test ..................   Passed    1.11 sec
      Start 11: nng.platform.resolver_test
11/81 Test #11: nng.platform.resolver_test ..................   Passed    0.67 sec
      Start 12: nng.compat.compat.nanomsg.compat_tcp_test
12/81 Test #12: nng.compat.compat.nanomsg.compat_tcp_test ...   Passed    1.36 sec
      Start 13: nng.sp.protocol.bus0.bug1247_test
13/81 Test #13: nng.sp.protocol.bus0.bug1247_test ...........   Passed    0.09 sec
      Start 14: nng.sp.protocol.pair0.pair0_test
14/81 Test #14: nng.sp.protocol.pair0.pair0_test ............   Passed    2.04 sec
      Start 15: nng.sp.protocol.pair1.pair1_test
15/81 Test #15: nng.sp.protocol.pair1.pair1_test ............   Passed    2.96 sec
      Start 16: nng.sp.protocol.pair1.pair1_poly_test
16/81 Test #16: nng.sp.protocol.pair1.pair1_poly_test .......   Passed    1.59 sec
      Start 17: nng.sp.protocol.pipeline0.pull_test
17/81 Test #17: nng.sp.protocol.pipeline0.pull_test .........   Passed    1.33 sec
      Start 18: nng.sp.protocol.pipeline0.push_test
18/81 Test #18: nng.sp.protocol.pipeline0.push_test .........   Passed    2.48 sec
      Start 19: nng.sp.protocol.pubsub0.pub_test
19/81 Test #19: nng.sp.protocol.pubsub0.pub_test ............   Passed    1.34 sec
      Start 20: nng.sp.protocol.pubsub0.sub_test
20/81 Test #20: nng.sp.protocol.pubsub0.sub_test ............   Passed    3.22 sec
      Start 21: nng.sp.protocol.pubsub0.xsub_test
21/81 Test #21: nng.sp.protocol.pubsub0.xsub_test ...........   Passed    1.98 sec
      Start 22: nng.sp.protocol.reqrep0.req_test
22/81 Test #22: nng.sp.protocol.reqrep0.req_test ............***Failed    5.36 sec
      Start 23: nng.sp.protocol.reqrep0.rep_test
23/81 Test #23: nng.sp.protocol.reqrep0.rep_test ............   Passed    2.42 sec
      Start 24: nng.sp.protocol.reqrep0.xrep_test
24/81 Test #24: nng.sp.protocol.reqrep0.xrep_test ...........   Passed    1.84 sec
      Start 25: nng.sp.protocol.reqrep0.xreq_test
25/81 Test #25: nng.sp.protocol.reqrep0.xreq_test ...........   Passed    1.67 sec
      Start 26: nng.sp.protocol.survey0.respond_test
26/81 Test #26: nng.sp.protocol.survey0.respond_test ........   Passed    2.07 sec
      Start 27: nng.sp.protocol.survey0.survey_test
27/81 Test #27: nng.sp.protocol.survey0.survey_test .........***Failed    2.51 sec
      Start 28: nng.sp.protocol.survey0.xrespond_test
28/81 Test #28: nng.sp.protocol.survey0.xrespond_test .......   Passed    1.74 sec
      Start 29: nng.sp.protocol.survey0.xsurvey_test
29/81 Test #29: nng.sp.protocol.survey0.xsurvey_test ........   Passed    1.74 sec
      Start 30: nng.sp.transport.ipc.ipc_test
30/81 Test #30: nng.sp.transport.ipc.ipc_test ...............***Timeout 180.03 sec
      Start 31: nng.sp.transport.tcp.tcp_test
31/81 Test #31: nng.sp.transport.tcp.tcp_test ...............***Failed    1.94 sec
      Start 32: nng.sp.transport.ws.ws_test
32/81 Test #32: nng.sp.transport.ws.ws_test .................   Passed    0.88 sec
      Start 33: nng.supplemental.base64_test
33/81 Test #33: nng.supplemental.base64_test ................   Passed    0.08 sec
      Start 34: nng.supplemental.sha1_test
34/81 Test #34: nng.supplemental.sha1_test ..................   Passed    0.08 sec
      Start 35: nng.supplemental.wssfile_test
35/81 Test #35: nng.supplemental.wssfile_test ...............   Passed    0.03 sec
      Start 36: nng.supplemental.websocket_test
36/81 Test #36: nng.supplemental.websocket_test .............   Passed    0.98 sec
      Start 37: nng.inproc_lat
37/81 Test #37: nng.inproc_lat ..............................   Passed   11.39 sec
      Start 38: nng.inproc_thr
38/81 Test #38: nng.inproc_thr ..............................   Passed    6.86 sec
      Start 39: nng.device
39/81 Test #39: nng.device ..................................   Passed    0.34 sec
      Start 40: nng.files
40/81 Test #40: nng.files ...................................   Passed    0.06 sec
      Start 41: nng.httpclient
41/81 Test #41: nng.httpclient ..............................   Passed    5.22 sec
      Start 42: nng.httpserver
42/81 Test #42: nng.httpserver ..............................   Passed    3.16 sec
      Start 43: nng.inproc
43/81 Test #43: nng.inproc ..................................   Passed    1.57 sec
      Start 44: nng.ipc
44/81 Test #44: nng.ipc .....................................***Failed    1.84 sec
      Start 45: nng.ipcsupp
45/81 Test #45: nng.ipcsupp .................................   Passed    0.09 sec
      Start 46: nng.ipcwinsec
46/81 Test #46: nng.ipcwinsec ...............................   Passed    0.09 sec
      Start 47: nng.multistress
47/81 Test #47: nng.multistress .............................***Timeout  60.02 sec
      Start 48: nng.nonblock
48/81 Test #48: nng.nonblock ................................   Passed   15.13 sec
      Start 49: nng.options
49/81 Test #49: nng.options .................................   Passed    0.05 sec
      Start 50: nng.pipe
50/81 Test #50: nng.pipe ....................................   Passed    0.48 sec
      Start 51: nng.pollfd
51/81 Test #51: nng.pollfd ..................................   Passed    0.51 sec
      Start 52: nng.scalability
52/81 Test #52: nng.scalability .............................   Passed    0.75 sec
      Start 53: nng.stats
53/81 Test #53: nng.stats ...................................   Passed    0.12 sec
      Start 54: nng.synch
54/81 Test #54: nng.synch ...................................   Passed    0.34 sec
      Start 55: nng.tls
55/81 Test #55: nng.tls .....................................   Passed    0.03 sec
      Start 56: nng.tcpsupp
56/81 Test #56: nng.tcpsupp .................................   Passed    0.12 sec
      Start 57: nng.tcp
57/81 Test #57: nng.tcp .....................................   Passed    1.90 sec
      Start 58: nng.tcp6
58/81 Test #58: nng.tcp6 ....................................   Passed    1.80 sec
      Start 59: nng.udp
59/81 Test #59: nng.udp .....................................***Failed    0.10 sec
      Start 60: nng.ws
60/81 Test #60: nng.ws ......................................   Passed    2.03 sec
      Start 61: nng.wss
61/81 Test #61: nng.wss .....................................   Passed    0.03 sec
      Start 62: nng.bus
62/81 Test #62: nng.bus .....................................   Passed    0.35 sec
      Start 63: nng.reqctx
63/81 Test #63: nng.reqctx ..................................   Passed    2.47 sec
      Start 64: nng.reqstress
64/81 Test #64: nng.reqstress ...............................   Passed   30.81 sec
      Start 65: nng.compat_block
65/81 Test #65: nng.compat_block ............................   Passed    0.30 sec
      Start 66: nng.compat_bug777
66/81 Test #66: nng.compat_bug777 ...........................   Passed    0.20 sec
      Start 67: nng.compat_bus
67/81 Test #67: nng.compat_bus ..............................   Passed    0.36 sec
      Start 68: nng.compat_cmsg
68/81 Test #68: nng.compat_cmsg .............................   Passed    0.11 sec
      Start 69: nng.compat_msg
69/81 Test #69: nng.compat_msg ..............................   Passed    0.15 sec
      Start 70: nng.compat_iovec
70/81 Test #70: nng.compat_iovec ............................   Passed    0.10 sec
      Start 71: nng.compat_device
71/81 Test #71: nng.compat_device ...........................   Passed    0.74 sec
      Start 72: nng.compat_pair
72/81 Test #72: nng.compat_pair .............................   Passed    0.09 sec
      Start 73: nng.compat_pipeline
73/81 Test #73: nng.compat_pipeline .........................   Passed    0.17 sec
      Start 74: nng.compat_poll
74/81 Test #74: nng.compat_poll .............................   Passed    0.45 sec
      Start 75: nng.compat_reqrep
75/81 Test #75: nng.compat_reqrep ...........................   Passed    1.14 sec
      Start 76: nng.compat_survey
76/81 Test #76: nng.compat_survey ...........................   Passed    3.09 sec
      Start 77: nng.compat_reqttl
77/81 Test #77: nng.compat_reqttl ...........................   Passed    0.33 sec
      Start 78: nng.compat_shutdown
78/81 Test #78: nng.compat_shutdown .........................   Passed    0.10 sec
      Start 79: nng.compat_surveyttl
79/81 Test #79: nng.compat_surveyttl ........................   Passed    0.36 sec
      Start 80: nng.compat_options
80/81 Test #80: nng.compat_options ..........................   Passed    0.11 sec
      Start 81: nng.cplusplus_pair
81/81 Test #81: nng.cplusplus_pair ..........................   Passed    0.12 sec

90% tests passed, 8 tests failed out of 81

Total Test time (real) = 563.77 sec

The following tests FAILED:
	  1 - nng.core.aio_test (Timeout)
	 22 - nng.sp.protocol.reqrep0.req_test (Failed)
	 27 - nng.sp.protocol.survey0.survey_test (Failed)
	 30 - nng.sp.transport.ipc.ipc_test (Timeout)
	 31 - nng.sp.transport.tcp.tcp_test (Failed)
	 44 - nng.ipc (Failed)
	 47 - nng.multistress (Timeout)
	 59 - nng.udp (Failed)
Errors while running CTest
```