### PR TITLE
emacs{-app,}-devel: update to 20230308

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -103,15 +103,15 @@ if {$subport eq $name || $subport eq "emacs-app"} {
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     PortGroup       github 1.0
 
-    github.setup    emacs-mirror emacs f59d012af7e607448fdb435fcb4becb6a6ebe665
+    github.setup    emacs-mirror emacs 5ff018524c740c77215ddb5d5983dbfcadb05599
     epoch           5
-    version         20221231
+    version         20230308
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  ddd42b2605c0865241762077da6ed96506ddae71 \
-                    sha256  9ce6855d06e31997fc9fa5d50d470420f463814ed36735bdb253d708aff03bb6 \
-                    size    46934030
+    checksums       rmd160  724779db748bc38491686c94865bf59a2bde874c \
+                    sha256  532fdcc0a6182ed7574367040eea080fe309525ac2c022d7719cbedf12935e16 \
+                    size    47021753
 
     configure.args-append \
         --with-sqlite3 \
@@ -148,7 +148,9 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
             port:tree-sitter-go \
             port:tree-sitter-go-mod \
             port:tree-sitter-yaml \
-            port:tree-sitter-rust
+            port:tree-sitter-rust \
+            port:tree-sitter-ruby \
+            port:tree-sitter-html
     }
 
     default_variants-append +treesitter


### PR DESCRIPTION
#### Description

Update to recent master. Has some new treesitter-based modes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
