### PR TITLE
ffmpeg-upstream: update to 6.0

### DIFF
--- a/multimedia/ffmpeg-upstream/Portfile
+++ b/multimedia/ffmpeg-upstream/Portfile
@@ -18,8 +18,8 @@ set my_name         ffmpeg
 conflicts           ffmpeg ffmpeg-devel
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
-version             5.1.2
-revision            4
+version             6.0
+revision            0
 epoch               0
 
 license             LGPL-2.1+
@@ -63,9 +63,9 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
-checksums           rmd160  75458f46e0106c76f34dd1780f417c4e58c1a13f \
-                    sha256  619e706d662c8420859832ddc259cd4d4096a48a2ce1eefd052db9e440eef3dc \
-                    size    10004956
+checksums           rmd160  591511f1b96534dcd007875394913ba63e82a4a4 \
+                    sha256  57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082 \
+                    size    10234012
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description

Update ffmpeg to the new major version

Also, there is a ticket on Trac (https://trac.macports.org/ticket/67095)

**Notes to maintainers:** 
* MPV is up to date (v0.35.1)
* It seems like the port doesn't have any tests, or, if it has that, on my env seems like it doesn't fine the test target.
* Regarding the variants, is there a way to test them automatically? I've installed with:
   * +nonfree
   * +librtmp
   * +gpl2
   * +gpl3

**Test execution:**

```shell
:notice:test --->  Testing ffmpeg-upstream
:debug:test Executing org.macports.test (ffmpeg-upstream)
:debug:test Environment:
:debug:test CC_PRINT_OPTIONS='YES'
:debug:test CC_PRINT_OPTIONS_FILE='/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_multimedia_ffmpeg-upstream/ffmpeg-upstream/work/.CC_PRINT_OPTIONS'
:debug:test CPATH='/opt/local/include'
:debug:test DEVELOPER_DIR='/Library/Developer/CommandLineTools'
:debug:test LIBRARY_PATH='/opt/local/lib'
:debug:test MACOSX_DEPLOYMENT_TARGET='13.0'
:debug:test MACPORTS_LEGACY_SUPPORT_DISABLED='1'
:debug:test SDKROOT='/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk'
:info:test Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_multimedia_ffmpeg-upstream/ffmpeg-upstream/work/ffmpeg-6.0" && /opt/local/bin/gmake test
:debug:test system:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_multimedia_ffmpeg-upstream/ffmpeg-upstream/work/ffmpeg-6.0" && /opt/local/bin/gmake test
:info:test gmake: *** No rule to make target 'test'.  Stop.
:info:test Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_multimedia_ffmpeg-upstream/ffmpeg-upstream/work/ffmpeg-6.0" && /opt/local/bin/gmake test
:info:test Exit code: 2
:error:test Failed to test ffmpeg-upstream: command execution failed
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3 22E252 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
