### PR TITLE
Serial-Studio: new port

### DIFF
--- a/sysutils/Serial-Studio/Portfile
+++ b/sysutils/Serial-Studio/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem             1.0
+PortGroup              github 1.0
+PortGroup              qmake5 1.0
+
+github.setup           Serial-Studio Serial-Studio 1.1.7 v
+revision               0
+
+categories             sysutils graphics
+license                MIT
+maintainers            {@sikmir disroot.org:sikmir} openmaintainer
+
+description            Multi-purpose serial data visualization & processing program
+long_description       {*}${description}
+
+homepage               https://serial-studio.github.io/
+
+# Fetch from git instead of distfile because it needs submodules
+fetch.type             git
+
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+qt5.depends_component  qtquickcontrols2 \
+                       qtserialport \
+                       qtsvg
+
+destroot {
+    copy ${worksrcpath}/SerialStudio.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description

https://serial-studio.github.io:
> Serial Studio allows you to easily display, process & export data from your embedded projects. The application is able to interact with serial ports, network sockets & MQTT brokers.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
