### PR TITLE
openjdk20-zulu: update to 20.30.11

### DIFF
--- a/java/openjdk20-zulu/Portfile
+++ b/java/openjdk20-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-20-sts&os=macos&package=jdk
-version      20.28.85
+version      20.30.11
 revision     0
 
-set openjdk_version 20.0.0
+set openjdk_version 20.0.1
 
 description  Azul Zulu Community OpenJDK 20 (Short Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  4d00726dfeef2c45772a0b5d59eaac10e7e9f386 \
-                 sha256  fde6cc17a194ea0d9b0c6c0cb6178199d8edfc282d649eec2c86a9796e843f86 \
-                 size    203018897
+    checksums    rmd160  3404ec8d2d3008e6df66baafda7137a469072080 \
+                 sha256  befee9db92345d5146945061b721d3a6c6e182471c1536f87dbadfd5aab0e241 \
+                 size    203031268
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  fd9efcf7a3e1a5ba707446a48a654f4b56a1433c \
-                 sha256  a2eff6a940c2df3a2352278027e83f5959f34dcfc8663034fe92be0f1b91ce6f \
-                 size    200541274
+    checksums    rmd160  a9dc3f90a5b1de952488766f7f9bfd7c326943e7 \
+                 sha256  01e59f0160d051524bb16d865652d25d00a85390581737a8f35f89057c80892d \
+                 size    200551830
 }
 
 worksrcdir   ${distname}/zulu-20.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 20.30.11.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?