### PR TITLE
onetbb: update to 2021.9.0

### DIFF
--- a/devel/onetbb/Portfile
+++ b/devel/onetbb/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        oneapi-src oneTBB 2021.8.0 v
+github.setup        oneapi-src oneTBB 2021.9.0 v
 github.tarball_from archive
 conflicts           tbb
 
@@ -22,11 +22,10 @@ long_description    oneTBB is a flexible C++ library that simplifies the work \
                     of adding parallelism to complex applications, even if you \
                     are not a threading expert.
 
-checksums           rmd160  2f9fae5f442066bf8e7eb5067104d71d6e1ce15d \
-                    sha256  eee380323bb7ce864355ed9431f85c43955faaae9e9bce35c62b372d7ffd9f8b \
-                    size    2575336
+checksums           rmd160  512a17da62b94d14a4ac4d0c5482557c90643ed6 \
+                    sha256  1ce48f34dada7837f510735ff1172f6e2c261b09460e3bf773b49791d247d24e \
+                    size    2579150
 
-patch.pre_args      -p1
 patchfiles          patch-onetbb-older-platforms.diff
 
 compiler.blacklist-append   {clang < 700}

--- a/devel/onetbb/files/patch-onetbb-older-platforms.diff
+++ b/devel/onetbb/files/patch-onetbb-older-platforms.diff
@@ -1,21 +1,7 @@
-# https://github.com/oneapi-src/oneTBB/pull/840
-
-From 91b43909e83e02945df77f37b95b042d8f03a1c9 Mon Sep 17 00:00:00 2001
-From: barracuda156 <vital.had@gmail.com>
-Date: Tue, 15 Nov 2022 18:06:45 +0800
-Subject: [PATCH] Restore support for 32-bit platforms, add fix-ups for PPC
-
-
-diff --git a/cmake/compilers/AppleClang.cmake b/cmake/compilers/AppleClang.cmake
-index 5ebbdbd1..f27e1382 100644
---- a/cmake/compilers/AppleClang.cmake
-+++ b/cmake/compilers/AppleClang.cmake
-@@ -1,4 +1,4 @@
--# Copyright (c) 2020-2022 Intel Corporation
-+# Copyright (c) 2020-2023 Intel Corporation
- #
- # Licensed under the Apache License, Version 2.0 (the "License");
- # you may not use this file except in compliance with the License.
+diff --git cmake/compilers/AppleClang.cmake cmake/compilers/AppleClang.cmake
+index 5ebbdbd1..f0681744 100644
+--- cmake/compilers/AppleClang.cmake
++++ cmake/compilers/AppleClang.cmake
 @@ -37,7 +37,7 @@ if (CMAKE_OSX_ARCHITECTURES)
  else()
      set(_tbb_target_architectures "${CMAKE_SYSTEM_PROCESSOR}")
@@ -25,10 +11,10 @@ index 5ebbdbd1..f27e1382 100644
      set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -mrtm $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},12.0>>:-mwaitpkg>)
  endif()
  unset(_tbb_target_architectures)
-diff --git a/cmake/compilers/GNU.cmake b/cmake/compilers/GNU.cmake
-index 4555d77b..0e7a0287 100644
---- a/cmake/compilers/GNU.cmake
-+++ b/cmake/compilers/GNU.cmake
+diff --git cmake/compilers/GNU.cmake cmake/compilers/GNU.cmake
+index b60172c8..1ca1ca12 100644
+--- cmake/compilers/GNU.cmake
++++ cmake/compilers/GNU.cmake
 @@ -36,7 +36,13 @@ if (NOT CMAKE_GENERATOR MATCHES "Ninja" AND NOT CMAKE_CXX_DEPENDS_USE_COMPILER)
  endif()
  
@@ -44,17 +30,10 @@ index 4555d77b..0e7a0287 100644
      set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -mrtm $<$<AND:$<NOT:$<CXX_COMPILER_ID:Intel>>,$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},11.0>>>:-mwaitpkg>)
  endif()
  
