### PR TITLE
openjdk17-corretto: update to 17.0.7.7.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.6.10.1
+version      17.0.7.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -24,24 +24,24 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  1ba0deb6888ce1011f9b829bd78d00a408920eb9 \
-                 sha256  1ba7e50d74c2f402431d365eb8e5f7b860b03b18956af59f5f364f6567a8463e \
-                 size    188117863
+    checksums    rmd160  bd162fbf90d70063bee180b86dc3bc0975398e75 \
+                 sha256  68e169404a1021d24f7c39b2fa2366d40075311377f9cbddd328f0aac6c2ea6c \
+                 size    188082617
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  ae84e6dd14eb0690fd1366a919ba2cf9f7e497c4 \
-                 sha256  f7411c1d8a94681e669b133ab57a7ef815aa145b3ecc041c93ca7ff1eb1811b3 \
-                 size    186179802
+    checksums    rmd160  ae628b5840f339e3d71d3c2527f8c61b056b6622 \
+                 sha256  d2410941ee1a8910412511c18a5ff954bc4bd1e4412cb4260a7f138be3a791dd \
+                 size    186100418
 }
 
 worksrcdir   amazon-corretto-17.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-17/blob/release-17.0.6.10.1/CHANGELOG.md
+if {${os.platform} eq "darwin" && ${os.major} < 20} {
+    # See https://github.com/corretto/corretto-17/blob/release-17.0.7.7.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."
+        ui_error "${name} ${version} is only supported on macOS 11 Big Sur or later."
         return -code error
     }
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.7.7.1.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?