### PR TITLE
crlibm: do not use x86 asm on Rosetta

### DIFF
--- a/devel/crlibm/Portfile
+++ b/devel/crlibm/Portfile
@@ -27,6 +27,13 @@ worksrcdir              ${name}
 
 patchfiles              patch-configure.diff
 
+platform darwin 10 powerpc {
+    # Otherwise Rosetta build fails:
+    # test_perf.c: error: unknown register name ‘edx’ in ‘asm’
+    configure.args-append \
+                        powerpc-apple-darwin${os.major}
+}
+
 livecheck.type          regex
 livecheck.url           http://lipforge.ens-lyon.fr/frs/?group_id=8
 livecheck.regex         "crlibm-(\\d+(?:\\.\\d+)*(?:\[a-z\]+\\d*)?)\.\[tz\]"


### PR DESCRIPTION
#### Description

Fix build on Rosetta.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
