### PR TITLE
gallery-dl: update to 1.25.2

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        mikf gallery-dl 1.25.1 v
+github.setup        mikf gallery-dl 1.25.2 v
 github.tarball_from releases
 distname            gallery_dl-${github.version}
 
@@ -12,9 +12,9 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  a45989118e034880344a1bd792e8c2878b01652e \
-                    sha256  bacf65cdc85db020f8b18e174357f88f7c0ab85b4466712e06b9526b71690cfe \
-                    size    530115
+checksums           rmd160  5b6b9553f304febc9ec3e1c5841a9ec69024ec6f \
+                    sha256  4fd3f3be339d70b68eee24f1059c6e71076200f569935fbdc037dca5284805d3 \
+                    size    532322
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites


### PR DESCRIPTION
#### Description

gallery-dl: update to 1.25.2

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
