### PR TITLE
openjdk19-oracle: obsolete

### DIFF
--- a/java/openjdk19-oracle/Portfile
+++ b/java/openjdk19-oracle/Portfile
@@ -1,89 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-10-26
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk19-oracle
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://jdk.java.net/19/
-version      19.0.2
-revision     0
-
-description  Oracle OpenJDK 19
-long_description Open-source Oracle build of OpenJDK 19, the Java Development Kit, an implementation of the Java SE Platform.
-
-master_sites https://download.java.net/java/GA/jdk${version}/fdb695a9d9064ad6b064dc6df578380c/7/GPL/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  cd7cd7da70bbf9247b3daf1772ff872eeda1ef41 \
-                 sha256  c57c7c511706738fff6540945e0159e97b8b328777e6460977dd64e00f4c2c0b \
-                 size    192580989
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  522dfae403bb90de79775796062f5a212a0bbd8b \
-                 sha256  4317442e14c5c2f4f698db0e41347df99d050a32137b2a02dfec28ed856577cc \
-                 size    190625723
-}
-
-worksrcdir   jdk-${version}.jdk
-
-homepage     https://jdk.java.net/19/
-
-livecheck.type      regex
-livecheck.url       https://jdk.java.net/19/
-livecheck.regex     OpenJDK JDK (19\.\[0-9\.\]+)
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk19-oracle
+categories  java devel
+version     19.0.2
+revision    1
+replaced_by openjdk20-oracle


### PR DESCRIPTION
#### Description

Obsolete `openjdk19-oracle`, replaced by `openjdk19-oracle`.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?