### PR TITLE
micronaut: update to 3.8.8

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.8.7 v
+github.setup    micronaut-projects micronaut-starter 3.8.8 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  f87cb5ce002b5d7f0a4412b2ba0a224f2c5cfeed \
-                sha256  d1807ccbc2f66cd037cedd860fb4dd0259270c055f5de77fdef069d78c409ab6 \
-                size    20156390
+checksums       rmd160  a156165abce2ede14fcf769bd4cad947bfe858fd \
+                sha256  2b87d2fdec2bb3a1bb12926869bb15102a9eb10fcc21e160f8a7b1a395045bdb \
+                size    20163621
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.8.8.

###### Tested on

macOS 13.3 22E252 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?