### PR TITLE
isl-devel: update to 0.26

### DIFF
--- a/devel/isl-devel/Portfile
+++ b/devel/isl-devel/Portfile
@@ -12,7 +12,7 @@ set my_name         isl
 # (e.g. port file all | sort -u | xargs grep -E ':isl( |$)' | cut -d / -f 13 | sort -u)
 # see https://lists.macports.org/pipermail/macports-dev/2019-May/040678.html
 epoch               0
-version             0.25
+version             0.26
 revision            0
 
 categories          devel math
@@ -40,9 +40,9 @@ master_sites        sourceforge:libisl
 distname            ${my_name}-${version}
 use_bzip2           yes
 
-checksums           rmd160  73b9005b8e7fe52eb9500b98ba65450bdfb9f7fb \
-                    sha256  4305c54d4eebc4bf3ce365af85f04984ef5aa97a52e01128445e26da5b1f467a \
-                    size    2304378
+checksums           rmd160  f8b6f0b9dcc250f810de4b8c546d7c4727be13eb \
+                    sha256  5eac8664e9d67be6bd0bee5085d6840b8baf738c06814df47eaf4166d9776436 \
+                    size    2365753
 
 platform darwin {
     # Be more strict about detecting C++11 for older compilers
@@ -61,6 +61,10 @@ platform darwin {
 configure.args      --disable-silent-rules
 
 triplet.add_build   cross
+
+notes "
+Older versions of gcc may not build against ${name}. In such a case consider installing isl port instead.
+"
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
#### Description

Only devel port is updated, so should be safe. I added a note that older gcc may not build against it: `gcc6` does not, for example.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
