### PR TITLE
gmtl: Fix build issues

### DIFF
--- a/math/gmtl/Portfile
+++ b/math/gmtl/Portfile
@@ -1,27 +1,67 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 
 name                gmtl
 version             0.6.1
+revision            1
+checksums           rmd160  19ca8c25cf54b1650272f7a387f5f8b8c5c3140c \
+                    sha256  f7d8e6958d96a326cb732a9d3692a3ff3fd7df240eb1d0921a7c5c77e37fc434 \
+                    size    339777
+
 categories          math
-platforms           darwin
-maintainers         iastate.edu:mccdo
+platforms           any
+supported_archs     noarch
+maintainers         {iastate.edu:mccdo @mccdo}
+# LGPL-2.1+ modified by an addendum
+license             Copyleft GPLConflict
+
 description         a lightweight math library
 long_description    The math library used by vrjuggler. It is \
                     implemented with c++ templates.
 homepage            http://ggt.sourceforge.net/
-master_sites        sourceforge:ggt
-checksums           md5 1391af2c5ea050dda7735855ea5bb4c1 \
-                    sha1 473a454d17956d3ce3babafdb57f73c0685579fd \
-                    rmd160 19ca8c25cf54b1650272f7a387f5f8b8c5c3140c
+master_sites        sourceforge:project/ggt/Generic%20Math%20Template%20Library/${version}
 
 depends_build       port:scons
 
-patchfiles          SConstruct.patch
+# gmtl-config uses python and flagpoll.
+# Use same python version as flagpoll to limit number of pythons installed.
+set python_version  2.7
+depends_run-append  port:flagpoll \
+                    port:python[string map [list . {}] ${python_version}]
+
+patchfiles          gmtl.pc.patch \
+                    gmtl-config.patch \
+                    SConstruct-clang.patch \
+                    SConstruct-no-archive.patch \
+                    SConstruct-python.patch \
+                    SConstruct-scons.patch
+
+post-patch {
+    reinplace "s|@PYTHON_BIN@|${prefix}/bin/python${python_version}|g" ${worksrcpath}/gmtl-config
+}
 
 use_configure       no
 
-build.cmd           scons
+build.cmd           ${prefix}/bin/scons
 build.target
-destroot.cmd        scons
+build.args          prefix=${prefix} \
+                    BoostPythonDir=/var/empty \
+                    CppUnitDir=/var/empty
+
 destroot.destdir    prefix=${destroot}${prefix}
-destroot.target     install
+
+post-destroot {
+    reinplace -W ${destroot}${prefix} "s|${destroot}||g" \
+        lib/pkgconfig/gmtl.pc \
+        share/flagpoll/gmtl-${version}-noarch.fpc
+
+    set docdir ${prefix}/share/doc/${subport}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} \
+        AUTHORS \
+        LICENSE \
+        LICENSE.addendum \
+        README \
+        ${destroot}${docdir}
+}

