### PR TITLE
kotlin: update to 1.8.21

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.8.20 v
+github.setup        JetBrains kotlin 1.8.21 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,9 +24,9 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  bc031c677f9b2ac67c30cbe6b0fb70d771f84164 \
-                    sha256  10df74c3c6e2eafd4c7a5572352d37cbe41774996e42de627023cb4c82b50ae4 \
-                    size    76325635
+checksums           rmd160  78e2be89a236e256384cc90640f819572ac97970 \
+                    sha256  6e43c5569ad067492d04d92c28cdf8095673699d81ce460bd7270443297e8fd7 \
+                    size    76338460
 
 java.version        1.8+
 java.fallback       openjdk17


### PR DESCRIPTION
#### Description

Update to Kotlin 1.8.21.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?