### PR TITLE
texinfo: fix universal build with GCC

### DIFF
--- a/textproc/texinfo/Portfile
+++ b/textproc/texinfo/Portfile
@@ -4,11 +4,16 @@ PortSystem          1.0
 PortGroup           clang_dependency 1.0
 PortGroup           perl5 1.0
 
+if {[string match *gcc* ${configure.compiler}]} {
+    # https://trac.macports.org/ticket/65995
+    PortGroup       muniversal 1.0
+
+}
+
 name                texinfo
 version             7.0.2
 revision            0
 categories          textproc
-platforms           darwin
 license             GPL-3+
 maintainers         nomaintainer
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/65995

#### Description

`texinfo` fails to build as universal, even though it uses `gcc-4.2` (see the ticket).
PG fixes that.
Since clangs do not need `muniversal` normally, I set it for gcc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
