### PR TITLE
openjdk11-corretto: update to 11.0.19.7.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-11/releases
 supported_archs  x86_64 arm64
 
-version      11.0.18.10.1
+version      11.0.19.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -24,24 +24,24 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  c2aec52951941566cefebd1ed0d250f5efe31460 \
-                 sha256  8f075fe7e0b6fb261a005a8cc8b8bddc6ac47cff5da580ad9b0b8a77d4ddccd7 \
-                 size    187836161
+    checksums    rmd160  70ca24d7e818cd5c2efdbe0b419b2d9b1da5ce67 \
+                 sha256  11e6010e96ca2ee48ae26bdc8d0e233d9fbe3f2a80c50f472f48ef564d245445 \
+                 size    187788888
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  4ee8c4ee9edce0ffe1d1075cee7674bc381df4c8 \
-                 sha256  ad8c9624f84d3c1e5fe6e381f605e37ba179e922f5c068b7f81492657d156689 \
-                 size    186188061
+    checksums    rmd160  7f072417e0e649756af593f84da59648487a237f \
+                 sha256  d8c19e5ab89ed3ccb66a15d9da59c762907e797ae215e0215ee6cc48175cfe4f \
+                 size    186072451
 }
 
 worksrcdir   amazon-corretto-11.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-11/blob/release-11.0.18.10.1/CHANGELOG.md
+if {${os.platform} eq "darwin" && ${os.major} < 20} {
+    # See https://github.com/corretto/corretto-11/blob/release-11.0.19.7.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."
+        ui_error "${name} ${version} is only supported on macOS 11 Big Sur or later."
         return -code error
     }
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.19.7.1.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?