### PR TITLE
GPXSee: bump to 13.1

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.0
+github.setup        tumic0 GPXSee 13.1
 revision            0
 
-checksums           rmd160  a5f75572a14e717b80bec7bc2e70b3a3300817bb \
-                    sha256  620a64ab34a080f5e9a08b559afc69237b13208ffdb9abaa8571dc8f57cb29fb \
-                    size    5496098
+checksums           rmd160  6b9ce097b8694016af172c5fc739d83f1d605d8e \
+                    sha256  b9cf79350dedfca7a53c241b689e47c959fe3d7ad05dce82b02d67ed8602ffd2 \
+                    size    5496359
 
 categories          gis graphics
 license             GPL-3

--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 QtPBFImagePlugin 2.3
-revision            1
+github.setup        tumic0 QtPBFImagePlugin 2.4
+revision            0
 categories          graphics
 license             LGPL-3
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -13,9 +13,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         PBF image plugin for Qt5
 long_description    Qt image plugin for displaying Mapbox vector tiles.
 
-checksums           rmd160  3a44c686a724c8bad71dc277d35b3b9327674c66 \
-                    sha256  af8c772472c81d25119cdf1222d8fb75ddfeab4b774286215cfb7518d232e5f0 \
-                    size    196465
+checksums           rmd160  562169c9e5b1ccfa33905311c69f69be4990f0cc \
+                    sha256  aada6fe94e6bee06a2f12e19c260aa082315c695c15ea8c793e04af816e87f85 \
+                    size    196556
 
 configure.args-append \
                     PROTOBUF=${prefix} ZLIB=${prefix}


### PR DESCRIPTION
#### Description
* [Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)
* QtPBFImagePlugin: update to 2.4

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
