### PR TITLE
gobject-introspection-devel: downgrade dependency to glib2-devel

### DIFF
--- a/gnome/gobject-introspection-devel/Portfile
+++ b/gnome/gobject-introspection-devel/Portfile
@@ -9,7 +9,7 @@ conflicts           gobject-introspection
 set my_name         gobject-introspection
 
 version             1.74.0
-revision            0
+revision            1
 
 categories          gnome
 platforms           darwin
@@ -40,9 +40,9 @@ depends_build       port:pkgconfig \
                     port:python${py_ver_nodot} \
                     port:py${py_ver_nodot}-cython
 
-# NOTE: Needs glib2 >= 2.74, currently only available via 'glib2-upstream'
+# NOTE: Needs glib2 >= 2.74, currently only available via 'glib2-devel'
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo \
-                    port:glib2-upstream \
+                    port:glib2-devel \
                     port:libffi \
                     port:py${py_ver_nodot}-mako \
                     port:py${py_ver_nodot}-markdown


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

`glib2-devel` has been updated to 2.74.0, so we can use it in `gobject-introspection-devel`. Needed for #17050.

Bump version to ensure dependency switchover.

Tested through build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
