### PR TITLE
lua-ansicolors: use luarocks_org PG

### DIFF
--- a/lua/lua-ansicolors/Portfile
+++ b/lua/lua-ansicolors/Portfile
@@ -1,15 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           luarocks 1.0
+PortGroup           luarocks_org 1.0
 
-luarocks.branches   5.1 5.2 5.3
-luarocks.setup      ansicolors 1.0.2-3
+name                lua-ansicolors
+version             1.0.2
 revision            0
+epoch               1
+luarocks.rock       ansicolors-${version}-3.src.rock
 license             MIT
-categories          lua
-supported_archs     noarch
-platforms           any
 maintainers         @gpanders openmaintainer
 
 description         Ansicolors is a simple Lua function for printing to the console in color
@@ -20,3 +19,8 @@ homepage            https://github.com/kikito/ansicolors.lua
 checksums           rmd160  e506533268414b8234e614a5b1293241257ad955 \
                     sha256  df6126501af3b9b944019164a08aed91377d82e6845c24432769140f12c815d6 \
                     size    4149
+
+luarocks.pure_lua   yes
+luarocks.worksrcdir ansicolors.lua-${version}
+
+luarocks.uploader   kikito


### PR DESCRIPTION
The epoch must be increased since the version scheme no longer includes the version of the rockspec file.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
