### PR TITLE
phosg: support tests; phosg, resource_dasm: some fixes for older systems and PPC

### DIFF
--- a/devel/phosg/Portfile
+++ b/devel/phosg/Portfile
@@ -10,6 +10,7 @@ github.tarball_from     archive
 
 # blacklisting to select C++20 capable compilers
 compiler.blacklist-append {clang < 1300}
+compiler.cxx_standard   2020
 
 version                 2023.03.04
 revision                0

--- a/devel/phosg/Portfile
+++ b/devel/phosg/Portfile
@@ -30,6 +30,15 @@ set python_version      [string index ${pyver} 0][string range ${pyver} 2 end]
 
 patchfiles              CMakeLists-txt.diff
 
+# https://github.com/fuzziqersoftware/phosg/pull/23
+if {${os.platform} eq "darwin" && ${os.major} < 20} {
+    patchfiles-append   0001-Encoding.hh-define-__STDC_FORMAT_MACROS.patch \
+                        0002-Image.hh-define-__darwin_ssize_t.patch \
+                        0003-Network.cc-add-missing-cstring-header.patch \
+                        0004-CMakeLists-fix-libatomic-for-macOS-ppc.patch \
+                        0005-Filesystem-replacement-for-fmemopen.patch
+}
+
 depends_build-append    port:python${python_version}
 
 configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python${pyver}
@@ -39,5 +48,6 @@ pre-test {
     append portsandbox_profile " (allow process-exec (literal \"/bin/ps\") (with no-profile))"
 }
 
+# Several tests fail on PPC: https://github.com/fuzziqersoftware/phosg/issues/24
 test.run                yes
 test.cmd                ctest

--- a/devel/phosg/Portfile
+++ b/devel/phosg/Portfile
@@ -32,3 +32,11 @@ patchfiles              CMakeLists-txt.diff
 depends_build-append    port:python${python_version}
 
 configure.args-append   -DPYTHON_EXECUTABLE=${prefix}/bin/python${pyver}
+
+pre-test {
+    # Test infrastructure uses /bin/ps, which is forbidden by sandboxing
+    append portsandbox_profile " (allow process-exec (literal \"/bin/ps\") (with no-profile))"
+}
+
+test.run                yes
+test.cmd                ctest

--- a/devel/phosg/files/0001-Encoding.hh-define-__STDC_FORMAT_MACROS.patch
+++ b/devel/phosg/files/0001-Encoding.hh-define-__STDC_FORMAT_MACROS.patch
@@ -1,0 +1,20 @@
+From af3d036dbc3c295a05789267db2002dafc170ad3 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 28 Mar 2023 00:46:39 +0700
+Subject: [PATCH 1/5] Encoding.hh: define __STDC_FORMAT_MACROS
+
+---
+ src/Encoding.hh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/Encoding.hh b/src/Encoding.hh
+index 41343e9..2c1beee 100644
+--- src/Encoding.hh
++++ src/Encoding.hh
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#define __STDC_FORMAT_MACROS
+ #include <stdint.h>
+ #include <inttypes.h>
+ 

--- a/devel/phosg/files/0002-Image.hh-define-__darwin_ssize_t.patch
+++ b/devel/phosg/files/0002-Image.hh-define-__darwin_ssize_t.patch
@@ -1,0 +1,23 @@
+From b3fe3a1675100660da408f76f22bddfb1af4d9d8 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 28 Mar 2023 01:04:07 +0700
+Subject: [PATCH 2/5] Image.hh: define __darwin_ssize_t
+
+---
+ src/Image.hh | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/Image.hh b/src/Image.hh
+index 76448cd..8aa9417 100644
+--- src/Image.hh
++++ src/Image.hh
+@@ -9,6 +9,9 @@
+ 
+ #include "Platform.hh"
+ 
++#ifdef __APPLE__
++typedef __darwin_ssize_t ssize_t;
++#endif
+ 
+ // an Image represents a drawing canvas. this class is fairly simple; it
+ // supports reading/writing individual pixels, drawing lines, and saving the

--- a/devel/phosg/files/0003-Network.cc-add-missing-cstring-header.patch
+++ b/devel/phosg/files/0003-Network.cc-add-missing-cstring-header.patch
@@ -1,0 +1,21 @@
+From adc9ad09c1fc4d2a1c452a0f27ecd9e0518c8649 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 28 Mar 2023 01:07:36 +0700
+Subject: [PATCH 3/5] Network.cc: add missing cstring header
+
+---
+ src/Network.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/Network.cc b/src/Network.cc
+index 2e77df5..841868f 100644
+--- src/Network.cc
++++ src/Network.cc
+@@ -21,6 +21,7 @@
+ 
+ #include "Filesystem.hh"
+ #include "Strings.hh"
++#include <cstring>
+ 
+ using namespace std;
+ 

