### PR TITLE
py-dicom: Mark replaced_by py-pydicom

### DIFF
--- a/python/py-dicom/Portfile
+++ b/python/py-dicom/Portfile
@@ -1,58 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           python 1.0
-PortGroup           github 1.0
-github.setup        pydicom pydicom 0.9.9.post1 v
+PortGroup           obsolete 1.0
+
 name                py-dicom
-python.versions     27
-platforms           {darwin any}
-license             MIT BSD
-maintainers         {eborisch @eborisch} \
-                    openmaintainer
-supported_archs     noarch
+categories          python
+version             1.0
 
-description         Python Module for working with DICOM files
+# OK to delete after 5/1/2024
+replaced_by         py-pydicom
 
-long_description    pydicom is a pure python package for working with DICOM \
-                    files. It was made for inspecting and modifying DICOM \
-                    files in an easy pythonic way. The modifications can be \
-                    written again to a new file. As a pure python package, it \
-                    should run anywhere python runs without any other \
-                    requirements. NOTE: Superseded by py-pydicom\; retained \
-                    for backward compatibility.
-
-checksums \
-    rmd160  dfcbce2681e92b0da9c29973d6e08a6c3a2effc0 \
-    sha256  2d7f1460c61a8cd85c59096dfe7aa1a292a4d33298e446e6015d32c9ba9ad845
-
-if {${name} ne ${subport}} {
-    depends_lib-append      port:py${python.version}-numpy
-    depends_build-append    port:py${python.version}-sphinx
-
-    worksrcdir          ${distname}/source
-
-    post-extract {
-        reinplace s/sphinx-build/sphinx-build-${python.branch}/ \
-            ../docs/Makefile
-    }
-
-    post-build {
-        system -W ${worksrcpath}/../docs/ \
-            "make html"
-    }
-    
-    post-destroot {
-        set DOCDIR ${destroot}${prefix}/share/doc/${subport}
-        xinstall -d ${DOCDIR}
-        file copy ${worksrcpath}/dicom/license.txt ${DOCDIR}
-        file copy ${worksrcpath}/../docs/release-notes.txt ${DOCDIR}
-        file copy ${worksrcpath}/../docs/_build/html ${DOCDIR}
-    }
-
-    notes "Port exists for compatibility. Ongoing development in pyNN-pydicom."
-
-    livecheck.type  none
+subport "py27-dicom" {
+    replaced_by py37-pydicom
 }
-
-github.livecheck.regex  {(0\.[^"]+)}


### PR DESCRIPTION
Maintainer update.

The upstream (pydicom) project/module was renamed from _dicom_ to _pydicom_ over [five years ago](https://github.com/pydicom/pydicom/issues/582). The py-dicom package (impacted by this change) was kept around for compatibility for a while, but it is well and truly outdated by this point.

Mark replaced_by py-pydicom.