### PR TITLE
plumber: update to 2.3.0

### DIFF
--- a/net/plumber/Portfile
+++ b/net/plumber/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/batchcorp/plumber 1.15.0 v
+go.setup            github.com/batchcorp/plumber 2.3.0 v
 github.tarball_from archive
 revision            0
 
@@ -27,17 +27,17 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  aa9eaf955194a11093b0db9823f511abe076bf9c \
-                    sha256  42ec3063004f63e7daf5f8286e2db685a1eed5fdf0617e94fc7d6e3e66c3bd00 \
-                    size    23595095
+checksums           rmd160  82a681870d7bb8fb4305d6103ddf66da58bb5374 \
+                    sha256  51ca7d2285238ca7ee198baf2236261aec2a18be794d9e6f121b09538cb63103 \
+                    size    24149097
 
+build.cmd           make
 build.pre_args-append \
-    -ldflags \"-X \
-        ${go.package}/options.VERSION=${github.tag_prefix}${version} \
-    \"
-
-build.args-append   -o ./_bin/${name}
+                    VERSION=${github.tag_prefix}${version}
+build.args          build/darwin-${goarch}
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/_bin/${name} ${destroot}${prefix}/bin/
+    xinstall -m 0755 \
+        {*}[glob ${worksrcpath}/build/${name}-*] \
+        ${destroot}${prefix}/bin/${name}
 }


### PR DESCRIPTION

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
