### PR TITLE
openjdk8: update to 8u372

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -8,9 +8,9 @@ name                openjdk8
 # https://github.com/openjdk/jdk8u/tags
 # Tags: https://github.com/openjdk/jdk8u/tags
 set major 8
-set update 362
+set update 372
 # Set to the build of the 'jdk8u${update}-b${build}' tag that corresponds to the latest tag with '-ga'
-set build 09
+set build 07
 version             ${major}u${update}
 revision            0
 categories          java devel
@@ -26,9 +26,9 @@ master_sites        https://git.openjdk.java.net/jdk8u/archive/refs/tags/
 distname            jdk${major}u${update}-ga
 worksrcdir          jdk8u-${distname}
 
-checksums           rmd160  f06e80750049168a3c7995b0c49c0a12a0a986dd \
-                    sha256  dd3606bd274d25c96f2dc2e63b7cab36a2b03d82b0ce4f312cfb53056f758d9f \
-                    size    87939909
+checksums           rmd160  7ffec6da71e24d2913b717b5f31d6be9c2fa7b7e \
+                    sha256  3235a744b51896beb1e8b738412982ebc06e2affb9d50ae3371203d9a46504da \
+                    size    88002433
 
 patchfiles          0001-8181503-Can-t-compile-hotspot-with-c-11.patch \
                     0002-Support-XCode-3-14.patch \


### PR DESCRIPTION
#### Description

Update to OpenJDK 8u372.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?