### PR TITLE
coreutils-uutils: update to 0.0.18

### DIFF
--- a/sysutils/coreutils-uutils/Portfile
+++ b/sysutils/coreutils-uutils/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo 1.0
 
 name                coreutils-uutils
 revision            0
-github.setup        uutils coreutils 0.0.17
+github.setup        uutils coreutils 0.0.18
 github.tarball_from archive
 categories          sysutils
 platforms           darwin
@@ -35,33 +35,39 @@ cargo.crates \
     aho-corasick                                        0.7.19  b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e \
     aliasable                                            0.1.3  250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd \
     android_system_properties                            0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    anstream                                             0.2.6  342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f \
+    anstyle                                              0.3.5  23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2 \
+    anstyle-parse                                        0.1.1  a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116 \
+    anstyle-wincon                                       0.2.0  c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa \
     arrayref                                             0.3.6  a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544 \
     arrayvec                                             0.7.2  8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6 \
-    atty                                                0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                                              1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
     bigdecimal                                           0.3.0  6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744 \
     binary-heap-plus                                     0.5.0  e4551d8382e911ecc0d0f0ffb602777988669be09447d536ff4388d1def11296 \
-    bindgen                                             0.62.0  c6720a8b7b2d39dd533285ed438d458f65b31b5c257e6ac7bb3d7e82844dd722 \
+    bindgen                                             0.63.0  36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885 \
     bitflags                                             1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    blake2b_simd                                         1.0.0  72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127 \
-    blake3                                               1.3.2  895adc16c8b3273fbbc32685a7d55227705eda08c01e77704020f3491924b44b \
+    blake2b_simd                                         1.0.1  3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc \
+    blake3                                               1.3.3  42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef \
     block-buffer                                        0.10.3  69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e \
-    bstr                                                 1.0.1  fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd \
+    bstr                                                 1.4.0  c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09 \
     bumpalo                                             3.11.1  572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba \
     bytecount                                            0.6.3  2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c \
     byteorder                                            1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
     cc                                                  1.0.77  e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4 \
     cexpr                                                0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
     cfg-if                                               1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    chrono                                              0.4.23  16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f \
+    chrono                                              0.4.24  4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b \
     clang-sys                                            1.4.0  fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3 \
-    clap                                                4.0.26  2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e \
-    clap_complete                                        4.0.6  b7b3c9eae0de7bf8e3f904a5e40612b21fb2e2e566456d177809a48b892d24da \
-    clap_lex                                             0.3.0  0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8 \
+    clap                                                 4.2.0  6efb5f0a41b5ef5b50c5da28c07609c20091df0c1fc33d418fa2a7e693c2b624 \
+    clap_builder                                         4.2.0  671fcaa5debda4b9a84aa7fde49c907c8986c0e6ab927e04217c9cb74e7c8bc9 \
+    clap_complete                                        4.2.0  01c22dcfb410883764b29953103d9ef7bb8fe21b3fa1158bc99986c2067294bd \
+    clap_lex                                             0.4.1  8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1 \
+    clap_mangen                                          0.2.9  bb0f09a0ca8f0dd8ac92c546b426f466ef19828185c6d504c80c48c9c2768ed9 \
     codespan-reporting                                  0.11.1  3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e \
     compare                                              0.1.0  120133d4db2ec47efe2e26502ee984747630c67f51974fca0b6c1340cf2368d3 \
-    console                                             0.15.2  c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c \
-    constant_time_eq                                     0.1.5  245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc \
+    concolor-override                                    1.0.0  a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f \
+    concolor-query                                       0.3.3  88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf \
+    console                                             0.15.5  c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60 \
     constant_time_eq                                     0.2.4  f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279 \
     conv                                                 0.3.3  78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299 \
     core-foundation-sys                                  0.8.3  5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc \
@@ -76,12 +82,12 @@ cargo.crates \
     crossbeam-deque                                      0.8.2  715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc \
     crossbeam-epoch                                     0.9.12  96bf8df95e795db1a4aca2957ad884a2df35413b24bbeb3114422f3cc21498e8 \
     crossbeam-utils                                     0.8.13  422f23e724af1240ec469ea1e834d87a4b59ce2efe2c6a96256b0c47e2fd86aa \
-    crossterm                                           0.25.0  e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67 \
+    crossterm                                           0.26.1  a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13 \
     crossterm_winapi                                     0.9.0  2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c \
     crunchy                                              0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
     crypto-common                                        0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
     ctor                                                0.1.26  6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096 \
