### PR TITLE
Update beets related ports

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -39,13 +39,13 @@ if {$subport eq $name} {
 subport ${name}-devel {
     conflicts       $name
 
-    github.setup    beetbox beets e201dd4fe57b0aa2e80890dc3939b0a803e3448d
-    version         20221101
+    github.setup    beetbox beets 2bcf16b10c305a02489aec75e61c5d4728cd34b3
+    version         20230422
     revision        0
 
-    checksums       rmd160  cc6f09ce89e63000d74d7bde281b21c368111499 \
-                    sha256  f0973c06ea5a03fa2399e8b0fd83efd32312cd967d8e6fe64509e36e87c6d3ab \
-                    size    1755119
+    checksums       rmd160  a2591ffd8da82cfda53b710625750863edecc0a5 \
+                    sha256  0c7993361a1f2b32a9ce28a516c3fe22da93cb2da0f3530d0a6bf5a85fce7311 \
+                    size    1866813
 
     depends_build-append \
                     port:py${python.version}-sphinx


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->