### PR TITLE
openimageio: remove obsolete field3d dependency

### DIFF
--- a/graphics/openimageio/Portfile
+++ b/graphics/openimageio/Portfile
@@ -123,9 +123,6 @@ if {${set_python_default}} {
     default_variants        +python311
 }
 
-#configure.args-append       -DUSE_FIELD3D=OFF
-depends_lib-append          port:field3d
-
 #configure.args-append       -DUSE_FFMPEG=OFF
 depends_lib-append          path:lib/libavcodec.dylib:ffmpeg
 

--- a/graphics/openimageio/Portfile
+++ b/graphics/openimageio/Portfile
@@ -49,6 +49,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 20} {
 
     patchfiles-append   patch-FindOpenJpeg.cmake.diff \
                         patch-libraw-0.21.0.diff
+
+    #configure.args-append       -DUSE_FIELD3D=OFF
+    depends_lib-append          port:field3d
 }
 
 if {${os.platform} eq "darwin" && ${os.major} > 20} {


### PR DESCRIPTION
#### Description

Remove obsolete dependency.  Field3d support was completely removed from openimageio as of version 2.4.4.1, 2022 October 1.
https://github.com/OpenImageIO/oiio/releases/tag/v2.4.4.1

However, retain field3d dependency in legacy case (MacOS < 11).  (See notes in Portfile.)

References: https://trac.macports.org/ticket/62065#comment:16

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
