### PR TITLE
harminv: update to 1.4.2, drop unneeded dep on guile

### DIFF
--- a/science/harminv/Portfile
+++ b/science/harminv/Portfile
@@ -2,13 +2,13 @@
 
 PortSystem          1.0
 PortGroup           compilers 1.0
+PortGroup           github 1.0
 PortGroup           linear_algebra 1.0
 
+github.setup        NanoComp harminv 1.4.2 v
 license             GPL-2
-name                harminv
 categories          science
-version             1.4
-revision            1
+revision            0
 platforms           darwin
 maintainers         saabusa.com:Yogesh.Sharma openmaintainer
 description         Harmonic inversion solver
@@ -16,11 +16,10 @@ long_description    Solve the problem of harmonic inversion: given a discrete-ti
                     finitely-many sinusoids (possibly exponentially decaying) \
                     in a given bandwidth, it determines the frequencies, decay constants, amplitudes, and phases of those sinusoids.
 homepage            http://ab-initio.mit.edu/wiki/index.php/Harminv
-master_sites        http://ab-initio.mit.edu/harminv
-checksums           md5     b95e24a9bc7e07d3d2202d1605e9e86f \
-                    sha1    521fcca261bf91f45741b607aa2b244c7a1e0aff \
-                    rmd160  3813c438339bb1fc048d62bb9d012df43535aecb
-depends_lib         port:guile
+checksums           rmd160  fcfd0aa598608db47fe16af2500a8094166e544e \
+                    sha256  5a9a1bf710972442f065d0d62c62d0c4ec3da4a3696d7160a35602c9470bc7a2 \
+                    size    459325
+github.tarball_from releases
 
 configure.args-append   --mandir="${prefix}/share/man"
 
@@ -33,7 +32,3 @@ pre-configure {
 
 test.run            yes
 test.target         check
-
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     The latest version is Harminv (\[0-9.\]+)


### PR DESCRIPTION
#### Description

No idea how `guile` got into this port, but there is no mention of it in upstream instructions: https://github.com/NanoComp/harminv/blob/master/doc/installation.md
De facto it is not used to compile anything too. Drop it.

Also old sites do not work anymore, redirecting to GitHub. Use GitHub PG.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
