### PR TITLE
onetbb: fix build on macOS 10.6

### DIFF
--- a/devel/onetbb/files/patch-onetbb-older-platforms.diff
+++ b/devel/onetbb/files/patch-onetbb-older-platforms.diff
@@ -453,13 +453,15 @@ index 69582983..350310e3 100644
  
          zone.size = &impl_malloc_usable_size;
          zone.malloc = &impl_malloc;
-@@ -150,8 +154,10 @@ struct DoMallocReplacement {
+@@ -150,8 +154,12 @@ struct DoMallocReplacement {
          zone.introspect = &introspect;
          zone.version = 8;
          zone.memalign = impl_memalign;
 +    #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__POWERPC__) // Unavailable on macOS < 10.6 and any PPC
          zone.free_definite_size = &impl_free_definite_size;
++    #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070 // Only available on macOS > 10.6
          zone.pressure_relief = &impl_pressure_relief;
++    #endif
 +    #endif
  
          // make sure that default purgeable zone is initialized


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->