### PR TITLE
llvm-cx: new port (version 22.1.1)

### DIFF
--- a/lang/llvm-cx/Portfile
+++ b/lang/llvm-cx/Portfile
@@ -1,0 +1,82 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   cmake 1.1
+
+# This custom compiler toolchain is based on llvm|clang-8 but each release adds fixes for newer SDKs.
+name                        llvm-cx
+version                     22.1.0
+dist_subdir                 wine
+categories                  lang
+platforms                   {darwin any >= 18}
+license                     NCSA
+maintainers                 nomaintainer
+description                 CodeWeavers custom compiler for -mwine32 targets ${version}.
+long_description            {*}${description}
+homepage                    https://codeweavers.com/
+master_sites                https://media.codeweavers.com/pub/crossover/source/
+extract.suffix              .tar.gz
+distname                    crossover-sources-${version}
+checksums                   rmd160  63352b837b4714a953bc06f1057e1087b659b0c7 \
+                            sha256  36425ef8e8067784006c775d0e2303bb62301d055cbdaeff639311c662ddd8ea \
+                            size    147889427
+
+supported_archs             x86_64
+
+# Use cmake-bootstrap
+depends_build-replace       path:bin/cmake:cmake port:cmake-bootstrap
+depends_skip_archcheck-append cmake-bootstrap
+configure.cmd               ${prefix}/libexec/cmake-bootstrap/bin/cmake
+
+
+worksrcdir                  sources/clang/llvm
+
+post-extract {
+    ln -s ${workpath}/sources/clang/clang ${workpath}/sources/clang/llvm/projects/clang
+}
+
+# sterilize MacPorts build environment; we want nothing picked up from MP prefix
+compiler.cpath
+compiler.library_path
+configure.cxx_stdlib
+configure.cflags
+configure.cxxflags
+configure.cppflags
+configure.optflags
+configure.ldflags
+configure.ccache            no
+configure.distcc            no
+
+# sterilize PATH
+configure.env-append        PATH=/usr/bin:/bin:/usr/sbin:/sbin
+build.env-append            PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+cmake.build_type            Release
+cmake.generator             {Unix Makefiles}
+
+# Install everything into libexec
+cmake.install_prefix        ${prefix}/libexec/${name}
+cmake.install_rpath
+
+configure.pre_args-replace  {*}[cmake::system_prefix_path] \
+                            -DCMAKE_SYSTEM_PREFIX_PATH="${cmake.install_prefix}\;/usr"
+
+configure.pre_args-replace  {*}[cmake::rpath_flags] \
+                            -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+
+configure.pre_args-delete   {*}[cmake::module_path]
+configure.pre_args-delete   {*}[cmake::ccaching]
+configure.pre_args-delete   -DCMAKE_INSTALL_NAME_DIR="${cmake.install_prefix}/lib"
+configure.args-append       -DLLVM_TARGETS_TO_BUILD=X86
+
+configure.args-append       -DLLVM_ENABLE_TERMINFO=OFF \
+                            -DLLVM_ENABLE_LIBXML2=OFF \
+                            -DLLVM_ENABLE_LIBEDIT=OFF \
+                            -DLLVM_ENABLE_LIBPFM=OFF \
+                            -DLLVM_ENABLE_THREADS=ON \
+                            -DLLVM_ENABLE_ZLIB=OFF
+
+# remove need for port:libxml2 dependency
+configure.args-append       -DLIBXML2_LIBRARIES=IGNORE
+
+livecheck.type              none

--- a/lang/llvm-cx/Portfile
+++ b/lang/llvm-cx/Portfile
@@ -5,7 +5,7 @@ PortGroup                   cmake 1.1
 
 # This custom compiler toolchain is based on llvm|clang-8 but each release adds fixes for newer SDKs.
 name                        llvm-cx
-version                     22.1.0
+version                     22.1.1
 dist_subdir                 wine
 categories                  lang
 platforms                   {darwin any >= 18}
@@ -17,9 +17,9 @@ homepage                    https://codeweavers.com/
 master_sites                https://media.codeweavers.com/pub/crossover/source/
 extract.suffix              .tar.gz
 distname                    crossover-sources-${version}
-checksums                   rmd160  63352b837b4714a953bc06f1057e1087b659b0c7 \
-                            sha256  36425ef8e8067784006c775d0e2303bb62301d055cbdaeff639311c662ddd8ea \
-                            size    147889427
+checksums                   rmd160  179d51fe18d20236a3893440ed5f61010a921a65 \
+                            sha256  ffcaa3366d3d78fd2c3ba4101b94eb7b1646449336b92a143663ba52ab3147ae \
+                            size    397802768
 
 supported_archs             x86_64
 

--- a/lang/llvm-cx/Portfile
+++ b/lang/llvm-cx/Portfile
@@ -17,9 +17,9 @@ homepage                    https://codeweavers.com/
 master_sites                https://media.codeweavers.com/pub/crossover/source/
 extract.suffix              .tar.gz
 distname                    crossover-sources-${version}
-checksums                   rmd160  179d51fe18d20236a3893440ed5f61010a921a65 \
-                            sha256  ffcaa3366d3d78fd2c3ba4101b94eb7b1646449336b92a143663ba52ab3147ae \
-                            size    397802768
+checksums                   rmd160  e514c407e3b7f75339a60fac84360f00791e97bb \
+                            sha256  cdfe282ce33788bd4f969c8bfb1d3e2de060eb6c296fa1c3cdf4e4690b8b1831 \
+                            size    147879629
 
 supported_archs             x86_64
 


### PR DESCRIPTION
#### Description

This is the custom version of llvm/clang required to build wine-crossover-19 and later sources for the `-mwine32` target

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D49 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
