### PR TITLE
vtm: update to 0.9.9d

### DIFF
--- a/sysutils/vtm/Portfile
+++ b/sysutils/vtm/Portfile
@@ -6,7 +6,7 @@ PortGroup               cmake 1.1
 PortGroup               legacysupport 1.1
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            netxs-group vtm 0.9.9c v
+github.setup            netxs-group vtm 0.9.9d v
 github.tarball_from     archive
 revision                0
 
@@ -19,9 +19,9 @@ description             Monotty Desktopio - text-based desktop environment \
 long_description        ${name} is a terminal multiplexer with window manager \
                         and session sharing.
 
-checksums               rmd160  7a421b1ad668a0c0eeed8fbe37656fb29fe9f91d \
-                        sha256  de0b0134ab2a4a8640ac35b5fe3805eeda77f2575b65720c272ccd8aed388c69 \
-                        size    1362915
+checksums               rmd160  c8246b23b6141e55b6944299b723494ee906990a \
+                        sha256  e8c7d45884514e16ae22d4a6d8ad7566a1244cf5e235dcd80e6ffd4a41544355 \
+                        size    1363017
 
 # Requires a compiler with full C++20 support
 compiler.cxx_standard   2020
@@ -29,8 +29,8 @@ compiler.cxx_standard   2020
 compiler.blacklist-append \
                         {clang}
 
-# Needed for std::filesystem
-legacysupport.newest_darwin_requires_legacy 18
+# Needed for std::filesystem and std::atomic_notify_all
+legacysupport.newest_darwin_requires_legacy 19
 # Use MacPorts libcxx only with Clang
 if {[string match *clang* ${configure.compiler}]} {
     legacysupport.use_mp_libcxx yes


### PR DESCRIPTION
* fix build on macOS 10.15

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
