### PR TITLE
google-cloud-sdk: update to 426.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             425.0.0
+version             426.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  532bbcdf8145dd00fd4c50307135d68c78952b98 \
-                    sha256  fda6e848ea6ee0fcfe43e5c1adae04e299c46bbe47eb98859b0f2b37c7f8b451 \
-                    size    104470917
+    checksums       rmd160  e65f47b0233098d4dc5c33365c337b9e0f938bcd \
+                    sha256  e80447f597b949fcb9a08b588dc75a99c52d2a63845fa063c933f8de611ad654 \
+                    size    104553114
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  f2f8c146ea3a7c1852a6fcd2f86fda2442f1261f \
-                    sha256  44a26c885a0daef7cd4cb0c59a7e5fdfce0bb16e95f499f14ab4e3b6bee1c5ad \
-                    size    124833944
+    checksums       rmd160  3b0a1cc95142c66b2bdac6811ffa887d599ee2c0 \
+                    sha256  1c9e58a16b0cb1b2de1d1bdaae1abf94f470f95cffa7633d267ca22934ad860b \
+                    size    124910295
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  f79d955bf57d1234ae278629ac240dce6dfbd359 \
-                    sha256  4fddab54b7b451c80345425e1f700c825eb80035c0a3e9dc04afc738efc0c29e \
-                    size    121666975
+    checksums       rmd160  232016ffc0929b5cd84e469f134fb9a2370dc0ea \
+                    sha256  2fca756c69cdd1e92a7ded3e6815714e30a1a73ccd5e2002ac1cc5d4fafd319b \
+                    size    121752922
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 426.0.0.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?