### PR TITLE
Github CI: install ports witch depends on subports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,30 @@ jobs:
           echo "subportlist=${subportlist}" >> $GITHUB_OUTPUT
         env:
           portlist: ${{ steps.portlist.outputs.portlist }}
+      - name: Determine list of ports which depends on changed subports
+        id: dependslist
+        run: |
+          set -eu
+
+          echo "#### Depends Ports" >> $GITHUB_STEP_SUMMARY
+
+          dependslist=""
+          for port in $subportlist; do
+            echo "::group::Listing depends for ${port}"
+            new_subports=$(port echo depends:$port | tr '\n' ' ')
+            for subport in $new_subports; do
+              echo "$subport"
+              echo "- ${subport}" >> $GITHUB_STEP_SUMMARY
+              dependslist="$dependslist $subport"
+            done
+            echo "::endgroup::"
+          done
+
+          dependslist=$(echo $dependslist | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
+
+          echo "dependslist=${dependslist}" >> $GITHUB_OUTPUT
+        env:
+          subportlist: ${{ steps.subportlist.outputs.subportlist }}
       - name: Run port lint for all changed subports
         run: |
           set -eu
@@ -210,6 +234,93 @@ jobs:
           exit "$fail"
         env:
           subportlist: ${{ steps.subportlist.outputs.subportlist }}
+      - name: Install ports which depends on changed subports
+        run: |
+          set -eu
+
+          echo "buildfromsource never" | sudo tee -a /opt/local/etc/macports/macports.conf >/dev/null
+          echo "revupgrade_autorun no" | sudo tee -a /opt/local/etc/macports/macports.conf >/dev/null
+          echo "revupgrade_mode report" | sudo tee -a /opt/local/etc/macports/macports.conf >/dev/null
+
+          echo "#### Install Depends Results" >> $GITHUB_STEP_SUMMARY
+
+          fail=0
+          for port in $dependslist; do
+            workdir="/tmp/mpbb/deps-$port"
+            mkdir -p "$workdir/logs"
+            echo "##### ${port}" >> $GITHUB_STEP_SUMMARY
+            touch "$workdir/logs/dependencies-progress.txt"
+
+            echo "::group::Cleaning up between ports"
+            sudo mpbb --work-dir "$workdir" cleanup
+            echo "::endgroup::"
+
+            echo "::group::Installing dependencies for ${port}"
+            sudo mpbb \
+              --work-dir "$workdir" \
+              install-dependencies \
+              "$port" >"$workdir/logs/install-dependencies.log" 2>&1 &
+            deps_pid=$!
+
+            tail -f "$workdir/logs/dependencies-progress.txt" 2>/dev/null &
+            tail_pid=$!
+
+            set +e
+            wait "$deps_pid"
+            deps_exit=$?
+            set -e
+
+            kill "$tail_pid" || true
+
+            if [ "$deps_exit" -ne 0 ]; then
+              echo "::endgroup::"
+              echo "::error::Failed to install dependencies for ${port}"
+
+              echo "⚠️ Failed to install dependencies" >> $GITHUB_STEP_SUMMARY
+              continue
+            fi
+            echo "::endgroup::"
+
+            echo "::group::Installing ${port}"
+
+            set +e
+            sudo mpbb \
+              --work-dir "$workdir" \
+              install-port \
+              "$port"
+            install_exit=$?
+            set -e
+            if [ "$install_exit" -ne 0 ]; then
+              echo "::endgroup::"
+              echo "::error::Failed to install ${port}"
+
+              echo "⚠️ Failed to install from binary archive" >> $GITHUB_STEP_SUMMARY
+              continue
+            fi
+
+            set +e
+            sudo port rev-upgrade > $workdir/logs/rev-upgrade.txt
+            tail -n 1 $workdir/logs/rev-upgrade.txt | grep 'No broken ports found'
+            rev_upgrade_exit=$?
+            set -e
+
+            if [ "$rev_upgrade_exit" -ne 0 ]; then
+              echo "::endgroup::"
+              echo "::error::Failed to rev-upgrade ${port}"
+
+              echo "❌ Failed to run rev-upgrade, see the log for more details" >> $GITHUB_STEP_SUMMARY
+
+              fail=1
+              continue
+            fi
+
+            echo "✅ Successfully install" >> $GITHUB_STEP_SUMMARY
+            echo "::endgroup::"
+          done
+
+          exit "$fail"
+        env:
+          dependslist: ${{ steps.dependslist.outputs.dependslist }}
       - name: Make logfiles readable
         if: always()
         run: |


### PR DESCRIPTION
#### Description

Here I've introduced a new check for Github CI, which checks that a contributor hasn't forgotten to bump the revision of dependent ports when necessary.

The idea is simple: try to install binary archives and run rev-upgrade, and if it doesn't complain => it's safe.

If binary archives aren't available, it marks that but doesn't fail.

Trade-off? Time. As usual.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

Github Action by dummy commit which simple bumps revision of two ports: https://github.com/catap/macports-ports/commit/0ba9dde28f898c42b25d58f614a548be0444430b

Results are available here: https://github.com/catap/macports-ports/actions/runs/4803595448

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
