### PR TITLE
openjdk19-sap: obsolete

### DIFF
--- a/java/openjdk19-sap/Portfile
+++ b/java/openjdk19-sap/Portfile
@@ -1,88 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-10-26
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk19-sap
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-version      19.0.2
-revision     0
-
-description  SAP Machine 19
-long_description An OpenJDK 19 release maintained and supported by SAP
-
-master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  c84187e2a07d8e2a89d05e6c3d9a58818467759a \
-                 sha256  526d827d243c97dcee965a40ec5735fc82dcb8d8b32ab5b118a9ce9199d213f9 \
-                 size    187912853
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  5fff841e1f27644d5f781cf26f182ba55c52e6bc \
-                 sha256  9378c84c6773fb93d4c65742aeff3d006fa636b12d9657e421a0ed2ebbd2040b \
-                 size    185942139
-}
-
-worksrcdir   sapmachine-jdk-${version}.jdk
-
-homepage     https://sap.github.io/SapMachine/
-
-livecheck.type      regex
-livecheck.url       https://github.com/SAP/SapMachine/releases
-livecheck.regex     sapmachine-jdk-(19\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk19-sap
+categories  java devel
+version     19.0.2
+revision    1
+replaced_by openjdk20-sap


### PR DESCRIPTION
#### Description

Obsolete `openjdk19-sap`, replaced by `openjdk20-sap`.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?