### PR TITLE
snac: update to 2.31

### DIFF
--- a/net/snac/Portfile
+++ b/net/snac/Portfile
@@ -5,7 +5,7 @@ PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 name                snac
-version             2.30
+version             2.31
 revision            0
 
 distname            ${version}
@@ -32,15 +32,14 @@ long_description    snac Social Networks Are Crap \
 
 homepage            https://codeberg.org/grunfink/snac2/
 master_sites        ${homepage}archive/
-checksums           rmd160 fa82e770561540774f23ccb1408231b066816c05 \
-                    sha256 e6a86ea05645f0b0ceaa2899f856b34e11bc42a8a0119c4e3ec8b0eda41e56db \
-                    size 106891
+checksums           rmd160 61497f594cc0f07978cf2f55416160e578538d9c \
+                    sha256 e0380fc165afbe1aebf8e735285f46d0abb35af0a934ed73cbaf41420861d920 \
+                    size 107849
 depends_lib         path:lib/libssl.dylib:openssl \
                     port:curl
 
 worksrcdir          ${name}2
 
-use_parallel_build  no
 patchfiles          Makefile.patch
 
 platform darwin {
@@ -55,4 +54,4 @@ configure.cflags-append \
 
 livecheck.type      regex
 livecheck.url       https://codeberg.org/grunfink/snac2/tags
-livecheck.regex     {/grunfink/snac2/src/tag/(\d+\.\d+)}
+livecheck.regex     {/grunfink/snac2/releases/tag/(\d+\.\d+)}


### PR DESCRIPTION
 * fix livecheck
 * allow for parallel builds again.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
