### PR TITLE
libjxl: unbreak build with gcc, add __STDC_FORMAT_MACROS

### DIFF
--- a/graphics/libjxl/Portfile
+++ b/graphics/libjxl/Portfile
@@ -48,7 +48,8 @@ patchfiles          giflib_include_order.patch \
                     include_order.patch \
                     find_asciidoc.patch \
                     apple-clang-version.patch \
-                    _mm512_cvtsi512_si32.patch
+                    _mm512_cvtsi512_si32.patch \
+                    unbreak-build-on-macOS-with-GCC-add.patch
 if {${os.platform} eq "darwin" && ${os.major} <= 15} {
     # No support for sized operator delete
     patchfiles-append   sized-deallocation.patch

--- a/graphics/libjxl/files/unbreak-build-on-macOS-with-GCC-add.patch
+++ b/graphics/libjxl/files/unbreak-build-on-macOS-with-GCC-add.patch
@@ -1,0 +1,84 @@
+# https://github.com/libjxl/libjxl/commit/97ec970d06ad04254f2cdcbe0bf8bba3166372b6
+
+--- examples/decode_oneshot.cc.orig	2023-02-03 20:15:36.000000000 +0800
++++ examples/decode_oneshot.cc	2023-04-28 00:07:50.000000000 +0800
+@@ -7,6 +7,10 @@
+ // available at once). The example outputs the pixels and color information to a
+ // floating point image and an ICC profile on disk.
+ 
++#ifndef __STDC_FORMAT_MACROS
++#define __STDC_FORMAT_MACROS
++#endif
++
+ #include <inttypes.h>
+ #include <limits.h>
+ #include <stdint.h>
+
+--- examples/decode_progressive.cc.orig	2023-02-03 20:15:36.000000000 +0800
++++ examples/decode_progressive.cc	2023-04-28 00:07:28.000000000 +0800
+@@ -6,6 +6,10 @@
+ // This C++ example decodes a JPEG XL image progressively (input bytes are
+ // passed in chunks). The example outputs the intermediate steps to PAM files.
+ 
++#ifndef __STDC_FORMAT_MACROS
++#define __STDC_FORMAT_MACROS
++#endif
++
+ #include <inttypes.h>
+ #include <limits.h>
+ #include <stdint.h>
+
+--- lib/jxl/base/status.h.orig	2023-02-03 20:15:36.000000000 +0800
++++ lib/jxl/base/status.h	2023-04-28 00:06:58.000000000 +0800
+@@ -94,12 +94,14 @@
+ //   #ifndef JXL_DEBUG_MYMODULE
+ //   #define JXL_DEBUG_MYMODULE 0
+ //   #endif JXL_DEBUG_MYMODULE
+-#define JXL_DEBUG(enabled, format, ...)                         \
+-  do {                                                          \
+-    if (enabled) {                                              \
+-      ::jxl::Debug(("%s:%d: " format "\n"), __FILE__, __LINE__, \
+-                   ##__VA_ARGS__);                              \
+-    }                                                           \
++#define JXL_DEBUG_TMP(format, ...) \
++  ::jxl::Debug(("%s:%d: " format "\n"), __FILE__, __LINE__, ##__VA_ARGS__)
++
++#define JXL_DEBUG(enabled, format, ...)     \
++  do {                                      \
++    if (enabled) {                          \
++      JXL_DEBUG_TMP(format, ##__VA_ARGS__); \
++    }                                       \
+   } while (0)
+ 
+ // JXL_DEBUG version that prints the debug message if the global verbose level
+
+--- lib/jxl/image_test_utils.h.orig	2023-02-03 20:15:36.000000000 +0800
++++ lib/jxl/image_test_utils.h	2023-04-28 00:05:06.000000000 +0800
+@@ -6,7 +6,13 @@
+ #ifndef LIB_JXL_IMAGE_TEST_UTILS_H_
+ #define LIB_JXL_IMAGE_TEST_UTILS_H_
+ 
++#ifndef __STDC_FORMAT_MACROS
++#define __STDC_FORMAT_MACROS
++#endif
++
++#include <inttypes.h>
+ #include <stddef.h>
++#include <stdint.h>
+ 
+ #include <cmath>
+ #include <limits>
+
+--- tools/speed_stats.cc.orig	2023-02-03 20:15:36.000000000 +0800
++++ tools/speed_stats.cc	2023-04-28 00:02:57.000000000 +0800
+@@ -5,6 +5,10 @@
+ 
+ #include "tools/speed_stats.h"
+ 
++#ifndef __STDC_FORMAT_MACROS
++#define __STDC_FORMAT_MACROS
++#endif
++
+ #include <inttypes.h>
+ #include <math.h>
+ #include <stddef.h>


### PR DESCRIPTION
#### Description

Known problem, known fix. PR to upstream: https://github.com/libjxl/libjxl/pull/2384

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
