### PR TITLE
new port: pooler (PrimerPooler), section science (biology)

### DIFF
--- a/science/pooler/Portfile
+++ b/science/pooler/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github      1.0
+PortGroup           makefile    1.0
+
+github.setup        ssb22 PrimerPooler 1.86 v
+github.tarball_from archive
+name                pooler
+revision            0
+
+homepage            https://ssb22.user.srcf.net/pooler/
+
+description         Optimise combinations of primers
+
+long_description    PrimerPooler optimises combinations of primers to \
+                    minimise the formation of dimers in multiplexed PCR.
+
+checksums           sha256  611184935617a8e0a3bcc07d38fc5d10fb9fa0a5d6204a031723d46b8ba215e8 \
+                    rmd160  52cfaa8a34f52a7880ec33040167951cf4ea3c4e \
+                    size    131658
+
+categories          science
+license             Apache-2
+maintainers         {@ssb22} \
+                    openmaintainers
+
+build.dir           ${worksrcpath}/pooler
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/pooler/pooler ${destroot}${prefix}/bin/
+
+    xinstall -m 0644 \
+        ${worksrcpath}/pooler/pooler.1 ${destroot}${prefix}/share/man/man1/
+}


### PR DESCRIPTION
#### Description

add package `pooler` for Primer Pooler (in FreeBSD it's `pkg install pooler`)

###### Type(s)
submission

###### Tested on
macOS 13.2.1 22D68 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
