### PR TITLE
symfony-cli: update to 5.5.5

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.5.4
+version             5.5.5
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  549837b47acc20fd00b2e581305bc2c9242d34cb \
-                        sha256  7ec3ca2882aff8c826d006454e4879076da2992c45a0462398874b2ae10502d6 \
-                        size    252280
+    checksums           rmd160  80de03e5d64f461f7b20e215fcbef396c070901b \
+                        sha256  5c32e34519871b95f65940543c0dc6186190b0d081b7859ad2425af9a59cfb47 \
+                        size    252773
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  adb9e3652b06c7443b0748ee227537ffe7af8adc \
-                        sha256  5c2bcfd8c59ec6fcf3603c0c7e4ab59526901ba1c3a7ce562e0c34503fcdcc29 \
-                        size    10955477
+    checksums           rmd160  6408e448db3c3e0c565bc4bfe6078587e148da37 \
+                        sha256  2529b6e34087ef1914580aa87f8d5b16502fb220c2dc7ed90e974961bebcac48 \
+                        size    10958295
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.5.5

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
