### PR TITLE
openjdk19-corretto: obsolete

### DIFF
--- a/java/openjdk19-corretto/Portfile
+++ b/java/openjdk19-corretto/Portfile
@@ -1,99 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2023-10-26
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk19-corretto
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://github.com/corretto/corretto-19/releases
-version      19.0.2.7.1
-revision     0
-
-description  Amazon Corretto OpenJDK 19 (Short Term Support)
-long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
-
-master_sites https://corretto.aws/downloads/resources/${version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  219c0b4b4ae39921339d2b28b5d77e8e3e8cf5d1 \
-                 sha256  ea9129fc264155e8fdb5d53a9742cb5f4a3939b5ac8fd66df6d3fac3f87b2020 \
-                 size    196357389
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  1d085c6de9febc1e177168ee63c4a263c521396e \
-                 sha256  b45e7541049f20c9d8ed2941b3029d37489342d8b55594279f2ee400e1376807 \
-                 size    194500036
-}
-
-worksrcdir   amazon-corretto-19.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 19} {
-    # See https://github.com/corretto/corretto-19/blob/release-19.0.2.7.1/CHANGELOG.md
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.15 Catalina or later."
-        return -code error
-    }
-}
-
-homepage     https://aws.amazon.com/corretto/
-
-livecheck.type      regex
-livecheck.url       https://github.com/corretto/corretto-19/releases
-livecheck.regex     amazon-corretto-(19\.\[0-9\.\]+)-macosx-.*\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk19-corretto
+categories  java devel
+version     19.0.2.7.1
+revision    1
+replaced_by openjdk20-corretto


### PR DESCRIPTION
#### Description

Obsolete `openjdk19-corretto`, replaced by `openjdk20-corretto`.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?