### PR TITLE
py-roman: update to 4.0

### DIFF
--- a/python/py-roman/Portfile
+++ b/python/py-roman/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-roman
-version             3.3
+version             4.0
 revision            0
 
 categories-append   textproc
@@ -18,17 +18,26 @@ long_description    {*}${description}.
 
 homepage            https://github.com/zopefoundation/roman
 
-checksums           rmd160  793b600babe15e5cc811f9eb9fe2fe931378a180 \
-                    sha256  2c46ac8db827d34e4fa9ccc0577e7f0b0d84f16ffe112351bd4f1ec2eb12d73f \
-                    size    7577
+checksums           rmd160  f35c7998cc7e4dcddfb349992f7209096be855a3 \
+                    sha256  6caab7ba51b83c46b5bf8839e5d782769a6b08fdea8abdfa62a4197c041fd513 \
+                    size    9380
 
 python.versions     27 35 36 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
 
+    if {${python.version} <= 36} {
+        version     3.3
+        revision    0
+        checksums   rmd160  793b600babe15e5cc811f9eb9fe2fe931378a180 \
+                    sha256  2c46ac8db827d34e4fa9ccc0577e7f0b0d84f16ffe112351bd4f1ec2eb12d73f \
+                    size    7577
+    }
+
     test.run                yes
-    test.cmd                ${python.bin} setup.py
+    python.test_framework   {}
+    test.cmd                ${python.bin} setup.py test
 
     livecheck.type          none
 }


### PR DESCRIPTION
#### Description

I ran `port test` for the 3.11 and 2.7 subport. I also tested out the functionality of the module. The only use of this in MP is py-docutils so I am keeping the list of Python subports in sync with that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
