### PR TITLE
lang/ruby32: update to 3.2.2

### DIFF
--- a/lang/ruby32/Portfile
+++ b/lang/ruby32/Portfile
@@ -10,7 +10,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 14
 
 set ruby_ver        3.2
-set ruby_patch      1
+set ruby_patch      2
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
@@ -37,9 +37,9 @@ master_sites        ruby:${ruby_ver}
 distname            ruby-${version}
 dist_subdir         ruby${ruby_ver_nodot}
 
-checksums           rmd160 81c2e76fa2fbc3a2812d533ddc257f15299b65c4 \
-                    sha256 13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd \
-                    size 20448976
+checksums           rmd160 510c28ffac900c7c3dd406097cffe664043056dc \
+                    sha256 96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc \
+                    size 20467023
 
 universal_variant   no
 


### PR DESCRIPTION
#### Description

[ruby 3.2.2](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/)

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
