### PR TITLE
rust-analyzer: update descriptions

### DIFF
--- a/devel/rust-analyzer/Portfile
+++ b/devel/rust-analyzer/Portfile
@@ -11,10 +11,10 @@ revision            0
 
 homepage            https://rust-analyzer.github.io
 
-description         An experimental Rust compiler front-end for IDEs
+description         A Rust compiler frontend providing LSP implementation
 
-long_description    rust-analyzer is an experimental modular compiler \
-                    frontend for the Rust language.  It is a part of a larger \
+long_description    rust-analyzer is a modular compiler frontend \
+                    for the Rust language.  It is a part of a larger \
                     rls-2.0 effort to create excellent IDE support for Rust.
 
 categories          devel


### PR DESCRIPTION
#### Description

`rust-analyzer` [isn't experimental](https://blog.rust-lang.org/2022/07/01/RLS-deprecation.html) anymore.

I suggest mentioning *LSP implementation* in the `description` for better discoverability of the port and, supposedly, more clarity [what the library is](https://rust-analyzer.github.io/manual.html). If not, "A Rust compiler front-end for IDEs" line should work fine as well.

`long_description` in this commit matches the text in [upstream README](https://github.com/rust-lang/rust-analyzer).

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

Not tested: Descriptions updates only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
