### PR TITLE
new port: input-leap (fork of aqua/barrier)

### DIFF
--- a/aqua/input-leap/Portfile
+++ b/aqua/input-leap/Portfile
@@ -1,0 +1,77 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+PortGroup           openssl 1.0
+github.setup        input-leap input-leap 198779cf9e798aac6ad41427e32d031305736de3
+version             2.4.0-20230416
+revision            0
+categories          aqua net sysutils
+license             {GPL-2 OpenSSLException}
+maintainers         {iki.fi:koston @Koston-0xDEADBEEF} openmaintainer
+description         share a keyboard and mouse over the network
+long_description    ${name} shares a keyboard, mouse, and clipboard over the network.\
+                    It supports multiple operating systems, including macOS,\
+                    Linux, FreeBSD, OpenBSD, and Windows. It is a fork of barrier,\
+                    which in turn is a fork of synergy.
+
+checksums           rmd160  c6da02aaf782727da7cfd62f2fc11eac41da3834 \
+                    sha256  9f893bfa8719a62acb7f7012847a40988d5ab6ec8f75e78881d68988a96ea4e0 \
+                    size    5171389
+
+patchfiles          set-cmake-revision.patch \
+                    remove-gtest.patch
+patch.pre_args      -p1
+
+compiler.cxx_standard 2014
+
+depends_build-append \
+    port:pkgconfig \
+    port:gtest \
+    port:ghc-filesystem
+
+configure.args-append \
+    -DINPUTLEAP_BUILD_INSTALLER=OFF \
+    -DINPUTLEAP_BUILD_TESTS=OFF
+
+if {[variant_isset debug]} {
+    cmake.build_type    Debug
+    configure.optflags  -O0
+} else {
+    cmake.build_type    RelWithDebInfo
+
+    # Clear optflags for non-debug build; controlled by project
+    configure.optflags
+}
+
+# the gui requires metal
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    configure.args-append \
+        -DINPUTLEAP_BUILD_GUI=OFF
+} else {
+    PortGroup           qt5 1.0
+    PortGroup           app 1.0
+
+    qt5.depends_component \
+        qttools
+
+    app.create yes
+    app.icon   dist/macos/bundle/InputLeap.app/Contents/Resources/InputLeap.icns
+    app.retina yes
+}
+
+post-destroot {
+    if {[variant_isset debug]} {
+        # Save debug symbols for a debug build
+        system -W ${destroot}${prefix} "find ./bin -type f -perm -111 -exec dsymutil {} +"
+    }
+    xinstall -m 0644 -W ${worksrcpath}/doc input-leapc.1 input-leaps.1 ${destroot}${prefix}/share/man/man1
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath}/doc/ \
+            input-leap.conf.example \
+            input-leap.conf.example-advanced \
+            input-leap.conf.example-barebones \
+            input-leap.conf.example-basic \
+            ${destroot}${prefix}/share/doc/${name}
+}

