### PR TITLE
erlang: update to 25.3

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                erlang
-version             25.0
+version             25.3
 revision            0
 
 categories          lang erlang
@@ -47,17 +47,17 @@ distfiles           otp_src_${version}${extract.suffix}                    \
                     otp_doc_html_${version}${extract.suffix}
 
 checksums           otp_src_${version}.tar.gz \
-                    rmd160  f977fc3a893525b668508e54db5a38cc6a084f26 \
-                    sha256  3e1e2e55409e9484e69b316fcd00ff7e2ed606bcfb2c7cac514f9b9aeb9651e8 \
-                    size    102972543 \
+                    rmd160  5e6fb5e0f158327c86c12a48cc930c63c3d3a0be \
+                    sha256  aeaa546e0c38e338010d16348d8c67f7fc8c02df728a88d8499838d8c9131e1c \
+                    size    103797057 \
                     otp_doc_man_${version}.tar.gz \
-                    rmd160  84029a74a10510b9cb3c5b604ccdcd85d985fbec \
-                    sha256  3edce27340f30019d7a2c6aeda7744cf864b0a7c8314360265152fcad524579d \
-                    size    1708111 \
+                    rmd160  0b4e2aabe13d2fba591d18f898e4b5a2469f8257 \
+                    sha256  675658e5cac834ffe726e180d3f7839e23d32fa57ae921a524ac9f808b6ed76e \
+                    size    1715883 \
                     otp_doc_html_${version}.tar.gz \
-                    rmd160  bc662efd0b3b036a4fc0223c8c013f5f2e82f9bd \
-                    sha256  0b8a751757d3c72f5def862d258e32de626a8fa9453c8493b9a0255d98f524f9 \
-                    size    40951434
+                    rmd160  fe6497919abcd708f5e8a6f60d94120258f5ac48 \
+                    sha256  35cd476ae1a013256d9c51c23216669840512031b8733e5391b6742c3477e140 \
+                    size    41054645
 
 worksrcdir          otp_src_${version}
 


### PR DESCRIPTION
#### Description

I don’t know much about Erlang, but it appears that Erlang 26 represents a significant change. It may be prudent to create an erlang25 port once Erlang 26 is stable.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E772610a x86_64
Command Line Tools 14.3.0.0.1.1679647830

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
