### PR TITLE
vtm: update to 0.9.8w

### DIFF
--- a/sysutils/vtm/Portfile
+++ b/sysutils/vtm/Portfile
@@ -6,7 +6,7 @@ PortGroup               cmake 1.1
 PortGroup               legacysupport 1.1
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            netxs-group vtm 0.9.8v v
+github.setup            netxs-group vtm 0.9.8w v
 github.tarball_from     archive
 revision                0
 
@@ -19,9 +19,9 @@ description             Monotty Desktopio - text-based desktop environment \
 long_description        ${name} is a terminal multiplexer with window manager \
                         and session sharing.
 
-checksums               rmd160  5403580b4d4409c0fda7ca2bb1060bbcedffcf0b \
-                        sha256  9ce261ef725bf96dc76cd2df364ea0573db6bac083ceae192ccc5414ce0b6399 \
-                        size    1358528
+checksums               rmd160  e07a99e27f874a41f87eef04bdb4ed2560ff10a8 \
+                        sha256  d958952b2180b294bf2fd472b44d7f5909703f4d55bcbbc174ead5bcb78d63a7 \
+                        size    1359802
 
 # Requires a compiler with full C++20 support
 compiler.cxx_standard   2020
@@ -31,7 +31,10 @@ compiler.blacklist-append \
 
 # Needed for std::filesystem
 legacysupport.newest_darwin_requires_legacy 18
-legacysupport.use_mp_libcxx yes
+# Use MacPorts libcxx only with Clang
+if {[string match *clang* ${configure.compiler}]} {
+    legacysupport.use_mp_libcxx yes
+}
 
 if {[variant_isset debug]} {
     cmake.build_type    Debug


### PR DESCRIPTION
* use MacPorts libcxx only with Clang

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
