### PR TITLE
symfony-cli: new port

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -1,0 +1,76 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+version             5.5.2
+revision            0
+
+if {${os.major} >= 17} {
+    set source_build    yes
+} else {
+    set source_build    no
+}
+
+if ${source_build} {
+    PortGroup           golang 1.0
+
+    go.setup            github.com/symfony-cli/symfony-cli ${version} v
+} else {
+    PortGroup           github 1.0
+
+    github.setup        symfony-cli symfony-cli ${version} v
+}
+
+name                symfony-cli
+
+homepage            https://symfony.com/download
+
+description         The Symfony CLI tool
+
+long_description    The Symfony CLI tool is a must-have tool when developing \
+                    Symfony applications on your local machine.
+
+categories          devel
+installs_libs       no
+license             AGPL-3.0
+maintainers         {@antalaron antalaron.hu:antalaron} \
+                    openmaintainer
+
+if ${source_build} {
+    # Allow Go to fetch dependencies at build time
+    build.env-delete    GO111MODULE=off GOPROXY=off
+    build.env           CGO_ENABLED=0
+    build.args          -o ${workpath}/symfony -trimpath -ldflags="-s -w -X 'main.version=${version}' -X 'main.channel=stable'"
+
+    use_parallel_build  no
+
+    checksums           rmd160  e125c2a85f8f011b1b9951bb7a7539183924ffb4 \
+                        sha256  a8b4c4c97deeab3bb002d31fd8303d8f18fc2a42d7bbf54a1d1ff68ccfb9d1c8 \
+                        size    249833
+
+    github.tarball_from archive
+} else {
+    build {}
+
+    distname            symfony-cli_darwin_all
+
+    checksums           rmd160  ddc726ee6ff7289d0694929f92eb05506211cd87 \
+                        sha256  fea3bd74de86b31c4b47fd40bd4532415c7125a7b5d4830c83365de43b600c98 \
+                        size    10908908
+
+    github.tarball_from releases
+
+    use_configure       no
+}
+
+destroot {
+    if ${source_build} {
+        if {${configure.build_arch} eq {arm64}} {
+            system "codesign -f -s - ${workpath}/symfony"
+        }
+    }
+
+    xinstall -m 0755 -W ${workpath} symfony ${destroot}${prefix}/bin
+}
+
+github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description

The Symfony binary is a must-have tool when developing Symfony applications on your local machine. It provides:

- The best way to create new Symfony applications;
- A powerful local web server to develop your projects with support for TLS certificates;
- A tool to check for security vulnerabilities;
- Seamless integration with Platform.sh.

https://github.com/symfony-cli/symfony-cli/

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?