### PR TITLE
openssl3: Fix CVE-2023-1255

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 8
 set major_v         3
 name                openssl$major_v
 version             ${major_v}.1.0
-revision            2
+revision            3
 
 # Please revbump these ports when updating the openssl3 version/revision
 #  - freeradius (#43461)
@@ -57,7 +57,8 @@ patchfiles          avx512.patch \
                     d79bb5316e1318bd776d6b2d6723a36778e07f9d.patch \
                     52a38144b019cfda6b0e5eaa0aca88ae11661a26.patch \
                     facfb1ab745646e97a1920977ae4a9965ea61d5c.patch \
-                    fc814a30fc4f0bc54fcea7d9a7462f5457aab061.patch
+                    fc814a30fc4f0bc54fcea7d9a7462f5457aab061.patch \
+                    bc2f61ad70971869b242fc1cb445b98bad50074a.patch
 
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Having the stdlib set to libc++ on 10.6 causes a dependency on a

--- a/devel/openssl3/files/bc2f61ad70971869b242fc1cb445b98bad50074a.patch
+++ b/devel/openssl3/files/bc2f61ad70971869b242fc1cb445b98bad50074a.patch
@@ -1,0 +1,47 @@
+From bc2f61ad70971869b242fc1cb445b98bad50074a Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.org>
+Date: Mon, 17 Apr 2023 16:51:20 +0200
+Subject: [PATCH] aesv8-armx.pl: Avoid buffer overrread in AES-XTS decryption
+
+Original author: Nevine Ebeid (Amazon)
+Fixes: CVE-2023-1255
+
+The buffer overread happens on decrypts of 4 mod 5 sizes.
+Unless the memory just after the buffer is unmapped this is harmless.
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+Reviewed-by: Tom Cosgrove <tom.cosgrove@arm.com>
+(Merged from https://github.com/openssl/openssl/pull/20759)
+
+(cherry picked from commit 72dfe46550ee1f1bbfacd49f071419365bc23304)
+
+Upstream-Status: Backport [bc2f61ad70971869b242fc1cb445b98bad50074a]
+---
+ crypto/aes/asm/aesv8-armx.pl |  4 +++-
+ 3 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/aes/asm/aesv8-armx.pl b/crypto/aes/asm/aesv8-armx.pl
+index ea74217317..efd3ccd1a4 100755
+--- ./crypto/aes/asm/aesv8-armx.pl
++++ ./crypto/aes/asm/aesv8-armx.pl
+@@ -3367,7 +3367,7 @@ $code.=<<___	if ($flavour =~ /64/);
+ .align	4
+ .Lxts_dec_tail4x:
+ 	add	$inp,$inp,#16
+-	vld1.32	{$dat0},[$inp],#16
++	tst	$tailcnt,#0xf
+ 	veor	$tmp1,$dat1,$tmp0
+ 	vst1.8	{$tmp1},[$out],#16
+ 	veor	$tmp2,$dat2,$tmp2
+@@ -3376,6 +3376,8 @@ $code.=<<___	if ($flavour =~ /64/);
+ 	veor	$tmp4,$dat4,$tmp4
+ 	vst1.8	{$tmp3-$tmp4},[$out],#32
+ 
++	b.eq	.Lxts_dec_abort
++	vld1.32	{$dat0},[$inp],#16
+ 	b	.Lxts_done
+ .align	4
+ .Lxts_outer_dec_tail:
+-- 
+2.40.0
+


### PR DESCRIPTION
#### Description

This affects the use of AES-XTS on 64-bit ARM, which is likely a good portion of our user base. See [\[1\]][1] for the advisory.

[1]: https://www.openssl.org/news/secadv/20230420.txt

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.3.1 22E261 x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

