### PR TITLE
py-blosc2, -ndindex: submission

### DIFF
--- a/python/py-blosc2/Portfile
+++ b/python/py-blosc2/Portfile
@@ -1,0 +1,62 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-blosc2
+version             2.2.0
+revision            0
+categories-append   devel
+license             BSD
+
+python.versions     38 39 310 311
+
+maintainers         nomaintainer
+
+description         Python package that wraps the Blosc2 compressor
+
+long_description    Blosc (http://www.blosc.org) is a high performance \
+                    compressor optimized for binary data.  It has been \
+                    designed to transmit data to the processor cache faster \
+                    than the traditional, non-compressed, direct memory fetch \
+                    approach via a memcpy() OS call. \
+                    \
+                    Blosc works well for compressing numerical arrays that \
+                    contains data with relatively low entropy, like sparse \
+                    data, time series, grids with regular-spaced values, etc. \
+                    \
+                    C-Blosc2 is the new major version of C-Blosc, and \
+                    is backward compatible with both the C-Blosc1 API \
+                    and its in-memory format. Python-Blosc2 is a \
+                    Python package that wraps C-Blosc2, the newest \
+                    version of the Blosc compressor.
+
+homepage            https://www.blosc.org/python-blosc2/python-blosc2.html
+
+checksums           rmd160  e23ddcafb6a0e2d6da0fb4377e81d7c6227178d8 \
+                    sha256  4cf3893fe85da4bd899ecf7a457fd09b2212fad256182100108de7a92b88aa87 \
+                    size    4135248
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        path:bin/cmake:cmake \
+                        path:bin/cython:py${python.version}-cython \
+                        port:ninja \
+                        port:py${python.version}-scikit-build \
+                        port:py${python.version}-setuptools
+
+    depends_lib-append  \
+                        port:py${python.version}-cpuinfo \
+                        port:py${python.version}-msgpack \
+                        port:py${python.version}-ndindex \
+                        port:py${python.version}-numpy \
+                        port:py${python.version}-rich
+
+    post-patch {
+        reinplace "s|, \"cmake\", \"ninja\"||" ${worksrcpath}/pyproject.toml
+        reinplace "s|oldest-supported-numpy|numpy|" ${worksrcpath}/pyproject.toml
+    }
+
+    test.run        yes
+    test.env        PYTHONPATH=${worksrcpath}
+}

--- a/python/py-ndindex/Portfile
+++ b/python/py-ndindex/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-ndindex
+version             1.7
+revision            0
+categories-append   devel
+license             MIT
+
+python.versions     37 38 39 310 311
+
+maintainers         nomaintainer
+
+description         A Python library for manipulating indices of ndarrays
+
+long_description    ${description}
+
+homepage            https://quansight-labs.github.io/ndindex/
+
+checksums           rmd160  3e3fc8e48bc295567e49b3a37190c89a9009dfca \
+                    sha256  bf9bd0b76eeada1c8275e04091f8291869ed2b373b7af48e56faf7579fd2efd2 \
+                    size    85371
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                        path:bin/cython:py${python.version}-cython
+    depends_lib-append  \
+                        port:py${python.version}-numpy
+    depends_test-append \
+                        port:py${python.version}-hypothesis \
+                        port:py${python.version}-pytest-cov
+
+    test.run            yes
+}


### PR DESCRIPTION
#### Description

Submitting `py-blosc2` and its dependency `py-ndindex`.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2026 x86_64
macOS 11.7.4 20G1120 x86_64
macOS 12.6.3 21G419 arm64


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
