### PR TITLE
hptt: fix compiler choice on <10.7, fix build on >10.6 Intel after recent change to gcc settings

### DIFF
--- a/math/hptt/Portfile
+++ b/math/hptt/Portfile
@@ -22,13 +22,14 @@ patchfiles          0001-CMakeLists-add-PPC-support-unbreak-build-on-Darwin.patc
                     0002-CMakeLists-fix-install-path-for-headers.patch \
                     0003-Add-hptt.pc-config-file.patch
 
+# Keep this above, otherwise a wrong compiler can be picked.
+compiler.cxx_standard   2011
 # It does not build with new clang: https://github.com/springer13/hptt/issues/21
 # See also: https://bugs.llvm.org/show_bug.cgi?id=36915
 compiler.blacklist-append \
                     *clang*
 compiler.fallback-append \
                     macports-gcc-12 macports-gcc-11
-compiler.cxx_standard   2011
 
 configure.args-append \
                     -DENABLE_ARM=OFF \

--- a/math/hptt/Portfile
+++ b/math/hptt/Portfile
@@ -31,6 +31,8 @@ compiler.blacklist-append \
 compiler.fallback-append \
                     macports-gcc-12 macports-gcc-11
 
+configure.cxx_stdlib    macports-libstdc++
+
 configure.args-append \
                     -DENABLE_ARM=OFF \
                     -DENABLE_AVX=OFF \


### PR DESCRIPTION
#### Description

On 10.6 gcc-4.2 gets picked; fix that.

Macports, unfortunately, moved GCC to use libc++, which is untested. To no surprise, it does not work. Set libstdc++ manually, fix the build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
