### PR TITLE
openssl3: fix build on PPC

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -51,7 +51,8 @@ checksums           rmd160  203ebe676bbdde1a869fc14c6c4e21983ce4b810 \
                     sha256  aaa925ad9828745c4cad9d9efeb273deca820f2cdcf2c3ac7d7c1212b7c497b4 \
                     size    15525381
 
-patchfiles          avx512.patch
+patchfiles          avx512.patch \
+                    patch-openssl3-ppc-asm.diff
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Having the stdlib set to libc++ on 10.6 causes a dependency on a

--- a/devel/openssl3/files/patch-openssl3-ppc-asm.diff
+++ b/devel/openssl3/files/patch-openssl3-ppc-asm.diff
@@ -1,0 +1,58 @@
+The new AES GCM assembler is written for IBM POWER9 and later
+and won't build on OSX PPC.
+
+Upstream PR: https://github.com/openssl/openssl/pull/20543
+
+--- crypto/chacha/build.info.orig
++++ crypto/chacha/build.info
+@@ -13,7 +13,7 @@ IF[{- !$disabled{asm} -}]
+   $CHACHAASM_aarch64=chacha-armv8.S chacha-armv8-sve.S
+ 
+   $CHACHAASM_ppc32=chacha_ppc.c chacha-ppc.s
+-  IF[{- $target{sys_id} ne "AIX" -}]
++  IF[{- $target{sys_id} ne "AIX" && $target{sys_id} ne "MACOSX" -}]
+     $CHACHAASM_ppc32=chacha_ppc.c chacha-ppc.s chachap10-ppc.s
+   ENDIF
+   $CHACHAASM_ppc64=$CHACHAASM_ppc32
+--- crypto/chacha/chacha_ppc.c.orig
++++ crypto/chacha/chacha_ppc.c
+@@ -30,7 +30,7 @@ void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp,
+                     size_t len, const unsigned int key[8],
+                     const unsigned int counter[4])
+ {
+-#ifndef OPENSSL_SYS_AIX
++#if !defined(OPENSSL_SYS_AIX) && !defined(OPENSSL_SYS_MACOSX)
+     OPENSSL_ppccap_P & PPC_BRD31
+         ? ChaCha20_ctr32_vsx_p10(out, inp, len, key, counter) :
+ #endif
+--- crypto/modes/build.info.orig
++++ crypto/modes/build.info
+@@ -33,7 +33,7 @@ IF[{- !$disabled{asm} -}]
+   $MODESDEF_parisc20_64=$MODESDEF_parisc11
+ 
+   $MODESASM_ppc32=ghashp8-ppc.s
+-  IF[{- $target{sys_id} ne "AIX" -}]
++  IF[{- $target{sys_id} ne "AIX" && $target{sys_id} ne "MACOSX" -}]
+     $MODESASM_ppc32=ghashp8-ppc.s aes-gcm-ppc.s
+   ENDIF
+   $MODESDEF_ppc32=
+--- include/crypto/aes_platform.h.orig
++++ include/crypto/aes_platform.h
+@@ -74,7 +74,7 @@ void AES_xts_decrypt(const unsigned char *inp, unsigned char *out, size_t len,
+ #   define HWAES_ctr32_encrypt_blocks aes_p8_ctr32_encrypt_blocks
+ #   define HWAES_xts_encrypt aes_p8_xts_encrypt
+ #   define HWAES_xts_decrypt aes_p8_xts_decrypt
+-#   ifndef OPENSSL_SYS_AIX
++#   if !defined(OPENSSL_SYS_AIX) && !defined(OPENSSL_SYS_MACOSX)
+ #    define PPC_AES_GCM_CAPABLE (OPENSSL_ppccap_P & PPC_MADD300)
+ #    define AES_GCM_ENC_BYTES 128
+ #    define AES_GCM_DEC_BYTES 128
+@@ -87,7 +87,7 @@ size_t ppc_aes_gcm_decrypt(const unsigned char *in, unsigned char *out,
+ #    define AES_GCM_ASM_PPC(gctx) ((gctx)->ctr==aes_p8_ctr32_encrypt_blocks && \
+                                    (gctx)->gcm.funcs.ghash==gcm_ghash_p8)
+ void gcm_ghash_p8(u64 Xi[2],const u128 Htable[16],const u8 *inp, size_t len);
+-#   endif /* OPENSSL_SYS_AIX */
++#   endif /* OPENSSL_SYS_AIX || OPENSSL_SYS_MACOSX */
+ #  endif /* PPC */
+ 
+ #  if (defined(__arm__) || defined(__arm) || defined(__aarch64__))


### PR DESCRIPTION
#### Description

OpenSSL 3.1 includes PPC assembler that is too new for OSX (does not compile so revbump not needed). It is easily excluded as is already done for AIX.

Tested through build.

See upstream PR: https://github.com/openssl/openssl/pull/20543
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
