### PR TITLE
skaffold: update to 2.3.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.3.0 v
+github.setup        GoogleContainerTools skaffold 2.3.1 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  8f4ba36d82d77fb51e4e287e45e838b97de373aa \
-                    sha256  3d594a51b1fcb57ad11f4db4087594d2d89561db362bc84cd0de1e95c874a2ab \
-                    size    41810108
+checksums           rmd160  61af41bc9b41e351c049babb59df53fb90fbb053 \
+                    sha256  dcea0f25943cecaec0b66f478e823fd0f053ed9db38bf8695e0c2f1767801f8d \
+                    size    41813787
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.3.1.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?