### PR TITLE
openjdk11-sap: update to 11.0.19

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/11
 supported_archs  x86_64 arm64
 
-version      11.0.18
+version      11.0.19
 revision     0
 
 description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  3f00e69115cfdbd7b9cae5a25b6715252d34578a \
-                 sha256  50eb0d30c6fc34e6e47763e24b3ad5e3ad9099e222abbf603c634681b7dbce50 \
-                 size    187212349
+    checksums    rmd160  0b9db762c251d352a4198b28a65545fc4773970f \
+                 sha256  6e57187b804f6614834db1b1cef5469e7e6c74aa9224b685b3fbf8cd99e0083d \
+                 size    187283662
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  ae87b493c5ac5de3ac7695c64192ccb93f46d310 \
-                 sha256  2a026c9083d27b5cf2e6c9690eeb7c6a9373bdd0cd6e29fc25bce8079b9aeb19 \
-                 size    185348676
+    checksums    rmd160  a1e2c3ccf989519d8d18e56e20f945783e35e700 \
+                 sha256  be9a2446297f641d4cdbbd4083f08a8839b6881d9a0a9dccff6be5038589c029 \
+                 size    185411755
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 11.0.19.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?