--- a/math/gmtl/files/SConstruct-clang.patch
+++ b/math/gmtl/files/SConstruct-clang.patch
@@ -1,0 +1,52 @@
+Fixes for determining "GCC" version when compiler is clang.
+https://sourceforge.net/p/ggt/bugs/28/
+--- SConstruct.orig	2009-11-21 15:31:52.000000000 -0600
++++ SConstruct	2023-03-08 18:28:02.000000000 -0600
+@@ -3,6 +3,7 @@
+ EnsureSConsVersion(0,96)
+ SConsignFile()
+ 
++from subprocess import Popen, PIPE
+ import os, string, sys
+ import re
+ import distutils.sysconfig
+@@ -129,26 +126,28 @@
+    framework_opt = '-F' + m.group(1)
+ 
+    CXX = os.environ.get("CXX", WhereIs('g++'))
+-
+-   ver_re = re.compile(r'gcc version ((\d+)\.(\d+)\.(\d+))')
+-   (gv_stdout, gv_stdin, gv_stderr) = os.popen3(CXX + ' -v')
+-   ver_str = gv_stderr.read()
+-
+-   match_obj = ver_re.search(ver_str)
+-
+    LINK = CXX
+    CXXFLAGS = ['-ftemplate-depth-256', '-DBOOST_PYTHON_DYNAMIC_LIB',
+                '-Wall', framework_opt, '-pipe']
+ 
+-   compiler_ver       = match_obj.group(1)
+-   compiler_major_ver = int(match_obj.group(2))
+-   compiler_minor_ver = int(match_obj.group(3))
++   p = Popen([CXX, '-dM', '-E', '-x', 'c++', '-'], stdout=PIPE)
++   preprocessor_macros = p.stdout.read().decode('utf-8')
++
++   ver_re = re.compile(r'#define __GNUC__ (\d+)')
++   match_obj = ver_re.search(preprocessor_macros)
++   compiler_major_ver = int(match_obj.group(1))
++
++   ver_re = re.compile(r'#define __GNUC_MINOR__ (\d+)')
++   match_obj = ver_re.search(preprocessor_macros)
++   compiler_minor_ver = int(match_obj.group(1))
++
++   compiler_ver = f'{compiler_major_ver}.{compiler_minor_ver}'
+ 
+    # GCC 4.0 in Mac OS X 10.4 and newer does not have -fcoalesce-templates.
+    if compiler_major_ver < 4:
+       CXXFLAGS.append('-fcoalesce-templates')
+    else:
+-      if compiler_minor_ver < 2:
++      if compiler_major_ver == 4 and compiler_minor_ver < 2:
+          CXXFLAGS += ['-Wno-long-double', '-no-cpp-precomp']
+ 
+    SHLIBSUFFIX = distutils.sysconfig.get_config_var('SO')

--- a/math/gmtl/files/SConstruct-no-archive.patch
+++ b/math/gmtl/files/SConstruct-no-archive.patch
@@ -1,0 +1,12 @@
+Do not create a tar.gz archive of the source code.
+https://sourceforge.net/p/ggt/bugs/30/
+--- SConstruct.orig	2023-03-10 01:05:19.000000000 -0600
++++ SConstruct	2023-03-10 01:05:19.000000000 -0600
+@@ -775,7 +775,6 @@
+ 
+    pkg.build()
+    installed_targets += pkg.getInstalledTargets()
+-   MakeSourceDist(pkg, env)
+ 
+ # Build everything by default
+ Default('.')

--- a/math/gmtl/files/SConstruct-python.patch
+++ b/math/gmtl/files/SConstruct-python.patch
@@ -1,15 +1,8 @@
 Fixes for Python 3 compatibility.
---- SConstruct.orig	2009-11-21 15:31:52.000000000 -0600
-+++ SConstruct	2023-03-08 06:47:38.000000000 -0600
-@@ -3,6 +3,7 @@
- EnsureSConsVersion(0,96)
- SConsignFile()
- 
-+from subprocess import Popen, PIPE
- import os, string, sys
- import re
- import distutils.sysconfig
-@@ -16,10 +17,6 @@
+https://sourceforge.net/p/ggt/bugs/29/
+--- SConstruct.orig	2023-03-09 18:31:41.000000000 -0600
++++ SConstruct	2023-03-09 18:33:02.000000000 -0600
+@@ -17,11 +17,6 @@
  sys.path.append('tools/build')
  from AutoDist import *
  
@@ -17,10 +10,11 @@ Fixes for Python 3 compatibility.
 -if sys.version[:3] == '2.2' and sys.version[3] != '.':
 -   False = 0
 -   True  = 1
- 
+-
  enable_python      = False
  boost_version      = '1.31'
-@@ -48,17 +45,17 @@
+ have_cppunit       = False
+@@ -49,17 +44,17 @@
  
  def GetPlatform():
     "Determines what platform this build is being run on."
@@ -44,18 +38,13 @@ Fixes for Python 3 compatibility.
        return 'win32'
     else:
        return sys.platform
-@@ -131,8 +128,8 @@
-    CXX = os.environ.get("CXX", WhereIs('g++'))
+@@ -218,21 +213,21 @@
+ def BuildWin32Environment():
+    global optimize, compiler_major_ver
  
