### PR TITLE
Update a few python ports which I'm care of

### DIFF
--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -19,7 +19,7 @@
 #
 # python.pep517: build using PEP517 (default is "no")
 # python.pep517_backend: specify the backend to use; one of "setuptools" (default),
-#   "flit", "hatch", or "poetry"
+#   "flit", "hatch", "poetry", or "maturin"
 #
 # python.test_framework: specify the test framework to use; one of "pytest" (default),
 #   "nose", "unittest", or <empty string>
@@ -395,6 +395,12 @@ proc python_add_dependencies {} {
                     poetry {
                         depends_build-delete    port:py${python.version}-poetry-core
                         depends_build-append    port:py${python.version}-poetry-core
+                    }
+                    maturin {
+                        depends_build-delete    port:py${python.version}-maturin \
+                                                port:py${python.version}-setuptools-rust
+                        depends_build-append    port:py${python.version}-maturin \
+                                                port:py${python.version}-setuptools-rust
                     }
                     default {}
                 }

--- a/net/qobuz-dl/Portfile
+++ b/net/qobuz-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                qobuz-dl
-version             0.9.9.8
+version             0.9.9.10
 revision            0
 
 categories          net
@@ -18,13 +18,13 @@ long_description    ${description}
 
 homepage            https://github.com/vitiko98/Qobuz-DL
 
-checksums           rmd160  7c59d4d95fb5c2be0d9c36e6bca89d2de3793651 \
-                    sha256  682da53e27d607308ec8dda26bc69dc320de2f6db422e7b1eeba58904582a628 \
-                    size    35837
+checksums           rmd160  8b40cbb144b587602581dd8f5d5ed9a844c89a2b \
+                    sha256  abb4d4977b1c83e8aca0b074c49bc92c2b6f254ecefa880c95fb6dd0eef7a9be \
+                    size    35976
 
 patchfiles          pick-2.0.diff
 
-python.default_version 310
+python.default_version 311
 
 depends_build-append \
                     port:py${python.version}-setuptools

--- a/python/py-coveralls/Portfile
+++ b/python/py-coveralls/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  76526fac69adffb06b50989648726c7d3a33a5db \
                     sha256  b32a8bb5d2df585207c119d6c01567b81fba690c9c10a753bfe27a335bfc43ea \
                     size    17964
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -32,15 +32,4 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-coverage \
                     port:py${python.version}-docopt \
                     port:py${python.version}-requests
-
-    depends_test-append \
-                    port:py${python.version}-coverage \
-                    port:py${python.version}-pip \
-                    port:py${python.version}-pytest \
-                    port:py${python.version}-wheel \
-                    port:py${python.version}-yaml
-
-    test.run        yes
-
-    livecheck.type  none
 }

--- a/python/py-docopt/Portfile
+++ b/python/py-docopt/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  c2e76c031e12096906b9c6b1f7dc62a9b30336f1 \
                     sha256  49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491 \
                     size    25901
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -34,6 +34,4 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} README.rst LICENSE-MIT \
             ${destroot}${docdir}
     }
-
-    test.run        yes
 }

--- a/python/py-flask/Portfile
+++ b/python/py-flask/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-flask
-version             2.3.1
+version             2.3.2
 revision            0
 
-checksums           rmd160  c09600e98bf27a64a10d08770011f7e936c645c1 \
-                    sha256  a6059db4297106e5a64b3215fa16ae641822c1cb97ecb498573549b2478602cb \
-                    size    686211
+checksums           rmd160  bcfe660783a1d9645fabebdb6c5330117dbe0310 \
+                    sha256  8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef \
+                    size    686251
 
 python.versions     27 37 38 39 310 311
 platforms           {darwin any}
@@ -38,6 +38,8 @@ if {${name} ne ${subport}} {
         checksums           rmd160  292144499de5f1a7d409c1646b61cb5010fc2922 \
                             sha256  77504c4c097f56ac5f29b00f9009213010cf9d2923a288c0e0564a5db2bb53d6 \
                             size    697568
+
+        livecheck.type      none
     }
 
     # The last supported version for 27
@@ -53,6 +55,8 @@ if {${name} ne ${subport}} {
 
         depends_build-append \
                             port:py${python.version}-setuptools
+
+        livecheck.type      none
     }
 
 
@@ -69,6 +73,4 @@ if {${name} ne ${subport}} {
     if {${python.version} > 27} {
         test.run            yes
     }
-
-    livecheck.type      none
 }

