### PR TITLE
graphite2: Fix universal build

### DIFF
--- a/graphics/graphite2/Portfile
+++ b/graphics/graphite2/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           muniversal 1.1
 
 github.setup        silnrsi graphite 1.3.14
 revision            0
@@ -30,6 +31,8 @@ extract.suffix      .tgz
 
 compiler.cxx_standard \
                     2011
+
+patchfiles-append   patch-src-CMakeLists.txt.diff
 
 set py_ver          3.11
 set py_ver_nodot    [string map {. {}} ${py_ver}]

--- a/graphics/graphite2/files/patch-src-CMakeLists.txt.diff
+++ b/graphics/graphite2/files/patch-src-CMakeLists.txt.diff
@@ -1,0 +1,14 @@
+Don't use -mfpmath=sse -msse2 on Mac OS universal ARM/Intel, PowerPC/Intel
+builds.
+https://github.com/silnrsi/graphite/pull/84
+--- src/CMakeLists.txt.orig	2020-04-01 04:53:13.000000000 +0200
++++ src/CMakeLists.txt	2023-04-04 15:43:50.000000000 +0200
+@@ -139,7 +139,7 @@
+         COMPILE_FLAGS   "-Wall -Wextra -Wno-unknown-pragmas -Wimplicit-fallthrough -Wendif-labels -Wshadow -Wno-ctor-dtor-privacy -Wno-non-virtual-dtor -fno-rtti -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden"
+         LINK_FLAGS      "-nodefaultlibs"
+         LINKER_LANGUAGE C)
+-    if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86|i.86")
++    if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86|i.86" AND NOT "${CMAKE_OSX_ARCHITECTURES}" MATCHES "arm|ppc")
+         add_definitions(-mfpmath=sse -msse2)
+     endif()
+     target_link_libraries(graphite2 c)


### PR DESCRIPTION
#### Description

Fix universal build for graphics/graphite2 which used to wrongly specify SSE flags if the build machine is Intel. There is a pull request in upstream: silnrsi/graphite#84

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.7.4
Xcode 13 / Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
