### PR TITLE
git-devel: new subport for development version of git (version 2.40.0-rc2)

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -6,28 +6,59 @@ PortGroup           perl5           1.0
 
 legacysupport.newest_darwin_requires_legacy 10
 
+# RELEASE VERSION
 name                git
 version             2.39.2
 revision            0
 
+homepage            https://git-scm.com/
+
 description         A fast version control system
+
 long_description    Git is a fast, scalable, distributed open source version \
                     control system focusing on speed and efficiency.
+
+# DEVELOPMENT VERSION
+subport ${name}-devel {
+    PortGroup           github  1.0
+
+    github.setup        git git 2.40.0-rc2 v
+    github.tarball_from archive
+
+    description     \
+        {*}${description} (Development Version)
+
+    long_description \
+        {*}${long_description} (Development Version)
+
+    conflicts           git
+}
+
 maintainers         {ciserlohn @ci42} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
+
+default_variants    +doc +pcre +credential_osxkeychain +diff_highlight
+
 categories          devel
 license             GPL-2 LGPL-2.1+
 installs_libs       no
-homepage            https://git-scm.com/
-master_sites        https://www.kernel.org/pub/software/scm/git/ \
-                    https://cdn.kernel.org/pub/software/scm/git/
-distname            git-${version}
-use_xz              yes
-distfiles           git-${version}${extract.suffix} \
-                    git-manpages-${version}${extract.suffix}
 
-checksums           git-${version}${extract.suffix} \
+master_sites-append https://www.kernel.org/pub/software/scm/git/:git \
+                    https://cdn.kernel.org/pub/software/scm/git/:git
+
+conflicts           ${name}-devel
+
+if {${name} eq ${subport}} {
+    # RELEASE VERSION
+
+    distname        git-${version}
+    use_xz          yes
+    distfiles-append \
+                    git-${version}${extract.suffix}:git \
+                    git-manpages-${version}${extract.suffix}:git
+
+    checksums       git-${version}${extract.suffix} \
                     rmd160  fae317477d3deaff885f932b0eab9889bfd1eeab \
                     sha256  475f75f1373b2cd4e438706185175966d5c11f68c4db1e48c26257c43ddcf2d6 \
                     size    7163224 \
@@ -35,6 +66,24 @@ checksums           git-${version}${extract.suffix} \
                     rmd160  60ec345f23549f9bd376f05ebe70427480741f79 \
                     sha256  0b3927a2f09db3d3ec91dd548409a7129d3af9dabf11847401872c8c0c529b25 \
                     size    557080
+
+    extract.only    git-${version}${extract.suffix} \
+                    git-manpages-${version}${extract.suffix}
+
+} else {
+    # DEVELOPMENT VERSION
+
+    checksums       ${distname}${extract.suffix} \
+                    rmd160  76af90b0d9a51bad6eb96a14d65c5d45ad4bea45 \
+                    sha256  5d64e985b6bf065b5d43bd62e39e27603b159fc7bdeebc25e8ac98754e14506a \
+                    size    10608830
+
+    depends_build-append \
+                    port:asciidoc \
+                    port:xmlto
+
+    build.target    all man html
+}
 
 perl5.require_variant   false
 perl5.conflict_variants yes
@@ -65,9 +114,6 @@ patch.pre_args      -p1
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     patchfiles-append   patch-ignore-fsmonitor-daemon-backend.diff
 }
-
-extract.only        git-${version}${extract.suffix} \
-                    git-manpages-${version}${extract.suffix}
 
 use_configure       no
 
