### PR TITLE
flagpoll: Update to 0.9.4

### DIFF
--- a/devel/flagpoll/Portfile
+++ b/devel/flagpoll/Portfile
@@ -1,6 +1,8 @@
-PortSystem        1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
 PortGroup               github 1.0
-PortGroup         python 1.0
+PortGroup               python 1.0
 
 github.setup            mccdo flagpoll 0.9.4 flagpoll-
 revision                0
@@ -8,20 +10,19 @@ checksums               rmd160  10d55524477c85434e0e1a690e287caa6a3288dd \
                         sha256  a43fc8c0bca1f13e3d3b8c40f3f4e0ee52fc582a2f172d83d3400749fa44ead1 \
                         size    54699
 
-categories        devel
-license           GPL-2+
-supported_archs   noarch
-platforms         {darwin any}
+categories              devel
+license                 GPL-2+
+supported_archs         noarch
+platforms               {darwin any}
 maintainers             {iastate.edu:mccdo @mccdo}
 
-description       a python based replacement for pkgconfig
-long_description  Flagpoll is a tool for developers to use \
-                  meta-data files for storing information \
-                  on what is needed to compile their software.\
-                  Think of it as the rpm of software development.\
-                  It enables developers total control over \
-                  which packages, versions, architectures, etc. \
-                  that they want to use meta-data from.
+description             a python based replacement for pkgconfig
+long_description        Flagpoll is a tool for developers to use meta-data \
+                        files for storing information on what is needed to \
+                        compile their software. Think of it as the rpm of \
+                        software development. It enables developers total \
+                        control over which packages, versions, architectures, \
+                        etc. that they want to use meta-data from.
 
 github.tarball_from     archive
 

--- a/devel/flagpoll/Portfile
+++ b/devel/flagpoll/Portfile
@@ -1,14 +1,19 @@
 PortSystem        1.0
+PortGroup               github 1.0
 PortGroup         python 1.0
 
-name              flagpoll
-version           0.9.1
-revision          1
+github.setup            mccdo flagpoll 0.9.4 flagpoll-
+revision                0
+checksums               rmd160  10d55524477c85434e0e1a690e287caa6a3288dd \
+                        sha256  a43fc8c0bca1f13e3d3b8c40f3f4e0ee52fc582a2f172d83d3400749fa44ead1 \
+                        size    54699
+
 categories        devel
 license           GPL-2+
 supported_archs   noarch
 platforms         {darwin any}
-maintainers       iastate.edu:mccdo
+maintainers             {iastate.edu:mccdo @mccdo}
+
 description       a python based replacement for pkgconfig
 long_description  Flagpoll is a tool for developers to use \
                   meta-data files for storing information \
@@ -18,13 +23,16 @@ long_description  Flagpoll is a tool for developers to use \
                   which packages, versions, architectures, etc. \
                   that they want to use meta-data from.
 
-homepage          https://web.archive.org/web/20061014125824/https://realityforge.vrsource.org/view/FlagPoll/WebHome
-master_sites      macports_distfiles
+github.tarball_from     archive
 
-checksums         md5 c4ac50ae99a880704abfc62a64ed16aa
+patchfiles              flagpoll.patch
 
-fetch.ignore_sslcert    yes
+post-patch {
+    reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/flagpoll
+}
 
 destroot.destdir        --prefix=${destroot}${prefix}
 
+# Incompatible with python 3.
+# https://github.com/mccdo/flagpoll/issues/4
 python.default_version  27

--- a/devel/flagpoll/files/flagpoll.patch
+++ b/devel/flagpoll/files/flagpoll.patch
@@ -1,0 +1,13 @@
+Let flagpoll find packages in the MacPorts prefix.
+https://github.com/mccdo/flagpoll/issues/7
+--- flagpoll.orig	2010-09-05 11:43:01.000000000 -0500
++++ flagpoll	2023-03-08 23:21:26.000000000 -0600
+@@ -240,7 +240,7 @@
+       path_list.extend(flg_cfg_dir)
+       path_list.extend(pkg_cfg_dir)
+       path_list.extend(ld_path)
+-      default_path_list = [pj('/','usr','lib64'), pj('/','usr','lib32'), pj('/','usr','lib'), pj('/','usr','share')]
++      default_path_list = ['@PREFIX@/lib', '@PREFIX@/share', pj('/','usr','lib64'), pj('/','usr','lib32'), pj('/','usr','lib'), pj('/','usr','share')]
+       default_path_pkg = [pj(p,'pkgconfig') for p in default_path_list]
+       default_path_flg = [pj(p,'flagpoll') for p in default_path_list]
+       path_list.extend(default_path_pkg)


### PR DESCRIPTION
#### Description

Updates flagpoll to 0.9.4 from its new home at GitHub.

@mccdo I've added your GitHub handle to the `maintainers` line. If you no longer wish to maintain this port let us know and I'll remove you instead. If you do still want to maintain but the email address listed in that line is no longer current let us know and we can update it.

In a separate commit I reformatted the whitespace to our 4-space-per-indent guidelines.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
