### PR TITLE
tree-sitter: address stealth update

### DIFF
--- a/devel/tree-sitter/Portfile
+++ b/devel/tree-sitter/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        tree-sitter tree-sitter 0.20.8 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://tree-sitter.github.io
 
@@ -26,23 +26,28 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
+dist_subdir         ${name}/${version}_${revision}
+
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f645eff5abe53bcd1d6d875825a84711053ee7d1 \
-                    sha256  65a0e24657d60e0ab44357aa6cfeff4159ebb289adf6c6213ece0016ffefc793 \
-                    size    2934832
+                    rmd160  c713660581947dfdad3b367daacb7ad4cbafa624 \
+                    sha256  6181ede0b7470bfca37e293e7d5dc1d16469b9485d13f13a605baec4a8b1f791 \
+                    size    2941223
 
 use_configure       no
 
 if {${subport} eq ${name}} {
     PortGroup       makefile 1.0
+
 }
 
 subport ${name}-cli {
     PortGroup       cargo 1.0
 
-    revision        1
+    revision        2
 
     build.dir       ${worksrcpath}/cli
+
+    dist_subdir     ${subport}/${version}_${revision}
 
     depends_run-append  path:bin/node:nodejs16
 
@@ -55,86 +60,121 @@ subport ${name}-cli {
     cargo.crates \
         aho-corasick                    0.7.20  cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac \
         ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
-        anyhow                          1.0.66  216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6 \
+        anyhow                          1.0.70  7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4 \
         ascii                            1.1.0  d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16 \
         atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
         autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
         bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-        bumpalo                         3.11.1  572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba \
-        cc                              1.0.77  e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4 \
+        bumpalo                         3.12.0  0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535 \
+        bytes                            1.4.0  89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be \
+        cc                              1.0.79  50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f \
+        cesu8                            1.1.0  6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c \
         cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-        chunked_transfer                 1.4.0  fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e \
+        chunked_transfer                 1.4.1  cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a \
         clap                            2.34.0  a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c \
+        combine                          4.6.6  35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4 \
+        core-foundation                  0.9.3  194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146 \
+        core-foundation-sys              0.8.4  e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa \
         ctor                            0.1.26  6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096 \
         diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
         difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
         dirs                             3.0.2  30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309 \
+        dirs                             4.0.0  ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059 \
         dirs-sys                         0.3.7  1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6 \
-        either                           1.8.0  90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797 \
-        fastrand                         1.8.0  a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499 \
+        either                           1.8.1  7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91 \
+        errno                            0.3.0  50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0 \
+        errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
+        fastrand                         1.9.0  e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be \
+        form_urlencoded                  1.1.0  a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8 \
         getrandom                        0.2.8  c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31 \
-        glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
+        glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
         hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
         hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
-        html-escape                     0.2.12  15315cfa9503e9aa85a477138eff76a1b203a430703548052c330b69d8d8c205 \
+        hermit-abi                       0.3.1  fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286 \
+        html-escape                     0.2.13  6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476 \
         httpdate                         1.0.2  c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421 \
-        indexmap                         1.9.2  1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399 \
+        idna                             0.3.0  e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6 \
+        indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
         instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
-        itoa                             1.0.4  4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc \
-        js-sys                          0.3.60  49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47 \
+        io-lifetimes                     1.0.9  09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb \
+        itoa                             1.0.6  453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6 \
+        jni                             0.21.1  1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97 \
+        jni-sys                          0.3.0  8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130 \
+        js-sys                          0.3.61  445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730 \
         lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-        libc                           0.2.138  db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8 \
+        libc                           0.2.141  3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5 \
         libloading                       0.7.4  b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f \
+        linux-raw-sys                    0.3.1  d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f \
         log                             0.4.17  abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e \
+        malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
         memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
-        once_cell                       1.16.0  86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860 \
+        ndk-context                      0.1.1  27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b \
+        objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
+        once_cell                       1.17.1  b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3 \
         output_vt100                     0.1.3  628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66 \
+        percent-encoding                 2.2.0  478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e \
         ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
         pretty_assertions                0.7.2  1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b \
-        proc-macro2                     1.0.47  5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725 \
-        quote                           1.0.21  bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179 \
+        proc-macro2                     1.0.56  2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435 \
+        quote                           1.0.26  4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc \
         rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
         rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
         rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+        raw-window-handle                0.5.2  f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9 \
         redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
+        redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
         redox_users                      0.4.3  b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b \
-        regex                            1.7.0  e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a \
-        regex-syntax                    0.6.28  456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848 \
-        remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+        regex                            1.7.3  8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d \
+        regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
         rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
-        ryu                             1.0.11  4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09 \
+        rustix                          0.37.7  2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d \
+        ryu                             1.0.13  f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041 \
         same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-        semver                          1.0.14  e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4 \
-        serde                          1.0.149  256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055 \
-        serde_derive                   1.0.149  b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4 \
-        serde_json                      1.0.89  020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db \
+        semver                          1.0.17  bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed \
+        serde                          1.0.159  3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065 \
+        serde_derive                   1.0.159  4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585 \
+        serde_json                      1.0.95  d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744 \
         smallbitvec                      2.5.1  75ce4f9dc4a41b4c3476cc925f1efb11b66df373a8fde5d4b8915fa91b5d995e \
         strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-        syn                            1.0.105  60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908 \
-        tempfile                         3.3.0  5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4 \
+        syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+        syn                             2.0.13  4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec \
+        tempfile                         3.5.0  b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998 \
         textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
-        thiserror                       1.0.37  10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e \
-        thiserror-impl                  1.0.37  982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb \
+        thiserror                       1.0.40  978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac \
+        thiserror-impl                  1.0.40  f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f \
         tiny_http                       0.12.0  389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82 \
-        toml                             0.5.9  8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7 \
-        unicode-ident                    1.0.5  6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3 \
+        tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+        tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
+        toml                            0.5.11  f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234 \
+        unicode-bidi                    0.3.13  92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460 \
+        unicode-ident                    1.0.8  e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4 \
+        unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
         unicode-width                   0.1.10  c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b \
         unindent                         0.2.1  5aa30f5ea51ff7edfc797c6d3f9ec8cbd8cfedef5371766b7181d33977f4814f \
+        url                              2.3.1  0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643 \
         utf8-width                       0.1.6  5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1 \
         vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
-        walkdir                          2.3.2  808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56 \
-        wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-        wasm-bindgen                    0.2.83  eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268 \
-        wasm-bindgen-backend            0.2.83  4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142 \
-        wasm-bindgen-macro              0.2.83  052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810 \
-        wasm-bindgen-macro-support      0.2.83  07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c \
-        wasm-bindgen-shared             0.2.83  1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f \
-        web-sys                         0.3.60  bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f \
-        webbrowser                       0.5.5  ecad156490d6b620308ed411cfee90d280b3cbd13e189ea0d3fada8acc89158a \
-        which                            4.3.0  1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b \
-        widestring                       0.4.3  c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c \
+        walkdir                          2.3.3  36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698 \
+        wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+        wasm-bindgen                    0.2.84  31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b \
+        wasm-bindgen-backend            0.2.84  95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9 \
+        wasm-bindgen-macro              0.2.84  4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5 \
+        wasm-bindgen-macro-support      0.2.84  2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6 \
+        wasm-bindgen-shared             0.2.84  0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d \
+        web-sys                         0.3.61  e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97 \
+        webbrowser                       0.8.8  579cc485bd5ce5bfa0d738e4921dd0b956eca9800be1fd2e5257ebe95bc4617e \
+        which                            4.4.0  2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269 \
         winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
         winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
         winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
-        winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+        winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+        windows-sys                     0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+        windows-targets                 0.42.2  8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
+        windows_aarch64_gnullvm         0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
+        windows_aarch64_msvc            0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
+        windows_i686_gnu                0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
+        windows_i686_msvc               0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
+        windows_x86_64_gnu              0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
+        windows_x86_64_gnullvm          0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
+        windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0
 }


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/67306

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