--- a/python/py-httpcore/Portfile
+++ b/python/py-httpcore/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-httpcore
-version             0.16.2
+version             0.17.0
 platforms           {darwin any}
 license             BSD
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -14,9 +14,9 @@ long_description    {*}${description}
 supported_archs     noarch
 homepage            https://github.com/encode/httpcore
 
-checksums           rmd160  aecd73702e8f44b3ccf525787292cd824706d2fc \
-                    sha256  c35c5176dc82db732acfd90b581a3062c999a72305df30c0fc8fafd8e4aca068 \
-                    size    54294
+checksums           rmd160  54170791ce2f2d79bcf49589c757aac17edf1559 \
+                    sha256  cc045a3241afbf60ce056202301b4d8b6af08845e3294055eb26b09913ef903c \
+                    size    57317
 
 python.versions     37 38 39 310 311
 
@@ -31,6 +31,4 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-h2 \
                     port:py${python.version}-socksio \
                     port:py${python.version}-sniffio
-
-    livecheck.type  none
 }

--- a/python/py-httpx/Portfile
+++ b/python/py-httpx/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-httpx
-version             0.23.1
+version             0.24.0
 revision            0
 platforms           {darwin any}
 license             BSD
@@ -17,9 +17,9 @@ long_description    {*}${description}
 supported_archs     noarch
 homepage            https://github.com/encode/httpx
 
-checksums           rmd160  62484533972b707d43b801d0c10d384828c88f11 \
-                    sha256  202ae15319be24efe9a8bd4ed4360e68fde7b38bcc2ce87088d416f026667d19 \
-                    size    90447
+checksums           rmd160  deefef505a81299ada0a03f6b91f4edb639710e0 \
+                    sha256  507d676fc3e26110d41df7d35ebd8b3b8585052450f4097401c9be59d928c63e \
+                    size    81136
 
 python.versions     37 38 39 310 311
 
@@ -38,8 +38,8 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-click \
                     port:py${python.version}-h2 \
                     port:py${python.version}-httpcore \
+                    port:py${python.version}-idna \
                     port:py${python.version}-pygments \
-                    port:py${python.version}-rfc3986 \
                     port:py${python.version}-rich \
                     port:py${python.version}-sniffio \
                     port:py${python.version}-socksio

--- a/python/py-hypothesis/Portfile
+++ b/python/py-hypothesis/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-hypothesis
-version             6.70.2
+version             6.75.2
 revision            0
 categories-append   devel
 platforms           {darwin any}
@@ -26,9 +26,9 @@ long_description \
 
 homepage            https://pypi.python.org/pypi/hypothesis
 
-checksums           rmd160  94279f85f3adeb6bce0b8b3a30e86535266cece1 \
-                    sha256  a8d1d96ae2214f8ca4b8109d555df08e1eb5c31dd7e3995e53413c7094f74dcc \
-                    size    341236
+checksums           rmd160  2ba6bf68c954fc4eb0a1d635276963fcbc5b3376 \
+                    sha256  50c270b38d724ce0fefa71b8e3511d123f7a31a9af9ea003447d4e1489292fbc \
+                    size    351356
 
 if {${name} ne ${subport}} {
     depends_build-append  port:py${python.version}-setuptools

--- a/python/py-ifaddr/Portfile
+++ b/python/py-ifaddr/Portfile
@@ -22,11 +22,9 @@ checksums           rmd160  a7d6fa7f48edb1ef317503a5cfa3e1c0ec65857e \
                     sha256  cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4 \
                     size    10485
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
-
-    livecheck.type  none
 }

--- a/python/py-inflate64/Portfile
+++ b/python/py-inflate64/Portfile
@@ -19,11 +19,12 @@ checksums           rmd160  5208ebf0e2b69016b8d4f805e8e8ab86c23d7abe \
                     sha256  b52dd8fefd2ba179e5dfa18d6eca7e2fc822584616271c039d5ef1f9ca90c71c \
                     size    895561
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-setuptools_scm
 
     depends_test-append \
                     port:py${python.version}-pyannotate \

--- a/python/py-jellyfish/Portfile
+++ b/python/py-jellyfish/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cargo_fetch 1.0
 PortGroup           python 1.0
 
 name                py-jellyfish
-version             0.9.0
+version             0.11.2
 revision            0
 
 license             BSD
