### PR TITLE
josm: update to 18721

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18678
+version             18721
 categories          gis editors java
 license             GPL-2+
 supported_archs     i386 x86_64
@@ -18,9 +18,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  e7896ec5867cee0aa4da9cbe43722554543322a1 \
-                    sha256  6254851f1dfb464753950dff640aa3f9eceff9c49589fb3147bb3a4bba43778a \
-                    size    78186728
+checksums           rmd160  884eae56dc49d53c6f0aa7041d07b3ef7c268890 \
+                    sha256  b9a8f7d8fba9c404b93daeeeb3db0879e7a9189e812258e6e357baa2707bcf14 \
+                    size    78285790
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[2023-05-03: Stable release 18721](https://josm.openstreetmap.de/wiki/Changelog#a2023-05-03:Stablerelease1872123.04)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
