### PR TITLE
paho.mqtt.c: update to 1.3.12

### DIFF
--- a/net/paho.mqtt.c/Portfile
+++ b/net/paho.mqtt.c/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
-github.setup        eclipse paho.mqtt.c 1.3.9 v
+github.setup        eclipse paho.mqtt.c 1.3.12 v
 revision            0
 categories          net
 maintainers         nomaintainer
@@ -28,6 +28,6 @@ legacysupport.newest_darwin_requires_legacy 15
 configure.args-append \
                     -DPAHO_WITH_SSL=ON
 
-checksums           rmd160  46cca2a33404c047bbf97758fe890f82173e06fa \
-                    sha256  c6a8b455f29affe5c4247fbef48f96f2a29ec1f6d56d333e0cddf57ee6163df9 \
-                    size    3632017
+checksums           rmd160  2bf983080856163b5ee62be1b3cdfb9a72bc38f5 \
+                    sha256  19791a8c8eab421c38e30884f681d0a06c79af9509c86b0a3a020457eeeae9bd \
+                    size    3623535


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/eclipse/paho.mqtt.c/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
