### PR TITLE
clang-*: fix use of -stdlib= on older machines

### DIFF
--- a/devel/libstdcxx_clang_fix/Portfile
+++ b/devel/libstdcxx_clang_fix/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libstdcxx_clang_fix
+version             0.0.1
+revision            0
+categories          devel
+maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
+homepage
+license             Permissive
+description         Install alternate math.h header file for use when using Clang and libstdc++.
+long_description    {*}${description}
+platforms           any
+supported_archs     noarch
+
+distfiles
+patchfiles
+use_configure       no
+build {}
+
+if {${os.major} >= 11} {
+    PortGroup        stub 1.0
+
+} else {
+    destroot {
+        set dir ${destroot}${prefix}/include/gcc/c++/backward
+        xinstall -d -m 0755 ${dir}
+        xinstall -m 0644 ${filespath}/math.h ${dir}
+    }
+}
+
+livecheck.type      none

--- a/devel/libstdcxx_clang_fix/files/math.h
+++ b/devel/libstdcxx_clang_fix/files/math.h
@@ -1,0 +1,24 @@
+// -*- C++ -*-
+
+// see https://github.com/macports/macports-ports/blob/master/lang/llvm-devel/files/0011-Fix-missing-long-long-math-prototypes-when-using-the.patch
+// see https://trac.macports.org/ticket/61778
+
+#ifndef __MACPORTS_MATH_H_FIX__
+#define __MACPORTS_MATH_H_FIX__
+
+#include_next <math.h>
+
+#ifdef __clang__
+// these prototypes are incorrectly omitted from <math.h> on Snow Leopard despite being available
+extern "C" {
+    extern long long int llrintl(long double);
+    extern long long int llrint(double);
+    extern long long int llrintf(float);
+
+    extern long long int llroundl(long double);
+    extern long long int llround(double);
+    extern long long int llroundf(float);
+}
+#endif
+
+#endif

--- a/lang/clang-11-bootstrap/Portfile
+++ b/lang/clang-11-bootstrap/Portfile
@@ -299,6 +299,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
 
 }
 
+if {${os.major} < 11} {
+    # see https://trac.macports.org/ticket/61778
+    depends_run-append  port:libstdcxx_clang_fix
+}
+
 post-patch {
     if { ${configure.build_arch} eq "arm64" } {
         # see https://github.com/macports/macports-ports/commit/be1e11a368f672d927a7bdb381f2fa71a79ba483

--- a/lang/llvm-10/Portfile
+++ b/lang/llvm-10/Portfile
@@ -560,6 +560,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 9001-macports-libstdcxx.diff
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             if { ${configure.build_arch} eq "arm64" } {

--- a/lang/llvm-11/Portfile
+++ b/lang/llvm-11/Portfile
@@ -558,6 +558,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 9001-macports-libstdcxx.diff
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             if { ${configure.build_arch} eq "arm64" } {

--- a/lang/llvm-12/Portfile
+++ b/lang/llvm-12/Portfile
@@ -416,6 +416,10 @@ if {${subport} eq "clang-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             if { ${configure.build_arch} eq "arm64" } {

--- a/lang/llvm-13/Portfile
+++ b/lang/llvm-13/Portfile
@@ -487,6 +487,10 @@ if {${subport} eq "clang-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             if { ${configure.build_arch} eq "arm64" } {

--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -500,6 +500,10 @@ if {${subport} eq "clang-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             if { ${configure.build_arch} eq "arm64" } {

--- a/lang/llvm-15/Portfile
+++ b/lang/llvm-15/Portfile
@@ -506,6 +506,10 @@ if {${subport} eq "clang-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             if { ${configure.build_arch} eq "arm64" } {

--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -506,6 +506,10 @@ if {${subport} eq "clang-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             if { ${configure.build_arch} eq "arm64" } {

--- a/lang/llvm-5.0/Portfile
+++ b/lang/llvm-5.0/Portfile
@@ -558,6 +558,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 9001-macports-libstdcxx.diff
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \

--- a/lang/llvm-6.0/Portfile
+++ b/lang/llvm-6.0/Portfile
@@ -629,6 +629,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 9001-macports-libstdcxx.diff
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \

--- a/lang/llvm-7.0/Portfile
+++ b/lang/llvm-7.0/Portfile
@@ -659,6 +659,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 9001-macports-libstdcxx.diff
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             reinplace "s|@@MACPORTS_GCC_INCLUDE_DIR@@|${prefix}/include/gcc/c++|g" \

--- a/lang/llvm-8.0/Portfile
+++ b/lang/llvm-8.0/Portfile
@@ -677,6 +677,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 9001-macports-libstdcxx.diff
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             if { ${configure.build_arch} eq "arm64" } {

--- a/lang/llvm-9.0/Portfile
+++ b/lang/llvm-9.0/Portfile
@@ -684,6 +684,10 @@ if {${subport} eq "llvm-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 9001-macports-libstdcxx.diff
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             if { ${configure.build_arch} eq "arm64" } {

--- a/lang/llvm-devel/Portfile
+++ b/lang/llvm-devel/Portfile
@@ -538,6 +538,10 @@ if {${subport} eq "clang-${llvm_version}"} {
     variant libstdcxx description {-stdlib=libstdc++_macports searches for MacPorts libstdc++} {
 
         patchfiles-append 0005-clang-support-macports-libstdcxx.patch
+        if {${os.major} < 11} {
+            # see https://trac.macports.org/ticket/61778
+            depends_run-append  port:libstdcxx_clang_fix
+        }
 
         post-patch {
             if { ${configure.build_arch} eq "arm64" } {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
