### PR TITLE
nanomq: update to 0.16.0

### DIFF
--- a/devel/cyclonedds/Portfile
+++ b/devel/cyclonedds/Portfile
@@ -1,0 +1,18 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        eclipse-cyclonedds cyclonedds 0.10.2
+revision            0
+categories          devel
+license             EPL-2
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+description         Eclipse Cyclone DDS project
+long_description    {*}${description}
+homepage            https://cyclonedds.io/
+
+checksums           rmd160  77e7c0261abe246e18a624fc36d60e59706c3596 \
+                    sha256  ac59ee08975cd25a1fb414ddeb0183fb8636b12d49cea80373013bea59465b43 \
+                    size    6978904

--- a/net/nanomq/Portfile
+++ b/net/nanomq/Portfile
@@ -4,7 +4,7 @@ PortSystem             1.0
 PortGroup              github 1.0
 PortGroup              cmake 1.1
 
-github.setup           emqx nanomq 0.13.1
+github.setup           emqx nanomq 0.16.0
 revision               0
 categories             net
 license                MIT
@@ -20,12 +20,16 @@ post-fetch {
     system -W ${worksrcpath} "git submodule update --init"
 }
 
-checksums              rmd160  a97e5762faa053041a2de3e68c59b92ebee6b6e5 \
-                       sha256  55ce01b39f2ee2e0b1e990ff27801ab808f79df620758569bfd4a282cbee0435 \
-                       size    7630839
+depends_build-append   path:bin/pkg-config:pkgconfig
 
-depends_lib-append     port:mbedtls \
-                       port:sqlite3
+depends_lib-append     port:cyclonedds \
+                       port:mbedtls \
+                       port:sqlite3 \
+                       port:zmq
 
-configure.args-append  -DNNG_ENABLE_TLS=ON \
-                       -DNNG_ENABLE_SQLITE=ON
+configure.args-append  -DBUILD_BENCH=ON \
+                       -DBUILD_DDS_PROXY=ON \
+                       -DBUILD_NANOMQ_CLI=ON \
+                       -DBUILD_ZMQ_GATEWAY=ON \
+                       -DNNG_ENABLE_SQLITE=ON \
+                       -DNNG_ENABLE_TLS=ON


### PR DESCRIPTION
#### Description
* nanomq: [changelog](https://github.com/emqx/nanomq/releases)
* add [cyclonedds](https://github.com/eclipse-cyclonedds/cyclonedds) dependency

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
