### PR TITLE
spice-gtk: Fix +quartz variant

### DIFF
--- a/gnome/spice-gtk/Portfile
+++ b/gnome/spice-gtk/Portfile
@@ -82,6 +82,6 @@ variant x11 conflicts quartz {
 
 if {![catch {set result [active_variants gtk3 quartz x11]}] && $result} {
     default_variants +quartz
-} else {
+} elseif {![variant_isset quartz]} {
     default_variants +x11
 }


### PR DESCRIPTION
#### Description

The +quartz variant can currently not be used if gtk3 is not installed:

```
$ port info -- +quartz
Error: spice-gtk: Variant quartz conflicts with x11
Error: Unable to open port: Error evaluating variants
```

Fix this by only enabling +x11 as the default variant if no conflicting variant is explicitly requested.

See also #11654.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18
without gtk3 installed.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?