### PR TITLE
openjdk20-sap: new submission

### DIFF
--- a/java/openjdk20-sap/Portfile
+++ b/java/openjdk20-sap/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk20-sap
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+version      20
+revision     0
+
+description  SAP Machine 20
+long_description An OpenJDK 20 release maintained and supported by SAP
+
+master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     sapmachine-jdk-${version}_macos-x64_bin
+    checksums    rmd160  e8146b27ed86cc98db97ab180dfc563a27c1e3d8 \
+                 sha256  d4e47a7b5cd233a4348aa393c4d9fb2d4c30ef76ce5bca163fecab85241386a7 \
+                 size    189052659
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     sapmachine-jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  b9c0b2057a40e02f3b36220e80aa7833411b4028 \
+                 sha256  c5c360e340902514c4c7a8966e2e48f0b73c9ef10dbd73527afe0384a2bb058c \
+                 size    186782315
+}
+
+worksrcdir   sapmachine-jdk-${version}.jdk
+
+homepage     https://sap.github.io/SapMachine/
+
+livecheck.type      regex
+livecheck.url       https://github.com/SAP/SapMachine/releases
+livecheck.regex     sapmachine-jdk-(20\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/jdk-20-sapmachine.jdk
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for SapMachine OpenJDK 20.

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?