### PR TITLE
openjdk19-zulu: obsolete

### DIFF
--- a/java/openjdk19-zulu/Portfile
+++ b/java/openjdk19-zulu/Portfile
@@ -1,104 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-10-26
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk19-zulu
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://www.azul.com/downloads/?version=java-19-sts&os=macos&package=jdk
-version      19.32.13
-revision     0
-
-set openjdk_version 19.0.2
-
-description  Azul Zulu Community OpenJDK 19 (Short Term Support)
-long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
-                 specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
-                 verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
-                 respective Java SE version.
-
-master_sites https://cdn.azul.com/zulu/bin/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  104b544fed67d3b671aa2e93f4a46c8a8dd386e3 \
-                 sha256  2804575ae9ac63e39caa910e57610bf52b0f9e2d671928a98d18e2fcc9f62ac1 \
-                 size    201637537
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  f4127a7dd6a55bdb3fd09b590a4703756630ff6a \
-                 sha256  177d058d968b2fbe7a5ff5eceb18cdc16f6376ce291004f1a3139e78b2fb6391 \
-                 size    199629921
-}
-
-worksrcdir   ${distname}/zulu-19.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 18} {
-    # See https://www.azul.com/downloads/?version=java-19-sts&os=macos&package=jdk
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.14 Mojave or later."
-        return -code error
-    }
-}
-
-homepage     https://www.azul.com/downloads/
-
-livecheck.type      regex
-livecheck.url       https://cdn.azul.com/zulu/bin/
-livecheck.regex     zulu(19\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk19-zulu
+categories  java devel
+version     19.32.13
+revision    1
+replaced_by openjdk20-zulu


### PR DESCRIPTION
#### Description

Obsolete Azul Zulu OpenJDK 19, replaced by Azul Zulu OpenJDK 20.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?