### PR TITLE
nss: Fix installing with dash as /bin/sh

### DIFF
--- a/net/nss/files/Makefile-MacPorts-Install.in
+++ b/net/nss/files/Makefile-MacPorts-Install.in
@@ -9,4 +9,5 @@ install:
 	$(INSTALL) -m 0644 Output.OBJD/lib/*.a     $(DESTDIR)$(PREFIX)/lib/nss
 	$(INSTALL) -m 0644 Output.OBJD/lib/*.chk   $(DESTDIR)$(PREFIX)/lib/nss
 	$(INSTALL) -m 0755 -d                      $(DESTDIR)$(PREFIX)/include/nss
-	$(INSTALL) -m 0644 public/{dbm,nss}/*.h    $(DESTDIR)$(PREFIX)/include/nss
+	$(INSTALL) -m 0644 public/dbm/*.h          $(DESTDIR)$(PREFIX)/include/nss
+	$(INSTALL) -m 0644 public/nss/*.h          $(DESTDIR)$(PREFIX)/include/nss


### PR DESCRIPTION
#### Description

If the user sets a less featureful shell like `dash` as `/bin/sh` then the `destroot` phase will fail with error:

```
install: public/{dbm,nss}/*.h: No such file or directory
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1
Xcode 14.3 / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
