### PR TITLE
openjdk19-temurin: obsolete

### DIFF
--- a/java/openjdk19-temurin/Portfile
+++ b/java/openjdk19-temurin/Portfile
@@ -1,85 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-10-26
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk19-temurin
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-# See https://adoptium.net/supported-platforms/
-platforms        {darwin any} {darwin >= 16}
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-# https://adoptium.net/temurin/releases/?version=19
-supported_archs  x86_64 arm64
-
-version      19.0.2
-set build    7
-revision     0
-
-description  Eclipse Temurin, based on OpenJDK 19
-long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
-
-master_sites https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${version}%2B${build}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     OpenJDK19U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  d099a6662e0631a5f290d663bfed44abb8efe62c \
-                 sha256  f59d4157b3b53a35e72db283659d47f14aecae0ff5936d5f8078000504299da6 \
-                 size    195407051
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     OpenJDK19U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  71bb0be73dd3238a3ee76e607dec99477e9d0ab8 \
-                 sha256  c419330cc8d6b9974d3bf1937f8f0e747c34c469afd5c546831d35aa19e03d49 \
-                 size    185296974
-}
-
-worksrcdir   jdk-${version}+${build}
-
-homepage     https://adoptium.net
-
-livecheck.type      regex
-livecheck.url       https://github.com/adoptium/temurin19-binaries/releases
-livecheck.regex     OpenJDK19U-.*_mac_hotspot_(19\[0-9\.\]*)_\[0-9\]+.tar.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk19-temurin
+categories  java devel
+version     19.0.2
+revision    1
+replaced_by openjdk20-temurin


### PR DESCRIPTION
#### Description

Obsolete `openjdk19-temurin`, replaced by `openjdk20-temurin`.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?