### PR TITLE
gcc6: restore gcj

### DIFF
--- a/lang/gcc6/Portfile
+++ b/lang/gcc6/Portfile
@@ -10,7 +10,7 @@ PortGroup xcode_workaround            1.0
 name                gcc6
 epoch               3
 version             6.5.0
-revision            7
+revision            8
 subport             libgcc6 { revision 4 }
 platforms           {darwin < 15}
 categories          lang
@@ -19,7 +19,7 @@ maintainers         nomaintainer
 license             {GPL-3+ Permissive}
 description         The GNU compiler collection
 long_description    The GNU compiler collection, including front ends for \
-                    C, C++, Objective-C, Objective-C++ and Fortran.
+                    C, C++, Objective-C, Objective-C++, Fortran and Java.
 
 homepage            https://gcc.gnu.org/
 master_sites        ftp://ftp.funet.fi/pub/mirrors/sources.redhat.com/pub/gcc/releases/gcc-${version}/ \
@@ -90,6 +90,8 @@ platform darwin {
 
     # see https://gcc.gnu.org/ml/gcc-patches/2012-05/msg00672.html
     patchfiles-append         patch-float128.diff
+    # https://github.com/macports/macports-ports/commit/e9f48ba8719d3752218b65b6893c002d5ef7cd6a
+    patchfiles-append         patch-gcj-unwind.diff
 }
 
 # fix build on Tiger Intel - same patch as gcc7 / libgcc works
@@ -99,7 +101,7 @@ platform darwin 8 i386 {
 
 configure.dir       ${workpath}/build
 configure.cmd       ${worksrcpath}/configure
-configure.args      --enable-languages=c,c++,objc,obj-c++,lto,fortran \
+configure.args      --enable-languages=c,c++,objc,obj-c++,lto,fortran,java \
                     --libdir=${prefix}/lib/${name} \
                     --includedir=${prefix}/include/${name} \
                     --infodir=${prefix}/share/info \
@@ -208,7 +210,7 @@ if {${subport} eq "libgcc6"} {
         --libdir=${prefix}/lib/libgcc
 
     configure.args-replace \
-        --enable-languages=c,c++,objc,obj-c++,lto,fortran \
+        --enable-languages=c,c++,objc,obj-c++,lto,fortran,java \
         --enable-languages=fortran
 
     # TODO: Possibly disable bootstrap with appropriate configure flags.
@@ -297,6 +299,7 @@ if {${subport} eq "libgcc6"} {
                 }
             }
         }
+        move ${destroot}${prefix}/lib/${name}/pkgconfig/libgcj-${major}.pc ${destroot}${prefix}/lib/pkgconfig/
     }
 
     select.group        gcc

--- a/lang/gcc6/Portfile
+++ b/lang/gcc6/Portfile
@@ -132,6 +132,13 @@ configure.args      --enable-languages=c,c++,objc,obj-c++,lto,fortran,java \
 configure.args-append \
                     --disable-tls
 
+# Need to disable bootstrap comparisons here as well
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    configure.args-replace \
+                    --with-build-config=bootstrap-debug \
+                    --without-build-config
+}
+
 configure.env-append \
                     AR_FOR_TARGET=${prefix}/bin/ar \
                     AS_FOR_TARGET=${prefix}/bin/as \

--- a/lang/gcc6/files/mp-gcc6
+++ b/lang/gcc6/files/mp-gcc6
@@ -1,6 +1,6 @@
 bin/gcc-mp-6
 bin/cpp-mp-6
 bin/g++-mp-6
--
+bin/gcj-mp-6
 bin/gcov-mp-6
 bin/gfortran-mp-6

--- a/lang/gcc6/files/patch-gcj-unwind.diff
+++ b/lang/gcc6/files/patch-gcj-unwind.diff
@@ -1,0 +1,78 @@
+https://trac.macports.org/ticket/58469
+
+--- libjava/posix.cc	2007-02-22 11:04:55.000000000 -0500
++++ libjava/posix.cc	2019-05-13 23:21:13.000000000 -0400
+@@ -10,6 +10,15 @@
+ 
+ #include <config.h>
+ 
++#if defined(__APPLE__) && defined(__MACH__)
++/* libgcj doesn't normally provide this symbol. Declare it as "hidden" to make
++ * sure that it's only available for libgcj's own use. The declaration must come
++ * before any other in order to ensure that the desired hidden visibility is
++ * applied. */
++extern "C" __attribute__ ((visibility ("hidden")))
++void * _darwin10_Unwind_FindEnclosingFunction (void *);
++#endif
++
+ #include "posix.h"
+ 
+ #include <stdlib.h>
+@@ -27,6 +36,10 @@
+ #include <java/io/InterruptedIOException.h>
+ #include <java/util/Properties.h>
+ 
++#if defined(__APPLE__) && defined(__MACH__)
++#include "unwind-dw2-fde.h"
++#endif
++
+ #if defined (ECOS)
+ extern "C" unsigned long long _clock (void);
+ #endif
+@@ -248,3 +261,15 @@
+ 
+   return ret_val;
+ }
++
++#if defined(__APPLE__) && defined(__MACH__)
++void *
++_darwin10_Unwind_FindEnclosingFunction (void *pc)
++{
++  struct dwarf_eh_bases bases;
++  const struct dwarf_fde *fde = _Unwind_Find_FDE ((void*)(((uintptr_t)pc)-1), &bases);
++  if (fde)
++    return bases.func;
++  return NULL;
++}
++#endif
+--- libgcc/unwind-dw2-fde.h	2015-01-22 11:22:31.000000000 -0500
++++ libgcc/unwind-dw2-fde.h	2019-05-13 21:08:51.000000000 -0400
+@@ -26,6 +26,10 @@
+ #ifndef GCC_UNWIND_DW2_FDE_H
+ #define GCC_UNWIND_DW2_FDE_H
+ 
++#ifdef __cplusplus
++extern "C" {
++#endif
++
+ #ifndef HIDE_EXPORTS
+ #pragma GCC visibility push(default)
+ #endif
+@@ -154,7 +158,7 @@
+ static inline const struct dwarf_cie *
+ get_cie (const struct dwarf_fde *f)
+ {
+-  return (const void *)&f->CIE_delta - f->CIE_delta;
++  return (const struct dwarf_cie *)((const void *)&f->CIE_delta - f->CIE_delta);
+ }
+ 
+ static inline const fde *
+@@ -179,4 +183,8 @@
+ #pragma GCC visibility pop
+ #endif
+ 
++#ifdef __cplusplus
++}
++#endif
++
+ #endif /* unwind-dw2-fde.h */


### PR DESCRIPTION
#### Description

@catap This may be useful for our work on JDK :)

P. S. I have added this patch, looks like it is relevant: https://github.com/macports/macports-ports/commit/e9f48ba8719d3752218b65b6893c002d5ef7cd6a

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
