### PR TITLE
libidn2: doesn't really need C++-2011

### DIFF
--- a/mail/libidn2/Portfile
+++ b/mail/libidn2/Portfile
@@ -34,8 +34,6 @@ configure.checks.implicit_function_declaration.whitelist-append strchr
 
 configure.args      --disable-silent-rules
 
-compiler.cxx_standard   2011
-
 patchfiles          patch-configure.diff
 
 if {${os.platform} eq "darwin" && ${os.major} < 10} {


### PR DESCRIPTION
#### Description

This requirements dramatically increase a number of compilers which is required to compile `curl -http2` which is used by guys like me with bootstrap MacPorts which is used to bring fresh `libcurl`.

See: https://trac.macports.org/ticket/66614

###### Type(s)

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->