@@ -16,26 +17,20 @@ long_description    {*}${description}
 
 homepage            https://github.com/jamesturk/jellyfish
 
-checksums           rmd160  e9ff243aba590976e18bf8f5c43ffc70212afa12 \
-                    sha256  40c9a2ffd8bd3016f7611d424120442f627f56d518a106847dc93f0ead6ad79a \
-                    size    132588
+checksums           ${distname}${extract.suffix} \
+                    rmd160  35028d061ef515011ffa60e71d7b81ab490f2ef6 \
+                    sha256  654f2b1543b9927c4429bd5d66f98d1f47e6eb9a4e56212e1907fb4eea258c5a \
+                    size    362969
 
-python.versions     37 38 39 310
+python.pep517           yes
+python.pep517_backend   maturin
+
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
 
-    depends_test-append \
-                    port:py${python.version}-pytest
-
-    pre-test {
-        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-    }
-
-    test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target     ${worksrcpath}/build/lib*/jellyfish/test.py
+    # Test is disabled, see: https://github.com/macports/macports-ports/pull/18480
+    # test.run        yes
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
@@ -43,4 +38,53 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} LICENSE README.md \
             ${destroot}${docdir}
     }
-}
+
+    cargo.crates \
+        ahash                    0.8.3                          2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f \
+        autocfg                  1.1.0                          d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+        bitflags                 1.3.2                          bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+        cfg-if                   1.0.0                          baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+        csv                      1.2.1                          0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad \
+        csv-core                 0.1.10                         2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90 \
+        getrandom                0.2.8                          c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31 \
+        indoc                    1.0.9                          bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306 \
+        itoa                     1.0.6                          453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6 \
+        libc                     0.2.140                        99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c \
+        lock_api                 0.4.9                          435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df \
+        memchr                   2.5.0                          2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
+        memoffset                0.8.0                          d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1 \
+        once_cell                1.17.1                         b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3 \
+        parking_lot              0.12.1                         3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
+        parking_lot_core         0.9.7                          9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521 \
+        proc-macro2              1.0.55                         1d0dd4be24fcdcfeaa12a432d588dc59bbad6cad3510c67e74a2b6b2fc950564 \
+        pyo3                     0.18.2                         cfb848f80438f926a9ebddf0a539ed6065434fd7aae03a89312a9821f81b8501 \
+        pyo3-build-config        0.18.2                         98a42e7f42e917ce6664c832d5eee481ad514c98250c49e0b03b20593e2c7ed0 \
+        pyo3-ffi                 0.18.2                         a0707f0ab26826fe4ccd59b69106e9df5e12d097457c7b8f9c0fd1d2743eec4d \
+        pyo3-macros              0.18.2                         978d18e61465ecd389e1f235ff5a467146dc4e3c3968b90d274fe73a5dd4a438 \
+        pyo3-macros-backend      0.18.2                         8e0e1128f85ce3fca66e435e08aa2089a2689c1c48ce97803e13f63124058462 \
+        quote                    1.0.26                         4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc \
+        redox_syscall            0.2.16                         fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
+        ryu                      1.0.13                         f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041 \
+        scopeguard               1.1.0                          d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+        serde                    1.0.159                        3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065 \
+        smallvec                 1.10.0                         a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0 \
+        syn                      1.0.109                        72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+        target-lexicon           0.12.6                         8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5 \
+        tinyvec                  1.6.0                          87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+        tinyvec_macros           0.1.1                          1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
+        unicode-ident            1.0.8                          e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4 \
+        unicode-normalization    0.1.22                         5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
+        unicode-segmentation     1.10.1                         1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36 \
+        unindent                 0.1.11                         e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c \
+        version_check            0.9.4                          49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+        wasi                     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+        windows-sys              0.45.0                         75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+        windows-targets          0.42.2                         8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
+        windows_aarch64_gnullvm  0.42.2                         597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
+        windows_aarch64_msvc     0.42.2                         e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
+        windows_i686_gnu         0.42.2                         c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
+        windows_i686_msvc        0.42.2                         44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
+        windows_x86_64_gnu       0.42.2                         8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
+        windows_x86_64_gnullvm   0.42.2                         26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
+        windows_x86_64_msvc      0.42.2                         9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0
+ }

--- a/python/py-maturin/Portfile
+++ b/python/py-maturin/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 name                py-maturin
 version             0.14.17
