### PR TITLE
lighttpd: Update to 1.4.70

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -5,11 +5,11 @@ PortGroup                   legacysupport 1.0
 PortGroup                   lua 1.0
 
 name                        lighttpd
-version                     1.4.69
+version                     1.4.70
 revision                    0
-checksums                   rmd160  1e39d192b9708b27070ffeb111b102a392630035 \
-                            sha256  16ac8db95e719629ba61949b99f8a26feba946a81d185215b28379bb4116b0b4 \
-                            size    1045516
+checksums                   rmd160  96708c4aa594220c36881b6db6a5636afd57c005 \
+                            sha256  921ebe1cf4b6b9897e03779ab7a23a31f4ba40a1abe2067525c33cd3ce61fe85 \
+                            size    1070048
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  www


### PR DESCRIPTION
#### Description

lighttpd: Update to 1.4.70

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 11.6

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?