### PR TITLE
google-cloud-sdk: update to 425.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             424.0.0
+version             425.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  0d37b90ae953a765edb3df0711a57697d54b6d08 \
-                    sha256  9d9dbf1413cb40bd81108cf0d3c3ba670c8822145d56120ae2806e62f2d8c6cb \
-                    size    104367299
+    checksums       rmd160  532bbcdf8145dd00fd4c50307135d68c78952b98 \
+                    sha256  fda6e848ea6ee0fcfe43e5c1adae04e299c46bbe47eb98859b0f2b37c7f8b451 \
+                    size    104470917
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b582dce82c0d9aa79f0a3144befd1cf19e0aa83e \
-                    sha256  bc1ee32e6d4ef50d1bd2a5dfac007cd4fb192f7b2b2961b7a634a41237384805 \
-                    size    124722704
+    checksums       rmd160  f2f8c146ea3a7c1852a6fcd2f86fda2442f1261f \
+                    sha256  44a26c885a0daef7cd4cb0c59a7e5fdfce0bb16e95f499f14ab4e3b6bee1c5ad \
+                    size    124833944
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  4b5dff14e22c8363c1e5f9d80e956505f36021e7 \
-                    sha256  cf8d9b662b55cfa1b4c794bdc354c29880030279e65c52b52c56a7a02e7ad150 \
-                    size    121570202
+    checksums       rmd160  f79d955bf57d1234ae278629ac240dce6dfbd359 \
+                    sha256  4fddab54b7b451c80345425e1f700c825eb80035c0a3e9dc04afc738efc0c29e \
+                    size    121666975
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 425.0.0.

###### Tested on

macOS 13.3 22E252 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?