### PR TITLE
lagrange: update to 1.15.5

### DIFF
--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 gitea.domain        git.skyjake.fi
-gitea.setup         skyjake the_Foundation 1.6.0 v
+gitea.setup         skyjake the_Foundation 1.6.1 v
 revision            0
 categories          devel
 license             BSD
@@ -18,9 +18,11 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Opinionated C11 library for low-level functionality
 long_description    {*}${description}
 
-checksums           rmd160  6780c91a4930c1d13fb2c746fc7b9ed60e92500e \
-                    sha256  15b1491195211f83fedc4b758a75f5ee4999dd9b86c33a94e70a08bc64ed2dfa \
-                    size    212502
+checksums           rmd160  3997da598b85744da052d373b2d6451417ffc1b3 \
+                    sha256  fde92455755528778aa17a4a6bb0e4ef9fa4770a28adeb7e14ddcbb1a0ebf80c \
+                    size    212529
+
+worksrcdir          ${name}
 
 depends_build-append \
                     port:pkgconfig

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.15.4 v
+gitea.setup         gemini lagrange 1.15.5 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  5c5f42c064880ea9ec7cd9efe921d42ab6c134b1 \
-                    sha256  d5ec0f01ca268158f060a77f2298fff9e9a9d4a78c7b292e67087e7a9d11dc2d \
-                    size    7487120
+checksums           rmd160  c2d16907332494a07db5abfba05076c6b6ec554a \
+                    sha256  50da4f206eb5cacf268a2511979731a3ff84fd52f5c7f02e8ed970fa5e8d3732 \
+                    size    7492631
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
