### PR TITLE
rubberband: fix for 32-bit platforms, update to 3.2.1

### DIFF
--- a/audio/rubberband/Portfile
+++ b/audio/rubberband/Portfile
@@ -50,6 +50,12 @@ if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
     configure.ldflags-append -stdlib=${configure.cxx_stdlib}
 }
 
+if {[string match *gcc* ${configure.compiler}]} {
+    # ___atomic_is_lock_free, ___atomic_load_8, ___atomic_store_8
+    # https://todo.sr.ht/~breakfastquay/rubberband/28
+    configure.ldflags-append -latomic
+}
+
 post-destroot {
     set docdir ${prefix}/share/doc/${subport}
     xinstall -d ${destroot}${docdir}

--- a/audio/rubberband/Portfile
+++ b/audio/rubberband/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           meson 1.0
 
 name                rubberband
-version             3.1.3
+version             3.2.1
 revision            0
-checksums           rmd160  895db0fe82f424acaf6f0284c286fa7f186dcda6 \
-                    sha256  3621c2c346cc3336fddd3fc34e5a7a1c106d24b182307c581f8fd40eda4f4e2b \
-                    size    218532
+checksums           rmd160  10ef23f0658f8c2937492395f1b39510a07ece3a \
+                    sha256  82edacd0c50bfe56a6a85db1fcd4ca3346940ffe02843fc50f8b92f99a97d172 \
+                    size    221756
 
 categories          audio
 maintainers         {ryandesign @ryandesign} openmaintainer


### PR DESCRIPTION
#### Description

@ryandesign Did in two commits, so that if update is not desirable for w/e reason, it can be dropped. The fix is necessary either way.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
