### PR TITLE
micronaut: update to 3.9.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.8.9 v
+github.setup    micronaut-projects micronaut-starter 3.9.0 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  adc68aab73bb9b3aecd84df9fef2f1f1c3e3c62c \
-                sha256  4dd2e7b991ceb76a8496466570d65613aa1ba2e5bab6d5ba45e73e2d6f129de4 \
-                size    20180490
+checksums       rmd160  8767745fc070422ae1e9bbff571715513fc6530a \
+                sha256  1ae064b32cd7751d3b24f762e0f9dfe8ff4032ac8102d3f413f9cf785d464c6f \
+                size    20258896
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.9.0.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?