-    ver_re = re.compile(r'gcc version ((\d+)\.(\d+)\.(\d+))')
--   (gv_stdout, gv_stdin, gv_stderr) = os.popen3(CXX + ' -v')
--   ver_str = gv_stderr.read()
-+   gv = Popen([CXX, '-v'], stderr=PIPE)
-+   ver_str = gv.stderr.read().decode('utf-8')
- 
-    match_obj = ver_re.search(ver_str)
- 
-@@ -220,16 +217,16 @@
+-   if ARGUMENTS.has_key("MSVS_VERSION"):
++   if "MSVS_VERSION" in ARGUMENTS:
+       # Python extension modules can only be built using Visual C++ 7.1 or
        # 9.0.
        msvs_ver = ARGUMENTS["MSVS_VERSION"]
        if msvs_ver not in ("7.1", "9.0"):
@@ -76,7 +65,7 @@ Fixes for Python 3 compatibility.
           sys.exit(1)
  
        env = Environment(MSVS_VERSION = msvs_ver)
-@@ -239,7 +236,7 @@
+@@ -242,7 +237,7 @@
     else:
        env = Environment(ENV = os.environ)
  
@@ -85,7 +74,7 @@ Fixes for Python 3 compatibility.
     compiler_major_ver = env["MSVS"]["VERSION"]
     
     # We need exception handling support turned on for Boost.Python.
-@@ -283,7 +280,7 @@
+@@ -286,7 +281,7 @@
     elif GetPlatform() == 'cygwin':
        env = BuildCygwinEnvironment()
     else:
@@ -94,7 +83,7 @@ Fixes for Python 3 compatibility.
        env = Environment()
  
     return env
-@@ -299,7 +296,7 @@
+@@ -302,7 +297,7 @@
        exp = re.compile('^(\d+\.\d+(\.\d+)?)\D*$')
        match = exp.search(value)
        boost_version = match.group(1)
@@ -103,7 +92,7 @@ Fixes for Python 3 compatibility.
     else:
        assert False, "Invalid Boost key"
  
-@@ -307,7 +304,7 @@
+@@ -310,7 +305,7 @@
     "Validate the boost option settings"
     global enable_python, optimize, compiler_major_ver
     req_boost_version = 103100
@@ -112,7 +101,7 @@ Fixes for Python 3 compatibility.
  
     if "BoostPythonDir" == key:
        version_dir = 'boost-' + re.sub(r'\.', '_', boost_version)   
-@@ -315,16 +312,16 @@
+@@ -318,16 +313,16 @@
        potential_inc_paths = [pj('include', version_dir), "include"]
        for pth in potential_inc_paths:
           if os.path.isdir(pj(value,pth)):
@@ -134,7 +123,7 @@ Fixes for Python 3 compatibility.
  
        ver_file = file(boost_ver_filename)
  
-@@ -334,7 +331,7 @@
+@@ -337,7 +332,7 @@
        sys.stdout.write("found version: %s\n" % ver_num)
  
        if ver_num < req_boost_version:
@@ -143,7 +132,7 @@ Fixes for Python 3 compatibility.
           Exit()
           return False
  
-@@ -414,16 +411,16 @@
+@@ -417,16 +412,16 @@
                                            '%s%s.%s' % (shlib_prefix, n,
                                                         shlib_ext))
  
@@ -163,7 +152,7 @@ Fixes for Python 3 compatibility.
              Exit()
              return False
  
-@@ -472,7 +469,7 @@
+@@ -475,7 +470,7 @@
           python = WhereIs('python')
           if not python:
              enable_python = False
@@ -172,7 +161,7 @@ Fixes for Python 3 compatibility.
              return False
  
           py_cmd = python + ' -c \'import sys; print sys.prefix; print sys.version[:3]\''
-@@ -493,7 +490,7 @@
+@@ -496,7 +491,7 @@
  
           # Version must match
           if float(py_ver) < required_version:
@@ -181,7 +170,7 @@ Fixes for Python 3 compatibility.
              enable_python = False
           else:
              # Build up the env information
-@@ -567,7 +564,7 @@
+@@ -570,11 +565,11 @@
        }
  
           my_file = env.SubstBuilder('file.out','file.in', submap=submap)
