### PR TITLE
libavif: fix incorrect configure.arg, add tests variant

### DIFF
--- a/multimedia/libavif/Portfile
+++ b/multimedia/libavif/Portfile
@@ -52,10 +52,10 @@ platform darwin {
         configure.args-delete \
                         -DAVIF_CODEC_RAV1E:BOOL=ON
     }
-    if { ${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc") } {
-        # https://trac.macports.org/ticket/62619
-        # aom does not build on 10.6 Rosetta too
-        depends_lib-delete      port:aom
-        configure.args-append   --disable-aom
+    if { ${os.major} < 10 } {
+        depends_lib-delete \
+                        port:aom
+        configure.args-delete \
+                        -DAVIF_CODEC_AOM:BOOL=ON
     }
 }

--- a/multimedia/libavif/Portfile
+++ b/multimedia/libavif/Portfile
@@ -22,11 +22,9 @@ checksums               rmd160  17a452e69ec04107295613b554bb7bb7d61ae789 \
 
 cmake.generator         Ninja
 
-depends_build-append \
-                        port:pkgconfig
+depends_build-append    port:pkgconfig
 
-depends_lib-append \
-                        port:aom \
+depends_lib-append      port:aom \
                         port:dav1d \
                         path:include/turbojpeg.h:libjpeg-turbo \
                         port:libpng \
@@ -35,8 +33,7 @@ depends_lib-append \
                         port:svt-av1 \
                         port:zlib
 
-configure.args-append \
-                        -DAVIF_ENABLE_WERROR:BOOL=OFF \
+configure.args-append   -DAVIF_ENABLE_WERROR:BOOL=OFF \
                         -DAVIF_BUILD_APPS:BOOL=ON \
                         -DAVIF_CODEC_AOM:BOOL=ON \
                         -DAVIF_CODEC_DAV1D:BOOL=ON \

--- a/multimedia/libavif/Portfile
+++ b/multimedia/libavif/Portfile
@@ -59,3 +59,9 @@ platform darwin {
                         -DAVIF_CODEC_AOM:BOOL=ON
     }
 }
+
+variant tests description "Enable testing" {
+    configure.args-append \
+                        -DAVIF_BUILD_TESTS=ON
+    test.run            yes
+}


### PR DESCRIPTION
#### Description

Fix incorrect configure.arg (possibly my mistake earlier, sorry).
Drop Rosetta case: `aom` builds now for it.
Add tests variant.
Fix alignments in portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
