### PR TITLE
azmq: new port in devel

### DIFF
--- a/devel/azmq/Portfile
+++ b/devel/azmq/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           boost 1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        zeromq azmq 1.0.3 v
+revision            0
+categories          devel
+license             Boost-1
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         C++ language binding library integrating ZeroMQ with Boost Asio
+long_description    {*}${description}
+checksums           rmd160  88ddb22a66c3d6991bc29a36878d4634f9537f4b \
+                    sha256  91143dd97b4748a422ebb78286430fca8b87a6ec0c0dc1324f6f317a95985464 \
+                    size    101669
+installs_libs       no
+supported_archs     noarch
+
+depends_lib-append  path:lib/libzmq.dylib:zmq
+
+post-patch {
+    reinplace "s|Boost 1.68|Boost ${boost.version}|" ${worksrcpath}/CMakeLists.txt
+}
+
+compiler.cxx_standard 2011
+
+# Counter-intuitively, BUILD_SHARED_LIBS stands for using dynamic libzmq and not building.
+configure.args-append \
+                    -DBUILD_SHARED_LIBS=ON \
+                    -DAZMQ_BUILD_TESTS=ON \
+                    -DAZMQ_BUILD_DOC=OFF
+
+test.run            yes


### PR DESCRIPTION
#### Description

New port: https://github.com/zeromq/azmq

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing azmq
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_azmq/azmq/work/build" && /usr/bin/make test 
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_azmq/azmq/work/build
    Start 1: test_message
1/6 Test #1: test_message .....................   Passed    0.11 sec
    Start 2: test_context_ops
2/6 Test #2: test_context_ops .................   Passed    0.08 sec
    Start 3: test_socket_ops
3/6 Test #3: test_socket_ops ..................   Passed    0.74 sec
    Start 4: test_socket
4/6 Test #4: test_socket ......................   Passed    5.99 sec
    Start 5: test_signal
5/6 Test #5: test_signal ......................   Passed    0.08 sec
    Start 6: test_actor
6/6 Test #6: test_actor .......................   Passed    0.08 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =   7.15 sec
```