### PR TITLE
ipmitool: Update to 1.8.19

### DIFF
--- a/sysutils/ipmitool/Portfile
+++ b/sysutils/ipmitool/Portfile
@@ -5,17 +5,16 @@ PortGroup       compiler_blacklist_versions 1.0
 PortGroup       github 1.0
 PortGroup       legacysupport 1.1
 
-# https://trac.macports.org/ticket/59132
+# strnlen, getline
 legacysupport.newest_darwin_requires_legacy 10
 
-# Using head of ipmitool until next release for openssl build fixes
-github.setup    ipmitool ipmitool 11c7605c0d5423f90f399f5e830d1095089f38a1
-version         1.8.18.20210622
-revision        1
-checksums       rmd160  273ded688a39ca722d5de4a7a11497b37e9833b9 \
-                sha256  f5e7c03254e3714fd14f5780833c028a03f97fa9a9832ff95644a80969e1411a \
-                size    638260
+github.setup    ipmitool ipmitool 1_8_19 IPMITOOL_
+revision        0
+checksums       rmd160  8990ac249bfda3812716601d909c10c938df64eb \
+                sha256  48b010e7bcdf93e4e4b6e43c53c7f60aa6873d574cbd45a8d86fa7aaeebaff9c \
+                size    641383
 
+version         [string map [list _ .] ${github.version}]
 categories      sysutils
 license         BSD
 maintainers     {dports @drkp} openmaintainer
@@ -33,7 +32,10 @@ long_description \
   information, read and set LAN configuration parameters, and perform \
   remote chassis power control.
 
-platforms       darwin
+# No configure script in tarball.
+use_autoreconf  yes
+autoreconf.cmd  ./bootstrap
+autoreconf.args
 
 depends_build   port:autoconf \
                 port:automake \
@@ -46,14 +48,12 @@ depends_lib     path:lib/libssl.dylib:openssl \
 
 github.tarball_from archive
 
+patchfiles      arm64-delloem.patch \
+                enterprise-numbers.patch
+
 configure.args  --enable-intf-lanplus \
-                --enable-ipmishell \
-                --mandir=${prefix}/share/man
+                --enable-ipmishell
 
 configure.cppflags-append   -Ds6_addr16=__u6_addr.__u6_addr16
 
 compiler.c_standard    2011
-
-pre-configure {
-    system -W ${worksrcpath} "./bootstrap"
-}

