### PR TITLE
cfourcc: update to 0.1.3.1

### DIFF
--- a/multimedia/cfourcc/Portfile
+++ b/multimedia/cfourcc/Portfile
@@ -9,17 +9,16 @@ categories      multimedia
 maintainers     nomaintainer
 license         GPL-2
 
-description     change avi fourcc codes
+description     Change AVI fourcc codes
 long_description \
                 Command-line utility for changing FOURCC codes in AVI files
-
-platforms       darwin
 
 checksums       rmd160  04a9a5a9adc924e08d5a8184e2e9c047bfe7d5ae \
                 sha256  7036de3dc7411bd2ceea517c2dbdf501bbfd2f93dd9eddd85417c824dfacf211 \
                 size    15562
 
 use_configure   no
+
 destroot {
     xinstall -m 755 -d ${destroot}${prefix}/bin
     xinstall -m 755 ${worksrcpath}/cfourcc ${destroot}${prefix}/bin

--- a/multimedia/cfourcc/Portfile
+++ b/multimedia/cfourcc/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    mypapit cfourcc 0.1.3
+github.setup    mypapit cfourcc 0.1.3.1
 
 categories      multimedia
 maintainers     nomaintainer
@@ -15,8 +15,9 @@ long_description \
 
 platforms       darwin
 
-checksums       rmd160  ce7451d031b3612bcc9c77644ec4eb6fb87dc477 \
-                sha256  db76ceb326f7a1f8a28a1f60e172d26a0e18ac4c5987bbc7e3888e08c33d07f5
+checksums       rmd160  04a9a5a9adc924e08d5a8184e2e9c047bfe7d5ae \
+                sha256  7036de3dc7411bd2ceea517c2dbdf501bbfd2f93dd9eddd85417c824dfacf211 \
+                size    15562
 
 use_configure   no
 destroot {


### PR DESCRIPTION
#### Description

Trivial update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
