### PR TITLE
rabbitmq-server: update to 3.11.15

### DIFF
--- a/net/rabbitmq-server/Portfile
+++ b/net/rabbitmq-server/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rabbitmq rabbitmq-server 3.10.0 v
+github.setup        rabbitmq rabbitmq-server 3.11.15 v
 revision            0
-checksums           rmd160  42449bd517d5a254091138db8596ea406ed0b169 \
-                    sha256  5058fc0d33305a016b0c08c9a54e328f63f51267366f07c31ce8d0a9cef508ea \
-                    size    12746956
+checksums           rmd160  c30a5ee11a501b8a271bda39f92dd8125230f4c6 \
+                    sha256  538be3c85e8cad10de62705714f71eaacb04339f73a81477c91478600bb8253c \
+                    size    20897748
 
 categories          net
 platforms           {darwin any}


### PR DESCRIPTION
#### Description


According to the [RabbitMQ and Erlang/OTP Compatibility Matrix](https://www.rabbitmq.com/which-erlang.html#compatibility-matrix), the rabbitmq-server port is currently broken due to compatibility issues with Erlang version 25.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E772610a x86_64
Command Line Tools 14.3.0.0.1.1679647830

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
