### PR TITLE
miniflux: update to 2.0.43

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.42
+go.setup            github.com/miniflux/v2 2.0.43
 go.package          miniflux.app
 name                miniflux
 revision            0
@@ -16,9 +16,9 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  fdfe49e34e1e2e2851723e55d38881690fcfd845 \
-                        sha256  68617cd149578400027fc30f9bb151e30f9c4f34084dd4d5ef0debf399de9766 \
-                        size    577211
+                        rmd160  cdfbb717d04d5c41ff8503b047a70ebcd1884748 \
+                        sha256  62f8f09cab6f436014491597fd7bda9b67cd81c6072beacbf4062a460af752a5 \
+                        size    587052
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
@@ -49,40 +49,40 @@ go.vendors          mvdan.cc/xurls \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
                     golang.org/x/text \
-                        lock    v0.6.0 \
-                        rmd160  41b7bda7df46797457b47aa00e5d745345b684bc \
-                        sha256  6172a6091f616a9fb644ed71ee61e3a69529f95f357abd9ce521599a1e57e2b9 \
-                        size    8361557 \
+                        lock    v0.8.0 \
+                        rmd160  46b8c9c9db41ffd579687f8c383b7d4134768744 \
+                        sha256  8e761ba6cd7022babf21ac86de9611c9682c499e048f7305d0b339104c2472aa \
+                        size    8360208 \
                     golang.org/x/term \
-                        lock    v0.4.0 \
-                        rmd160  ab690adab1da9bf826e1e2960b3c032c9284a23e \
-                        sha256  fe08b220b0929e25392011fd72353f50b7ac64d52cffff4a868318b0f16beab0 \
-                        size    14800 \
+                        lock    v0.6.0 \
+                        rmd160  cb472da6ed94fc7801534c41cea8c7db352800f1 \
+                        sha256  57ce8bc9922a775392a237a3c127dc76469edd9580fff38a08837f718d207da8 \
+                        size    14796 \
                     golang.org/x/sys \
-                        lock    v0.4.0 \
-                        rmd160  83e9289b4e409a6a5a96cf70f6adda487c3f1170 \
-                        sha256  97f4948f84af5fe499733870e49ce277786e512787690065e3be9828d4a6c738 \
-                        size    1425728 \
+                        lock    v0.6.0 \
+                        rmd160  eed022d31d3cd2b2a5c7d1bad325b6667db1d831 \
+                        sha256  28b3d661c0b094ccb133bb2f30a2db8fcd64be036f4fc42ee6c2ab4b00867bd3 \
+                        size    1435230 \
                     golang.org/x/oauth2 \
-                        lock    v0.4.0 \
-                        rmd160  3492641d8a6a0b335f4c2ceb4cecbbcd135bfcab \
-                        sha256  bcd56fd25196c1620b9a9a3ff6facd1903db31a7a4db11fb193872dc91bb2b6f \
-                        size    87089 \
+                        lock    v0.6.0 \
+                        rmd160  366ba3c2430d9c5b14d6c9a20665baa4018008e9 \
+                        sha256  1f3362a4cca627bac5a0d79c676d770e27a3d9129bcbd3f2d9610d14ad0d3fab \
+                        size    86662 \
                     golang.org/x/net \
-                        lock    v0.5.0 \
-                        rmd160  5c6bd81ab31a211f0e6f520dbec3c02c506d9ea6 \
-                        sha256  34827849fc6295d493c21df54fea819dae369bc37ff7d7e283030fe140118c0e \
-                        size    1238525 \
+                        lock    v0.8.0 \
+                        rmd160  9fad54bb4c2f96a60e6d5126ff16ffa4064b1844 \
+                        sha256  8e2ecc9dc226234900b728b1b340e096675a27b3724298ce964d21a276f5bc05 \
+                        size    1244466 \
                     golang.org/x/crypto \
-                        lock    v0.5.0 \
-                        rmd160  d1a21b7260574f31cbc6588e1c392eb8f373a9e6 \
-                        sha256  a21df3765c9643d1fadcfb966fde4173c0c930851fb01a24bdef28abd950f13c \
-                        size    1633695 \
+                        lock    v0.7.0 \
+                        rmd160  88543af3c42d0c465ee8b4144b4dbf7e54c204e8 \
+                        sha256  e25aba4438946c18a951fe4d7921af122f9408f828a0f0e289b23a9a19e5752d \
+                        size    1634536 \
                     github.com/yuin/goldmark \
-                        lock    v1.5.3 \
-                        rmd160  19ec5216062b33aa1442099e489ffc81fef34679 \
-                        sha256  be4f796428f98b24196b09c626909b7aa88b8eb14ab21102193f1287f6e48be7 \
-                        size    259890 \
+                        lock    v1.5.4 \
+                        rmd160  7e428750043e781507d94e54431c488a2e07110a \
+                        sha256  125ebf860067caab104024f6b3072c86b8b94f131a9bbf8346b459724b097a54 \
+                        size    260013 \
                     github.com/technoweenie/multipartstreamer \
                         lock    v1.0.1 \
                         rmd160  f1ac41924fe0ca28bf79b5737680452a907b70b4 \
@@ -94,15 +94,15 @@ go.vendors          mvdan.cc/xurls \
                         sha256  ec3d36b70718e240d985ffb44998ff043680dbaf8800abb8acabd509ad3c06a5 \
                         size    2949 \
                     github.com/tdewolff/parse \
-                        lock    v2.6.4 \
-                        rmd160  0612d3fec268f391bfef648eb9c80582b2311d13 \
-                        sha256  546b8ff32196b9bedff6e93d001ce784fc5ca1bd96b54c1cb62f17f7c18ef70d \
-                        size    102405 \
+                        lock    v2.6.5 \
+                        rmd160  da41b43201a259b16f31cc3f98b3f075fdc0142f \
+                        sha256  cf43970b52d797dfe041e357df348bb1e7e407b5cd4bbcadd1f1310b8832a83f \
+                        size    104778 \
                     github.com/tdewolff/minify \
-                        lock    v2.12.4 \
-                        rmd160  4a18087fb935bed355030e6933e5e19b57ed7420 \
-                        sha256  0ad32e8938fe52e7e1963d4a78d4b4f0ceb73c851ebc0b9c9e10cf19d57d47dc \
-                        size    7008558 \
+                        lock    v2.12.5 \
+                        rmd160  462386a770743a1eacadb6f8cf50f6e9aadd4685 \
+                        sha256  cf0db1d207def082990b406145dfc58b42ae68b6e19894a3422ab282eae3bb1e \
+                        size    7008959 \
                     github.com/stretchr/testify \
                         lock    v1.7.0 \
                         rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
@@ -204,10 +204,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  a567b37da6b02ae582740bf015864a29cfd3b44af4815b0ac1680040fe46f67d \
                         size    33105 \
                     github.com/PuerkitoBio/goquery \
-                        lock    v1.8.0 \
-                        rmd160  81d239bcf19ee6e8dcadea494b9fc04c96f9480f \
-                        sha256  ea72d407535c049adac1a50fd783a5e3a2563dd6e6b60ddfb8a00691c43d78bd \
-                        size    105214
+                        lock    v1.8.1 \
+                        rmd160  0c42976812209bbd0738cb12a4f5357e6c25d677 \
+                        sha256  59d4df67e0aa0c11ae7f019ef5462d38f3e7200ed7aea48412bef8cc486eb880 \
+                        size    106576
 
 build.args-append   -ldflags=\"-s -w -X '${go.package}/version.Version=${version}'\"
 


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.43) (CVE-2023-27592, CVE-2023-27591)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
