### PR TITLE
tree-sitter-cli: add runtime NodeJS depencency, don't fetch deps at build time

### DIFF
--- a/devel/tree-sitter/Portfile
+++ b/devel/tree-sitter/Portfile
@@ -40,11 +40,9 @@ if {${subport} eq ${name}} {
 subport ${name}-cli {
     PortGroup       cargo 1.0
 
-    build.dir       ${worksrcpath}/cli
+    revision        1
 
-    # Allow cargo to fetch dependencies at build time
-    build.pre_args-delete \
-        --frozen
+    build.dir       ${worksrcpath}/cli
 
     depends_run-append  path:bin/node:nodejs16
 
@@ -53,4 +51,90 @@ subport ${name}-cli {
             ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
             ${destroot}${prefix}/bin/
     }
+
+    cargo.crates \
+        aho-corasick                    0.7.20  cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac \
+        ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+        anyhow                          1.0.66  216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6 \
+        ascii                            1.1.0  d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16 \
+        atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+        autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+        bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+        bumpalo                         3.11.1  572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba \
+        cc                              1.0.77  e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4 \
+        cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+        chunked_transfer                 1.4.0  fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e \
+        clap                            2.34.0  a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c \
+        ctor                            0.1.26  6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096 \
+        diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
+        difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
+        dirs                             3.0.2  30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309 \
+        dirs-sys                         0.3.7  1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6 \
+        either                           1.8.0  90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797 \
+        fastrand                         1.8.0  a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499 \
+        getrandom                        0.2.8  c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31 \
+        glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+        hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+        hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+        html-escape                     0.2.12  15315cfa9503e9aa85a477138eff76a1b203a430703548052c330b69d8d8c205 \
+        httpdate                         1.0.2  c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421 \
+        indexmap                         1.9.2  1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399 \
+        instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
+        itoa                             1.0.4  4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc \
+        js-sys                          0.3.60  49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47 \
+        lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+        libc                           0.2.138  db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8 \
+        libloading                       0.7.4  b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f \
+        log                             0.4.17  abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e \
+        memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
+        once_cell                       1.16.0  86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860 \
+        output_vt100                     0.1.3  628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66 \
+        ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
+        pretty_assertions                0.7.2  1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b \
+        proc-macro2                     1.0.47  5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725 \
+        quote                           1.0.21  bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179 \
+        rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+        rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+        rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+        redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
+        redox_users                      0.4.3  b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b \
+        regex                            1.7.0  e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a \
+        regex-syntax                    0.6.28  456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848 \
+        remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+        rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
+        ryu                             1.0.11  4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09 \
+        same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+        semver                          1.0.14  e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4 \
+        serde                          1.0.149  256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055 \
+        serde_derive                   1.0.149  b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4 \
+        serde_json                      1.0.89  020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db \
+        smallbitvec                      2.5.1  75ce4f9dc4a41b4c3476cc925f1efb11b66df373a8fde5d4b8915fa91b5d995e \
+        strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
+        syn                            1.0.105  60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908 \
+        tempfile                         3.3.0  5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4 \
+        textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
+        thiserror                       1.0.37  10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e \
+        thiserror-impl                  1.0.37  982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb \
+        tiny_http                       0.12.0  389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82 \
+        toml                             0.5.9  8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7 \
+        unicode-ident                    1.0.5  6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3 \
+        unicode-width                   0.1.10  c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b \
+        unindent                         0.2.1  5aa30f5ea51ff7edfc797c6d3f9ec8cbd8cfedef5371766b7181d33977f4814f \
+        utf8-width                       0.1.6  5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1 \
+        vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
+        walkdir                          2.3.2  808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56 \
+        wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+        wasm-bindgen                    0.2.83  eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268 \
+        wasm-bindgen-backend            0.2.83  4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142 \
+        wasm-bindgen-macro              0.2.83  052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810 \
+        wasm-bindgen-macro-support      0.2.83  07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c \
+        wasm-bindgen-shared             0.2.83  1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f \
+        web-sys                         0.3.60  bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f \
+        webbrowser                       0.5.5  ecad156490d6b620308ed411cfee90d280b3cbd13e189ea0d3fada8acc89158a \
+        which                            4.3.0  1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b \
+        widestring                       0.4.3  c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c \
+        winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+        winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+        winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+        winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
 }

--- a/devel/tree-sitter/Portfile
+++ b/devel/tree-sitter/Portfile
@@ -46,6 +46,8 @@ subport ${name}-cli {
     build.pre_args-delete \
         --frozen
 
+    depends_run-append  path:bin/node:nodejs16
+
     destroot {
         xinstall -m 0755 \
             ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \


### PR DESCRIPTION
#### Description

It was discovered in https://trac.macports.org/ticket/66595 that the tree-sitter CLI tool shells out to `node`.

Also the port seemingly unnecessarily fetches deps at build time, so I added `cargo.crates` generated by cargo2port. It built successfully on my machine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
