### PR TITLE
openjdk17-graalvm: fix incorrect version for aarch64

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -14,25 +14,26 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.3.2
-revision     0
-
 # There is no macOS aarch64 build for 22.3.2
+set x86_64_version  22.3.2
 set aarch64_version 22.3.1
+
+revision     0
 
 description  GraalVM Community Edition based on OpenJDK 17
 long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
                  JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
 
-master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-
 if {${configure.build_arch} eq "x86_64"} {
+    version      ${x86_64_version}
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${x86_64_version}/
     distname     graalvm-ce-java17-darwin-amd64-${version}
     checksums    rmd160  c0dd0bbf1c976a1b89a749d5f28d03befde5f364 \
                  sha256  470d538e34dc168255ee8ceadca74aab4b028ec6c699c4bd8e0226b0a7d3f155 \
                  size    261116951
 } elseif {${configure.build_arch} eq "arm64"} {
     version      ${aarch64_version}
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${aarch64_version}/
     distname     graalvm-ce-java17-darwin-aarch64-${version}
     checksums    rmd160  2243e23de57909f7cb6f88b51d51e623b4f0ca87 \
                  sha256  e3307c29e71423038960c38a6f8c0525f7c6f430c494d9c16935335c291c7ce1 \
@@ -97,6 +98,7 @@ subport ${name}-native-image {
     long_description   ${description}
 
     if {${configure.build_arch} eq "x86_64"} {
+        version      ${x86_64_version}
         set jar_file native-image-installable-svm-java17-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
         checksums    rmd160  889bbd69a50db60314d2e23d4aa69a6f9c744f74 \


### PR DESCRIPTION
#### Description

Fix incorrect version for aarch64. MacPorts would show an update to 22.3.2 on aarch64 machines, which is not available.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?