### PR TITLE
libdeflate: update to 1.18

### DIFF
--- a/archivers/libdeflate/Portfile
+++ b/archivers/libdeflate/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake           1.1
 PortGroup           github          1.0
 PortGroup           legacysupport   1.1
 
-github.setup        ebiggers libdeflate 1.17 v
+github.setup        ebiggers libdeflate 1.18 v
 github.tarball_from archive
 revision            0
 
@@ -28,6 +28,6 @@ maintainers         {linux.com:nickblack @dankamongmen} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  51b06fdab654c35d5d4ce9d4f33f87095eb94595 \
-                    sha256  fa4615af671513fa2a53dc2e7a89ff502792e2bdfc046869ef35160fcc373763 \
-                    size    184121
+checksums           rmd160  f5b19e3d2c526660630f26a5087a86cbb8c3faf4 \
+                    sha256  225d982bcaf553221c76726358d2ea139bb34913180b20823c782cede060affd \
+                    size    184924


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
