### PR TITLE
crystal: update to 1.8.0

### DIFF
--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        crystal-lang crystal 1.7.2
+github.setup        crystal-lang crystal 1.8.0
 github.tarball_from archive
 revision            0
 categories          lang
@@ -18,7 +18,7 @@ long_description    Crystal is a fast, compiled programming language with a \
 
 homepage            https://crystal-lang.org
 
-set llvm_version    14
+set llvm_version    15
 
 depends_lib         port:boehmgc \
                     port:gmp \
@@ -40,13 +40,13 @@ master_sites-append https://github.com/crystal-lang/${name}/releases/download/${
 distfiles-append    ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  48f2fed91fb6aaa7b6ae10af188c4799011b98bd \
-                    sha256  614844c9cfc8306dbff15637beaa02647d2a2deacecefe37c1ff833e0047e4a4 \
-                    size    3121696 \
+                    rmd160  10a34f556ae2acaee55a315ee218256bb439d6dd \
+                    sha256  6353c3b3ca5a1ed6c8b3ee80e5141d130856ebc736c30d1684661001279c2fe1 \
+                    size    3169681 \
                     ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix} \
-                    rmd160  064b2227be3d5649c7d8d9615c60407d276d8a79 \
-                    sha256  29a64cb9a84fd86d0975fbdac4d69a9eb568322d142ce09eea6cf64a42e56e65 \
-                    size    46777712
+                    rmd160  00f12ba4b74f668264b110106477392415bc426c \
+                    sha256  08a6dc8873ce53af1ba603045a145fefe23f803c6badaa2b4d7e02c666d342d0 \
+                    size    57516167
 
 patchfiles          patch-static.diff
 


### PR DESCRIPTION
###### Tested on
macOS 12.6.4 21G526 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?