### PR TITLE
ansible-lint: Register missing dependency on black

### DIFF
--- a/sysutils/ansible-lint/Portfile
+++ b/sysutils/ansible-lint/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        ansible-community ansible-lint 6.15.0 v
-revision            0
+revision            1
 
 categories          sysutils
 supported_archs     noarch
@@ -34,6 +34,7 @@ depends_build-append \
 
 depends_run-append  port:py${python.version}-ansible \
                     port:py${python.version}-ansible-compat \
+                    port:py${python.version}-black \
                     port:yamllint
 
 depends_lib-append  port:py${python.version}-enrich \


### PR DESCRIPTION
#### Description

Upon installing ansible-lint and running it with no arguments in a directory with a simple Ansible project, it fails with `ModuleNorFoundError: No module named 'black'`. This patch specifies the black module as a runtime dependency, which enables ansible-lint to run successfully.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.5 21G531 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
