### PR TITLE
cdo: update to 2.2.0

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,19 +5,19 @@ PortGroup                   mpi 1.0
 PortGroup                   legacysupport 1.0
 
 name                        cdo
-version                     2.1.1
-revision                    1
+version                     2.2.0
+revision                    0
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} openmaintainer
 license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/27654
+master_sites                https://code.mpimet.mpg.de/attachments/download/28012
 
-checksums           rmd160  234ae2c2b2dafa98b741fdc06743dbe24ffa201b \
-                    sha256  c29d084ccbda931d71198409fb2d14f99930db6e7a3654b3c0243ceb304755d9 \
-                    size    12079495
+checksums           rmd160  37f4224a6f1c7242a380c56f572ed95dece5673e \
+                    sha256  006f5acb21ed54571535e2dbcbc78e6cbf36c2731029ea1a7b110c49c8b4c9cd \
+                    size    13307196
 
 long_description \
     CDO is a collection of command line Operators               \


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.2.0
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.3.1 22E261 x86_64
Command Line Tools 14.3.0.0.1.1679647830

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
