### PR TITLE
mpv: patch youtube-dl hook to fix youtube playback

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -7,7 +7,7 @@ PortGroup               legacysupport 1.1
 
 # Please revbump mpv whenever ffmpeg{,-devel} is updated!
 github.setup            mpv-player mpv 0.35.1 v
-revision                1
+revision                2
 categories              multimedia
 license                 GPL-2+
 maintainers             {ionic @Ionic} {i0ntempest @i0ntempest} openmaintainer
@@ -248,6 +248,9 @@ platform darwin {
                         The X11 backend should have been enabled automatically.
         }
     }
+
+    # Fix youtube-dl hook for streaming youtube videos
+    patchfiles   patch-youtubedl-edl-track-error.diff
 
     # coreaudio does not build on < 10.6 so use pulseaudio instead (tested and works).
     if {${os.major} < 10} {

--- a/multimedia/mpv/files/patch-youtubedl-edl-track-error.diff
+++ b/multimedia/mpv/files/patch-youtubedl-edl-track-error.diff
@@ -1,0 +1,11 @@
+--- player/lua/ytdl_hook.lua.orig	2023-03-21 11:35:15 -0500
++++ player/lua/ytdl_hook.lua	2023-03-21 11:31:18 -0500
+@@ -451,7 +451,7 @@
+             end
+         end
+ 
+-        local url = edl_track or track.url
++        local url = track.url
+         local hdr = {"!new_stream", "!no_clip", "!no_chapters"}
+         local skip = #tracks == 0
+         local params = ""


### PR DESCRIPTION
#### Description

patches `mpv`'s youtube-dl hook to fix playback from youtube that previously threw an error  and wouldn't play the audio track of a video.

For example:

```
> mpv "https://www.youtube.com/watch?v=ZU4JhPgA5EM"
[ytdl_hook] EDL doesn't support fragmentswithout duration with MP4 DASH
EDL specifies no segments.'
EDL parsing failed.
Error in EDL.
EDL: source file 'edl://!mp4_dash,init=%901%https://rr1---sn-gjo-vgqs.googlevideo.com/videoplayback?expire=1679440885&ei=lecZZJbhNoWilu8Pv-SGgAs&ip=<REDACTED>&id=o-AKNjE9PULKVpIu1CNDp1h9kq9u9ZlN1r460RAL3Y03Zi&itag=243&source=youtube&requiressl=yes&mh=r5&mm=31%2C29&mn=sn-gjo-vgqs%2Csn-vgqsrns6&ms=au%2Crdu&mv=m&mvi=1&pl=21&initcwndbps=170000&spc=H3gIhqOK7UbzMuIPu1WGYFXT_-X_-AY&vprv=1&svpuc=1&mime=video%2Fwebm&gir=yes&clen=9342392&dur=2101.732&lmt=1677213445658829&mt=1679418800&fvip=4&keepalive=yes&fexp=24007246&c=ANDROID&txp=5437434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=AOq0QJ8wRQIgTvwEbty7ZAu3BYQHFPjteRY0_mdMiFrVjcLIYc4QffICIQDcsidQQnkA7GVYahKuihdSLodBx0Ktvqf6G92abEyKrw%3D%3D&lsparams=mh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AG3C_xAwRAIgWnMq25Nc0zBOrG6oK4SIEFCOkVAd_gE8LErUEHVdgzICIGC9-Z05cn37vDGQQlI1XGEe0Xa9m7Dpffo5baBkRfMw&range=0-9342392;' has unknown duration.
```

this patch applies [a fix](https://github.com/mpv-player/mpv/issues/11392) which will eventually be merged into a future mpv release.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?


