### PR TITLE
R: more support for tests

### DIFF
--- a/R/R-XML/Portfile
+++ b/R/R-XML/Portfile
@@ -19,6 +19,13 @@ depends_build-append \
                     port:pkgconfig
 depends_lib-append  port:libxml2
 
-# Without this a wrong compiler can be picked by configure script:
-destroot.env-append \
-                    CC=${configure.cc}
+patchfiles          patch-cc.diff
+
+post-patch {
+    reinplace "s,@CC@,${configure.cc}," ${worksrcpath}/configure
+}
+
+depends_test-append port:R-bitops \
+                    port:R-RCurl
+
+test.run            yes

--- a/R/R-XML/files/patch-cc.diff
+++ b/R/R-XML/files/patch-cc.diff
@@ -1,0 +1,11 @@
+--- configure.orig	2022-12-04 14:36:19.000000000 +0700
++++ configure	2023-03-19 01:55:25.000000000 +0700
+@@ -33,7 +33,7 @@
+ esac
+ fi
+ 
+-
++CC=@CC@
+ 
+ # Reset variables that may have inherited troublesome values from
+ # the environment.

--- a/R/R-hms/Portfile
+++ b/R/R-hms/Portfile
@@ -7,7 +7,7 @@ R.setup             github tidyverse hms 1.1.2 v
 revision            0
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
-description         A simple class for storing time-of-day values.
+description         A simple class for storing time-of-day values
 long_description    {*}${description}
 homepage            https://hms.tidyverse.org
 checksums           rmd160  54f3d45e9fab563063fe903ab8b28ed27aba222f \
@@ -15,8 +15,15 @@ checksums           rmd160  54f3d45e9fab563063fe903ab8b28ed27aba222f \
                     size    114651
 supported_archs     noarch
 
-depends_lib-append  port:R-ellipsis\
+depends_lib-append  port:R-ellipsis \
                     port:R-lifecycle \
                     port:R-pkgconfig \
                     port:R-rlang \
                     port:R-vctrs
+
+depends_test-append port:R-crayon \
+                    port:R-lubridate \
+                    port:R-pillar \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-lmtest/Portfile
+++ b/R/R-lmtest/Portfile
@@ -18,3 +18,11 @@ checksums           rmd160  4e93c3801eddd16b09b05f2ee7c6261d37592e40 \
 depends_lib-append  port:R-zoo
 
 compilers.setup     require_fortran
+
+depends_test-append port:R-AER \
+                    port:R-car \
+                    port:R-dynlm \
+                    port:R-sandwich \
+                    port:R-strucchange
+
+test.run            yes

--- a/R/R-readr/Portfile
+++ b/R/R-readr/Portfile
@@ -38,3 +38,16 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
         reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/src/Makevars
     }
 }
+
+depends_test-append port:R-covr \
+                    port:R-curl \
+                    port:R-knitr \
+                    port:R-rmarkdown \
+                    port:R-spelling \
+                    port:R-stringi \
+                    port:R-testthat \
+                    port:R-waldo \
+                    port:R-withr \
+                    port:R-xml2
+
+test.run            yes

--- a/R/R-tidyselect/Portfile
+++ b/R/R-tidyselect/Portfile
@@ -22,3 +22,15 @@ depends_lib-append  port:R-cli \
                     port:R-rlang \
                     port:R-vctrs \
                     port:R-withr
+
+depends_test-append port:R-covr \
+                    port:R-crayon \
+                    port:R-dplyr \
+                    port:R-knitr \
+                    port:R-magrittr \
+                    port:R-rmarkdown \
+                    port:R-stringr \
+                    port:R-testthat \
+                    port:R-tibble
+
+test.run            yes


### PR DESCRIPTION
#### Description

Added support for tests.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