-revision            0
+revision            1
 categories-append   devel
 license             MIT Apache-2
 supported_archs     arm64 x86_64
@@ -31,6 +31,8 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools-rust
+
+    patchfiles      patch-maturin-command.diff
 
     if {${python.version} < 311} {
         depends_run-append \

--- a/python/py-maturin/files/patch-maturin-command.diff
+++ b/python/py-maturin/files/patch-maturin-command.diff
@@ -1,0 +1,49 @@
+--- maturin/__init__.py	2023-04-06 02:38:20
++++ maturin/__init__.py	2023-05-03 00:03:28
+@@ -52,7 +52,7 @@
+     # PEP 517 specifies that only `sys.executable` points to the correct
+     # python interpreter
+     command = [
+-        "maturin",
++        f"maturin-{sys.version_info.major}.{sys.version_info.minor}",
+         "pep517",
+         "build-wheel",
+         "-i",
+@@ -92,7 +92,7 @@
+ 
+ # noinspection PyUnusedLocal
+ def build_sdist(sdist_directory, config_settings=None):
+-    command = ["maturin", "pep517", "write-sdist", "--sdist-directory", sdist_directory]
++    command = [f"maturin-{sys.version_info.major}.{sys.version_info.minor}", "pep517", "write-sdist", "--sdist-directory", sdist_directory]
+ 
+     print("Running `{}`".format(" ".join(command)))
+     sys.stdout.flush()
+@@ -154,7 +154,7 @@
+         sys.exit(1)
+ 
+     command = [
+-        "maturin",
++        f"maturin-{sys.version_info.major}.{sys.version_info.minor}",
+         "pep517",
+         "write-dist-info",
+         "--metadata-directory",
+--- maturin/import_hook.py	2023-04-06 02:38:20
++++ maturin/import_hook.py	2023-05-03 00:04:17
+@@ -84,7 +84,7 @@
+     if project_dir.exists():
+         shutil.rmtree(project_dir)
+ 
+-    command = ["maturin", "new", "-b", bindings, project_dir]
++    command = [f"maturin-{sys.version_info.major}.{sys.version_info.minor}", "new", "-b", bindings, project_dir]
+     result = subprocess.run(command, stdout=subprocess.PIPE)
+     if result.returncode != 0:
+         sys.stderr.write(
+@@ -103,7 +103,7 @@
+ def build_module(
+     manifest_path: pathlib.Path, bindings: Optional[str] = None, release: bool = False
+ ):
+-    command = ["maturin", "develop", "-m", manifest_path]
++    command = [f"maturin-{sys.version_info.major}.{sys.version_info.minor}", "develop", "-m", manifest_path]
+     if bindings:
+         command.append("-b")
+         command.append(bindings)

--- a/python/py-mediafile/Portfile
+++ b/python/py-mediafile/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-mediafile
-version             0.10.1
+version             0.11.0
 revision            0
 
 categories-append   multimedia
@@ -21,23 +21,19 @@ homepage            https://mediafile.readthedocs.io/
 
 maintainers         {@catap korins.ky:kirill} openmaintainer
 
-checksums           rmd160  e1796e3c1bf38739afc6d5321262d4c6b08138fe \
-                    sha256  929642a17ee5023b9086221ce80cdc2c51d06021a890d4433b0bd5bd32f2b29f \
-                    size    563478
+checksums           rmd160  ef74e5f8a91c15abacd51fcf227e041e7014a08d \
+                    sha256  2771ae95a31b773635c1446957cf5cd91d29967b9606f8c8c6accba1715c5eaf \
+                    size    563296
 
-python.pep517       yes
-python.versions     37 38 39 310
+python.pep517           yes
+python.pep517_backend   flit
+
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-flit_core \
-                    port:py${python.version}-setuptools
-
     depends_lib-append \
                     port:py${python.version}-six \
                     port:py${python.version}-mutagen
 
     test.run        yes
-
-    livecheck.type  none
 }

--- a/python/py-mpd2/Portfile
+++ b/python/py-mpd2/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-mpd2
 python.rootname     python-mpd2
-version             3.0.5
+version             3.1.0
 revision            0
 
 categories-append   devel audio
@@ -20,21 +20,17 @@ long_description    {*}${description}
 
 homepage            https://github.com/Mic92/python-mpd2
 
-checksums           rmd160  15071a52b8e2433fcd6ef7773fcdf4bb042f3784 \
-                    sha256  6f1bffd93b9a32fc018a9bbf3487505b52e0d757ec34066905c60a912d492384 \
-                    size    57963
+checksums           rmd160  68c5f82df8dc02ec11a221ec0f0259b2dd60e361 \
+                    sha256  f33c2cdb0d6baa74a36724f38c1c4a099a7ce2c8ec4a2bb7192150a5855df476 \
+                    size    58269
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
+
+python.test_framework   unittest
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
     test.run        yes
-    test.cmd        ${python.bin}
-    test.args       -m unittest discover
-    test.target
-    test.env        PYTHONPATH=${worksrcpath}/build/lib
-
-    livecheck.type  none
 }

--- a/python/py-multivolumefile/Portfile
+++ b/python/py-multivolumefile/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  cdc129e1e9473e762ed5ff0103bbc0e2c8f59358 \
                     sha256  a0648d0aafbc96e59198d5c17e9acad7eb531abea51035d08ce8060dcad709d6 \
                     size    77984
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -38,6 +38,4 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-pytest-cov
 
     test.run        yes
-
-    livecheck.type  none
 }

--- a/python/py-orjson/Portfile
+++ b/python/py-orjson/Portfile
@@ -30,13 +30,10 @@ checksums           ${distname}${extract.suffix} \
                     sha256  dcf6adb4471b69875034afab51a14b64f1026bc968175a2bb02c5f6b358bd413 \
                     size    836541
 
+python.pep517           yes
+python.pep517_backend   maturin
+
 if {${name} ne ${subport}} {
-    python.pep517   yes
-
-    depends_build-append \
-                    port:py${python.version}-maturin \
-                    port:py${python.version}-setuptools-rust
-
     depends_run-append \
                     port:py${python.version}-autoflake \
                     port:py${python.version}-black \

--- a/python/py-pathvalidate/Portfile
+++ b/python/py-pathvalidate/Portfile
@@ -22,11 +22,9 @@ checksums           rmd160  5ab548950b8b435f1a699945d1e8891366108534 \
                     sha256  5ff57d0fabe5ecb7a4f1e4957bfeb5ad8ab5ab4c0fa71f79c6bbc24bd9b7d14d \
                     size    26715
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
-
-    livecheck.type  none
 }

--- a/python/py-py7zr/Portfile
+++ b/python/py-py7zr/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-py7zr
-version             0.20.2
+version             0.20.5
 revision            0
 
 platforms           {darwin any}
@@ -16,13 +16,13 @@ long_description    {*}${description}
 
 homepage            https://github.com/miurahr/py7zr
 
-checksums           rmd160  992e6adf4655aea6cb9d9f2d3b65e97776f23c2c \
-                    sha256  791ef912a295b61b91c5fe0c23adeddb80bf13500308062c082b8fec6c8c9653 \
-                    size    4983066
+checksums           rmd160  0521155fc61ac3d8e85c0a18421df2a9092f320b \
+                    sha256  6fb4889c0fa32581818a3366984083253585d6c794e82c3242b8a12d6aeaabd3 \
+                    size    4985655
 
 python.pep517       yes
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -53,6 +53,4 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-pytest-remotedata
 
     test.run        yes
-
-    livecheck.type  none
 }

