### PR TITLE
lbzip2: enable legacysupport.use_static

### DIFF
--- a/archivers/lbzip2/Portfile
+++ b/archivers/lbzip2/Portfile
@@ -6,9 +6,12 @@ PortGroup               legacysupport 1.1
 # _SC_NPROCESSORS_ONLN
 legacysupport.newest_darwin_requires_legacy 8
 
+# link legacysupport statically for archiver
+legacysupport.use_static              yes
+
 name                    lbzip2
 version                 2.5
-revision                2
+revision                3
 categories              archivers
 maintainers             {eborisch @eborisch} openmaintainer
 license                 GPL-3+


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/67334 (when lbzip2 depends on legacysupport, it is unable to facilitate upgrading it.)