### PR TITLE
R: unbreak build after curl update

### DIFF
--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -92,6 +92,10 @@ depends_lib                 port:readline \
 
 legacysupport.newest_darwin_requires_legacy 10
 
+# Temporary fix from upstream, to be dropped with the next release of R.
+# https://trac.macports.org/ticket/67177
+patchfiles-append           patch-curl.diff
+
 # avoid finding ${prefix}/bin/xdg-open first
 configure.env-append        R_PDFVIEWER=/usr/bin/open \
                             R_BROWSER=/usr/bin/open

--- a/math/R/files/patch-curl.diff
+++ b/math/R/files/patch-curl.diff
@@ -1,0 +1,22 @@
+--- configure.orig	2023-03-08 07:16:14.000000000 +0800
++++ configure	2023-04-02 08:58:48.000000000 +0800
+@@ -47587,8 +47587,8 @@
+ done
+ 
+ if test "x${have_libcurl}" = "xyes"; then
+-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libcurl is version 7 and >= 7.28.0" >&5
+-printf %s "checking if libcurl is version 7 and >= 7.28.0... " >&6; }
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libcurl is >= 7.28.0" >&5
++printf %s "checking if libcurl is >= 7.28.0... " >&6; }
+ if test ${r_cv_have_curl728+y}
+ then :
+   printf %s "(cached) " >&6
+@@ -47606,7 +47606,7 @@
+ {
+ #ifdef LIBCURL_VERSION_MAJOR
+ #if LIBCURL_VERSION_MAJOR > 7
+-  exit(1);
++  exit(0);
+ #elif LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 28
+   exit(0);
+ #else


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/67177

#### Description

Major release of `curl` has broken `R` builds. PR borrows the patch from upstream to fix that. See the ticket.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
