### PR TITLE
i2pd: unbreak 2.47.0 for 32-bit platforms

### DIFF
--- a/security/i2pd/Portfile
+++ b/security/i2pd/Portfile
@@ -70,6 +70,12 @@ if {${build_arch} in [list ppc ppc64]} {
                         -DBOOST_SP_USE_STD_ATOMIC
 }
 
+# Temporary fix for: https://github.com/PurpleI2P/i2pd/issues/1908
+# Drop once fixed in upstream release.
+if {(${configure.build_arch} in [list i386 ppc]) && [string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append -latomic
+}
+
 post-destroot {
     xinstall -d ${destroot}${prefix}/etc/${name}
     foreach item {i2pd.conf subscriptions.txt tunnels.conf tunnels.d} {


### PR DESCRIPTION
Atomics tests were broken in 2.47.0: https://github.com/PurpleI2P/i2pd/issues/1908
For now, pass -latomic manually.

#### Description

@herbygillot @catap 
Not really clear to me what broke atomic tests, but they work in 2.46.1 and fail in 2.47.0. Until solution is found with upstream, link manually.

No need to revbump, since it does not build otherwise.

P. S. Changes between releases: https://github.com/PurpleI2P/i2pd/compare/2.46.1...2.47.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
