### PR TITLE
py-htmldocs: Update to latest.

### DIFF
--- a/lang/py-htmldocs/Portfile
+++ b/lang/py-htmldocs/Portfile
@@ -15,8 +15,8 @@ if {$subport != $name} {
     if {${python.version} == 37} { version 3.7.16 }
     if {${python.version} == 38} { version 3.8.16 }
     if {${python.version} == 39} { version 3.9.16 }
-    if {${python.version} == 310} { version 3.10.10 }
-    if {${python.version} == 311} { version 3.11.2 }
+    if {${python.version} == 310} { version 3.10.11 }
+    if {${python.version} == 311} { version 3.11.3 }
 }
 
 categories          lang
@@ -33,6 +33,7 @@ description         Local HTML documentation for Python.
 long_description    {*}${description}
 homepage            https://www.python.org/
 master_sites        https://www.python.org/ftp/python/doc/
+archive_sites
 
 if {${name} != ${subport}} {
     description         HTML documentation for Python ${version}
@@ -70,15 +71,15 @@ if {${name} != ${subport}} {
     }
 
     if {${python.version} == 310} {
-        checksums   rmd160  b49a6392b4d28e3024157d04c2aaff74da6f74e9 \
-                    sha256  cbdfb63a140f31ddb1d293bc83ab8889244aeb91f54653478908ca6cb0ba196e \
-                    size    7387634
+        checksums   rmd160  557b3dd93039380c54fff67bacb77641cc2d639c \
+                    sha256  a311c58b38e33210f6a8bd02d79e00c7900c3dabc87d4adef16aeb41a9cf1d7b \
+                    size    7390187
     }
 
     if {${python.version} == 311} {
-        checksums   rmd160  7d5581e0cbee9b2d7c151ef593589138ba8acf12 \
-                    sha256  705f31d7bd47804c07f11cc018c7ce8468433bd0f03ffcb8d27f8437dbe32ec1 \
-                    size    7779519
+        checksums   rmd160  4fee7b14f5df92a337d45845b649df2ecd8fc3ce \
+                    sha256  175d8fe269d540fb40c3bc84a06f965558fd7af432941c80a37bb4f4a32aef6e \
+                    size    7779259
     }
 
     dist_subdir         ${name}/${revision}


### PR DESCRIPTION
Disable archive_sites; this is essentially just a re-archival of the distribution file (no "build"), so save the BW and download from canonical source.

[Maintainer update]