### PR TITLE
submission: resource_dasm and phosg

### DIFF
--- a/devel/phosg/Portfile
+++ b/devel/phosg/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+PortGroup               compiler_blacklist_versions 1.0
+
+github.setup            fuzziqersoftware phosg e1bd000
+github.tarball_from     archive
+
+# blacklisting to select C++20 capable compilers
+compiler.blacklist-append {clang < 1300}
+
+version                 2023.03.04
+revision                0
+categories              devel
+maintainers             {alum.wpi.edu:arno+macports @fracai} openmaintainer
+license                 MIT
+
+description             Phosg is a basic C++ wrapper library around some common C routines.
+long_description        {*}${description}
+
+checksums               rmd160  526fb52a0eadbb3e33da6e2711c4c43afca04eda \
+                        sha256  802170acf4b8bae5383183c9361812d5309cb3e79d703e365b96feffe5d776cd \
+                        size    147998
+
+set pyver               3.11
+set python_version      [string index ${pyver} 0][string range ${pyver} 2 end]
+
+patchfiles              CMakeLists-txt.diff
+
+depends_build-append    port:python${python_version}
+
+configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python${pyver}

--- a/devel/phosg/files/CMakeLists-txt.diff
+++ b/devel/phosg/files/CMakeLists-txt.diff
@@ -1,0 +1,10 @@
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -71,5 +71,5 @@
+ install(TARGETS jsonformat DESTINATION bin)
+ install(TARGETS parse-data DESTINATION bin)
+ install(FILES ${Headers} DESTINATION include/phosg)
+-install(FILES phosg-config.cmake DESTINATION lib)
+-install(EXPORT phosg DESTINATION lib)
++install(FILES phosg-config.cmake DESTINATION lib/cmake/phosg)
++install(EXPORT phosg DESTINATION lib/cmake/phosg)

--- a/devel/resource_dasm/Portfile
+++ b/devel/resource_dasm/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+PortGroup               compiler_blacklist_versions 1.0
+
+github.setup            fuzziqersoftware resource_dasm 46ad32e
+github.tarball_from     archive
+
+# blacklisting to select C++20 capable compilers
+compiler.blacklist-append {clang < 1300}
+
+version                 2023.03.15
+revision                0
+categories              devel
+maintainers             {alum.wpi.edu:arno+macports @fracai} openmaintainer
+license                 MIT
+
+description             Tools for reverse-engineering classic Mac OS applications and games.
+long_description        {*}${description}
+
+checksums               rmd160  190a5eb9a174d8eafdc17ca736f730e2d12862ec \
+                        sha256  db5e42d9ef9df9d4d40f42fd7c1b67cc2f5108a06e30ae983fd6e40046ad22e0 \
+                        size    457269
+
+set pyver               3.11
+set python_version      [string index ${pyver} 0][string range ${pyver} 2 end]
+
+patchfiles              CMakeLists-txt.diff
+
+depends_build-append    port:python${python_version}
+depends_lib-append      port:phosg \
+                        port:zlib
+depends_run-append      port:netpbm
+
+configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python${pyver} \
+                        -Dphosg_DIR=${prefix}/lib/cmake/phosg

--- a/devel/resource_dasm/files/CMakeLists-txt.diff
+++ b/devel/resource_dasm/files/CMakeLists-txt.diff
@@ -1,0 +1,10 @@
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -130,5 +130,5 @@
+ file(GLOB EmulatorsHeaders ${CMAKE_SOURCE_DIR}/src/Emulators/*.hh)
+ install(FILES ${EmulatorsHeaders} DESTINATION include/resource_file/Emulators)
+ 
+-install(FILES resource_file-config.cmake DESTINATION lib)
+-install(EXPORT resource_file DESTINATION lib)
++install(FILES resource_file-config.cmake DESTINATION lib/cmake/resource_dasm)
++install(EXPORT resource_file DESTINATION lib/cmake/resource_dasm)


### PR DESCRIPTION
#### Description

Portfiles for `resource_dasm` and dependency `phosg`

`phosg` doesn't have any releases and uses the latest commit (as of submission).
`resource_dasm` does have some release tags, but there have been many commits since the last tag, so also uses the latest commit (as of submission).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
