### PR TITLE
micronaut: update to 3.9.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.9.0 v
+github.setup    micronaut-projects micronaut-starter 3.9.1 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  8767745fc070422ae1e9bbff571715513fc6530a \
-                sha256  1ae064b32cd7751d3b24f762e0f9dfe8ff4032ac8102d3f413f9cf785d464c6f \
-                size    20258896
+checksums       rmd160  3cf825f6675e06a7177be5606c6fc2c7a1ce4ce0 \
+                sha256  ebe6d5c8b1680a0075b6df38258ff539f0e4f2a61721c43118b4fa3bea5a60c4 \
+                size    20262460
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.9.1.

###### Tested on

macOS 13.3.1 22E261 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?