### PR TITLE
lua-luazip: use luarocks_org PG

### DIFF
--- a/lua/lua-luazip/Portfile
+++ b/lua/lua-luazip/Portfile
@@ -1,20 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           luarocks 1.0
+PortGroup           luarocks_org 1.0
 
-luarocks.branches   5.1 5.2 5.3
-luarocks.setup      luazip 1.2.7-1
-revision            1
+name                lua-luazip
+version             1.2.7
+revision            0
+epoch               1
+luarocks.rock       luazip-${version}-1.src.rock
 license             MIT
-categories          lua archivers
+categories          lua devel archivers
 maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         LuaZip is a Lua extension library used to read files stored inside zip files.
 long_description    LuaZip is a lightweight Lua extension library used to read files stored inside zip files. \
                     The API is very similar to the standard Lua I/O library API.
-
-homepage            https://github.com/mpeterv/luazip
 
 checksums           rmd160  c450d2eeb42ee54ce0618f1c5ad9d7020fd7af24 \
                     sha256  7480e980da7a1b1e51094242e16fb83f3d5f2bbc0e23e421d47099ab42a6f9fa \
@@ -22,6 +22,4 @@ checksums           rmd160  c450d2eeb42ee54ce0618f1c5ad9d7020fd7af24 \
 
 depends_lib         port:libzzip
 
-livecheck.url       ${homepage}/tags
-livecheck.regex     {archive/refs/tags/([0-9.]+)\.tar\.gz}
-livecheck.version   [lindex [split ${version} -] 0]
+luarocks.uploader   mpeterv


### PR DESCRIPTION
The epoch must be increased since the version scheme no longer includes the version of the rockspec file.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
