### PR TITLE
retdec-devel: update to 20230404

### DIFF
--- a/devel/retdec/Portfile
+++ b/devel/retdec/Portfile
@@ -98,16 +98,16 @@ if {${name} eq ${subport}} {
 subport retdec-devel {
     conflicts       $name
 
-    github.setup    avast retdec 53e55b4b26e9b843787f0e06d867441e32b1604e
-    version         20221208
+    github.setup    avast retdec 5821bbe735262187bd5d48930d0eda8b7b48bba8
+    version         20230404
     revision        0
     epoch           1
 
     checksums-append \
                     ${distname}${extract.suffix} \
-                    rmd160  3f0d02db6e5a7c6adda86a268ce1a535ec8ae9c1 \
-                    sha256  46db5ce52ce2928d07276f41ef3510fe4667f70477b95dacfc637617fb910a1a \
-                    size    27197302
+                    rmd160  b8de5e6483fb24890826025326bfddd8916f5646 \
+                    sha256  163c9e5889a354ddf9eaef51e40474728c0c8f163ca2da83f97fbacbbeef8bbe \
+                    size    27197443
 }
 
 master_sites-append https://github.com/capstone-engine/capstone/archive/refs/tags:capstone \
@@ -125,6 +125,12 @@ distfiles-append    ${capstone_version}${extract.suffix}:capstone \
                     v${yara_version}${extract.suffix}:yara \
                     ${yaramod_version}${extract.suffix}:yaramod \
                     ${support_pkg_version}.tar.xz:support_pkg
+
+# extract.rename won't work with multiple files, emulate it
+# See: https://trac.macports.org/ticket/66993
+post-extract {
+    move {*}[glob ${workpath}/${github.author}-${github.project}-*] ${worksrcpath}
+}
 
 # Verify that cmake.deps has expected checksums
 post-extract {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->