### PR TITLE
openjdk11-graalvm: update x86_64 to 22.3.2

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -14,8 +14,11 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.3.1
+version      22.3.2
 revision     0
+
+# There is no macOS aarch64 build for 22.3.2
+set aarch64_version 22.3.1
 
 description  GraalVM Community Edition based on OpenJDK 11
 long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
@@ -25,10 +28,11 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-ce-java11-darwin-amd64-${version}
-    checksums    rmd160  2905f35da1e544301215f832b97cd8813b73bfed \
-                 sha256  325afad5f1c4a07a458c95e7c444cff63514a6afa6f2655c12b4f494dccf2228 \
-                 size    254200487
+    checksums    rmd160  31d6a6c00d2241775b1a54d9cc9ad6d0735a18e4 \
+                 sha256  da3c52cc68ce0fb4dcc27dba3c59beadafb7588fec9e9d2812f5bc7c7d00ab63 \
+                 size    254235978
 } elseif {${configure.build_arch} eq "arm64"} {
+    version      ${aarch64_version}
     distname     graalvm-ce-java11-darwin-aarch64-${version}
     checksums    rmd160  3421d1754a491b0cfa44d09df798ff5053fcefc8 \
                  sha256  c59f32289d92671bea46a34f4227fef484a4aa9eeece159e59a486205aaa6c31 \
@@ -95,10 +99,11 @@ subport ${name}-native-image {
     if {${configure.build_arch} eq "x86_64"} {
         set jar_file native-image-installable-svm-java11-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  844176cbaca0f02bc46c326a2b8bdc24c5aff647 \
-                     sha256  2aae087a4a012e86b0db4afb1fe0c8cf25345e35088c8c659d8668d66a4bdc0c \
-                     size    28427632
+        checksums    rmd160  f6ef5181f146264d198705ad88f0e2f9f7debf34 \
+                     sha256  ae542383b033576e26d0431b0b62b4f7c048fee3b209dad2a257c4ae6345f1fb \
+                     size    28458434
     } elseif {${configure.build_arch} eq "arm64"} {
+        version      ${aarch64_version}
         set jar_file native-image-installable-svm-java11-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}
         checksums    rmd160  65a84d8dd894be0830673ffdf7e77a0ca19cf1ac \


### PR DESCRIPTION
#### Description

Update GraalVM x86_64 to 22.3.2.

###### Tested on

macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?