### PR TITLE
libxkbcommon: fix executable linkages

### DIFF
--- a/devel/libxkbcommon/Portfile
+++ b/devel/libxkbcommon/Portfile
@@ -31,6 +31,9 @@ homepage            https://xkbcommon.org
 master_sites        ${homepage}/download/
 use_xz              yes
 
+# https://trac.macports.org/ticket/67349
+patchfiles          patch-libxkbcommon-mesonbuild-linkages.diff
+
 depends_build-append \
                     port:bison \
                     port:pkgconfig \
@@ -44,7 +47,7 @@ configure.args      -Ddefault_library=both \
                     -Denable-x11=false
 
 if {${subport} eq ${name}} {
-    revision        0
+    revision        1
 
     depends_lib-append \
                     port:libxml2 \
@@ -52,7 +55,7 @@ if {${subport} eq ${name}} {
 }
 
 subport ${name}-x11 {
-    revision        0
+    revision        1
 
     PortGroup       legacysupport 1.0
 

--- a/devel/libxkbcommon/files/patch-libxkbcommon-mesonbuild-linkages.diff
+++ b/devel/libxkbcommon/files/patch-libxkbcommon-mesonbuild-linkages.diff
@@ -1,0 +1,10 @@
+--- meson.build.orig	2023-05-02 18:42:33
++++ meson.build	2023-05-02 18:46:02
+@@ -414,6 +414,7 @@
+     tools_dep = declare_dependency(
+         include_directories: [include_directories('tools', 'include')],
+         link_with: libxkbcommon_tools_internal,
++        dependencies: dep_libxkbcommon,
+     )
+ 
+     executable('xkbcli', 'tools/xkbcli.c',


### PR DESCRIPTION
meson.build needs to declare that these executables link against libxkbcommon.0.dylib in order for meson to know to rewrite these linkages on installation.

closes: https://trac.macports.org/ticket/67349