### PR TITLE
hut: new port, CLI for SourceHut API

### DIFF
--- a/devel/hut/Portfile
+++ b/devel/hut/Portfile
@@ -1,0 +1,64 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            git.sr.ht/~emersion/hut 0.3.0 v
+revision            0
+
+description         A CLI tool for sr.ht.
+
+long_description    ${name} lets you interact with the SourceHut API from the \
+                    command line. See the man page for a full list of \
+                    available commands.
+
+categories          devel
+installs_libs       no
+license             AGPL-3
+maintainers         {woolsweater.net:macports @woolsweater} \
+                    openmaintainer
+
+checksums           rmd160  6d031cf9704c4645e0f1036989000126ae78d482 \
+                    sha256  ca191d663be81000c8ac0e952cd1b95fbded8c1d918d6d89ff08adbcd3d75289 \
+                    size    116316
+
+depends_build-append \
+                    port:scdoc
+
+# Tarball contents name conflicts with the default work dir name
+worksrcdir          ${name}-${version}-${epoch}
+
+# Allow Go to fetch dependencies at build time
+build.env-delete    GO111MODULE=off GOPROXY=off
+
+build.cmd           \
+    ${build.cmd} -ldflags \" \
+        -X main.version=v${version} -X main.builtBy=macports \
+    \" \&\& \
+    make completions doc/${name}.1
+
+destroot {
+    # install binary:
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+
+    # install man page:
+    xinstall -m 0644 \
+        ${worksrcpath}/doc/${name}.1 \
+        ${destroot}${prefix}/share/man/man1/${name}.1
+
+    # install shell completions:
+    # bash:
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    file copy ${worksrcpath}/${name}.bash \
+        ${destroot}${prefix}/share/bash-completion/completions/${name}
+
+    # zsh:
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    file copy ${worksrcpath}/${name}.zsh \
+        ${destroot}${prefix}/share/zsh/site-functions/_${name}
+
+    # fish:
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
+    file copy ${worksrcpath}/${name}.fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d/${name}.fish
+}


### PR DESCRIPTION
#### Description

Add [`hut`, a CLI for the SourceHut.org API](https://sr.ht/~emersion/hut/), to the MacPorts tree.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 21G419 arm64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
