### PR TITLE
ruby-build: Update to v20230309

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230222 v
+github.setup        rbenv ruby-build 20230309 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  22877e3ad0da65de29699906d15d4433a78ce189 \
-                    sha256  6bd49fa25de222dd2218682982dc98ecce47f5be0a0976fecd9c5ff4eb416287 \
-                    size    78338
+checksums           rmd160  7152f89ce10995908c539a4bbb814dfb640e510d \
+                    sha256  b77ed80cad46ef09c5e2ce66d58fec8350fe9f0afb5517c9fc021d234abb3e44 \
+                    size    78498
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

- 20230306
  - Add mruby-3.2.0 by @hasumikin in rbenv/ruby-build#2155
  - Automatically detect and link to Homebrew's libyaml by @dreyks in rbenv/ruby-build#1929

- 20230309
  -  Add  JRuby 9.4.2.0 by @headius in rbenv/ruby-build#2160

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?