### PR TITLE
openjdk17-graalvm: update x86_64 to 22.3.2

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -14,8 +14,11 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.3.1
+version      22.3.2
 revision     0
+
+# There is no macOS aarch64 build for 22.3.2
+set aarch64_version 22.3.1
 
 description  GraalVM Community Edition based on OpenJDK 17
 long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
@@ -25,10 +28,11 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-ce-java17-darwin-amd64-${version}
-    checksums    rmd160  f1453dbeff665c53920f492d4e5020ba0e483788 \
-                 sha256  e46b539fdafa4117ff2ea81feaeeab7db411f5dc8d13047f0405ed21c5a68c0a \
-                 size    261026390
+    checksums    rmd160  c0dd0bbf1c976a1b89a749d5f28d03befde5f364 \
+                 sha256  470d538e34dc168255ee8ceadca74aab4b028ec6c699c4bd8e0226b0a7d3f155 \
+                 size    261116951
 } elseif {${configure.build_arch} eq "arm64"} {
+    version      ${aarch64_version}
     distname     graalvm-ce-java17-darwin-aarch64-${version}
     checksums    rmd160  2243e23de57909f7cb6f88b51d51e623b4f0ca87 \
                  sha256  e3307c29e71423038960c38a6f8c0525f7c6f430c494d9c16935335c291c7ce1 \
@@ -95,10 +99,11 @@ subport ${name}-native-image {
     if {${configure.build_arch} eq "x86_64"} {
         set jar_file native-image-installable-svm-java17-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  a137dae8e574aeed7eca0d548970553c89ea82a0 \
-                     sha256  23e2db58a167307ff5ff4397b7dd82e2f8a587e8631392e2fe0b1d64d97672c3 \
-                     size    30664017
+        checksums    rmd160  889bbd69a50db60314d2e23d4aa69a6f9c744f74 \
+                     sha256  f3325ba7fbbcb865c3cc38ee531398482344fae2dd364073391568b0e5b0a77a \
+                     size    30685976
     } elseif {${configure.build_arch} eq "arm64"} {
+        version      ${aarch64_version}
         set jar_file native-image-installable-svm-java17-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}
         checksums    rmd160  c1fe4d16e586fd7302271c8f2a5f8bd22dd10f81 \


### PR DESCRIPTION
#### Description

Update GraalVM x86_64 to 22.3.2.

###### Tested on

macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?