### PR TITLE
gcc*: allow ppc64

### DIFF
--- a/lang/gcc5/Portfile
+++ b/lang/gcc5/Portfile
@@ -12,7 +12,7 @@ epoch               2
 version             5.5.0
 revision            6
 platforms           {darwin < 15} {darwin >= 10}
-supported_archs     x86_64 i386 ppc
+supported_archs     x86_64 i386 ppc ppc64
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc6/Portfile
+++ b/lang/gcc6/Portfile
@@ -13,7 +13,7 @@ version             6.5.0
 revision            7
 subport             libgcc6 { revision 4 }
 platforms           {darwin < 15}
-supported_archs     x86_64 i386 ppc
+supported_archs     x86_64 i386 ppc ppc64
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -13,7 +13,7 @@ version             7.5.0
 revision            3
 subport             libgcc7 { revision 1 }
 platforms           {darwin < 15}
-supported_archs     x86_64 i386 ppc
+supported_archs     x86_64 i386 ppc ppc64
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -13,7 +13,7 @@ version             8.5.0
 revision            1
 subport             libgcc8 { revision 1 }
 platforms           {darwin < 15} {darwin >= 10}
-supported_archs     x86_64 i386 ppc
+supported_archs     x86_64 i386 ppc ppc64
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -13,7 +13,7 @@ version             9.5.0
 revision            0
 subport             libgcc9 { revision 2 }
 platforms           {darwin < 15} {darwin >= 10}
-supported_archs     x86_64 i386 ppc
+supported_archs     x86_64 i386 ppc ppc64
 categories          lang
 maintainers         nomaintainer
 # an exception in the license allows dependents to not be GPL


### PR DESCRIPTION
#### Description

Recent commit mistakenly omitted `ppc64` from archs list: https://github.com/macports/macports-ports/commit/105898812d94afbce6c41b37562c05df9467ad90
Fix that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
