### PR TITLE
GrandPerspective: update to 3.1.0

### DIFF
--- a/aqua/GrandPerspective/Portfile
+++ b/aqua/GrandPerspective/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           xcode 1.0
 
 name                GrandPerspective
-version             3.0.1
+version             3.1.0
 set version_unsc    [string map {. _} ${version}]
 license             GPL-2+
 categories          aqua sysutils
@@ -20,10 +20,11 @@ master_sites        sourceforge:project/grandperspectiv/grandperspective/${versi
 
 distname            ${name}-${version_unsc}-src
 extract.suffix      .tgz
+worksrcdir          ${name}-${version_unsc}
 
-checksums           rmd160  dcb1ff6e30db0de91a7ce0bc11e49783b9bf3c84 \
-                    sha256  56a5d424ac70c83b0347de02ed778edd6250f56c0216005caf9049af9a7ba748 \
-                    size    1914021
+checksums           rmd160  c681bba3f740bf024309083285e049d1a3a35d5d \
+                    sha256  ed579909d35fb1de4871773e6fb789a81281965ab6f4cd130555f73cffc75fcb \
+                    size    1935038
 
 build.dir           ${worksrcpath}/src
 


### PR DESCRIPTION
#### Description

Xcode fails with a weird error locally; trying on CI

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.2.1 22D68 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
