### PR TITLE
openssl3: Fix CVE-2023-0465, CVE-2023-0466

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 8
 set major_v         3
 name                openssl$major_v
 version             ${major_v}.1.0
-revision            1
+revision            2
 
 # Please revbump these ports when updating the openssl3 version/revision
 #  - freeradius (#43461)
@@ -55,7 +55,9 @@ patchfiles          avx512.patch \
                     patch-openssl3-ppc-asm.diff \
                     2017771e2db3e2b96f89bbe8766c3209f6a99545.patch \
                     d79bb5316e1318bd776d6b2d6723a36778e07f9d.patch \
-                    52a38144b019cfda6b0e5eaa0aca88ae11661a26.patch
+                    52a38144b019cfda6b0e5eaa0aca88ae11661a26.patch \
+                    facfb1ab745646e97a1920977ae4a9965ea61d5c.patch \
+                    fc814a30fc4f0bc54fcea7d9a7462f5457aab061.patch
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Having the stdlib set to libc++ on 10.6 causes a dependency on a

--- a/devel/openssl3/files/facfb1ab745646e97a1920977ae4a9965ea61d5c.patch
+++ b/devel/openssl3/files/facfb1ab745646e97a1920977ae4a9965ea61d5c.patch
@@ -1,0 +1,54 @@
+From facfb1ab745646e97a1920977ae4a9965ea61d5c Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Tue, 7 Mar 2023 16:52:55 +0000
+Subject: [PATCH] Ensure that EXFLAG_INVALID_POLICY is checked even in leaf
+ certs
+
+Even though we check the leaf cert to confirm it is valid, we
+later ignored the invalid flag and did not notice that the leaf
+cert was bad.
+
+Fixes: CVE-2023-0465
+
+Reviewed-by: Hugo Landau <hlandau@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/20586)
+
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/facfb1ab]
+---
+ crypto/x509/x509_vfy.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/x509/x509_vfy.c b/crypto/x509/x509_vfy.c
+index 9384f1da9b..a0282c3ef1 100644
+--- ./crypto/x509/x509_vfy.c
++++ ./crypto/x509/x509_vfy.c
+@@ -1654,15 +1654,23 @@ static int check_policy(X509_STORE_CTX *ctx)
+         goto memerr;
+     /* Invalid or inconsistent extensions */
+     if (ret == X509_PCY_TREE_INVALID) {
+-        int i;
++        int i, cbcalled = 0;
+ 
+         /* Locate certificates with bad extensions and notify callback. */
+-        for (i = 1; i < sk_X509_num(ctx->chain); i++) {
++        for (i = 0; i < sk_X509_num(ctx->chain); i++) {
+             X509 *x = sk_X509_value(ctx->chain, i);
+ 
++            if ((x->ex_flags & EXFLAG_INVALID_POLICY) != 0)
++                cbcalled = 1;
+             CB_FAIL_IF((x->ex_flags & EXFLAG_INVALID_POLICY) != 0,
+                        ctx, x, i, X509_V_ERR_INVALID_POLICY_EXTENSION);
+         }
++        if (!cbcalled) {
++            /* Should not be able to get here */
++            ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);
++            return 0;
++        }
++        /* The callback ignored the error so we return success */
+         return 1;
+     }
+     if (ret == X509_PCY_TREE_FAILURE) {
+-- 
+2.40.0
+

--- a/devel/openssl3/files/fc814a30fc4f0bc54fcea7d9a7462f5457aab061.patch
+++ b/devel/openssl3/files/fc814a30fc4f0bc54fcea7d9a7462f5457aab061.patch
@@ -1,0 +1,48 @@
+From fc814a30fc4f0bc54fcea7d9a7462f5457aab061 Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.org>
+Date: Tue, 21 Mar 2023 16:15:47 +0100
+Subject: [PATCH] Fix documentation of X509_VERIFY_PARAM_add0_policy()
+
+The function was incorrectly documented as enabling policy checking.
+
+Fixes: CVE-2023-0466
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+Reviewed-by: Matt Caswell <matt@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/20562)
+
+Upstream-Status: Backport [https://github.com/openssl/openssl/commit/fc814a30fc]
+---
+ doc/man3/X509_VERIFY_PARAM_set_flags.pod | 9 +++++++--
+ 3 files changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/doc/man3/X509_VERIFY_PARAM_set_flags.pod b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+index 20aea99b5b..fcbbfc4c30 100644
+--- ./doc/man3/X509_VERIFY_PARAM_set_flags.pod
++++ ./doc/man3/X509_VERIFY_PARAM_set_flags.pod
+@@ -98,8 +98,9 @@ B<trust>.
+ X509_VERIFY_PARAM_set_time() sets the verification time in B<param> to
+ B<t>. Normally the current time is used.
+ 
+-X509_VERIFY_PARAM_add0_policy() enables policy checking (it is disabled
+-by default) and adds B<policy> to the acceptable policy set.
++X509_VERIFY_PARAM_add0_policy() adds B<policy> to the acceptable policy set.
++Contrary to preexisting documentation of this function it does not enable
++policy checking.
+ 
+ X509_VERIFY_PARAM_set1_policies() enables policy checking (it is disabled
+ by default) and sets the acceptable policy set to B<policies>. Any existing
+@@ -400,6 +401,10 @@ The X509_VERIFY_PARAM_get_hostflags() function was added in OpenSSL 1.1.0i.
+ The X509_VERIFY_PARAM_get0_host(), X509_VERIFY_PARAM_get0_email(),
+ and X509_VERIFY_PARAM_get1_ip_asc() functions were added in OpenSSL 3.0.
+ 
++The function X509_VERIFY_PARAM_add0_policy() was historically documented as
++enabling policy checking however the implementation has never done this.
++The documentation was changed to align with the implementation.
++
+ =head1 COPYRIGHT
+ 
+ Copyright 2009-2023 The OpenSSL Project Authors. All Rights Reserved.
+-- 
+2.40.0
+


### PR DESCRIPTION
#### Description

See https://www.openssl.org/news/secadv/20230328.txt for the advisory. Both of these are low severity fixes and do not change ABI or installed files. For these reasons, no bump of the openssl port or the other ports mentioned in the Portfile is required.

CVE: CVE-2023-0465, CVE-2023-0466

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.4 21G526 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
