### PR TITLE
oce: fix build on amr64

### DIFF
--- a/graphics/oce/Portfile
+++ b/graphics/oce/Portfile
@@ -20,6 +20,8 @@ checksums                   rmd160  3bfe060893dca29baefd70d88b05098f9457ee20 \
                             sha256  792ec7d735f1e8ffb9db4bf20fc724c6ec2d2a435aa78e5df795c36fb0f360a1 \
                             size    24636499
 
+patchfiles-append           patch-use-isfinite-on-arm64.diff
+
 depends_lib-append          port:freetype
 
 # install it into libexec to avoid conflict with opencascade port

--- a/graphics/oce/files/patch-use-isfinite-on-arm64.diff
+++ b/graphics/oce/files/patch-use-isfinite-on-arm64.diff
@@ -1,0 +1,13 @@
+diff --git src/OSD/OSD.cxx src/OSD/OSD.cxx
+index 904adb065..cd956acf0 100644
+--- src/OSD/OSD.cxx
++++ src/OSD/OSD.cxx
+@@ -18,7 +18,7 @@
+ #include <math.h>
+ #ifdef WNT
+ # define finite _finite
+-#elif defined(isfinite)
++#elif defined(isfinite) || defined(__arm64__)
+ # define finite isfinite
+ #endif
+ 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E261 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->