### PR TITLE
openjdk11-temurin: update to 11.0.19

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      11.0.18
-set build    10
+version      11.0.19
+set build    7
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  637b246bebddefe76ef71cda8982ccc694d6b786 \
-                 sha256  75d79315d7265cc4b89fd9e844161ff90798bc6482ace8c1ac75f862a5b3b565 \
-                 size    187254949
+    checksums    rmd160  c1ca32c99f7d71b7e644d1d197e1b6974fb60a3a \
+                 sha256  fc34c4f0e590071dcd65a0f93540913466ccac3aa8caa984826713b67afb696d \
+                 size    186680275
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  3889af586b13549d678996ed068d7c00c603d17a \
-                 sha256  5c5e9ac08de335d7ed2d6518d3a9cad900874d1e1d572a4046ac64071e239cc7 \
-                 size    185368596
+    checksums    rmd160  c925feba4623cb6f05fe264410a60ae36be908ac \
+                 sha256  f3b416ecccf51f45cc8c986975eb7bd35e7e1ad953656ab0a807125963fcf73b \
+                 size    185411705
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.19.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?