### PR TITLE
aerc: update to 0.15.0

### DIFF
--- a/mail/aerc/Portfile
+++ b/mail/aerc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile    1.0
 PortGroup           sourcehut   1.0
 
-sourcehut.setup     rjarry aerc 0.14.0
+sourcehut.setup     rjarry aerc 0.15.0
 revision            0
 
 homepage            https://aerc-mail.org
@@ -22,9 +22,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  941179d86461aa605415b2122fdbc21408aeb0aa \
-                    sha256  60bfd15e5528a504dd11a03a33a11438ebbac7d5daca46e02d0bdc983adf9012 \
-                    size    332575
+checksums           rmd160  bc9fcdc298188d0d1f4379a33bae8e853d12e1d8 \
+                    sha256  dbeb41abc71d4469da9067d401146843732d9838972067d18f836729006ca033 \
+                    size    330999
 
 depends_build-append \
                     port:go \


### PR DESCRIPTION
#### Description
[Changelog](https://git.sr.ht/~rjarry/aerc/refs/0.15.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

