### PR TITLE
openjdk8-temurin: update to 8u372

### DIFF
--- a/java/openjdk8-temurin/Portfile
+++ b/java/openjdk8-temurin/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64
 
-version      8u362
-set build    09
+version      8u372
+set build    07
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 8
@@ -26,9 +26,9 @@ master_sites https://github.com/adoptium/temurin8-binaries/releases/download/jdk
 distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  926d966ab7b961fe50f9949d53c11ff6624f5982 \
-             sha256  80996b72377990e2ec13f22e0a63c265640a4f53216596163a651e7e1bfe8319 \
-             size    107290360
+checksums    rmd160  ceed8ad4a8e633082a8fcbac142d52bd1e4394ff \
+             sha256  9c33db312cc46b6bfe705770fdc5c08edb7d790ba70be4e8b12a98e79da5f4a1 \
+             size    107968606
 
 homepage     https://adoptium.net
 


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 8u372.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?