### PR TITLE
openjdk17-temurin: update to 17.0.7

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.6
-set build    10
+version      17.0.7
+set build    7
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  fd7b466f49ece8b1e492dcd5d14e7f61eacdd983 \
-                 sha256  faa2927584cf2bd0a35d2ac727b9f22725e23b2b24abfb3b2ac7140f4d65fbb4 \
-                 size    187219587
+    checksums    rmd160  211c719fba6b08f28e5056c8da6abaceb699e80d \
+                 sha256  50d0e9840113c93916418068ba6c845f1a72ed0dab80a8a1f7977b0e658b65fb \
+                 size    187285514
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  c3ad5f4a2e5d031e0ee8878df348d91c847f9dd4 \
-                 sha256  e4904557f6e02f62b830644dc257c0910525f03df77bcffaaf92fa02a057230c \
-                 size    177369180
+    checksums    rmd160  90803dc1a390b4fecb57f86bc12aa374b2b76ff2 \
+                 sha256  1d6aeb55b47341e8ec33cc1644d58b88dfdcce17aa003a858baa7460550e6ff9 \
+                 size    177451420
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.7.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?