### PR TITLE
emacs{-app,}-devel: include tree-sitter support for JavaScript

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -106,6 +106,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     github.setup    emacs-mirror emacs c4e038c7be38b2e6cf2d2c7c39264f068f789c02
     epoch           5
     version         20230420
+    revision        1
 
     master_sites    ${github.master_sites}
 
@@ -133,6 +134,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
         configure.args-append   --with-tree-sitter
         depends_lib-append  port:tree-sitter
         depends_run-append  port:tree-sitter-typescript \
+            port:tree-sitter-javascript \
             port:tree-sitter-tsx \
             port:tree-sitter-c \
             port:tree-sitter-cpp \


### PR DESCRIPTION
#### Description

Emacs 29+ includes `js-ts-mode` for which the tree-sitter-javascript port is required.

It was missing from the deps list before because unlike (almost) every other *-ts-mode it is not mentioned in the NEWS.29 file. Thanks @wyuenho for pointing it out.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.3.1 22E261 x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
