### PR TITLE
shadowsocks-libev: new port

### DIFF
--- a/net/shadowsocks-libev/Portfile
+++ b/net/shadowsocks-libev/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        shadowsocks shadowsocks-libev 3.3.5 v
+github.tarball_from releases
+
+revision            0
+categories          net
+license             GPL-3
+maintainers         nomaintainer
+description         Lightweight secured SOCKS5 proxy
+
+long_description \
+    Shadowsocks-libev is written in pure C and depends on libev. \
+    It's designed to be a lightweight implementation of shadowsocks \
+    protocol, in order to keep the resource usage as low as possible.
+
+depends_build-append    port:autoconf \
+                        port:automake \
+                        port:libtool \
+                        port:asciidoc \
+                        port:xmlto
+depends_lib-append      port:mbedtls \
+                        port:libsodium \
+                        port:libev \
+                        port:c-ares \
+                        port:pcre
+
+checksums           rmd160  f59f766398f0ec6bdaf830d944cc349c88dbc6d3 \
+                    sha256  cfc8eded35360f4b67e18dc447b0c00cddb29cc57a3cec48b135e5fb87433488 \
+                    size    1959146
+
+set ssuser          _shadowsocks
+add_users ${ssuser} group=${ssuser} realname=Shadowsocks\ Daemon


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

[Shadowsocks-libev](https://github.com/shadowsocks/shadowsocks-libev) is a C implementation of the Shadowsocks SOCKS5 proxy protocol based on libev.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.4 20G1120 x86_64
Command Line Tools 13.2.0.0.1.1638488800

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
