### PR TITLE
cantera-devel: remove obsolete subport

### DIFF
--- a/science/cantera/Portfile
+++ b/science/cantera/Portfile
@@ -119,13 +119,4 @@ variant sundials description {Build with sundials support} {
 
 default_variants    +sundials
 
-# Remove after January 2023.
-subport ${name}-devel {
-    PortGroup           obsolete 1.0
-    replaced_by         ${name}
-    depends_build
-    depends_lib
-    depends_run
-}
-
 github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
