### PR TITLE
cmake: Update to 3.24.4

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -10,8 +10,7 @@ if { ${os.platform} eq "darwin" && ${os.major} >= 20 && ${build_arch} eq "x86_64
 
 }
 
-PortGroup           xcodeversion 1.0
-PortGroup           gitlab 1.0
+PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 # CMake is a dependency of clang
@@ -32,25 +31,19 @@ set base_long_description \
     used in conjunction with the native build environment."
 homepage            https://cmake.org
 platforms           darwin freebsd
-gitlab.instance     https://gitlab.kitware.com
 
-gitlab.setup        cmake   cmake 3.24.3 v
-checksums           rmd160  09373f97fee569133852498f0de6e9f6db10084b \
-                    sha256  0c6930c922f423c3a55dd336b18d90062fa7d46919567116af41d894dd8d5e99 \
-                    size    7977326
+github.setup        Kitware CMake 3.24.4 v
+checksums           rmd160  27361e6bac14691aacb46a132d7c016f39b022a9 \
+                    sha256  32c9e499510eff7070d3f0adfbabe0afea2058608c5fa93e231beb49fbfa2296 \
+                    size    10400358
 revision            0
 
-# have to do the extract rename for this port to work
-# this will not do anything in the current release 3.8.0 or prior
-# it will be part of the next release: 3.8.1 or 3.9.0
-# https://trac.macports.org/ticket/66415
-# remove the 'if' clause with the next 'port' release, leaving just the middle line
-if {[exists extract.rename]} {
-    extract.rename  yes
-}
-
 # limit livecheck to the current major.minor version
-gitlab.livecheck.regex {(3\.24\.[0-9.]+)}
+set branch          [join [lrange [split ${version} .] 0 1] .]
+github.livecheck.regex ([quotemeta ${branch}]\\.\[0-9.\]+)
+
+github.tarball_from releases
+distname            ${name}-${version}
 
 # CMake can be built with C++11, but some older Clang on OSX 10.9 and
 # earlier claim C++11 support yet don't actually support certain features.
@@ -279,7 +272,7 @@ if {[variant_isset docs]} {
 
     # set default +python* variant if none were already selected
     if {!${python_isset}} {
-        default_variants +python39
+        default_variants +python311
     }
 
     # make sure one of the +python* variants is set


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/67080

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
