### PR TITLE
mat2: new port, version 0.13.3

### DIFF
--- a/multimedia/mat2/Portfile
+++ b/multimedia/mat2/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                mat2
+version             0.13.3
+revision            0
+categories-prepend  multimedia
+license             LGPL-3
+supported_archs     noarch
+platforms           {darwin any}
+maintainers         {@akierig fastmail.de:akierig} \
+                    openmaintainer
+
+description         metadata removal tool
+long_description    mat2 is a metadata removal tool, supporting a wide range \
+                    of commonly used file formats, written in python3.
+homepage            https://0xacab.org/jvoisin/mat2
+
+checksums           rmd160  90d001f866a48fde781a092a0b88db1c2f623997 \
+                    sha256  6446e0141987cc7356b00e5e5ae7a0a13d7d64bfdd2f2439568c766e2f07f0c0 \
+                    size    46331
+
+python.default_version 310
+
+depends_lib-append  port:py${python.version}-cairo \
+                    port:py${python.version}-mutagen \
+                    port:py${python.version}-gobject3 \
+                    port:gdk-pixbuf2 \
+                    port:librsvg \
+                    port:ffmpeg \
+                    port:exiftool


### PR DESCRIPTION
#### Description

Adds `mat2` a tool for the automated removal of sensitive metadata from a variety of file types

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
