### PR TITLE
epy: update to 2023.2.8

### DIFF
--- a/python/epy/Portfile
+++ b/python/epy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        wustho epy 2022.12.11 v
+github.setup        wustho epy 2023.2.8 v
 github.tarball_from archive
 revision            0
 supported_archs     noarch
@@ -21,9 +21,9 @@ long_description    A CLI ebook reader that supports epub (.epub, .epub3), \
 
 homepage            https://github.com/wustho/epy
 
-checksums           rmd160  13cbc6b5cf25e416df2cf5cc1a91833082497698 \
-                    sha256  2dd9df8703a51a6fd4d77fc5d2aa71c3db2c9d8d856f18d9a99725e6badbf3ed \
-                    size    228954
+checksums           rmd160  537b748d5ab601b3c06a7f58a91ab1148d3b20b5 \
+                    sha256  22404cb30a4886d1fa7f75c6792b81a280ccb1d458ac56e0ec08adc864e507ff \
+                    size    198894
 
 depends_build-append \
                     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Update epy to version 2023.2.8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.5 21G531 arm64
Xcode 14.2 14C18


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
