### PR TITLE
openjdk8-corretto: update to 8.372.07.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      8.362.08.1
+version      8.372.07.1
 revision     0
 
 description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -24,24 +24,24 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  4a026a80e17c0993e7fa1f723cf5f0a3ed07b5f2 \
-                 sha256  2f6a307970a74440a6020e33ab166856f602fa644cb94352bd6efd91de515989 \
-                 size    118782619
+    checksums    rmd160  f3100eebfd9c51c758cdab504a85171fb06cd4cd \
+                 sha256  2cce42e96fe56e85a3ed9d2d28ce56133054fc4be4e20085e869a05f121dcbf0 \
+                 size    118746691
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  9c2dd9d57a9fddd26d8be1e8ca8b3f9e1b469eb1 \
-                 sha256  4e6781effb34b37b49603e25d8c4fd6951aff3aadae3116b52313257a66675d9 \
-                 size    104216967
+    checksums    rmd160  d014e0559d5a51abcc6b5fb0e1c1444581507451 \
+                 sha256  5f34b20138b6fe0adbb410fb0fdfa3183cd486770d6045865cf9336850e55b4d \
+                 size    104171446
 }
 
 worksrcdir   amazon-corretto-8.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-8/blob/release-8.362.08.1/CHANGELOG.md
+if {${os.platform} eq "darwin" && ${os.major} < 20} {
+    # See https://github.com/corretto/corretto-8/blob/release-8.372.07.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."
+        ui_error "${name} ${version} is only supported on macOS 11 Big Sur or later."
         return -code error
     }
 }


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.372.07.1.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?