### PR TITLE
texlive: update to 2023

### DIFF
--- a/tex/biblatex-biber/Portfile
+++ b/tex/biblatex-biber/Portfile
@@ -12,9 +12,9 @@ epoch           3
 
 perl5.branches  5.34
 
-perl5.setup     Biber 2.17
+perl5.setup     Biber 2.19
 version         ${perl5.moduleversion}
-revision        1
+
 
 categories      tex
 license         {Artistic-2 GPL}
@@ -37,9 +37,9 @@ master_sites    https://github.com/plk/biber/archive/
 distname        v${version}
 worksrcdir      biber-${version}
 
-checksums           rmd160  3289b2c2e180fbb11ca41e8af044083427c2a036 \
-                    sha256  1ee7efdd8343e982046f2301c1b0dcf09e1f9a997ac86ed1018dcb41d04c9e88 \
-                    size    1607708
+checksums           rmd160  58ed60d834f7061768405ef2d61f3637c886bf3a \
+                    sha256  1c1266bc8adb1637c4c59e23c47d919c5a38da4e53544a3c22c21de4a68fc9fe \
+                    size    1634803
 #patchfiles      patch-use-encode.pm
 
 depends_build-append    port:p${perl5.major}-config-autoconf \
@@ -79,6 +79,7 @@ depends_lib-append      port:p${perl5.major}-autovivification \
                         port:p${perl5.major}-regexp-common \
                         port:p${perl5.major}-sort-key \
                         port:p${perl5.major}-storable \
+                        port:p${perl5.major}-text-balanced \
                         port:p${perl5.major}-text-bibtex \
                         port:p${perl5.major}-text-csv \
                         port:p${perl5.major}-text-csv_xs \

--- a/tex/luametatex/Portfile
+++ b/tex/luametatex/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       github 1.0
+PortGroup       cmake  1.0
+
+github.setup    contextgarden luametatex 2.10.08 v
+
+categories      tex
+maintainers     {dports @drkp} openmaintainer
+license         GPL-2+
+description     LuaMetaTeX engine for ConTeXt
+long_description \
+   LuaMetaTeX is a follow-up to the LuaTeX engine for use with ConTeXt
+
+platforms darwin
+
+checksums       rmd160  f8e72665ccc996ea6e2c8c37f4200210b00a4a13 \
+                sha256  da91e742755463e20828b223dc86597c5776b594bfee8cc60277e29e16fd8b2d \
+                size    3104560

--- a/tex/texlive-basic/Portfile
+++ b/tex/texlive-basic/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-basic
-version             62858
-revision            2
+version             66584
+revision            0
 
 categories          tex
 maintainers         {dports @drkp}
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Essential programs and files
 long_description    These files are regarded as basic for any TeX system, covering plain TeX macros, Computer Modern fonts, and configuration for common drivers\; no LaTeX.
 
-checksums           texlive-basic-62858-run.tar.xz \
-                    rmd160  1232641d3fdb287e3a283b35b9abd61ee04f9723 \
-                    sha256  7ac3b2249692f8719ccf38591f282cbd329d27a86b9269dc23cbe9ec7c9f9942 \
-                    size    20543380 \
-                    texlive-basic-62858-doc.tar.xz \
-                    rmd160  0a3f8f4cae915994c2c5d83d98bbe76291cb4713 \
-                    sha256  92d062edd66ce66ce2610395482f5480f89286af2db786fa8d742e2d598b10a5 \
-                    size    15247396 \
-                    texlive-basic-62858-src.tar.xz \
-                    rmd160  93901371deb6af684241c9e4f41a79a216ad1617 \
-                    sha256  083341ad83da98c7a3b7866bd8cafd736688aeb66271b28899dd43bb2ab7d725 \
-                    size    293560
+checksums           texlive-basic-66584-run.tar.xz \
+                    rmd160  5995551438a5bcd912e008edea8f1a0c1c8f0c75 \
+                    sha256  bfec18b5c55b52a3a89387eef25f458718e58894acf8c295bc1bdd19ce0c0901 \
+                    size    21118176 \
+                    texlive-basic-66584-doc.tar.xz \
+                    rmd160  ae7ed738d5411254953e43dcc7e7f9cbe0081224 \
+                    sha256  d5e28f5ae6983d3bb7a471c241083f962414f3b172059e50892809f52de1db87 \
+                    size    15827532 \
+                    texlive-basic-66584-src.tar.xz \
+                    rmd160  2975892398a150e28a82991cd5cc391002c828cb \
+                    sha256  dccf820124f8b87d6b34d1a8be2ef5b3c91e260cb6aa20bd67b4ec674c83fd73 \
+                    size    293228
 
 texlive.formats      \
     {1 luahbtex luahbtex language.def,language.dat.lua {luatex.ini}} \

--- a/tex/texlive-bibtex-extra/Portfile
+++ b/tex/texlive-bibtex-extra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-bibtex-extra
-version             62866
+version             66579
 revision            0
 
 categories          tex
@@ -13,22 +13,22 @@ license             Copyleft Permissive
 description         TeX Live: BibTeX additional styles
 long_description    Additional BibTeX styles and bibliography data(bases), notably including BibLaTeX.
 
-checksums           texlive-bibtex-extra-62866-run.tar.xz \
-                    rmd160  044580d65d1e44ed619088d320db8ad47f9d442a \
-                    sha256  ece68df688dad6eda44739ec95dd356b5d81e694d75c47b0c8f257b5a53a1577 \
-                    size    68457644 \
-                    texlive-bibtex-extra-62866-doc.tar.xz \
-                    rmd160  c9ca07a98f776c58a2fc1e41ee031779c279b5ad \
-                    sha256  846c43b88b8df0659eb497fc1efe2e6190604e34f89f80c3647845827e7d1d4d \
-                    size    62524252 \
-                    texlive-bibtex-extra-62866-src.tar.xz \
-                    rmd160  48b7a7ee8135a0418f8858cf404cac408794e422 \
-                    sha256  61914b1e80be58f2bbb425396ed4b3481c82a1b6ab458969fec7dff112833016 \
-                    size    2442816
+checksums           texlive-bibtex-extra-66579-run.tar.xz \
+                    rmd160  95930e43a87010d3c48e64d36b6b68c7927f6fe9 \
+                    sha256  f6d35b7574ae80c60c87aa60019bf52dc35f42e2d54599a280629651f5b721f2 \
+                    size    78574524 \
+                    texlive-bibtex-extra-66579-doc.tar.xz \
+                    rmd160  ffd7f82c4e551633ef9b4d3cdc3e68624455a31d \
+                    sha256  63906257729615f309c69d832f37fbc4905dc5335251f3fb2559cc7af19c227b \
+                    size    70464204 \
+                    texlive-bibtex-extra-66579-src.tar.xz \
+                    rmd160  d4a7804cda32ad7da3f80672b7df6067171e02e2 \
+                    sha256  3f6b1cd52a4cdb588304cc8a33d8cc3a68bd04a90d16aae6264d2caf30223614 \
+                    size    3917656
 
 depends_lib         port:texlive-latex
 
-texlive.binaries    bbl2bib bib2gls bibdoiadd bibexport bibmradd biburl2doi bibzbladd citeproc convertgls2bib listbib ltx2crossrefxml multibibliography urlbst
+texlive.binaries    bbl2bib bib2gls bibcop bibdoiadd biber-ms bibexport bibmradd biburl2doi bibzbladd citeproc-lua convertgls2bib listbib ltx2crossrefxml multibibliography urlbst
 
 
 texlive.texmfport

--- a/tex/texlive-bin-extra/Portfile
+++ b/tex/texlive-bin-extra/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-bin-extra
-version             62815
-revision            1
+version             66529
+revision            0
 
 categories          tex
 maintainers         {dports @drkp}
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: TeX auxiliary programs
 long_description    Myriad additional TeX-related support programs. Includes programs and macros for DVI file manipulation, literate programming, patgen, and plenty more.
 
-checksums           texlive-bin-extra-62815-run.tar.xz \
-                    rmd160  0b9ba54662c67c0348c8b590c88842568820fe9c \
-                    sha256  a922dc190ea6e0ddc8fca27ba694fd5b467e395f90b230a568a7c622665b193b \
-                    size    125585280 \
-                    texlive-bin-extra-62815-doc.tar.xz \
-                    rmd160  a408176ad234b366608f8ac12b1ed4029426fa19 \
-                    sha256  68d95dd00daab2e15495446ee3efa84ba89288e903a75219563826f94cb29718 \
-                    size    28989620 \
-                    texlive-bin-extra-62815-src.tar.xz \
-                    rmd160  0dd489f81a9224d01a20c05a015ab2cadd48552a \
-                    sha256  7cdeb753656b55c3b9c807fcf0dc83d1da1ceb42a76647bc4df7a78d8fc1bb0e \
-                    size    441472
+checksums           texlive-bin-extra-66529-run.tar.xz \
+                    rmd160  2f1324a454663afbffb0f075ce2e5550021abba5 \
+                    sha256  a4f640e4f52d3178da7ae362c28a5fe97e090e9949698fd8116a0526087d2b79 \
+                    size    132228964 \
+                    texlive-bin-extra-66529-doc.tar.xz \
+                    rmd160  ec3137238b8f6e812cc44cb445b0390add106635 \
+                    sha256  b913212ddedfbfabb769dca1f06e7e1acefbd5f1247ddb08ca787e1b4ebab5e5 \
+                    size    33750888 \
+                    texlive-bin-extra-66529-src.tar.xz \
+                    rmd160  6b80cdbd8c8d10d7cb4551493418efc43ffbb7a0 \
+                    sha256  a12944c29dca007e12aa2a955ace92e1e3e412b803cb0c2162475f212e6d4e1b \
+                    size    457204
 
 depends_lib         port:texlive-basic
 
@@ -33,11 +33,11 @@ texlive.formats      \
     {1 luajittex luajittex language.def,language.dat.lua {luatex.ini}} \
     {0 mflua mflua-nowin - {mf.ini}}
 
-texlive.binaries    a2ping a5toa4 adhocfilelist allcm allec allneeded arara arlatex bibtex8 bibtexu bundledoc checklistings chkdvifont chklref chktex chkweb cllualatex cluttex clxelatex ctan-o-mat ctanbib ctangle ctanify ctanupload ctie ctwill ctwill-refsort ctwill-twinx cweave de-macro depythontex deweb dt2dv dtxgen dv2dt dvi2fax dviasm dvibook dviconcat dvicopy dvidvi dvihp dviinfox dvilj dvilj2p dvilj4 dvilj4l dvilj6 dvipos dvired dviselect dvispc dvitodvi dvitype e2pall findhyph fragmaster git-latexdiff gsftopk installfont-tl ketcindy kpsepath kpsetool kpsewhere kpsexpand lacheck latex-git-log latex-papersize latex2man latex2nemeth latexdef latexfileversion latexindent latexpand listings-ext.sh llmk ltxfileinfo ltximg luajithbtex luajittex make4ht match_parens mflua mflua-nowin mfluajit mfluajit-nowin mkjobtexmf mkocp mkofm optexcount pamphletangler patgen pdfbook2 pdfclose pdfcrop pdflatexpicscale pdfopen pdftex-quiet pdftosrc pdfxup pfarrei pkfix pkfix-helper pooltype ps2frag pslatex purifyeps pythontex rpdfcrop spix srcredact sty2dtx synctex tangle tex4ebook texconfig texconfig-dialog texconfig-sys texcount texdef texdiff texdirflatten texdoc texdoctk texfot texlinks texliveonfly texloganalyser texlogfilter texlogsieve texluajit texluajitc texosquery texosquery-jre5 texosquery-jre8 texplate tie tlcockpit tpic2pdftex twill typeoutfileinfo weave xindex
+texlive.binaries    a2ping a5toa4 adhocfilelist allcm allec allneeded arara arlatex bibtex8 bibtexu bundledoc checklistings chkdvifont chklref chktex chkweb cllualatex cluttex clxelatex ctan-o-mat ctanbib ctangle ctanify ctanupload ctie ctwill ctwill-refsort ctwill-twinx cweave de-macro depythontex deweb digestif dt2dv dtxgen dv2dt dvi2fax dviasm dvibook dviconcat dvicopy dvidvi dvihp dviinfox dvilj dvilj2p dvilj4 dvilj4l dvilj6 dvipos dvired dviselect dvispc dvitodvi dvitype e2pall findhyph fragmaster git-latexdiff gsftopk installfont-tl ketcindy kpsepath kpsetool kpsewhere kpsexpand lacheck latex-git-log latex-papersize latex2man latex2nemeth latexdef latexfileversion latexindent latexpand listings-ext.sh llmk ltxfileinfo ltximg luajithbtex luajittex make4ht match_parens mflua mflua-nowin mfluajit mfluajit-nowin mkjobtexmf mkocp mkofm optexcount pamphletangler patgen pdfbook2 pdfclose pdfcrop pdflatexpicscale pdfopen pdftex-quiet pdftosrc pdfxup pfarrei pkfix pkfix-helper pooltype ps2frag pslatex purifyeps pythontex rpdfcrop spix srcredact sty2dtx synctex tangle tex4ebook texaccents texconfig texconfig-dialog texconfig-sys texcount texdef texdiff texdirflatten texdoc texdoctk texfot texlinks texliveonfly texloganalyser texlogfilter texlogsieve texluajit texluajitc texosquery texosquery-jre5 texosquery-jre8 texplate tie tlcockpit tpic2pdftex twill typeoutfileinfo upmendex weave xindex
 
 # Dependencies for tools that are part of this package in TeX Live,
 # but are packaged as separate ports
