### PR TITLE
gallery-dl:  adopt

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -9,7 +9,7 @@ github.tarball_from releases
 distname            gallery_dl-${github.version}
 
 categories          net
-maintainers         nomaintainer
+maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
 checksums           rmd160  988da01c35539f8df742af599de298068e802d8c \


### PR DESCRIPTION
#### Description

adopts gallery-dl and sets a default variant for improved compatibility

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18


###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?