### PR TITLE
tmate: Use latest msgpack version

### DIFF
--- a/sysutils/tmate/Portfile
+++ b/sysutils/tmate/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        tmate-io tmate 2.4.0
-revision            0
+revision            1
 
 checksums           rmd160  8c4e3c305e19914932b79a91e2e266ae59647505 \
                     sha256  4e99b367f54baade14250d8c146aa019741b3f8eaee99ee80ca0d468fe6b650a \
@@ -22,7 +22,7 @@ depends_build       port:pkgconfig
 
 depends_lib         port:libevent \
                     port:ncurses \
-                    port:msgpack1 \
+                    port:msgpack \
                     port:libssh
 
 use_autoreconf      yes


### PR DESCRIPTION
#### Description

The `tmate` currently depends on the `msgpack1` port, rather than the latest `msgpack`, which is what it should depend on. For me, this makes it conflict with `nevoid`. This PR removes the version specifier.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 21G419 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
