### PR TITLE
jdk20: update to 20.0.1

### DIFF
--- a/java/jdk20/Portfile
+++ b/java/jdk20/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk20-mac
-version      20
+version      20.0.1
 revision     0
 
 description  Oracle Java SE Development Kit 20
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/20/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  cd9571debaac419d3bbc8aab4373764422312636 \
-                 sha256  2edd1fe55ad66d796a9e950d9bb47531e0cce904d84b16401b1841bdaed77813 \
-                 size    187912823
+    checksums    rmd160  07b19469bf70705ab47855d62f589785d8fc0eca \
+                 sha256  3f8b53c63d1f821d5ff8875140428cbb679159ce0d91294ac349b1634fe994df \
+                 size    187934697
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  316aacce83655f3e02d6c715f747714c934dfdf9 \
-                 sha256  cfde57f46d1a24d95681d18e2267fc6ecf890e3ed4f1f46d87e551e7da8ac935 \
-                 size    185480492
+    checksums    rmd160  ae7141bee462cfd6bfdf7d54aa18d16a4851fbc8 \
+                 sha256  c264fd7452dd0aa86022b371b8abea3fa2a0b62b45ff7d189e7c519fe837bdb8 \
+                 size    185476515
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 20.0.1.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?