### PR TITLE
madness: update to current upstream (2023.04.23)

### DIFF
--- a/science/madness/Portfile
+++ b/science/madness/Portfile
@@ -7,8 +7,8 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        m-a-d-n-e-s-s madness 8dcbd1076f4891f3965b836de18f155c9b2f0ce1
-version             2023.04.04
+github.setup        m-a-d-n-e-s-s madness 8825cc78291909c15abefb4268206133fc9d5ad0
+version             2023.04.23
 revision            0
 categories          science math
 license             GPL-2
@@ -18,9 +18,9 @@ long_description    MADNESS provides a high-level environment for the solution \
                     of integral and differential equations in many dimensions \
                     using adaptive, fast methods with guaranteed precision \
                     based on multi-resolution analysis and novel separated representations.
-checksums           rmd160  ddebb3e54afee883e840e59f10383d1dbd033795 \
-                    sha256  e4fcd2ee70f4faf20c55068bc2b607832d8b542136554d5b39e4a3d25704fe29 \
-                    size    7370987
+checksums           rmd160  a8e26aaebc8415a21ef9100bc6d416a16f230bf6 \
+                    sha256  80c789d94d4ca3cd0eefc5ddfea59bff656683cadb0efa7bf735b7792ccc801a \
+                    size    7371102
 
 set py_ver          3.11
 set py_ver_nodot    [string map {. {}} ${py_ver}]

--- a/science/madness/files/0002-Do-not-build-chem-it-is-broken.patch
+++ b/science/madness/files/0002-Do-not-build-chem-it-is-broken.patch
@@ -7,14 +7,14 @@ diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 index 08f743e12..01d359790 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -8,7 +8,3 @@ endif()
- install(FILES madness.h
+@@ -9,6 +9,3 @@ endif()
      	DESTINATION "${MADNESS_INSTALL_INCLUDEDIR}"
      	COMPONENT madness)
--
--install(FILES chem.h
--		DESTINATION "${MADNESS_INSTALL_INCLUDEDIR}/madness"
+ 
+-install(FILES madchem.h
+-		DESTINATION "${MADNESS_INSTALL_INCLUDEDIR}"
 -		COMPONENT chem)
+
 diff --git a/src/madness/CMakeLists.txt b/src/madness/CMakeLists.txt
 index 8fbd38511..73fb5ca68 100644
 --- a/src/madness/CMakeLists.txt


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
