### PR TITLE
solfege: Update homepage; add size to checksums

### DIFF
--- a/audio/solfege/Portfile
+++ b/audio/solfege/Portfile
@@ -4,14 +4,15 @@ PortSystem          1.0
 
 name                solfege
 version             3.22.2
+revision            0
 checksums           rmd160  35f3a7adbf30c95552e9f62ca8bc06d8f3f71065 \
-                    sha256  e46a0960c83e4998d9dcf7bb07b8269e03fc81fab6c4485f8112c5a3e6488fe4
+                    sha256  e46a0960c83e4998d9dcf7bb07b8269e03fc81fab6c4485f8112c5a3e6488fe4 \
+                    size    6890977
 
 categories          audio education python
 maintainers         gmail.com:allencmcbride
 description         Ear training software
 license             GPL-3
-homepage            http://www.solfege.org/
 long_description    Solfege is a free eartraining program. The program is part \
                     of the GNU Project. One of the ideas of this program is \
                     that you can extend the program without having to dig into \
@@ -20,7 +21,6 @@ long_description    Solfege is a free eartraining program. The program is part \
                     included, you can write lesson files and put them into a \
                     lessonfiles subdirectory in your home directory.
 
-platforms           darwin
 supported_archs     noarch
 
 # Solfege fails to load its icon without librsvg; it should be a dependency of
@@ -33,6 +33,7 @@ depends_build       port:texinfo \
                     port:pkgconfig
 depends_run         port:qtplay
 
+homepage            https://www.gnu.org/software/solfege/
 master_sites        sourceforge:project/solfege/solfege-stable/${version} \
                     gnu
 

--- a/audio/solfege/Portfile
+++ b/audio/solfege/Portfile
@@ -10,7 +10,8 @@ checksums           rmd160  35f3a7adbf30c95552e9f62ca8bc06d8f3f71065 \
                     size    6890977
 
 categories          audio education python
-maintainers         gmail.com:allencmcbride
+maintainers         nomaintainer
+
 description         Ear training software
 license             GPL-3
 long_description    Solfege is a free eartraining program. The program is part \


### PR DESCRIPTION
#### Description

Update `homepage` (the old homepage is owned by someone else now)
Add `size` to `checksums`
Remove `platforms darwin` line (that's now the default)
Add `revision 0` line (although it's the default, we like to include this now)

I'll notify the maintainer by email.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
