### PR TITLE
py-semver: update to 3.0.0

### DIFF
--- a/python/py-semver/Portfile
+++ b/python/py-semver/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-semver
-version             2.13.0
+version             3.0.0
 revision            0
 
 supported_archs     noarch
@@ -17,30 +17,23 @@ long_description    {*}${description}
 
 homepage            https://github.com/k-bx/python-semver
 
-checksums           sha256  fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f \
-                    rmd160  8e5914920e95e3c7db2ca658ed2915641fb19d57 \
-                    size    45816
+checksums           sha256  94df43924c4521ec7d307fc86da1531db6c2c33d9d5cdc3e64cca0eb68569269 \
+                    rmd160  8baa3b0127443e027d3d59d0db20011ca61748fb \
+                    size    204359
 
 python.versions     37 38 39 310 311
+python.pep517       yes
 
 if {${name} ne ${subport}} {
-    depends_lib-append \
-                    port:py${python.version}-setuptools
-
-    depends_test-append \
-                    port:py${python.version}-pytest \
-                    port:py${python.version}-pytest-cov
+    depends_build-append \
+                    port:py${python.version}-setuptools_scm
 
     test.run        yes
-    test.cmd        py.test-${python.branch} test_semver.py
-    test.args       -o addopts=''
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
-        xinstall -m 0644 -W ${worksrcpath} README.rst \
+        xinstall -m 0644 -W ${worksrcpath} README.rst CHANGELOG.rst \
             LICENSE.txt ${destroot}${docdir}
     }
 }


### PR DESCRIPTION
#### Description
- use python.pep517, simplify test phase

Closes: https://trac.macports.org/ticket/67215

###### Tested on
macOS 13.3.1 22E261 x86_64
Xcode 14.3 14E222b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