--- a/python/py-pyannotate/Portfile
+++ b/python/py-pyannotate/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  1f18624a1f79bfbe2594d699da35159281c46ab5 \
                     sha256  04ed5804bab38153d5981fc92d83dcf6a22883453768561f057e777e5c057599 \
                     size    45706
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -32,6 +32,4 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-six
 
     test.run        yes
-
-    livecheck.type  none
 }

--- a/python/py-pybcj/Portfile
+++ b/python/py-pybcj/Portfile
@@ -20,11 +20,10 @@ checksums           rmd160  cf622c5fe17f49d5127de7d5e91a5c2e2b98e8ea \
                     size    2110963
 
 python.pep517       yes
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm
 
     depends_test-append \

--- a/python/py-pycryptodome/Portfile
+++ b/python/py-pycryptodome/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 # also update py-pycryptodomex
 name                py-pycryptodome
-version             3.16.0
+version             3.17
 revision            0
 
 homepage            https://www.pycryptodome.org
@@ -23,9 +23,9 @@ long_description    PyCryptodome is a self-contained Python package of \
 
 python.versions     27 35 36 37 38 39 310 311
 
-checksums           rmd160  ede7631df66a5e1c622492b7df703c82f3044106 \
-                    sha256  0e45d2d852a66ecfb904f090c3f87dc0dfb89a499570abad8590f10d9cffb350 \
-                    size    4548083
+checksums           rmd160  8d68b19a294cef0449a377098622132353dcbae1 \
+                    sha256  bce2e2d8e82fcf972005652371a3e8731956a0c1fbb719cc897943b3695ad91b \
+                    size    4633800
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pycryptodomex/Portfile
+++ b/python/py-pycryptodomex/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 # also update py-pycryptodome
 name                py-pycryptodomex
