### PR TITLE
openjdk20-oracle: new submission

### DIFF
--- a/java/openjdk20-oracle/Portfile
+++ b/java/openjdk20-oracle/Portfile
@@ -1,0 +1,89 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk20-oracle
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://jdk.java.net/20/
+version      20
+revision     0
+
+description  Oracle OpenJDK 20
+long_description Open-source Oracle build of OpenJDK 20, the Java Development Kit, an implementation of the Java SE Platform.
+
+master_sites https://download.java.net/java/GA/jdk${version}/bdc68b4b9cbc4ebcb30745c85038d91d/36/GPL/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     openjdk-${version}_macos-x64_bin
+    checksums    rmd160  54d754bdb6ca6b152d6a1602ee3c1c55d6c939e2 \
+                 sha256  47cf960d9bb89dbe987535a389f7e26c42de7c984ef5108612d77c81aa8cc6a4 \
+                 size    194328775
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     openjdk-${version}_macos-aarch64_bin
+    checksums    rmd160  723284f11a4a4ae47fa207c6b5497f586eff5852 \
+                 sha256  d020f5c512c043cfb7119a591bc7e599a5bfd76d866d939f5562891d9db7c9b3 \
+                 size    191881541
+}
+
+worksrcdir   jdk-${version}.jdk
+
+homepage     https://jdk.java.net/20/
+
+livecheck.type      regex
+livecheck.url       https://jdk.java.net/20/
+livecheck.regex     OpenJDK JDK (20\.\[0-9\.\]+)
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/jdk-20-oracle-openjdk.jdk
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Oracle OpenJDK 20.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?