### PR TITLE
openjdk11-graalvm: fix parse error on ppc

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -14,9 +14,12 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-# There is no macOS aarch64 build for 22.3.2
-set x86_64_version  22.3.2
-set aarch64_version 22.3.1
+if {${configure.build_arch} eq "arm64"} {
+    # There is no macOS aarch64 build for 22.3.2
+    version 22.3.1
+} else {
+    version 22.3.2
+}
 
 revision     0
 
@@ -24,17 +27,14 @@ description  GraalVM Community Edition based on OpenJDK 11
 long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
                  JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
 
+master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+
 if {${configure.build_arch} eq "x86_64"} {
-    version      ${x86_64_version}
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${x86_64_version}/
     distname     graalvm-ce-java11-darwin-amd64-${version}
     checksums    rmd160  31d6a6c00d2241775b1a54d9cc9ad6d0735a18e4 \
                  sha256  da3c52cc68ce0fb4dcc27dba3c59beadafb7588fec9e9d2812f5bc7c7d00ab63 \
                  size    254235978
 } elseif {${configure.build_arch} eq "arm64"} {
-    version      ${aarch64_version}
-    master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${aarch64_version}/
-    version      ${aarch64_version}
     distname     graalvm-ce-java11-darwin-aarch64-${version}
     checksums    rmd160  3421d1754a491b0cfa44d09df798ff5053fcefc8 \
                  sha256  c59f32289d92671bea46a34f4227fef484a4aa9eeece159e59a486205aaa6c31 \
@@ -99,14 +99,12 @@ subport ${name}-native-image {
     long_description   ${description}
 
     if {${configure.build_arch} eq "x86_64"} {
-        version      ${x86_64_version}
         set jar_file native-image-installable-svm-java11-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
         checksums    rmd160  f6ef5181f146264d198705ad88f0e2f9f7debf34 \
                      sha256  ae542383b033576e26d0431b0b62b4f7c048fee3b209dad2a257c4ae6345f1fb \
                      size    28458434
     } elseif {${configure.build_arch} eq "arm64"} {
-        version      ${aarch64_version}
         set jar_file native-image-installable-svm-java11-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}
         checksums    rmd160  65a84d8dd894be0830673ffdf7e77a0ca19cf1ac \


### PR DESCRIPTION
#### Description

Fix version parse error on ppc machines.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix