### PR TITLE
R-Rcpp: fix for 10.4

### DIFF
--- a/R/R-Rcpp/Portfile
+++ b/R/R-Rcpp/Portfile
@@ -15,6 +15,11 @@ checksums           rmd160  8bcb98cd68da1789f5a2a4161543d621bd05291a \
                     sha256  1e65e24a9981251ab5fc4f9fd65fe4eab4ba0255be3400a8c5abe20b62b5d546 \
                     size    2936173
 
+# https://trac.macports.org/ticket/67254
+platform darwin 8 {
+    patchfiles      patch-tiger.diff
+}
+
 depends_test-append port:R-inline \
                     port:R-pkgKitten \
                     port:R-rbenchmark \

--- a/R/R-Rcpp/files/patch-tiger.diff
+++ b/R/R-Rcpp/files/patch-tiger.diff
@@ -1,0 +1,23 @@
+--- inst/include/Rcpp/exceptions_impl.h.orig	2023-04-21 01:26:17.000000000 +0800
++++ inst/include/Rcpp/exceptions_impl.h	2023-04-21 01:26:37.000000000 +0800
+@@ -21,6 +21,10 @@
+ #ifndef Rcpp__exceptions_impl__h
+ #define Rcpp__exceptions_impl__h
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ // disable demangler on platforms where we have no support
+ #ifndef RCPP_DEMANGLER_ENABLED
+ # if defined(_WIN32)     || \
+@@ -32,7 +36,8 @@
+     defined(_AIX)        || \
+     defined(__MUSL__)    || \
+     defined(__HAIKU__)   || \
+-    defined(__ANDROID__)
++    defined(__ANDROID__) || \
++    (defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED < 1050)
+ #  define RCPP_DEMANGLER_ENABLED 0
+ # elif defined(__GNUC__)  || defined(__clang__)
+ #  include <execinfo.h>


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/67254

#### Description

Seems to fix the problem.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
