### PR TITLE
openssl3: Update to 3.1.0

### DIFF
--- a/devel/openssl/Portfile
+++ b/devel/openssl/Portfile
@@ -6,7 +6,7 @@ PortGroup           openssl 1.0
 name                openssl
 epoch               2
 version             [openssl::default_branch]
-revision            9
+revision            10
 
 categories          devel security
 platforms           darwin

--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -10,8 +10,8 @@ legacysupport.newest_darwin_requires_legacy 8
 
 set major_v         3
 name                openssl$major_v
-version             ${major_v}.0.8
-revision            1
+version             ${major_v}.1.0
+revision            0
 
 # Please revbump these ports when updating the openssl3 version/revision
 #  - freeradius (#43461)
@@ -47,9 +47,9 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           rmd160  bd9d4750c3f0e10047da662ce77d7db8a2b93bc7 \
-                    sha256  6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e \
-                    size    15151328
+checksums           rmd160  203ebe676bbdde1a869fc14c6c4e21983ce4b810 \
+                    sha256  aaa925ad9828745c4cad9d9efeb273deca820f2cdcf2c3ac7d7c1212b7c497b4 \
+                    size    15525381
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Having the stdlib set to libc++ on 10.6 causes a dependency on a
@@ -172,7 +172,6 @@ variant legacy description {enable legacy providers by default} {
         close ${cnf}
     }
 }
-default_variants-append +legacy
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             9.2p1
-revision            0
+revision            1
 categories          net
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 license             BSD

--- a/sysutils/freeradius/Portfile
+++ b/sysutils/freeradius/Portfile
@@ -5,7 +5,7 @@ PortGroup               muniversal 1.0
 
 name                    freeradius
 version                 3.0.21
-revision                13
+revision                14
 checksums               rmd160  04a038b701f19d9c598e826a795a0cdaacd3768b \
                         sha256  c22dad43954b0cbc957564d3f8cbb942ff09853852d2c2155d54e6bd641a4e7d \
                         size    3184588


### PR DESCRIPTION
#### Description

openssl3: Update to 3.1.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?