### PR TITLE
snac: Fix manpage location, compiler, flags

### DIFF
--- a/net/snac/Portfile
+++ b/net/snac/Portfile
@@ -2,10 +2,12 @@
 
 PortSystem          1.0
 PortGroup           legacysupport 1.1
+PortGroup           makefile 1.0
 
 name                snac
 version             2.26
-revision            0
+revision            1
+
 distname            ${version}
 categories          net
 license             MIT
@@ -35,11 +37,14 @@ depends_lib         path:lib/libssl.dylib:openssl \
 
 worksrcdir          ${name}2
 
-use_configure       no
 use_parallel_build  no
 patchfiles          Makefile.patch
-post-patch          {reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/Makefile}
+
+platform darwin {
+    configure.cflags-append \
+                    -Dst_mtim=st_mtimespec
+}
 
 livecheck.type      regex
 livecheck.url       https://codeberg.org/grunfink/snac2/tags
-livecheck.regex     "/grunfink/snac2/src/tag/(\\d+\\.\\d+)"
+livecheck.regex     {/grunfink/snac2/src/tag/(\d+\.\d+)}

--- a/net/snac/files/Makefile.patch
+++ b/net/snac/files/Makefile.patch
@@ -1,16 +1,30 @@
---- Makefile
-+++ Makefile
-@@ -1,6 +1,7 @@
- PREFIX=/usr/local
- PREFIX_MAN=$(PREFIX)/man
+--- Makefile.orig	2023-03-08 13:17:33.000000000 -0600
++++ Makefile	2023-04-07 01:37:47.000000000 -0500
+@@ -1,31 +1,31 @@
+-PREFIX=/usr/local
+-PREFIX_MAN=$(PREFIX)/man
 -CFLAGS?=-g -Wall
-+DESTDIR                ?=
-+CFLAGS?=-g -Wall -D st_mtim=st_mtimespec
++PREFIX?=/usr/local
++PREFIX_MAN?=$(PREFIX)/share/man
++CFLAGS+=-g -Wall
  
  all: snac
  
-@@ -18,14 +19,14 @@
- 	$(CC) -I/usr/local/include -MM *.c > makefile.depend
+ snac: snac.o main.o data.o http.o httpd.o webfinger.o \
+     activitypub.o html.o utils.o format.o upgrade.o
+-	$(CC) $(CFLAGS) -L/usr/local/lib *.o -lcurl -lcrypto -pthread $(LDFLAGS) -o $@
++	$(CC) $(CFLAGS) $^ $(LDFLAGS) -lcurl -lcrypto -pthread -o $@
+ 
+ .c.o:
+-	$(CC) $(CFLAGS) $(CPPFLAGS) -I/usr/local/include -c $<
++	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
+ 
+ clean:
+ 	rm -rf *.o *.core snac makefile.depend
+ 
+ dep:
+-	$(CC) -I/usr/local/include -MM *.c > makefile.depend
++	$(CC) $(CPPFLAGS) -MM *.c > makefile.depend
  
  install:
 -	mkdir -p -m 755 $(PREFIX)/bin
@@ -21,14 +35,14 @@
 -	install -m 644 doc/snac.5 $(PREFIX_MAN)/man5/snac.5
 -	mkdir -p -m 755 $(PREFIX_MAN)/man8
 -	install -m 644 doc/snac.8 $(PREFIX_MAN)/man8/snac.8
-+	mkdir -p -m 755 $(DESTDIR)$(PREFIX_MAN)/share/man1
++	mkdir -p -m 755 $(DESTDIR)$(PREFIX)/bin
 +	install -m 755 snac $(DESTDIR)$(PREFIX)/bin/snac
-+	mkdir -p -m 755 $(DESTDIR)$(PREFIX_MAN)/share/man1
-+	install -m 644 doc/snac.1 $(DESTDIR)$(PREFIX_MAN)/share/man1/snac.1
-+	mkdir -p -m 755 $(DESTDIR)$(PREFIX_MAN)/share/man5
-+	install -m 644 doc/snac.5 $(DESTDIR)$(PREFIX_MAN)/share/man5/snac.5
-+	mkdir -p -m 755 $(DESTDIR)$(PREFIX_MAN)/share/man8
-+	install -m 644 doc/snac.8 $(DESTDIR)$(PREFIX_MAN)/share/man8/snac.8
++	mkdir -p -m 755 $(DESTDIR)$(PREFIX_MAN)/man1
++	install -m 644 doc/snac.1 $(DESTDIR)$(PREFIX_MAN)/man1/snac.1
++	mkdir -p -m 755 $(DESTDIR)$(PREFIX_MAN)/man5
++	install -m 644 doc/snac.5 $(DESTDIR)$(PREFIX_MAN)/man5/snac.5
++	mkdir -p -m 755 $(DESTDIR)$(PREFIX_MAN)/man8
++	install -m 644 doc/snac.8 $(DESTDIR)$(PREFIX_MAN)/man8/snac.8
  
  activitypub.o: activitypub.c xs.h xs_encdec.h xs_json.h xs_curl.h \
-  xs_mime.h xs_openssl.h xs_regex.h xs_time.h snac.h
+  xs_mime.h xs_openssl.h xs_regex.h xs_time.h xs_set.h snac.h


### PR DESCRIPTION
#### Description

Put manpages in the right directory. Use the right compiler and flags so that legacy support can work properly.

Closes: https://trac.macports.org/ticket/66751

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.4 21G526 x86_64
Xcode 13.2.1 13C100


###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
