### PR TITLE
spdlog: fix for systems without pthread_threadid_np

### DIFF
--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -24,3 +24,6 @@ long_description    {*}${description}
 
 compiler.cxx_standard   2011
 compiler.thread_local_storage yes
+
+# https://github.com/gabime/spdlog/commit/c65aa4e4889939c1afa82001db349cac237a13f8
+patchfiles          patch-pthread.diff

--- a/devel/spdlog/files/patch-pthread.diff
+++ b/devel/spdlog/files/patch-pthread.diff
@@ -1,0 +1,32 @@
+--- include/spdlog/details/os-inl.h.orig	2022-11-03 05:13:08.000000000 +0800
++++ include/spdlog/details/os-inl.h	2023-04-28 04:51:00.000000000 +0800
+@@ -60,6 +60,10 @@
+ 
+ #endif // unix
+ 
++#if defined __APPLE__
++#    include <AvailabilityMacros.h>
++#endif
++
+ #ifndef __has_feature          // Clang - feature checking macros.
+ #    define __has_feature(x) 0 // Compatibility with non-clang compilers.
+ #endif
+@@ -353,7 +357,17 @@
+     return static_cast<size_t>(::thr_self());
+ #elif __APPLE__
+     uint64_t tid;
+-    pthread_threadid_np(nullptr, &tid);
++#    if (MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || defined(__POWERPC__)
++        tid = pthread_mach_thread_np(pthread_self());
++#    elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++        if (&pthread_threadid_np) {
++            pthread_threadid_np(nullptr, &tid);
++        } else {
++            tid = pthread_mach_thread_np(pthread_self());
++        }
++#    else
++        pthread_threadid_np(nullptr, &tid);
++#    endif
+     return static_cast<size_t>(tid);
+ #else // Default to standard C++11 (other Unix)
+     return static_cast<size_t>(std::hash<std::thread::id>()(std::this_thread::get_id()));


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/67212

#### Description

Merged to upstream in: https://github.com/gabime/spdlog/commit/c65aa4e4889939c1afa82001db349cac237a13f8

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
