### PR TITLE
qtkeychain: update to 0.13.2 for Qt5/6, 0.11.1 for Qt 4 

### DIFF
--- a/security/qtkeychain/Portfile
+++ b/security/qtkeychain/Portfile
@@ -4,37 +4,68 @@ PortSystem          1.0
 PortGroup           github  1.0
 
 name                qtkeychain
-github.setup        frankosterfeld qtkeychain 0.9.1 v
+version             0.13.2
+
+description         QtKeyChain stores passwords securely
+long_description    {*}${description}
 
 categories          security
 license             BSD
 maintainers         nomaintainer
 
-description         QtKeyChain stores passwords securely
-long_description    ${description}
+depends_lib-append  port:pkgconfig
 
 use_parallel_build  no
 
-checksums           rmd160  5b1a99b7f798f1d0f4b3e93136cfc04af694391e \
-                    sha256  e2426197f2786435ea986595943e98689cd596f70b68896186e5060b4cd11f12 \
-                    size    35803
-
-foreach qt_major {4 5} {
+foreach qt_major {4 5 6} {
     subport ${name}-qt${qt_major} {
         PortGroup cmake         1.1
         PortGroup qt${qt_major} 1.0
 
-        if {${qt_major} eq 5} {
-            qt5.depends_component qttranslations
-            configure.args-append -DBUILD_WITH_QT4=OFF
+        # Only versions older than 0.12.0 support Qt4
+        if {${qt_major} eq 4} {
+            github.setup frankosterfeld qtkeychain 0.11.1 v
+
+            checksums   rmd160  9f587e90344fe2661f967a29ec7464a1977c2af1 \
+                        sha256  77fc6841c1743d9e6bd499989481cd9239c21bc9bf0760d41a4f4068d2f0a49d \
+                        size    41001
         } else {
-            configure.args-append -DBUILD_WITH_QT4=ON
+            github.setup frankosterfeld qtkeychain ${version} v
+
+            checksums   rmd160  15931f1356fb7109882eb89bf69332a3cc27f19d \
+                        sha256  20beeb32de7c4eb0af9039b21e18370faf847ac8697ab3045906076afbc4caa5 \
+                        size    43494
         }
 
-        # correct module directory is not found for either Qt4 or Qt5
-        # see cmake/Modules/ECMGeneratePriFile.cmake
-        configure.args-append \
-            -DECM_MKSPECS_INSTALL_DIR=${qt_mkspecs_dir}/modules
+        github.tarball_from archive
+
+        switch ${qt_major} {
+            6 {
+                qt6.depends_lib-append  qttranslations
+                configure.args-append -DBUILD_WITH_QT6=ON
+                configure.args-append -DBUILD_WITH_QT4=OFF
+            }
+
+            5 {
+                qt5.depends_component qttranslations
+                configure.args-append -DBUILD_WITH_QT4=OFF
+            }
+
+            4 {
+                configure.args-append -DBUILD_WITH_QT4=ON
+            }
+        }
+
+        if {${qt_major} ne 6} {
+            # correct module directory is not found for either Qt4 or Qt5
+            # see cmake/Modules/ECMGeneratePriFile.cmake
+            configure.args-append \
+                -DECM_MKSPECS_INSTALL_DIR=${qt_mkspecs_dir}/modules
+        } else {
+            # $qt_mkspecs_dir is not defined by the Qt6 portgroups
+            configure.args-append \
+                -DECM_MKSPECS_INSTALL_DIR=${prefix}/libexec/qt6/mkspecs/modules
+        }
     }
 }
 
@@ -56,5 +87,10 @@ if {${subport} eq ${name}} {
     variant qt5 description "build Qt5 version of ${name}" {
         depends_lib-append port:${name}-qt5
     }
-    default_variants +qt5
+
+    variant qt6 description "build Qt6 version of ${name}" {
+        depends_lib-append port:${name}-qt6
+    }
+
+    default_variants +qt6
 }


### PR DESCRIPTION
- add Qt6 subport

CC: @MarcusCalhoun-Lopez - should this port default to the `qt6` variant now?

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
