### PR TITLE
ufo-ai: new port

### DIFF
--- a/games/ufo-ai/Portfile
+++ b/games/ufo-ai/Portfile
@@ -1,0 +1,105 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                ufo-ai
+version             2.5
+revision            0
+
+homepage            https://ufoai.org
+
+description         \
+    UFO: Alien Invasion is a squad-based tactical strategy game in the \
+    tradition of the old X-COM PC games.
+
+long_description    {*}${description}
+
+categories          games
+installs_libs       no
+license             GPL-2 MIT public-domain permissive
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+master_sites        sourceforge:ufoai
+use_bzip2           yes
+
+distname            ufoai-${version}-source
+
+distfiles           ${distname}${extract.suffix}:gamesrc \
+                    ufoai-${version}-data.tar:gamedata
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  4a60a9f69c7b046378719ca0ae7d0c83da75de06 \
+                    sha256  0c7cc3bc9efeb276f71cbe6ee8ff7c76f98d183de79f1a069fa63059cf182a8f \
+                    size    24239539 \
+                    ufoai-${version}-data.tar \
+                    rmd160  b4a758b2267865cfd35e3cedb62aa2ad04204bb2 \
+                    sha256  5e706a424aff6a2ea30a4c798129d6304e897387eadf808528129b512b7dcdb0 \
+                    size    1277143040
+
+compiler.cxx_standard \
+                    2011
+
+depends_build-append \
+                    port:gawk \
+                    port:grep \
+                    port:gsed \
+                    port:pkgconfig
+
+depends_lib-append  path:include/AL/al.h:openal-soft \
+                    port:curl \
+                    port:jpeg \
+                    port:libpng \
+                    port:libsdl2 \
+                    port:libsdl2_mixer \
+                    port:libsdl2_ttf \
+                    port:libtheora \
+                    port:p7zip \
+                    port:python27 \
+                    port:XviD \
+                    port:zlib
+
+post-extract {
+    file mkdir ${workpath}/gamedata
+
+    system -W ${workpath} \
+        "/usr/bin/tar -C gamedata -xf ${distpath}/ufoai-${version}-data.tar"
+}
+
+patch.pre_args      -p1
+
+patchfiles-append   patch-bug-5345.diff \
+                    patch-bug-5336.diff
+
+set game_share_dir  ${prefix}/share/${name}
+
+configure.args-append \
+                    --datadir=${game_share_dir} \
+                    --enable-release
+
+platform darwin {
+    configure.args-append \
+                    --target-os=darwin
+}
+
+build.target        all lang
+
+use_parallel_build  no
+
+destroot {
+    # Install binaries
+    foreach gamebin {ufo ufo2map ufoded ufomodel ufoslicer} {
+        xinstall -m 0775 ${worksrcpath}/${gamebin} ${destroot}${prefix}/bin/
+    }
+
+    # Install game data
+    xinstall -d ${destroot}${game_share_dir}/base
+
+    copy    {*}[glob ${workpath}/gamedata/base/*] \
+            ${destroot}${game_share_dir}/base/
+
+    copy    {*}[glob ${worksrcpath}/base/*] \
+            ${destroot}${game_share_dir}/base/
+}
+
+notes "Run ${prefix}/bin/ufo to start UFO: Alien Invasion"

--- a/games/ufo-ai/files/patch-bug-5336.diff
+++ b/games/ufo-ai/files/patch-bug-5336.diff
@@ -1,0 +1,20 @@
+commit c334125fbbb7994d6bcab8ecf735bf19a2ef1444
+Author: Martin Gerhardy <martin.gerhardy@gmail.com>
+Date:   Wed Jun 25 11:06:25 2014 +0200
+
+    * hopefully fixed bug #5336 (active c++11 for mac only to fix a compile problem until we sort out the windows build chain issues)
+    
+    * Compile error on Mac OS 10.9: src/client/cl_http.cpp:192:53: error: cannot pass object of non-POD type 'std::__1::nullptr_t' through variadic function
+
+diff --git a/build/platforms/darwin.mk b/build/platforms/darwin.mk
+index 89a20a5806..8dee5e3138 100644
+--- a/build/platforms/darwin.mk
++++ b/build/platforms/darwin.mk
+@@ -4,6 +4,7 @@ SO_LDFLAGS                = -dynamiclib
+ SO_LIBS                  := -ldl
+ 
+ CFLAGS                   += -D_BSD_SOURCE -D_XOPEN_SOURCE
++CXXFLAGS                 += -std=c++11
+ LDFLAGS                  += -framework IOKit -framework Foundation -framework Cocoa -headerpad_max_install_names
+ 
+ ### most mac users will have their additional libs and headers under /opt/local

--- a/games/ufo-ai/files/patch-bug-5345.diff
+++ b/games/ufo-ai/files/patch-bug-5345.diff
@@ -1,0 +1,62 @@
+From ebcf1fed873f1a75487acedf106f03b299bf8b7e Mon Sep 17 00:00:00 2001
+From: Martin Gerhardy <martin.gerhardy@gmail.com>
+Date: Sun, 20 Oct 2013 20:02:48 +0200
+Subject: [PATCH] * fixed c++11 warnings
+
+---
+ src/client/battlescape/cl_particle.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/client/battlescape/cl_particle.cpp b/src/client/battlescape/cl_particle.cpp
+index 58d9211631..2e092cce21 100644
+--- a/src/client/battlescape/cl_particle.cpp
++++ b/src/client/battlescape/cl_particle.cpp
+@@ -138,7 +138,7 @@ static char const* const pc_strings[] = {
+ CASSERT(lengthof(pc_strings) == PC_NUM_PTLCMDS);
+ 
+ /** @brief particle commands parameter and types */
+-static const int pc_types[PC_NUM_PTLCMDS] = {
++static const unsigned int pc_types[PC_NUM_PTLCMDS] = {
+ 	0,
+ 
+ 	V_UNTYPED, V_UNTYPED, V_UNTYPED,
+-- 
+2.37.0 (Apple Git-136)
+
+From 79495daac64362202abce00379f899069d1ca1a5 Mon Sep 17 00:00:00 2001
+From: Martin Gerhardy <martin.gerhardy@gmail.com>
+Date: Sun, 8 Jun 2014 17:21:58 +0200
+Subject: [PATCH] * fixed narrowing compile error with clang
+
+* case value evaluates to -1, which cannot be narrowed to type 'GLenum' (aka 'unsigned int')
+---
+ src/client/renderer/r_state.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/client/renderer/r_state.cpp b/src/client/renderer/r_state.cpp
+index 71d966f542..d03a52cf11 100644
+--- a/src/client/renderer/r_state.cpp
++++ b/src/client/renderer/r_state.cpp
+@@ -147,7 +147,8 @@ void R_UseMaterial (const material_t* material)
+ 
+ void R_BindArray (GLenum target, GLenum type, const void* array)
+ {
+-	switch (target) {
++	const int v = static_cast<int>(target);
++	switch (v) {
+ 	case GL_VERTEX_ARRAY:
+ 		glVertexPointer(COMPONENTS_VERTEX_ARRAY3D, type, 0, array);
+ 		break;
+@@ -180,7 +181,8 @@ void R_BindArray (GLenum target, GLenum type, const void* array)
+  */
+ void R_BindDefaultArray (GLenum target)
+ {
+-	switch (target) {
++	const int v = static_cast<int>(target);
++	switch (v) {
+ 	case GL_VERTEX_ARRAY:
+ 		R_BindArray(target, GL_FLOAT, r_state.vertex_array_3d);
+ 		break;
+-- 
+2.37.0 (Apple Git-136)
+


### PR DESCRIPTION
(Work in progress) 

This PR is an attempt to port **[UFO: Alien Invasion](https://ufoai.org)**

Trac issue: https://trac.macports.org/ticket/67240

Current issues:

- Build failing with:
  ```
  src/client/cl_http.cpp:196:53: error: cannot pass object of non-POD type 'std::nullptr_t' through variadic function; call will abort at runtime [-Wnon-pod-varargs]
                curl_easy_setopt(dl->curl, CURLOPT_WRITEFUNCTION, nullptr);
                                                                  ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/__nullptr:48:17: note: expanded from macro 'nullptr'
  #define nullptr _VSTD::__get_nullptr_t()
                ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/__config:858:15: note: expanded from macro '_VSTD'
  #define _VSTD std::_LIBCPP_ABI_NAMESPACE
              ^
  ```
- Needs Python 2.6 or 2.7, but the `configure` script is not detecting MacPorts `python27`
- `gtkglext` seems to have compilation issues on macOS 12?