### PR TITLE
lua-metalua-parser: use luarocks_org PG

### DIFF
--- a/lua/lua-metalua-parser/Portfile
+++ b/lua/lua-metalua-parser/Portfile
@@ -1,15 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           luarocks 1.0
+PortGroup           luarocks_org 1.0
 
-luarocks.branches   5.1 5.2 5.3
-luarocks.setup      metalua-parser 0.7.3-2
+name                lua-metalua-parser
+version             0.7.3
 revision            0
+epoch               1
+luarocks.rock       metalua-parser-${version}-2.src.rock
 license             {EPL MIT}
-categories          lua
-supported_archs     noarch
-platforms           any
 maintainers         @gpanders openmaintainer
 
 description         Define and generate an AST format for Lua programs
@@ -17,8 +16,12 @@ long_description    This is a subset of the full Metalua compiler. It defines an
                     generates an AST format for Lua programs, which offers a nice \
                     level of abstraction to reason about and manipulate Lua programs.
 
-homepage            https://git.eclipse.org/c/koneki/org.eclipse.koneki.metalua.git
-
 checksums           rmd160  d1f65c989b1fa18b3b757548c1ce37a1ace68f43 \
                     sha256  3a2556a999c215641bc6e443a6a3d3a61238ee67b5abd9f706737b125a3a2ef6 \
                     size    91340
+
+luarocks.pure_lua   yes
+
+luarocks.worksrcdir org.eclipse.koneki.metalua-v${version}
+
+luarocks.uploader   luarocks


### PR DESCRIPTION
The epoch must be increased since the version scheme no longer includes the version of the rockspec file.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
