### PR TITLE
py-urwid: add subport py311-urwid

### DIFF
--- a/python/py-urwid/Portfile
+++ b/python/py-urwid/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  4d8666717bee9d9fdabcc1c7b551ff583a28e307 \
                     sha256  c21112c3c524110dd5cad78f7987a9fe0c57a66b756e1e0385e572b946ec86d1 \
                     size    607749
 
-python.versions     27 35 36 37 38 39 310
+python.versions     27 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Dependency that I needed. Added Python 3.11 support and did a very basic test:
```py
>>> import urwid
>>> urwid.supports_unicode()
True
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
