### PR TITLE
libquvi*: use lua PG and Lua version 5.2

### DIFF
--- a/net/libquvi-scripts/Portfile
+++ b/net/libquvi-scripts/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           lua 1.0
 
 name                libquvi-scripts
 version             0.9.20131130
-revision            3
+revision            4
 categories          net www
 license             AGPL-3
 maintainers         openmaintainer {snc @nerdling}
@@ -18,7 +19,7 @@ homepage            http://quvi.sourceforge.net/
 
 platforms           any
 depends_build       port:pkgconfig
-depends_lib         port:lua-luabitop port:lua-luaexpat port:lua-luajson port:lua-luasocket
+lua.modules         luabitop luaexpat luajson luasocket
 installs_libs       no
 supported_archs     noarch
 
@@ -29,6 +30,9 @@ checksums           rmd160  69423930338a59c5f23f108177a441a2a590165e \
                     sha256  17f21f9fac10cf60af2741f2c86a8ffd8007aa334d1eb78ff6ece130cb3777e3
 
 configure.cppflags  -I${worksrcpath}/include -I${prefix}/include
+
+# see libquvi Portfile
+lua.version         5.2
 
 # tests require libquvi to be installed but libquvi depends on libquvi-scripts
 test.run            no

--- a/net/libquvi/Portfile
+++ b/net/libquvi/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           lua 1.0
 
 name                libquvi
 version             0.9.4
-revision            2
+revision            3
 categories          net www
 license             GPL-3
 maintainers         openmaintainer {snc @nerdling}
@@ -23,8 +24,7 @@ depends_lib         port:curl \
                     port:libgpg-error \
                     port:libgcrypt \
                     port:libquvi-scripts \
-                    port:libproxy \
-                    port:lua
+                    port:libproxy
 
 patchfiles          patch-src-quvi-quvi-Makefile.in.diff
 
@@ -33,6 +33,9 @@ use_xz              yes
 
 checksums           rmd160  831061cc162a883ee4ecabad4f04687e6f4d17b3 \
                     sha256  2d3fe28954a68ed97587e7b920ada5095c450105e993ceade85606dadf9a81b2
+
+# more recent Lua versions seem to break build
+lua.version         5.2
 
 configure.cppflags  -I${worksrcpath}/include -I${prefix}/include
 


### PR DESCRIPTION
more recent Lua versions seem to break build

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
