### PR TITLE
symfony-cli: update to v5.5.4

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.5.2
+version             5.5.4
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  e125c2a85f8f011b1b9951bb7a7539183924ffb4 \
-                        sha256  a8b4c4c97deeab3bb002d31fd8303d8f18fc2a42d7bbf54a1d1ff68ccfb9d1c8 \
-                        size    249833
+    checksums           rmd160  549837b47acc20fd00b2e581305bc2c9242d34cb \
+                        sha256  7ec3ca2882aff8c826d006454e4879076da2992c45a0462398874b2ae10502d6 \
+                        size    252280
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  ddc726ee6ff7289d0694929f92eb05506211cd87 \
-                        sha256  fea3bd74de86b31c4b47fd40bd4532415c7125a7b5d4830c83365de43b600c98 \
-                        size    10908908
+    checksums           rmd160  adb9e3652b06c7443b0748ee227537ffe7af8adc \
+                        sha256  5c2bcfd8c59ec6fcf3603c0c7e4ab59526901ba1c3a7ce562e0c34503fcdcc29 \
+                        size    10955477
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.5.4

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for
the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
