### PR TITLE
KeePassXC-devel: update to 20230416.git28e2806

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -38,6 +38,7 @@ if {${subport} eq ${name}} {
     distname            keepassxc-${version}-src
     use_xz              yes
     distfiles-append    ${distname}${extract.suffix}.sig
+    worksrcdir          keepassxc-${version}
 
     conflicts           KeePassXC-devel
 
@@ -54,21 +55,25 @@ if {${subport} eq ${name}} {
     gpg_verify.use_gpg_verification \
                         yes
 
+    patchfiles-append    add_support_for_qt5.6.diff
+
 } else {
     # devel subport
-    github.setup        keepassxreboot keepassxc 12be175d583fbfac5a7b6b250a3bb5f792925285
+    github.setup        keepassxreboot keepassxc 28e2806e077a2871dbb4f7e960febfc3653b6719
     set githash         [string range ${github.version} 0 6]
-    version             20221120.git${githash}
+    version             20230416.git${githash}
     revision            0
 
     conflicts           KeePassXC
 
-    checksums           rmd160  031fee017468df9410f58cdca2841d0c7d01cfbe \
-                        sha256  9e81c92baefe7adafbd3f1caee927ef9a55c02b2d7f8f4efb70b6f1390ad963a \
-                        size    11245059
+    checksums           rmd160  f7368e399fd091a089878257c7bdc875115fd33e \
+                        sha256  04b44a3bf60e57b50577d755a470524ca45b919fa48082a1a23db0ec38813ed1 \
+                        size    10718196
 
     gpg_verify.use_gpg_verification \
                         no
+
+    patchfiles-append   devel/add_support_for_old_macos-2.diff
 
 }
 
@@ -103,8 +108,7 @@ depends_lib-append      port:argon2 \
 
 patchfiles-append       patch-no-deployqt.diff \
                         patch-no-findpackage-path.diff \
-                        add_support_for_old_macos.diff \
-                        add_support_for_qt5.6.diff
+                        add_support_for_old_macos.diff
 
 # KeePassXC uses -fstack-protector-strong on Clang [1]. That flag is not
 # available until clang 602 [2] or upstream clang 3.5 [3]

--- a/security/KeePassXC/files/devel/add_support_for_old_macos-2.diff
+++ b/security/KeePassXC/files/devel/add_support_for_old_macos-2.diff
@@ -1,0 +1,34 @@
+--- src/gui/osutils/macutils/AppKitImpl.mm
++++ src/gui/osutils/macutils/AppKitImpl.mm
+@@ -66,7 +66,7 @@
+ 
+ - (void) observeValueForKeyPath:(NSString *)keyPath
+                       ofObject:(id)object
+-                        change:(NSDictionary<NSKeyValueChangeKey,id> *)change
++                        change:(NSDictionary *)change
+                        context:(void *)context
+ {
+     Q_UNUSED(object)
+@@ -80,8 +80,10 @@
+             };
+ 
+             if(@available(macOS 11.0, *)) {
++#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
+                 // Not sure why exactly this call is needed, but Apple sample code uses it so it's best to use it here too
+                 [NSApp.effectiveAppearance performAsCurrentDrawingAppearance:emitBlock];
++#endif
+             }
+             else {
+                 emitBlock();
+@@ -139,7 +141,11 @@
+ //
+ - (bool) isDarkMode
+ {
++#if __clang_major__ >= 9 && MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
+     return [NSApp.effectiveAppearance.name isEqualToString:NSAppearanceNameDarkAqua];
++#else
++    return false;
++#endif
+ }
+ 
+ 


### PR DESCRIPTION
#### Description
KeePassXC-devel:
 - update to 20230416.git28e2806 (latest commit of upstream's
release/2.7.x branch)
 - add patch to build on older macos

KeePassXC:
 - fix build with MacPorts 2.8.1 (set worksrcdir)
 - no need to increment revision
 - 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
