### PR TITLE
maven3: update to 3.9.2

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.9.1
+version         3.9.2
 revision        0
 
 categories      java devel
@@ -35,9 +35,9 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  41d18a278307d883d203485f2a6460f1f7881cf1 \
-                sha256  0869a4f71238e3eeec21051d062cfd915d34abe905c9bfebf94cd34578db0be7 \
-                size    9039409
+checksums       rmd160  fe3a31c000f81eda7a18d6f44edce0a42f582349 \
+                sha256  809ef3220c6d179195c06c324cb9a6d34d8ecba566c5cfd8eb83167bc034117d \
+                size    9248920
 
 java.version    1.8+
 java.fallback   openjdk17


### PR DESCRIPTION
#### Description

Update to Maven 3.9.2.

###### Tested on

macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?