### PR TITLE
binwalk: upgrade dependency to python311

### DIFF
--- a/cross/binwalk/Portfile
+++ b/cross/binwalk/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        ReFirmLabs binwalk 2.3.4 v
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          cross
 platforms           {darwin any}
@@ -20,7 +20,7 @@ checksums           rmd160  837c0c083bcdbf1feac208f60fb74fe4467433f0 \
                     sha256  60416bfec2390cec76742ce942737df3e6585c933c2467932f59c21e002ba7a9 \
                     size    39723471
 
-python.default_version  310
+python.default_version  311
 
 depends_lib-append  port:py${python.default_version}-setuptools \
                     port:py${python.default_version}-pylzma


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 21G531 x86_64
Xcode 14.1 14B47b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