-    ctrlc                                                3.2.3  1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173 \
+    ctrlc                                                3.2.4  1631ca6e3c59112501a9d87fd86f21591ff77acd31331e8a73f8d80a65bbdd71 \
     custom_derive                                        0.1.7  ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9 \
     cxx                                                 1.0.82  d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453 \
     cxx-build                                           1.0.82  06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0 \
@@ -99,16 +105,18 @@ cargo.crates \
     encode_unicode                                       0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
     env_logger                                           0.8.4  a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3 \
     errno                                                0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
+    errno                                                0.3.0  50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0 \
     errno-dragonfly                                      0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
-    exacl                                                0.9.0  129c7b60e19ea8393c47b2110f8e3cea800530fd962380ef110d1fef6591faee \
+    exacl                                               0.10.0  1cfeb22a59deb24c3262c43ffcafd1eb807180f371f9fcc99098d181b5d639be \
     fastrand                                             1.8.0  a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499 \
     file_diff                                            1.0.0  31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5 \
     filetime                                            0.2.18  4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3 \
     flate2                                              1.0.24  f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6 \
     fnv                                                  1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    fs_extra                                             1.2.0  2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394 \
+    fs_extra                                             1.3.0  42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c \
     fsevent-sys                                          4.1.0  76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2 \
-    fts-sys                                              0.2.3  32bd98333d10742c0b048272ebf4cb05336d415423b853961c92ccb398966a03 \
+    fts-sys                                              0.2.4  9a66c0a21e344f20c87b4ca12643cf4f40a7018f132c98d344e989b959f49dd1 \
+    fundu                                                0.5.0  bd020eeb034c9fc682e8fe6b9a28e1c0eda92eeb347c38776c09a0b227cdf9e5 \
     futures                                             0.3.25  38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0 \
     futures-channel                                     0.3.25  52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed \
     futures-core                                        0.3.25  04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac \
@@ -119,24 +127,25 @@ cargo.crates \
     futures-task                                        0.3.25  2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea \
     futures-timer                                        3.0.2  e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c \
     futures-util                                        0.3.25  197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6 \
-    gcd                                                  2.1.0  f37978dab2ca789938a83b2f8bc1ef32db6633af9051a6cd409eff72cbaaa79a \
+    gcd                                                  2.3.0  1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a \
     generic-array                                       0.14.6  bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9 \
     getrandom                                            0.2.8  c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31 \
-    glob                                                 0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
-    half                                                 2.1.0  ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554 \
+    glob                                                 0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
+    half                                                 2.2.1  02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0 \
     hashbrown                                           0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
-    heck                                                 0.4.0  2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9 \
     hermit-abi                                          0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    hermit-abi                                           0.3.1  fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286 \
     hex                                                  0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    hex-literal                                          0.3.4  7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0 \
+    hex-literal                                          0.4.0  4bcb5b3e439c92a7191df2f9bbe733de8de55c3f86368cdb1c63f8be7e9e328e \
     hostname                                             0.3.1  3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867 \
     iana-time-zone                                      0.1.53  64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765 \
     iana-time-zone-haiku                                 0.1.1  0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca \
-    indicatif                                           0.17.2  4295cbb7573c16d310e99e713cf9e75101eb190ab31fccd35f2d2691b4352b19 \
+    indicatif                                           0.17.3  cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729 \
     inotify                                              0.9.6  f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff \
     inotify-sys                                          0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
     instant                                             0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
-    io-lifetimes                                         0.7.5  59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074 \
+    io-lifetimes                                         1.0.5  1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3 \
+    is-terminal                                          0.4.6  256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8 \
     itertools                                           0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
     itoa                                                 1.0.4  4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc \
     js-sys                                              0.3.60  49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47 \
@@ -145,10 +154,11 @@ cargo.crates \
     kqueue-sys                                           1.0.3  8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587 \
     lazy_static                                          1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lazycell                                             1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
-    libc                                               0.2.137  fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89 \
+    libc                                               0.2.140  99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c \
     libloading                                           0.7.4  b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f \
     link-cplusplus                                       1.0.7  9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369 \
-    linux-raw-sys                                       0.0.46  d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d \
+    linux-raw-sys                                        0.1.4  f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4 \
+    linux-raw-sys                                        0.3.0  cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d \
     lock_api                                             0.4.9  435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df \
     log                                                 0.4.17  abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e \
     lscolors                                            0.13.0  c2dedc85d67baf5327114fad78ab9418f8893b1121c17d5538dd11005ad1ddf2 \
