### PR TITLE
gtk4: update to 4.10.3

### DIFF
--- a/gnome/gtk4/Portfile
+++ b/gnome/gtk4/Portfile
@@ -15,8 +15,8 @@ set my_name         gtk4
 # GNOME project name
 set gname           gtk
 
-version             4.8.2
-revision            1
+version             4.10.3
+revision            0
 
 categories          gnome
 license             LGPL-2.1+
@@ -38,9 +38,9 @@ use_xz              yes
 set python_branch   3.10
 set python_version  [string map {. {}} ${python_branch}]
 
-checksums           rmd160  689c489e32ca9101bb7dd53829c2316230ac7db7 \
-                    sha256  85b7a160b6e02eafa4e7d38f046f8720fab537d3fe73c01c864333a983a692a9 \
-                    size    20210736
+checksums           rmd160  87fb1855136f279058df4231423acb4f1e13dfb5 \
+                    sha256  4545441ad79e377eb6e0a705026dc7a46886e46a1b034db40912909da801cea9 \
+                    size    20483468
 
 depends_build-append \
                     port:pkgconfig \
@@ -54,6 +54,7 @@ depends_build-append \
 depends_lib-append  path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:graphene \
+                    path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     port:hicolor-icon-theme \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libepoxy \
@@ -67,9 +68,11 @@ license_noconflict  gobject-introspection
 # Specify name of executable for 'rst2man'
 patchfiles-append   patch-docs-rst2man.diff
 
-patchfiles-append   patch-testsuite-python.diff
+#patchfiles-append   patch-testsuite-python.diff
 
 patchfiles-append   patch-meson-dont-werror-on-missing-declarations.diff
+
+patchfiles-append   patch-quartz-nspasteboardtype.diff
 
 post-patch {
     reinplace "s|@@PYTHON_VERSION@@|${python_branch}|" \

--- a/gnome/gtk4/files/patch-quartz-nspasteboardtype.diff
+++ b/gnome/gtk4/files/patch-quartz-nspasteboardtype.diff
@@ -1,0 +1,47 @@
+#==================================================================================================
+# gdk/macos: fix builds on macOS before 10.13
+# https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5813
+#==================================================================================================
+diff --git a/gdk/macos/gdkmacosclipboard-private.h b/gdk/macos/gdkmacosclipboard-private.h
+index 5679b13a36fdaf394e10e292beefcc548c9495cc..4866cf22e006ec07c9d81f6aeeab661d92a5ecc9 100644
+--- gdk/macos/gdkmacosclipboard-private.h
++++ gdk/macos/gdkmacosclipboard-private.h
+@@ -27,10 +27,6 @@
+ 
+ G_BEGIN_DECLS
+ 
+-#ifndef AVAILABLE_MAC_OS_X_VERSION_10_13_AND_LATER
+-typedef NSString *NSPasteboardType;
+-#endif
+-
+ #define GDK_TYPE_MACOS_CLIPBOARD (_gdk_macos_clipboard_get_type())
+ 
+ G_DECLARE_FINAL_TYPE (GdkMacosClipboard, _gdk_macos_clipboard, GDK, MACOS_CLIPBOARD, GdkClipboard)
+diff --git a/gdk/macos/gdkmacospasteboard-private.h b/gdk/macos/gdkmacospasteboard-private.h
+index cac18a8fde5fa5a074258c9b1a46002778e71ea4..cc7f6b8e475c2f97500708e574e044f1aee1f07e 100644
+--- gdk/macos/gdkmacospasteboard-private.h
++++ gdk/macos/gdkmacospasteboard-private.h
+@@ -26,6 +26,10 @@
+ 
+ G_BEGIN_DECLS
+ 
++#ifndef AVAILABLE_MAC_OS_X_VERSION_10_13_AND_LATER
++typedef NSString *NSPasteboardType;
++#endif
++
+ @interface GdkMacosPasteboardItemDataProvider : NSObject <NSPasteboardItemDataProvider>
+ {
+   GdkContentProvider *_contentProvider;
+diff --git a/gdk/macos/gdkmacospasteboard.c b/gdk/macos/gdkmacospasteboard.c
+index 0903c5352accda899092addb241feb4c19de8b77..b26248a9548f3438ae8aff20b72b1ae3e32fe514 100644
+--- gdk/macos/gdkmacospasteboard.c
++++ gdk/macos/gdkmacospasteboard.c
+@@ -400,7 +400,7 @@ _gdk_macos_pasteboard_register_drag_types (NSWindow *window)
+       gdk_content_formats_get_gtypes (formats, &n_gtypes);
+ 
+       if (n_gtypes)
+-        [ret addObject:NSPasteboardTypeURL];
++        [ret addObject:PTYPE(URL)];
+ 
+       gdk_content_formats_unref (formats);
+     }


### PR DESCRIPTION
### Description

* Update `gtk4` to 4.10.3
* I've focused primarily on `quartz`, since that's how all of my macOS systems are setup.
* The majority of automated tests succeed, but a not-insignificant number fail.
* The previous patch to fix the python path for tests, may need to change. (Or perhaps it's no longer needed?) Presently it's disabled, in order to allow the build to succeed.
* Submitting this PR for review/feedback from the original author (@kencu), along with @lukaso and other interested parties.

Fixes:
* [66900 - gtk4 @4.8.2: out of date](https://trac.macports.org/ticket/66900)