### PR TITLE
postgis3: Update to version 3.3.2

### DIFF
--- a/databases/postgis3/Portfile
+++ b/databases/postgis3/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 name                postgis3
 categories          databases gis
 license             GPL-2+
-version             3.2.0
-revision            5
+version             3.3.2
+revision            0
 platforms           darwin
 maintainers         {vince @Veence} openmaintainer
 
@@ -17,14 +17,14 @@ long_description    PostGIS adds geometrical, geographical and topological\
                     types, and functions operating thereon, to the PostGreSQL\
                     database. It also handles raster tiles and MVT format.
 
-homepage            http://postgis.net/
+homepage            https://postgis.net/
 
-master_sites        http://download.osgeo.org/postgis/source
+master_sites        https://download.osgeo.org/postgis/source
 distname            postgis-${version}
 
-checksums           rmd160  ac46701c61ef4b86b4346eb9c5f17d5e8bee6cbd \
-                    sha256  7ab9e154c6947c0cffb8fa12d70806add9aa060e62b6c86a2e206f9d4b507cfd \
-                    size    16884722
+checksums           rmd160  09eddf9110c0d2c9d01572d6142615d8ddf7c379 \
+                    sha256  9a2a219da005a1730a39d1959a1c7cec619b1efb009b65be80ffc25bad299068 \
+                    size    17793976
 
 depends_build       port:autoconf \
                     port:automake \
@@ -39,50 +39,36 @@ depends_lib         port:geos\
                     port:protobuf-c \
                     path:lib/pkgconfig/icu-uc.pc:icu
 
-# PostGIS 3.0 is not compatible with prior releases
-
 conflicts           postgis postgis2
 
-# Neither is PostGIS 2.0 compatible with PostGreSQL 8
-# Database variants (from the GDAL port)
-set postgresql_suffixes {14 13 12}
+# PostgreSQL database variants
+set postgresql_suffixes {12 13 14 15}
 
-set postgresql_variants {}
+set portsgresql_variants {}
+set postgresql_default_variant "if {"
 
