### PR TITLE
openjdk11-zulu: update to 11.64.19

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      11.62.17
+version      11.64.19
 revision     0
 
-set openjdk_version 11.0.18
+set openjdk_version 11.0.19
 
 description  Azul Zulu Community OpenJDK 11 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  394a69bcf5e5dfc7a835c6bc059aac45f803004c \
-                 sha256  bd171664187064d4d136f026b88054f8714e017cc6518f489cb04e57f07814e3 \
-                 size    194060010
+    checksums    rmd160  5f0696c379c1dcde166d36258451c9f7a53cd803 \
+                 sha256  222630bd333f901f53cd0d2341975ec9a31fd6846166d4ce86e8a57a3d734ac5 \
+                 size    194038289
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  56b61e43e29a2fe5b7abc0eabadbeca700f2b8b9 \
-                 sha256  2a3f56af83f9d180dfce5d6e771a292bbbd68a77c7c18ed3bdb607e86d773704 \
-                 size    192162152
+    checksums    rmd160  b6550b7fcd364566038c98ab5560c2ce6974fcdf \
+                 sha256  f0d84d5f1ae9d67bbb28d4e97fe365692fcdf8f5ad49c57b525281ebb5807577 \
+                 size    192155959
 }
 
 worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 11.64.19.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?