### PR TITLE
py-argcomplete: update to 3.0.5

### DIFF
--- a/python/py-argcomplete/Portfile
+++ b/python/py-argcomplete/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-argcomplete
-version             2.0.0
+version             3.0.5
 license             Apache-2
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 
@@ -13,9 +13,9 @@ long_description    {*}${description}
 
 homepage            https://kislyuk.github.io/argcomplete
 
-checksums           rmd160  8b2287463686c297936e40164fcc2d5afcfd1601 \
-                    sha256  6372ad78c89d662035101418ae253668445b391755cfe94ea52f1b9d22425b20 \
-                    size    54164
+checksums           rmd160  836c52fbbbaaa43a9122ef7a6260126ccfde30ed \
+                    sha256  fe3ce77125f434a0dd1bffe5f4643e64126d5731ce8d173d36f62fa43d6eb6f7 \
+                    size    65470
 
 python.versions     37 38 39 310 311
 


### PR DESCRIPTION
###### Tested on
macOS 12.6.4 21G526 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?