### PR TITLE
Radian: Python-based GUI for R

### DIFF
--- a/math/radian/Portfile
+++ b/math/radian/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        randy3k radian 0.6.4 v
+revision            0
+categories          math python R
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         A XXI century R console
+long_description    radian is an alternative console for the R program with multiline editing and rich syntax highlight. \
+                    One would consider radian as a ipython clone for R, though its design is more aligned to Julia.
+
+checksums           rmd160  b7cc661d678becac17dab113d75366414dfa4784 \
+                    sha256  ccdca2a3c3079dbdea393a0fa081de26344af290c370a6990cd7d3ad4982b2a0 \
+                    size    74412
+supported_archs     noarch
+
+python.default_version 311
+
+depends_build-append \
+                    port:py${python.version}-pytest-runner \
+                    port:py${python.version}-setuptools
+depends_lib-append  port:py${python.version}-prompt_toolkit \
+                    port:py${python.version}-pygments \
+                    port:py${python.version}-rchitect
+depends_run-append  port:R
+
+depends_test-append port:py${python.version}-pexpect \
+                    port:py${python.version}-ptyprocess \
+                    port:py${python.version}-pyte
+
+test.run            yes

--- a/python/py-rchitect/Portfile
+++ b/python/py-rchitect/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        randy3k rchitect 0.3.40 v
+name                py-rchitect
+revision            0
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Mapping R API to Python
+long_description    {*}${description}
+
+checksums           rmd160  2e59a9a673c7edf6a1b61b12ce074b1dd474df4f \
+                    sha256  c1edf37c59ed66c044724b7f1a9d4542f3f9d2e05109a6413b10cce64c584b05 \
+                    size    36456
+
+depends_build-append \
+                    port:py${python.version}-pytest-runner \
+                    port:py${python.version}-setuptools
+depends_lib-append  port:py${python.version}-cffi \
+                    port:py${python.version}-six
+
+python.pep517       no
+python.versions     39 310 311


### PR DESCRIPTION
#### Description

New ports:
https://github.com/randy3k/radian
https://github.com/randy3k/rchitect (its dependency)

Unfortunately, it is pretty useless on 10.5.8 due to: https://trac.macports.org/ticket/67046
But Intel should work fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
