### PR TITLE
glib2: Remove unused reinplace

### DIFF
--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -124,8 +124,7 @@ post-patch {
     reinplace -W ${worksrcpath} "s|@PREFIX@|${prefix}|g" \
         gio/xdgmime/xdgmime.c \
         glib/gi18n-lib.h \
-        glib/gi18n.h \
-        gio/gdbusaddress.c
+        glib/gi18n.h
 
     reinplace -W ${worksrcpath} "s|data_dirs = \"/usr|data_dirs = \"${prefix}/share:/usr|g" \
         glib/gutils.c


### PR DESCRIPTION
#### Description
The patch that adds `@PREFIX@` to `gio/gdbusaddress.c` (`patch-get-launchd-dbus-session-address.diff`) was removed in afd850d194d7e19342c9cbf73eaac966a546a433. As a consequence, this now causes an unused reinplace warning.

Fix this warning, but do not increase revision, because this does not change any installed files.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 21G531 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
