### PR TITLE
mssql-tools, msodbcsql*: Use platforms {darwin any}

### DIFF
--- a/databases/msodbcsql/Portfile
+++ b/databases/msodbcsql/Portfile
@@ -5,7 +5,7 @@ version             13.1.9.2
 revision            1
 epoch               1
 categories          databases
-platforms           darwin
+platforms           {darwin any}
 supported_archs     x86_64
 maintainers         {jann @roederja} openmaintainer
 license             Restrictive

--- a/databases/msodbcsql17/Portfile
+++ b/databases/msodbcsql17/Portfile
@@ -4,6 +4,7 @@ name                msodbcsql17
 version             17.10.2.1
 revision            2
 categories          databases
+platforms           {darwin any}
 supported_archs     arm64 x86_64
 maintainers         {jann @roederja} openmaintainer
 license             Restrictive

--- a/databases/mssql-tools/Portfile
+++ b/databases/mssql-tools/Portfile
@@ -4,7 +4,7 @@ name                mssql-tools
 version             17.10.1.1
 revision            1
 categories          databases
-platforms           darwin
+platforms           {darwin any}
 supported_archs     arm64 x86_64
 maintainers         {jann @roederja} openmaintainer
 license             Restrictive


### PR DESCRIPTION
#### Description

These ports install binaries that do not vary by OS version.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.4 21G526 x86_64
Xcode 13.2.1 13C100
