### PR TITLE
libtomcrypt: unbreak build on <10.7

### DIFF
--- a/security/libtomcrypt/Portfile
+++ b/security/libtomcrypt/Portfile
@@ -35,7 +35,8 @@ worksrcdir          ${name}-${version}
 use_configure       no
 
 build.args-append   CPPFLAGS="-DUSE_LTM -DLTM_DESC -I${prefix}/include/libtommath/" \
-                    CFLAGS="${configure.cc_archflags}"
+                    CFLAGS="${configure.cc_archflags}" \
+                    V=1
 build.target
 build.env           CC=${configure.cc}
 

--- a/security/libtomcrypt/Portfile
+++ b/security/libtomcrypt/Portfile
@@ -6,18 +6,16 @@ PortGroup           github 1.0
 github.setup        libtom libtomcrypt 1.18.2 v
 revision            1
 categories          security
-platforms           darwin
 maintainers         nomaintainer
 license             public-domain
 
-description         cryptographic toolkit
-long_description \
-	LibTomCrypt is a fairly comprehensive, modular and portable \
-	cryptographic toolkit that provides developers with a vast \
-	array of well known published block ciphers, one-way hash \
-	functions, chaining modes, pseudo-random number generators, \
-	public key cryptography and a plethora of other routines.
-homepage            http://www.libtom.net/LibTomCrypt/
+description         Cryptographic toolkit
+long_description    LibTomCrypt is a fairly comprehensive, modular and portable \
+                    cryptographic toolkit that provides developers with a vast \
+                    array of well known published block ciphers, one-way hash \
+                    functions, chaining modes, pseudo-random number generators, \
+                    public key cryptography and a plethora of other routines.
+homepage            https://www.libtom.net/LibTomCrypt
 
 distname            crypt-${version}
 github.tarball_from releases
@@ -34,10 +32,9 @@ patchfiles          patch-unbreak-10.6.diff
 
 worksrcdir          ${name}-${version}
 
-use_configure no
+use_configure       no
 
-build.args-append \
-                    CFLAGS="-DUSE_LTM -DLTM_DESC -I${prefix}/include/libtommath/"
+build.args-append   CFLAGS="-DUSE_LTM -DLTM_DESC -I${prefix}/include/libtommath/"
 build.target
 build.env           CC=${configure.cc} CFLAGS=${configure.cc_archflags}
 

--- a/security/libtomcrypt/Portfile
+++ b/security/libtomcrypt/Portfile
@@ -34,9 +34,10 @@ worksrcdir          ${name}-${version}
 
 use_configure       no
 
-build.args-append   CFLAGS="-DUSE_LTM -DLTM_DESC -I${prefix}/include/libtommath/"
+build.args-append   CPPFLAGS="-DUSE_LTM -DLTM_DESC -I${prefix}/include/libtommath/" \
+                    CFLAGS="${configure.cc_archflags}"
 build.target
-build.env           CC=${configure.cc} CFLAGS=${configure.cc_archflags}
+build.env           CC=${configure.cc}
 
 destroot.args       LIBPATH=${prefix}/lib INCPATH=${prefix}/include \
                     USER=`id -u` GROUP=`id -g` NODOCS=1

--- a/security/libtomcrypt/Portfile
+++ b/security/libtomcrypt/Portfile
@@ -29,6 +29,9 @@ checksums           rmd160  484fa6695e84448270d45851123249276d8add8d \
 
 depends_build       port:libtommath
 
+# https://github.com/libtom/libtomcrypt/issues/614
+patchfiles          patch-unbreak-10.6.diff
+
 worksrcdir          ${name}-${version}
 
 use_configure no

--- a/security/libtomcrypt/files/patch-unbreak-10.6.diff
+++ b/security/libtomcrypt/files/patch-unbreak-10.6.diff
@@ -1,0 +1,21 @@
+--- makefile_include.mk.orig	2023-04-15 18:26:17.000000000 +0800
++++ makefile_include.mk	2023-04-15 18:26:46.000000000 +0800
+@@ -92,7 +92,9 @@
+ LTC_CFLAGS += -Wwrite-strings
+ endif
+ 
++ifneq ($(findstring clang,$(CC)),)
+ LTC_CFLAGS += -Wno-type-limits
++endif
+ 
+ ifdef LTC_DEBUG
+ $(info Debug build)
+@@ -128,7 +130,7 @@
+ ifneq ($(findstring mingw,$(CC)),)
+ LTC_CFLAGS += -Wno-shadow -Wno-attributes
+ endif
+-ifeq ($(PLATFORM), Darwin)
++ifneq ($(findstring clang,$(CC)),)
+ LTC_CFLAGS += -Wno-nullability-completeness
+ endif
+ 


### PR DESCRIPTION
#### Description

Build system unconditionally uses flags which break the build with Apple gcc. Condition those correctly.

P. S. Reported to upstream, did not meet enthusiasm to have it fixed there: https://github.com/libtom/libtomcrypt/issues/614

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
