### PR TITLE
openjdk20-sap: update to 20.0.1

### DIFF
--- a/java/openjdk20-sap/Portfile
+++ b/java/openjdk20-sap/Portfile
@@ -13,7 +13,8 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-version      20
+# https://sap.github.io/SapMachine/latest/20
+version      20.0.1
 revision     0
 
 description  SAP Machine 20
@@ -23,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  e8146b27ed86cc98db97ab180dfc563a27c1e3d8 \
-                 sha256  d4e47a7b5cd233a4348aa393c4d9fb2d4c30ef76ce5bca163fecab85241386a7 \
-                 size    189052659
+    checksums    rmd160  0277c0c118d66cf9ef77b6e0f47cef40d8810541 \
+                 sha256  2140c1c35966c5202e4ded8e3a22b2e2114ad011cd49ea561b529dfd2b4257ab \
+                 size    189058189
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  b9c0b2057a40e02f3b36220e80aa7833411b4028 \
-                 sha256  c5c360e340902514c4c7a8966e2e48f0b73c9ef10dbd73527afe0384a2bb058c \
-                 size    186782315
+    checksums    rmd160  417c8666b5b768281e81e6dae56397433e72d5c4 \
+                 sha256  7f587844546558174f3ab48d7e1523373bb4b35144cdf87b66ff4c9e88885177 \
+                 size    186789886
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 20.0.1.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?