### PR TITLE
GPXSee: bump to 13.0

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 12.4
+github.setup        tumic0 GPXSee 13.0
 revision            0
 
-checksums           rmd160  8c577ccbeccc1a445a23ef7f3d931e526a08bd44 \
-                    sha256  ea1672bedae756b201801300a8a13d1de545ae203e6ee07178130d6cfda4d1b5 \
-                    size    5485729
+checksums           rmd160  a5f75572a14e717b80bec7bc2e70b3a3300817bb \
+                    sha256  620a64ab34a080f5e9a08b559afc69237b13208ffdb9abaa8571dc8f57cb29fb \
+                    size    5496098
 
 categories          gis graphics
 license             GPL-3

--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -7,9 +7,8 @@ PortGroup           qmake5 1.0
 github.setup        tumic0 QtPBFImagePlugin 2.3
 revision            1
 categories          graphics
-platforms           darwin
 license             LGPL-3
-maintainers         {@sikmir gmail.com:sikmir} openmaintainer
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 
 description         PBF image plugin for Qt5
 long_description    Qt image plugin for displaying Mapbox vector tiles.
@@ -23,5 +22,8 @@ configure.args-append \
 
 depends_lib-append  port:protobuf3-cpp \
                     port:zlib
+
+# Workaround xcrun: error: SDK "macosx12" cannot be located
+configure.sdk_version
 
 use_xcode           yes


### PR DESCRIPTION
#### Description
* [Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)
* QtPBFImagePlugin: fix build

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
