### PR TITLE
cdo: revision bump: changed upstream tarball

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -6,18 +6,18 @@ PortGroup                   legacysupport 1.0
 
 name                        cdo
 version                     2.2.0
-revision                    0
+revision                    1
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} openmaintainer
 license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/28012
+master_sites                https://code.mpimet.mpg.de/attachments/download/28013
 
-checksums           rmd160  37f4224a6f1c7242a380c56f572ed95dece5673e \
-                    sha256  006f5acb21ed54571535e2dbcbc78e6cbf36c2731029ea1a7b110c49c8b4c9cd \
-                    size    13307196
+checksums           rmd160  ed59b051f0ceedac33bd9a50b7431c76780543d3 \
+                    sha256  679c8d105706caffcba0960ec5ddc4a1332c1b40c52f82c3937356999d8fadf2 \
+                    size    13305096
 
 long_description \
     CDO is a collection of command line Operators               \


### PR DESCRIPTION
#### Description

Upstream changed the tarball soon after first publishing it.
Revision 0 was based on the old tarball. This revision (1) links to the new tarball, and hence has updated location, size, and checksums

Closes: https://trac.macports.org/ticket/67358

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.3.1 22E261 x86_64
Command Line Tools 14.3.0.0.1.1679647830

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
