### PR TITLE
py-fido2: add python3.11 subport

### DIFF
--- a/python/py-fido2/Portfile
+++ b/python/py-fido2/Portfile
@@ -21,11 +21,15 @@ checksums           rmd160  0c8ba2335962501c9da55b24d1bbe2f4a1c63e87 \
                     sha256  2b4b4e620c2100442c20678e0e951ad6d1efb3ba5ca8ebb720c4c8d543293674 \
                     size    243526
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
+
+python.pep517       yes
+python.pep517_backend poetry
 
 if {${name} ne ${subport}} {
     depends_build-append \
-        port:py${python.version}-setuptools
+        port:py${python.version}-setuptools \
+        port:py${python.version}-idna
 
     depends_lib-append \
         port:py${python.version}-six \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
