### PR TITLE
gallery-dl: update to 1.25.4

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        mikf gallery-dl 1.25.3 v
+github.setup        mikf gallery-dl 1.25.4 v
 github.tarball_from releases
 distname            gallery_dl-${github.version}
 
@@ -12,9 +12,9 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  9b0d9148ad46b4c6208efa63ef1f2d02d3ddf6ca \
-                    sha256  6a8b1a03c17c4d5067634333f936d16108d55b91540e24a2a2197feefa97c22b \
-                    size    540124
+checksums           rmd160  bba4157beeb78882720ee15df99e7be3ec788d10 \
+                    sha256  e31d178d7ae21002564a66c68c15b16795895bdaee184f7056b7596137bac04e \
+                    size    541137
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites


### PR DESCRIPTION
#### Description

gallery-dl: update to 1.25.4

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

