### PR TITLE
keybase: update to version 6.0.4

### DIFF
--- a/security/keybase/Portfile
+++ b/security/keybase/Portfile
@@ -3,7 +3,9 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/keybase/client 5.8.1 v
+go.setup            github.com/keybase/client 6.0.4 v
+revision            0
+
 name                keybase
 categories          security
 license             BSD
@@ -13,12 +15,17 @@ long_description    ${description}
 
 depends_run         path:bin/gpg:gnupg2
 
-checksums           rmd160  0b5ad228679679dba7a7910e00039c41d0641455 \
-                    sha256  6afdaab5621d8c801ce7a351c9c02dcffac68bc7e17360320741af11b746636d \
-                    size    81055333
+checksums           rmd160  c71594f92b9fe4f631a421727ca44f2ea30de937 \
+                    sha256  59905cee69fffd62ff0e1fdc6eebbb7b9d42af0e98ce3a9e621cb2b104c60dec \
+                    size    57271515
 
+build.dir           ${worksrcpath}/go
+build.env           GOPATH=${gopath}
+build.cmd           ${go.bin} install
 build.args          -tags production ${go.package}/go/keybase
 
+test.run            no
+
 destroot {
-    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 0755 ${workpath}/gopath/bin/${name} ${destroot}${prefix}/bin/
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Update to version 6.0.4. and build the command line client from [README.md](https://raw.githubusercontent.com/keybase/client/master/go/README.md).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
