### PR TITLE
proxmark3-iceman: enhance envs and fix library deps

### DIFF
--- a/science/proxmark3-iceman/Portfile
+++ b/science/proxmark3-iceman/Portfile
@@ -12,7 +12,7 @@ checksums           sha256  cd97f7cdbba3c3d6519ce90cec806a0c72ef39f4aa8861403339
                     rmd160  6e2ded3d11ff71e80b3a4a7a3b7ae7761472fe2d \
                     size    25039535
 
-revision            0
+revision            1
 license             GPL-3+
 categories          science comms
 platforms           darwin
@@ -29,8 +29,11 @@ depends_lib-append  port:readline \
                     port:jansson \
                     port:lua52 \
                     port:python311 \
-                    port:bzip2
+                    port:bzip2 \
+                    port:openssl11
 
+# Although port:pkgconfig is required (see comments below), because the qt5 PortGroup
+# includes it, its not listed here.
 depends_build-append \
                     port:arm-none-eabi-gcc \
                     port:arm-none-eabi-binutils \
@@ -55,13 +58,17 @@ configure.pkg_config_path-append \
 # pm3 does not have a ./configure script
 use_configure       no
 
+# PKG_CONFIG_ENV is used by the upstream buildsystem,
+# which basically is a variable to point out PKG_CONFIG_PATH
+# to shell calls inside Makefiles.
 build.env-append    USE_BREW=0 \
                     USE_MACPORTS=1 \
                     PREFIX=${prefix} \
                     SKIPWHEREAMISYSTEM=1 \
                     MACPORTS_PREFIX=${prefix} \
                     PATH=${prefix}/libexec/gnubin:$env(PATH) \
-                    PKG_CONFIG_PATH=${configure.pkg_config_path}
+                    PKG_CONFIG_PATH=${configure.pkg_config_path} \
+                    PKG_CONFIG_ENV=PKG_CONFIG_PATH=${configure.pkg_config_path}
 
 build.args-append   CC=${configure.cc} \
                     CXX=${configure.cxx} \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Some non-critical parts of the upstream repository have imports to OpenSSL, we (at upstream) prefer OpenSSL 1.1; though somehow even I did not reference it as a dependency in the Portfile, it still gets built.

This PR adds the unreferenced dependency and adds clarified environment variables.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

macOS 13 still has trace mode broken, `-vs` flag is used instead of `-vst`.