### PR TITLE
skaffold: update to 2.3.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.2.0 v
+github.setup        GoogleContainerTools skaffold 2.3.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  6ee06639d482a71bfbd261a6384e2d845040f856 \
-                    sha256  97c60efce2b9fd9e5feb62acb891d88da8a05249dcf638dbed9daeaeee3a139d \
-                    size    41752612
+checksums           rmd160  8f4ba36d82d77fb51e4e287e45e838b97de373aa \
+                    sha256  3d594a51b1fcb57ad11f4db4087594d2d89561db362bc84cd0de1e95c874a2ab \
+                    size    41810108
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.3.0.

###### Tested on

macOS 13.3 22E252 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?