-depends_run         port:texlive-tlpdb \
+depends_run-append  port:texlive-tlpdb \
                     port:latexmk \
                     port:opendetex \
                     port:latexdiff \
@@ -86,7 +86,6 @@ depends_run-append port:p${perl5.major}-file-copy-recursive
 # dependencies for ctanupload
 depends_run-append port:p${perl5.major}-html-formatter \
                    port:p${perl5.major}-www-mechanize
-
 # dependencies for latex-git-log
 depends_run-append port:p${perl5.major}-ipc-system-simple
 
@@ -98,5 +97,12 @@ depends_run-append port:p${perl5.major}-tk \
 
 # ltximg also depends on p5-data-dumper
 
+pre-activate {
+    # Handle conflicts for TL2023 update
+    if { ![catch {set vers [lindex [registry_active texlive-lang-japanese] 0]}]
+         && ([vercmp [lindex $vers 1] 66482] < 0) } {
+        registry_deactivate_composite texlive-lang-japanese "" [list ports_nodepcheck 1]
+    }
+}
 
 texlive.texmfport

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -9,8 +9,7 @@ PortGroup       texlive 1.0
 PortGroup       muniversal 1.1
 
 name            texlive-bin
-version         2022.62882
-revision        3
+version         2023.66589
 
 categories      tex
 maintainers     {dports @drkp}
@@ -30,13 +29,12 @@ license         Copyleft Permissive LGPL-2.1+ BSD
 
 # Our distfile is a stripped-down version of the texlive source
 # tarball, available from CTAN in systems/texlive/Source. For faster
-# download time, it omits a number of libraries and utilities that we
-# don't build. However, the port should still work with an unmodified
-# texlive distfile.
+# download (and configure) time, it omits a number of libraries and
+# utilities that we don't build. However, the port will still work
+# with an unmodified texlive distfile.
 master_sites    https://www.ambulatoryclam.net/texlive/ \
                 https://alpaca.cs.washington.edu/texlive/ \
                 https://giraffe.cs.washington.edu/texlive/
-
 
 use_xz          yes
 distname        texlive-source-${version}-stripped
@@ -49,14 +47,14 @@ compiler.cxx_standard \
 set tlpkgdistname   tlpkg-TeXLive-${version}
 distfiles-append    ${tlpkgdistname}${extract.suffix}
 
-checksums           texlive-source-2022.62882-stripped.tar.xz \
-                    rmd160  ad6a0e9a19b7e9c55acedd778e97570b68cde9a2 \
-                    sha256  086ffc6634225a4f1f501de8267892d80b02a47953e42b00d9ab46d7c1ec61d2 \
-                    size    24722892 \
-                    tlpkg-TeXLive-2022.62882.tar.xz \
-                    rmd160  388de063147e9911476730a81bf061180b019db7 \
-                    sha256  6663b2d049a89e9c0ab10b7d08669ec501208d702c02e3d62a5cb540e7569873 \
-                    size    115464
+checksums           texlive-source-2023.66589-stripped.tar.xz \
+                    rmd160  ce70d3d301f09f73f432a909f2a49698369935c2 \
+                    sha256  45622f77afda8ce81ef4e6c7af12e00924af6266dd9274b006527ce7d4d1e775 \
+                    size    23701704 \
+                    tlpkg-TeXLive-2023.66589.tar.xz \
+                    rmd160  f227e9db7551599372d283e1fcbb9d8732f3d997 \
+                    sha256  56252cbcd852958946afee26308251e8755b1014f9e2075a4997241c2e5ed826 \
+                    size    116640
 
 depends_lib     port:fontconfig \
                 port:freetype \
@@ -86,12 +84,13 @@ depends_build-append \
 # patches related to changes in install paths
 patchfiles-append  \
                    patch-texk_tex4htk_Makefile.in.diff \
-                   patch-texk_texlive_linked_scripts_Makefile.in.diff \
                    patch-texk_kpathsea_Makefile.in.diff \
                    patch-texk_chktex_Makefile.in.diff \
+                   patch-texk_texlive_linked_scripts_Makefile.in.diff \
                    patch-texk_xdvik_xdvi-sh.in.diff \
                    patch-utils_texdoctk_Makefile.in.diff
 
+    
 # patches to luajit/luajittex's config scripts to correctly detect
 # architecture in universal builds
 patchfiles-append  patch-libs_luajit_configure.diff \
