### PR TITLE
hstr: update to 3.0.0

### DIFF
--- a/shells/hstr/Portfile
+++ b/shells/hstr/Portfile
@@ -3,14 +3,14 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dvorka hstr 2.6
+github.setup        dvorka hstr 3.0
 while {[llength [split ${version} .]] < 3} {
     version         ${version}.0
 }
 revision            0
-checksums           rmd160  144b2f5ebdcc50e3aaa3ecac39c9b12ee062cff5 \
-                    sha256  91100b00132a5f5f535141f117c18bfd7d6c95b3a161bf10c13c1195cf81cd1d \
-                    size    178263
+checksums           rmd160  325310ba3213efe8e644cc23157aa701fd74a063 \
+                    sha256  2b86871f5879e3e55b63130e498adfcbb910cd0e1a6e1c723e7b30076f8b974c \
+                    size    180128
 
 categories          shells
 license             Apache-2


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
