### PR TITLE
stimfit: Fix build on arm64 (finite -> isfinite)

### DIFF
--- a/science/stimfit/Portfile
+++ b/science/stimfit/Portfile
@@ -24,6 +24,8 @@ depends_lib         port:fftw-3 \
                     port:hdf5 \
                     port:${wxWidgets.port}
 
+patchfiles          isfinite.patch
+
 compiler.cxx_standard \
                     2017
 

--- a/science/stimfit/files/isfinite.patch
+++ b/science/stimfit/files/isfinite.patch
@@ -1,0 +1,36 @@
+Replace finite with isfinite and include math header.
+https://github.com/neurodroid/stimfit/commit/fb2fa2b1f8701d04bbaf2ec0902fb0e9289b334e
+https://github.com/neurodroid/stimfit/commit/e7561b9277e24fbbf6766b696f4cc6e46422844e
+--- src/libbiosiglite/biosig4c++/t210/sopen_heka_read.c.orig
++++ src/libbiosiglite/biosig4c++/t210/sopen_heka_read.c
+@@ -24,6 +24,7 @@
+ #include <ctype.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <math.h>
+ #ifdef _WIN32
+ // Can't include sys/stat.h or sopen is declared twice.
+ #include <sys/types.h>
+@@ -71,7 +72,7 @@ void rational (double x, double tol, long *n, long *d) {
+                 return;
+         }
+ 
+-	if (!finite(x)) {
++	if (!isfinite(x)) {
+ 	        *n = x>0; 	// i.e. sign(x)
+                 *d = 0;
+                 return;
+--- src/libstfnum/levmar/compiler.h.orig
++++ src/libstfnum/levmar/compiler.h
+@@ -33,9 +33,9 @@
+ #ifdef _MSC_VER
+ #define LM_FINITE _finite // MSVC
+ #elif defined(__ICC) || defined(__INTEL_COMPILER) || defined(__GNUC__)
+-#define LM_FINITE finite // ICC, GCC
++#define LM_FINITE isfinite // ICC, GCC
+ #else
+-#define LM_FINITE finite // other than MSVC, ICC, GCC, let's hope this will work
++#define LM_FINITE isfinite // other than MSVC, ICC, GCC, let's hope this will work
+ #endif
+ 
+ #ifdef _MSC_VER


### PR DESCRIPTION
#### Description

stimfit: Fix build on arm64 (finite -> isfinite)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.3.1 21E258 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