-version             3.16.0
+version             3.17
 revision            0
 
 license             BSD
@@ -17,9 +17,9 @@ long_description    ${description}
 
 homepage            https://www.pycryptodome.org
 
-checksums           rmd160  d94f4d4c700cd4a00772d05c99c90fa66298015c \
-                    sha256  e9ba9d8ed638733c9e95664470b71d624a6def149e2db6cc52c1aca5a6a2df1d \
-                    size    4548384
+checksums           rmd160  520d81d4549039408708f738cbc1d68f933edf54 \
+                    sha256  0af93aad8d62e810247beedef0261c148790c52f3cd33643791cc6396dd217c1 \
+                    size    4634167
 
 python.versions     38 39 310 311
 

--- a/python/py-pyppmd/Portfile
+++ b/python/py-pyppmd/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  ea08c307ea98c16c9e8c2384c3f48292edaaab39 \
                     sha256  075c9bd297e3b0a87dd7aeabca7fee668218acbe69ecc1c6511064558de8840f \
                     size    1350611
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -35,6 +35,4 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-pytest-timeout
 
     test.run        yes
-
-    livecheck.type  none
 }

--- a/python/py-pytest-remotedata/Portfile
+++ b/python/py-pytest-remotedata/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pytest-remotedata
-version             0.3.3
+version             0.4.0
 revision            0
 
 platforms           {darwin any}
@@ -17,11 +17,11 @@ long_description    {*}${description}
 
 homepage            https://astropy.org
 
-checksums           rmd160  59af296ed687cf750b7cc067367509f7756a6049 \
-                    sha256  66920bf1c62928b079d0e611379111a0d49f10a9509ced54c8269514ccce6ee3 \
-                    size    12718
+checksums           rmd160  5d2bb59c5d35a86b638bb80cda8508aee5a5b829 \
+                    sha256  be21c558e34d7c11b0f6aeb50956c09520bffcd02b7fce9c6f8e8531a401a1c8 \
+                    size    13227
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -33,6 +33,4 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-pytest
 
     test.run        yes
-
-    livecheck.type  none
 }

--- a/python/py-pytest-sugar/Portfile
+++ b/python/py-pytest-sugar/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pytest-sugar
-version             0.9.6
+version             0.9.7
 revision            0
 
 categories-append   devel
@@ -20,9 +20,9 @@ long_description    {*}${description}
 
 homepage            http://pivotfinland.com/pytest-sugar/
 
-checksums           rmd160  0104a230e55bb62a87d3177b1f875111891932fe \
-                    sha256  c4793495f3c32e114f0f5416290946c316eb96ad5a3684dcdadda9267e59b2b8 \
-                    size    13702
+checksums           rmd160  d9c6b4eb386d7783b85cd61de546e8ae20c0cb16 \
+                    sha256  f1e74c1abfa55f7241cf7088032b6e378566f16b938f3f08905e2cf4494edd46 \
+                    size    14874
 
 python.versions     37 38 39 310 311
 

--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-pytest
-version             7.2.1
+version             7.3.1
 revision            0
 
 categories-append   devel
@@ -25,9 +25,9 @@ long_description    The pytest framework makes it easy to write small tests, \
 
 homepage            https://pytest.org
 
