### PR TITLE
gd2: enable AVIF, fix HEIF, fix DEFAULT_FONTPATH

### DIFF
--- a/graphics/gd2/Portfile
+++ b/graphics/gd2/Portfile
@@ -10,7 +10,7 @@ PortGroup                   legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 github.setup                libgd libgd 2.3.3 gd-
-revision                    2
+revision                    3
 checksums                   rmd160  97564248f7f14e90921c5571ff69d1aba5e016cc \
                             sha256  3fe822ece20796060af63b7c60acb151e5844204d289da0ce08f8fdf131e5a61 \
                             size    2809056
@@ -39,11 +39,13 @@ long_description            gd is a graphics library. It allows your code to \
 github.tarball_from         releases
 use_xz                      yes
 
-depends_build               port:gettext
+depends_build               port:gettext \
+                            port:pkgconfig
 
 depends_lib                 port:freetype \
                             port:fontconfig \
                             path:include/turbojpeg.h:libjpeg-turbo \
+                            port:libavif \
                             port:libheif \
                             port:libiconv \
                             port:libpng \
@@ -53,24 +55,22 @@ depends_lib                 port:freetype \
 
 patchfiles                  patch-src-gdft.c.diff
 
-# Supports libavif but we don't have a port for it yet.
-
 configure.args-append       --disable-werror \
                             --with-freetype=${prefix} \
                             --with-fontconfig=${prefix} \
+                            --with-avif=${prefix} \
                             --with-heif=${prefix} \
                             --with-jpeg=${prefix} \
                             --with-png=${prefix} \
                             --with-tiff=${prefix} \
                             --with-webp=${prefix} \
                             --with-zlib=${prefix} \
-                            --without-avif \
                             --without-liq \
                             --without-raqm \
                             --without-x \
                             --without-xpm
 
-configure.cflags-append     -DDEFAULT_FONTPATH=\\\"/System/Library/Fonts:/Library/Fonts\\\"
+configure.cflags-append     -DDEFAULT_FONTPATH='"/System/Library/Fonts:/Library/Fonts"'
 
 variant x11 {
     depends_lib-append      port:xpm


### PR DESCRIPTION
Need pkgconfig to reliably enable HEIF support (e.g. during trace mode)

Avoid `-Winvalid-pp-token` warnings during configure due to improper escaping of `DEFAULT_FONTPATH`, e.g.:

```
configure:3612: ccache /usr/bin/clang -o conftest -pipe -Os -DDEFAULT_FONTPATH=\"/System/Library/Fonts:/Library/Fonts\" -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 -I/opt/local/include -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-syslibroot,/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -arch x86_64 conftest.c  >&5
In file included from <built-in>:371:
<command line>:1:27: warning: missing terminating '"' character [-Winvalid-pp-token]
#define DEFAULT_FONTPATH \"/System/Library/Fonts:/Library/Fonts\"
                          ^
1 warning generated.

```

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.5 Intel
Command Line Tools 14.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
