### PR TITLE
mingw-w64: Update to 11.0.1

### DIFF
--- a/cross/mingw-w64/Portfile
+++ b/cross/mingw-w64/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        mirror mingw-w64 10.0.0 v
-revision            1
+github.setup        mingw-w64 mingw-w64 11.0.1 v
+revision            0
 set mingw_name      w64-mingw32
 
 license             ZPL-2.1
@@ -16,11 +16,11 @@ description         GCC cross-compiler for Windows 64 & 32 bits
 long_description    Mingw-w64 is an advancement of the original mingw.org project, \
                     created to support the GCC compiler on Windows systems.
 
-homepage            http://mingw-w64.sourceforge.net/
+homepage            https://mingw-w64.sourceforge.net/
 
-checksums           rmd160  cda1704d75239f6b6f51b7a548b0c2ac27c0f895 \
-                    sha256  9dd3d3d5e02c194963f630089731eeea907c47664aee30924a79f42cd24a4548 \
-                    size    13263930
+checksums           rmd160  124722990dd68875683a9ce8d20eaa75d2ef544b \
+                    sha256  493cb0bde1e470a281c7a633fcc1158de3b8919f687020c60a936e7b2512398d \
+                    size    13919536
 
 # needs an out-of-source build
 configure.dir       ${workpath}/build


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E772610a x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