--- a/devel/phosg/files/0004-CMakeLists-fix-libatomic-for-macOS-ppc.patch
+++ b/devel/phosg/files/0004-CMakeLists-fix-libatomic-for-macOS-ppc.patch
@@ -1,0 +1,41 @@
+From 83854a38491856c8fbaea9fe8bed04754ea6cafe Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 28 Mar 2023 01:36:33 +0700
+Subject: [PATCH 4/5] CMakeLists: fix libatomic for macOS ppc
+
+---
+ CMakeLists.txt | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ffe2368..053d92d 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -8,10 +8,12 @@ project(phosg)
+ 
+ set(CMAKE_CXX_STANDARD 20)
+ set(CMAKE_CXX_STANDARD_REQUIRED True)
+-if (MSVC)
++if(MSVC)
+     # Disabled warnings:
+     # 4458 = declaration of '%s' hides class member (I use this->x for members)
+     add_compile_options(/W4 /WX /wd4458)
++elseif(APPLE AND ${CMAKE_OSX_ARCHITECTURES} MATCHES "ppc|ppc64")
++    add_compile_options(-fpermissive -Wall -Wextra -Wno-strict-aliasing -Wno-unused-result -Wno-overflow)
+ else()
+     add_compile_options(-Wall -Wextra -Werror -Wno-strict-aliasing -Wno-unused-result -Wno-overflow)
+ endif()
+@@ -31,10 +33,11 @@ add_library(phosg src/Encoding.cc src/Filesystem.cc src/Hash.cc src/Image.cc src
+ target_link_libraries(phosg pthread z)
+ 
+ # It seems that on some Linux variants (e.g. Raspbian) we also need -latomic,
+-# but this library does not exist on others (e.g. Ubuntu) nor on macOS
++# but this library does not exist on others (e.g. Ubuntu).
++# Linking to libatomic is also needed on macOS ppc32. Use CMAKE_OSX_ARCHITECTURES to take care of Rosetta case.
+ message(STATUS "Target architecture is ${CMAKE_HOST_SYSTEM_PROCESSOR}")
+ string(FIND ${CMAKE_HOST_SYSTEM_PROCESSOR} "armv" IS_LINUX_ARMV)
+-if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "aarch64" OR ${IS_LINUX_ARMV} GREATER_EQUAL 0)
++if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "aarch64" OR ${IS_LINUX_ARMV} GREATER_EQUAL 0 OR ${CMAKE_OSX_ARCHITECTURES} STREQUAL "ppc")
+   target_link_libraries(phosg atomic)
+ endif()
+ 

--- a/devel/phosg/files/0005-Filesystem-replacement-for-fmemopen.patch
+++ b/devel/phosg/files/0005-Filesystem-replacement-for-fmemopen.patch
@@ -1,0 +1,136 @@
+From 0b9460cc026fe69ece6d6a96740bbc1d31c91d31 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 28 Mar 2023 01:24:42 +0700
+Subject: [PATCH 5/5] Filesystem: replacement for fmemopen
+
+---
+ src/Filesystem.cc | 94 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/Filesystem.hh | 13 +++++++
+ 2 files changed, 107 insertions(+)
+
+diff --git a/src/Filesystem.cc b/src/Filesystem.cc
+index 884128b..36d2764 100644
+--- src/Filesystem.cc
++++ src/Filesystem.cc
+@@ -678,3 +678,97 @@ unordered_map<int, short> Poll::poll(int timeout_ms) {
+   }
+   return ret;
+ }
++
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 101300
++// https://github.com/NimbusKit/memorymapping/blob/master/src/fmemopen.c
++
++#include <sys/mman.h>
++
++struct fmem {
++  size_t pos;
++  size_t size;
++  char *buffer;
++};
++typedef struct fmem fmem_t;
++
++static int readfn(void *handler, char *buf, int size) {
++  fmem_t *mem = handler;
++  size_t available = mem->size - mem->pos;
++  
++  if (size > available) {
++    size = available;
++  }
++  memcpy(buf, mem->buffer + mem->pos, sizeof(char) * size);
++  mem->pos += size;
++  
++  return size;
++}
++
++static int writefn(void *handler, const char *buf, int size) {
++  fmem_t *mem = handler;
++  size_t available = mem->size - mem->pos;
++
++  if (size > available) {
++    size = available;
++  }
++  memcpy(mem->buffer + mem->pos, buf, sizeof(char) * size);
++  mem->pos += size;
++
++  return size;
++}
++
++static fpos_t seekfn(void *handler, fpos_t offset, int whence) {
++  size_t pos;
++  fmem_t *mem = handler;
++
++  switch (whence) {
++    case SEEK_SET: {
++      if (offset >= 0) {
++        pos = (size_t)offset;
++      } else {
++        pos = 0;
++      }
++      break;
++    }
++    case SEEK_CUR: {
++      if (offset >= 0 || (size_t)(-offset) <= mem->pos) {
++        pos = mem->pos + (size_t)offset;
++      } else {
++        pos = 0;
++      }
++      break;
++    }
++    case SEEK_END: pos = mem->size + (size_t)offset; break;
++    default: return -1;
++  }
++
++  if (pos > mem->size) {
++    return -1;
++  }
++
++  mem->pos = pos;
++  return (fpos_t)pos;
++}
++
++static int closefn(void *handler) {
++  free(handler);
++  return 0;
++}
++
++FILE *fmemopen(void *buf, size_t size, const char *mode) {
++  // This data is released on fclose.
++  fmem_t* mem = (fmem_t *) malloc(sizeof(fmem_t));
++
++  // Zero-out the structure.
++  memset(mem, 0, sizeof(fmem_t));
++
++  mem->size = size;
++  mem->buffer = buf;
++
++  // funopen's man page: https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/funopen.3.html
++  return funopen(mem, readfn, writefn, seekfn, closefn);
++}
++#endif
++#endif
+diff --git a/src/Filesystem.hh b/src/Filesystem.hh
+index fcaf9b8..63ebbf2 100644
+--- src/Filesystem.hh
++++ src/Filesystem.hh
+@@ -20,6 +20,19 @@
+ #include <utility>
+ #include <vector>
+ 
++#ifdef __APPLE__
++  #include <AvailabilityMacros.h>
++  #if MAC_OS_X_VERSION_MAX_ALLOWED < 101300
++  // https://github.com/NimbusKit/memorymapping/blob/master/src/fmemopen.h
++    #if defined __cplusplus
++      extern "C" {
++    #endif
++    FILE *fmemopen(void *buf, size_t size, const char *mode);
++    #ifdef __cplusplus
++      }
++    #endif
++  #endif
++#endif
+ 
+ 
+ std::string basename(const std::string& filename);

