### PR TITLE
mariadb-10.11: fix the build for 32-bit

### DIFF
--- a/databases/mariadb-10.11/Portfile
+++ b/databases/mariadb-10.11/Portfile
@@ -214,6 +214,11 @@ if {$subport eq $name} {
     # temporary fix for C/C++ flag discovery
     patchfiles-append patch-fix-flag-discovery.diff
 
+    # Disable a static assert that breaks the build, see: https://trac.macports.org/ticket/67278
+    if {${build_arch} in [list arm i386 ppc]} {
+        patchfiles-append patch-fix-32-bit.diff
+    }
+
     post-patch {
         reinplace "s|@NAME@|${name_mysql}|g" \
             ${worksrcpath}/cmake/install_layout.cmake

--- a/databases/mariadb-10.11/Portfile
+++ b/databases/mariadb-10.11/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           legacysupport 1.0
+
 # CLOCK_REALTIME
 legacysupport.newest_darwin_requires_legacy 15
 

--- a/databases/mariadb-10.11/Portfile
+++ b/databases/mariadb-10.11/Portfile
@@ -268,6 +268,11 @@ if {$subport eq $name} {
                         -DWITH_PCRE=system \
                         -DBISON_EXECUTABLE=${prefix}/bin/bison
 
+    if {[string match *gcc* ${configure.compiler}]} {
+        # ___atomic_store_8, ___atomic_fetch_add_8, ___atomic_load_8
+        configure.ldflags-append -latomic
+    }
+
     configure.checks.implicit_function_declaration.whitelist-append select getthrid
 
     post-destroot {

--- a/databases/mariadb-10.11/files/patch-fix-32-bit.diff
+++ b/databases/mariadb-10.11/files/patch-fix-32-bit.diff
@@ -1,0 +1,11 @@
+--- a/sql/sql_yacc.yy	2022-11-15 02:10:21.000000000 +0800
++++ b/sql/sql_yacc.yy	2023-04-21 12:14:10.000000000 +0800
+@@ -333,7 +333,7 @@
+ 
+ %{
+ /* avoid unintentional %union size increases, it's what a parser stack made of */
+-static_assert(sizeof(YYSTYPE) == sizeof(void*)*2+8, "%union size check");
++/* static_assert(sizeof(YYSTYPE) == sizeof(void*)*2+8, "%union size check"); */
+ bool my_yyoverflow(short **a, YYSTYPE **b, size_t *yystacksize);
+ %}
+ 


### PR DESCRIPTION
#### Description

A very simple fix to allow it build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
