### PR TITLE
py-pyside2: update to 5.15.8

### DIFF
--- a/python/py-pyside2/Portfile
+++ b/python/py-pyside2/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    py-pyside2
-version                 5.15.3
+version                 5.15.8
 revision                0
 categories-append       devel aqua
 platforms               darwin
@@ -18,14 +18,14 @@ master_sites            https://download.qt.io/official_releases/QtForPython/pys
 distname                pyside-setup-opensource-src-${version}
 use_xz                  yes
 
-checksums               rmd160  e47a57c7d372862a286c7f1fa362896bff2e3b41 \
-                        sha256  7ff5f1cc4291fffb6d5a3098b3090abe4d415da2adec740b4e901893d95d7137 \
-                        size    3572248
+checksums               rmd160  49384ee04a5755d42dfaa89b7b11bbdbf58d012e \
+                        sha256  23436302c8deb5b4cbc769b205d09604e38ba83b40708efccb7bd8c9af6f6b5d \
+                        size    3582256
 
 
 python.versions         37 38 39 310
 
-set llvm_version        13
+set llvm_version        15
 
 if {${name} ne ${subport}} {
     PortGroup           qt5 1.0
@@ -43,11 +43,8 @@ if {${name} ne ${subport}} {
     # Needed for generating shiboken2 documentation
     qt5.depends_build_component sqlite-plugin
 
-    post-patch {
-        # undeclared identifier NPY_ARRAY_UPDATEIFCOPY
-        reinplace "s|NPY_ARRAY_UPDATEIFCOPY|NPY_ARRAY_WRITEBACKIFCOPY|g" \
-            ${worksrcpath}/sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp
-    }
+    # undeclared identifier NPY_ARRAY_UPDATEIFCOPY
+    patchfiles-append   patch-shiboken2-numpy-1.23.0.diff
 
     depends_build-append \
         path:bin/cmake:cmake \
@@ -97,6 +94,8 @@ if {${name} ne ${subport}} {
         qtlocation \
         qtmacextras \
         qtmultimedia \
+        qtquickcontrols2 \
+        qtremoteobjects \
         qtscript \
         qtscxml \
         qtsensors \
@@ -107,16 +106,6 @@ if {${name} ne ${subport}} {
         qtwebchannel \
         qtwebengine \
         qtwebsockets
-
-    if {[vercmp ${qt5.version} 5.6] >=0 } {
-        qt5.depends_component \
-            qtquickcontrols2
-    }
-
-    if {[vercmp ${qt5.version} 5.9] >=0 } {
-        qt5.depends_component \
-            qtremoteobjects
-    }
 
     livecheck.type      none
 } else {

--- a/python/py-pyside2/files/patch-shiboken2-numpy-1.23.0.diff
+++ b/python/py-pyside2/files/patch-shiboken2-numpy-1.23.0.diff
@@ -1,0 +1,34 @@
+From 1422cf4a7f277fb13fd209f24a90d6c02641497d Mon Sep 17 00:00:00 2001
+From: Friedemann Kleint <Friedemann.Kleint@qt.io>
+Date: Thu, 23 Jun 2022 10:44:01 +0200
+Subject: libshiboken: Fix build with numpy 1.23.0
+
+Pick-to: 6.3 6.2 5.15
+Change-Id: I885c332d6c948820140946c73ae1926e88834143
+Reviewed-by: Christian Tismer <tismer@stackless.com>
+---
+ sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+(limited to 'sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp')
+
+diff --git a/sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp b/sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp
+index 3048ffba6..c8541adf5 100644
+--- sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp.orig
++++ sources/shiboken2/libshiboken/sbknumpyarrayconverter.cpp
+@@ -115,8 +115,13 @@ std::ostream &operator<<(std::ostream &str, PyArrayObject *o)
+             str << " NPY_ARRAY_NOTSWAPPED";
+         if ((flags & NPY_ARRAY_WRITEABLE) != 0)
+             str << " NPY_ARRAY_WRITEABLE";
++#if NPY_VERSION >= 0x00000010 // NPY_1_23_API_VERSION
++        if ((flags & NPY_ARRAY_WRITEBACKIFCOPY) != 0)
++            str << " NPY_ARRAY_WRITEBACKIFCOPY";
++#else
+         if ((flags & NPY_ARRAY_UPDATEIFCOPY) != 0)
+             str << " NPY_ARRAY_UPDATEIFCOPY";
++#endif
+     } else {
+         str << '0';
+     }
+-- 
+cgit v1.2.1


### PR DESCRIPTION
Prefer patch with upstream approach (which will likely be present in 5.15.11)
Closes: https://trac.macports.org/ticket/65412

Use latest LLVM in MacPorts (currently 15)

Additional cleanup following 8925eed5988a

[skip ci]

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5 Intel
Xcode 14.2 / Command Line Tools 14.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
Only tried simplebrowser.py
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
