### PR TITLE
audiowmark: fix build with Clang >=15

### DIFF
--- a/audio/audiowmark/Portfile
+++ b/audio/audiowmark/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 gitlab.instance     https://code.uplex.de
 gitlab.setup        stefan audiowmark 0.6.1
-revision            0
+revision            1
 
 categories          audio
 maintainers         {@aeiouaeiouaeiouaeiouaeiouaeiou outlook.com:aeioudev} openmaintainer
@@ -35,23 +35,21 @@ depends_build       port:pkgconfig \
                     port:autoconf-archive
 
 depends_lib         port:fftw-3-single \
+                    path:lib/libavcodec.dylib:ffmpeg \
                     port:libsndfile \
                     port:libgcrypt \
                     port:libzita-resampler \
                     port:mpg123
 
+patchfiles          patch-llvm-random.diff
+
 compiler.cxx_standard \
                     2014
-# Random generator is incompatible with LLVM 15;
-# also do not use Xcode Clang due to failing buildbots
-# https://github.com/swesterfeld/audiowmark/issues/29
-compiler.blacklist  {clang} macports-clang-15
+# do not use Xcode Clang due to failing buildbots
+compiler.blacklist  {clang}
 
-variant ffmpeg description {Build with HTTP Live Streaming support} {
-     depends_lib-append path:lib/libavcodec.dylib:ffmpeg
-     configure.args-append \
-                    --with-ffmpeg
-}
+# videowmark always requires ffmpeg libraries
+configure.args      --with-ffmpeg
 
 use_autoreconf      yes
 

--- a/audio/audiowmark/files/patch-llvm-random.diff
+++ b/audio/audiowmark/files/patch-llvm-random.diff
@@ -1,0 +1,38 @@
+From 99ffa6b4a4f311c88b6b38b31e579b2102453f3a Mon Sep 17 00:00:00 2001
+From: Stefan Westerfeld <stefan@space.twc.de>
+Date: Sat, 28 Jan 2023 20:49:45 +0100
+Subject: [PATCH] Make random number generator code compile with clang++-15 +
+ libc++-15.
+
+A uniform random bit generator G needs to have a typedef for G::result_type.
+See issue #29.
+
+Signed-off-by: Stefan Westerfeld <stefan@space.twc.de>
+--- src/random.hh
++++ src/random.hh
+@@ -49,7 +49,9 @@ public:
+   Random (uint64_t seed, Stream stream);
+   ~Random();
+ 
+-  uint64_t
++  typedef uint64_t result_type;
++
++  result_type
+   operator()()
+   {
+     if (buffer_pos == buffer.size())
+@@ -57,12 +59,12 @@ public:
+ 
+     return buffer[buffer_pos++];
+   }
+-  static constexpr uint64_t
++  static constexpr result_type
+   min()
+   {
+     return 0;
+   }
+-  static constexpr uint64_t
++  static constexpr result_type
+   max()
+   {
+     return UINT64_MAX;


### PR DESCRIPTION
* make the ffmpeg dependency permanent

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
