### PR TITLE
openjdk8-zulu: update to 8.70.0.23

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -13,11 +13,11 @@ universal_variant no
 
 supported_archs  x86_64 arm64
 
-# https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk
-version      8.68.0.19
+# https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
+version      8.70.0.23
 revision     0
 
-set openjdk_version 8.0.362
+set openjdk_version 8.0.372
 
 description  Azul Zulu Community OpenJDK 8 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  460595dc1b90fc98c9e48499ca5654e5972c8d58 \
-                 sha256  1d4020045b5183407e65b511ca4c805195f896da2e4fc2d572466a9d3bc5e5d4 \
-                 size    106563403
+    checksums    rmd160  af0d52375aa27dcf9400ca03a668b7a1eed2a730 \
+                 sha256  d35a7bedfb3dde69701d27b7df6100143c5617d5fee746acb3d845311a9573af \
+                 size    106571859
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  71678c5726e55b9b10dd74f7876baeb18413b6a9 \
-                 sha256  8957358fb0e26971371f228e845978f6038a8cbc1b196297c859acb7b4c22409 \
-                 size    104467621
+    checksums    rmd160  aab341da1f3dfe79742aea393a6dcabe97db9a4f \
+                 sha256  ae68ae6a93d1d9952e5ff096f6612eea486846a8506e30dec3dd3b3e52b9d005 \
+                 size    104474376
 }
 
 worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu OpenJDK 8.70.0.23.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?