### PR TITLE
jemalloc: backport linking fix from upstream

### DIFF
--- a/devel/jemalloc/Portfile
+++ b/devel/jemalloc/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           muniversal 1.1
 
 github.setup        jemalloc jemalloc 5.3.0
-revision            3
+revision            4
 license             BSD
 categories          devel
 maintainers         nomaintainer
@@ -25,7 +25,8 @@ github.tarball_from releases
 
 compiler.cxx_standard 2014
 
-patchfiles          patch-quantum.diff
+patchfiles          patch-quantum.diff \
+                    patch-Makefile.diff
 
 # building as x86_64 on an arm64 Mac gives an error if rosetta is installed
 # https://trac.macports.org/ticket/65671

--- a/devel/jemalloc/files/patch-Makefile.diff
+++ b/devel/jemalloc/files/patch-Makefile.diff
@@ -1,0 +1,16 @@
+# https://github.com/jemalloc/jemalloc/commit/4422f88d17404944a312825a1aec96cd9dc6c165
+
+--- Makefile.in.orig	2022-05-07 02:29:14.000000000 +0800
++++ Makefile.in	2023-03-06 22:56:10.000000000 +0800
+@@ -513,7 +513,11 @@
+ 
+ $(objroot)lib/$(LIBJEMALLOC).$(SOREV) : $(if $(PIC_CFLAGS),$(C_PIC_OBJS),$(C_OBJS)) $(if $(PIC_CFLAGS),$(CPP_PIC_OBJS),$(CPP_OBJS))
+ 	@mkdir -p $(@D)
++ifeq (@enable_cxx@, 1)
++	$(CXX) $(DSO_LDFLAGS) $(call RPATH,$(RPATH_EXTRA)) $(LDTARGET) $+ $(LDFLAGS) $(LIBS) $(EXTRA_LDFLAGS)
++else
+ 	$(CC) $(DSO_LDFLAGS) $(call RPATH,$(RPATH_EXTRA)) $(LDTARGET) $+ $(LDFLAGS) $(LIBS) $(EXTRA_LDFLAGS)
++endif
+ 
+ $(objroot)lib/$(LIBJEMALLOC)_pic.$(A) : $(C_PIC_OBJS) $(CPP_PIC_OBJS)
+ $(objroot)lib/$(LIBJEMALLOC).$(A) : $(C_OBJS) $(CPP_OBJS)


### PR DESCRIPTION
#### Description

Backport of: https://github.com/jemalloc/jemalloc/commit/4422f88d17404944a312825a1aec96cd9dc6c165

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
