### PR TITLE
ncarg: Remove jasper dependency, overlinked

### DIFF
--- a/science/ncarg/Portfile
+++ b/science/ncarg/Portfile
@@ -68,7 +68,6 @@ depends_lib                 path:lib/pkgconfig/cairo.pc:cairo \
                             port:libxml2    \
                             port:gsl        \
                             port:flex       \
-                            port:jasper     \
                             port:xorg-libXaw
 depends_build               port:triangle
 depends_run                 bin:ESMF_RegridWeightGen:esmf \


### PR DESCRIPTION
#### Description

Remove overlinking, fix build conflict between jasper and jasper2.  Jasper is not used directly in NCARG, only in a couple of dependencies.

This PR hopes to fix current CI build failures.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
