### PR TITLE
sc: fix compilation, use debian patches

### DIFF
--- a/finance/sc/Portfile
+++ b/finance/sc/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 
 name                sc
 version             7.16
-revision            2
+revision            3
+set git_commit      e84d756c0b398e437020d58e15b89abfae64f69f
+license             public-domain
 maintainers         nomaintainer
 
 categories          finance
@@ -15,25 +17,22 @@ platforms           darwin
 
 homepage            http://www.ibiblio.org/pub/Linux/apps/financial/spreadsheet/
 
-master_sites        ${homepage}
+master_sites        https://salsa.debian.org/debian/sc/-/archive/master/
+distname            ${name}-${git_commit}
+use_bzip2           yes
+worksrcdir          ${name}-master-${git_commit}
 
-checksums           rmd160  bcaffd292bc3d0868e5be870fee743c6b3294377 \
-                    sha256  1997a00b6d82d189b65f6fd2a856a34992abc99e50d9ec463bbf1afb750d1765
+checksums           rmd160  4feb67769f96a4dc31bc211343e1a47ddcee9eeb \
+                    sha256  c51d1b6d00058beaf92f80a18f0b37bc29d06c55f7c8bb26959c8a2da7ba785c \
+                    size    175814
 
-patchfiles          Makefile.diff
+patchfiles          Makefile.diff \
+                    patch-sc.h.diff
 
 depends_lib         port:ncurses \
                     port:bison
 
 use_configure       no
-
-# TODO: This is a real bug that clang is complaining about.
-#       Fix it rather than just working around it
-if {[string match "*clang*" ${configure.compiler}]} {
-    configure.cflags-append -Wno-error=return-type
-}
-
-variant universal {}
 
 build.args-append   CC="${configure.cc} ${configure.cppflags} ${configure.cflags} [get_canonical_archflags]"
 

--- a/finance/sc/files/Makefile.diff
+++ b/finance/sc/files/Makefile.diff
@@ -1,42 +1,35 @@
---- Makefile.orig	2002-09-14 05:39:56.000000000 +0200
-+++ Makefile	2016-01-27 11:03:26.000000000 +0100
-@@ -26,13 +26,13 @@
+--- Makefile.orig	2022-05-27 15:45:34.000000000 -0400
++++ Makefile	2023-04-29 08:03:15.037784865 -0400
+@@ -26,7 +26,7 @@
  EXDIR=${prefix}/bin
- 
+
  # This is where the man page goes.
 -MANDIR=${prefix}/man/man1
 +MANDIR=${prefix}/share/man/man1
  MANEXT=1
  MANMODE=644
- 
- # This is where the library file (tutorial) goes.
- #LIBDIR=/usr/local/share/$(name) # reno
--LIBDIR=${prefix}/lib/$(name)
-+LIBDIR=${prefix}/share/doc/$(name)
- LIBRARY=-DLIBDIR=\"${LIBDIR}\"
- 
- # Set SIMPLE for lex.c if you don't want arrow keys or lex.c blows up
+
 @@ -499,32 +499,32 @@
  	 $(MANDIR)/p$(name).$(MANEXT)
- 
+
  $(EXDIR)/$(name): $(name)
 -	cp $(name) $(EXDIR)
 -	strip $(EXDIR)/$(name)
 +	cp $(name) $(DESTDIR)$(EXDIR)/
 +	strip $(DESTDIR)$(EXDIR)/$(name)
- 
+
  $(EXDIR)/$(name)qref: $(name)qref
 -	cp $(name)qref $(EXDIR)
 -	strip $(EXDIR)/$(name)qref
 +	cp $(name)qref $(DESTDIR)$(EXDIR)/
 +	strip $(DESTDIR)$(EXDIR)/$(name)qref
- 
+
  $(EXDIR)/p$(name): p$(name)
 -	cp p$(name) $(EXDIR)
 -	strip $(EXDIR)/p$(name)
 +	cp p$(name) $(DESTDIR)$(EXDIR)/
 +	strip $(DESTDIR)$(EXDIR)/p$(name)
- 
+
  $(LIBDIR)/tutorial: tutorial.sc $(LIBDIR)
 -	-mkdir -p $(LIBDIR)/plugins
 -	cp tutorial.sc $(LIBDIR)/tutorial.$(name)
@@ -44,22 +37,22 @@
 +	-mkdir -p $(DESTDIR)$(LIBDIR)/plugins
 +	cp tutorial.sc $(DESTDIR)$(LIBDIR)/tutorial.$(name)
 +	chmod $(MANMODE) $(DESTDIR)$(LIBDIR)/tutorial.$(name)
- 
+
  $(LIBDIR):
 -	mkdir $(LIBDIR)
 +	mkdir -p $(DESTDIR)$(LIBDIR)
- 
+
  $(MANDIR)/$(name).$(MANEXT): $(name).1
 -	cp $(name).1 $(MANDIR)/$(name).$(MANEXT)
 -	chmod $(MANMODE) $(MANDIR)/$(name).$(MANEXT)
 +	cp $(name).1 $(DESTDIR)$(MANDIR)/$(name).$(MANEXT)
 +	chmod $(MANMODE) $(DESTDIR)$(MANDIR)/$(name).$(MANEXT)
- 
+
  $(MANDIR)/p$(name).$(MANEXT): p$(name).1
 -	cp p$(name).1 $(MANDIR)/p$(name).$(MANEXT)
 -	chmod $(MANMODE) $(MANDIR)/p$(name).$(MANEXT)
 +	cp p$(name).1 $(DESTDIR)$(MANDIR)/p$(name).$(MANEXT)
 +	chmod $(MANMODE) $(DESTDIR)$(MANDIR)/p$(name).$(MANEXT)
- 
+
  uninstall:
  	rm -f $(EXDIR)/$(name)

--- a/finance/sc/files/patch-sc.h.diff
+++ b/finance/sc/files/patch-sc.h.diff
@@ -1,0 +1,23 @@
+--- sc.h.old	2023-04-26 18:42:31.790081128 -0400
++++ sc.h	2023-04-26 18:42:46.452346995 -0400
+@@ -614,6 +614,20 @@
+
+ void yankr(struct ent *v1, struct ent *v2);
+
++void ljustify(int sr, int sc, int er, int ec);
++void rjustify(int sr, int sc, int er, int ec);
++void center(int sr, int sc, int er, int ec);
++void add_abbr(char *string);
++void yankrow(int arg);
++void getframe(int fd);
++void yankcol(int arg);
++void getrange(char *name, int fd);
++void doeval(struct enode *e, char *fmt, int row, int col, int fd);
++void doseval(struct enode *e, int row, int col, int fd);
++void dogetkey();
++void list_frames(FILE *f);
++void gotonote();
++
+
+ #if BSD42 || SYSIII
+


### PR DESCRIPTION
#### Description

Switch to using Debian as the upstream source as they have been maintaining patches. Unfortunately the Debian Salsa repo doesn't have useful tags so I am using the commit hash.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