-diff --git a/include/oneapi/tbb/task_group.h b/include/oneapi/tbb/task_group.h
-index 2bbacd55..dc671acb 100644
---- a/include/oneapi/tbb/task_group.h
-+++ b/include/oneapi/tbb/task_group.h
-@@ -1,5 +1,5 @@
- /*
--    Copyright (c) 2005-2022 Intel Corporation
-+    Copyright (c) 2005-2023 Intel Corporation
- 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
+diff --git include/oneapi/tbb/task_group.h include/oneapi/tbb/task_group.h
+index 2bbacd55..d282a5af 100644
+--- include/oneapi/tbb/task_group.h
++++ include/oneapi/tbb/task_group.h
 @@ -187,6 +187,23 @@ private:
      };
      task_group_context_version my_version;
@@ -100,13 +79,13 @@ index 2bbacd55..dc671acb 100644
  
  enum task_group_status {
      not_complete,
-diff --git a/src/tbb/def/mac32-tbb.def b/src/tbb/def/mac32-tbb.def
+diff --git src/tbb/def/mac32-tbb.def src/tbb/def/mac32-tbb.def
 new file mode 100644
-index 00000000..b3b1288a
+index 00000000..10eedc3c
 --- /dev/null
-+++ b/src/tbb/def/mac32-tbb.def
++++ src/tbb/def/mac32-tbb.def
 @@ -0,0 +1,159 @@
-+# Copyright (c) 2005-2023 Intel Corporation
++# Copyright (c) 2005-2021 Intel Corporation
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
 +# you may not use this file except in compliance with the License.
@@ -265,10 +244,110 @@ index 00000000..b3b1288a
 +_TBB_runtime_interface_version
 +_TBB_runtime_version
 +
-diff --git a/src/tbb/tools_api/ittnotify_config.h b/src/tbb/tools_api/ittnotify_config.h
+diff --git src/tbb/semaphore.h src/tbb/semaphore.h
+index 9d27f3ac..b8942329 100644
+--- src/tbb/semaphore.h
++++ src/tbb/semaphore.h
+@@ -22,8 +22,16 @@
+ #if _WIN32||_WIN64
+ #include <windows.h>
+ #elif __APPLE__
++#include <AvailabilityMacros.h>
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1060
+ #include <dispatch/dispatch.h>
+ #else
++#include <mach/semaphore.h>
++#include <mach/task.h>
++#include <mach/mach_init.h>
++#include <mach/error.h>
++#endif
++#else
+ #include <semaphore.h>
+ #ifdef TBB_USE_DEBUG
+ #include <cerrno>
+@@ -144,6 +152,7 @@ private:
+ };
+ #elif __APPLE__
+ //! Edsger Dijkstra's counting semaphore
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1060
+ class semaphore : no_copy {
+ public:
+     //! ctor
+@@ -160,6 +169,34 @@ public:
+ private:
+     dispatch_semaphore_t my_sem;
+ };
++#else
++class semaphore : no_copy {
++public:
++    //! ctor
++    semaphore(int start_cnt_ = 0) : sem(start_cnt_) { init_semaphore(start_cnt_); }
++    //! dtor
++    ~semaphore() {
++        kern_return_t ret = semaphore_destroy( mach_task_self(), sem );
++        __TBB_ASSERT_EX( ret==err_none, nullptr);
++    }
++    //! wait/acquire
++    void P() {
++        int ret;
++        do {
++            ret = semaphore_wait( sem );
++        } while( ret==KERN_ABORTED );
++        __TBB_ASSERT( ret==KERN_SUCCESS, "semaphore_wait() failed" );
++    }
++    //! post/release
++    void V() { semaphore_signal( sem ); }
++private:
++    semaphore_t sem;
++    void init_semaphore(int start_cnt_) {
++        kern_return_t ret = semaphore_create( mach_task_self(), &sem, SYNC_POLICY_FIFO, start_cnt_ );
++        __TBB_ASSERT_EX( ret==err_none, "failed to create a semaphore" );
++    }
++};
++#endif /* __APPLE__ */
+ #else /* Linux/Unix */
+ typedef uint32_t sem_count_t;
+ //! Edsger Dijkstra's counting semaphore
+@@ -231,7 +268,35 @@ private:
+ #endif /* !__TBB_USE_SRWLOCK */
+ #elif __APPLE__
+ //! binary_semaphore for concurrent monitor
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1060
+ using binary_semaphore = semaphore;
++#else
++class binary_semaphore : no_copy {
++public:
++    //! ctor
++    binary_semaphore() : my_sem(0) {
++        kern_return_t ret = semaphore_create( mach_task_self(), &my_sem, SYNC_POLICY_FIFO, 0 );
++        __TBB_ASSERT_EX( ret==err_none, "failed to create a semaphore" );
++    }
++    //! dtor
++    ~binary_semaphore() {
++        kern_return_t ret = semaphore_destroy( mach_task_self(), my_sem );
++        __TBB_ASSERT_EX( ret==err_none, nullptr);
++    }
++    //! wait/acquire
++    void P() {
++        int ret;
++        do {
++            ret = semaphore_wait( my_sem );
++        } while( ret==KERN_ABORTED );
++        __TBB_ASSERT( ret==KERN_SUCCESS, "semaphore_wait() failed" );
++    }
++    //! post/release
++    void V() { semaphore_signal( my_sem ); }
++private:
++    semaphore_t my_sem;
++};
++#endif /* __APPLE__ */
+ #else /* Linux/Unix */
+ 
+ #if __TBB_USE_FUTEX
+diff --git src/tbb/tools_api/ittnotify_config.h src/tbb/tools_api/ittnotify_config.h
 index 0f5d80f6..60cde151 100644
