### PR TITLE
google-cloud-sdk: update to 427.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             426.0.0
+version             427.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  e65f47b0233098d4dc5c33365c337b9e0f938bcd \
-                    sha256  e80447f597b949fcb9a08b588dc75a99c52d2a63845fa063c933f8de611ad654 \
-                    size    104553114
+    checksums       rmd160  12908d1ccf5c797c957d2aa6f6ed1eabedabbcad \
+                    sha256  26d87cc13d9d080616af6a40ed4eeeb07df2fb4f1590d85c06de02de886caaab \
+                    size    104576697
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  3b0a1cc95142c66b2bdac6811ffa887d599ee2c0 \
-                    sha256  1c9e58a16b0cb1b2de1d1bdaae1abf94f470f95cffa7633d267ca22934ad860b \
-                    size    124910295
+    checksums       rmd160  42f844e447d8b449d9d56cb91e5956920b3362cc \
+                    sha256  49ab70fa04c7be42ee6c54e7850e4ae5b71dce7021274ecebae9deb3479869c0 \
+                    size    124857252
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  232016ffc0929b5cd84e469f134fb9a2370dc0ea \
-                    sha256  2fca756c69cdd1e92a7ded3e6815714e30a1a73ccd5e2002ac1cc5d4fafd319b \
-                    size    121752922
+    checksums       rmd160  f70610e52f0245e7e8d84fa5c524d959c16e1bf9 \
+                    sha256  be417295deabba637ce93de1cec6576e53db6d270b0d5995f5a1bc3cd8660150 \
+                    size    121968796
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 427.0.0.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?