### PR TITLE
py-pudb: add subports py39-pudb, py310-pudb, py311-pudb

### DIFF
--- a/python/py-pudb/Portfile
+++ b/python/py-pudb/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  8255d1bae550efb63b1a1cf67981f1630b27b734 \
                     sha256  e8f0ea01b134d802872184b05bffc82af29a1eb2f9374a277434b932d68f58dc \
                     size    59548
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

Adding subports for Python 3.9, 3.10 and 3.11. I did a very simple test in Python 3.11:
```py
import pudb
pudb.load_config()
```

I also called `pudb3-3.11 --help` to verify that there were no linker errors.

Earlier I tested Python 3.10 in a similar way (I just migrated from 3.10 to 3.11). I have not tested 3.9, but there is a 3.8 subport and when both 3.10 and 3.11 appear to work, I do not see why 3.9 would not.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
