### PR TITLE
google-cloud-sdk: update to 428.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             427.0.0
+version             428.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  12908d1ccf5c797c957d2aa6f6ed1eabedabbcad \
-                    sha256  26d87cc13d9d080616af6a40ed4eeeb07df2fb4f1590d85c06de02de886caaab \
-                    size    104576697
+    checksums       rmd160  10714afd3557725ccd48bd8d73764732b578f869 \
+                    sha256  8771833361d9a3f9529066078ae8efce13d9d89d265ec5078b3b71420f07b4f3 \
+                    size    104677139
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  42f844e447d8b449d9d56cb91e5956920b3362cc \
-                    sha256  49ab70fa04c7be42ee6c54e7850e4ae5b71dce7021274ecebae9deb3479869c0 \
-                    size    124857252
+    checksums       rmd160  4a62c1519e371c2209b977c5ad8b0a2d6e1ce9a9 \
+                    sha256  90c70769bd265f15b1ce3fda4b41586a466904e1ab508388232c4f64e127e3eb \
+                    size    124954736
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  f70610e52f0245e7e8d84fa5c524d959c16e1bf9 \
-                    sha256  be417295deabba637ce93de1cec6576e53db6d270b0d5995f5a1bc3cd8660150 \
-                    size    121968796
+    checksums       rmd160  f1dec5371b84ff2cd52be43d3d3d30645dda29ce \
+                    sha256  cb5d7f880b94dc75484b2a2bdd3829cd7f50c6e2ab2e4a4882312e41d002e22b \
+                    size    122075380
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 428.0.0.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?