### PR TITLE
openjdk17-zulu: update to 17.42.19

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.40.19
+version      17.42.19
 revision     0
 
-set openjdk_version 17.0.6
+set openjdk_version 17.0.7
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  084086f554bb0f888c9dd6c6c9fa86fcc486203a \
-                 sha256  1710c8b2f53d78760c4f446e29119a32f40afb0a3830f68c02dc37b11799ab6f \
-                 size    193883691
+    checksums    rmd160  41ec8cac543cbf2f199c0b1105a1e11629b596bf \
+                 sha256  fd8c32cbe06b9ecda87acc25ee212d74b7e221de5edc067f38ab5ba0c43445ae \
+                 size    193927373
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  82a9757956f1765ca636a21d1f88cbff7a980805 \
-                 sha256  f75ee3fbc1744e661ba61058c4c0c37217f6ffb24710987ba2fbcdf801aa462e \
-                 size    191640717
+    checksums    rmd160  1ecad80bf8ffd61c41b7d357fc0756a018d29a51 \
+                 sha256  650be4ed94caa22ec4242b007f90f8f3bad32f66c0a60ff9a18044ce2761a049 \
+                 size    191683319
 }
 
 worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 17.42.19.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?