-foreach suffix ${postgresql_suffixes} {
-    lappend postgresql_variants postgresql${suffix}
+foreach s ${postgresql_suffixes} {
+    lappend portsgresql_variants postgresql${s}
+    set postgresql_default_variant "${postgresql_default_variant}!\[variant_isset postgresql${s}] && "
 }
 
-foreach suffix ${postgresql_suffixes} {
-    set vrt postgresql${suffix}
-    set pgversion [string index ${suffix} 0].[string index ${suffix} 1]
-    set index [lsearch -exact ${postgresql_variants} ${vrt}]
-    set conf [lreplace ${postgresql_variants} ${index} ${index}]
+set postgresql_default_variant [string range ${postgresql_default_variant} 0 end-4]
+set postgresql_default_variant "${postgresql_default_variant}} {default_variants +postgresql${s}}"
+eval $postgresql_default_variant
 
-    variant ${vrt} \
-        conflicts ${conf} \
-        description "Use PostgreSQL ${pgversion}" \
-        "
-        depends_lib-append      port:${vrt}
-        configure.args-append   --libdir=${prefix}/lib/${vrt} \
-            --with-pgconfig=${prefix}/lib/${vrt}/bin/pg_config
-        build.args-append       \
-            PGSQL_DOCDIR=${destroot}${prefix}/share/doc/${vrt} \
-            PGSQL_MANDIR=${destroot}${prefix}/share/man
-        "
+foreach s ${postgresql_suffixes} {
+    set p postgresql${s}
+    set v [string index ${s} 0].[string index ${s} 1]
+    set i [lsearch -exact ${portsgresql_variants} ${p}]
+    set c [lreplace ${portsgresql_variants} ${i} ${i}]
+    variant ${p} description "Use PostgreSQL ${v}" conflicts {*}${c} "
+        depends_lib-append      port:${p}
+        configure.args-append   --libdir=${prefix}/lib/${p} \
+                                --with-pgconfig=${prefix}/lib/${p}/bin/pg_config
+        build.args-append       PGSQL_DOCDIR=${destroot}${prefix}/share/doc/${p} \
+                                PGSQL_MANDIR=${destroot}${prefix}/share/man
+    "
 }
-
-# postgresql default
-set pgdefault "if {"
-
-foreach suffix ${postgresql_suffixes} {
-    set pgdefault "${pgdefault}!\[variant_isset postgresql${suffix}\] && "
-}
-
-set pgdefault [string range ${pgdefault} 0 end-4]
-set pgdefault "${pgdefault}} { default_variants +postgresql14 }"
-
-eval ${pgdefault}
 
 variant raster              description {Build raster support} {
 
@@ -101,29 +87,37 @@ variant sfcgal              description {Uses SFCGAL for 3D queries} {
     configure.args-append   --with-sfcgal=${prefix}/bin/sfcgal-config
 }
 
-variant proj6 description {Build with Proj 6} conflicts proj7 proj8 {
-    depends_lib-append      port:proj6
-    configure.args-append   PROJ_CFLAGS=-I${prefix}/lib/proj6/include
-    configure.args-append   PROJ_LIBS="-L${prefix}/lib/proj6/lib -lproj"
+variant lto                 description {Build with Link Time Optimization (LTO)} {
+    configure.args-append   --enable-lto
 }
 
-variant proj7 description {Build with Proj 7} conflicts proj6 proj8 {
-    depends_lib-append      port:proj7
-    configure.args-append   PROJ_CFLAGS=-I${prefix}/lib/proj7/include
-    configure.args-append   PROJ_LIBS="-L${prefix}/lib/proj7/lib -lproj"
+# Set PROJ variant
+set proj_versions {6 7 8 9}
+
+set proj_variants {}
+foreach pjver ${proj_versions} {
+    lappend proj_variants proj${pjver}
+}
+foreach proj_ver ${proj_versions} {
+    set index [lsearch -exact ${proj_variants} proj${proj_ver}]
+    set cflcts [lreplace ${proj_variants} ${index} ${index}]
+
+    variant proj${proj_ver} description "Use Proj${proj_ver}" conflicts {*}${cflcts} "
+            depends_lib-append      port:proj${proj_ver}
+            configure.args-append   PROJ_CFLAGS=-I${prefix}/lib/proj${proj_ver}/include \
+                                    PROJ_LIBS=\"-L${prefix}/lib/proj${proj_ver}/lib -lproj\"
+        "
 }
 
-variant proj8 description {Build with Proj 8} conflicts proj6 proj7 {
-    depends_lib-append      port:proj8
-    configure.args-append   PROJ_CFLAGS=-I${prefix}/lib/proj8/include
-    configure.args-append   PROJ_LIBS="-L${prefix}/lib/proj8/lib -lproj"
+set projdf "if {"
+foreach pv ${proj_versions} {
+    set projdf "${projdf}!\[variant_isset proj${pv}\] && "
 }
+set projdf [string range ${projdf} 0 end-4]
+set projdf "${projdf}} { default_variants +proj${pv} }"
+eval ${projdf}
 
 default_variants            +raster +topology
-
-if {![variant_isset proj6] && ![variant_isset proj7] && ![variant_isset proj8]} {
-    default_variants        +proj8
-}
 
 # Port phases
 
@@ -131,7 +125,7 @@ configure.cflags-append \
     -Diconv=libiconv -Diconv_open=libiconv_open -Diconv_close=libiconv_close
 
 # see https://trac.macports.org/wiki/UsingTheRightCompiler
-configure.env-append    CPPBIN=${configure.cpp}
+configure.env-append        CPPBIN=${configure.cpp}
 
 post-configure {
     if {[variant_exists universal] && [variant_isset universal]} {
@@ -145,25 +139,25 @@ post-configure {
 }
 
 build.args                  ICONV_LDFLAGS='-L${prefix}/lib -liconv'
-use_parallel_build          yes 
+use_parallel_build          yes
 
-notes                       "\
-                            ! This version comes with the following warning if you use postgresql14:\
-                            ‘Due to some query performance degradation with the new fast index build\
-                            that requires PG14, we have decided to disable the feature by default\
-                            until we get more user testing as to the true impact of real-world queries.\
-                            If you are running PG14+, you can reenable it by doing: \
-                            \
-                                ALTER OPERATOR FAMILY gist_geometry_ops_2d USING gist \
-                                    ADD FUNCTION 11 (geometry) \
-                                        geometry_gist_sortsupport_2d (internal); \
-                            \
-                            and then reindex your gist indexes.\
-                            To revert back to the old index behavior:\
-                            \
-                                ALTER OPERATOR FAMILY gist_geometry_ops_2d using gist\
-                                    DROP FUNCTION 11 (geometry);\
-                            \
+notes                       "\n\
+                            ! This version comes with the following warning if you use postgresql14:\n\
+                            ‘Due to some query performance degradation with the new fast index build\n\
+                            that requires PG14, we have decided to disable the feature by default\n\
+                            until we get more user testing as to the true impact of real-world queries.\n\
+                            If you are running PG14+, you can reenable it by doing:\n\
+                            \n\
+                                ALTER OPERATOR FAMILY gist_geometry_ops_2d USING gist\n\
+                                    ADD FUNCTION 11 (geometry)\n\
+                                        geometry_gist_sortsupport_2d (internal);\n\
+                            \n\
+                            and then reindex your gist indexes.\n\
+                            To revert back to the old index behavior:\n\
+                            \n\
+                                ALTER OPERATOR FAMILY gist_geometry_ops_2d using gist\n\
+                                    DROP FUNCTION 11 (geometry);\n\
+                            \n\
                             and then reindex your gist indexes.’"
 
 livecheck.type              regex


### PR DESCRIPTION
#### Description
Update `postgis3` to version 3.3.2.

Following variants were added:
- +postgresql15  (now default)
- +proj9 (now default)
- +lto, build with Link Time Optimization

Some general linting improvements were also made.


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.5 21G531 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
