### PR TITLE
clang-*: fix use of -stdlib=macports-libstdc++ on newer machines

### DIFF
--- a/lang/clang-11-bootstrap/Portfile
+++ b/lang/clang-11-bootstrap/Portfile
@@ -8,7 +8,7 @@ PortGroup           muniversal 1.0
 name                clang-11-bootstrap
 
 version             11.1.0
-revision            3
+revision            4
 epoch               0
 
 platforms           darwin
@@ -300,17 +300,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
 }
 
 post-patch {
-    if { ${configure.build_arch} eq "arm64" } {
-        # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-        set gcc_arch    aarch64
-    } else {
-        set gcc_arch    ${configure.build_arch}
-    }
-
     reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
         ${worksrcpath}/tools/clang/lib/Frontend/InitHeaderSearch.cpp \
         ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp
-    reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+    reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
         ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp
     reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
         ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp

--- a/lang/llvm-10/Portfile
+++ b/lang/llvm-10/Portfile
@@ -12,7 +12,7 @@ set clang_executable_version 10
 set lldb_executable_version 10
 name                    llvm-${llvm_version}
 revision                3
-subport                 clang-${llvm_version} { revision 7 }
+subport                 clang-${llvm_version} { revision 8 }
 subport                 lldb-${llvm_version} { revision 3 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -562,17 +562,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
         patchfiles-append 9001-macports-libstdcxx.diff
 
         post-patch {
-            if { ${configure.build_arch} eq "arm64" } {
-                # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-                set gcc_arch    aarch64
-            } else {
-                set gcc_arch    ${configure.build_arch}
-            }
-
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
                 ${worksrcpath}/tools/clang/lib/Frontend/InitHeaderSearch.cpp \
                 ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp
-            reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+            reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
                 ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp
             reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
                 ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp

--- a/lang/llvm-11/Portfile
+++ b/lang/llvm-11/Portfile
@@ -26,7 +26,7 @@ checksums               rmd160  f566b4b75c8f30418f19069a9a84864ead766401 \
 
 name                    llvm-${llvm_version}
 revision                4
-subport                 clang-${llvm_version} { revision 6 }
+subport                 clang-${llvm_version} { revision 7 }
 subport                 flang-${llvm_version} { revision 1 }
 subport                 lldb-${llvm_version} { revision 2 }
 set suffix              mp-${llvm_version}
@@ -560,17 +560,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
         patchfiles-append 9001-macports-libstdcxx.diff
 
         post-patch {
-            if { ${configure.build_arch} eq "arm64" } {
-                # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-                set gcc_arch    aarch64
-            } else {
-                set gcc_arch    ${configure.build_arch}
-            }
-
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
                 ${worksrcpath}/tools/clang/lib/Frontend/InitHeaderSearch.cpp \
                 ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp
-            reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+            reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
                 ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp
             reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
                 ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp

--- a/lang/llvm-12/Portfile
+++ b/lang/llvm-12/Portfile
@@ -33,7 +33,7 @@ use_xz                  yes
 
 name                    llvm-${llvm_version}
 revision                3
-subport                 clang-${llvm_version} {revision 1}
+subport                 clang-${llvm_version} {revision 2}
 subport                 lldb-${llvm_version}  {revision 2}
 dist_subdir             llvm
 set suffix              mp-${llvm_version}
@@ -418,17 +418,10 @@ if {${subport} eq "clang-${llvm_version}"} {
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
 
         post-patch {
-            if { ${configure.build_arch} eq "arm64" } {
-                # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-                set gcc_arch    aarch64
-            } else {
-                set gcc_arch    ${configure.build_arch}
-            }
-
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
                 ${patch.dir}/clang/lib/Frontend/InitHeaderSearch.cpp \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
-            reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+            reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
             reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp

--- a/lang/llvm-13/Portfile
+++ b/lang/llvm-13/Portfile
@@ -27,7 +27,7 @@ version                 ${llvm_version}.0.1
 name                    llvm-${llvm_version}
 revision                2
 subport                 mlir-${llvm_version}  { revision 0 }
-subport                 clang-${llvm_version} { revision 2 }
+subport                 clang-${llvm_version} { revision 3 }
 subport                 lldb-${llvm_version}  { revision 1 }
 subport                 flang-${llvm_version} { revision 0 }
 
@@ -489,17 +489,10 @@ if {${subport} eq "clang-${llvm_version}"} {
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
 
         post-patch {
-            if { ${configure.build_arch} eq "arm64" } {
-                # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-                set gcc_arch    aarch64
-            } else {
-                set gcc_arch    ${configure.build_arch}
-            }
-
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
                 ${patch.dir}/clang/lib/Frontend/InitHeaderSearch.cpp \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
-            reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+            reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
             reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp

--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -28,7 +28,7 @@ version                 ${llvm_version}.0.6
 name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision 0 }
-subport                 clang-${llvm_version} { revision 0 }
+subport                 clang-${llvm_version} { revision 1 }
 subport                 lldb-${llvm_version}  { revision 0 }
 subport                 flang-${llvm_version} { revision 0 }
 
@@ -502,17 +502,10 @@ if {${subport} eq "clang-${llvm_version}"} {
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
 
         post-patch {
-            if { ${configure.build_arch} eq "arm64" } {
-                # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-                set gcc_arch    aarch64
-            } else {
-                set gcc_arch    ${configure.build_arch}
-            }
-
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
                 ${patch.dir}/clang/lib/Lex/InitHeaderSearch.cpp \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
-            reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+            reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
             reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp

--- a/lang/llvm-15/Portfile
+++ b/lang/llvm-15/Portfile
@@ -28,7 +28,7 @@ version                 ${llvm_version}.0.7
 name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
-subport                 clang-${llvm_version} { revision [ expr ${revision} + 1 ] }
+subport                 clang-${llvm_version} { revision [ expr ${revision} + 2 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
 
@@ -508,17 +508,10 @@ if {${subport} eq "clang-${llvm_version}"} {
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
 
         post-patch {
-            if { ${configure.build_arch} eq "arm64" } {
-                # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-                set gcc_arch    aarch64
-            } else {
-                set gcc_arch    ${configure.build_arch}
-            }
-
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
                 ${patch.dir}/clang/lib/Lex/InitHeaderSearch.cpp \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
-            reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+            reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
             reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp

--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -28,7 +28,7 @@ version                 ${llvm_version}.0.1
 name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
-subport                 clang-${llvm_version} { revision [ expr ${revision} + 0 ] }
+subport                 clang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
 
@@ -508,17 +508,10 @@ if {${subport} eq "clang-${llvm_version}"} {
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
 
         post-patch {
-            if { ${configure.build_arch} eq "arm64" } {
-                # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-                set gcc_arch    aarch64
-            } else {
-                set gcc_arch    ${configure.build_arch}
-            }
-
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
                 ${patch.dir}/clang/lib/Lex/InitHeaderSearch.cpp \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
-            reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+            reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
             reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -11,7 +11,7 @@ set clang_executable_version 5.0
 set lldb_executable_version 5.0.2
 name                    llvm-${llvm_version}
 revision                4
-subport                 clang-${llvm_version} { revision 5 }
+subport                 clang-${llvm_version} { revision 6 }
 subport                 lldb-${llvm_version} { revision 2 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -370,7 +370,7 @@ platform darwin {
 
         # https://llvm.org/bugs/show_bug.cgi?id=25680
         configure.cxxflags-append -U__STRICT_ANSI__
-        
+
         # Wrong type in OrcRemoteTargetClient.h
         # error: could not convert 'Src->((llvm::orc::remote::OrcRemoteTargetClient<ChannelT>*)this)->callB<llvm::orc::remote::OrcRemoteTargetRPCAPI::ReadMem>(Size)'
         # from 'Expected<vector<unsigned char,allocator<unsigned char>>>' to 'Expected<vector<char,allocator<char>>>'

--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -15,7 +15,7 @@ set clang_executable_version 6.0
 set lldb_executable_version 6.0.1
 name                    llvm-${llvm_version}
 revision                4
-subport                 clang-${llvm_version} { revision 4 }
+subport                 clang-${llvm_version} { revision 5 }
 subport                 lldb-${llvm_version} { revision 2 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -16,7 +16,7 @@ set clang_executable_version 7
 set lldb_executable_version 7.1.0
 name                    llvm-${llvm_version}
 revision                3
-subport                 clang-${llvm_version} { revision 2 }
+subport                 clang-${llvm_version} { revision 3 }
 subport                 lldb-${llvm_version} { revision 1 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}

--- a/lang/llvm-8.0/Portfile
+++ b/lang/llvm-8.0/Portfile
@@ -16,7 +16,7 @@ set llvm_patch_revision 1
 set lldb_executable_version 8.0.${llvm_patch_revision}
 name                    llvm-${llvm_version}
 revision                3
-subport                 clang-${llvm_version} { revision 3 }
+subport                 clang-${llvm_version} { revision 4 }
 subport                 lldb-${llvm_version} { revision 2 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -679,16 +679,9 @@ if {${subport} eq "llvm-${llvm_version}"} {
         patchfiles-append 9001-macports-libstdcxx.diff
 
         post-patch {
-            if { ${configure.build_arch} eq "arm64" } {
-                # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-                set gcc_arch    aarch64
-            } else {
-                set gcc_arch    ${configure.build_arch}
-            }
-
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
                 ${worksrcpath}/tools/clang/lib/Frontend/InitHeaderSearch.cpp
-            reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+            reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
                 ${worksrcpath}/tools/clang/lib/Frontend/InitHeaderSearch.cpp
             reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
                 ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp

--- a/lang/llvm-9.0/Portfile
+++ b/lang/llvm-9.0/Portfile
@@ -15,7 +15,7 @@ set clang_executable_version 9
 set lldb_executable_version 9.0.0
 name                    llvm-${llvm_version}
 revision                3
-subport                 clang-${llvm_version} { revision 6 }
+subport                 clang-${llvm_version} { revision 7 }
 subport                 lldb-${llvm_version} { revision 3 }
 set suffix              mp-${llvm_version}
 set sub_prefix          ${prefix}/libexec/llvm-${llvm_version}
@@ -686,17 +686,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
         patchfiles-append 9001-macports-libstdcxx.diff
 
         post-patch {
-            if { ${configure.build_arch} eq "arm64" } {
-                # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-                set gcc_arch    aarch64
-            } else {
-                set gcc_arch    ${configure.build_arch}
-            }
-
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
                 ${worksrcpath}/tools/clang/lib/Frontend/InitHeaderSearch.cpp \
                 ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp
-            reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+            reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
                 ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp
             reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
                 ${worksrcpath}/tools/clang/lib/Driver/ToolChains/Darwin.cpp

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -47,7 +47,7 @@ checksums               rmd160  0fd2ccc6f5fbbacf52e5f6b8e6ce03e67a7c244d \
 
 name                    llvm-${llvm_version}
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
-subport                 clang-${llvm_version} { revision [ expr ${revision} + 0 ] }
+subport                 clang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
 
@@ -540,17 +540,10 @@ if {${subport} eq "clang-${llvm_version}"} {
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
 
         post-patch {
-            if { ${configure.build_arch} eq "arm64" } {
-                # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483
-                set gcc_arch    aarch64
-            } else {
-                set gcc_arch    ${configure.build_arch}
-            }
-
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \
                 ${patch.dir}/clang/lib/Lex/InitHeaderSearch.cpp \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
-            reinplace "s|@@MACPORTS_HOST_NAME@@|${gcc_arch}-apple-darwin${os.major}|g" \
+            reinplace "s|@@MACPORTS_HOST_NAME@@|${configure.build_arch}-apple-darwin${os.major}|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp
             reinplace "s|@@MACPORTS_libstdc++@@|${prefix}/lib/libgcc/libstdc++.6.dylib|g" \
                 ${patch.dir}/clang/lib/Driver/ToolChains/Darwin.cpp


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
