### PR TITLE
openjdk17-microsoft: update to 17.0.7

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      17.0.6
-set build    10
+version      17.0.7
+set build    7
 revision     0
 
 description  Microsoft Build of OpenJDK 17 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  261645167231eb218701bff3d1737739fb04e89b \
-                 sha256  8dce6849b8bab15c636ae9071e3a7d6cb4951df210c6119233d9c2bd4b6edf16 \
-                 size    187604848
+    checksums    rmd160  15310019479998e592e2fdf5ffcf6f7687da0030 \
+                 sha256  1a7ccf0b748c9b3ef441678aebfe85631986f7860f8b1c5eab263cfee41889c0 \
+                 size    187677698
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  6fd388010bddd3026e6fad9cdf7a8ceb15d72f1d \
-                 sha256  fcf089eb05cfe5684ed4b33edfb55696f5573c3508d4b2ecf745846e5fc78a9e \
-                 size    177759316
+    checksums    rmd160  f4427717f247b887fce6a371de4e7d8902f4f52b \
+                 sha256  48e4f97b524ae4aed5c80b4672fa746c72efb648172a99828ffe5ed501029a6e \
+                 size    177836676
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.7.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?