### PR TITLE
fish: update to 3.6.1

### DIFF
--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -5,11 +5,11 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               legacysupport 1.0
 
-github.setup            fish-shell fish-shell 3.6.0
+github.setup            fish-shell fish-shell 3.6.1
 revision                0
-checksums               rmd160  32b7ff26bb6837b96707314303d7d72c34de39ae \
-                        sha256  97044d57773ee7ca15634f693d917ed1c3dc0fa7fde1017f1626d60b83ea6181 \
-                        size    2892296
+checksums               rmd160  c69c3d1bd6db6a9b3d9d614d35c0a712d7fc0ac9 \
+                        sha256  55402bb47ca6739d8aba25e41780905b5ce1bce0a5e0dd17dca908b5bc0b49b2 \
+                        size    2866100
 use_xz                  yes
 
 name                    fish


### PR DESCRIPTION
#### Description

fish: update to 3.6.1

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?