### PR TITLE
qpdf: add legacysupport and use_mp_libcxx

### DIFF
--- a/textproc/qpdf/Portfile
+++ b/textproc/qpdf/Portfile
@@ -3,6 +3,10 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+
+legacysupport.newest_darwin_requires_legacy 16
+legacysupport.use_mp_libcxx yes
 
 github.setup        qpdf qpdf 11.3.0 v
 revision            0


### PR DESCRIPTION
#### Description

QPDF 11.3.0 uses `std::variant`, requiring a newer libc++ on older platforms. Judging by the build stats, High Sierra (Darwin 17) seems to be the oldest version that has `std::variant`. Since it build fine on 10.6 I have no reason to believe that something else is wrong. Adding legacysupport with use_mp_libcxx fixes the build on 10.9 at least.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Port does not have tests. I checked one variant (gnutls) and believe that there is nothing here that would break the other one (openssl). Tested `qpdf --version` and `qpdf --help` to verify that there were no linker errors.