### PR TITLE
py-csvkit: update to 1.1.1, with support for python 3.11

### DIFF
--- a/python/py-agate-dbf/Portfile
+++ b/python/py-agate-dbf/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  8dfd67b33db6ed8b9d474cb04abf2e30fbeb6cf7 \
                     sha256  589682b78c5c03f2dc8511e6e3edb659fb7336cd118e248896bb0b44c2f1917b \
                     size    2863
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-agate-excel/Portfile
+++ b/python/py-agate-excel/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  3afd4d0df268d1742b5248b105a9c206171aea35 \
                     sha256  62315708433108772f7f610ca769996b468a4ead380076dbaf6ffe262831b153 \
                     size    161131
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-agate-sql/Portfile
+++ b/python/py-agate-sql/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  11e6b3b8198585aa1b2e1bd8b023ef3ec9b8c013 \
                     sha256  581e062ae878cc087d3d0948670d46b16589df0790bf814524b0587a359f2ada \
                     size    15182
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-agate/Portfile
+++ b/python/py-agate/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  f217d911e0cdcf28fb3c90901cae1f1bb5e071ed \
                     sha256  e0f2f813f7e12311a4cdccc97d6ba0a6781e9c1aa8eca0ab00d5931c0113a308 \
                     size    202102
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-csvkit/Portfile
+++ b/python/py-csvkit/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-csvkit
-version             1.0.7
+version             1.1.1
 revision            0
 
 categories-append   textproc
@@ -22,11 +22,11 @@ long_description    csvkit is a suite of utilities for converting to and working
 
 homepage            https://csvkit.readthedocs.io/
 
-checksums           rmd160  70a142e902ec1ded1c62d06ed50cacc3e429639b \
-                    sha256  0019e29ccadfe3d5cb0d159a443cba3ce8dfc37c967317db983ce3f19f0ca050 \
-                    size    3792335
+checksums           rmd160  e5c6c9829f98ea9fac4b59057a8df8566c342083 \
+                    sha256  beddb7b78f6b22adbed6ead5ad5de4bfb31dd2c55f3211b2a2b3b65529049223 \
+                    size    3792699
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-agate \

--- a/python/py-csvkit/files/py311-csvkit
+++ b/python/py-csvkit/files/py311-csvkit
@@ -1,0 +1,11 @@
+bin/csvclean-3.11
+bin/csvcut-3.11
+bin/csvgrep-3.11
+bin/csvjoin-3.11
+bin/csvjson-3.11
+bin/csvlook-3.11
+bin/csvsort-3.11
+bin/csvsql-3.11
+bin/csvstack-3.11
+bin/csvstat-3.11
+bin/in2csv-3.11

--- a/python/py-dbfread/Portfile
+++ b/python/py-dbfread/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  6599d0c691b9047c46ec75842ed380880c595567 \
 
 homepage            https://dbfread.readthedocs.io/
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-leather/Portfile
+++ b/python/py-leather/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  cdcbef561aacd19bc5ba0d35ec70cf65a1704141 \
                     sha256  b43e21c8fa46b2679de8449f4d953c06418666dc058ce41055ee8a8d3bb40918 \
                     size    30605
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pytimeparse/Portfile
+++ b/python/py-pytimeparse/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  e56358a299e95b6593e39f2b57013a4157a412b0 \
                     sha256  e86136477be924d7e670646a98561957e8ca7308d44841e21f5ddea757556a0a \
                     size    9403
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

This updates py-csvkit to upstream version 1.1.1 which adds python 3.11 support.
En passant, dependencies are also bumped up with python 3.11 support:
- py-agate*
- py-dbfread
- py-pytimeread
- py-leather

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2.1 22D68 x86_64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
