### PR TITLE
portmidi: fix build on <10.7

### DIFF
--- a/audio/portmidi/Portfile
+++ b/audio/portmidi/Portfile
@@ -34,6 +34,11 @@ post-patch {
 configure.args      -DCMAKE_BUILD_WITH_INSTALL_RPATH=OFF \
                     -DBUILD_PORTMIDI_TESTS=ON
 
+# pmmacosxcm.c: error: ‘for’ loop initial declaration used outside C99 mode
+# Passing -std=c99 does not save though, the build then fails with numerous errors of the kind:
+# readbinaryplist.c: error: ‘struct value_struct’ has no member named ‘integer’
+compiler.blacklist-append *gcc-4.*
+
 # There is no way to run the full test suite automatically.
 # See pm_test/README.txt. So this just runs one of the tests
 # that doesn't require manual MIDI input.


### PR DESCRIPTION
#### Description

It fails to build with gcc-4.2 (see comment in portfile for details). Blacklist defunct old gccs, fix the build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
