### PR TITLE
saga: patch use of finite() non-standard function

### DIFF
--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           wxWidgets 1.0
+
 wxWidgets.use       wxWidgets-3.2
 
 compiler.cxx_standard  2011
@@ -10,7 +11,7 @@ name                saga
 categories          gis
 license             GPL
 version             7.9.1
-revision            5
+revision            6
 maintainers         {vince @Veence} openmaintainer
 
 description         SAGA is a GIS oriented towards statistics and analysis
@@ -26,7 +27,8 @@ checksums           rmd160  fe7b74b3627277428e17141fe216f209d587a5ef \
                     sha256  26ad4b84149e26eabd4a5365fe4a3923cfa39e36672cc7c660d3549f3556a3bc \
                     size    5512365
 
-patchfiles          patch-configure.diff
+patchfiles          patch-configure.diff \
+                    patch-me-cpp.diff
 
 depends_build       port:autoconf \
                     port:automake \
@@ -80,7 +82,7 @@ variant python description "build Python 3.9 bindings" {
     configure.env-append    PYTHON_VERSION=3.9
 }
 
-variant libfire {
+variant libfire description "build with libfire" {
     configure.args-delete   --disable-libfire
 }
 

--- a/gis/saga/files/patch-me-cpp.diff
+++ b/gis/saga/files/patch-me-cpp.diff
@@ -1,0 +1,11 @@
+--- src/tools/imagery/imagery_maxent/me.cpp.orig	2021-07-07 17:32:32.000000000 +0200
++++ src/tools/imagery/imagery_maxent/me.cpp	2023-04-13 19:50:07.000000000 +0200
+@@ -21,7 +21,7 @@
+ #ifdef _SAGA_MSW
+ #define isinf(x) (!_finite(x))
+ #else
+-#define isinf(x) (!finite(x))
++#define isinf(x) (!isfinite(x))
+ #endif
+ 
+ /** The input array contains a set of log probabilities lp1, lp2, lp3


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Patches use of non-standard `finite()` function, causing compilation failure on (at least) ARM builds:

```
libtool: compile:  /usr/bin/clang++ -std=gnu++11 -DHAVE_CONFIG_H -I. -I../../../.. -I/opt/local/include -I/opt/local/lib/proj8/include -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk -fPIC -I../../../../src/saga_core -D_SAGA_LINUX -D_TYPEDEF_BYTE -D_TYPEDEF_WORD -g -DDEBUG -pipe -Os -std=c++11 -gdwarf-3 -stdlib=libc++ -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk -arch arm64 -MT me.lo -MD -MP -MF .deps/me.Tpo -c me.cpp  -fno-common -DPIC -o .libs/me.o
me.cpp:38:7: error: use of undeclared identifier 'finite'; did you mean 'isfinite'?
  if (isinf(max)) // the largest probability is 0 (log prob= -inf)
      ^
me.cpp:24:20: note: expanded from macro 'isinf'
#define isinf(x) (!finite(x))
                   ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/c++/v1/math.h:452:1: note: 'isfinite' declared here
isfinite(_A1 __lcpp_x) _NOEXCEPT
^
me.cpp:50:7: error: use of undeclared identifier 'finite'; did you mean 'isfinite'?
  if (isinf(logprob1) && isinf(logprob2)) 
      ^
me.cpp:24:20: note: expanded from macro 'isinf'
#define isinf(x) (!finite(x))
                   ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/c++/v1/math.h:452:1: note: 'isfinite' declared here
isfinite(_A1 __lcpp_x) _NOEXCEPT
^
me.cpp:50:26: error: use of undeclared identifier 'finite'; did you mean 'isfinite'?
  if (isinf(logprob1) && isinf(logprob2)) 
                         ^
me.cpp:24:20: note: expanded from macro 'isinf'
#define isinf(x) (!finite(x))
                   ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/c++/v1/math.h:452:1: note: 'isfinite' declared here
isfinite(_A1 __lcpp_x) _NOEXCEPT
^
3 errors generated.
make[5]: *** [me.lo] Error 1
```


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6.3 21G419 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