@@ -121,7 +167,8 @@ pre-test {
 destroot.target     install
 pre-destroot {
     destroot.args  {*}${build.args}
-    xinstall -m 644 ${worksrcpath}/contrib/subtree/git-subtree.1 ${workpath}/man1
+    xinstall -m 0644 \
+        ${worksrcpath}/contrib/subtree/git-subtree.1 ${workpath}/man1
 }
 
 set docdestroot         ${destroot}${prefix}/share/doc/git-doc
@@ -129,12 +176,23 @@ set guidir              ${prefix}/share/git-gui/lib/Git\ Gui.app/Contents
 set system_gitconfig    ${prefix}/etc/gitconfig
 
 post-destroot {
+
     foreach f {1 5 7} {
         xinstall -d ${destroot}${prefix}/share/man/man${f}
-        foreach m [glob -directory ${workpath} man${f}/*.${f}] {
-            xinstall ${m} ${destroot}${prefix}/share/man/man${f}
+
+        if {${name} eq ${subport}} {
+            # RELEASE man pages
+            foreach m [glob -directory ${workpath} man${f}/*.${f}] {
+                xinstall ${m} ${destroot}${prefix}/share/man/man${f}
+            }
+        } else {
+            # DEVEL man pages
+            foreach m [glob -directory ${worksrcpath} Documentation/*.${f}] {
+                xinstall ${m} ${destroot}${prefix}/share/man/man${f}
+            }
         }
     }
+
     if {![variant_isset svn]} {
         system "rm ${destroot}${prefix}/libexec/git-core/git-svn*"
     }
@@ -150,16 +208,16 @@ post-destroot {
 
     set completions_path ${destroot}${prefix}/share/bash-completion/completions
     xinstall -d ${completions_path}
-    xinstall -m 644 ${worksrcpath}/contrib/completion/git-completion.bash \
+    xinstall -m 0644 ${worksrcpath}/contrib/completion/git-completion.bash \
         ${completions_path}/git
 
     set share_path ${destroot}${prefix}/share/${name}
     xinstall -d ${share_path}
-    xinstall -m 644 ${worksrcpath}/contrib/completion/git-prompt.sh \
+    xinstall -m 0644 ${worksrcpath}/contrib/completion/git-prompt.sh \
         ${share_path}/git-prompt.sh
 
     xinstall -d ${destroot}${prefix}/libexec/git-core
-    xinstall -m 755 ${worksrcpath}/contrib/subtree/git-subtree.sh \
+    xinstall -m 0755 ${worksrcpath}/contrib/subtree/git-subtree.sh \
         ${destroot}${prefix}/libexec/git-core/git-subtree
 
     # Tiger doesn't build the GUI, so check for its existence before mucking with it
@@ -181,38 +239,51 @@ variant pcre description {Use pcre} {
 }
 
 variant doc description {Install HTML and plaintext documentation} {
-    distfiles-append        git-htmldocs-${version}${extract.suffix}
-    checksums-append        git-htmldocs-${version}${extract.suffix} \
+
+    if {${name} eq ${subport}} {
+        # RELEASE
+        distfiles-append    git-htmldocs-${version}${extract.suffix}:git
+        checksums-append    git-htmldocs-${version}${extract.suffix} \
                             rmd160  98cea7039d4d87e8c1ba422303638ca825e6b4aa \
                             sha256  f729edf1821c688efc6767b1c0bb728aec673bc15b80a6b8be6a18c2cbb9d67e \
                             size    1505352
 
-    patchfiles-append       patch-git-subtree.html.diff
+        patchfiles-append   patch-git-subtree.html.diff
 
-    post-extract {
-        file mkdir ${workpath}/htmldocs
-        system -W ${workpath}/htmldocs "${extract.cmd} ${extract.pre_args} \
-            '${distpath}/git-htmldocs-${version}${extract.suffix}' \
-            ${extract.post_args}"
-    }
-
-    pre-destroot {
-        xinstall -m 644 ${worksrcpath}/contrib/subtree/git-subtree.html ${workpath}/htmldocs
-    }
-
-    post-destroot {
-        foreach f [glob ${workpath}/htmldocs/*] {
-            file delete -force "${docdestroot}/[file tail ${f}]"
-            file attribute ${f} -permissions ugo+r
-            copy ${f} ${docdestroot}
+        post-extract {
+            file mkdir ${workpath}/htmldocs
+            system -W ${workpath}/htmldocs "${extract.cmd} ${extract.pre_args} \
+                '${distpath}/git-htmldocs-${version}${extract.suffix}' \
+                ${extract.post_args}"
         }
 
-        fs-traverse f [list ${docdestroot}/howto ${docdestroot}/technical ${docdestroot}/RelNotes] {
-            if {[file isdirectory ${f}]} {
-                file attribute ${f} -permissions ugo+rx
-            } else {
+        pre-destroot {
+            xinstall -m 0644 \
+                ${worksrcpath}/contrib/subtree/git-subtree.html \
+                ${workpath}/htmldocs
+        }
+
+        post-destroot {
+            foreach f [glob ${workpath}/htmldocs/*] {
+                file delete -force "${docdestroot}/[file tail ${f}]"
                 file attribute ${f} -permissions ugo+r
+                copy ${f} ${docdestroot}
             }
+
+            fs-traverse f [list ${docdestroot}/howto ${docdestroot}/technical ${docdestroot}/RelNotes] {
+                if {[file isdirectory ${f}]} {
+                    file attribute ${f} -permissions ugo+rx
+                } else {
+                    file attribute ${f} -permissions ugo+r
+                }
+            }
+        }
+
+    } else {
+        # DEVEL
+        post-destroot {
+            system -W ${worksrcpath} \
+                "${destroot.cmd} install-html prefix=${destroot}/${prefix}"
         }
     }
 }
@@ -227,14 +298,14 @@ variant gitweb description {Install gitweb.cgi} {
         xinstall -W ${worksrcpath}/gitweb \
             gitweb.cgi \
             ${destroot}${prefix}/share/${name}/gitweb
-        xinstall -m 444 -W ${worksrcpath}/gitweb/static \
+        xinstall -m 0444 -W ${worksrcpath}/gitweb/static \
             gitweb.css \
             gitweb.js \
             git-favicon.png \
             git-logo.png \
             ${destroot}${prefix}/share/${name}/gitweb
         xinstall -d ${docdestroot}/gitweb
-        xinstall -m 444 -W ${worksrcpath}/gitweb README INSTALL \
+        xinstall -m 0444 -W ${worksrcpath}/gitweb README INSTALL \
             ${docdestroot}/gitweb
     }
 }
@@ -322,8 +393,6 @@ platform darwin 8 {
     build.args-append   NO_APPLE_COMMON_CRYPTO=1
     build.args-append   CC_LD_DYNPATH=-R
 }
-
-default_variants        +doc +pcre +credential_osxkeychain +diff_highlight
 
 livecheck.type          regexm
 livecheck.regex         {<span class="version">.*?(\d+\.\d+\.\d+).*?</span>}


### PR DESCRIPTION
Adds a subport that allows for testing devel versions of Git.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
