### PR TITLE
openjdk17-sap: update to 17.0.7

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.6
+version      17.0.7
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  64f9afa9a9f6be420e4c31b9825a635a32120ece \
-                 sha256  2332a717bb7e204b93fb017035a9ecca33ee440df652df2c3ab32ab76be4bcc6 \
-                 size    180278103
+    checksums    rmd160  a320b141567ab7aba6f521f4002a4945852a415a \
+                 sha256  16b876049d34050d1442fe7971c70b581e70c1dec74c3755e2f53c1d04bd2ad0 \
+                 size    180385214
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  f922feab54bef43cecdf89fd1babf932e1985328 \
-                 sha256  31c7d36a8dfd4d0b14fcd82edeccb14be408128099dcdd41e89f0698f0882ac9 \
-                 size    177990627
+    checksums    rmd160  ab54760f972b274e9c6ca59076a4aa4cad46629f \
+                 sha256  3db9ccca0b5df89a10f53c566bc78f3fd5742d07c11044957996e13f2459c6f6 \
+                 size    178090814
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.7.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?