### PR TITLE
libvidstab: fix build for PPC

### DIFF
--- a/multimedia/libvidstab/Portfile
+++ b/multimedia/libvidstab/Portfile
@@ -22,5 +22,8 @@ checksums           rmd160  870c17142e443955ddd4eefabb020df4ddd9a112 \
                     sha256  9001b6df73933555e56deac19a0f225aae152abbc0e97dc70034814a1943f3d4 \
                     size    80717
 
+# https://github.com/georgmartius/vid.stab/pull/122
+patchfiles          0001-serialize.c-fix-for-Darwin-PPC.patch
+
 configure.args-append \
                     -DUSE_OMP=OFF

--- a/multimedia/libvidstab/files/0001-serialize.c-fix-for-Darwin-PPC.patch
+++ b/multimedia/libvidstab/files/0001-serialize.c-fix-for-Darwin-PPC.patch
@@ -1,0 +1,38 @@
+From ac395384bfb170f88e3e31adb831f6961e1ee915 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 3 Apr 2023 05:12:02 +0800
+Subject: [PATCH] serialize.c: fix for Darwin PPC
+
+---
+ src/serialize.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/serialize.c b/src/serialize.c
+index 2b0a1b2..da62045 100644
+--- src/serialize.c
++++ src/serialize.c
+@@ -39,6 +39,16 @@
+     defined(_MIBSEB) || defined(__MIBSEB) || defined(__MIBSEB__)
+ // It's a big-endian target architecture
+ #define __IS_BIG_ENDIAN__
++#ifdef __APPLE__
++// Make sure that byte swap functions are not already defined.
++#if !defined(bswap_16)
++// Mac OS X / Darwin features
++#include <libkern/OSByteOrder.h>
++#define __bswap_16(x) OSSwapInt16(x)
++#define __bswap_32(x) OSSwapInt32(x)
++#define byteSwapDouble(x) OSSwapInt64(x)
++#endif
++#else
+ #include <byteswap.h>
+ static double byteSwapDouble(double v)
+ {
+@@ -56,6 +66,7 @@ static double byteSwapDouble(double v)
+     memcpy(&result, out, 8);
+     return result;
+ }
++#endif
+ #elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN || \
+     defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ || \
+     defined(__LITTLE_ENDIAN__) || \


### PR DESCRIPTION
#### Description

Source code includes non-existent header, see: https://github.com/georgmartius/vid.stab/pull/122
Fix the build by adding correct defines.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