--- a/sysutils/ipmitool/files/arm64-delloem.patch
+++ b/sysutils/ipmitool/files/arm64-delloem.patch
@@ -1,0 +1,78 @@
+delloem: Fix the unalign bug in arm64
+
+For computers using the arm64 of the Apple chip, the link requires strict
+alignment of pointers in 32-bit form. Replace the struct vFlashstr to valstr.
+Replace the Function get_vFlash_compcode_str to val2str.
+
+https://github.com/ipmitool/ipmitool/commit/206dba615d740a31e881861c86bcc8daafd9d5b1
+--- include/ipmitool/ipmi_delloem.h.orig
++++ include/ipmitool/ipmi_delloem.h
+@@ -343,10 +343,6 @@ typedef struct _power_headroom
+     uint16_t peakheadroom;
+ } __attribute__ ((packed)) POWER_HEADROOM;
+ 
+-struct vFlashstr {
+-	uint8_t val;
+-	const char * str;
+-};
+ typedef struct ipmi_vFlash_extended_info
+ {
+ 	uint8_t  vflashcompcode;
+--- lib/ipmi_delloem.c.orig
++++ lib/ipmi_delloem.c
+@@ -115,7 +115,7 @@ char NIC_Selection_Mode_String_12g[] [50] = {
+ 	"shared with failover all loms"
+ };
+ 
+-const struct vFlashstr vFlash_completion_code_vals[] = {
++const struct valstr vFlash_completion_code_vals[] = {
+ 	{0x00, "SUCCESS"},
+ 	{0x01, "NO_SD_CARD"},
+ 	{0x63, "UNKNOWN_ERROR"},
+@@ -232,8 +232,6 @@ static void ipmi_powermonitor_usage(void);
+ /* vFlash Function prototypes */
+ static int ipmi_delloem_vFlash_main(struct ipmi_intf *intf, int argc,
+ 		char **argv);
+-const char *get_vFlash_compcode_str(uint8_t vflashcompcode,
+-		const struct vFlashstr *vs);
+ static int ipmi_get_sd_card_info(struct ipmi_intf *intf);
+ static int ipmi_delloem_vFlash_process(struct ipmi_intf *intf, int current_arg,
+ 		char **argv);
+@@ -3756,28 +3754,6 @@ ipmi_delloem_vFlash_main(struct ipmi_intf * intf, int __UNUSED__(argc), char **
+ 	rc = ipmi_delloem_vFlash_process(intf, current_arg, argv);
+ 	return rc;
+ }
+-/*
+- * Function Name: 	get_vFlash_compcode_str
+- *
+- * Description: 	This function maps the vFlash completion code
+- * 		to a string
+- * Input : vFlash completion code and static array of codes vs strings
+- * Output: -
+- * Return: returns the mapped string
+- */
+-const char *
+-get_vFlash_compcode_str(uint8_t vflashcompcode, const struct vFlashstr *vs)
+-{
+-	static char un_str[32];
+-	int i;
+-	for (i = 0; vs[i].str; i++) {
+-		if (vs[i].val == vflashcompcode)
+-			return vs[i].str;
+-	}
+-	memset(un_str, 0, 32);
+-	snprintf(un_str, 32, "Unknown (0x%02X)", vflashcompcode);
+-	return un_str;
+-}
+ /*
+  * Function Name: 	ipmi_get_sd_card_info
+  *
+@@ -3822,7 +3798,7 @@ ipmi_get_sd_card_info(struct ipmi_intf * intf) {
+ 		return -1;
+ 	} else if (sdcardinfoblock->vflashcompcode != 0x00) {
+ 		lprintf(LOG_ERR, "Error in getting SD Card Extended Information (%s)",
+-				get_vFlash_compcode_str(sdcardinfoblock->vflashcompcode,
++				val2str(sdcardinfoblock->vflashcompcode,
+ 					vFlash_completion_code_vals));
+ 		return -1;
+ 	}

--- a/sysutils/ipmitool/files/enterprise-numbers.patch
+++ b/sysutils/ipmitool/files/enterprise-numbers.patch
@@ -1,0 +1,43 @@
+Fix enterprise-numbers URL
+
+IANA has changed their URL scheme, and the content at the old URL for
+enterprise-numbers switched from text/plain to text/html.
+
+Fix Makefile.am to use the new URL
+https://github.com/ipmitool/ipmitool/commit/1edb0e27e44196d1ebe449aba0b9be22d376bcb6
+
+Also fix manpages (no corresponding upstream commit; repository is archived and
+no longer accepts contributions)
+--- Makefile.am.orig
++++ Makefile.am
+@@ -41,7 +41,7 @@ MAINTAINERCLEANFILES = Makefile.in aclocal.m4 configure configure-stamp \
+ 	$(distdir).tar.gz $(distdir).tar.bz2
+ 
+ SUBDIRS = lib src include doc contrib control
+-IANA_PEN = http://www.iana.org/assignments/enterprise-numbers
++IANA_PEN = http://www.iana.org/assignments/enterprise-numbers.txt
+ 
+ dist-hook:
+ 	cp control/ipmitool.spec $(distdir)
+--- doc/ipmievd.8.in.orig
++++ doc/ipmievd.8.in
+@@ -221,7 +221,7 @@
+ .SH FILES
+ .TP
+ .B @IANADIR@/enterprise-numbers
+-system IANA PEN registry taken from http://www.iana.org/assignments/enterprise-numbers
++system IANA PEN registry taken from http://www.iana.org/assignments/enterprise-numbers.txt
+ .TP
+ .B ~/@IANAUSERDIR@/enterprise-numbers
+ user's override for the system IANA PEN registry, this file if it exists is loaded instead
+--- doc/ipmitool.1.in.orig
++++ doc/ipmitool.1.in
+@@ -3831,7 +3831,7 @@
+ .SH FILES
+ .TP
+ .B @IANADIR@/enterprise-numbers
+-system IANA PEN registry taken from http://www.iana.org/assignments/enterprise-numbers
++system IANA PEN registry taken from http://www.iana.org/assignments/enterprise-numbers.txt
+ .TP
+ .B ~/@IANAUSERDIR@/enterprise-numbers
+ user's override for the system IANA PEN registry, this file if it exists is loaded instead


### PR DESCRIPTION
#### Description

Update ipmitool to 1.8.19 and fix two additional bugs.

Closes: https://trac.macports.org/ticket/64636
Closes: https://trac.macports.org/ticket/67156

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