---- a/src/tbb/tools_api/ittnotify_config.h
-+++ b/src/tbb/tools_api/ittnotify_config.h
+--- src/tbb/tools_api/ittnotify_config.h
++++ src/tbb/tools_api/ittnotify_config.h
 @@ -184,6 +184,10 @@
  #  define ITT_ARCH_RISCV64  10
  #endif /* ITT_ARCH_RISCV64 */
@@ -291,17 +370,10 @@ index 0f5d80f6..60cde151 100644
  #    define ITT_ARCH ITT_ARCH_PPC64
  #  elif defined __loongarch__
  #    define ITT_ARCH ITT_ARCH_LOONGARCH64
-diff --git a/src/tbb/tools_api/ittnotify_static.c b/src/tbb/tools_api/ittnotify_static.c
-index 0b9aa492..23cff36d 100644
---- a/src/tbb/tools_api/ittnotify_static.c
-+++ b/src/tbb/tools_api/ittnotify_static.c
-@@ -1,5 +1,5 @@
- /*
--    Copyright (c) 2005-2021 Intel Corporation
-+    Copyright (c) 2005-2023 Intel Corporation
- 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
+diff --git src/tbb/tools_api/ittnotify_static.c src/tbb/tools_api/ittnotify_static.c
+index 0b9aa492..0144ebee 100644
+--- src/tbb/tools_api/ittnotify_static.c
++++ src/tbb/tools_api/ittnotify_static.c
 @@ -125,7 +125,7 @@ static const char* ittnotify_lib_name = "libittnotify.dylib";
  
  
@@ -311,13 +383,13 @@ index 0b9aa492..23cff36d 100644
  #define LIB_VAR_NAME INTEL_LIBITTNOTIFY32
  #else
  #define LIB_VAR_NAME INTEL_LIBITTNOTIFY64
-diff --git a/src/tbbmalloc/def/mac32-tbbmalloc.def b/src/tbbmalloc/def/mac32-tbbmalloc.def
+diff --git src/tbbmalloc/def/mac32-tbbmalloc.def src/tbbmalloc/def/mac32-tbbmalloc.def
 new file mode 100644
-index 00000000..4dae67f9
+index 00000000..b729364c
 --- /dev/null
-+++ b/src/tbbmalloc/def/mac32-tbbmalloc.def
++++ src/tbbmalloc/def/mac32-tbbmalloc.def
 @@ -0,0 +1,45 @@
-+# Copyright (c) 2005-2023 Intel Corporation
++# Copyright (c) 2005-2021 Intel Corporation
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
 +# you may not use this file except in compliance with the License.
@@ -362,17 +434,10 @@ index 00000000..4dae67f9
 +__ZN3rml13pool_identifyEPv
 +__ZN3rml10pool_msizeEPNS_10MemoryPoolEPv
 +
-diff --git a/src/tbbmalloc_proxy/proxy_overload_osx.h b/src/tbbmalloc_proxy/proxy_overload_osx.h
-index 69582983..942933e2 100644
---- a/src/tbbmalloc_proxy/proxy_overload_osx.h
-+++ b/src/tbbmalloc_proxy/proxy_overload_osx.h
-@@ -1,5 +1,5 @@
- /*
--    Copyright (c) 2005-2022 Intel Corporation
-+    Copyright (c) 2005-2023 Intel Corporation
- 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
+diff --git src/tbbmalloc_proxy/proxy_overload_osx.h src/tbbmalloc_proxy/proxy_overload_osx.h
+index 69582983..350310e3 100644
+--- src/tbbmalloc_proxy/proxy_overload_osx.h
++++ src/tbbmalloc_proxy/proxy_overload_osx.h
 @@ -134,10 +134,14 @@ struct DoMallocReplacement {
          introspect.force_lock = &zone_force_lock;
          introspect.force_unlock = &zone_force_unlock;
@@ -399,17 +464,10 @@ index 69582983..942933e2 100644
  
          // make sure that default purgeable zone is initialized
          malloc_default_purgeable_zone();
-diff --git a/test/common/doctest.h b/test/common/doctest.h
-index 3b906764..b7116596 100644
---- a/test/common/doctest.h
-+++ b/test/common/doctest.h
-@@ -1,5 +1,5 @@
- /*
--    Modifications Copyright (c) 2020-2022 Intel Corporation
-+    Modifications Copyright (c) 2020-2023 Intel Corporation
-     Modifications Licensed under the Apache License, Version 2.0;
-     You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- */
+diff --git test/common/doctest.h test/common/doctest.h
+index 3b906764..0d349aa9 100644
+--- test/common/doctest.h
++++ test/common/doctest.h
 @@ -412,6 +412,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
  #elif defined(DOCTEST_PLATFORM_MAC)
  #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
