### PR TITLE
cpuid: blacklist old gcc, fixes build on macOS <10.6

### DIFF
--- a/sysutils/cpuid/Portfile
+++ b/sysutils/cpuid/Portfile
@@ -26,6 +26,9 @@ checksums           rmd160  036bcc55d4d5812d2aa0b13c5cf7afdc3d5351fd \
 
 patchfiles-append   patch-makefile.diff
 
+compiler.blacklist-append \
+                    gcc-3.3 *gcc-4.0 *gcc-4.2
+
 configure {
     # no configure script, just a few changes that need to be made to the Makefile
     # for it to be configured correctly. Doing these reinplaces in configure{} instead
@@ -36,3 +39,5 @@ configure {
 }
 
 build.args-append   CC=${configure.cc} LD=${configure.cc} V=1
+destroot.args-append \
+                    CC=${configure.cc} LD=${configure.cc}


### PR DESCRIPTION
#### Description

gcc <=4.2 doesn't support the options used in the Makefile, or the 'asm' statement used for the cpuid instruction.

Fixes: https://trac.macports.org/ticket/67395

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.4.8 8L2127 i386
Component versions: DevToolsCore-798.0; DevToolsSupport-794.0

macOS 10.5.8 9L30 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
