### PR TITLE
qbs: Update to 2.0.0

### DIFF
--- a/devel/qbs/Portfile
+++ b/devel/qbs/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 name                qbs
-version             1.23.0
+version             2.0.0
 revision            0
 
 categories          devel
@@ -21,11 +21,10 @@ homepage            https://wiki.qt.io/Qbs
 distname            qbs-src-${version}
 master_sites        https://download.qt.io/official_releases/qbs/${version}/
 
-checksums           rmd160  69a2581f7eb1bea1847c37bb0aaeacca2bfa0a95 \
-                    sha256  c86aa775446aec728bcbbed782ec128f4e6e2c26536710017343e684bb616d7a \
-                    size    5078941
+checksums           rmd160  12fa4f49fe40337d342408abb680e596b89bfad6 \
+                    sha256  d78555691ea732949346860e56f68c7c44e9384011359722b032a49b52dfccfd \
+                    size    5509775
 
-qt5.depends_component qtscript
 qt5.min_version     5.14.0
 
 compiler.cxx_standard 2017
@@ -43,7 +42,8 @@ cmake.generator     Ninja
 #      Reason: image not found
 # set TMPDIR to avoid
 #    SOFT ASSERT: job->state() == AbstractJob::StateRunning in api/project.cpp:153
-patchfiles-append patch-environment.diff
+#patchfiles-append patch-environment.diff patch-qbs-docs.diff
+patchfiles-append patch-environment.diff patch-find-package.diff
 
 livecheck.type      regex
 livecheck.url       https://download.qt.io/official_releases/qbs/
@@ -64,10 +64,10 @@ subport ${name}-docs {
     # TODO: only HTML docs are installed, dunno how to run
     # `cmake --install .` twice
     configure.args-append -DQBS_INSTALL_HTML_DOCS=YES -DQBS_INSTALL_QCH_DOCS=Yes -DPYTHON_EXECUTABLE:FILEPATH=${prefix}/bin/python${py_ver}
-    build.target       BuildQbsDocumentation
+    build.target       qbs_docs
 
     destroot.pre_args  --install
-    destroot.args      . --component qbs_html_docs
+    destroot.args      . --component qbs_docs
     destroot.target    ""
     destroot.cmd cmake
 }

--- a/devel/qbs/Portfile
+++ b/devel/qbs/Portfile
@@ -51,16 +51,19 @@ livecheck.regex     {(\d+(?:\.\d+)+)/}
 
 subport ${name}-docs {
 
+    set py_ver          3.11
+    set py_ver_nodot    [string map {. {}} ${py_ver}]
+
     universal_variant  no
     supported_archs    noarch
     qt5.depends_build_component sqlite-plugin qttools
-    depends_build-append       port:python310 \
-                               port:py310-beautifulsoup4 \
-                               port:py310-lxml
+    depends_build-append       port:python${py_ver_nodot} \
+                               port:py${py_ver_nodot}-beautifulsoup4 \
+                               port:py${py_ver_nodot}-lxml
 
     # TODO: only HTML docs are installed, dunno how to run
     # `cmake --install .` twice
-    configure.args-append -DQBS_INSTALL_HTML_DOCS=YES -DQBS_INSTALL_QCH_DOCS=Yes
+    configure.args-append -DQBS_INSTALL_HTML_DOCS=YES -DQBS_INSTALL_QCH_DOCS=Yes -DPYTHON_EXECUTABLE:FILEPATH=${prefix}/bin/python${py_ver}
     build.target       BuildQbsDocumentation
 
     destroot.pre_args  --install

--- a/devel/qbs/files/patch-find-package.diff
+++ b/devel/qbs/files/patch-find-package.diff
@@ -1,0 +1,10 @@
+--- CMakeLists.txt.orig	2023-05-06 22:13:00
++++ CMakeLists.txt	2023-05-06 22:12:49
+@@ -54,6 +54,7 @@
+   if(NOT TARGET Qt6Core5Compat)
+     add_library(Qt6Core5Compat INTERFACE)
+   endif()
++  find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS DocTools)
+ endif()
+ 
+ if (QBS_INSTALL_HTML_DOCS OR QBS_INSTALL_QCH_DOCS)


### PR DESCRIPTION
#### Description

Update to upstream and remove QtScript dependency

###### Type(s)


- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
