### PR TITLE
py-dulwich: update to 0.21.3

### DIFF
--- a/python/py-dulwich/Portfile
+++ b/python/py-dulwich/Portfile
@@ -29,12 +29,14 @@ if {${name} ne ${subport}} {
         version                 0.19.16
         revision                1
 
-        checksums               rmd160  1029473c8fd18718ef7f4a3dea082a053ee92ca4 \
-                                sha256  6d225b7d5f5a293beb1d0855f41feef74230605ffde7929a5719eed4019cb6d1 \
-                                size    369717
+        checksums               rmd160  3aa193d26c22c45e9ac3d07258f9a97e303cc503 \
+                                sha256  f74561c448bfb6f04c07de731c1181ae4280017f759b0bb04fa5770aa84ca850 \
+                                size    375483
 
         build.target-append build_ext
         build.args-append   --inplace
+        patchfiles      patch-archflags-27.diff \
+                        patch-strnlen-lion.diff
     } else {
         python.pep517           yes
 
@@ -42,10 +44,10 @@ if {${name} ne ${subport}} {
             depends_build-append \
                     port:py${python.version}-importlib-metadata
         }
+        patchfiles      patch-archflags.diff \
+                        patch-strnlen-lion.diff
     }
 
-    patchfiles      patch-archflags.diff \
-                    patch-strnlen-lion.diff
 
     depends_lib-append \
                     port:py${python.version}-setuptools \

--- a/python/py-dulwich/Portfile
+++ b/python/py-dulwich/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-dulwich
-version             0.20.50
+version             0.21.3
 categories-append   devel
 maintainers         {danchr @danchr} openmaintainer
 license             GPL-2+
@@ -17,9 +17,9 @@ long_description    Simple Pure-Python implementation of the Git file \
 
 homepage            https://www.dulwich.io
 
-checksums           rmd160  75b0e9721c937b038855b504007e29515c07c714 \
-                    sha256  50a941796b2c675be39be728d540c16b5b7ce77eb9e1b3f855650ece6832d2be \
-                    size    430389
+checksums           rmd160  b79b7514d466cf67fe0cbeac335dcc73649e1cce \
+                    sha256  7ca3b453d767eb83b3ec58f0cfcdc934875a341cdfdb0dc55c1431c96608cf83 \
+                    size    437815
 
 python.versions     27 37 38 39 310 311
 

--- a/python/py-dulwich/files/patch-archflags-27.diff
+++ b/python/py-dulwich/files/patch-archflags-27.diff
@@ -1,0 +1,26 @@
+Do not ignore the -arch flags MacPorts tells it to build with.
+--- setup.py.orig	2023-03-06 09:49:23.300851775 -0500
++++ setup.py	2023-03-06 09:49:34.774129595 -0500
+@@ -39,22 +39,6 @@
+
+     pure = False
+
+-
+-if sys.platform == 'darwin' and os.path.exists('/usr/bin/xcodebuild'):
+-    # XCode 4.0 dropped support for ppc architecture, which is hardcoded in
+-    # distutils.sysconfig
+-    import subprocess
+-    p = subprocess.Popen(
+-        ['/usr/bin/xcodebuild', '-version'], stdout=subprocess.PIPE,
+-        stderr=subprocess.PIPE, env={})
+-    out, err = p.communicate()
+-    for line in out.splitlines():
+-        line = line.decode("utf8")
+-        # Also parse only first digit, because 3.2.1 can't be parsed nicely
+-        if (line.startswith('Xcode') and
+-                int(line.split()[1].split('.')[0]) >= 4):
+-            os.environ['ARCHFLAGS'] = ''
+-
+ tests_require = ['fastimport']
+
+


### PR DESCRIPTION
#### Description

This was tested with dulwich on the CLI with a clone, which worked fine. There isn't any API breakage in the major version bump.

For the one checksum mismatch, I downloaded the old MacPorts distfile and diffed it against the upstream:

```
Only in dulwich-new/dulwich: PKG-INFO
Only in dulwich-new/dulwich: dulwich.egg-info
diff -ru dulwich-old/dulwich/setup.cfg dulwich-new/dulwich/setup.cfg
--- dulwich-old/dulwich/setup.cfg	2020-04-17 14:31:46.000000000 -0400
+++ dulwich-new/dulwich/setup.cfg	2020-04-17 14:32:10.000000000 -0400
@@ -1,2 +1,7 @@
 [flake8]
 exclude = build,.git,build-pypy,.tox
+
+[egg_info]
+tag_build =
+tag_date = 0
+
Binary files dulwich-old/dulwich-0.19.16.tar.gz and dulwich-new/dulwich-0.19.16.tar.gz differ
```

The name of the extracted directory changed too, but MacPorts was handling that already. One patch had bitrotted and I re-applied it to 2.7. The 2.7 version was able to successfully clone repos so I think it is working fine as well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
