### PR TITLE
openjdk20-oracle: update to 20.0.1

### DIFF
--- a/java/openjdk20-oracle/Portfile
+++ b/java/openjdk20-oracle/Portfile
@@ -14,24 +14,24 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://jdk.java.net/20/
-version      20
+version      20.0.1
 revision     0
 
 description  Oracle OpenJDK 20
 long_description Open-source Oracle build of OpenJDK 20, the Java Development Kit, an implementation of the Java SE Platform.
 
-master_sites https://download.java.net/java/GA/jdk${version}/bdc68b4b9cbc4ebcb30745c85038d91d/36/GPL/
+master_sites https://download.java.net/java/GA/jdk${version}/b4887098932d415489976708ad6d1a4b/9/GPL/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  54d754bdb6ca6b152d6a1602ee3c1c55d6c939e2 \
-                 sha256  47cf960d9bb89dbe987535a389f7e26c42de7c984ef5108612d77c81aa8cc6a4 \
-                 size    194328775
+    checksums    rmd160  afe22426379c1fb266baa139e41e1251da393cff \
+                 sha256  215a181fda2ac9f33d8262476eba6c9beb0ae20d2b592e03411fe71a7d89bb24 \
+                 size    194341938
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  723284f11a4a4ae47fa207c6b5497f586eff5852 \
-                 sha256  d020f5c512c043cfb7119a591bc7e599a5bfd76d866d939f5562891d9db7c9b3 \
-                 size    191881541
+    checksums    rmd160  64775d68ff1a17c72b8aceb1fdf9e979b70501fe \
+                 sha256  78ae5bb4c96632df8d3f776919c95653d1afd3e715981c4d33be5b3c81d05420 \
+                 size    191896005
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle OpenJDK 20.0.1.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?