### PR TITLE
cmake-devel: Update to 20230308-3.26.0-rc6-454bfa77

### DIFF
--- a/devel/cmake-devel/Portfile
+++ b/devel/cmake-devel/Portfile
@@ -10,7 +10,6 @@ if { ${os.platform} eq "darwin" && ${os.major} >= 20 && ${build_arch} eq "x86_64
 
 }
 
-PortGroup           xcodeversion 1.0
 PortGroup           gitlab 1.0
 PortGroup           legacysupport 1.1
 
@@ -37,14 +36,13 @@ homepage            https://cmake.org
 platforms           darwin freebsd
 gitlab.instance     https://gitlab.kitware.com
 
-gitlab.setup        cmake   cmake 29bcbcab4fe3750d7529f49e9d71768c76a23a47
-version             20230209-3.26.0-rc2-[string range ${gitlab.version} 0 7]
-checksums           rmd160  ea789ed7acbace36146854dd6e25a6940bf9da94 \
-                    sha256  c16907017f755cbc504075487e98a7eefb1d9a5dbb12e42af8ccafabbbcac1ec \
-                    size    8144372
+gitlab.setup        cmake   cmake 454bfa77b2951cc53296da86928dce00885d4d5b
+version             20230308-3.26.0-rc6-[string range ${gitlab.version} 0 7]
+checksums           rmd160  14084f8407a6c6a189f443ebcbe5c5b6d9baa4cf \
+                    sha256  ce091ec5972ea67cb79efa63460b9a71623a75b7cb54ad5468ab077c5a54064f \
+                    size    8147049
 revision            0
 
-# switched from "3.23.0" to "date-ver-hash"
 epoch               1
 
 dist_subdir         ${my_name}
@@ -262,7 +260,7 @@ subport ${subport_docs} {
     }
 
     # Supported pythons
-    set python_versions {35 36 37 38 39}
+    set python_versions {35 36 37 38 39 310 311}
 
     # declare all +python* variants, with conflicts
     foreach pyver ${python_versions} {
@@ -296,7 +294,7 @@ subport ${subport_docs} {
     # set default +python* variant if none were already selected
     if {!${python_isset}} {
         set python_isset true
-        default_variants +python39
+        default_variants +python311
     }
 
     # make sure one of the +python* variants is set

--- a/devel/cmake-devel/files/patch-qt5gui.diff
+++ b/devel/cmake-devel/files/patch-qt5gui.diff
@@ -53,7 +53,7 @@
  	<key>CFBundleSignature</key>
 --- CMakeLists.txt.orig
 +++ CMakeLists.txt
-@@ -425,12 +425,20 @@
+@@ -419,12 +419,20 @@
      if(APPLE)
        set(CMAKE_BUNDLE_VERSION
          "${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}.${CMake_VERSION_PATCH}")
@@ -78,3 +78,4 @@
 -      string(APPEND CMAKE_INSTALL_PREFIX "CMake.app/Contents")
      endif()
    endif()
+ 


### PR DESCRIPTION
#### Description

cmake-devel: Update to 20230308-3.26.0-rc6-454bfa77

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.3.1 21E258 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
