### PR TITLE
texworks: update to 0.6.8; fix qt5 variant

### DIFF
--- a/editors/texworks/Portfile
+++ b/editors/texworks/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        TeXworks texworks 0.6.3 release-
+github.setup        TeXworks texworks 0.6.8 release-
 platforms           darwin
 categories          editors tex
 maintainers         {mojca @mojca} openmaintainer
@@ -15,9 +15,9 @@ long_description    TeXworks is an environment for authoring TeX (LaTeX, ConTeXt
                     with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, \
                     simple interface accessible to casual and non-technical users.
 
-checksums           rmd160  dc56df2c97b4bc408fbfeb9c2b30d4024ed8c5f5 \
-                    sha256  eb7426b9296aa92da06183690f542c2dcf0f2236215de5843f4585dd544d28be \
-                    size    12082392
+checksums           rmd160  bf665cf18de09904318001fdb4db02222a48d287 \
+                    sha256  d051210a6ed0898f47852475416e6a83e3e0eab530661515bc3a2c7c6733c981 \
+                    size    12486989
 
 depends_build-append \
                     port:pkgconfig
@@ -38,16 +38,18 @@ configure.args-append       -DWITH_LUA=ON \
 
 variant qt4 description {Build against Qt 4} {
     PortGroup               qt4 1.0
+
     depends_lib-append      port:poppler-qt4-mac
     configure.args-append   -DDESIRED_QT_VERSION=4
     configure.env-append    PKG_CONFIG_PATH=${prefix}/libexec/poppler-qt4-mac/lib/pkgconfig:${prefix}/lib/pkgconfig
 }
 
-# TODO: doesn't work at the moment
 variant qt5 description {Build against Qt 5} {
     PortGroup               qt5 1.0
+
+    qt5.depends_component   qttools qtdeclarative qtscript
     depends_lib-append      port:poppler-qt5
-    configure.args-append   -DDESIRED_QT_VERSION=5
+    configure.args-append   -DQT_DEFAULT_MAJOR_VERSION=5
 }
 
 # not properly tested yet
@@ -68,4 +70,17 @@ if {![variant_isset qt4] && ![variant_isset qt5]} {
 post-destroot {
     # alternatively set the DESTDIR straight to ${destroot}${applications_dir}
     move ${destroot}${prefix}/TeXworks.app ${destroot}${applications_dir}
+
+    if {[variant_isset qt5]} {
+        # These are the plugin directories that macdeployqt would copy inside
+        # the application. Linking them seems to be enough to make the application
+        # run correctly even without using macdeployqt.
+        ln -s   ${qt_plugins_dir}/bearer \
+                ${qt_plugins_dir}/iconengines \
+                ${qt_plugins_dir}/imageformats \
+                ${qt_plugins_dir}/platforms \
+                ${qt_plugins_dir}/printsupport \
+                ${qt_plugins_dir}/styles \
+                ${destroot}${applications_dir}/TeXworks.app/Contents/PlugIns/
+    }
 }


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/55226

#### Description

I have not tested the qt4 variant, as it is currently broken anyway due to the problems with poppler-qt4-mac (see https://trac.macports.org/ticket/66556).
I have not tested the qtpdf variant.

If the qt5 variant turns out to be fully functional (I only did a superficial test of basic functionality), we can make it the default variant in the future.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
