### PR TITLE
openjdk20-temurin: new submission

### DIFF
--- a/java/openjdk20-temurin/Portfile
+++ b/java/openjdk20-temurin/Portfile
@@ -1,0 +1,85 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk20-temurin
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+# See https://adoptium.net/supported-platforms/
+platforms        {darwin any} {darwin >= 16}
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://adoptium.net/temurin/releases/?version=20
+supported_archs  x86_64 arm64
+
+version      20
+set build    36
+revision     0
+
+description  Eclipse Temurin, based on OpenJDK 20
+long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
+
+master_sites https://github.com/adoptium/temurin20-binaries/releases/download/jdk-${version}%2B${build}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     OpenJDK20U-jdk_x64_mac_hotspot_${version}_${build}
+    checksums    rmd160  1ae8e4cc8f8a9638a14f86c9b3fb358c910bdcbd \
+                 sha256  9e96ea09f50128c61090a8f24736078bc763966a521c3b59d531709f08e624b2 \
+                 size    197173097
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     OpenJDK20U-jdk_aarch64_mac_hotspot_${version}_${build}
+    checksums    rmd160  d55610578a5db607abbf49be9d69896f5158daca \
+                 sha256  1cd48a8b1070826a52e4895e9a406a3b2ccd207f863588c25c29fb96cdccc7c4 \
+                 size    186401798
+}
+
+worksrcdir   jdk-${version}+${build}
+
+homepage     https://adoptium.net
+
+livecheck.type      regex
+livecheck.url       https://github.com/adoptium/temurin20-binaries/releases
+livecheck.regex     OpenJDK20U-.*_mac_hotspot_(20\[0-9\.\]*)_\[0-9\]+.tar.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/jdk-20-eclipse-temurin.jdk
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Eclipse Temurin OpenJDK 20.

###### Tested on

macOS 13.3 22E252 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?