### PR TITLE
nrsc5: new port

### DIFF
--- a/audio/nrsc5/Portfile
+++ b/audio/nrsc5/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        theori-io nrsc5 eb76474193f228fd8fa697fc267b123c6c845a22
+
+revision            0
+version             1.0-20230418
+categories          audio
+maintainers         {netjibbing.com:blake @trodemaster} \
+                    openmaintainer
+license             GPL-3+
+
+description         This program receives NRSC-5 digital radio stations using an RTL-SDR dongle
+long_description    \
+This program receives NRSC-5 digital radio stations using an RTL-SDR dongle. It offers a command-line interface as well as an API upon which other applications can be built.
+
+checksums           rmd160  c0bade3db2333ebe2a8bc7a2ce27b88b1f229a59 \
+                    sha256  793a70b25c585babe5041267ab7bccf7d8f549bebe53d9228c4bf1e00c20ab41 \
+                    size    23168318
+
+patchfiles         CMakeLists.txt.diff
+
+configure.args-append \
+    -DUSE_NEON=ON \
+    -DUSE_SSE=ON \
+    -DUSE_FAAD2=ON
+
+depends_build-append \
+                    port:libtool \
+                    port:cmake \
+                    port:autoconf \
+                    port:automake
+
+depends_run         port:fftw \
+                    port:faad2
+
+depends_lib-append  port:rtl-sdr \
+                    port:libao
+

--- a/audio/nrsc5/files/CMakeLists.txt.diff
+++ b/audio/nrsc5/files/CMakeLists.txt.diff
@@ -1,0 +1,29 @@
+index d598c31..6680b2b 100644
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -81,7 +81,7 @@ endif ()
+ 
+ if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm.*")
+     if (USE_NEON)
+-        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4")
++        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mcpu=apple-m1")
+         add_definitions (-DHAVE_NEON)
+     endif()
+ endif()
+index cee353f..e300fd8 100644
+--- src/CMakeLists.txt.orig
++++ src/CMakeLists.txt
+@@ -18,12 +18,12 @@ endif()
+ 
+ configure_file (config.h.in config.h)
+ include_directories (
++    "${CMAKE_SOURCE_DIR}/include"
+     ${FAAD2_INCLUDE_DIRS}
+     ${AO_INCLUDE_DIRS}
+     ${RTL_SDR_INCLUDE_DIRS}
+     ${FFTW3F_INCLUDE_DIRS}
+     "${CMAKE_CURRENT_BINARY_DIR}"
+-    "${CMAKE_SOURCE_DIR}/include"
+ )
+ link_directories (
+     ${FAAD2_LIBRARY_DIRS}


### PR DESCRIPTION
#### Description
Adding new port nrsc5

###### Type(s)
- [x] enhancement

###### Tested on
macOS 13.3.1 22E261 arm64
Xcode 14.1 14B47b

###### Verification 

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [X] tested basic functionality of all binary files?
