### PR TITLE
openjdk20-temurin: update to 20.0.1

### DIFF
--- a/java/openjdk20-temurin/Portfile
+++ b/java/openjdk20-temurin/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=20
 supported_archs  x86_64 arm64
 
-version      20
-set build    36
+version      20.0.1
+set build    9
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 20
@@ -26,14 +26,14 @@ master_sites https://github.com/adoptium/temurin20-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK20U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  1ae8e4cc8f8a9638a14f86c9b3fb358c910bdcbd \
-                 sha256  9e96ea09f50128c61090a8f24736078bc763966a521c3b59d531709f08e624b2 \
-                 size    197173097
+    checksums    rmd160  f271f4a672bf6f86a3f01bd5c9d9db7d64186351 \
+                 sha256  7cccfc4fb9f63410b7fdc315fd1c7739cf61888930d7f88f3eee6589d14e861f \
+                 size    197180058
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK20U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  d55610578a5db607abbf49be9d69896f5158daca \
-                 sha256  1cd48a8b1070826a52e4895e9a406a3b2ccd207f863588c25c29fb96cdccc7c4 \
-                 size    186401798
+    checksums    rmd160  cdce5c4d9f1579c59d7332aa8e3b04a520413baa \
+                 sha256  e743f7a4aebb46bfb02e164c7aa009a29bcce1d7dd0c4926541893ea6ed21d82 \
+                 size    186409240
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 20.0.1.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?