@@ -156,14 +166,13 @@ cargo.crates \
     md-5                                                0.10.5  6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca \
     memchr                                               2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
     memmap2                                              0.5.8  4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc \
-    memoffset                                            0.6.5  5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce \
     memoffset                                            0.7.1  5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4 \
     minimal-lexical                                      0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                                          0.5.4  96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34 \
     mio                                                  0.8.5  e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de \
-    nix                                                 0.25.0  e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb \
-    nom                                                  7.1.1  a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36 \
-    notify                                               5.0.0  ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a \
+    nix                                                 0.26.2  bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a \
+    nom                                                  7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
+    notify                                               5.1.0  58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9 \
     nu-ansi-term                                        0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
     num-bigint                                           0.4.3  f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f \
     num-integer                                         0.1.45  225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9 \
@@ -171,19 +180,17 @@ cargo.crates \
     num_cpus                                            1.14.0  f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5 \
     num_threads                                          0.1.6  2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44 \
     number_prefix                                        0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
-    once_cell                                           1.16.0  86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860 \
+    once_cell                                           1.17.1  b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3 \
     onig                                                 6.4.0  8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f \
     onig_sys                                            69.8.1  7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7 \
     ordered-multimap                                     0.4.3  ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a \
     os_display                                           0.1.3  7a6229bad892b46b0dcfaaeb18ad0d2e56400f5aaea05b768bde96e73676cf75 \
-    os_str_bytes                                         6.4.1  9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee \
-    ouroboros                                           0.15.5  dfbb50b356159620db6ac971c6d5c9ab788c9cc38a6f49619fca2a27acb062ca \
-    ouroboros_macro                                     0.15.5  4a0d9d1a6191c4f391f87219d1ea42b23f09ee84d64763cd05ee6ea88d9f384d \
+    ouroboros                                           0.15.6  e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db \
+    ouroboros_macro                                     0.15.6  5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7 \
     output_vt100                                         0.1.3  628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66 \
     overload                                             0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     parking_lot                                         0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
     parking_lot_core                                     0.9.4  4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0 \
-    paste                                                1.0.9  b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1 \
     peeking_take_while                                   0.1.2  19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099 \
     phf                                                 0.11.1  928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c \
     phf_codegen                                         0.11.1  a56ac890c5e3ca598bbdeaa99964edb5b0258a583a9eb6ef4e89fc85d9224770 \
@@ -199,7 +206,7 @@ cargo.crates \
     proc-macro-error                                     1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
     proc-macro-error-attr                                1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
     proc-macro2                                         1.0.47  5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725 \
-    procfs                                              0.14.1  2dfb6451c91904606a1abe93e83a8ec851f45827fa84273f256ade45dc095818 \
+    procfs                                              0.15.1  943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f \
     quick-error                                          2.0.1  a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3 \
     quickcheck                                           1.0.3  588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6 \
     quote                                               1.0.21  bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179 \
@@ -207,68 +214,66 @@ cargo.crates \
     rand_chacha                                          0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                                            0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     rand_pcg                                             0.3.1  59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e \
-    rayon                                                1.6.0  1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b \
-    rayon-core                                          1.10.1  cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3 \
+    rayon                                                1.7.0  1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b \
+    rayon-core                                          1.11.0  4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d \
     redox_syscall                                       0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
     reference-counted-singleton                          0.1.2  f1bfbf25d7eb88ddcbb1ec3d755d0634da8f7657b2cb8b74089121409ab8228f \
-    regex                                                1.7.0  e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a \
+    regex                                                1.7.3  8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d \
     regex-automata                                      0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
-    regex-syntax                                        0.6.28  456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848 \
-    remove_dir_all                                       0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
-    remove_dir_all                                       0.7.0  882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40 \
-    retain_mut                                           0.1.7  8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086 \
-    rlimit                                               0.8.3  f7278a1ec8bfd4a4e07515c589f5ff7b309a373f987393aef44813d9dcf87aa3 \
-    rstest                                              0.16.0  b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf \
-    rstest_macros                                       0.16.0  7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7 \
+    regex-syntax                                        0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
+    rlimit                                               0.9.1  f8a29d87a652dc4d43c586328706bb5cdff211f3f39a530f240b53f7221dab8e \
+    roff                                                 0.2.1  b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316 \
+    rstest                                              0.17.0  de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962 \
+    rstest_macros                                       0.17.0  290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8 \
     rust-ini                                            0.18.0  f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df \
     rustc-hash                                           1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustc_version                                        0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
