### PR TITLE
syncthing: update to v1.23.2

### DIFF
--- a/net/syncthing/Portfile
+++ b/net/syncthing/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/syncthing/syncthing 1.23.0 v
+go.setup            github.com/syncthing/syncthing 1.23.2 v
 github.tarball_from archive
 revision            0
 
@@ -17,9 +17,9 @@ long_description    Syncthing replaces proprietary sync and cloud services \
                     where it is stored, if it is shared with some third party \
                     and how it's transmitted over the Internet.
 
-checksums           rmd160  7c42bfa2deef7f7e90e1bdbf94887a4d51f62e01 \
-                    sha256  3ac5002419d261b7d9352a621dbe20fada165372444824213b9d46910df7502e \
-                    size    6342650
+checksums           rmd160  878385ba1e836014401955e65dfb265cbb77cee0 \
+                    sha256  036bff4610791aa278a40cdda530e412bf44958c7951b720160c31c87b03d61c \
+                    size    6529048
 
 categories          net
 installs_libs       no


### PR DESCRIPTION
#### Description

Updates syncthing to 1.23.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
