### PR TITLE
google-cloud-sdk: update to 424.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             423.0.0
+version             424.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  18f620155604074400be9e47fc4793abaacdda45 \
-                    sha256  d153a2d77e672995d9003ebdd324747b3f2622a3a22beb3193f924ea53420478 \
-                    size    111627917
+    checksums       rmd160  0d37b90ae953a765edb3df0711a57697d54b6d08 \
+                    sha256  9d9dbf1413cb40bd81108cf0d3c3ba670c8822145d56120ae2806e62f2d8c6cb \
+                    size    104367299
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  f85b152f52b311b957765c77c33ad4240fd7c490 \
-                    sha256  c7531aeca2439133e6dd3880dfec594414c40e19f2022c1a709ff39d4f994696 \
-                    size    131947251
+    checksums       rmd160  b582dce82c0d9aa79f0a3144befd1cf19e0aa83e \
+                    sha256  bc1ee32e6d4ef50d1bd2a5dfac007cd4fb192f7b2b2961b7a634a41237384805 \
+                    size    124722704
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  fe219ebc0da42cda3bf1ca48ad23384b87cf7564 \
-                    sha256  de3c70d5f95f1df22e857a9f4d3328d5f8d3bd36cfa6a6f7fda976f4964f3bfd \
-                    size    128792776
+    checksums       rmd160  4b5dff14e22c8363c1e5f9d80e956505f36021e7 \
+                    sha256  cf8d9b662b55cfa1b4c794bdc354c29880030279e65c52b52c56a7a02e7ad150 \
+                    size    121570202
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 424.0.0.

###### Tested on

macOS 13.3 22E252 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?