### PR TITLE
lua-checks: use luarocks_org PG

### DIFF
--- a/lua/lua-checks/Portfile
+++ b/lua/lua-checks/Portfile
@@ -1,13 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           luarocks 1.0
+PortGroup           luarocks_org 1.0
 
-luarocks.branches   5.1 5.2 5.3
-luarocks.setup      checks 1.0-1
+name                lua-checks
+version             1.0
 revision            0
+epoch               1
+luarocks.rock       checks-${version}-3.src.rock
 license             Eclipse
-categories          lua
 maintainers         @gpanders openmaintainer
 
 description         Provides a `checks()` function for Lua
@@ -15,8 +16,8 @@ long_description    This library declares a `checks()` function and a \
                     `checkers` table, which allow to check the parameters \
                     passed to a Lua function in a fast and unobtrusive way.
 
-homepage            https://luarocks.org/modules/luarocks/checks
+checksums           rmd160  4ada374bf6344424c2713a03bb6485513c3fb69b \
+                    sha256  dbc8d32961b69a440ad23e3a43d94140539f80d4c52b1c401df650c4aca4d758 \
+                    size    5043
 
-checksums           rmd160  48804a58ab9b1da86ad86d7d1a4c0df0959dfc9c \
-                    sha256  3f56ab82bd1e6e58304f833fd142d77964dcf9392ef0d6df11bb19612e37fb33 \
-                    size    5083
+luarocks.uploader   fab13n


### PR DESCRIPTION
The epoch must be increased since the version scheme no longer includes the version of the rockspec file.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
