### PR TITLE
update vim to revision 1499

### DIFF
--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -18,12 +18,12 @@ if {${os.platform} eq "darwin" && ${os.major} <= 14} {
                     sha256  7185577d6cd3708b62b2079b69a29215bb6a6048070d34e960d2d565c18b8a9b \
                     size    16851486
 } else {
-    set vim_patchlevel 1276
+    set vim_patchlevel 1499
     set port_revision  0
 
-    checksums       rmd160  a1630ecb5b3e8e68f926f595f85ea519d8bf867d \
-                    sha256  9e0690a0225b622e3b8cca1be866f3472062e4c43d9da47fe4536b33c60e97cf \
-                    size    16955692
+    checksums       rmd160  10d9edf0b19197771722e4a2fcf2e36021c34fa6 \
+                    sha256  3db98ddcbb8628ec9818da50353c4dd08d62938c80c71d38062250205310cdc3 \
+                    size    17010976
 }
 
 github.setup        vim vim ${vim_version}.${vim_patchlevel} v
@@ -41,7 +41,9 @@ long_description    Vim is an advanced text editor that seeks to provide the\
 
 homepage            https://www.vim.org/
 
-depends_lib         port:ncurses \
+
+depends_lib-append \
+                    port:ncurses \
                     port:gettext \
                     port:libiconv
 
@@ -56,7 +58,8 @@ autoconf.pre_args
 autoconf.args
 autoconf.dir ${worksrcpath}/src
 
-configure.args      --disable-gui \
+configure.args-append \
+                    --disable-gui \
                     --without-x \
                     --without-local-dir \
                     --disable-gpm \


### PR DESCRIPTION
This is necessary to fix a know bug related to syntax highlighting of .sh files

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E261 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
