### PR TITLE
FastAD: new port in math

### DIFF
--- a/math/FastAD/Portfile
+++ b/math/FastAD/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.0
+PortGroup           github 1.0
+
+github.setup        JamesYang007 FastAD 3.2.1 v
+revision            0
+license             MIT
+categories          math
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         FastAD is a C++ implementation of automatic differentiation both forward and reverse mode
+long_description    {*}${description}
+checksums           rmd160  a2472c50a0a5b50cd623307d7d2b698df7b81f09 \
+                    sha256  062a07ff4180e9ad9b41c64c2fb5237da44a7c8f0e85fd74ca6dd6e08f8b7789 \
+                    size    86856
+supported_archs     noarch
+installs_libs       no
+
+depends_build-append \
+                    port:gtest
+depends_lib-append  path:include/eigen3:eigen3
+
+compiler.cxx_standard 2017
+
+patchfiles          patch-gtest.diff
+
+post-patch {
+    reinplace "s,@GTESTDIR@,${prefix}/src/googletest," ${worksrcpath}/CMakeLists.txt
+}
+
+configure.args-append \
+                    -DFASTAD_ENABLE_BENCHMARK=OFF \
+                    -DFASTAD_ENABLE_COVERAGE=OFF \
+                    -DFASTAD_ENABLE_EXAMPLE=OFF \
+                    -DFASTAD_ENABLE_TEST=ON \
+                    -DGTEST_DIR=${prefix}/src/googletest
+
+test.run            yes

--- a/math/FastAD/files/patch-gtest.diff
+++ b/math/FastAD/files/patch-gtest.diff
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2020-09-14 03:50:02.000000000 +0800
++++ CMakeLists.txt	2023-03-07 23:46:49.000000000 +0800
+@@ -79,7 +79,7 @@
+     enable_testing()
+ 
+     # Points to the root of Google Test
+-    set(GTEST_DIR ${PROJECT_SOURCE_DIR}/libs/benchmark/googletest/googletest)
++    set(GTEST_DIR @GTESTDIR@)
+ 
+     # add test subdirectory
+     add_subdirectory(${PROJECT_SOURCE_DIR}/test ${PROJECT_BINARY_DIR}/test)


### PR DESCRIPTION
#### Description

New port: https://github.com/JamesYang007/FastAD

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

All tests pass in Rosetta:
```
--->  Testing FastAD
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_FastAD/FastAD/work/FastAD-3.2.1" && /usr/bin/make test 
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_FastAD/FastAD/work/FastAD-3.2.1
    Start 1: utility_unittest
1/5 Test #1: utility_unittest .................   Passed    0.22 sec
    Start 2: forward_core_unittest
2/5 Test #2: forward_core_unittest ............   Passed    0.17 sec
    Start 3: reverse_core_unittest
3/5 Test #3: reverse_core_unittest ............   Passed    0.24 sec
    Start 4: reverse_stat_unittest
4/5 Test #4: reverse_stat_unittest ............   Passed    0.33 sec
    Start 5: integration_test
5/5 Test #5: integration_test .................   Passed    0.21 sec

100% tests passed, 0 tests failed out of 5

Total Test time (real) =   1.35 sec
```