### PR TITLE
spatialite, spatialite-tools : add proj9 variants

### DIFF
--- a/databases/spatialite-tools/Portfile
+++ b/databases/spatialite-tools/Portfile
@@ -3,8 +3,8 @@
 PortSystem 1.0
 
 name                    spatialite-tools
-version                 4.3.0
-revision                6
+version                 5.0.0
+revision                0
 categories              databases gis
 license                 GPL-3
 platforms               darwin
@@ -15,18 +15,17 @@ long_description        These CLI tools allow to interact with a SpatiaLite DB,\
                         prepare a virtual network for routing.
 
 homepage                https://www.gaia-gis.it/fossil/spatialite-tools/index
-master_sites            http://www.gaia-gis.it/gaia-sins/
+master_sites            https://www.gaia-gis.it/gaia-sins/
 distname                spatialite-tools-${version}
 
-checksums               rmd160  97314411fc2a93e376ddd1e1b219e226fb6f68b8 \
-                        sha256  f739859bc04f38735591be2f75009b98a2359033675ae310dffc3114a17ccf89 \
-                        size    540811
+checksums               rmd160  44abc50b98431b9ccad4f75ebac08d4c3ea89fef \
+                        sha256  ad092d90ccb2c480f372d1e24b1e6ad9aa8a4bb750e094efdcc6c37edb6b6d32 \
+                        size    591215
 
 depends_build           port:pkgconfig
 depends_lib             port:spatialite\
                         port:libiconv\
                         port:geos\
-                        port:proj\
                         port:expat \
                         port:readosm
 
@@ -34,13 +33,34 @@ depends_lib             port:spatialite\
 configure.args          --disable-readline
 configure.args-append   --disable-freexl
 
-configure.cppflags-append   -I${prefix}/lib/proj5/include
-configure.ldflags-append    -L${prefix}/lib/proj5/lib
-
 variant readline description {Uses readline for input} {
     configure.args-delete   --disable-readline
     configure.args-append   --enable-readline
 }
+
+# Set PROJ
+set proj_versions {6 7 8 9}
+set proj_variants {}
+foreach pjver ${proj_versions} {
+    lappend proj_variants proj${pjver}
+}
+foreach proj_ver ${proj_versions} {
+    set index [lsearch -exact ${proj_variants} proj${proj_ver}]
+    set cflcts [lreplace ${proj_variants} ${index} ${index}]
+
+    variant proj${proj_ver} description "Use Proj${proj_ver}" conflicts {*}${cflcts} "
+        depends_lib-append          port:proj${proj_ver}
+        configure.cppflags-append   -I${prefix}/lib/proj${proj_ver}/include
+        configure.ldflags-append    -L${prefix}/lib/proj${proj_ver}/lib
+    "
+}
+set projdf "if {"
+foreach pv ${proj_versions} {
+    set projdf "${projdf}!\[variant_isset proj${pv}\] && "
+}
+set projdf [string range ${projdf} 0 end-4]
+set projdf "${projdf}} { default_variants +proj${pv} }"
+eval ${projdf}
 
 default_variants        +readline
 

--- a/databases/spatialite/Portfile
+++ b/databases/spatialite/Portfile
@@ -20,7 +20,7 @@ long_description    SpatiaLite is a library for geographic information \
                     projects.
 
 homepage            https://www.gaia-gis.it/fossil/libspatialite/index
-master_sites        http://www.gaia-gis.it/gaia-sins
+master_sites        https://www.gaia-gis.it/gaia-sins
 distname            libspatialite-${version}
 
 checksums           rmd160  b308c62df01a47286d7e2ff56c6992d537c5c8cd \

--- a/databases/spatialite/Portfile
+++ b/databases/spatialite/Portfile
@@ -5,7 +5,7 @@ PortGroup           debug 1.0
 
 name                spatialite
 version             5.0.1
-revision            4
+revision            5
 categories          databases gis
 platforms           darwin
 license             {MPL-1.1 GPL-2+ LGPL-2.1+}
@@ -42,27 +42,29 @@ configure.args-append \
 
 configure.cppflags-delete   -I${prefix}/include
 
-variant proj8 description {Build with Proj 8} conflicts proj6 proj7 {
-    depends_lib-append          port:proj8
-    configure.cppflags-append   -I${prefix}/lib/proj8/include
-    configure.ldflags-append    -L${prefix}/lib/proj8/lib
+# Set PROJ
+set proj_versions {6 7 8 9}
+set proj_variants {}
+foreach pjver ${proj_versions} {
+    lappend proj_variants proj${pjver}
 }
+foreach proj_ver ${proj_versions} {
+    set index [lsearch -exact ${proj_variants} proj${proj_ver}]
+    set cflcts [lreplace ${proj_variants} ${index} ${index}]
 
-variant proj6 description {Build with Proj 6} conflicts proj8 proj7 {
-    depends_lib-append          port:proj6
-    configure.cppflags-append   -I${prefix}/lib/proj6/include
-    configure.ldflags-append    -L${prefix}/lib/proj6/lib
+    variant proj${proj_ver} description "Use Proj${proj_ver}" conflicts {*}${cflcts} "
+        depends_lib-append          port:proj${proj_ver}
+        configure.cppflags-append   -I${prefix}/lib/proj${proj_ver}/include
+        configure.ldflags-append    -L${prefix}/lib/proj${proj_ver}/lib
+    "
 }
-
-variant proj7 description {Build with Proj 7} conflicts proj8 proj6 {
-    depends_lib-append          port:proj7
-    configure.cppflags-append   -I${prefix}/lib/proj7/include
-    configure.ldflags-append    -L${prefix}/lib/proj7/lib
+set projdf "if {"
+foreach pv ${proj_versions} {
+    set projdf "${projdf}!\[variant_isset proj${pv}\] && "
 }
-
-if {![variant_isset proj8] && ![variant_isset proj6] && ![variant_isset proj7]} {
-    default_variants +proj8
-}
+set projdf [string range ${projdf} 0 end-4]
+set projdf "${projdf}} { default_variants +proj${pv} }"
+eval ${projdf}
 
 livecheck.type      regex
 livecheck.url       ${homepage}


### PR DESCRIPTION
#### Description

Adds `+proj9` variant to both `spatialite` and `spatialite-tools`.

This also includes a version bump of `spatialite-tools` to 5.0.0 and the hardcoded dependency of `proj` is removed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