-checksums           rmd160  fc0f99532e2f4ebe6f4c3d08f1cde5338fe4e114 \
-                    sha256  d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42 \
-                    size    1301901
+checksums           rmd160  4ec52815c19f50fc1acb827a82344bff2daf36b7 \
+                    sha256  434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3 \
+                    size    1336938
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -55,7 +55,7 @@ if {${name} ne ${subport}} {
 
     if {${python.version} eq 27} {
         version             4.6.3
-        revision            2
+        revision            0
         distname            ${python.rootname}-${version}
         checksums           rmd160  5d88707bd2fc29ee675087b24461a9ca8cbe1ffb \
                             sha256  4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45 \

--- a/python/py-pyzstd/Portfile
+++ b/python/py-pyzstd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pyzstd
-version             0.15.3
+version             0.15.7
 revision            0
 
 platforms           darwin
@@ -16,21 +16,15 @@ long_description    ${description}
 
 homepage            https://github.com/animalize/pyzstd
 
-checksums           rmd160  16ec0b9625bd91ff729ad2958d645deb14bb9d38 \
-                    sha256  ac4edab5d3955343e8f7f287e62cd2882907d46bcba4b406a1e9f84aa2887472 \
-                    size    758625
+checksums           rmd160  08254474123133046fcf30800171f86ab621be4c \
+                    sha256  55e503f28f5a9d225ce9d0639e3f5b1801bacace5aea926ec2998e73c5150fe7 \
+                    size    805496
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools
 
-    pre-test {
-        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-    }
-
     test.run        yes
-
-    livecheck.type  none
 }

--- a/python/py-soco/Portfile
+++ b/python/py-soco/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-soco
-version             0.28.1
+version             0.29.1
 revision            0
 
 platforms           {darwin any}
@@ -18,11 +18,11 @@ long_description    {*}${description}
 
 homepage            https://github.com/SoCo/SoCo
 
-checksums           rmd160  d8e7cf5475c0357f5ab8634057fec44edb77a84a \
-                    sha256  57254e4f5d967e6a71c97013a3852694cfe2e63e08c5a74f540bf4510bc039ac \
-                    size    728401
+checksums           rmd160  bddc1487e2983c5c4b420eea757627bec5eabd45 \
+                    sha256  6f164ab8c282d5d2e4cc382d55b7e7c1bb45f400d7e784f64b50f97a6c9f7363 \
+                    size    729825
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -41,6 +41,4 @@ if {${name} ne ${subport}} {
 
     test.run        yes
     test.args       -m 'not integration'
-
-    livecheck.type  none
 }

--- a/python/py-werkzeug/Portfile
+++ b/python/py-werkzeug/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-werkzeug
 python.rootname     Werkzeug
-version             2.3.0
+version             2.3.3
 revision            0
 categories-append   www
 license             BSD
@@ -28,12 +28,9 @@ long_description    Werkzeug is a one of the most advanced WSGI utility \
 
 homepage            https://palletsprojects.com/p/werkzeug/
 
-checksums           rmd160  9eaa6bfaa1030e25bda365bfe07a9dc19dbd6271 \
-                    sha256  3b6b46926d052b8ebca97c4dc73c12e47bdd07d57ab0600c039c3155450227bc \
-                    size    824640
-
-python.test_framework \
-                    pytest
+checksums           rmd160  e7fbc016314d6671e23a0850719915cac54be434 \
+                    sha256  a987caf1092edc7523edb139edb20c70571c4a8d5eed02e0b547b4739174d091 \
+                    size    831963
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-markupsafe \
@@ -47,6 +44,8 @@ if {${name} ne ${subport}} {
         checksums           rmd160  9dc625e19c6cb90783972a8d467bd5270aafe30c \
                             sha256  6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c \
                             size    904455
+
+        livecheck.type      none
     }
 
     if {${python.version} == 37} {
@@ -55,6 +54,8 @@ if {${name} ne ${subport}} {
         checksums           rmd160  6b8cb31aadd1f6f4c306b3cc6952134a23a643c7 \
                             sha256  2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe \
                             size    845884
+
+        livecheck.type      none
     }
 
     post-destroot {
@@ -90,6 +91,4 @@ if {${name} ne ${subport}} {
         # See: https://github.com/pallets/werkzeug/issues/2515
         test.args       -o addopts="-m 'not dev_server'"
     }
-
-    livecheck.type  none
 }


### PR DESCRIPTION
#### Description

Here an update of a cluster of python ports which I'm care of.

It includes adding a few `py311` subport.

I've also removed run tests which was removed by upstream, and cleaned up some portfiles.

And the last changes: I've added support of backend `maturin` into python PG, which is used now at two ports :)

Thus, I'm maintainer or co-maintainer of all of these ports with one exception: `py-orjson` which I've switched to new PG's backend.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->