### PR TITLE
onetbb: fix build on clean 10.6 and 10.7

### DIFF
--- a/devel/onetbb/files/patch-onetbb-older-platforms.diff
+++ b/devel/onetbb/files/patch-onetbb-older-platforms.diff
@@ -12,7 +12,7 @@ index 5ebbdbd1..f0681744 100644
  endif()
  unset(_tbb_target_architectures)
 diff --git cmake/compilers/GNU.cmake cmake/compilers/GNU.cmake
-index b60172c8..1ca1ca12 100644
+index 34c10db0..2496580d 100644
 --- cmake/compilers/GNU.cmake
 +++ cmake/compilers/GNU.cmake
 @@ -36,7 +36,13 @@ if (NOT CMAKE_GENERATOR MATCHES "Ninja" AND NOT CMAKE_CXX_DEPENDS_USE_COMPILER)
@@ -435,10 +435,55 @@ index 00000000..b729364c
 +__ZN3rml10pool_msizeEPNS_10MemoryPoolEPv
 +
 diff --git src/tbbmalloc_proxy/proxy_overload_osx.h src/tbbmalloc_proxy/proxy_overload_osx.h
-index 69582983..350310e3 100644
+index 69582983..bf4df54f 100644
 --- src/tbbmalloc_proxy/proxy_overload_osx.h
 +++ src/tbbmalloc_proxy/proxy_overload_osx.h
-@@ -134,10 +134,14 @@ struct DoMallocReplacement {
+@@ -76,11 +76,13 @@ static void zone_statistics(malloc_zone_t *, malloc_statistics_t *s)
+     s->size_in_use = s->max_size_in_use = s->size_allocated = 0;
+ }
+ 
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__POWERPC__) // zone_locked is not defined on macOS < 10.6 and any PPC
+ static boolean_t zone_locked(malloc_zone_t *)
+ {
+     return false;
+ }
+ 
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070 // Only available on macOS > 10.6
+ static boolean_t impl_zone_enable_discharge_checking(malloc_zone_t *)
+ {
+     return false;
+@@ -88,6 +90,8 @@ static boolean_t impl_zone_enable_discharge_checking(malloc_zone_t *)
+ 
+ static void impl_zone_disable_discharge_checking(malloc_zone_t *) {}
+ static void impl_zone_discharge(malloc_zone_t *, void *) {}
++#endif
++#endif
+ static void impl_zone_destroy(struct _malloc_zone_t *) {}
+ 
+ /* note: impl_malloc_usable_size() is called for each free() call, so it must be fast */
+@@ -105,17 +109,21 @@ static void impl_free(struct _malloc_zone_t *, void *ptr);
+ static void *impl_realloc(struct _malloc_zone_t *, void *ptr, size_t size);
+ static void *impl_memalign(struct _malloc_zone_t *, size_t alignment, size_t size);
+ 
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060 && !defined(__POWERPC__) // zone_locked is not defined on macOS < 10.6 and any PPC
+ /* ptr is in zone and have reported size */
+ static void impl_free_definite_size(struct _malloc_zone_t*, void *ptr, size_t size)
+ {
+     __TBB_malloc_free_definite_size(ptr, size);
+ }
+ 
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070 // Only available on macOS > 10.6
+ /* Empty out caches in the face of memory pressure. */
+ static size_t impl_pressure_relief(struct _malloc_zone_t *, size_t  /* goal */)
+ {
+     return 0;
+ }
++#endif
++#endif
+ 
+ static malloc_zone_t *system_zone = nullptr;
+ 
+@@ -134,10 +142,14 @@ struct DoMallocReplacement {
          introspect.force_lock = &zone_force_lock;
          introspect.force_unlock = &zone_force_unlock;
          introspect.statistics = zone_statistics;
@@ -453,7 +498,7 @@ index 69582983..350310e3 100644
  
          zone.size = &impl_malloc_usable_size;
          zone.malloc = &impl_malloc;
-@@ -150,8 +154,12 @@ struct DoMallocReplacement {
+@@ -150,8 +162,12 @@ struct DoMallocReplacement {
          zone.introspect = &introspect;
          zone.version = 8;
          zone.memalign = impl_memalign;
@@ -481,7 +526,7 @@ index 3b906764..0d349aa9 100644
  #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT (hicpp-no-assembler)
  #endif
 diff --git test/conformance/conformance_allocators.cpp test/conformance/conformance_allocators.cpp
-index 60ec5cae..7e40b0ab 100644
+index 60ec5cae..0c1b9a6c 100644
 --- test/conformance/conformance_allocators.cpp
 +++ test/conformance/conformance_allocators.cpp
 @@ -31,6 +31,7 @@ TEST_CASE("Allocator concept") {


### PR DESCRIPTION
#### Description

I've extend the patch to cover by `#if` unused functions that allows to compile it on old system with very pesky compiler like clang-15 which is used by build bots on clean system these days.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->