### PR TITLE
p5-net-ssleay: Rebump for OpenSSL 3.1 update

### DIFF
--- a/devel/openssl3/Portfile
+++ b/devel/openssl3/Portfile
@@ -16,6 +16,7 @@ revision            3
 # Please revbump these ports when updating the openssl3 version/revision
 #  - freeradius (#43461)
 #  - openssh (#54990)
+#  - p5-net-ssleay (#67321, for minor version bumps)
 #  - openssl (to rebuild the shim links).
 
 categories          devel security

--- a/perl/p5-net-ssleay/Portfile
+++ b/perl/p5-net-ssleay/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         Net-SSLeay 1.92
-revision            0
+revision            1
 license             Artistic-2
 maintainers         nomaintainer
 description         Perl extension for using OpenSSL


### PR DESCRIPTION
#### Description

Software that depends on p5-net-ssleay (e.g., p5-io-socket-ssl) contains checks that assume that every minor version bump of OpenSSL is an ABI change, which is incorrect. This incorrect assumption then leads to build failures.

Revbump p5-net-ssleay to fix this and add a note to the openssl3 Portfile to do this every time openssl3 is updated to a new minor version.

Closes: https://trac.macports.org/ticket/67321

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.3.1 22E261 x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

