### PR TITLE
tetgen: new port

### DIFF
--- a/science/tetgen/Portfile
+++ b/science/tetgen/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+
+name                    tetgen
+version                 1.6.0
+revision                0
+categories              science
+license                 AGPL-3
+maintainers             {xyloid.org:dave @mdave} openmaintainer
+description             A Quality Tetrahedral Mesh Generator and a 3D Delaunay Triangulator
+long_description        TetGen is a program to generate tetrahedral meshes of any 3D polyhedral \
+                        domains. TetGen generates exact constrained Delaunay \
+                        tetrahedralizations, boundary conforming Delaunay meshes, \
+                        and Voronoi partitions.
+
+homepage                https://wias-berlin.de/software/tetgen/
+master_sites            http://www.tetgen.org/1.5/src/
+distname                tetgen${version}
+
+patchfiles-append       cmake-fix.diff
+
+checksums               rmd160  644889f1234e34ce27276ff062fb265a7e35cada \
+                        sha256  87b5e61ebd3a471fc4f2cdd7124c2b11dd6639f4feb1f941a5d2f5110d05ce39 \
+                        size    296711

--- a/science/tetgen/files/cmake-fix.diff
+++ b/science/tetgen/files/cmake-fix.diff
@@ -1,0 +1,37 @@
+--- CMakeLists.txt.orig	2023-03-30 09:53:15
++++ CMakeLists.txt	2023-03-30 09:51:22
+@@ -1,14 +1,26 @@
+ # Set  the minimum  required version  of cmake  for a  project.
+ cmake_minimum_required(VERSION 2.6)
+ 
+-# Add an executable to the project using the specified source files.
+-add_executable(tetgen tetgen.cxx predicates.cxx)
++set(TET_MAJOR_VERSION 1)
++set(TET_MINOR_VERSION 6)
++set(TET_PATCH_VERSION 0)
+ 
+-#Add a library to the project using the specified source files. 
+-# In Linux/Unix, it will creates the libtet.a
+-add_library(tet STATIC tetgen.cxx predicates.cxx)
+-
++#Add a shared library to the project using the specified source files.
++add_library(tetlib SHARED tetgen.cxx predicates.cxx)
+ #Set properties on a target. 
+ #We use this here to set -DTETLIBRARY for when compiling the
+ #library
+-set_target_properties(tet PROPERTIES "COMPILE_DEFINITIONS" TETLIBRARY)
+\ No newline at end of file
++set_target_properties(tetlib PROPERTIES "COMPILE_DEFINITIONS" TETLIBRARY)
++set_target_properties(tetlib PROPERTIES OUTPUT_NAME tet)
++set_target_properties(tetlib PROPERTIES
++    VERSION ${TET_MAJOR_VERSION}.${TET_MINOR_VERSION}.${TET_PATCH_VERSION}
++    SOVERSION ${TET_MAJOR_VERSION}.${TET_MINOR_VERSION})
++
++# Add an executable to the project using the specified source files.
++add_executable(tetgen tetgen.cxx)
++target_link_libraries(tetgen tetlib)
++
++# Install
++install(TARGETS tetgen DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
++install(TARGETS tetlib DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
++install(FILES tetgen.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)


### PR DESCRIPTION
#### Description

This PR adds a new port for the `tetgen` mesh generator. It ships with a small patch to fix CMake installation and build a shared library vs. static libraries, adopted from that found in Debian packaging.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.2.1 22D68 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