-    rustix                                             0.35.13  727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9 \
-    rustversion                                          1.0.9  97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8 \
+    rustix                                              0.36.8  f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644 \
+    rustix                                              0.37.3  62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2 \
     same-file                                            1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scopeguard                                           1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
     scratch                                              1.0.2  9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898 \
-    selinux                                              0.3.1  966a861c0b329c3078d82b404f7086009487123fd0cc905a9caac55d8b13bee1 \
-    selinux-sys                                          0.6.1  e4c02c5c6e2db8a78b3ffffc666f75fcda5bbd7068ba3c0f560e5504f4d88443 \
+    selinux                                              0.4.0  a00576725d21b588213fbd4af84cd7e4cc4304e8e9bd6c0f5a1498a3e2ca6a51 \
+    selinux-sys                                          0.6.2  806d381649bb85347189d2350728817418138d11d738e2482cb644ec7f3c755d \
     semver                                              1.0.14  e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4 \
     serde                                              1.0.147  d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965 \
     sha1                                                0.10.5  f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3 \
     sha2                                                0.10.6  82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0 \
     sha3                                                0.10.6  bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9 \
     shlex                                                1.1.0  43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3 \
-    signal-hook                                         0.3.14  a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d \
+    signal-hook                                         0.3.15  732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9 \
     signal-hook-mio                                      0.2.3  29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af \
     signal-hook-registry                                 1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
     siphasher                                           0.3.10  7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de \
     slab                                                 0.4.7  4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef \
+    sm3                                                  0.4.1  f943a7c5e3089f2bd046221d1e9f4fa59396bf0fe966360983649683086215da \
     smallvec                                            1.10.0  a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0 \
     smawk                                                0.3.1  f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043 \
     socket2                                              0.4.7  02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd \
+    static_assertions                                    1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                                              0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
-    strum                                               0.24.1  063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f \
-    strum_macros                                        0.24.3  1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59 \
     subtle                                               2.4.1  6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601 \
     syn                                                1.0.103  a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d \
-    tempfile                                             3.3.0  5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4 \
+    tempfile                                             3.4.0  af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95 \
     term_grid                                            0.1.7  230d3e804faaed5a39b08319efb797783df2fd9671b39b7596490cb486d702cf \
     termcolor                                            1.1.3  bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755 \
-    terminal_size                                       0.1.17  633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df \
-    terminal_size                                        0.2.2  40ca90c434fd12083d1a6bdcbe9f92a14f96c8a1ba600ba451734ac334521f7a \
+    terminal_size                                        0.2.5  4c9afddd2cec1c0909f06b00ef33f94ab2cc0578c4a610aa208ddfec8aa2b43a \
     textwrap                                            0.16.0  222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d \
     thiserror                                           1.0.37  10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e \
     thiserror-impl                                      1.0.37  982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb \
-    time                                                0.3.17  a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376 \
+    time                                                0.3.20  cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890 \
     time-core                                            0.1.0  2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd \
-    time-macros                                          0.2.6  d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2 \
+    time-macros                                          0.2.8  fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36 \
     typenum                                             1.15.0  dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987 \
     unicode-ident                                        1.0.5  6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3 \
     unicode-linebreak                                    0.1.4  c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137 \
-    unicode-segmentation                                1.10.0  0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a \
+    unicode-segmentation                                1.10.1  1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36 \
     unicode-width                                       0.1.10  c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b \
     unicode-xid                                          0.2.4  f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c \
-    unindent                                            0.1.10  58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112 \
+    unindent                                             0.2.1  5aa30f5ea51ff7edfc797c6d3f9ec8cbd8cfedef5371766b7181d33977f4814f \
     users                                               0.11.0  24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032 \
     utf-8                                                0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
+    utf8parse                                            0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
     uuid                                                 1.2.2  422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c \
     version_check                                        0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
     walkdir                                              2.3.2  808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56 \
@@ -285,24 +290,26 @@ cargo.crates \
     winapi-util                                          0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
     winapi-x86_64-pc-windows-gnu                         0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
     windows-sys                                         0.42.0  5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7 \