@@ -420,17 +478,10 @@ index 3b906764..b7116596 100644
  #else
  #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT (hicpp-no-assembler)
  #endif
-diff --git a/test/conformance/conformance_allocators.cpp b/test/conformance/conformance_allocators.cpp
-index 60ec5cae..f0b3c1b4 100644
---- a/test/conformance/conformance_allocators.cpp
-+++ b/test/conformance/conformance_allocators.cpp
-@@ -1,5 +1,5 @@
- /*
--    Copyright (c) 2005-2021 Intel Corporation
-+    Copyright (c) 2005-2023 Intel Corporation
- 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
+diff --git test/conformance/conformance_allocators.cpp test/conformance/conformance_allocators.cpp
+index 60ec5cae..7e40b0ab 100644
+--- test/conformance/conformance_allocators.cpp
++++ test/conformance/conformance_allocators.cpp
 @@ -31,6 +31,7 @@ TEST_CASE("Allocator concept") {
      TestAllocator<oneapi::tbb::cache_aligned_allocator<void>>(Concept);
      TestAllocator<oneapi::tbb::tbb_allocator<void>>(Concept);


### PR DESCRIPTION
@barracuda156 Could you provide an updated patch for older platforms? The current patch fails to apply in the new version.

###### Tested on
macOS 12.6.4 21G526 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?