### PR TITLE
tilemaker: update to 2.4.0

### DIFF
--- a/gis/tilemaker/Portfile
+++ b/gis/tilemaker/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
-github.setup        systemed tilemaker 2.3.0 v
+github.setup        systemed tilemaker 2.4.0 v
 revision            0
 
 categories          gis
@@ -17,9 +17,9 @@ long_description    {*}${description}
 
 installs_libs       no
 
-checksums           rmd160  3402b2674ddec4a9d6ee33686ab7bd450d416bc5 \
-                    sha256  fa936c887d2decd09eef07239477f3ad733017d6a359d40e5e10b17951816013 \
-                    size    42972568
+checksums           rmd160  bc0f9002a6499b88780abdcb8bef2871e2edd174 \
+                    sha256  228545ac07814dab7e1a043bb1752f7407471240e9ca09f0b2eac026dcf567b0 \
+                    size    42973680
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/systemed/tilemaker/blob/v2.4.0/CHANGELOG.md)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
