### PR TITLE
arpack: enable ISO_C_BINDING support

### DIFF
--- a/math/arpack/Portfile
+++ b/math/arpack/Portfile
@@ -8,7 +8,7 @@ PortGroup           linear_algebra 1.0
 
 github.setup        opencollab arpack-ng 3.9.0
 name                arpack
-revision            0
+revision            1
 categories          math
 license             BSD
 platforms           darwin
@@ -70,6 +70,10 @@ if {!${universal_possible} || ![variant_isset universal]} {
 # LDFLAGS needs to be cleared to avoid it having a "-arch" option, considered illegal by gfortran
 # also, if it has ${prefix}/lib it will prevent +accelerate from working if atlas is present.
 configure.args-append LDFLAGS=''
+
+# Enable ISO_C_BINDING support.
+# This requires compiler support, and is supported by GNU Fortran 4.3 or later.
+configure.args-append --enable-icb
 
 pre-configure {
     configure.args-append --with-blas="-L${prefix}/lib ${linalglib}"


### PR DESCRIPTION
#### Description

This enables ISO_C_BINDING support, and installs headers that make structured use from C or C++ possible. It does not remove or change functionality that was already included in the port.

This requires compiler support, however, all GCC versions starting with 4.3 have it, so I think there is no reason to make this a variant.

See https://github.com/opencollab/arpack-ng#iso_c_binding-support

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C504

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
