### PR TITLE
borgbackup: Allow msgpack 1.0.5

### DIFF
--- a/sysutils/borgbackup/Portfile
+++ b/sysutils/borgbackup/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                borgbackup
 version             1.2.3
-revision            0
+revision            1
 
 checksums           rmd160  80c3ad862ed67235ebb5936fccecbded37f8e8ac \
                     sha256  e32418f8633c96fa9681352a56eb63b98e294203472c114a5242709d36966785 \
@@ -26,6 +26,9 @@ long_description    BorgBackup (short: Borg) is a deduplicating backup \
                     backups to not fully trusted targets.
 
 homepage            https://www.borgbackup.org/
+
+patchfiles          2842463f21499e3cb0258283ba4f0e349e46678e.patch
+patch.pre_args      -p1
 
 python.default_version  310
 

--- a/sysutils/borgbackup/files/2842463f21499e3cb0258283ba4f0e349e46678e.patch
+++ b/sysutils/borgbackup/files/2842463f21499e3cb0258283ba4f0e349e46678e.patch
@@ -1,0 +1,40 @@
+From 2842463f21499e3cb0258283ba4f0e349e46678e Mon Sep 17 00:00:00 2001
+From: Thomas Waldmann <tw@waldmann-edv.de>
+Date: Thu, 9 Mar 2023 17:58:57 +0100
+Subject: [PATCH] allow msgpack 1.0.5 also
+
+---
+ setup.py                    | 4 ++--
+ src/borg/helpers/msgpack.py | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 81b64e5272..feb7f5c33d 100644
+--- a/setup.py
++++ b/setup.py
+@@ -67,10 +67,10 @@
+ install_requires = [
+     # we are rather picky about msgpack versions, because a good working msgpack is
+     # very important for borg, see: https://github.com/borgbackup/borg/issues/3753
+-    'msgpack >=0.5.6, <=1.0.4, !=1.0.1',
+     # Please note:
+-    # using any other version is not supported by borg development and
++    # using any other msgpack version is not supported by borg development and
+     # any feedback related to issues caused by this will be ignored.
++    'msgpack >=0.5.6, <=1.0.5, !=1.0.1',
+     'packaging',
+ ]
+ 
+diff --git a/src/borg/helpers/msgpack.py b/src/borg/helpers/msgpack.py
+index 3c98b1358a..3c6565639d 100644
+--- a/src/borg/helpers/msgpack.py
++++ b/src/borg/helpers/msgpack.py
+@@ -182,7 +182,7 @@ def is_slow_msgpack():
+ def is_supported_msgpack():
+     # DO NOT CHANGE OR REMOVE! See also requirements and comments in setup.py.
+     import msgpack
+-    return (0, 5, 6) <= msgpack.version <= (1, 0, 4) and \
++    return (0, 5, 6) <= msgpack.version <= (1, 0, 5) and \
+            msgpack.version not in [(1, 0, 1), ]  # < add bad releases here to deny list
+ 
+ 


### PR DESCRIPTION
#### Description

The borg developers seem to want to test every single minor upstream release of msgpack, so this will likely happen again.

Upstream-Status: Backport [https://github.com/borgbackup/borg/commit/2842463f21499e3cb0258283ba4f0e349e46678e]

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 21G419 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?