### PR TITLE
jdk19: obsolete

### DIFF
--- a/java/jdk19/Portfile
+++ b/java/jdk19/Portfile
@@ -1,91 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-10-26
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             jdk19
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          NFTC NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://www.oracle.com/java/technologies/downloads/#jdk19-mac
-version      19.0.2
-revision     0
-
-description  Oracle Java SE Development Kit 19
-long_description Java Platform, Standard Edition Development Kit (JDK). \
-    The JDK is a development environment for building applications and components using the Java programming language. \
-    This software is provided under the Oracle No-Fee Terms and Conditions (NFTC) license (https://java.com/freeuselicense).
-
-master_sites https://download.oracle.com/java/19/archive/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  e67fd2674d8575c5f5fa2d6b32aa7f5fc2abed72 \
-                 sha256  50f60a959bbc12703aa3c493d0e4bb1bd58accd4b3cfc00cf06e8ee1e294fe2a \
-                 size    186187327
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  4079a2ed95db857aa6af530824993e71911ddcb9 \
-                 sha256  5787befa778fd16032c8385d3e682aac6987181ce3ba3a4983de04c3621b6111 \
-                 size    184210656
-}
-
-worksrcdir   jdk-${version}.jdk
-
-homepage     https://www.oracle.com/java/
-
-livecheck.type      regex
-livecheck.url       https://www.oracle.com/java/technologies/downloads/
-livecheck.regex     Java SE Development Kit (19\.\[0-9\.\]+)
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        jdk19
+categories  java devel
+version     19.0.2
+revision    1
+replaced_by jdk20


### PR DESCRIPTION
#### Description

Obsolete `jdk19`, replaced by `jdk20`.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?