### PR TITLE
*-mingw32-binutils: Import upstream fix for ld

### DIFF
--- a/cross/i686-w64-mingw32-binutils/Portfile
+++ b/cross/i686-w64-mingw32-binutils/Portfile
@@ -8,9 +8,11 @@ set mingw_name      w64-mingw32
 set mingw_arch      i686
 set mingw_target    ${mingw_arch}-${mingw_name}
 crossbinutils.setup ${mingw_target} 2.40
-revision            0
+revision            1
 
 maintainers         {mojca @mojca} openmaintainer
+
+patchfiles          0001-pr30079.diff
 
 configure.args-append \
                     --disable-multilib \

--- a/cross/i686-w64-mingw32-binutils/files/0001-pr30079.diff
+++ b/cross/i686-w64-mingw32-binutils/files/0001-pr30079.diff
@@ -1,0 +1,31 @@
+From b7eab2a9d4f4e92692daf14b09fc95ca11b72e30 Mon Sep 17 00:00:00 2001
+From: Michael Matz <matz@suse.de>
+Date: Thu, 9 Feb 2023 15:29:00 +0100
+Subject: [PATCH] Fix PR30079: abort on mingw
+
+the early-out in wild_sort is not enough, it might still be
+that filenames are equal _and_ the wildcard list doesn't specify
+a sort order either.  Don't call compare_section then.
+
+Tested on all targets.
+---
+ ld/ldlang.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git ld/ldlang.c ld/ldlang.c
+index 84a2914fc26..b5e0d026ae4 100644
+--- ld/ldlang.c
++++ ld/ldlang.c
+@@ -649,7 +649,8 @@ wild_sort (lang_wild_statement_type *wild,
+ 	 looking at the sections for this file.  */
+ 
+       /* Find the correct node to append this section.  */
+-      if (compare_section (sec->spec.sorted, section, (*tree)->section) < 0)
++      if (sec && sec->spec.sorted != none && sec->spec.sorted != by_none
++	  && compare_section (sec->spec.sorted, section, (*tree)->section) < 0)
+ 	tree = &((*tree)->left);
+       else
+ 	tree = &((*tree)->right);
+-- 
+2.31.1
+

--- a/cross/x86_64-w64-mingw32-binutils/Portfile
+++ b/cross/x86_64-w64-mingw32-binutils/Portfile
@@ -8,9 +8,11 @@ set mingw_name      w64-mingw32
 set mingw_arch      x86_64
 set mingw_target    ${mingw_arch}-${mingw_name}
 crossbinutils.setup ${mingw_target} 2.40
-revision            0
+revision            1
 
 maintainers         {mojca @mojca} openmaintainer
+
+patchfiles          0001-pr30079.diff
 
 configure.args-append \
                     --disable-multilib \

--- a/cross/x86_64-w64-mingw32-binutils/files/0001-pr30079.diff
+++ b/cross/x86_64-w64-mingw32-binutils/files/0001-pr30079.diff
@@ -1,0 +1,31 @@
+From b7eab2a9d4f4e92692daf14b09fc95ca11b72e30 Mon Sep 17 00:00:00 2001
+From: Michael Matz <matz@suse.de>
+Date: Thu, 9 Feb 2023 15:29:00 +0100
+Subject: [PATCH] Fix PR30079: abort on mingw
+
+the early-out in wild_sort is not enough, it might still be
+that filenames are equal _and_ the wildcard list doesn't specify
+a sort order either.  Don't call compare_section then.
+
+Tested on all targets.
+---
+ ld/ldlang.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git ld/ldlang.c ld/ldlang.c
+index 84a2914fc26..b5e0d026ae4 100644
+--- ld/ldlang.c
++++ ld/ldlang.c
+@@ -649,7 +649,8 @@ wild_sort (lang_wild_statement_type *wild,
+ 	 looking at the sections for this file.  */
+ 
+       /* Find the correct node to append this section.  */
+-      if (compare_section (sec->spec.sorted, section, (*tree)->section) < 0)
++      if (sec && sec->spec.sorted != none && sec->spec.sorted != by_none
++	  && compare_section (sec->spec.sorted, section, (*tree)->section) < 0)
+ 	tree = &((*tree)->left);
+       else
+ 	tree = &((*tree)->right);
+-- 
+2.31.1
+


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Patch for https://sourceware.org/bugzilla/show_bug.cgi?id=30079 this causes linker issues when importing a lib

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D49 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
