### PR TITLE
py-llvmlite: fix build on macOS before 10.13

### DIFF
--- a/python/py-llvmlite/Portfile
+++ b/python/py-llvmlite/Portfile
@@ -7,6 +7,7 @@ PortGroup           compiler_wrapper 1.0
 
 github.setup        numba llvmlite 0.40.0 v
 name                py-llvmlite
+revision            1
 categories-append   devel science
 license             BSD
 
@@ -25,6 +26,11 @@ checksums           rmd160  f94ace13e4b93b3a642dbbd6b278982b16946e6b \
                     size    260666
 
 if {${name} ne ${subport}} {
+    PortGroup           legacysupport 1.1
+
+    legacysupport.newest_darwin_requires_legacy \
+                        17
+
     patchfiles-append   patch-ffi_Makefile.osx.diff
 
     set llvmver "11"
@@ -34,13 +40,14 @@ if {${name} ne ${subport}} {
 
         if {${os.major} <= 10} {
             # https://trac.macports.org/ticket/61302
-            reinplace "s|%%MP_EXTRA_LDFLAGS%%|-framework CoreFoundation|" \
-                ${worksrcpath}/ffi/Makefile.osx
+            configure.ldflags-append \
+                        -framework CoreFoundation
         } elseif {${os.major} >= 22} {
-            reinplace "s|%%MP_EXTRA_LDFLAGS%%|-lLLVM|" ${worksrcpath}/ffi/Makefile.osx
-        } else {
-            reinplace "s|%%MP_EXTRA_LDFLAGS%%||" ${worksrcpath}/ffi/Makefile.osx
+            configure.ldflags-append \
+                        -lLLVM
         }
+
+        reinplace "s|%%MP_EXTRA_LDFLAGS%%|${configure.ldflags}|" ${worksrcpath}/ffi/Makefile.osx
     }
 
     post-destroot {


### PR DESCRIPTION
#### Description


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->