### PR TITLE
liblsl: use boost181, fix build for older systems

### DIFF
--- a/science/liblsl/Portfile
+++ b/science/liblsl/Portfile
@@ -22,6 +22,9 @@ long_description    The lab streaming layer is a simple all-in-one approach \
                     lab, e.g. instrument time series, event markers, audio,\
                     and so on.
 
+# Based on our python patch, see: https://trac.macports.org/ticket/67212
+patchfiles          0001-loguru-fix-for-missing-pthread_is_threaded_np.patch
+
 compiler.cxx_standard \
                     2011
 
@@ -30,6 +33,11 @@ depends_build-append \
 
 configure.args-append   -DLSL_BUNDLED_BOOST=OFF \
                         -DLSL_BUNDLED_PUGIXML=OFF
+
+if {[string match *gcc* ${configure.compiler}]} {
+    # cc1: error: '-fno-fat-lto-objects' are supported only with linker plugin
+    configure.args-append   -DLSL_OPTIMIZATIONS=OFF
+}
 
 variant static description {Build LSL as a static library.} {
     configure.args-append   -DLSL_BUILD_STATIC=ON

--- a/science/liblsl/Portfile
+++ b/science/liblsl/Portfile
@@ -5,9 +5,13 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
+# https://github.com/sccn/liblsl/issues/189
+boost.version       1.81
+
 license             MIT
 
 github.setup        sccn liblsl 1.16.1 v
+revision            1
 categories          science
 maintainers         nomaintainer
 

--- a/science/liblsl/files/0001-loguru-fix-for-missing-pthread_is_threaded_np.patch
+++ b/science/liblsl/files/0001-loguru-fix-for-missing-pthread_is_threaded_np.patch
@@ -1,0 +1,32 @@
+From 87b69ef1025986168add56b55b034f1e8beb5288 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 11 Apr 2023 06:27:04 +0800
+Subject: [PATCH] loguru: fix for missing pthread_is_threaded_np
+
+---
+ thirdparty/loguru/loguru.cpp | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/thirdparty/loguru/loguru.cpp b/thirdparty/loguru/loguru.cpp
+index affe3b90..90110d8e 100644
+--- thirdparty/loguru/loguru.cpp
++++ thirdparty/loguru/loguru.cpp
+@@ -1084,7 +1084,17 @@ namespace loguru
+ 
+ 			#ifdef __APPLE__
+ 				uint64_t thread_id;
+-				pthread_threadid_np(pthread_self(), &thread_id);
++				#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060 || defined __POWERPC__
++				    thread_id = pthread_mach_thread_np(pthread_self());
++				#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++				    if (&pthread_threadid_np) {
++				        pthread_threadid_np(pthread_self(), &thread_id);
++				    } else {
++				        thread_id = pthread_mach_thread_np(pthread_self());
++				    }
++				#else
++				    pthread_threadid_np(pthread_self(), &thread_id);
++				#endif
+ 			#elif defined(__FreeBSD__)
+ 				long thread_id;
+ 				(void)thr_self(&thread_id);


### PR DESCRIPTION
#### Description

@herbygillot Please take a look.
As for why boost176 is problematic, see reply from upstream: https://github.com/sccn/liblsl/issues/189
boost171 fails, boost180 does not build with gcc. boost181 is generally preferable IMO, since several relevant bugs were fixed in it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