@@ -189,8 +178,20 @@ Fixes for Python 3 compatibility.
 +         env.AddPostAction (my_file, Chmod('$TARGET', 0o644))
           env.Depends(my_file, 'version.h')
     """
-    targets = map(lambda x: str(x), target)
-@@ -587,7 +584,7 @@
+-   targets = map(lambda x: str(x), target)
+-   sources = map(lambda x: str(x), source)
++   targets = [str(x) for x in target]
++   sources = [str(x) for x in source]
+ 
+    submap = env['submap']
+ 
+@@ -585,12 +580,12 @@
+ 
+       # Go through the substitution dictionary and modify the contents read in
+       # from the source file
+-      for key, value in submap.items():
++      for key, value in list(submap.items()):
+          contents = contents.replace(key, value);
  
        # Write out the target file with the new contents
        open(targets[i], 'w').write(contents)
@@ -199,7 +200,7 @@ Fixes for Python 3 compatibility.
  
  def generate_builder_str(target, source, env):
     builderStr = "generating: ";
-@@ -606,7 +603,7 @@
+@@ -609,7 +604,7 @@
  
  # Figure out what version of GMTL we're building
  GMTL_VERSION = GetGMTLVersion()
@@ -208,7 +209,7 @@ Fixes for Python 3 compatibility.
  
  help_text = "\n---- GMTL Build System ----\n"
  
-@@ -617,7 +614,7 @@
+@@ -620,7 +615,7 @@
  Prefix(PREFIX)
  Export('PREFIX')
  Export('optimize')
@@ -217,7 +218,7 @@ Fixes for Python 3 compatibility.
  
  baseEnv = BuildPlatformEnv()
  baseEnv["BUILDERS"]["SubstBuilder"] = \
-@@ -659,7 +656,7 @@
+@@ -662,7 +657,7 @@
  Export('installed_targets')
  
  if not has_help_flag:
@@ -226,8 +227,22 @@ Fixes for Python 3 compatibility.
  
     # Create the GMTL package
     pkg = Package('gmtl', '%i.%i.%i' % GMTL_VERSION)
-@@ -711,7 +708,7 @@
-       base_inst_paths['include'] = pj('${fp_file_cwd}' ,'..' ,'..', 'include',
+@@ -693,10 +688,9 @@
+ 
+    # Find gmtl headers, set up install rule and add to package
+    gmtl_headers = []
+-   def get_headers(hdrs, dirname, flist):
+-      hdrs.extend( [pj(dirname,f) for f in flist if f.endswith('.h')])
+-   os.path.walk('gmtl',get_headers,gmtl_headers)
+-   #print "GMTL Headers:\n", gmtl_headers, "\n"
++   for dirname, _, flist in os.walk('gmtl'):
++      gmtl_headers.extend([pj(dirname, f) for f in flist if f.endswith('.h')])
++   #print("GMTL Headers:\n", gmtl_headers, "\n")
+ 
+    # --- Setup installation paths --- #
+    base_inst_paths = {}
+@@ -715,7 +709,7 @@
+       base_inst_paths['include'] = pj(base_inst_paths['base'], 'include',
                                        include_version)
  
 -   print "using prefix:", base_inst_paths['base']         
@@ -235,12 +250,12 @@ Fixes for Python 3 compatibility.
        
     for h in gmtl_headers:
        installed_targets += baseEnv.InstallAs(pj(PREFIX, include_dir, h), h)
-@@ -758,7 +755,7 @@
+@@ -762,7 +756,7 @@
     fpc_filename = "-".join(name_parts) + ".fpc"
     gmtl_fpc = env.SubstBuilder(pj(base_inst_paths['flagpoll'], fpc_filename), 
                                 'gmtl.fpc.in', submap = submap)
 -   env.AddPostAction(gmtl_fpc, Chmod('$TARGET', 0644))
 +   env.AddPostAction(gmtl_fpc, Chmod('$TARGET', 0o644))
     env.Depends(gmtl_fpc, 'gmtl/Version.h')
- 
-    installed_targets += env.Install(base_inst_paths['bin'], 'gmtl-config')
+    gmtl_pc = env.SubstBuilder(pj(base_inst_paths['pkgconfig'], "gmtl.pc"), 
+                                'gmtl.fpc.in', submap = submap)

--- a/math/gmtl/files/SConstruct-scons.patch
+++ b/math/gmtl/files/SConstruct-scons.patch
@@ -1,0 +1,66 @@
+Fixes for new SCons versions.
+https://sourceforge.net/p/ggt/code/1267/
+https://sourceforge.net/p/ggt/code/1277/
+--- SConstruct.orig	2023-03-08 19:53:26.000000000 -0600
++++ SConstruct	2023-03-08 19:53:26.000000000 -0600
+@@ -627,7 +627,7 @@
+ Export('baseEnv')
+ 
+ options_cache = 'options.cache.' + distutils.util.get_platform()
+-opts = Options(options_cache)
++opts = Variables(options_cache)
+ AddCppUnitOptions(opts)
+ AddPythonOptions(opts)
+ AddBoostOptions(opts)
+@@ -725,7 +725,7 @@
+       subdirs.append('Test')
+    SConscript(dirs = subdirs)
+ 
+-   env = baseEnv.Copy()
++   env = baseEnv.Clone()
+ 
+    # Build up the provides vars for the .fpc files
+    provides = "gmtl"
+--- Test/TestSuite/SConscript.orig
++++ Test/TestSuite/SConscript
+@@ -14,7 +14,7 @@
+ sources.extend(testcases_sources)
+ 
+ # Setup the runtests executable target
+-env = baseEnv.Copy()
++env = baseEnv.Clone()
+ ApplyCppUnitOptions(env)
+ env.Append(CPPPATH = Split('#Test/TestSuite #'))
+ 
+--- python/SConscript.orig
++++ python/SConscript
+@@ -20,7 +20,7 @@
+ 
+ 
+ # Define the Python module
+-env = baseEnv.Copy()
++env = baseEnv.Clone()
+ 
+ # If using GCC, deal with ld O(n^2) algorithm.
+ if env['CXX'][:3] == 'g++' and WhereIs('objcopy'):
+--- tools/build/AutoDist.py.orig
++++ tools/build/AutoDist.py
+@@ -109,7 +109,7 @@
+ 
+       # Clone the base environment if we have one
+       if baseEnv:
+-         self.data['env'] = baseEnv.Copy()
++         self.data['env'] = baseEnv.Clone()
+       else:
+          self.data['env'] = Environment()
+ 
+@@ -378,7 +378,7 @@
+    """
+    # Clone the base environment if we have one
+    if baseEnv:
+-      env = baseEnv.Copy()
++      env = baseEnv.Clone()
+    else:
+       env = Environment()
+ 
+Terms Privacy Opt Out Advertise

