### PR TITLE
hivex: new port

### DIFF
--- a/devel/hivex/Portfile
+++ b/devel/hivex/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+name                hivex
+version             1.3.23
+revision            0
+categories          devel
+license             LGPL-2.1
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         A self-contained library for reading and writing Windows \
+                    Registry \"hive\" binary files.
+
+long_description    {*}${description}
+
+homepage            https://github.com/libguestfs/hivex
+
+master_sites        https://download.libguestfs.org/hivex/
+
+checksums           rmd160  ed4041d779dd4d31ebab7d42f85fb6a59aadc84e \
+                    sha256  40cf5484f15c94672259fb3b99a90bef6f390e63f37a52a1c06808a2016a6bbd \
+                    size    738076
+
+perl5.default_branch    5.34
+perl5.branches          ${perl5.default_branch}
+perl5.create_variants   ${perl5.branches}
+
+depends_build-append    port:pkgconfig
+
+depends_lib-append  port:libxml2 \
+                    port:readline
+
+configure.args      --disable-ocaml \
+                    --disable-python \
+                    --disable-ruby
+
+build.args          INSTALLDIRS=vendor
+
+post-patch {
+    reinplace "s|perl Makefile.PL|${perl5.bin} Makefile.PL|" \
+        ${worksrcpath}/perl/Makefile.in
+    reinplace "s|#!/usr/bin/env perl|#!${perl5.bin}|" \
+        ${worksrcpath}/regedit/hivexregedit
+}
+
+post-destroot {
+    delete ${destroot}[perl5.extract_config privlib]/${perl5.arch}/perllocal.pod
+    delete ${destroot}${perl5.archlib}/auto/Win/Hivex/.packlist
+}


### PR DESCRIPTION
#### Description

[hivex](https://github.com/libguestfs/hivex) - a library for reading and writing Windows Registry "hive" files

###### Tested on
macOS 12.6.4 21G526 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?