### PR TITLE
yajl-fort: new port in fortran

### DIFF
--- a/fortran/yajl-fort/Portfile
+++ b/fortran/yajl-fort/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+
+github.setup        nncarlson yajl-fort 1.3 v
+revision            0
+categories          fortran
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Modern Fortran interface to the YAJL library
+long_description    The YAJL-Fort package provides a modern object-oriented Fortran interface to the YAJL C library, \
+                    which is an event-driven parser for JSON data streams.
+checksums           rmd160  be6f0da4b8dfe6f4698cd55ed52b4465cd7ca18a \
+                    sha256  276f4d0a329b02f30e52dfb5a94ea10714dd0098d2749a68cf8edde4878f6111 \
+                    size    32800
+
+depends_lib-append  port:yajl
+
+# Fix building dynamic lib; install .mod files into a sane directory.
+patchfiles          patch-fix-CMakeLists.diff
+
+compilers.setup     require_fortran
+compiler.blacklist-append \
+                    {*gcc-[34].*} {clang < 421}
+
+configure.args-append \
+                    -DBUILD_TESTS=ON \
+                    -DBUILD_HTML=OFF
+
+test.args-append    DYLD_LIBRARY_PATH=${cmake.build_dir}/src
+test.run            yes

--- a/fortran/yajl-fort/files/patch-fix-CMakeLists.diff
+++ b/fortran/yajl-fort/files/patch-fix-CMakeLists.diff
@@ -1,0 +1,19 @@
+--- src/CMakeLists.txt.orig	2018-03-25 07:41:28.000000000 +0800
++++ src/CMakeLists.txt	2023-05-03 20:04:06.000000000 +0800
+@@ -3,7 +3,7 @@
+ 
+ set(LIB_MOD_DIR ${CMAKE_CURRENT_BINARY_DIR}/mod_files/)
+ 
+-add_library(yajl_fort ${SRC})
++add_library(yajl_fort SHARED ${SRC})
+ 
+ set_target_properties(yajl_fort PROPERTIES
+     Fortran_MODULE_DIRECTORY ${LIB_MOD_DIR})
+@@ -20,6 +20,5 @@
+ install(TARGETS yajl_fort
+         EXPORT  yajl_fort
+         LIBRARY DESTINATION lib
+-        ARCHIVE DESTINATION lib
+ )
+-install(DIRECTORY ${LIB_MOD_DIR} DESTINATION lib)
++install(DIRECTORY ${LIB_MOD_DIR} DESTINATION include/yajl_fort)


### PR DESCRIPTION
#### Description

New port: https://github.com/nncarlson/yajl-fort

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Tests on Rosetta:
```
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_fortran_yajl-fort/yajl-fort/work/build
      Start  1: strip-file1
 1/10 Test  #1: strip-file1 ......................   Passed    0.02 sec
      Start  2: json-ex1
 2/10 Test  #2: json-ex1 .........................   Passed    0.03 sec
      Start  3: json-ex2
 3/10 Test  #3: json-ex2 .........................   Passed    0.03 sec
      Start  4: json-ex3
 4/10 Test  #4: json-ex3 .........................   Passed    0.03 sec
      Start  5: json-ex4
 5/10 Test  #5: json-ex4 .........................   Passed    0.03 sec
      Start  6: json-ex5
 6/10 Test  #6: json-ex5 .........................   Passed    0.03 sec
      Start  7: json-ex6
 7/10 Test  #7: json-ex6 .........................   Passed    0.03 sec
      Start  8: json-ex7
 8/10 Test  #8: json-ex7 .........................   Passed    0.03 sec
      Start  9: json-ex8
 9/10 Test  #9: json-ex8 .........................   Passed    0.03 sec
      Start 10: json-ex9
10/10 Test #10: json-ex9 .........................   Passed    0.03 sec

100% tests passed, 0 tests failed out of 10

Total Test time (real) =   0.33 sec
```