--- a/math/gmtl/files/gmtl-config.patch
+++ b/math/gmtl/files/gmtl-config.patch
@@ -1,0 +1,8 @@
+--- gmtl-config.orig	2010-01-02 11:13:17.000000000 -0600
++++ gmtl-config	2023-03-08 20:56:06.000000000 -0600
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!@PYTHON_BIN@
+ 
+ # GMTL is (C) Copyright 2001-2010 by Allen Bierbaum
+ # Distributed under the GNU Lesser General Public License 2.1 with an

--- a/math/gmtl/files/gmtl.pc.patch
+++ b/math/gmtl/files/gmtl.pc.patch
@@ -1,0 +1,64 @@
+Install gmtl.pc.
+https://sourceforge.net/p/ggt/code/1264
+
+Because gmtl*.fpc and gmtl.pc get built at install time, not at build time, and
+because at install time we have to use prefix=${destroot}${prefix} because this
+build system doesn't support DESTDIR, gmtl*.fpc and gmtl.pc contain the path to
+the destroot, which we have to remove in a post-destroot block in the Portfile.
+--- SConstruct.orig
++++ SConstruct
+@@ -701,14 +701,15 @@
+    base_inst_paths['lib'] = pj(base_inst_paths['base'], 'lib')
+    base_inst_paths['share'] = pj(base_inst_paths['base'], 'share')
+    base_inst_paths['flagpoll'] = pj(base_inst_paths['share'], 'flagpoll')
++   base_inst_paths['pkgconfig'] = pj(base_inst_paths['lib'], 'pkgconfig')
+    base_inst_paths['bin'] = pj(base_inst_paths['base'], 'bin')
+    include_dir = pj(base_inst_paths['base'], 'include')
+-   base_inst_paths['include'] = pj('${fp_file_cwd}' ,'..' ,'..', 'include')
++   base_inst_paths['include'] = pj(base_inst_paths['base'], 'include')
+ 
+    if baseEnv['versioning'] == 'yes' and not sys.platform.startswith("win"):
+       include_version = "gmtl-%s.%s.%s" % GetGMTLVersion()
+       include_dir = pj(include_dir, include_version)
+-      base_inst_paths['include'] = pj('${fp_file_cwd}' ,'..' ,'..', 'include',
++      base_inst_paths['include'] = pj(base_inst_paths['base'], 'include',
+                                       include_version)
+ 
+    print "using prefix:", base_inst_paths['base']         
+@@ -743,7 +744,7 @@
+    # Build up substitution map
+    submap = {
+       '@provides@'                : provides,
+-      '@prefix@'                  : pj('${fp_file_cwd}', '..', '..'),
++      '@prefix@'                  : base_inst_paths['base'],
+       '@exec_prefix@'             : '${prefix}',
+       '@gmtl_cxxflags@'           : '',
+       '@includedir@'              : base_inst_paths['include'],
+@@ -760,9 +761,14 @@
+                                'gmtl.fpc.in', submap = submap)
+    env.AddPostAction(gmtl_fpc, Chmod('$TARGET', 0644))
+    env.Depends(gmtl_fpc, 'gmtl/Version.h')
++   gmtl_pc = env.SubstBuilder(pj(base_inst_paths['pkgconfig'], "gmtl.pc"), 
++                               'gmtl.fpc.in', submap = submap)
++   env.AddPostAction(gmtl_pc, Chmod('$TARGET', 0o644))
++   env.Depends(gmtl_pc, 'gmtl/Version.h')
+ 
+    installed_targets += env.Install(base_inst_paths['bin'], 'gmtl-config')
+    installed_targets += gmtl_fpc
++   installed_targets += gmtl_pc
+ 
+    pkg.build()
+    installed_targets += pkg.getInstalledTargets()
+--- gmtl.fpc.in.orig
++++ gmtl.fpc.in
+@@ -1,3 +1,4 @@
++prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ cxxflags=@gmtl_cxxflags@
+ includedir=@includedir@
+@@ -11,4 +12,4 @@
+ Libs:
+ Cflags: -I${includedir}
+ Arch: @arch@
+-prefix: @prefix@
++prefix: ${prefix}


### PR DESCRIPTION
#### Description

Add patches to fix build failures when using clang, when using the latest version of scons, when scons is using python 3, and to prevent the creation of the unwanted file gmtl-0.6.1.tar.gz and to install the file gmtl.pc.

Add runtime dependencies on flagpoll and python which are used by gmtl-config. flagpoll is currently incompatible with python 3 and uses python27 so use the same python here to reduce the number of pythons a user needs to install.

Specify absolute path to scons.

Specify prefix at build time so that build output does not give the erroneous impression that files will be installed in /usr/local.

Specify empty directories for Boost and CppUnit at build time so that any Boost or CppUnit that might be installed in /usr/local is not inadvertently used.

No need to specify destroot.cmd or destroot.target; the defaults work.

Add modeline.

Modernize checksums.

Set platforms to any and set supported_archs to noarch because this port doesn't install anything architecture- or OS-specific.

Add GitHub handle to maintainers line.

Install documentation files.

Indicate license. The software claims to be licensed LGPL-2.1+ but there is also a license addendum that imposes additional restrictions and the LGPL does not permit the imposition of additional restrictions.

Rewrite master_sites to avoid redirects.

Closes: https://trac.macports.org/ticket/57421

-----

@mccdo as with #17916 I've added your GitHub handle to the maintainers line. If you don't want to maintain this port anymore let us know and we'll remove you. If the email address needs updating let us know the new address. If you allow others to make changes to this port without consulting you let us know and we'll add `openmaintainer`.

I did already make one change to this port without consulting you — d4a979bd0a5ca18d5d9104394eabe30cc94c7c44 — apologies. This was based on the fact that you had not responded to [the ticket that this PR fixes](https://trac.macports.org/ticket/57421) for over four years and the port had not been installable at all since Xcode 5 was released almost ten years ago.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