--- a/devel/resource_dasm/Portfile
+++ b/devel/resource_dasm/Portfile
@@ -4,12 +4,17 @@ PortSystem              1.0
 PortGroup               cmake 1.1
 PortGroup               github 1.0
 PortGroup               compiler_blacklist_versions 1.0
+PortGroup               legacysupport 1.1
+
+# MAP_ANONYMOUS
+legacysupport.newest_darwin_requires_legacy 14
 
 github.setup            fuzziqersoftware resource_dasm 46ad32e
 github.tarball_from     archive
 
 # blacklisting to select C++20 capable compilers
 compiler.blacklist-append {clang < 1300}
+compiler.cxx_standard   2020
 
 version                 2023.03.15
 revision                0


### PR DESCRIPTION
#### Description

Currently the port is broken on Catalina and downwards: https://ports.macports.org/port/phosg/details
This PR fixes the build on 10.6.8; it may fix it on some other systems too.
It also enables testing.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

P. S. Several tests fail in Rosetta:
```
--->  Testing phosg
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_phosg/phosg/work/build" && ctest test 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_phosg/phosg/work/build
      Start  1: EncodingTest
 1/12 Test  #1: EncodingTest .....................   Passed    0.03 sec
      Start  2: FilesystemTest
 2/12 Test  #2: FilesystemTest ...................   Passed    0.03 sec
      Start  3: HashTest
 3/12 Test  #3: HashTest .........................Subprocess aborted***Exception:   0.06 sec
      Start  4: ImageTest
 4/12 Test  #4: ImageTest ........................Subprocess aborted***Exception:   0.05 sec
      Start  5: JSONTest
 5/12 Test  #5: JSONTest .........................   Passed    0.04 sec
      Start  6: KDTreeTest
 6/12 Test  #6: KDTreeTest .......................   Passed    0.04 sec
      Start  7: LRUSetTest
 7/12 Test  #7: LRUSetTest .......................   Passed    0.03 sec
      Start  8: LRUMapTest
 8/12 Test  #8: LRUMapTest .......................   Passed    0.03 sec
      Start  9: ProcessTest
 9/12 Test  #9: ProcessTest ......................Subprocess aborted***Exception:   0.27 sec
      Start 10: StringsTest
10/12 Test #10: StringsTest ......................Subprocess aborted***Exception:   0.04 sec
      Start 11: TimeTest
11/12 Test #11: TimeTest .........................   Passed    1.03 sec
      Start 12: UnitTestTest
12/12 Test #12: UnitTestTest .....................   Passed    0.04 sec

67% tests passed, 4 tests failed out of 12

Total Test time (real) =   1.77 sec

The following tests FAILED:
	  3 - HashTest (Subprocess aborted)
	  4 - ImageTest (Subprocess aborted)
	  9 - ProcessTest (Subprocess aborted)
	 10 - StringsTest (Subprocess aborted)
Errors while running CTest
```