### PR TITLE
google-glog-0.4: remove obsolete subport

### DIFF
--- a/devel/google-glog/Portfile
+++ b/devel/google-glog/Portfile
@@ -82,16 +82,4 @@ post-destroot {
         ${dest_doc}
 }
 
-subport ${name}-0.4 {
-    PortGroup       obsolete 1.0
-
-    version         0.4.0
-    revision        1
-    replaced_by     google-glog
-
-    # Obsolete Date: 2022-02-16
-    # NOTE: This subport only existed for a few days, so we needn't wait 12
-    #   months for deletion.
-}
-
 github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