-    windows_aarch64_gnullvm                             0.42.0  41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e \
-    windows_aarch64_msvc                                0.42.0  dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4 \
-    windows_i686_gnu                                    0.42.0  fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7 \
-    windows_i686_msvc                                   0.42.0  84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246 \
-    windows_x86_64_gnu                                  0.42.0  bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed \
-    windows_x86_64_gnullvm                              0.42.0  09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028 \
-    windows_x86_64_msvc                                 0.42.0  f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5 \
-    xattr                                                0.2.3  6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc \
+    windows-sys                                         0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+    windows-targets                                     0.42.1  8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7 \
+    windows_aarch64_gnullvm                             0.42.1  8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608 \
+    windows_aarch64_msvc                                0.42.1  4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7 \
+    windows_i686_gnu                                    0.42.1  de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640 \
+    windows_i686_msvc                                   0.42.1  bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605 \
+    windows_x86_64_gnu                                  0.42.1  c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45 \
+    windows_x86_64_gnullvm                              0.42.1  628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463 \
+    windows_x86_64_msvc                                 0.42.1  447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd \
+    xattr                                                1.0.0  ea263437ca03c1522846a4ddafbca2542d0ad5ed9b784909d4b27b76f62bc34a \
     yansi                                                0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec \
     z85                                                  3.0.5  2a599daf1b507819c1121f0bf87fa37eb19daac6aff3aefefd4e6e2e0f2020fc \
-    zip                                                  0.6.3  537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080
+    zip                                                  0.6.4  0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160  11d1212976e5c11896483a65c6257acc86f33e80 \
-                    sha256  a133449db283c145483e7945c925104007294d600b75991c5dad2cc91dc11d2e \
-                    size    1964596
+                    rmd160  53a3ebbed6c76d36f2be477cbee63b8bec400ae4 \
+                    sha256  1eed6317763c2fad1283bac057b25eae81a61fd8f364b814f20e1aaa32d16f8d \
+                    size    1993469
 
-build.pre_args-append --features macos
+build.pre_args-append --features macos,feat_acl
 
 # Get these from coreutils --help in a standard 80x25 term
 set binaries {
@@ -321,12 +328,19 @@ set binaries {
 }
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/target/[cargo.rust_platform]/release/coreutils ${destroot}${prefix}/bin/
+    xinstall -m 0755 ${worksrcpath}/target/[cargo.rust_platform]/release/coreutils ${destroot}${prefix}/bin
     xinstall -m 755 -d ${destroot}${prefix}/libexec/uutils
+    xinstall -m 755 -d ${destroot}${prefix}/libexec/uutils/man/man1
+
+    set coreutils_bin ${destroot}${prefix}/bin/coreutils
 
     foreach binary ${binaries} {
             ln -s ${prefix}/bin/coreutils ${destroot}${prefix}/libexec/uutils/${binary}
             ln -s ${prefix}/bin/coreutils ${destroot}${prefix}/bin/uu-${binary}
+
+            set manpage ${prefix}/share/man/man1/uu-${binary}.1
+            system "${coreutils_bin} manpage ${binary} > ${destroot}${manpage}"
+            ln -s ${manpage}.gz ${destroot}${prefix}/libexec/uutils/man/man1/${binary}.1.gz
     }
 
     if {[variant_isset bash_completion]} {
@@ -338,7 +352,7 @@ destroot {
             if {${binary} eq {[}} {
                 continue
             }
-            system "${destroot}${prefix}/bin/coreutils completion ${binary} bash >> ${temp_file}"
+            system "${coreutils_bin} completion ${binary} bash >> ${temp_file}"
         }
 
         xinstall -m 644 ${temp_file} ${completions_path}/coreutils-uutils
@@ -350,7 +364,7 @@ destroot {
         xinstall -d ${completions_path}
 
         foreach binary ${binaries} {
-            system "${destroot}${prefix}/bin/coreutils completion ${binary} zsh >> ${temp_file}"
+            system "${coreutils_bin} completion ${binary} zsh >> ${temp_file}"
         }
 
         xinstall -m 644 ${temp_file} ${completions_path}/coreutils-uutils
@@ -362,7 +376,7 @@ destroot {
         xinstall -d ${completions_path}
 
         foreach binary ${binaries} {
-            system "${destroot}${prefix}/bin/coreutils completion ${binary} fish >> ${temp_file}"
+            system "${coreutils_bin} completion ${binary} fish >> ${temp_file}"
         }
 
         xinstall -m 644 ${temp_file} ${completions_path}/coreutils-uutils.fish


### PR DESCRIPTION
#### Description

This enables ACL support in the cp command. I have also started installing the manpages.

One question: i have it installing the manpages in `uu-xyz` form to the standard manpath under the MP prefix. This is working fine. I'd like to symlink unprefixed manpages under the `libexec/uutils` path. I tried several attempts at this but was unable to make it work. If you do it during the destroot phase you get symlinks pointing to the worksrcdir which is unusable. I tried adding a post-destroot (as I notice the GNU packages set up their symlinks in a post-destroot) but couldn't get that to work for whatever reason. Is there a standard way to do this, or some other package that's figured it out?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
