### PR TITLE
nim: update to 1.6.12

### DIFF
--- a/lang/nim/Portfile
+++ b/lang/nim/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                nim
-version             1.6.10
+version             1.6.12
 revision            0
 license             MIT
 categories          lang
@@ -20,9 +20,9 @@ long_description    Nim is a statically typed compiled systems programming \
 homepage            https://nim-lang.org
 
 master_sites        ${homepage}/download/
-checksums           rmd160  1e6388cbdb349cba4b4faa504549f86701201f63 \
-                    sha256  13d7702f8b57087babe8cd051c13bc56a3171418ba867b49c6bbd09b29d24fea \
-                    size    5216284
+checksums           rmd160  6481711d9d9fcd5d939b797b61a114528ed723d2 \
+                    sha256  acef0b0ab773604d4d7394b68519edb74fb30f46912294b28bc27e0c7b4b4dc2 \
+                    size    5180496
 
 use_configure       no
 use_xz              yes


### PR DESCRIPTION
#### Description

Update the nim language installation to the current version, 1.6.12

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 21G419 arm64
Xcode 13.3.1 13E500a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
