### PR TITLE
py-awscli2: update to 2.11.3

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 PortGroup           github 1.0
 
 name                py-awscli2
-github.setup        aws aws-cli 2.11.0
+github.setup        aws aws-cli 2.11.3
 revision            0
 
 categories          python devel
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  e7ca20d8115ba36270ccb2d9bc75c67843e5f962 \
-                    sha256  3a982c3c64d8749ef462cb78e3a0991631d928208a8fb51e42c341d46066d565 \
-                    size    12991889
+checksums           rmd160  487141f829e34460a580b6bca2d0949fa1f814ee \
+                    sha256  3c76c026ced9237a5d0f27e4696da45f1af507726d24aa296ca26f3478e23c93 \
+                    size    13019278
 
 python.versions     38 39 310 311
 python.pep517       yes

--- a/python/py-awscli2/files/patch-requirements.diff
+++ b/python/py-awscli2/files/patch-requirements.diff
@@ -18,7 +18,7 @@ diff -ru aws-cli-2.11.0-orig/pyproject.toml aws-cli-2.11.0/pyproject.toml
  dependencies = [
 -    "colorama>=0.2.5,<0.4.7",
 -    "docutils>=0.10,<0.20",
--    "cryptography>=3.3.2,<38.0.5",
+-    "cryptography>=3.3.2,<39.0.3",
 -    "ruamel.yaml>=0.15.0,<=0.17.21",
 +    "colorama",
 +    "docutils",

--- a/python/py-awscrt/Portfile
+++ b/python/py-awscrt/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-awscrt
 # This is only used by awscli2. Bump when Amazon bumps
 # their pinned version in awscli2's setup.cfg.
-version             0.16.10
+version             0.16.13
 revision            0
 
 categories-append   devel
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  96cfd5fc285af75415c6f7aa6bae2e879a579fdd \
-                    sha256  3101499b479b82f0403f615bf520c1f8b9506818d275e3e28ade25cc6bcdb92b \
-                    size    21880170
+checksums           rmd160  f7589cad2a9be218f8426cd6c24e560a83951c12 \
+                    sha256  b7ec07435e178400369024450d118834a1c8b01ccfebe8140b82102fb161720d \
+                    size    27094087
 
 python.versions     38 39 310 311
 


### PR DESCRIPTION
#### Description

Tested locally with basic s3 use

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
