### PR TITLE
gcc10-bootstrap: mark unsupported Xcode / CLT

### DIFF
--- a/lang/gcc10-bootstrap/Portfile
+++ b/lang/gcc10-bootstrap/Portfile
@@ -65,6 +65,17 @@ checksums           ${distname}${extract.suffix} \
                     sha256  fcf78dd9656c10eb8cf9fbd5f59a0b6b01386205fe1934b3b287a0a1898145c0 \
                     size    2261594
 
+# GCC can't be build by clang from Xcode / CLT 14.0.x
+# See: https://github.com/iains/gcc-12-branch/issues/6
+if {([vercmp ${xcodeversion} >= 14.0] && [vercmp ${xcodeversion} < 14.1]) || \
+    ([vercmp ${xcodecltversion} >= 14.0] && [vercmp ${xcodecltversion} < 14.1])} {
+    known_fail          yes
+    pre-fetch {
+        ui_error "GCC build is known to fail on Xcode / CLT 14.0.x"
+        return -code error "incompatible Xcode / CLT version"
+    }
+}
+
 extract {
     foreach f ${distfiles} {
         set f [lindex [split ${f} :] 0]


### PR DESCRIPTION
#### Description

This is trivial PR which marks some xcode as unsupported. Unfortunately such version are installed at buildbots.

See: https://github.com/iains/gcc-12-branch/issues/6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->