### PR TITLE
openjdk17-graalvm: fix parse error on ppc

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -14,9 +14,12 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-# There is no macOS aarch64 build for 22.3.2
-set x86_64_version  22.3.2
-set aarch64_version 22.3.1
+if {${configure.build_arch} eq "arm64"} {
+    # There is no macOS aarch64 build for 22.3.2
+    version 22.3.1
+} else {
+    version 22.3.2
+}
 
 revision     0
 
@@ -24,16 +27,14 @@ description  GraalVM Community Edition based on OpenJDK 17
 long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
                  JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
 
+master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+
 if {${configure.build_arch} eq "x86_64"} {
-    version      ${x86_64_version}
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${x86_64_version}/
     distname     graalvm-ce-java17-darwin-amd64-${version}
     checksums    rmd160  c0dd0bbf1c976a1b89a749d5f28d03befde5f364 \
                  sha256  470d538e34dc168255ee8ceadca74aab4b028ec6c699c4bd8e0226b0a7d3f155 \
                  size    261116951
 } elseif {${configure.build_arch} eq "arm64"} {
-    version      ${aarch64_version}
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${aarch64_version}/
     distname     graalvm-ce-java17-darwin-aarch64-${version}
     checksums    rmd160  2243e23de57909f7cb6f88b51d51e623b4f0ca87 \
                  sha256  e3307c29e71423038960c38a6f8c0525f7c6f430c494d9c16935335c291c7ce1 \
@@ -98,14 +99,12 @@ subport ${name}-native-image {
     long_description   ${description}
 
     if {${configure.build_arch} eq "x86_64"} {
-        version      ${x86_64_version}
         set jar_file native-image-installable-svm-java17-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
         checksums    rmd160  889bbd69a50db60314d2e23d4aa69a6f9c744f74 \
                      sha256  f3325ba7fbbcb865c3cc38ee531398482344fae2dd364073391568b0e5b0a77a \
                      size    30685976
     } elseif {${configure.build_arch} eq "arm64"} {
-        version      ${aarch64_version}
         set jar_file native-image-installable-svm-java17-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}
         checksums    rmd160  c1fe4d16e586fd7302271c8f2a5f8bd22dd10f81 \


### PR DESCRIPTION
#### Description

Fix version parse error on ppc machines.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix