### PR TITLE
sympow: fix build on macOS 10.8

### DIFF
--- a/math/sympow/Portfile
+++ b/math/sympow/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem              1.0
 PortGroup               gitlab 1.0
+PortGroup               compiler_blacklist_versions 1.0
 
 gitlab.setup            rezozer/forks sympow 2.023.6 v
 revision                0
@@ -26,6 +27,9 @@ checksums               rmd160  335dfe0835fabaa3565316f499ec3d0bc6f1a4a8 \
 
 compiler.c_standard     2011
 compiler.cxx_standard   2011
+
+# error: The double precision of your FPU is 53 bits.
+compiler.blacklist-append {clang < 600}
 
 configure.cmd           sh ./Configure
 configure.env-append    PREFIX=${prefix}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->