### PR TITLE
cdo: add python build dependency for test

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -6,7 +6,7 @@ PortGroup                   legacysupport 1.0
 
 name                        cdo
 version                     2.2.0
-revision                    1
+revision                    2
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} openmaintainer
 license                     GPL-2
@@ -54,8 +54,14 @@ configure.args              --with-netcdf=${prefix} \
 configure.cppflags-append   -I${prefix}/include/udunits2
 configure.ldflags-append    -lhdf5
 
+# Since cdo 2.2.0, running tests requires the Python 3 interpreter. But since the configure always looks
+# for a recent Python and does not distinguish whether test is requested, it is added here as a build dependency.
+# To make sure that it works prior to Catalina, it is best to simply require the latest python3 package.
+
+depends_build-append        port:python311
+configure.env-append        PYTHON=${prefix}/bin/python3.11
+
 test.run                    yes
-test.dir                    ${worksrcpath}/test
 test.args                   -j1
 test.target                 check
 


### PR DESCRIPTION
#### Description

Update needed because configure looks for Python > 3.6 even though it is only used for testing.
Hence, python311 is now added to depends_build

En passant, I fixed test.dir that changed since this release. One test remains with FAIL status (already so for years).

Closes: https://trac.macports.org/ticket/67364

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.3.1 22E261 x86_64
Command Line Tools 14.3.0.0.1.1679647830
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
