### PR TITLE
Updated inline comment about VideoToolbox

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -218,7 +218,7 @@ platform darwin {
     }
 
     # VideoToolbox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".
-    # It provides support for H264, H263, MPEG1, MPEG2 and MPEG4.
+    # It provides support for H265, H264, H263, MPEG1, MPEG2 and MPEG4.
     if {${os.major} > 11} {
         configure.args-replace --disable-videotoolbox --enable-videotoolbox
     }

--- a/multimedia/ffmpeg-upstream/Portfile
+++ b/multimedia/ffmpeg-upstream/Portfile
@@ -211,7 +211,7 @@ platform darwin {
     }
 
     # VideoToolbox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".
-    # It provides support for H264, H263, MPEG1, MPEG2 and MPEG4.
+    # It provides support for H265, H264, H263, MPEG1, MPEG2 and MPEG4.
     if {${os.major} > 11} {
         configure.args-replace --disable-videotoolbox --enable-videotoolbox
     }

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -218,7 +218,7 @@ platform darwin {
     }
 
     # VideoToolbox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".
-    # It provides support for H264, H263, MPEG1, MPEG2 and MPEG4.
+    # It provides support for H265, H264, H263, MPEG1, MPEG2 and MPEG4.
     if {${os.major} > 11} {
         configure.args-replace --disable-videotoolbox --enable-videotoolbox
     }

--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -201,7 +201,7 @@ platform darwin {
     }
 
     # VideotoolBox, a new hardware acceleration framework, is supported on 10.8+ and "here to stay".
-    # It provides support for H264, H263, MPEG1, MPEG2 and MPEG4.
+    # It provides support for H265, H264, H263, MPEG1, MPEG2 and MPEG4.
     if {${os.major} > 14} {
         configure.args-delete   --disable-videotoolbox-gl
         configure.args-append   --enable-videotoolbox-gl


### PR DESCRIPTION
FFmpeg can use the HW accelerated H265 encoder exposed by VideoToolbox via hevc_videotoolbox

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix
