### PR TITLE
kokkos-devel: new port to track upstream, with support for 32-bit

### DIFF
--- a/devel/kokkos/Portfile
+++ b/devel/kokkos/Portfile
@@ -31,6 +31,8 @@ configure.args-append       -DBUILD_SHARED_LIBS=ON \
 
 variant tests description {Enable tests} {
     configure.args-append   -DKokkos_ENABLE_TESTS=ON
-    test.args-append        DYLD_LIBRARY_PATH=${cmake.build_dir}/core/unit_test:${cmake.build_dir}/containers/src:${cmake.build_dir}/core/src
+    configure.pre_args-replace \
+                            -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                            -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
     test.run                yes
 }

--- a/devel/kokkos/Portfile
+++ b/devel/kokkos/Portfile
@@ -5,6 +5,7 @@ PortGroup                   github 1.0
 PortGroup                   cmake 1.1
 
 github.setup                kokkos kokkos 3.7.01
+conflicts                   kokkos-devel
 revision                    0
 categories                  devel
 license                     BSD
@@ -16,8 +17,23 @@ checksums                   rmd160  b73fbb7e3cc532545100412415bcb602414f7656 \
                             sha256  b9888a524345dd3ad6c6bb04b2e3e7f854a5caf61c3b09b628f2b1526ec45105 \
                             size    2305267
 
-# see https://github.com/kokkos/kokkos/blob/5ad609661e570ba6aa7716a26a91cb67d559f8a2/CMakeLists.txt#L126
-supported_archs             arm64 x86_64 ppc64
+subport kokkos-devel {
+    github.setup            kokkos kokkos 5fa72b590e4ebdf3b93898934c465c8d2f972ef6
+    version                 2023.05.06
+    conflicts               kokkos
+    maintainers-append      {@barracuda156 gmail.com:vital.had}
+    checksums               rmd160  5d87f5ef3bd605d41bdc1487b444e94e17d51ef8 \
+                            sha256  7660d3a44a931ff11b28eb6cd72f7a4faa27c7a592657b9a4ceebfa3e8d2ac24 \
+                            size    2317160
+    git.branch              develop
+    # 32-bit support added in: https://github.com/kokkos/kokkos/pull/5916
+}
+
+if {${subport} ne "kokkos-devel"} {
+    # Keep this until support for 32-bit platforms is merged into master.
+    # https://github.com/kokkos/kokkos/blob/5ad609661e570ba6aa7716a26a91cb67d559f8a2/CMakeLists.txt#L126
+    supported_archs         arm64 x86_64 ppc64
+}
 
 compiler.cxx_standard       2014
 compiler.openmp_version     4.0
@@ -28,6 +44,15 @@ configure.args-append       -DBUILD_SHARED_LIBS=ON \
                             -DKokkos_ENABLE_OPENMP=ON \
                             -DKokkos_ENABLE_SERIAL=ON \
                             -DKokkos_ENABLE_HWLOC=ON
+
+if {${subport} eq "kokkos-devel"} {
+    if {[string match *clang* ${configure.compiler}]} {
+        # https://github.com/macports/macports-ports/pull/17877#discussion_r1183486766
+        configure.ldflags-append \
+                            -L${prefix}/lib/libomp \
+                            -lomp
+    }
+}
 
 variant tests description {Enable tests} {
     configure.args-append   -DKokkos_ENABLE_TESTS=ON


### PR DESCRIPTION
#### Description

This is based on `develop` branch of upstream.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
