### PR TITLE
libocca: update patch to fix clang builds on <10.12

### DIFF
--- a/devel/libocca/files/0003-Check-for-CLOCK_UPTIME_RAW-on-macOS-before-using-it.patch
+++ b/devel/libocca/files/0003-Check-for-CLOCK_UPTIME_RAW-on-macOS-before-using-it.patch
@@ -3,20 +3,23 @@ From: Sergey Fedorov <vital.had@gmail.com>
 Date: Tue, 28 Feb 2023 23:20:26 +0800
 Subject: [PATCH 3/3] Check for CLOCK_UPTIME_RAW on macOS before using it
 
----
- src/occa/internal/utils/sys.cpp | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/src/occa/internal/utils/sys.cpp b/src/occa/internal/utils/sys.cpp
-index eedbd4cb..01d6b0ed 100644
 --- src/occa/internal/utils/sys.cpp
 +++ src/occa/internal/utils/sys.cpp
-@@ -82,7 +82,7 @@ namespace occa {
+@@ -20,7 +20,7 @@
+ #    include <sys/sysinfo.h>
+ #  else // OCCA_MACOS_OS
+ #    include <mach/mach_host.h>
+-#    ifdef __clang__
++#    ifdef CLOCK_UPTIME_RAW
+ #      include <CoreServices/CoreServices.h>
+ #      include <mach/mach_time.h>
+ #    else
+@@ -82,7 +82,7 @@
  
        return (double) (ct.tv_sec + (1.0e-9 * ct.tv_nsec));
  #elif (OCCA_OS == OCCA_MACOS_OS)
 -#  ifdef __clang__
-+#  if defined __clang__ && defined CLOCK_UPTIME_RAW
++#  ifdef CLOCK_UPTIME_RAW
        uint64_t nanoseconds = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
  
        return 1.0e-9 * nanoseconds;


### PR DESCRIPTION
#### Description

Currently `libocca` fails on all Intel systems < 10.12. I cannot test these, but looking at the failures in logs, this seems to be a likely fix. I have verified the build on 10.6 with gcc.
See: https://trac.macports.org/ticket/67259

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
