### PR TITLE
qt5-qtwebengine : enabled proprietary codecs option

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1808,6 +1808,7 @@ foreach {module module_info} [array get modules] {
                     --                             \
                     -webengine-native-spellchecker \
                     -webengine-kerberos \
+                    -webengine-proprietary-codecs \
                     -system-webengine-icu \
                     -system-webengine-ffmpeg
 

--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -677,7 +677,7 @@ array set modules {
         {"Qt WebEngine"}
         "very large and relatively new"
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtwebglplugin {


### PR DESCRIPTION
#### Description

Without this option, a lot of major video platforms can't be used (video won't play), like Vimeo, any PeerTube instance, and even some basic HTML5 video examples, depending on the encoding. This option is enabled by default in every Linux distribution and should be enabled in MacPorts too

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

It's kind a bugfix because a lot of videos won't play without this option, but it can also be considered as an enhancement I guess.

###### Tested on
macOS 12.5.1 21G83 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

I tested the built library on my app, that contains an internal navigator, and videos are playing even on Vimeo, PeerTube, etc