### PR TITLE
svt-av1: fixes for <10.6 and PPC

### DIFF
--- a/multimedia/svt-av1/Portfile
+++ b/multimedia/svt-av1/Portfile
@@ -27,6 +27,7 @@ checksums               rmd160  a96687f2b1dab1f94836757601d191f2626185a3 \
 # error: unknown type name '__m256i'
 compiler.blacklist-append \
                         *gcc-4.8* *gcc-4.9* {clang < 500}
+compiler.cxx_standard   2011
 
 depends_build-append    port:yasm
 

--- a/multimedia/svt-av1/Portfile
+++ b/multimedia/svt-av1/Portfile
@@ -9,7 +9,7 @@ gitlab.setup            AOMediaCodec SVT-AV1 1.4.1 v
 name                    svt-av1
 revision                0
 categories              multimedia
-license                 BSD-3
+license                 BSD
 maintainers             {i0ntempest @i0ntempest} openmaintainer
 
 description             Scalable Video Technology for AV1

--- a/multimedia/svt-av1/Portfile
+++ b/multimedia/svt-av1/Portfile
@@ -34,6 +34,8 @@ if {${os.arch} ne "powerpc"} {
                         port:yasm
 }
 
+patchfiles              patch-no-dispatch-on-old-OS.diff
+
 post-destroot {
     ln -s SvtAv1EncApp ${destroot}${prefix}/bin/svtav1enc
     ln -s SvtAv1DecApp ${destroot}${prefix}/bin/svtav1dec

--- a/multimedia/svt-av1/Portfile
+++ b/multimedia/svt-av1/Portfile
@@ -29,7 +29,10 @@ compiler.blacklist-append \
                         *gcc-4.8* *gcc-4.9* {clang < 500}
 compiler.cxx_standard   2011
 
-depends_build-append    port:yasm
+if {${os.arch} ne "powerpc"} {
+    depends_build-append \
+                        port:yasm
+}
 
 post-destroot {
     ln -s SvtAv1EncApp ${destroot}${prefix}/bin/svtav1enc

--- a/multimedia/svt-av1/Portfile
+++ b/multimedia/svt-av1/Portfile
@@ -34,9 +34,15 @@ if {${os.arch} ne "powerpc"} {
                         port:yasm
 }
 
-patchfiles              patch-no-dispatch-on-old-OS.diff
+patchfiles              patch-no-dispatch-on-old-OS.diff \
+                        patch-fix-native.diff
 
 post-destroot {
     ln -s SvtAv1EncApp ${destroot}${prefix}/bin/svtav1enc
     ln -s SvtAv1DecApp ${destroot}${prefix}/bin/svtav1dec
+}
+
+variant native description "Optimize for cpu" {
+    configure.args-append \
+                        -DNATIVE=ON
 }

--- a/multimedia/svt-av1/files/patch-fix-native.diff
+++ b/multimedia/svt-av1/files/patch-fix-native.diff
@@ -1,0 +1,17 @@
+--- CMakeLists.txt.orig	2022-12-10 06:30:47.000000000 +0800
++++ CMakeLists.txt	2023-04-01 23:55:44.000000000 +0800
+@@ -310,9 +310,13 @@
+     check_both_flags_add(TYPE DEBUG /Od)
+ else()
+     check_both_flags_add(PREPEND -Wall)
+-    option(NATIVE "Build for native performance (march=native)" OFF)
++    option(NATIVE "Build for native performance (march=native or mcpu=native)" OFF)
+     if(NATIVE)
++      if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc|ppc64|powerpc|powerpc64|power" OR CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64")
++        check_both_flags_add(-mtune=native)
++      else()
+         check_both_flags_add(-march=native)
++      endif()
+     endif()
+     if(MINGW)
+         check_both_flags_add(-mxsave -fno-asynchronous-unwind-tables)

--- a/multimedia/svt-av1/files/patch-no-dispatch-on-old-OS.diff
+++ b/multimedia/svt-av1/files/patch-no-dispatch-on-old-OS.diff
@@ -1,0 +1,50 @@
+--- Source/Lib/Common/Codec/EbThreads.c.orig	2022-12-10 06:30:47.000000000 +0800
++++ Source/Lib/Common/Codec/EbThreads.c	2023-04-01 21:29:58.000000000 +0800
+@@ -45,8 +45,11 @@
+ #include <unistd.h>
+ #endif // _WIN32
+ #ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 && !defined(__ppc__)
+ #include <dispatch/dispatch.h>
+ #endif
++#endif
+ #if PRINTF_TIME
+ #include <time.h>
+ #ifdef _WIN32
+@@ -208,7 +211,7 @@
+                                                  initial_count, // initial semaphore count
+                                                  max_count, // maximum semaphore count
+                                                  NULL); // semaphore is not named
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 && !defined(__ppc__)
+     UNUSED(max_count);
+     semaphore_handle = (EbHandle)dispatch_semaphore_create(initial_count);
+ #else
+@@ -236,7 +239,7 @@
+                                      NULL) // pointer to previous count (optional)
+         ? EB_ErrorSemaphoreUnresponsive
+         : EB_ErrorNone;
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 && !defined(__ppc__)
+     dispatch_semaphore_signal((dispatch_semaphore_t)semaphore_handle);
+     return_error = EB_ErrorNone;
+ #else
+@@ -257,7 +260,7 @@
+     return_error = WaitForSingleObject((HANDLE)semaphore_handle, INFINITE)
+         ? EB_ErrorSemaphoreUnresponsive
+         : EB_ErrorNone;
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 && !defined(__ppc__)
+     return_error = dispatch_semaphore_wait((dispatch_semaphore_t)semaphore_handle,
+                                            DISPATCH_TIME_FOREVER)
+         ? EB_ErrorSemaphoreUnresponsive
+@@ -280,7 +283,7 @@
+ #ifdef _WIN32
+     return_error = !CloseHandle((HANDLE)semaphore_handle) ? EB_ErrorDestroySemaphoreFailed
+                                                           : EB_ErrorNone;
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 && !defined(__ppc__)
+     dispatch_release((dispatch_semaphore_t)semaphore_handle);
+     return_error = EB_ErrorNone;
+ #else


### PR DESCRIPTION
#### Description

1. There is no libdispatch on <10.6 and no support for it on 10.6.x ppc/Rosetta (libdispatch needs blocks, which require clang, which is broken for ppc).
2. CMakeLists set cxx_standard 2011, use it.
3. Add native variant, use correct flags.
4. Fix the license (BSD-3 not supported at the moment, use BSD).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
