### PR TITLE
asciidoc: Fix documentation install directory

### DIFF
--- a/textproc/asciidoc/Portfile
+++ b/textproc/asciidoc/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        asciidoc asciidoc-py3 10.2.0
-revision            1
+revision            2
 checksums           rmd160  e6369eddc6d72a4ea910f06f320881be105cd348 \
                     sha256  f830cb726d0b1448a451e916a7e60abfd27fce7f4dbce4c0c8f1ff856c1765ee \
                     size    1199960
@@ -34,6 +34,13 @@ homepage            https://asciidoc-py.github.io/
 # Need autoconf to generate and install docs; python 1.0 PG disables configure, we can just re-enable it
 use_autoreconf      yes
 use_configure       yes
+# The default for docdir is ${datarootdir}/doc/${PACKAGE_TARNAME}, and while
+# these have the values we expect them to have in the configure script, this
+# variable is left unexpanded and ${PACKAGE_TARNAME} is not defined in the
+# Makefile after Makefile generation, ends up empty, and the documentation is
+# installed in ${datarootdir}/doc. This is clearly a bug, but I'm not sure
+# whether it is in autoconf or asciidoc.
+configure.args      --docdir=${prefix}/share/doc/${name}
 
 python.versions     311
 python.default_version \
@@ -62,7 +69,7 @@ post-build {
 }
 
 post-destroot {
-    system -W ${worksrcpath} "make docs DESTDIR='${destroot}${prefix}'"
+    system -W ${worksrcpath} "make docs DESTDIR='${destroot}'"
     xinstall -d -m 0755 ${destroot}${prefix}/share/man/man1
     xinstall -m 0644 -W ${worksrcpath} \
         doc/a2x.1 \


### PR DESCRIPTION
#### Description

The default for docdir is `${datarootdir}/doc/${PACKAGE_TARNAME}`, and while these have the values we expect them to have in the configure script, this variable is left unexpanded and `${PACKAGE_TARNAME}` is not defined in the Makefile after Makefile generation, ends up empty, and the documentation is installed in `${datarootdir}/doc`. This is clearly a bug, but I'm not sure whether it is in autoconf or asciidoc.

Closes: https://trac.macports.org/ticket/67081

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 21G419 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
