### PR TITLE
opencv4, opencv4-devel, opencv3, opencv3-devel: update Python bindings to 3.11

### DIFF
--- a/graphics/opencv3-devel/Portfile
+++ b/graphics/opencv3-devel/Portfile
@@ -78,7 +78,7 @@ platform macosx {
 # Python build support
 #------------------------------------------------------------------------------
 set default_python_branch \
-                    3.10
+                    3.11
 set default_python_version \
                     [join [lrange [split ${default_python_branch} .] 0 1] ""]
 set default_python_path \
@@ -396,7 +396,7 @@ foreach python_branch {2.7} {
     }
 }
 
-set python_branches {3.7 3.8 3.9 3.10}
+set python_branches {3.7 3.8 3.9 3.10 3.11}
 foreach python_branch ${python_branches} {
     set python_version [join [lrange [split ${python_branch} .] 0 1] ""]
     subport py${python_version}-${name} {

--- a/graphics/opencv3/Portfile
+++ b/graphics/opencv3/Portfile
@@ -78,7 +78,7 @@ platform macosx {
 # Python build support
 #------------------------------------------------------------------------------
 set default_python_branch \
-                    3.10
+                    3.11
 set default_python_version \
                     [join [lrange [split ${default_python_branch} .] 0 1] ""]
 set default_python_path \
@@ -396,7 +396,7 @@ foreach python_branch {2.7} {
     }
 }
 
-set python_branches {3.7 3.8 3.9 3.10}
+set python_branches {3.7 3.8 3.9 3.10 3.11}
 foreach python_branch ${python_branches} {
     set python_version [join [lrange [split ${python_branch} .] 0 1] ""]
     subport py${python_version}-${name} {

--- a/graphics/opencv4-devel/Portfile
+++ b/graphics/opencv4-devel/Portfile
@@ -92,7 +92,7 @@ dist_subdir         ${my_name}
 # Python build support
 #------------------------------------------------------------------------------
 set default_python_branch \
-                    3.10
+                    3.11
 set default_python_version \
                     [join [lrange [split ${default_python_branch} .] 0 1] ""]
 set default_python_path \
@@ -347,7 +347,7 @@ platform darwin {
 }
 
 # Python Bindings
-set python_branches {3.7 3.8 3.9 3.10}
+set python_branches {3.7 3.8 3.9 3.10 3.11}
 foreach python_branch ${python_branches} {
     set python_version [join [lrange [split ${python_branch} .] 0 1] ""]
     subport py${python_version}-${name} {

--- a/graphics/opencv4/Portfile
+++ b/graphics/opencv4/Portfile
@@ -92,7 +92,7 @@ dist_subdir         ${my_name}
 # Python build support
 #------------------------------------------------------------------------------
 set default_python_branch \
-                    3.10
+                    3.11
 set default_python_version \
                     [join [lrange [split ${default_python_branch} .] 0 1] ""]
 set default_python_path \
@@ -347,7 +347,7 @@ platform darwin {
 }
 
 # Python Bindings
-set python_branches {3.7 3.8 3.9 3.10}
+set python_branches {3.7 3.8 3.9 3.10 3.11}
 foreach python_branch ${python_branches} {
     set python_version [join [lrange [split ${python_branch} .] 0 1] ""]
     subport py${python_version}-${name} {


### PR DESCRIPTION
#### Description

Adding Python 3.11 bindings and updating the default version from 3.10 to 3.11. I only have opencv4 installed, but `port lint` complained about conflicts with missing ports, so I added the other ones as well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

I did the last three things for py311-opencv4, but not opencv3 or the devel ports.
