### PR TITLE
skaffold: update to 2.4.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.3.1 v
+github.setup        GoogleContainerTools skaffold 2.4.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  61af41bc9b41e351c049babb59df53fb90fbb053 \
-                    sha256  dcea0f25943cecaec0b66f478e823fd0f053ed9db38bf8695e0c2f1767801f8d \
-                    size    41813787
+checksums           rmd160  b8be837746302c90dfacb078b0b032e17127a947 \
+                    sha256  53d3ec0297d7438790bc3768740aefe689e4286fa13344f0c373fe44f7870a58 \
+                    size    41853716
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.4.0.

###### Tested on

macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?