### PR TITLE
openjdk11: update to 11.0.19

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk11
 # https://github.com/openjdk/jdk11u/tags
-version             11.0.18
-set build 10
+version             11.0.19
+set build 7
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,9 +19,9 @@ master_sites        https://git.openjdk.java.net/jdk11u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk11u-${distname}
 
-checksums           rmd160  3e3420a28b10abf88c3ddf852f482922c2c79a8b \
-                    sha256  c0560c3480e7ded2a59d783ddf2cb624a44ece9d3036f4a7a7575d597b18fb2e \
-                    size    123369840
+checksums           rmd160  7bb4029949f8c590d3738900a004588a7a8ab206 \
+                    sha256  5077e9713e59ccf92fbe58b9bb63e18294fb2110df644f476638e1528e5dfd46 \
+                    size    123660996
 
 depends_lib         port:freetype
 depends_build       port:autoconf \


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.19.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?