### PR TITLE
openjdk11-microsoft: update to 11.0.19

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      11.0.18
-set build    10
+version      11.0.19
+set build    7
 revision     0
 
 description  Microsoft Build of OpenJDK 11 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  86963ff53f3ba89ca52825194b123455d351ed81 \
-                 sha256  176278a8aa13bdd328924df0526c7dc70a72c8a381d4a541131c58f76f9182ee \
-                 size    187433767
+    checksums    rmd160  b6d503d1a9bcccfb58e3777478b284c6bcfc7657 \
+                 sha256  61c3b5e5770154788505670085df8345173f2881e456c396659e4ba5e54552cc \
+                 size    187478168
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  947cc17d48d85b68678a4d78fd6f6f2834dbcf2b \
-                 sha256  14078e04becfcd856bd3707a477a84d61418f71f28afde0a55cabaf6de06a518 \
-                 size    185016321
+    checksums    rmd160  f9f07d546fb632762f030c9f0c103876746f424f \
+                 sha256  ea35aa9cdadd6bde65fc470b60e88a1ed015ef445ae3958f968317d7d643657c \
+                 size    185045288
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.19.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?