### PR TITLE
toml-f: build should depend on git for <10.9

### DIFF
--- a/fortran/toml-f/Portfile
+++ b/fortran/toml-f/Portfile
@@ -18,6 +18,15 @@ checksums           rmd160  d1c0c3a84e3142e8fbaf67a3abd7499a969f42ea \
                     sha256  0e5a8b18d3b2f82222639ec08d7bc34f14ec0ccfcd7f1c46bac92086e0a40f66 \
                     size    437822
 
+platform darwin {
+    if {${os.major} < 13} {
+        # Lion+ (with Xcode 4.1+) have git; earlier need to bring their own.
+        # On 10.8.5 git fetch fails with ssl error.
+        depends_build-append    port:git
+        git.cmd                 ${prefix}/bin/git
+    }
+}
+
 compilers.choose    fc f90
 compilers.setup     require_fortran
 


### PR DESCRIPTION
#### Description

Missed this part, with system `git` build fails: https://build.macports.org/builders/ports-10.8_x86_64-builder/builds/129575/steps/install-port/logs/stdio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
