### PR TITLE
wxWidgets-3.2: Enable debugreport for qa library

### DIFF
--- a/graphics/wxWidgets-3.2/Portfile
+++ b/graphics/wxWidgets-3.2/Portfile
@@ -8,7 +8,7 @@ PortGroup           wxWidgets       1.0
 # remember to bump version of wxWidgets-common
 github.setup        wxWidgets wxWidgets 3.2.2.1 v
 github.tarball_from releases
-revision            0
+revision            1
 name                wxWidgets-3.2
 wxWidgets.use       wxWidgets-3.2
 
@@ -87,7 +87,7 @@ configure.args      --prefix=${wxWidgets.prefix} \
                     --enable-display \
                     --enable-geometry \
                     --enable-optimise \
-                    --disable-debugreport \
+                    --enable-debugreport \
                     --enable-uiactionsim \
                     --enable-autoidman \
                     --enable-aui \


### PR DESCRIPTION
#### Description

The qa library of wxWidgets-3.0 is required by other ports (e.g., hugin-app).
To migrate this port to wxWidgets-3.2 hence requires to include this library.

I wasn't sure why this feature was disabled in the first place. If desired, I can also make this into a variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