@@ -253,6 +252,13 @@ set texdist_mp           ${texdist_root}/${texdist_name}.texdist
 set texdist_mpfd         ${texdist_root}/${texdist_fd}/${texdist_name}/Contents
 
 post-destroot   {
+    # TL2023: Some ConTeXt-related stubs are not currently
+    # installed. How these are installed will probably change in
+    # future releases
+    foreach bin {context contextjit ctxtools luatools mtxrun mtxrunjit pstopdf texexec texmfstart} {
+        file copy ${worksrcpath}/texk/texlive/linked_scripts/context/stubs/unix/${bin} ${destroot}${texlive_bindir}
+    }
+
     # Anything that gets installed into texmf-dist will be installed
     # by one of the texmf ports
     delete ${destroot}${prefix}/share/texmf-dist

--- a/tex/texlive-bin/files/patch-texk_texlive_linked_scripts_Makefile.in.diff
+++ b/tex/texlive-bin/files/patch-texk_texlive_linked_scripts_Makefile.in.diff
@@ -1,6 +1,6 @@
---- texk/texlive/linked_scripts//Makefile.in.orig
-+++ texk/texlive/linked_scripts//Makefile.in
-@@ -266,7 +266,7 @@
+--- texk/texlive/linked_scripts/Makefile.in.orig	2023-03-12 17:08:04
++++ texk/texlive/linked_scripts/Makefile.in	2023-03-12 17:10:03
+@@ -269,7 +269,7 @@
  # dangling symlinks produced by `make install'.
  # The instances in texmf* are the masters (except when it is CTAN).
  #
@@ -9,10 +9,10 @@
  texmf_shell_scripts = \
  	adhocfilelist/adhocfilelist.sh \
  	bibexport/bibexport.sh \
-@@ -700,19 +700,14 @@
- @WIN32_TRUE@	  echo "$(INSTALL_SCRIPT) '$(runscript)' '$(DESTDIR)$(bindir)/$$link.exe'"; \
- @WIN32_TRUE@	  $(INSTALL_SCRIPT) $(runscript) $(DESTDIR)$(bindir)/$$link.exe || exit 1; \
- @WIN32_TRUE@	done
+@@ -751,19 +751,14 @@
+ @WIN32_TRUE@	$(INSTALL_SCRIPT) $(top_srcdir)/$(WIN_WRAPPER)/runscript.dll $(DESTDIR)$(bindir)
+ @WIN32_TRUE@	$(INSTALL_SCRIPT) $(top_srcdir)/$(WIN_WRAPPER)/runscript.exe $(DESTDIR)$(bindir)
+ @WIN32_TRUE@	$(INSTALL_SCRIPT) $(top_srcdir)/$(WIN_WRAPPER)/runscript.tlu $(DESTDIR)$(bindir)
 -@WIN32_FALSE@	@REL=`$(relpath) '$(DESTDIR)' '$(bindir)' '$(datarootdir)'`; \
 -@WIN32_FALSE@	if test -z "$$REL"; then \
 -@WIN32_FALSE@	  echo 'unable to compute relative path for linked scripts' >&2; \
@@ -31,3 +31,19 @@
  @WIN32_FALSE@	  done && \
  @WIN32_FALSE@	  for s in $(bin_links); do \
  @WIN32_FALSE@	    link=`echo $$s | sed 's,.*:,,'`; \
+@@ -772,12 +767,12 @@
+ @WIN32_FALSE@	    echo "creating link '$$link' -> '$$file'"; \
+ @WIN32_FALSE@	    $(LN_S) $$file $$link || exit 1; \
+ @WIN32_FALSE@	  done && \
+-@WIN32_FALSE@	  if test -d "$$REL/texmf-dist/doc/man" \
++@WIN32_FALSE@	  if test -d "@@TEXMFDIST@@/doc/man" \
+ @WIN32_FALSE@	     && test -z "$(TL_INSTALL_OMIT_MAN_LINK)" \
+ @WIN32_FALSE@	     && (test -h man || test ! -e man); then \
+-@WIN32_FALSE@	    echo "creating link 'man' -> '$$REL/texmf-dist/doc/man'"; \
++@WIN32_FALSE@	    echo "creating link 'man' -> '@@TEXMFDIST@@/doc/man'"; \
+ @WIN32_FALSE@	    rm -f man; \
+-@WIN32_FALSE@	    (ln -s "$$REL/texmf-dist/doc/man" man || :); \
++@WIN32_FALSE@	    (ln -s "@@TEXMFDIST@@/doc/man" man || :); \
+ @WIN32_FALSE@	  else :; fi
+ 
+ .PHONY: install-links

--- a/tex/texlive-common/Portfile
+++ b/tex/texlive-common/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-common
-version             2022
+version             2023
 
 categories          tex
 maintainers         {dports @drkp}
@@ -25,9 +25,9 @@ master_sites        https://www.ambulatoryclam.net/texlive/ \
 worksrcdir          ${distname}
 use_xz              yes
 
-checksums           rmd160  500aa26a18e28c17e07f5d18fe6f6dc690f6f4e8 \
-                    sha256  197e984be3c70f53cba3cfdd0c304895041e11bae5cc4ba3f002413d028f5369 \
-                    size    18304
+checksums           rmd160  94fc95fac313356b142781eff86bb5dc09708572 \
+                    sha256  a700a69714fd34dce384b5406bfb974c8a5d1e9ba5f9af579e0095e4afdee20a \
+                    size    19176
 
 livecheck.type  regex
 livecheck.url   [lindex ${master_sites} 0]

--- a/tex/texlive-context/Portfile
+++ b/tex/texlive-context/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-context
-version             62071
+version             66562
 revision            0
 
 categories          tex
@@ -13,35 +13,28 @@ license             Copyleft Permissive
 description         TeX Live: ConTeXt and packages
 long_description    Hans Hagen's powerful ConTeXt system, http://pragma-ade.com. Also includes third-party ConTeXt packages.
 
-checksums           texlive-context-62071-run.tar.xz \
-                    rmd160  2b9a54c4648347b4b1feabe2e8cb0ad82fcb326e \
-                    sha256  c5313ef9417df92a0bf7c90d9818e923c47328978c99656708ceabfa21f40733 \
-                    size    113524292 \
-                    texlive-context-62071-doc.tar.xz \
-                    rmd160  d9a0fa286bf70c1d0b89498627320c781f4a40c1 \
-                    sha256  f235a18bad84a18466943e65fc4e692e0420c7e9167acad3b4c9a6b24c417f9f \
-                    size    103765884 \
-                    texlive-context-62071-src.tar.xz \
-                    rmd160  f035dd5797e5f4b9b858151f3ebc0eeab809d883 \
-                    sha256  c045c8404fa0ec64ef8f3ef3a12bafa2ea5f5980a82f82186331a02087a9b78a \
-                    size    6700
+checksums           texlive-context-66562-run.tar.xz \
+                    rmd160  44d15247f4a45a9f3827371a3308022041bae501 \
+                    sha256  28ce8ded576710e2498dab5cdf98379d2c9c7da65d07146706f321b0160aea01 \
+                    size    99969888 \
+                    texlive-context-66562-doc.tar.xz \
+                    rmd160  8679a7445fe01f233ea7b81e7ac9e0789e57b11d \
+                    sha256  23bdab22143686c26534e9c3be9adc8ad9e38d498bbed5d06ac626a6685c8ece \
+                    size    90002060 \
+                    texlive-context-66562-src.tar.xz \
+                    rmd160  47e20abd65294a6bd31ddcc84efbe7929b9facac \
+                    sha256  996e169540943b7d866f03fcfcaa2f42c5ed93feb6b15bef3d3507da87f96199 \
+                    size    6716
 
 depends_lib         port:texlive-basic
-
-texlive.formats      \
-    {1 cont-en pdftex cont-usr.tex {-8bit *cont-en.mkii}} \
-    {1 cont-en xetex cont-usr.tex {-8bit *cont-en.mkii}} \
-    {0 cont-fr pdftex cont-usr.tex {-8bit *cont-fr.mkii}} \
-    {0 cont-it pdftex cont-usr.tex {-8bit *cont-it.mkii}} \
-    {0 cont-nl pdftex cont-usr.tex {-8bit *cont-nl.mkii}} \
-    {0 cont-ro pdftex cont-usr.tex {-8bit *cont-ro.mkii}}
 
 texlive.maps      \
     {Map original-context-symbol.map}
 
-texlive.binaries    context contextjit luatools mtxrun mtxrunjit texexec texmfstart
+texlive.binaries    context context.lua mtxrun mtxrun.lua
 
-depends_lib-append  port:texlive-latex \
+depends_lib-append  port:luametatex \
+                    port:texlive-latex \
                     port:texlive-metapost \
                     port:texlive-xetex \
                     port:texlive-fonts-recommended \

--- a/tex/texlive-fonts-extra/Portfile
+++ b/tex/texlive-fonts-extra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-fonts-extra
-version             62622
+version             66328
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Additional fonts
 long_description    Additional fonts
 
-checksums           texlive-fonts-extra-62622-run.tar.xz \
-                    rmd160  d0cacbdf4ac29689dabbc2e4a56720efc2c02e69 \
-                    sha256  5fbdc65f2cd139e06e00b493668bc2e6cb4a2076c057052e5f9ee1ef581cdd65 \
-                    size    701425136 \
-                    texlive-fonts-extra-62622-doc.tar.xz \
-                    rmd160  4b37e2fee6c459e8013c4863f0f9f58382c4cf4c \
-                    sha256  7228b45a00a4a0b1fba1ff4f17df40406e928d8d8f2d5c2a30726973393cb077 \
-                    size    153371268 \
-                    texlive-fonts-extra-62622-src.tar.xz \
-                    rmd160  4ff798f82ccbca9477454a9352581fa8ba44ea48 \
-                    sha256  049fe8bb36b7aaef840f4d373e613297716f9e05dd67cc98dd10799ce42070c4 \
-                    size    25091460
+checksums           texlive-fonts-extra-66328-run.tar.xz \
+                    rmd160  931c44dae747326ebd87ea88e19d36c1c8e5c1fd \
+                    sha256  df33d3afd83776bf1646b233814d7559f61ec12f895e2a9073121508fb9a7852 \
+                    size    727420344 \
+                    texlive-fonts-extra-66328-doc.tar.xz \
+                    rmd160  4f6e1ca54839cc2b71aa7b316e39dd7d2cd484db \
+                    sha256  169b0fb362a6d70ae0895e73bba7ab57ed2b2ac05948078775ed2421041f2522 \
+                    size    172897120 \
+                    texlive-fonts-extra-66328-src.tar.xz \
+                    rmd160  8db03e984d939a4f51052ad35b60a005ac55d6c7 \
+                    sha256  479767f70e3e4e86d2e50db33bbb5d4f7ec3e24601fd1fcbc4f62b578fec7710 \
+                    size    9239036
 
 depends_lib         port:texlive-basic
 
@@ -77,6 +77,7 @@ texlive.maps      \
     {Map CascadiaCodThree.map} \
     {Map ccicons.map} \
     {Map clm.map} \
+    {Map charssil.map} \
     {Map Chivo.map} \
     {Map cinzel.map} \
     {Map Clara.map} \
@@ -92,6 +93,7 @@ texlive.maps      \
     {Map comfortaa.map} \
     {Map ComicNeue.map} \
     {Map ComicNeueAngular.map} \
+    {Map CooperHewitt.map} \
     {Map CormorantGaramond.map} \
     {Map countriesofeurope.map} \
     {Map CourierOneZeroPitch.map} \
@@ -250,10 +252,12 @@ texlive.maps      \
     {Map sansmathfonts.map} \
     {Map ScholaX.map} \
     {MixedMap semaf.map} \
+    {Map simpleicons.map} \
     {Map SourceCodePro.map} \
     {Map SourceSansPro.map} \
     {Map SourceSerifPro.map} \
     {Map spectral.map} \
+    {Map srbtiks.map} \
     {Map starfont.map} \
     {Map icelandic.map} \
     {Map STEP.map} \

--- a/tex/texlive-fonts-recommended/Portfile
+++ b/tex/texlive-fonts-recommended/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-fonts-recommended
-version             61983
+version             65956
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Recommended fonts
 long_description    Recommended fonts, including the base 35 PostScript fonts, Latin Modern, TeX Gyre, and T1 and other encoding support for Computer Modern, in outline form.
 
-checksums           texlive-fonts-recommended-61983-run.tar.xz \
-                    rmd160  140aa3d8d4425df98bd97fd763224f826e5b4fa8 \
-                    sha256  c87f1bb06e05ee62fe679eb74f3051b7e3253ac82d10c1c2ee8dc5d66d95a301 \
-                    size    109054036 \
-                    texlive-fonts-recommended-61983-doc.tar.xz \
-                    rmd160  389ad6aa21d46212da5a3f087ae0919bb90c9542 \
-                    sha256  d62ecfa0f1a8cf0886fabe8db08c1e624cffc8137a6ef93abbf3aa6ff217a834 \
-                    size    13946576 \
-                    texlive-fonts-recommended-61983-src.tar.xz \
-                    rmd160  d11b74c74648e2d36c3d450b1a5a6c7bbf870037 \
-                    sha256  950894dc99931a31d1c4e6c79f4c9edaa5fa95044966158f77f93d2b254427a8 \
-                    size    1605724
+checksums           texlive-fonts-recommended-65956-run.tar.xz \
+                    rmd160  33012c50acdf0c76e9ed27deb52d527cb61e907f \
+                    sha256  897a7b0a68c429668bcf0e598d4dea618ac6ca3147612fb88ae504dda6bbe6f2 \
+                    size    114332444 \
+                    texlive-fonts-recommended-65956-doc.tar.xz \
+                    rmd160  2c96272f3e4c28096f3114cbb48c4e03b9c6e160 \
+                    sha256  23b837542a1279b9d20c49cb35d5cf957ffe49213d41c51d6f21b5730710a603 \
+                    size    19323180 \
+                    texlive-fonts-recommended-65956-src.tar.xz \
+                    rmd160  bfa3613c3bda78c87f991c5d6f521cc1a19e9dd3 \
+                    sha256  5282ce502f20ce73e53fcf80a2aa41555ac095044a1d75506d0f71feb69a041d \
+                    size    1613636
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-fontutils/Portfile
+++ b/tex/texlive-fontutils/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-fontutils
-version             62517
+version             66461
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Graphics and font utilities
 long_description    Programs for conversion between font formats, testing fonts, virtual fonts, .gf and .pk manipulation, mft, fontinst, etc. Manipulating OpenType, TrueType, Type 1,and for manipulation of PostScript and other image formats.
 
-checksums           texlive-fontutils-62517-run.tar.xz \
-                    rmd160  a5e4f03521f1cb543db96f4899becf4459536fd8 \
-                    sha256  9c7a4e6931cf1cf09965bae3224373bcbb02c2b54c5bdb3c3a1f74dd24fa74bb \
-                    size    5033552 \
-                    texlive-fontutils-62517-doc.tar.xz \
-                    rmd160  eba786a052a4992ae75d31b2cdc58a7adc2e0bf1 \
-                    sha256  1ef048757ed58db55f7df09ad0d80ceed5e2230b26a1ece4b8f9c6119d05dd97 \
-                    size    1943172 \
-                    texlive-fontutils-62517-src.tar.xz \
-                    rmd160  4fcfb33b26d9b480c3a1c7dcaadf2b9aa3059cfc \
-                    sha256  2d09259d0685263c2cd316f0bddef092baaea0cd55a542869865b90abfd33043 \
-                    size    667664
+checksums           texlive-fontutils-66461-run.tar.xz \
+                    rmd160  3b94b996aaad8dae878e84d477e6259d49ae59f6 \
+                    sha256  24cf1efbae391ee347a0492d315425a1426269eb69991d46310fa09db36ef197 \
+                    size    7971852 \
+                    texlive-fontutils-66461-doc.tar.xz \
+                    rmd160  bc7b58aa0d5ff9bc341f7e7bd1c54686467da82b \
+                    sha256  77bba916f2de627fa4c12e1282c06bfea456c8207edd49940d21c6f3f7feef63 \
+                    size    1958280 \
+                    texlive-fontutils-66461-src.tar.xz \
+                    rmd160  0075dcd33c808e17bd0ecbdb9ddd1a4d4a800649 \
+                    sha256  35d71957d9bb7f95c6730bcea296b566a6e6b9c82159f55b2272c90134c9f99e \
+                    size    674740
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-formats-extra/Portfile
+++ b/tex/texlive-formats-extra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-formats-extra
-version             62642
+version             66203
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Additional formats
 long_description    Collected TeX `formats', i.e., large-scale macro packages designed to be dumped into .fmt files -- excluding the most common ones, such as latex and context, which have their own package(s). It also includes the Aleph engine and related Omega formats and packages, and the HiTeX engine and related.
 
-checksums           texlive-formats-extra-62642-run.tar.xz \
-                    rmd160  119c28b4605fed7e973988fa7e3d432bd19914c5 \
-                    sha256  d474bb3cf001a5b5dcd98d45e7c1cbe6d00221ed3819fec17254696389612552 \
-                    size    7636856 \
-                    texlive-formats-extra-62642-doc.tar.xz \
-                    rmd160  471813105ababf021f3d668e2ce23ec17cbfa2ff \
-                    sha256  4ef6cff0b377d0ffb49e8a29ffd468f579c599f39085581a62024c16445bc1d9 \
-                    size    5567308 \
-                    texlive-formats-extra-62642-src.tar.xz \
-                    rmd160  8c50bf4ec4618c5b852392b2b8190652c4e3fedc \
-                    sha256  da6c171d309333fa34c1a825dadbacaa1ce824bd131b07432558952cbcd1c6d2 \
-                    size    479408
+checksums           texlive-formats-extra-66203-run.tar.xz \
+                    rmd160  b19edaec401d44576b5fb87b7219b2596e2d0883 \
+                    sha256  3064d8f222bac689eb95e7b8d336395e27cdb5b2e17c39bb800af8edd1326782 \
+                    size    7646984 \
+                    texlive-formats-extra-66203-doc.tar.xz \
+                    rmd160  e1f83a4356d28f74eca3ac9ea3a4c3694a5691f3 \
+                    sha256  a5ca7995afedf28991038a8c2c9d2bc6b1599ac93f6b56298f6d9b6fd4c0c890 \
+                    size    5672364 \
+                    texlive-formats-extra-66203-src.tar.xz \
+                    rmd160  5e6b49bf30faf61bcba140e65bac48701403b2fc \
+                    sha256  e02c3036165dddab9fd3f22b1cf3744c21ca78f28c8f54fbe7216c7fb9d176eb \
+                    size    370952
 
 depends_lib         port:texlive-basic port:texlive-latex
 

--- a/tex/texlive-games/Portfile
+++ b/tex/texlive-games/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-games
-version             62102
+version             66190
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Games typesetting
 long_description    Setups for typesetting various games, including chess.
 
-checksums           texlive-games-62102-run.tar.xz \
-                    rmd160  7689d676f127ca90279db6b430aa212889c939fa \
-                    sha256  0218653916009fcbda24c423621c7d94d199db2125255df569d4ca24872dcba7 \
-                    size    16462136 \
-                    texlive-games-62102-doc.tar.xz \
-                    rmd160  2e25c2603d327784f34cdff4a3933725375228b8 \
-                    sha256  fb0242a9993a64e881e4a53ec0bd5e44ab747c4e8155414c9c1fcb8a7bbbd622 \
-                    size    15643908 \
-                    texlive-games-62102-src.tar.xz \
-                    rmd160  6dad708482a3781a01a0040ef202555b1060a5a9 \
-                    sha256  e155b2364bca8dcc0f3c9c6510fbe544462b61e763684c48dfd40e320662fec5 \
-                    size    377732
+checksums           texlive-games-66190-run.tar.xz \
+                    rmd160  2c502b295711ea8315004e3cf28b7ff5bbf09273 \
+                    sha256  02bb5e66da2380533d6007e5a84c62b87642c9abfff0bb17451216dfc89aa7f1 \
+                    size    40115220 \
+                    texlive-games-66190-doc.tar.xz \
+                    rmd160  97fd40e3f0d46f0cabbca318c6ccc0353eab96a8 \
+                    sha256  e22e3e6433cea6a63bfe9ef63763a51bd708ab63103deee4e4bcaf48611bb2fb \
+                    size    34070276 \
+                    texlive-games-66190-src.tar.xz \
+                    rmd160  4fd60c9d8a26a8cd082cd647fd9b56f32a31488c \
+                    sha256  704d25a9628d9616246d17caf9cca5f1bba945c948e5a980c30bcfb8d40d2f50 \
+                    size    536900
 
 depends_lib         port:texlive-latex
 

--- a/tex/texlive-humanities/Portfile
+++ b/tex/texlive-humanities/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-humanities
-version             61878
+version             65502
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Humanities packages
 long_description    Packages for law, linguistics, social sciences, humanities, etc.
 
-checksums           texlive-humanities-61878-run.tar.xz \
-                    rmd160  43bb5d2826265fae99949db0af99997b42a20e17 \
-                    sha256  8efcf619ff97d700ce2af79a22329bd1ac56b1cb25295d7f9038edfd6c4c00f2 \
-                    size    27823640 \
-                    texlive-humanities-61878-doc.tar.xz \
-                    rmd160  e7889ad8330c907412f3904d72caf64aa940b308 \
-                    sha256  6c69a638e02a7b39d54e29fe6858832237dc7c38032e7468050cd212b8d9bf41 \
-                    size    26996324 \
-                    texlive-humanities-61878-src.tar.xz \
-                    rmd160  55b63d92ce0f5b6bdbc01417d497d2f9eb102153 \
-                    sha256  12b329b1c38fbdb21a1957b5a671c83cbac69edf44863ed7ce29d4b54b4b4f8f \
-                    size    646508
+checksums           texlive-humanities-65502-run.tar.xz \
+                    rmd160  64e16b3a845059b237be7146e3b39f867bde2d08 \
+                    sha256  e09bf39ebf0fdf75a19d5e0fa7f94e65c17d167549567f3c3e324af161044192 \
+                    size    27635180 \
+                    texlive-humanities-65502-doc.tar.xz \
+                    rmd160  b972d9fa83c2739ca5496a5a960d81b4244c6583 \
+                    sha256  f2303f9258b421fa851674a6064013f49bc4ef192ae9b9f854d97955cc4f3cce \
+                    size    26702564 \
+                    texlive-humanities-65502-src.tar.xz \
+                    rmd160  5f52401991458c609fe332454a1533f301da8fe7 \
+                    sha256  cc6d397d39282ddffc8ae43b6264a02171b6c1257eab47df910074eb11c6f79a \
+                    size    634380
 
 depends_lib         port:texlive-latex
 

--- a/tex/texlive-lang-arabic/Portfile
+++ b/tex/texlive-lang-arabic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-arabic
-version             62109
+version             66115
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Arabic
 long_description    Support for Arabic and Persian.
 
-checksums           texlive-lang-arabic-62109-run.tar.xz \
-                    rmd160  6a38a4b94452bec7296fd100a892dd8864339fc6 \
-                    sha256  a6c34cce41b7c3c7f7507b7aaeb28f04356a71453ad62a39a243af30598d400a \
-                    size    25885148 \
-                    texlive-lang-arabic-62109-doc.tar.xz \
-                    rmd160  261e806cda97645966950db5d73d60dee2bf3dd5 \
-                    sha256  d01232ae5a657d331a562afd5f112d8c956c2d28ce03573f82b704b1d75b2b68 \
-                    size    20487820 \
-                    texlive-lang-arabic-62109-src.tar.xz \
-                    rmd160  58b94be1f4fb1247495bcb2f4ebbcf748e099336 \
-                    sha256  a9548f650f40ac4ba0d8df42d27f9b142790a21a260a681b220e4955160d687d \
-                    size    259476
+checksums           texlive-lang-arabic-66115-run.tar.xz \
+                    rmd160  30dda6a1b5c93e386930cd2c14e41171f1b1a780 \
+                    sha256  1c9070a39e8e84c0d8adcdbd0e49edf7edbcce10bf3c5b3ca4846b26b6751ab0 \
+                    size    27143512 \
+                    texlive-lang-arabic-66115-doc.tar.xz \
+                    rmd160  605a46f65af201445e5fd5816a34682beb7cefeb \
+                    sha256  2fb50d421925a42960e48195b451700c6d1968e7e0f0f6b9277c6a211e8864be \
+                    size    21752548 \
+                    texlive-lang-arabic-66115-src.tar.xz \
+                    rmd160  5f8fef991ba12785c704abe7921be49baca61472 \
+                    sha256  279968be5e0e1a7435a5279c7b0ca1b097757264492fa2180145fca505d66cba \
+                    size    274424
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-chinese/Portfile
+++ b/tex/texlive-lang-chinese/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-chinese
-version             62312
+version             66188
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Chinese
 long_description    Support for Chinese\; additional packages in collection-langcjk.
 
-checksums           texlive-lang-chinese-62312-run.tar.xz \
-                    rmd160  3ff96276861c3078a41b078df549bddcf55af685 \
-                    sha256  140e6f5110b48701b2e0f64f99fda9caf7d37095197ff082594d6906c83f8ae2 \
-                    size    87136248 \
-                    texlive-lang-chinese-62312-doc.tar.xz \
-                    rmd160  156e8a510e5ae7c841dd52101caf8825dc92abfd \
-                    sha256  dae26714e7f1efb3a9ec3b757823a155cc9c3d96ada8ce8832ff073920f36e18 \
-                    size    21524704 \
-                    texlive-lang-chinese-62312-src.tar.xz \
-                    rmd160  c85b9d6816655be862472e6375759304b3fea42a \
-                    sha256  f00c91b9dc05179f2341fc4a72b28a8e261f7abef28b6aa0283719f0cce04433 \
-                    size    344660
+checksums           texlive-lang-chinese-66188-run.tar.xz \
+                    rmd160  4cc2c9f8bee5a894c474bb2511d80e0bd3676e2a \
+                    sha256  39825308f61fc94df4ef07f66574983aaeb3bc5f5b32a3b205fab0cf208eacb9 \
+                    size    89038632 \
+                    texlive-lang-chinese-66188-doc.tar.xz \
+                    rmd160  94c894a0342dabdc271bcf885866b46bb64ef030 \
+                    sha256  8b043b3255a594b3162dc58786a9d48e844784ebb4d3587ce94e92ec85d56cfb \
+                    size    23538892 \
+                    texlive-lang-chinese-66188-src.tar.xz \
+                    rmd160  dd106e9ab3e17ddde12a4f123f961de10c6f0472 \
+                    sha256  a861f09e1be983feaa317733635cc615bf87a393382d4475620e52c02dac82a3 \
+                    size    350020
 
 depends_lib         port:texlive-lang-cjk
 

--- a/tex/texlive-lang-cjk/Portfile
+++ b/tex/texlive-lang-cjk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-cjk
-version             62864
+version             66552
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Chinese/Japanese/Korean (base)
 long_description    Packages supporting a combination of Chinese, Japanese, Korean, including macros, fonts, documentation. Also Thai in the c90 encoding, since there is some overlap in those fonts\; standard Thai support is in collection-langother. Additional packages for CJK are in their individual language collections.
 
-checksums           texlive-lang-cjk-62864-run.tar.xz \
-                    rmd160  80ea67abff8057d4561a4f185d1cb3dc4f726b7c \
-                    sha256  15c4060e52257ea0281876c371d4066407827c5a8be747a073d7ec6a6ccc4750 \
-                    size    7451672 \
-                    texlive-lang-cjk-62864-doc.tar.xz \
-                    rmd160  301e4c0d20ab66f84148b6c63833e14c88ec4860 \
-                    sha256  fb0c680c1f7150bc5f62a673521fb38188ce8d65f6634a7e5ef5b51f6b2cadee \
-                    size    4533284 \
-                    texlive-lang-cjk-62864-src.tar.xz \
-                    rmd160  b7776793ecec855875bc6597ef31dea8a8a00a41 \
-                    sha256  198946da840de6f979f46fbd53df5c079dd1ada47393f2e237e69ce762c706aa \
-                    size    180528
+checksums           texlive-lang-cjk-66552-run.tar.xz \
+                    rmd160  2651e1dec71d19a5e43af99894e3e608a8a7ddc1 \
+                    sha256  4e4c6a64b5803ac37bf5d55dd360257c11f14a927d90100afab6890a0cf31278 \
+                    size    7796988 \
+                    texlive-lang-cjk-66552-doc.tar.xz \
+                    rmd160  d2912cd6e75b497a69bef5b17776398cffb54076 \
+                    sha256  c9ea1580462abcbab8938bb356f6b98ca2a9057eb226f7e5308a7ed617c41149 \
+                    size    4910932 \
+                    texlive-lang-cjk-66552-src.tar.xz \
+                    rmd160  2d2316110a8b82b5d483d482d832c57f88d2aede \
+                    sha256  da6418e393f1778a20e30727c6c557b9568ca6a09ccb2d2f32822fde558b88b1 \
+                    size    181444
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-cyrillic/Portfile
+++ b/tex/texlive-lang-cyrillic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-cyrillic
-version             62517
+version             64588
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Cyrillic
 long_description    Support for Cyrillic scripts (Bulgarian, Russian, Serbian, Ukrainian), even if Latin alphabets may also be used.
 
-checksums           texlive-lang-cyrillic-62517-run.tar.xz \
-                    rmd160  d6cd52be55e69d55c9b8c38edd2132572d7a2af9 \
-                    sha256  fb69da1cdced0744a86b73d11d35a85df3001836b1067b8b947740927eddcde6 \
-                    size    20754272 \
-                    texlive-lang-cyrillic-62517-doc.tar.xz \
-                    rmd160  841914dd232141de16dd06dae401a0b686853ec3 \
-                    sha256  6036400eeb0a366ef58d8e8fae38dee466c4e4fbff416315350ec1aafa116626 \
-                    size    17516092 \
-                    texlive-lang-cyrillic-62517-src.tar.xz \
-                    rmd160  57b1cdb7e88a21fb149b4ae0b211ad70cdd9b709 \
-                    sha256  2bba53b8050355644a8094c49169ab4b768068d3e68ff115001494780ba44dd1 \
-                    size    201992
+checksums           texlive-lang-cyrillic-64588-run.tar.xz \
+                    rmd160  d5da6e496e6ed6bdefcff3c42a7c3dd262975a69 \
+                    sha256  17a7e7280d47cb4dbb6c22a4041bf239595e2ef63dca8e97b3320c351e0cd75d \
+                    size    20821908 \
+                    texlive-lang-cyrillic-64588-doc.tar.xz \
+                    rmd160  fa2eb1abd2dfcd7ad16d5e1142f7fa6aeccb6ace \
+                    sha256  d374148f2056bc0b9d7c0f45cb8c3b3155befbc28e52bcc5dda69f8e12aedf70 \
+                    size    17538380 \
+                    texlive-lang-cyrillic-64588-src.tar.xz \
+                    rmd160  a5ede50ec9de4fd3895c911d2905d8160c47e7b6 \
+                    sha256  8ae5d91e1a53071a53e1ba5a0a36ddc423a0039e1cc3a3717ac4ae9e235df061 \
+                    size    201860
 
 depends_lib         port:texlive-basic port:texlive-latex
 

--- a/tex/texlive-lang-czechslovak/Portfile
+++ b/tex/texlive-lang-czechslovak/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-czechslovak
-version             62854
+version             66186
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Czech/Slovak
 long_description    Support for Czech/Slovak.
 
-checksums           texlive-lang-czechslovak-62854-run.tar.xz \
-                    rmd160  ff48624ed65f93101d095be55b12ae3d52e9bacc \
-                    sha256  951469bf2d61cb1a3f46209a4c05a48ef69926a52e414f86e317a2d46034e84a \
-                    size    10974520 \
-                    texlive-lang-czechslovak-62854-doc.tar.xz \
-                    rmd160  934f7c9bea0ff58325a94430144a5151d993ba59 \
-                    sha256  b1c0619bff38b1599cba1792c898e4bcfcaf061a1bab5118b1df3002936111d8 \
-                    size    8984184 \
-                    texlive-lang-czechslovak-62854-src.tar.xz \
-                    rmd160  cd50227e610599b39d6aaa5f503bc3653bfda23c \
-                    sha256  ef1d34ce376e0322b5b06857deb194a22c61802e7cbbd9ecdf64bf98f6c05abc \
-                    size    37156
+checksums           texlive-lang-czechslovak-66186-run.tar.xz \
+                    rmd160  c54d98de13cf4fe1ff38b04a62ae597f32655f88 \
+                    sha256  25356fd787230d9f40c37a22adbadef15a3afb8355aa393ad0352a7d43db05bf \
+                    size    10985608 \
+                    texlive-lang-czechslovak-66186-doc.tar.xz \
+                    rmd160  09e2a64767aadd06eba2431b782eeceab7432879 \
+                    sha256  ad49b5821b418b122c51f970fed3ff3ee2e4e173ace6636f50a94f821e691552 \
+                    size    8987776 \
+                    texlive-lang-czechslovak-66186-src.tar.xz \
+                    rmd160  bf9a19492a15903d8c52d2867cd8de57fe3b123b \
+                    sha256  bd6542b036365bd1d51a742335daeef724fbeb248edeedd2bebe3949e041cd7e \
+                    size    37284
 
 depends_lib         port:texlive-basic port:texlive-latex
 

--- a/tex/texlive-lang-english/Portfile
+++ b/tex/texlive-lang-english/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-english
-version             62564
+version             66271
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: US and UK English
 long_description    Support for, and documentation in, English.
 
-checksums           texlive-lang-english-62564-run.tar.xz \
-                    rmd160  91ef450dd075a3051c1133b672456bb8d1060cb3 \
-                    sha256  dd1a7f10e7ca949c810a96135f8018e6a18ddd0c4e532b7b63d253706f1264fe \
-                    size    134087672 \
-                    texlive-lang-english-62564-doc.tar.xz \
-                    rmd160  90f3ec8c8cb44a86ac1b04524d1e4a59112aea4d \
-                    sha256  b072f7b352c66eac07704ec419dfd8a73f764508038aaa3d66ff79499ea1cb5a \
-                    size    134034144 \
-                    texlive-lang-english-62564-src.tar.xz \
-                    rmd160  e891fdc49732320123a3e7f8c2069eb9a769f2e8 \
-                    sha256  98f80146975479ad24003501008a8d3e716a8848ff547d8449947623414b6bbf \
-                    size    8180
+checksums           texlive-lang-english-66271-run.tar.xz \
+                    rmd160  107d4b3c5aefe52ede4eaec681691b0e157f9291 \
+                    sha256  c67af1b7fcf899cf722b6703566e4deb69dde4aab13b24bf8159385ea0d120b7 \
+                    size    155864172 \
+                    texlive-lang-english-66271-doc.tar.xz \
+                    rmd160  70703b5f57024179692d3eee1aa20fb965bbc9c9 \
+                    sha256  b0f665aab858024b52b2471d98eb38850510245be01ca35b5f921148e016e5c3 \
+                    size    155806808 \
+                    texlive-lang-english-66271-src.tar.xz \
+                    rmd160  5f571d7b6a544a46ab8355605860032133ef80f5 \
+                    sha256  34a0b57f54e34afce35f9a4886aecaa4b4128a65db7efbdf28ab30322383bcdc \
+                    size    8184
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-european/Portfile
+++ b/tex/texlive-lang-european/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-european
-version             62549
+version             66513
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Other European languages
 long_description    Support for a number of European languages\; others (Greek, German, French, ...) have their own collections, depending simply on the size of the support.
 
-checksums           texlive-lang-european-62549-run.tar.xz \
-                    rmd160  9cd723020564e6f5acb670340520373260316f9b \
-                    sha256  ab9823731b593827c1b9f69b4b8b9851a489216e30bce113cef561e80ae7412f \
-                    size    15643056 \
-                    texlive-lang-european-62549-doc.tar.xz \
-                    rmd160  418e28fa19990b4473f1448112749efd5ad16974 \
-                    sha256  184802c3ca4bce1be409f228b88a54f4b6d2a4157dc95cf372e2770395a8d37a \
-                    size    13797752 \
-                    texlive-lang-european-62549-src.tar.xz \
-                    rmd160  832b2e9deba9f01d5b4c0509e4756b4542156a7b \
-                    sha256  0e18bf7bc164bd54e29e3bc15e3dce39d9f3f4a0ebac0d92042055f1b45b5452 \
-                    size    152108
+checksums           texlive-lang-european-66513-run.tar.xz \
+                    rmd160  3898ebcfd5daee1a35eb24e16b70146e3086e8cb \
+                    sha256  288d1a177bd34827af86923ea40c5011382ebbe14cab04d26eeb2b568595b1a4 \
+                    size    16167904 \
+                    texlive-lang-european-66513-doc.tar.xz \
+                    rmd160  dd04d79445eb4a543982ae933cdfd539f09b15e1 \
+                    sha256  8e932ca6090d237890cdf992beca5ccf54ce62f941dfd96cdbfb9064cc825be2 \
+                    size    14319972 \
+                    texlive-lang-european-66513-src.tar.xz \
+                    rmd160  ee7f5fbb1279360a02f97171c69284d165adac32 \
+                    sha256  eb1a9b35d253dae27127fdf5bad41bd946f90deee96ad764039bfd3f5ead6c07 \
+                    size    153776
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-french/Portfile
+++ b/tex/texlive-lang-french/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-french
-version             62879
+version             66581
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: French
 long_description    Support for French and Basque.
 
-checksums           texlive-lang-french-62879-run.tar.xz \
-                    rmd160  f1f1421e172d4dfcefdb54a893cff9ad8cf40287 \
-                    sha256  be3f5f2975a66b9529c847a8797c056188b8c3d697eda093bc86cd68cf8ad796 \
-                    size    81039976 \
-                    texlive-lang-french-62879-doc.tar.xz \
-                    rmd160  4d1753c4daf94e3c52b040fe76268449d8ef578a \
-                    sha256  16b2496909cc2fac4b828cc79b29983072ad6e984069389691f36c7759438369 \
-                    size    78290248 \
-                    texlive-lang-french-62879-src.tar.xz \
-                    rmd160  73abd35cd4554ed5ac80cc9a53a9a98b1914b6d8 \
-                    sha256  0342deeaab449eae4ac35524d025731edaeff56db930df912b1177ffe9b7594e \
-                    size    2521492
+checksums           texlive-lang-french-66581-run.tar.xz \
+                    rmd160  1ca6cdc2544107fa9ede396bd1d59e14e7e912c9 \
+                    sha256  c2dd00d494af9a5f390c6ae3cdee6aeec68618b0426fb005cf45bf804b7f3443 \
+                    size    84503304 \
+                    texlive-lang-french-66581-doc.tar.xz \
+                    rmd160  4a2470dcc621810ae7157ef68e2c5441f25e90e3 \
+                    sha256  e3e7ec61a2444a25d1e09b603bf135de4cb554c3f601d4d1b2154dfddcf1dc8c \
+                    size    80498932 \
+                    texlive-lang-french-66581-src.tar.xz \
+                    rmd160  0b1a695b4c5c0a167a98908f0e7d74ec845b3886 \
+                    sha256  a1a6239b0841151fb7a1b00e4f5cf9000b04156cc76752b1a7c7f5b546121508 \
+                    size    2559500
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-german/Portfile
+++ b/tex/texlive-lang-german/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-german
-version             62734
+version             66573
 revision            0
 
 categories          tex
@@ -13,24 +13,24 @@ license             Copyleft Permissive
 description         TeX Live: German
 long_description    Support for German.
 
-checksums           texlive-lang-german-62734-run.tar.xz \
-                    rmd160  20481ab9d01e34fb848828f5a5df348625464c4a \
-                    sha256  99a368248c4adbff0b40684d9154832f2204892eb9ee6ce7e1451fdcb2ffebc2 \
-                    size    20511128 \
-                    texlive-lang-german-62734-doc.tar.xz \
-                    rmd160  b3738b2ac417a806ed7f1f69a80fa783cc3fc839 \
-                    sha256  94fb7e0e1d2e75be22030b832e160fc3970965c1304fe2682de99934f70302ee \
-                    size    19305920 \
-                    texlive-lang-german-62734-src.tar.xz \
-                    rmd160  11a5a12ee90c5ca0a00602e029d6b4a6925e8601 \
-                    sha256  17decc0baa1d75c2e4cab4ed101d194a647946aad52778f8e3ca86d8301e888f \
-                    size    129612
+checksums           texlive-lang-german-66573-run.tar.xz \
+                    rmd160  d261b3cd2c4024a2bc5861f17e9668f332ed7232 \
+                    sha256  67a913711b792f9f70c294ad33ea14278857074ceed5461802b8389ebdf225d1 \
+                    size    20481520 \
+                    texlive-lang-german-66573-doc.tar.xz \
+                    rmd160  64cf0f5a8361da1e5bf92874640bc785b148c3f2 \
+                    sha256  1c78228a50214fda545729de4b670b37053d3f6783280ce54877bc5454600751 \
+                    size    19212732 \
+                    texlive-lang-german-66573-src.tar.xz \
+                    rmd160  87b5a293a2975a25ab72f4d36ea67699a3cdd215 \
+                    sha256  b3a97dcd7e2d5e612f905738f57f95b5547cc2a9763e8ef11fb1e09e16559d11 \
+                    size    129724
 
 depends_lib         port:texlive-basic
 
 texlive.languages      \
-    {german-x-2022-03-16 dehypht-x-2022-03-16.tex 2 2 {german-x-latest} {hyph-de-1901.pat.txt} {} {} } \
-    {ngerman-x-2022-03-16 dehyphn-x-2022-03-16.tex 2 2 {ngerman-x-latest} {hyph-de-1996.pat.txt} {} {} } \
+    {german-x-2023-03-06 dehypht-x-2023-03-06.tex 2 2 {german-x-latest} {hyph-de-1901.pat.txt} {} {} } \
+    {ngerman-x-2023-03-06 dehyphn-x-2023-03-06.tex 2 2 {ngerman-x-latest} {hyph-de-1996.pat.txt} {} {} } \
     {german loadhyph-de-1901.tex 2 2 {} {hyph-de-1901.pat.txt} {} {} } \
     {ngerman loadhyph-de-1996.tex 2 2 {} {hyph-de-1996.pat.txt} {} {} } \
     {swissgerman loadhyph-de-ch-1901.tex 2 2 {} {hyph-de-ch-1901.pat.txt} {} {} }

--- a/tex/texlive-lang-greek/Portfile
+++ b/tex/texlive-lang-greek/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-greek
-version             61820
+version             66513
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Greek
 long_description    Support for Greek.
 
-checksums           texlive-lang-greek-61820-run.tar.xz \
-                    rmd160  a8b1f8ef5511d35f64c8654b17dcae27cd0a4deb \
-                    sha256  a1ed57060708ae148ef65f571d04ac15e050bff8b221f28733169c178e4ae255 \
-                    size    77602764 \
-                    texlive-lang-greek-61820-doc.tar.xz \
-                    rmd160  76be8e1bd5e8b0ef654ff8dca66cfdbf68c4ca6b \
-                    sha256  ef82230aa002ebf41aa14cc84cf24dcc8e09bf9be6489d4d170af880ec50b450 \
-                    size    8964152 \
-                    texlive-lang-greek-61820-src.tar.xz \
-                    rmd160  f5641a134f76deac0906f70b68d94b03f8d53abc \
-                    sha256  40dfcccfa810b0cd58fadba72fad42cf176b6cf778b98384e96e517a210ed34e \
-                    size    87824
+checksums           texlive-lang-greek-66513-run.tar.xz \
+                    rmd160  419b4ea4281f71732dc9905185cf62efc7c82ffd \
+                    sha256  eb7a113213b9f8e7ed0a39191ee8c6830249476523d787a86b047bcc032e5658 \
+                    size    78223928 \
+                    texlive-lang-greek-66513-doc.tar.xz \
+                    rmd160  3e9e4ad1b10a68081473fe3d67ebf0ba72db84a9 \
+                    sha256  a32d00843c6b0a7b61d27c6f22857eb2342c0d53c131a4bbfa82e0709527c196 \
+                    size    9506084 \
+                    texlive-lang-greek-66513-src.tar.xz \
+                    rmd160  d03b0acc223aa008f1c66034dc16f69048f54f6c \
+                    sha256  fc2d482be0a1dbc4824b9ecbd8c06e550275894497d1cb9cc7de2238276fdc5d \
+                    size    105084
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-italian/Portfile
+++ b/tex/texlive-lang-italian/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-italian
-version             58653
+version             62890
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Italian
 long_description    Support for Italian.
 
-checksums           texlive-lang-italian-58653-run.tar.xz \
-                    rmd160  f2e8b92a071a3d38b7c5dada56d54b15a76666d4 \
-                    sha256  76fe39968c9587eb58c199399e00d67f0ea834db7d1f6da07c2db32428fb8fe8 \
-                    size    10676336 \
-                    texlive-lang-italian-58653-doc.tar.xz \
-                    rmd160  6c0a37a72d0062034ceaa5256586bd75e25d0c14 \
-                    sha256  5e5ed5e640b89de7e326369bb2cec20d91ce8a7b13e8627bfb9c6083d05a8b10 \
-                    size    10577184 \
-                    texlive-lang-italian-58653-src.tar.xz \
-                    rmd160  ebe5454e4a5d944cdc6adb36957852f0eb8dcafd \
-                    sha256  746c2f81e6094fffa88c9b7040ebaf6d91ee1c553a5c9f61f446f95069585d83 \
-                    size    98844
+checksums           texlive-lang-italian-62890-run.tar.xz \
+                    rmd160  bd905068207e3f2cb3b28ece167caecc90378277 \
+                    sha256  f4f27da19431e199cfd34f19b81c4a78e6f8348b98544d413aee7e6c432628a2 \
+                    size    10752952 \
+                    texlive-lang-italian-62890-doc.tar.xz \
+                    rmd160  ef38690f2635604f3da0cbd72cced2bba6d1dfc5 \
+                    sha256  9643e8bcef079f1fa78985a8fdf617fb205e6cd3be87f55e14893d23051ee602 \
+                    size    10648272 \
+                    texlive-lang-italian-62890-src.tar.xz \
+                    rmd160  1d62d433baa21dbc3de53ab93cede0fb3f4e8d97 \
+                    sha256  edc8ee0c289773521cdc7a06ec9f07def3c25b407a62fc010513bb77aafbc63f \
+                    size    99920
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-japanese/Portfile
+++ b/tex/texlive-lang-japanese/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-japanese
-version             62825
+version             66482
 revision            0
 
 categories          tex
@@ -13,30 +13,30 @@ license             Copyleft Permissive
 description         TeX Live: Japanese
 long_description    Support for Japanese\; additional packages are in collection-langcjk.
 
-checksums           texlive-lang-japanese-62825-run.tar.xz \
-                    rmd160  de95bdf1b9a7dc979dc1269fc255f91111bd86f2 \
-                    sha256  baa75fb2eca5d357789c94348bca78c20bed2258ffb54ef82c79b926e6fb1c66 \
-                    size    112422488 \
-                    texlive-lang-japanese-62825-doc.tar.xz \
-                    rmd160  23a68b98fffc7e7199ea29ac7a4bd2e867a99643 \
-                    sha256  3ea7d2a5474e6d673592c3824311276fe8f52ed793b092f2fa6a2e7154254281 \
-                    size    21545836 \
-                    texlive-lang-japanese-62825-src.tar.xz \
-                    rmd160  9ded7b996418cc889ebb1ec4b3be2506ccaf3930 \
-                    sha256  dea48b6421e94052243b40b0ed4a62e6eb1d7f3824772f51fa848199951fe2fd \
-                    size    721452
+checksums           texlive-lang-japanese-66482-run.tar.xz \
+                    rmd160  77e788c73bc8e980ef0ec4592b0671cebf96183f \
+                    sha256  31e4bf0f40641e7b6b69f0ca815946cccb4ce6e4f5dd057a474b27b6fad5aceb \
+                    size    119649308 \
+                    texlive-lang-japanese-66482-doc.tar.xz \
+                    rmd160  2549c68ba25ffe8ca9cb9a0709c0396f51d2ebf1 \
+                    sha256  8e4b267ecccecb4c71da955902d4fd48579f403594e50a695d4e81dcb139b4d0 \
+                    size    23905056 \
+                    texlive-lang-japanese-66482-src.tar.xz \
+                    rmd160  778e9cecb76ac782c0005d494c46e2138ac7e82c \
+                    sha256  0933ed3c7b79e857acd87f6c35531b808d7386a30a0a1659ada3757718a2fa88 \
+                    size    724732
 
 depends_lib         port:texlive-lang-cjk
 
 texlive.formats      \
     {1 platex eptex language.dat {*platex.ini}} \
-    {1 platex-dev eptex language.dat {*platex.ini}} \
+    {1 platex-dev euptex language.dat {*platex.ini}} \
     {1 eptex eptex language.def {*eptex.ini}} \
-    {1 ptex ptex - {ptex.ini}} \
+    {1 ptex eptex - {ptex.ini}} \
     {1 uplatex euptex language.dat {*uplatex.ini}} \
     {1 uplatex-dev euptex language.dat {*uplatex.ini}} \
     {1 euptex euptex language.def {*euptex.ini}} \
-    {1 uptex uptex - {uptex.ini}}
+    {1 uptex euptex - {uptex.ini}}
 
 texlive.maps      \
     {Map ascmac.map} \
@@ -58,7 +58,7 @@ texlive.maps      \
     {Map mr2j.map} \
     {Map mrj.map}
 
-texlive.binaries    convbkmk eptex euptex kanji-config-updmap kanji-config-updmap-sys kanji-config-updmap-user kanji-fontmap-creator makejvf mendex pbibtex pdvitomp pdvitype platex platex-dev pmpost ppltotf ptex ptex2pdf ptftopl r-pmpost r-upmpost upbibtex updvitomp updvitype uplatex uplatex-dev upmendex upmpost uppltotf uptex uptftopl wovp2ovf
+texlive.binaries    convbkmk eptex euptex kanji-config-updmap kanji-config-updmap-sys kanji-config-updmap-user kanji-fontmap-creator makejvf mendex pbibtex pdvitomp pdvitype platex platex-dev pmpost ppltotf ptex ptex2pdf ptftopl r-pmpost r-upmpost upbibtex updvitomp updvitype uplatex uplatex-dev upmpost uppltotf uptex uptftopl wovp2ovf
 
 
 texlive.texmfport

--- a/tex/texlive-lang-korean/Portfile
+++ b/tex/texlive-lang-korean/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-korean
-version             62856
+version             66513
 revision            0
 
 categories          tex
@@ -13,17 +13,17 @@ license             Copyleft Permissive
 description         TeX Live: Korean
 long_description    Support for Korean\; additional packages in collection-langcjk.
 
-checksums           texlive-lang-korean-62856-run.tar.xz \
-                    rmd160  54cb8fe0b4928fb4a3259f7fdb33f3d78be5b03f \
-                    sha256  71e1120290de9d13b881843a19b93242ae4a9cfdadfdadf51e068de2dc5cc6fd \
-                    size    71741748 \
-                    texlive-lang-korean-62856-doc.tar.xz \
-                    rmd160  4cc7ad531479abe6dc8b210df5beb2f5c0528a78 \
-                    sha256  e527318f6d4aae3048c80d0062563503d222d587046ac900c68fe68ded8997bd \
-                    size    9592356 \
-                    texlive-lang-korean-62856-src.tar.xz \
-                    rmd160  4ace588108ca235152aaf98e6401a9935e7a1acc \
-                    sha256  a845d878eeed98b1965bc5a21b21f87edd2b7fa9ac641d0c97970026009b2111 \
+checksums           texlive-lang-korean-66513-run.tar.xz \
+                    rmd160  ce68f0c5fc31905f191d99a1d348132936b2a9a8 \
+                    sha256  2cb00830c39510821ed3fd10937433284f096c1464a04c2d644a424d6ffbcb90 \
+                    size    74609460 \
+                    texlive-lang-korean-66513-doc.tar.xz \
+                    rmd160  25de44ef1f5964dbe361b762cb948d2664524670 \
+                    sha256  e00bde0064a232b92aafed4d927a7a750b4e0075d1d9a52b99952014b53d1f12 \
+                    size    12561528 \
+                    texlive-lang-korean-66513-src.tar.xz \
+                    rmd160  d598dde7aa8a1c17ed17937d336a007442a3ee7f \
+                    sha256  78b8198b0435e83b22b061e43e59fe25c9e372d69b4d5aa225411e8c0c3171ae \
                     size    200
 
 depends_lib         port:texlive-lang-cjk

--- a/tex/texlive-lang-other/Portfile
+++ b/tex/texlive-lang-other/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-other
-version             62837
+version             66225
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Other languages
 long_description    Support for languages not otherwise listed, including Indic, Thai, Vietnamese, Hebrew, Indonesian, African languages, and plenty more. The split is made simply on the basis of the size of the support, to keep both collection sizes and the number of collections reasonable.
 
-checksums           texlive-lang-other-62837-run.tar.xz \
-                    rmd160  aa18436ee6dc2fb33e04fc0ce0646a444c28b096 \
-                    sha256  22a7dcdf367b59a7dd9a85d1b6d97302bdc42c6dcd435e7284dada29405870d2 \
-                    size    45640708 \
-                    texlive-lang-other-62837-doc.tar.xz \
-                    rmd160  9890ffe0eaf41c15d349f248747c8cb27f965a33 \
-                    sha256  6476c379517037702680da140f74a8dfe586a33df97b9ca9a11f8e7b30e3c981 \
-                    size    11581004 \
-                    texlive-lang-other-62837-src.tar.xz \
-                    rmd160  8f8fa714e462f3b0108941c8ef2d713a9dd43891 \
-                    sha256  640c827931c71de4ccf7f28cba46cf74e6a34b9078a81476528137464c379cbf \
-                    size    10289576
+checksums           texlive-lang-other-66225-run.tar.xz \
+                    rmd160  8bf7607283419397b21483a821ebcb5b3a7b6c26 \
+                    sha256  436160b60506ce441ebe95d7194ae62d727aff39032b8daa3852dea592809c3a \
+                    size    45417696 \
+                    texlive-lang-other-66225-doc.tar.xz \
+                    rmd160  398de15b94c7233708da5018a862b13ac8046212 \
+                    sha256  f7480ca621703652222d8199a0839006d6a344b7bb812d2dfc557f8e0345eff4 \
+                    size    11578480 \
+                    texlive-lang-other-66225-src.tar.xz \
+                    rmd160  339f40136151baffe13b3725b4b024b4a3684e93 \
+                    sha256  f7f226197ad14c3ab1fe32da1b21126df53c46dfb2ded411e7c48eeb61b5824b \
+                    size    10099384
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-polish/Portfile
+++ b/tex/texlive-lang-polish/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-polish
-version             62841
+version             66576
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Polish
 long_description    Support for Polish.
 
-checksums           texlive-lang-polish-62841-run.tar.xz \
-                    rmd160  8b137adbf8158b9464aa2439b98cd54d2552e251 \
-                    sha256  65c778c97b0c475c2942a5c0c5a14b580c1c6eb90600ea568060a6d0b2f979da \
-                    size    7751528 \
-                    texlive-lang-polish-62841-doc.tar.xz \
-                    rmd160  b3d3d86e8e25c7cd780622cdbff2d2c609aacf55 \
-                    sha256  1f0ce17b3c06d1ca9fe043ad24abedb492d879a4c487a144af9a8b728fad282d \
-                    size    5151064 \
-                    texlive-lang-polish-62841-src.tar.xz \
-                    rmd160  925d9eb11f8dc9426aa6476ac97aad76f26f0f11 \
-                    sha256  b3b078c8356d420741edef44d073ccba6a8ec9e0773a688b421e1898d85fded0 \
-                    size    110412
+checksums           texlive-lang-polish-66576-run.tar.xz \
+                    rmd160  17ad171521aa934089926b063dd1ebe33a7a7b2b \
+                    sha256  c3543af094d289473f076186419199882217e2e05be7331a1fea682cd4d51f06 \
+                    size    8706940 \
+                    texlive-lang-polish-66576-doc.tar.xz \
+                    rmd160  6be41bdcb95c7f41c68851a1c66c6732f1bdfeb6 \
+                    sha256  aac701f6b876ccffc67d96f025109ac877d8e5ca3450a80352a71812ce0adf8d \
+                    size    6108976 \
+                    texlive-lang-polish-66576-src.tar.xz \
+                    rmd160  1c81412b9be50bb08f7cedb549f98f60ee629543 \
+                    sha256  dbf90c9318270c2f8afb35a96da107aaffc5aad9190f4e951603c47c9d1cfe42 \
+                    size    110156
 
 depends_lib         port:texlive-basic port:texlive-latex
 

--- a/tex/texlive-lang-portuguese/Portfile
+++ b/tex/texlive-lang-portuguese/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-portuguese
-version             59977
+version             63374
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Portuguese
 long_description    Support for Portuguese.
 
-checksums           texlive-lang-portuguese-59977-run.tar.xz \
-                    rmd160  8c861953707836267fb5b73b45df57f72818dc38 \
-                    sha256  8cce546fb474b4f2ee252058e7d67e219f52f94c5e4114079e2d4dcd5f9d77ed \
-                    size    11874496 \
-                    texlive-lang-portuguese-59977-doc.tar.xz \
-                    rmd160  f429cd0c97c77a697de77d4c2a32f7aa40c703c1 \
-                    sha256  03f05c427ca0b2f1b3febee89b4becf3f09c53a0312c737147198af81518aaea \
-                    size    11853344 \
-                    texlive-lang-portuguese-59977-src.tar.xz \
-                    rmd160  1d498c95b8eb9673836fda0453f9a87e87b83910 \
-                    sha256  d8521ab162c8342644ad5b2dd34d58e4d3316770baba29eb25a51cb118e27bd0 \
-                    size    13248
+checksums           texlive-lang-portuguese-63374-run.tar.xz \
+                    rmd160  ba186dea06cc97275c86346b9e226a637b51bf57 \
+                    sha256  6c746870568c984d6e57fe759a85e48c088d6e3ce8e8d197c9d6555480125f6e \
+                    size    11856104 \
+                    texlive-lang-portuguese-63374-doc.tar.xz \
+                    rmd160  83a8afeb05f58b02b49c183bbba636f26d85d0b8 \
+                    sha256  126247d8dca0c53212f1d7ce792cc392a23027f2fb1b6be3de5aaacd2e1c5d74 \
+                    size    11833552 \
+                    texlive-lang-portuguese-63374-src.tar.xz \
+                    rmd160  4a469ee82604cb77ad26d67ebdafa49c80ed3580 \
+                    sha256  eaaeb5ca8938e22c78a81dd7e52a4cc824bda03d967b373983a79ce2a96122e1 \
+                    size    13340
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-lang-spanish/Portfile
+++ b/tex/texlive-lang-spanish/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-lang-spanish
-version             62677
+version             66059
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Spanish
 long_description    Support for Spanish.
 
-checksums           texlive-lang-spanish-62677-run.tar.xz \
-                    rmd160  73af52fc67abde0add0d84c430b385c6aaa1b2d1 \
-                    sha256  b61b35170071bb5f7531863324f879d6c76fedd02d4a2c26ebf19549738c9395 \
-                    size    9177232 \
-                    texlive-lang-spanish-62677-doc.tar.xz \
-                    rmd160  1f69364463b11b35e95fe86971423ec38f7f7ec8 \
-                    sha256  99b916362625556238a1fd129bb5cacdf658bfc7ca4492d2dfc28d8812df7fb6 \
-                    size    9094668 \
-                    texlive-lang-spanish-62677-src.tar.xz \
-                    rmd160  a61143189496acd0d050bf084ee26f0910c072da \
-                    sha256  8d51e9b1f24d17aeef8c866fb49e5f934c85c8cd7b8a01aaa4c2748d54dbb89a \
-                    size    66224
+checksums           texlive-lang-spanish-66059-run.tar.xz \
+                    rmd160  fb60af540529fe79d8e44b5fa487d2a0f1463462 \
+                    sha256  2d9beaf073fe50af6f2379668a2e4bf953611e3070e4dcd73a970972809f0bca \
+                    size    10950364 \
+                    texlive-lang-spanish-66059-doc.tar.xz \
+                    rmd160  29527e24cb2901bfcabe3959b722be3c2867eb85 \
+                    sha256  1bdedeca9c344ce4ed38ac0faba4a01ac1513304f9bb69b301ead1bff1f2e98c \
+                    size    10865900 \
+                    texlive-lang-spanish-66059-src.tar.xz \
+                    rmd160  286e51950825ef37272014214836bc63d9b02c2a \
+                    sha256  ac9c138b1a37e0a9c99447a737583a24d5e74c25d31e8d277a66dbc326a60ffe \
+                    size    66164
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-latex-extra/Portfile
+++ b/tex/texlive-latex-extra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-latex-extra
-version             62868
+version             66551
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: LaTeX additional packages
 long_description    A very large collection of add-on packages for LaTeX.
 
-checksums           texlive-latex-extra-62868-run.tar.xz \
-                    rmd160  2accb4b23c58eaeec5f62d516bf12d3f7821b009 \
-                    sha256  6e99d3a31d294f20789d33c86767757778fec99c5fe27decf595f39705c5b298 \
-                    size    607053756 \
-                    texlive-latex-extra-62868-doc.tar.xz \
-                    rmd160  a89fdf3d36f5e690c01c3d6d647f883891d4260b \
-                    sha256  fd8090fc4e4af6ec08b4adeacbff00f3f12c409716f7912d19286d26c7f8d104 \
-                    size    579187256 \
-                    texlive-latex-extra-62868-src.tar.xz \
-                    rmd160  ceaab1443d08b3877842888f9d477abde2c280cb \
-                    sha256  6bd5ada2cd501ba4c3e96768fb7fdf66592c5e28b12f6a6d383022adb6ec108b \
-                    size    13339856
+checksums           texlive-latex-extra-66551-run.tar.xz \
+                    rmd160  3ee20c59d891575c383a8faaf5d189ca952b9027 \
+                    sha256  08861d8fd861a4ae7ad53309064c2fc91b5885e929525ad9fca146d5862d1520 \
+                    size    668490840 \
+                    texlive-latex-extra-66551-doc.tar.xz \
+                    rmd160  c7f2b55b42e30b2b8158c44d09479170dff56926 \
+                    sha256  68c5c5217e5b5fadd0a6cb7fff4554858140c950518742aff0facf70c207b703 \
+                    size    624732152 \
+                    texlive-latex-extra-66551-src.tar.xz \
+                    rmd160  825fd4b1ec43814284a295ce505aa9d063c12fc3 \
+                    sha256  ad1513d44e5aaa02b884ce15d76542e3979f3ad40080f08c013b7fda3c2b053b \
+                    size    19254432
 
 depends_lib         port:texlive-latex-recommended port:texlive-pictures
 
@@ -39,7 +39,7 @@ texlive.maps      \
     {MixedMap esint.map} \
     {Map scanpages.map}
 
-texlive.binaries    authorindex dvilualatex-dev exceltex hyperxmp-add-bytecount l3build latex-dev lualatex-dev makedtx makeglossaries makeglossaries-lite pdfannotextractor pdflatex-dev perltex pygmentex splitindex svn-multi vpe webquiz wordcount yplan
+texlive.binaries    authorindex dvilualatex-dev exceltex hyperxmp-add-bytecount l3build latex-dev lualatex-dev makedtx makeglossaries makeglossaries-lite pagelayoutapi pdfannotextractor pdflatex-dev perltex pygmentex splitindex svn-multi textestvis vpe webquiz wordcount yplan
 
 pre-activate {
     # Handle conflicts for TL2019 upgrade

--- a/tex/texlive-latex-recommended/Portfile
+++ b/tex/texlive-latex-recommended/Portfile
@@ -4,27 +4,27 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-latex-recommended
-version             62874
+version             66587
 revision            0
 
 categories          tex
 maintainers         {dports @drkp}
 license             Copyleft Permissive
 description         TeX Live: LaTeX recommended packages
-long_description    A collection of recommended add-on packages for LaTeX which have widespread use, and the release candidate formats latex-dev, etc.
+long_description    A collection of recommended add-on packages for LaTeX which have widespread use.
 
-checksums           texlive-latex-recommended-62874-run.tar.xz \
-                    rmd160  de1d97d544a2a47869482f73eacdd00dc9d42cb7 \
-                    sha256  bc577099ed95aa79d518ca7ca716b2104ceb02138ac6732691f1321b83cdf5d9 \
-                    size    66037656 \
-                    texlive-latex-recommended-62874-doc.tar.xz \
-                    rmd160  2c0ee135476b1671bacd4d337c3ff656d06a446d \
-                    sha256  a872939531147c4cf00c118f47da2946a80b8849a5784fd81bbfe303eeecc306 \
-                    size    49069020 \
-                    texlive-latex-recommended-62874-src.tar.xz \
-                    rmd160  c9105b3348dde97c2561525e58a68744f30b06a2 \
-                    sha256  aed7be5212fa93451c9220120889f154e93be8e4d53e7ed61f1a2c5db166c89f \
-                    size    2517032
+checksums           texlive-latex-recommended-66587-run.tar.xz \
+                    rmd160  08bb3dbe9b7e1977a3d371ef7967c2cb96927d30 \
+                    sha256  64bb3ff25ee6c588df5e3640da316c4d063bf70be12c7569d7633644ecf84a2c \
+                    size    61737976 \
+                    texlive-latex-recommended-66587-doc.tar.xz \
+                    rmd160  95d378ab870c01e445de2cb9eeb815c1d78cee99 \
+                    sha256  b9bb8e1afd1f54120696ffe0e759a72754ad4e5a5d128d8a9c4630e39dc226f6 \
+                    size    50416004 \
+                    texlive-latex-recommended-66587-src.tar.xz \
+                    rmd160  0b4f09e32579d51db215ddc704eca986b956d1bf \
+                    sha256  6bb234363606020d665496bcbbd03ec1541b857977fb9ddf26ed3daa9233ec8a \
+                    size    2520972
 
 depends_lib         port:texlive-latex
 

--- a/tex/texlive-latex/Portfile
+++ b/tex/texlive-latex/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-latex
-version             62387
+version             66204
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: LaTeX fundamental packages
 long_description    These packages are either mandated by the core LaTeX team, or very widely used and strongly recommended in practice.
 
-checksums           texlive-latex-62387-run.tar.xz \
-                    rmd160  77e6c599faebebe4471336aed32f575b3bc50a56 \
-                    sha256  47b72b8e0104f5cc72356e9c615b18aa7eed1342bf0f5488892fb0c3b6bef1d5 \
-                    size    82848224 \
-                    texlive-latex-62387-doc.tar.xz \
-                    rmd160  49774acf0bfdd82bd17bbb10c9bbb17e3e71cc1e \
-                    sha256  15adbf5f24af2e849739e3e6022e3fe4c5103434aa5696859f648e6ef4d3b7a2 \
-                    size    78304832 \
-                    texlive-latex-62387-src.tar.xz \
-                    rmd160  80e7d5d21467d5f49004c93561100ca762639cd3 \
-                    sha256  6f4ea8f73f9988a32f1107a6f3510724cfdf9138b57718d01b7d4b1c1f9978bb \
-                    size    3565512
+checksums           texlive-latex-66204-run.tar.xz \
+                    rmd160  5b6910ada55d020ad052f0175f05bde82f4b531f \
+                    sha256  f9905ebf199e4cd375fd8721a494bb2893128601bb1ed128f15f829d0dd1328f \
+                    size    89048760 \
+                    texlive-latex-66204-doc.tar.xz \
+                    rmd160  a66124232c7bcc0109756371f61702dc588e68e0 \
+                    sha256  b3d7a9add4a61e8f57241cc055d66d0e7516fab433db95c1e3c142a50cda169f \
+                    size    84415104 \
+                    texlive-latex-66204-src.tar.xz \
+                    rmd160  4caeb76b523a19924a7a6c16c3281f0a28e65cc6 \
+                    sha256  1113353b2183434592c5c1d1ade6fc2b9e0d48d55aad68de659889f95e58ce1a \
+                    size    3619080
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-luatex/Portfile
+++ b/tex/texlive-luatex/Portfile
@@ -4,27 +4,27 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-luatex
-version             62870
+version             66513
 revision            0
 
 categories          tex
 maintainers         {dports @drkp}
 license             Copyleft Permissive
 description         TeX Live: LuaTeX packages
-long_description    Packages for LuaTeX, a Unicode-aware extension of pdfTeX, using Lua as an embedded scripting and extension language. http://luatex.org/
+long_description    Packages for LuaTeX, a TeX engine using Lua as an embedded scripting and extension language, with native support for Unicode, OpenType/TrueType fonts, and both PDF and DVI output. The LuaTeX engine itself (and plain formats) are in collection-basic.
 
-checksums           texlive-luatex-62870-run.tar.xz \
-                    rmd160  b29275cac9ec7925b58e392dc08849716a2179b8 \
-                    sha256  1ab17b8b93c30cc6fb0ede627b640c98efb565fbeec21886d4315ee2babe246d \
-                    size    18187568 \
-                    texlive-luatex-62870-doc.tar.xz \
-                    rmd160  5f402e10153f8e7bba08e45a4d751a28f7365375 \
-                    sha256  a6d34dbf627f810a20afa4a6a464b6f51aaae87f9f5b01a79881c8858b2ac62c \
-                    size    15765988 \
-                    texlive-luatex-62870-src.tar.xz \
-                    rmd160  fda4fcf5c1adddcb22407ee248b7b7922844c5ea \
-                    sha256  5a4c3c89f118f90dc4ff2d7e28ead047460eff123e7faee2085b1ff5714e7933 \
-                    size    302764
+checksums           texlive-luatex-66513-run.tar.xz \
+                    rmd160  d92474a0ca32325176999539bd6103daac773342 \
+                    sha256  49f00bf6f66df1344a31f93039f055e225d11c8be5760638b9db7fb687bce6c5 \
+                    size    23398536 \
+                    texlive-luatex-66513-doc.tar.xz \
+                    rmd160  0c5f4720fce4c4b05a6f3faa2408404734f82399 \
+                    sha256  ecb928d786debb9e64406033fede1c0c3ae87f8285a6370860a42e6d2dd6e100 \
+                    size    20667232 \
+                    texlive-luatex-66513-src.tar.xz \
+                    rmd160  5b6371470be1df5c60100ef3b32b9ab8c5426171 \
+                    sha256  f8ae4365416b56bd3c680cbe6fdf87a8456fc2709d84ac9952a5584843321eec \
+                    size    387432
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-math-science/Portfile
+++ b/tex/texlive-math-science/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-math-science
-version             62660
+version             66461
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Mathematics, natural sciences, computer science packages
 long_description    Mathematics, natural sciences, computer science packages
 
-checksums           texlive-math-science-62660-run.tar.xz \
-                    rmd160  dbdf6107296dd6ee165e359c2264abab00da5b43 \
-                    sha256  4b487a2751a372b9bffb361674b643d8f2a2979d84fa8a13556d6773b93118a1 \
-                    size    82196068 \
-                    texlive-math-science-62660-doc.tar.xz \
-                    rmd160  fc74deff2ccebae0acd0f09d423df1a235e1167c \
-                    sha256  40dbc86bc0eb22d6e5e7561084c9ae72d9dfe1ccaacec437c710df1c59c1108f \
-                    size    77101100 \
-                    texlive-math-science-62660-src.tar.xz \
-                    rmd160  252ac29bde72988596e354749aff0df37795a22b \
-                    sha256  0e18f9b4f49725b20d1eeba776476b339578c82575ff279ebd6a028fd144dee4 \
-                    size    1748008
+checksums           texlive-math-science-66461-run.tar.xz \
+                    rmd160  04c02cf135e274f9a63e6ad437ed04e1da577d14 \
+                    sha256  e686e3d67a26e13e9dbe9b3848c1ec4e47fa51ca83d6d3f35eb816df6ec5f406 \
+                    size    89711540 \
+                    texlive-math-science-66461-doc.tar.xz \
+                    rmd160  b2ba6e0e2a8a603d9dc0defb959c726bfda0180f \
+                    sha256  b6163c09d32b08edcc7f76a8f13da7f5e9aa98e9bc5e5e485ebb33ab6d847d68 \
+                    size    84238552 \
+                    texlive-math-science-66461-src.tar.xz \
+                    rmd160  d7a22c0265aa169548e2f53bae4602ddc2eaceba \
+                    sha256  ef3cbbcfea0cd88ee5b28d15968495ae1e08668003580725cb410c9c2fa3848a \
+                    size    1874648
 
 depends_lib         port:texlive-fonts-recommended port:texlive-latex
 

--- a/tex/texlive-metapost/Portfile
+++ b/tex/texlive-metapost/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-metapost
-version             62678
+version             66264
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: MetaPost and Metafont packages
 long_description    MetaPost and Metafont packages
 
-checksums           texlive-metapost-62678-run.tar.xz \
-                    rmd160  bb28ead46f652b1034df35a6de08bb8522b5c5fb \
-                    sha256  a1a2e642ebece1d200efe6664b5fe22119e56c9f33d1039ba28c8f36efec7990 \
-                    size    37159820 \
-                    texlive-metapost-62678-doc.tar.xz \
-                    rmd160  193d342201f7a11782b73f38bc8f22722e474dfa \
-                    sha256  a9e84b0b46b5d096a104a40db98a0521f7e62206471db5d0efdb1e34bbba2b75 \
-                    size    36479244 \
-                    texlive-metapost-62678-src.tar.xz \
-                    rmd160  4fd7e06c95d2dc2182e4e7fcfb87c1cef027da06 \
-                    sha256  c72fceb420df74fdbe5d3ed9de4c8358b9b07ab389cd94c708b81f661d9dd5b5 \
-                    size    325860
+checksums           texlive-metapost-66264-run.tar.xz \
+                    rmd160  8c81eed5d88a813ce78b1cc307758bbd136bcb1b \
+                    sha256  44ca5f9afae4e05a8fb8665e8e4f0c95a781f8d6759d6d4ac14c28be65b8539d \
+                    size    36650620 \
+                    texlive-metapost-66264-doc.tar.xz \
+                    rmd160  70ef0248cfdde22c93d1b8470a7328bf0d248c24 \
+                    sha256  65bc95a7f25bf32489cee15c23e1305d7ccbc01870c8ab15cca04d5f7ca2d927 \
+                    size    35969308 \
+                    texlive-metapost-66264-src.tar.xz \
+                    rmd160  ba4272d175f9678688687eebc311aa9b74c4a823 \
+                    sha256  d60acfc8124fe6aaddfa920b61c09158c5b81a0a830d3b7cb85616de133dd383 \
+                    size    325896
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-music/Portfile
+++ b/tex/texlive-music/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-music
-version             62610
+version             66278
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Music packages
 long_description    Music-related fonts and packages.
 
-checksums           texlive-music-62610-run.tar.xz \
-                    rmd160  d595121ae4758d99410771af33618981f6c55de5 \
-                    sha256  c89aff2ba5b3ce4302498a9e075a7779c29041707ebfc61f66991b57c4889620 \
-                    size    65392908 \
-                    texlive-music-62610-doc.tar.xz \
-                    rmd160  42b3b8747b2b39e1937cfb09f89ed085ba735c54 \
-                    sha256  d446b7adc735c36c34b58077f6dd18a7cc8259ca6324346369f258659e760547 \
-                    size    18183308 \
-                    texlive-music-62610-src.tar.xz \
-                    rmd160  a5d304cab7cb2321e11c11a3d2cd5e05bbcf9d97 \
-                    sha256  437bc395249668955123b41390f044613874fbcea9942358b3d7853ffa83a1bc \
-                    size    24277552
+checksums           texlive-music-66278-run.tar.xz \
+                    rmd160  9757da175c9e7ae4be63fc18cb24b7d9c60cb711 \
+                    sha256  c351d5f6701943be2102f5b72abdea5540deeb2a9a0cf45dd5fa37b0b088750b \
+                    size    65763656 \
+                    texlive-music-66278-doc.tar.xz \
+                    rmd160  e1d0a50a755c1bba14c93da38e2438637a815e2c \
+                    sha256  d1ffd382b8eabceb234c58244102865f4f72aebabe27fe5aadef55b4055277c0 \
+                    size    18450556 \
+                    texlive-music-66278-src.tar.xz \
+                    rmd160  b07644347a69c1b15799e3378676af5e531ee7be \
+                    sha256  f203ef8eb4f31740ee17fec3c76eba0c88a3ed481303324fecf9e28dd958ec31 \
+                    size    24284084
 
 depends_lib         port:texlive-latex
 

--- a/tex/texlive-pictures/Portfile
+++ b/tex/texlive-pictures/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-pictures
-version             62759
+version             66549
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Graphics, pictures, diagrams
 long_description    Including TikZ, pict, etc., but MetaPost and PStricks are separate.
 
-checksums           texlive-pictures-62759-run.tar.xz \
-                    rmd160  23ba99f60175df502c92efd28185f4abfe2bf62f \
-                    sha256  0e08ead8987a1b1f970a1424893201c53e0d98afee0b116424cc3c47c7ac8be8 \
-                    size    202431056 \
-                    texlive-pictures-62759-doc.tar.xz \
-                    rmd160  adca2d5e7c14ca0e6c62b542397b9ee5fb4cc9d6 \
-                    sha256  da7981f62423e03ecfae99c948542f5f04194b54610075437e350dbafc5c154f \
-                    size    190984504 \
-                    texlive-pictures-62759-src.tar.xz \
-                    rmd160  6fcefc8d04c6b2807e10ecca606246bceff369f5 \
-                    sha256  43b51ef93f9c413b73e9decb832e5dc940f68418f0757835e46d820f0f59fcd8 \
-                    size    2745036
+checksums           texlive-pictures-66549-run.tar.xz \
+                    rmd160  b068d3a0782f6a4d1818946dd8a46cffa2cd83bf \
+                    sha256  6a9f0738398400d86e9655aadbc097685658fb28b890183a6ff08f7d85fcfc1a \
+                    size    232466064 \
+                    texlive-pictures-66549-doc.tar.xz \
+                    rmd160  b2d2777aa2df30ed1883743e86f1a27799e93d4e \
+                    sha256  589d73fad052e40abd3c767b7aab06f38ffd59e4fac2869624297b53cd3931d2 \
+                    size    213883000 \
+                    texlive-pictures-66549-src.tar.xz \
+                    rmd160  49ba7ca59ffbf66436e9c0138d178b4c70a5d952 \
+                    sha256  8455909796a1337270b116282c30ab037c2e1b220d54e0361f3a02a07522a496 \
+                    size    2786160
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-plain-generic/Portfile
+++ b/tex/texlive-plain-generic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-plain-generic
-version             62875
+version             66530
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Plain (La)TeX packages
 long_description    Add-on packages and macros that work with plain TeX, often LaTeX, and occasionally other formats.
 
-checksums           texlive-plain-generic-62875-run.tar.xz \
-                    rmd160  9fbbe7c9bac2eefa91ff74502fcb2cc65150d608 \
-                    sha256  2441d78892b5ff3df43bfbee6cd299eda828557faa8eaa86b45aa6c060dc0978 \
-                    size    28641500 \
-                    texlive-plain-generic-62875-doc.tar.xz \
-                    rmd160  ccd4442fbe2a8552c80e26c0983df0549a11600a \
-                    sha256  4d45e24a8e12e531ecdda25aa82796904dc54257c64bb2e12c995405a8feb8de \
-                    size    25150704 \
-                    texlive-plain-generic-62875-src.tar.xz \
-                    rmd160  6831aadcfa6cea89bb74f65ad66a5bf5ff64a3c7 \
-                    sha256  db787066d8d6c7ca04049d57031e70bd3e49b28f47c4d1199e4c67b84ac697de \
-                    size    1606556
+checksums           texlive-plain-generic-66530-run.tar.xz \
+                    rmd160  658ea9b5a3d03f5e6c88cd6f0fac04db625b2050 \
+                    sha256  d1b8812e68186a416965e771cdce4cc18d93de130fc321c7a4e5bb9f7c310aa5 \
+                    size    29893928 \
+                    texlive-plain-generic-66530-doc.tar.xz \
+                    rmd160  7f2441ffa61f258c0b9899c0717e0598d4d081c2 \
+                    sha256  d36f1e4189cc90d2b2bbdcd9d11ec5fb3b8889c9b97b4b010397fdcd5061209c \
+                    size    26038900 \
+                    texlive-plain-generic-66530-src.tar.xz \
+                    rmd160  9ebabaebf8a0ffeda90ae49e372f5a2e2255d582 \
+                    sha256  db0a5ee1280253eb84cd8209f9273b3fde6507e376236373cabffb3c6dc0f5db \
+                    size    1699796
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive-pstricks/Portfile
+++ b/tex/texlive-pstricks/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-pstricks
-version             61917
+version             66115
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: PSTricks
 long_description    PSTricks core and all add-on packages.
 
-checksums           texlive-pstricks-61917-run.tar.xz \
-                    rmd160  1d2ee80758dac4e03c5c0e7b1249e0e88895f836 \
-                    sha256  3eb5d00acba451b01bf5bb38b4686b2fd01bb2efcb72bafbfcd6761fe4cce974 \
-                    size    291423184 \
-                    texlive-pstricks-61917-doc.tar.xz \
-                    rmd160  77bdcb7ad1322b42d2ddd9271afd45f175a534ed \
-                    sha256  9d43882a4606db6105bffc85609d198628c1c2e85e26776eecb9855d4ad1c5e2 \
-                    size    264428276 \
-                    texlive-pstricks-61917-src.tar.xz \
-                    rmd160  dca11e537430d010c9e66a3c4cc5fe03a6a54c52 \
-                    sha256  58af80f6d30d57fd23476b7d023a761fdfe48071411f46997c957d82bcf386be \
-                    size    445480
+checksums           texlive-pstricks-66115-run.tar.xz \
+                    rmd160  a0f438854ec5bf0a57ff03bc8ab2bff95ef6f389 \
+                    sha256  86d004e6606b420cb76c501b1825e966497fb625e21c4d85db5b276edac01357 \
+                    size    294194368 \
+                    texlive-pstricks-66115-doc.tar.xz \
+                    rmd160  86ed5b2afa1fd66f65fb9720d2c90d3d79c7fed2 \
+                    sha256  a5bf587779a3ec992935fcc62ef52585579a17cc19ec11b7a2279353ae397e62 \
+                    size    263947188 \
+                    texlive-pstricks-66115-src.tar.xz \
+                    rmd160  3a044f7e8167d40ce0e813df0e6d077ec55de8fb \
+                    sha256  dc0289a9d3fdfcddc289e0ba5782ab216cf010ffc6346f5b98deb21a209124d8 \
+                    size    445092
 
 depends_lib         port:texlive-basic port:texlive-plain-generic
 

--- a/tex/texlive-publishers/Portfile
+++ b/tex/texlive-publishers/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-publishers
-version             62872
+version             66550
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: Publisher styles, theses, etc.
 long_description    Publisher styles, theses, etc.
 
-checksums           texlive-publishers-62872-run.tar.xz \
-                    rmd160  07452408cf78dc3115aa4eb06c4bd19ba957ca31 \
-                    sha256  ab1a3c58634ead3ee690a74f5deea09ca3624bdb33e302f388ce969debad679f \
-                    size    225980696 \
-                    texlive-publishers-62872-doc.tar.xz \
-                    rmd160  773cef39c3d9686611e8493ac4b514e38754ca88 \
-                    sha256  86fe434a30fb247c6b2c3abc6315bf7f698c7d7b56bfddf976c64e563ab3ad8e \
-                    size    202817912 \
-                    texlive-publishers-62872-src.tar.xz \
-                    rmd160  4f141bf32da7bb875f8a4a3f3f927e94eae548e7 \
-                    sha256  3d75cc0385da5771ada2127624c04762c34908c2076d792e0844b232d6cea1eb \
-                    size    3234288
+checksums           texlive-publishers-66550-run.tar.xz \
+                    rmd160  c6e49557c193e0ca8665bcaf61a413ce74dee652 \
+                    sha256  79005e89eb3e291621bfb625916e5f50535091f8ccaefc38a61befd1d50154ba \
+                    size    236934908 \
+                    texlive-publishers-66550-doc.tar.xz \
+                    rmd160  0b05ef0b45c6a0b04dbf56bd2c4001ca66e29711 \
+                    sha256  e9106ef7cdb16e6c3d914c31ea861d8a8d5325f7eec31e9f952c565e1b2963b8 \
+                    size    212558912 \
+                    texlive-publishers-66550-src.tar.xz \
+                    rmd160  81fb9917f6ef93a9fe39e803a35d06301aeedd42 \
+                    sha256  03fee20ec59fbba0beb0962ee6677cc444dba03c151ec9a92b7e5c78785d2ae6 \
+                    size    3514520
 
 depends_lib         port:texlive-latex
 

--- a/tex/texlive-tlpdb/Portfile
+++ b/tex/texlive-tlpdb/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-tlpdb
-version             2022.62882
+version             2023.66589
 
 categories          tex
 maintainers         {dports @drkp}
@@ -23,9 +23,9 @@ master_sites        https://www.ambulatoryclam.net/texlive/ \
 
 use_xz              yes
 
-checksums           rmd160  5a74956d5a0398e7c95aa3938c7c854541759ebf \
-                    sha256  15ed5f7ab82ab86648255d41922609602a22f02aef1796f70bb4e661aa0c1d17 \
-                    size    1346136
+checksums           rmd160  3dcba9fe8c93dbba3f2c412b5d80be3b52975183 \
+                    sha256  1085b7b507a2bd08b6523dc132421fbf2c5021f472d578bf2713682f469a7096 \
+                    size    1395552
 
 livecheck.type  regex
 livecheck.url   [lindex ${master_sites} 0]

--- a/tex/texlive-xetex/Portfile
+++ b/tex/texlive-xetex/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                texlive-xetex
-version             62790
+version             66394
 revision            0
 
 categories          tex
@@ -13,18 +13,18 @@ license             Copyleft Permissive
 description         TeX Live: XeTeX and packages
 long_description    Packages for XeTeX, the Unicode/OpenType-enabled TeX by Jonathan Kew, http://tug.org/xetex.
 
-checksums           texlive-xetex-62790-run.tar.xz \
-                    rmd160  ea7325872ad79b0d756ba00f5e42f38413be2ba5 \
-                    sha256  ac2a62c9ba5f497222443f9558478c1aecd2afd43681d40358575c4263ccd898 \
-                    size    11085556 \
-                    texlive-xetex-62790-doc.tar.xz \
-                    rmd160  d49355a21640f2d6e3b2df70718c0c14144b7273 \
-                    sha256  3066c6c7082f7f4b38a054a84b3664290e8078b915a839436d093ecdd8ac40e1 \
-                    size    10404440 \
-                    texlive-xetex-62790-src.tar.xz \
-                    rmd160  0ebb4fb158cb4a91b2e4cf2243bd5d68a76ddea8 \
-                    sha256  4f3911ab4de4c7c3b169401490e4612522242d0289184c22db7cda7b04bcb785 \
-                    size    53088
+checksums           texlive-xetex-66394-run.tar.xz \
+                    rmd160  1f1a9fffeb3619742e0dbd1ec69d65c6aa30375e \
+                    sha256  5fa8b25e8aa5b05de59237925602b5ce515418d3c585159981a700d3cd32a89b \
+                    size    11353340 \
+                    texlive-xetex-66394-doc.tar.xz \
+                    rmd160  03e0a0b2d07740cf075750e8fe654912858ae99c \
+                    sha256  09d101bb3ad1252b15d0f68652fa45f1aeb3d19fa79d6886c63f530c9b0d0b6d \
+                    size    10656856 \
+                    texlive-xetex-66394-src.tar.xz \
+                    rmd160  e512571fa1efae9e3b2d077bb0b04e1a10d95c8b \
+                    sha256  ccae19869875c50924fbf4daa36ee7a87f1af219d7cba110eaacd10962c5394a \
+                    size    52960
 
 depends_lib         port:texlive-basic
 

--- a/tex/texlive/Portfile
+++ b/tex/texlive/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       texlive 1.0
 
 name            texlive
-version         2022
+version         2023
 
 categories      tex
 maintainers     {dports @drkp}


### PR DESCRIPTION
This is a mostly complete update of the texlive ports to the 2023 release of TeX Live.

The only remaining blocker that I'm aware of is that it doesn't yet properly build ConTeXt with the new luametatex engine. There is a port included for luametatex, which successfully builds that, but I haven't yet worked out how to build the formats.

@mojca, do you have any info on how to get ConTeXt built here? I saw that there was some discussion on the tl-distro list but haven't had time to sort through the latest.

Beyond that, if anyone feels like reviewing or testing, the update should be otherwise complete.
