### PR TITLE
cutter: update to 1.2.8

### DIFF
--- a/devel/cutter/Portfile
+++ b/devel/cutter/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 name                cutter
-version             1.2.4
-revision            1
+version             1.2.8
+revision            0
 categories          devel
 maintainers         clear-code.com:kou openmaintainer
 
@@ -15,13 +15,16 @@ long_description    Cutter is a xUnit family Unit Testing Framework for C and C+
                     It provides easy to write test API, useful output format for debugging \
                     and so on.
 
-homepage            http://cutter.sourceforge.net/
+homepage            https://cutter.sourceforge.net/
 platforms           darwin
 license             LGPL-3+
 
-master_sites        sourceforge:project/cutter/cutter/${version}
-checksums           rmd160  e744ea0374222c32b7ba5d92ae4279908ba35216 \
-                    sha256  b917a5b67b1d5f24458db5ab177dc11d23b47f04f9cb7eef757f456483c629c6
+master_sites        https://osdn.dl.osdn.net/cutter/73761/ \
+                    https://free.nchc.org.tw/osdn//cutter/73761/ \
+                    https://ftp.halifax.rwth-aachen.de/osdn/cutter/73761/
+checksums           rmd160  cb95a65640754fa2312d662eb7314583ade70921 \
+                    sha256  bd5fcd6486855e48d51f893a1526e3363f9b2a03bac9fc23c157001447bc2a23 \
+                    size    2662044
 
 depends_build       port:intltool \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description

Trivial update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
