### PR TITLE
google-cloud-sdk: update to 421.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             420.0.0
+version             421.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  dc86a11af25edf23aef81c4fbd0772262e824092 \
-                    sha256  5779e84e97498953e3ab58228bab2186ea10837df430b140e8f9cb6ec7e780f2 \
-                    size    111350022
+    checksums       rmd160  12a6cf42829d777659668f26597a09da236ab5cc \
+                    sha256  d14efccf3dc78d6acb097d2e623660ab8604b1a467384a56564ce3f91958ab20 \
+                    size    111473424
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  1840187c81eafd98c2a197177d1c2ac335d21ba5 \
-                    sha256  1ac7975a810156f533bc76522b015bb67eb6f2a372a40db84de8223282d7ca67 \
-                    size    131671377
+    checksums       rmd160  c23934d9dede084a0a5e33ea3808db18aba902ec \
+                    sha256  3738438f70edc87bc94a1ee4ee4da9fc16c84141c2bb038e4db2827a5232ea37 \
+                    size    131804176
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  fea72ce75e32a5a39a5df108524d8b0c8f9fb167 \
-                    sha256  375d44afb56ad1a217a0cf927b323a0d4c36ca9f87c66722db3fa02a48536986 \
-                    size    128516074
+    checksums       rmd160  204d0b2c09331a244c68c350de687a437bda3795 \
+                    sha256  baf3b0d0fd934ecea74a20b56f25828b7e3e8b848191bf6f487056c18212e03b \
+                    size    128642965
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -88,6 +88,7 @@ variant cloud_sql_proxy description {Add Cloud SQL Proxy} { dict set variant_to_
 variant config_connector description {Add config connector} { dict set variant_to_component config_connector config-connector }
 variant datalab description {Add Cloud Datalab Command Line Tool} { dict set variant_to_component datalab datalab }
 variant docker_credential_gcr description {Add Google Container Registry's Docker credential helper} { dict set variant_to_component docker_credential_gcr docker-credential-gcr }
+variant enterprise_certificate_proxy description {Add Enterprise certificate proxy} { dict set variant_to_component enterprise_certificate_proxy enterprise-certificate-proxy }
 variant gke_gcloud_auth_plugin description {Add GKE Google Cloud auth plugin} { dict set variant_to_component gke_gcloud_auth_plugin gke-gcloud-auth-plugin }
 variant kpt description {Add kpt} { dict set variant_to_component kpt kpt }
 variant kubectl description {Add kubectl} { dict set variant_to_component kubectl kubectl }


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 421.0.0.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?