### PR TITLE
google-cloud-sdk: update to 423.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             422.0.0
+version             423.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  2c2d5fbde94a7842753cf7cc2186ace24e6192d9 \
-                    sha256  284c669ce9e47f6c0123dfa2c3e5f7cbe3508bf0e5647d0b6c78c7851690867b \
-                    size    111481738
+    checksums       rmd160  18f620155604074400be9e47fc4793abaacdda45 \
+                    sha256  d153a2d77e672995d9003ebdd324747b3f2622a3a22beb3193f924ea53420478 \
+                    size    111627917
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  cbb2eb7e6e75c64581cb1f507489d2c2d0b1950f \
-                    sha256  32bd2e205fb91de2b7f4859945ef8f400e02e633911474377f629a4e1b828224 \
-                    size    131813834
+    checksums       rmd160  f85b152f52b311b957765c77c33ad4240fd7c490 \
+                    sha256  c7531aeca2439133e6dd3880dfec594414c40e19f2022c1a709ff39d4f994696 \
+                    size    131947251
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  5c271411964b67939ed474641b33013764aad77b \
-                    sha256  c733bb9cf29484d03c8ec45d20e2bf0d8b95b2e1dc63e38583f3144577435313 \
-                    size    128653804
+    checksums       rmd160  fe219ebc0da42cda3bf1ca48ad23384b87cf7564 \
+                    sha256  de3c70d5f95f1df22e857a9f4d3328d5f8d3bd36cfa6a6f7fda976f4964f3bfd \
+                    size    128792776
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 423.0.0.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?