--- a/aqua/input-leap/files/macOS-add-support-for-right-side-modifier-keys.patch
+++ b/aqua/input-leap/files/macOS-add-support-for-right-side-modifier-keys.patch
@@ -1,0 +1,202 @@
+diff --git a/src/lib/platform/OSXKeyState.cpp b/src/lib/platform/OSXKeyState.cpp
+index afcac51d..a932716a 100644
+--- a/src/lib/platform/OSXKeyState.cpp
++++ b/src/lib/platform/OSXKeyState.cpp
+@@ -28,17 +28,6 @@
+ 
+ namespace inputleap {
+ 
+-// Note that some virtual keys codes appear more than once.  The
+-// first instance of a virtual key code maps to the KeyID that we
+-// want to generate for that code.  The others are for mapping
+-// different KeyIDs to a single key code.
+-static const std::uint32_t s_shiftVK = kVK_Shift;
+-static const std::uint32_t s_controlVK = kVK_Control;
+-static const std::uint32_t s_altVK = kVK_Option;
+-static const std::uint32_t s_superVK = kVK_Command;
+-static const std::uint32_t s_capsLockVK = kVK_CapsLock;
+-static const std::uint32_t s_numLockVK = kVK_ANSI_KeypadClear; // 71
+-
+ static const std::uint32_t s_brightnessUp = 144;
+ static const std::uint32_t s_brightnessDown = 145;
+ static const std::uint32_t s_missionControlVK = 160;
+@@ -108,22 +97,21 @@ static const KeyEntry    s_controlKeys[] = {
+     // to map to.  also the enter key with numlock on is a modifier but i
+     // don't know which.
+ 
+-    // modifier keys.  OS X doesn't seem to support right handed versions
+-    // of modifier keys so we map them to the left handed versions.
+-    { kKeyShift_L,        s_shiftVK },
+-    { kKeyShift_R,        s_shiftVK }, // 60
+-    { kKeyControl_L,    s_controlVK },
+-    { kKeyControl_R,    s_controlVK }, // 62
+-    { kKeyAlt_L,        s_altVK },
+-    { kKeyAlt_R,        s_altVK },
+-    { kKeySuper_L,        s_superVK },
+-    { kKeySuper_R,        s_superVK }, // 61
+-    { kKeyMeta_L,        s_superVK },
+-    { kKeyMeta_R,        s_superVK }, // 61
++    // modifier keys. Support for right side keys is a later addition in macOS.
++    { kKeyShift_L,          kVK_Shift },        // 56
++    { kKeyShift_R,          kVK_RightShift },   // 60
++    { kKeyControl_L,        kVK_Control },      // 59
++    { kKeyControl_R,        kVK_RightControl }, // 62
++    { kKeyAlt_L,            kVK_Option },       // 58
++    { kKeyAlt_R,            kVK_RightOption },  // 61
++    { kKeySuper_L,          kVK_Command },      // 55
++    { kKeySuper_R,          kVK_RightCommand }, // 54
++    { kKeyMeta_L,           kVK_Command },      // 55
++    { kKeyMeta_R,           kVK_RightCommand }, // 54
+ 
+     // toggle modifiers
+-    { kKeyNumLock,        s_numLockVK },
+-    { kKeyCapsLock,        s_capsLockVK },
++    { kKeyNumLock,        kVK_ANSI_KeypadClear },
++    { kKeyCapsLock,        kVK_CapsLock },
+ 
+     { kKeyMissionControl, s_missionControlVK },
+     { kKeyLaunchpad, s_launchpadVK },
+@@ -521,30 +509,50 @@ void OSXKeyState::postHIDVirtualKey(const std::uint8_t virtualKeyCode, const boo
+ 
+     switch (virtualKeyCode)
+     {
+-    case s_shiftVK:
+-    case s_superVK:
+-    case s_altVK:
+-    case s_controlVK:
+-    case s_capsLockVK:
++    case kVK_Shift:
++    case kVK_RightShift:
++    case kVK_Command:
++    case kVK_RightCommand:
++    case kVK_Option:
++    case kVK_RightOption:
++    case kVK_Control:
++    case kVK_RightControl:
++    case kVK_CapsLock:
+         switch (virtualKeyCode)
+         {
+-        case s_shiftVK:
++        case kVK_Shift:
+                 modifiersDelta = NX_SHIFTMASK | NX_DEVICELSHIFTKEYMASK;
+                 m_shiftPressed = postDown;
+                 break;
+-        case s_superVK:
++        case kVK_RightShift:
++                modifiersDelta = NX_SHIFTMASK | NX_DEVICERSHIFTKEYMASK;
++                m_shiftPressed = postDown;
++                break;
++        case kVK_Command:
+                 modifiersDelta = NX_COMMANDMASK | NX_DEVICELCMDKEYMASK;
+                 m_superPressed = postDown;
+                 break;
+-        case s_altVK:
++        case kVK_RightCommand:
++                modifiersDelta = NX_COMMANDMASK | NX_DEVICERCMDKEYMASK;
++                m_superPressed = postDown;
++                break;
++        case kVK_Option:
+                 modifiersDelta = NX_ALTERNATEMASK | NX_DEVICELALTKEYMASK;
+                 m_altPressed = postDown;
+                 break;
+-        case s_controlVK:
++        case kVK_RightOption:
++                modifiersDelta = NX_ALTERNATEMASK | NX_DEVICERALTKEYMASK;
++                m_altPressed = postDown;
++                break;
++        case kVK_Control:
+                 modifiersDelta = NX_CONTROLMASK | NX_DEVICELCTLKEYMASK;
+                 m_controlPressed = postDown;
+                 break;
+-        case s_capsLockVK:
++        case kVK_RightControl:
++                modifiersDelta = NX_CONTROLMASK | NX_DEVICERCTLKEYMASK;
++                m_controlPressed = postDown;
++                break;
++        case kVK_CapsLock:
+                 modifiersDelta = NX_ALPHASHIFTMASK;
+                 m_capsPressed = postDown;
+                 break;
+@@ -794,7 +802,7 @@ bool OSXKeyState::map_hot_key_to_mac(KeyID key, KeyModifierMask mask,
+     return true;
+ }
+ 
+-void OSXKeyState::handleModifierKeys(const EventTarget* target,
++void OSXKeyState::handleModifierKeys(const EventTarget* target, std::uint32_t virtualKey,
+                                      KeyModifierMask oldMask, KeyModifierMask newMask)
+ {
+     // compute changed modifiers
+@@ -802,27 +810,27 @@ void OSXKeyState::handleModifierKeys(const EventTarget* target,
+ 
+     // synthesize changed modifier keys
+     if ((changed & KeyModifierShift) != 0) {
+-        handleModifierKey(target, s_shiftVK, kKeyShift_L,
++        handleModifierKey(target, virtualKey, m_virtualKeyMap.find(virtualKey)->second,
+                             (newMask & KeyModifierShift) != 0, newMask);
+     }
+     if ((changed & KeyModifierControl) != 0) {
+-        handleModifierKey(target, s_controlVK, kKeyControl_L,
++        handleModifierKey(target, virtualKey, m_virtualKeyMap.find(virtualKey)->second,
+                             (newMask & KeyModifierControl) != 0, newMask);
+     }
+     if ((changed & KeyModifierAlt) != 0) {
+-        handleModifierKey(target, s_altVK, kKeyAlt_L,
++        handleModifierKey(target, virtualKey, m_virtualKeyMap.find(virtualKey)->second,
+                             (newMask & KeyModifierAlt) != 0, newMask);
+     }
+     if ((changed & KeyModifierSuper) != 0) {
+-        handleModifierKey(target, s_superVK, kKeySuper_L,
++        handleModifierKey(target, virtualKey, m_virtualKeyMap.find(virtualKey)->second,
+                             (newMask & KeyModifierSuper) != 0, newMask);
+     }
+     if ((changed & KeyModifierCapsLock) != 0) {
+-        handleModifierKey(target, s_capsLockVK, kKeyCapsLock,
++        handleModifierKey(target, virtualKey, m_virtualKeyMap.find(virtualKey)->second,
+                             (newMask & KeyModifierCapsLock) != 0, newMask);
+     }
+     if ((changed & KeyModifierNumLock) != 0) {
+-        handleModifierKey(target, s_numLockVK, kKeyNumLock,
++        handleModifierKey(target, virtualKey, m_virtualKeyMap.find(virtualKey)->second,
+                             (newMask & KeyModifierNumLock) != 0, newMask);
+     }
+ }
+diff --git a/src/lib/platform/OSXKeyState.h b/src/lib/platform/OSXKeyState.h
+index 2288d9ce..df0ae3a4 100644
+--- a/src/lib/platform/OSXKeyState.h
++++ b/src/lib/platform/OSXKeyState.h
+@@ -51,7 +51,7 @@ public:
+     Determines which modifier keys have changed and updates the modifier
+     state and sends key events as appropriate.
+     */
+-    void handleModifierKeys(const EventTarget* target,
++    void handleModifierKeys(const EventTarget* target, std::uint32_t virtualKey,
+                             KeyModifierMask oldMask, KeyModifierMask newMask);
+ 
+     //@}
+diff --git a/src/lib/platform/OSXScreen.mm b/src/lib/platform/OSXScreen.mm
+index 214a6958..c8c74abd 100644
+--- a/src/lib/platform/OSXScreen.mm
++++ b/src/lib/platform/OSXScreen.mm
+@@ -1193,7 +1193,7 @@ OSXScreen::onKey(CGEventRef event)
+ 		// get old and new modifier state
+ 		KeyModifierMask oldMask = getActiveModifiers();
+ 		KeyModifierMask newMask = m_keyState->mapModifiersFromOSX(macMask);
+-        m_keyState->handleModifierKeys(get_event_target(), oldMask, newMask);
++        m_keyState->handleModifierKeys(get_event_target(), virtualKey, oldMask, newMask);
+ 
+ 		// if the current set of modifiers exactly matches a modifiers-only
+ 		// hot key then generate a hot key down event.
+diff --git a/src/lib/platform/OSXUchrKeyResource.cpp b/src/lib/platform/OSXUchrKeyResource.cpp
+index e4b87b65..b38082d5 100644
+--- a/src/lib/platform/OSXUchrKeyResource.cpp
++++ b/src/lib/platform/OSXUchrKeyResource.cpp
+@@ -97,8 +97,7 @@ OSXUchrKeyResource::isValid() const
+ 
+ std::uint32_t OSXUchrKeyResource::getNumModifierCombinations() const
+ {
+-    // only 32 (not 256) because the righthanded modifier bits are ignored
+-    return 32;
++    return 256;
+ }
+ 
+ std::uint32_t OSXUchrKeyResource::getNumTables() const

--- a/aqua/input-leap/files/remove-gtest.patch
+++ b/aqua/input-leap/files/remove-gtest.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index c62d96f1..1481b5c2 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -26,8 +26,6 @@ if (WIN32)
+     add_subdirectory(daemon)
+ endif()
+ 
+-include(../cmake/gtest.cmake)
+-
+ if(INPUTLEAP_BUILD_TESTS)
+     add_subdirectory(test/integtests)
+     add_subdirectory(test/unittests)

--- a/aqua/input-leap/files/set-cmake-revision.patch
+++ b/aqua/input-leap/files/set-cmake-revision.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/Version.cmake b/cmake/Version.cmake
+index 907e2fa0..84eb35d2 100644
+--- a/cmake/Version.cmake
++++ b/cmake/Version.cmake
+@@ -3,7 +3,8 @@ cmake_minimum_required (VERSION 3.4)
+ set(INPUTLEAP_VERSION_MAJOR 2)
+ set(INPUTLEAP_VERSION_MINOR 4)
+ set(INPUTLEAP_VERSION_PATCH 0)
+-set(INPUTLEAP_VERSION_STAGE "release")
++set(INPUTLEAP_VERSION_STAGE "git")
++set(INPUTLEAP_REVISION "00000000")
+ 
+ # InputLeap Version
+ if(NOT DEFINED INPUTLEAP_VERSION_MAJOR)


### PR DESCRIPTION
###### Type(s)
It's a new port, although mostly just a copy of existing 'aqua/barrier' port.
 * Added a patch which has yet to get merged upstream (which I'm the author of)
 * Set myself as port maintainer
 * Ad-hoc fixed debug variant to also package debug symbols

###### Tested on
macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

[skip notification]
