### PR TITLE
openjdk11-graalvm: fix incorrect version for aarch64

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -14,24 +14,26 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version      22.3.2
-revision     0
-
 # There is no macOS aarch64 build for 22.3.2
+set x86_64_version  22.3.2
 set aarch64_version 22.3.1
+
+revision     0
 
 description  GraalVM Community Edition based on OpenJDK 11
 long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
                  JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
 
-master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-
 if {${configure.build_arch} eq "x86_64"} {
+    version      ${x86_64_version}
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${x86_64_version}/
     distname     graalvm-ce-java11-darwin-amd64-${version}
     checksums    rmd160  31d6a6c00d2241775b1a54d9cc9ad6d0735a18e4 \
                  sha256  da3c52cc68ce0fb4dcc27dba3c59beadafb7588fec9e9d2812f5bc7c7d00ab63 \
                  size    254235978
 } elseif {${configure.build_arch} eq "arm64"} {
+    version      ${aarch64_version}
+    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${aarch64_version}/
     version      ${aarch64_version}
     distname     graalvm-ce-java11-darwin-aarch64-${version}
     checksums    rmd160  3421d1754a491b0cfa44d09df798ff5053fcefc8 \
@@ -97,6 +99,7 @@ subport ${name}-native-image {
     long_description   ${description}
 
     if {${configure.build_arch} eq "x86_64"} {
+        version      ${x86_64_version}
         set jar_file native-image-installable-svm-java11-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
         checksums    rmd160  f6ef5181f146264d198705ad88f0e2f9f7debf34 \


### PR DESCRIPTION
#### Description

Fix incorrect version for aarch64. MacPorts would show an update to 22.3.2 on aarch64 machines, which is not available.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?