### PR TITLE
qrcp: Update to 0.10.1, fix license

### DIFF
--- a/sysutils/qrcp/Portfile
+++ b/sysutils/qrcp/Portfile
@@ -3,21 +3,31 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/claudiodangelis/qrcp 0.9.1
+go.setup            github.com/claudiodangelis/qrcp 0.10.1
 categories          sysutils net
 maintainers         {cal @neverpanic} openmaintainer
 
-license             MIT
+license             MIT MPL-2 BSD LGPL-3 Apache-2
 homepage            https://claudiodangelis.com/qrcp/
 description         Transfer files over wifi from your computer to your mobile device by scanning a QR code without leaving the terminal.
 long_description    ${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  fb63108b0df675608f0f981e14d3fb6f9d036711 \
-                        sha256  dcbd3cbc1df98b55e61533393b1aae8d649093f7b230b328ed44634f37c6e35a \
-                        size    26509931
+                        rmd160  15076964700f5dc6b9f7329d0534754edf985eee \
+                        sha256  7e5687a5d44732219762b592e7ae558efe67fbf309949eb9a90dd64f0ecf4e2c \
+                        size    26510141
 
-go.vendors          gopkg.in/cheggaaa/pb.v1 \
+go.vendors          gopkg.in/yaml.v3 \
+                        lock    9f266ea9e77c \
+                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
+                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
+                        size    86890 \
+                    gopkg.in/yaml.v2 \
+                        lock    v2.2.2 \
+                        rmd160  03aea7b7e847179b29044d5a928b9f8a889fe87b \
+                        sha256  da1e31b7beb9a6907947caa794134bdc2501d1a3474568b61cc2562a398d3d87 \
+                        size    70676 \
+                    gopkg.in/cheggaaa/pb.v1 \
                         lock    v1.0.28 \
                         rmd160  d344c349278a6ba83ab17a1854523493632762a3 \
                         sha256  2a6cdb7d2c7984ad3f1d06cee4bef99453fe09720a79024083270b312845cdb0 \
@@ -27,26 +37,71 @@ go.vendors          gopkg.in/cheggaaa/pb.v1 \
                         rmd160  b63165c8909a27edc15dda210df66a1b49efb49e \
                         sha256  7e5547c6471cc48da89a7c87f965b20ca5311f43fc4d883ca62f9fccf7551630 \
                         size    31597 \
+                    golang.org/x/text \
+                        lock    v0.3.0 \
+                        rmd160  81061ce2006da3d6f7a8ef8dae237d65305513d3 \
+                        sha256  6243d5bbd9d8550bc44cb58a0d70180f7a3f6767299b490015107b4d27c604ae \
+                        size    6102563 \
                     golang.org/x/sys \
-                        lock    fbc7d0a398ab \
-                        rmd160  74d1e245e6473231f02d012ca12cc6ff7cfdd817 \
-                        sha256  0207fd717974942b034492a88751e013f9524fd9deec38fa61178d808752406a \
-                        size    1354073 \
+                        lock    v0.7.0 \
+                        rmd160  06b7e1f7f518376deaad92ca77d2d54b8a6807ec \
+                        sha256  82e99ca5ba1b5fddecc2dfef4b08e6cc1137ffe5eb41d0e0232fbdd8124e1ebf \
+                        size    1435346 \
+                    github.com/stretchr/testify \
+                        lock    v1.6.1 \
+                        rmd160  7e5b798212a8f15cd58a63985ae0b928eede8e6b \
+                        sha256  44d77d9b5c1dc08fa710eac9bb324898210660458085cdf965b78a39b1010f2a \
+                        size    84248 \
+                    github.com/spf13/viper \
+                        lock    v1.4.0 \
+                        rmd160  a89f447feafc87e3b18f304634f122e0a81c9c15 \
+                        sha256  42f30be9b1797160ace166dc959e34c32f171b7d7b1b48d734fd23b3e2490d48 \
+                        size    44191 \
                     github.com/spf13/pflag \
                         lock    v1.0.3 \
                         rmd160  32abdd77a987af95ce5b647846bfdbb2d8db91a0 \
                         sha256  046b6b81e3925ffe60e2213e9a239303ff98a51e76764590b807b591fedf2d1e \
                         size    46029 \
+                    github.com/spf13/jwalterweatherman \
+                        lock    v1.0.0 \
+                        rmd160  364fd0d61e94bd3651b5506d61f0e9652d6e33a3 \
+                        sha256  e70eb4dbab0603ad35c32bf89cefd595b2d6d56d66695866bfad2350db939404 \
+                        size    6405 \
                     github.com/spf13/cobra \
                         lock    v1.0.0 \
                         rmd160  73602c4d37ad508ba8b35812c793e1df3eda7bb9 \
                         sha256  6cdf3f445559b8f41f5288366a4c26e8d1b1601dac6924af091a49f1f6b11396 \
                         size    128931 \
+                    github.com/spf13/cast \
+                        lock    v1.3.0 \
+                        rmd160  26b82e9734f643bc70be8c73742d4a4f514b6dd2 \
+                        sha256  f2913fc10731a578c016701bd10e6a267c299b94e69d8362d258ce8482d14faf \
+                        size    11086 \
+                    github.com/spf13/afero \
+                        lock    v1.1.2 \
+                        rmd160  dc2ff3aa582c3dc782e3c062e35b65564bfc44e5 \
+                        sha256  08dca858dce5a4336ca385028ff38e0fa6a9f064f5c874fdabe2096a34b6fc91 \
+                        size    45324 \
                     github.com/skip2/go-qrcode \
                         lock    9434209cb086 \
                         rmd160  30a042f8d9e6d8a3d4f44bfb8107d53dd440a9be \
                         sha256  14df66c360abe69e729592ce94654a86492595adcfaf485f655aaa9ada90222d \
                         size    36086 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/pelletier/go-toml \
+                        lock    v1.2.0 \
+                        rmd160  8d91b6485f373ccaa894abcb3bd53839e55b9057 \
+                        sha256  0a9503f2b53444e0c3ea960d18febe14d472c16279844f231994c5ccb81dbdff \
+                        size    57515 \
+                    github.com/mitchellh/mapstructure \
+                        lock    v1.1.2 \
+                        rmd160  a4e01781ea5bb0c987e18e8e450c8f1023d5a857 \
+                        sha256  9c1076f5a8e923d028cb65c36143f3b1478cbaa4420e2e8f332719edc2fc4f71 \
+                        size    20992 \
                     github.com/mattn/go-runewidth \
                         lock    v0.0.9 \
                         rmd160  412c0e508e55f4fe437be0f71d7d22eca2b4366f \
@@ -67,6 +122,11 @@ go.vendors          gopkg.in/cheggaaa/pb.v1 \
                         rmd160  9dc391ee449f2d9c535ab79b19b2ae54c8340d23 \
                         sha256  fed2ddd7c8e15bb66c2679dba0b948cda9e752a4aed5149fb1e65fa9c5331445 \
                         size    26673 \
+                    github.com/magiconair/properties \
+                        lock    v1.8.0 \
+                        rmd160  327cf3e96df60025444491a413aba0145ef448f3 \
+                        sha256  1a51357a88b298284fa48607836e7d05bee5fc58e00c87ba943a8d719d2ece2c \
+                        size    29500 \
                     github.com/lunixbochs/vtclean \
                         lock    2d01aacdc34a \
                         rmd160  a378a8e18f9fc0f242d5d25bfe8f3a321f2cfd25 \
@@ -97,11 +157,21 @@ go.vendors          gopkg.in/cheggaaa/pb.v1 \
                         rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
                         sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
                         size    2291 \
+                    github.com/hashicorp/hcl \
+                        lock    v1.0.0 \
+                        rmd160  ad8d0b523bb708fd6ae77df8bb414c103a75aa92 \
+                        sha256  4fc0e87ac9d3d6cd042f044df2db2703bed569051fb8c179d505edeb4433e96e \
+                        size    70636 \
                     github.com/glendc/go-external-ip \
                         lock    139229dcdddd \
                         rmd160  c0f7a7447c6025c8d2f4c14d9092cd1a4bb155fe \
                         sha256  9f0bf3945d0ff2e41278137ec7204f7b8a52c84d3eb876e12d4bd6f825cee724 \
                         size    5659 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.4.7 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147 \
                     github.com/fatih/color \
                         lock    v1.9.0 \
                         rmd160  1d8418b4f1b3cb597f680b93aaa08afcc9651be4 \
@@ -112,6 +182,11 @@ go.vendors          gopkg.in/cheggaaa/pb.v1 \
                         rmd160  3bc7409fda500b63dee7372dc9f49e7f03ee33d9 \
                         sha256  79087c296ad6a4c8dc60e862a19d094ef63ff89e432497dd6012b23023a54be3 \
                         size    8564 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
                     github.com/chzyer/test \
                         lock    a1ea475d72b1 \
                         rmd160  61f83d79b356cde63a27df0f2832ef92fcbc216d \
@@ -136,7 +211,12 @@ go.vendors          gopkg.in/cheggaaa/pb.v1 \
                         lock    v0.3.2 \
                         rmd160  c54789954a6a2f1f919215273459b6927021a0ad \
                         sha256  61988f4f3ebb2ea0bdb594f94fa7d5894a561bfff47a53dc06200dee0454fc80 \
-                        size    16126
+                        size    16126 \
+                    github.com/BurntSushi/toml \
+                        lock    v0.3.1 \
+                        rmd160  fb9650e2d16525153645e5547626f242f3800149 \
+                        sha256  8cc9e5dc68e247554227973d0b4e023b27bbd9ba5a26e4fb40f44743afcb35f1 \
+                        size    42087
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

Add the various licenses of the dependencies as determined by the go-licenses port.

Note that this uses a newer golang.org/x/sys package compared to upstream, because the one referenced in upstream's go.mod file does not seem to compile on macOS.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 21G531 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
