### PR TITLE
mpv: added yt-dlp variant

### DIFF
--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -154,6 +154,7 @@ platform macosx {
         # Keep using the "system compiler" for now. Also means one less
         # dependency on recent systems, so yay.
         PortGroup                   xcodeversion 1.0
+
         minimum_xcodeversions       {11 4.4}
 
         # Force recent enough SDK.
@@ -451,8 +452,12 @@ variant screenshot description {Enable optional screenshot support} {
                             --enable-jpeg
 }
 
-variant network description {Enable networking support via youtube-dl (supports wide variety of pages)} {
+variant network conflicts ytdlp description {Enable networking support via youtube-dl (supports wide variety of pages)} {
     depends_run-append      port:youtube-dl
+}
+
+variant ytdlp conflicts network description {Enable networking support via yt-dlp instead of youtube-dl (supports wide variety of pages)} {
+    depends_run-append      port:yt-dlp
 }
 
 variant bluray description {Enable Bluray and AACS/BD+ encryption support} {


### PR DESCRIPTION
#### Description
adds a variant to `mpv` to use `yt-dlp` instead of `youtube-dl`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
