### PR TITLE
openjdk17: update to 17.0.7

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk17
 # https://github.com/openjdk/jdk17u/tags
-version             17.0.6
-set build 10
+version             17.0.7
+set build 7
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,9 +19,9 @@ master_sites        https://git.openjdk.java.net/jdk17u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk17u-[string map {+ -} ${distname}]
 
-checksums           rmd160  a6516dbb66f8dbaad1311badb31529ca96a7d481 \
-                    sha256  f1d1c29ff5ac8254dc81d1635d60f658b6f2b790476acab836ddcb488c8c7fbe \
-                    size    105221267
+checksums           rmd160  ffd3f5eeb5d45a6321b3ed61239e01ff5ae72a35 \
+                    sha256  8024cc0c1e516870b8407bce60c1e67e6572a736518baa3682178937af3fe5a7 \
+                    size    105568148
 
 depends_lib         port:freetype
 depends_build       port:autoconf \


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.7.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?