### PR TITLE
smake:  Update to 1.7

### DIFF
--- a/devel/smake/Portfile
+++ b/devel/smake/Portfile
@@ -1,41 +1,114 @@
-PortSystem 1.0
-PortGroup  compiler_blacklist_versions 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			smake
-version			1.2.5
-categories		devel
-platforms		darwin
-maintainers		nomaintainer
-license			CDDL
-description		highly portable make program with automake features
-long_description	Smake is a highly portable make program with automake \
-				features. It is currently mainly targeted to be used \
-				with the makefiles system. 
+PortSystem              1.0
+PortGroup               makefile 1.0
+PortGroup               compiler_blacklist_versions 1.0
+PortGroup               conflicts_build 1.0
+PortGroup               codeberg 1.0
+PortGroup               muniversal 1.1
 
-homepage		https://sourceforge.net/projects/s-make/
-master_sites	sourceforge:project/s-make
-use_bzip2		yes
+name                    smake
+codeberg.setup          schilytools schilytools 2023-04-19
+version                 1.7-${codeberg.version}
+revision                0
+categories              devel
+maintainers             {hotmail.com:amtor @RobK88} \
+                        openmaintainer
+license                 CDDL
+description             A highly portable make program with automake features
+long_description        Smake is a highly portable make program with automake \
+                        features. It is currently mainly targeted to be used \
+                        with the Schily SING makefile system.
 
-checksums           rmd160  f683a4051273b3e24e45a2b435ddb23509db55bf \
-                    sha256  27566aa731a400c791cd95361cc755288b44ff659fa879933d4ea35d052259d4
+checksums               rmd160  e154278ecbe7d778bc1d6766ed163c9963b1cc82 \
+                        sha256  a4270cdcca5dd69c0114079277b06e5efad260b0a099c9c09d31e16e99a23ff5 \
+                        size    5896292
 
-use_configure	no
-
-# https://trac.macports.org/ticket/31616
-compiler.blacklist-append llvm-gcc-4.2 {clang < 318}
-
-build.type		gnu
-build.args      CC=${configure.cc}
-use_parallel_build  no
-
-destroot.args       CC=${configure.cc}
-destroot.destdir	INS_BASE=${destroot}${prefix} \
-					MANDIR=man \
-					INSUSR=`id -u` INSGRP=`id -g`
-post-destroot	{
-	file delete -force ${destroot}${prefix}/share/man/man5 \
-		${destroot}${prefix}/lib ${destroot}${prefix}/include
+post-extract {
+                        copy ${filespath}/Gmake.smake ${worksrcpath}
 }
 
-livecheck.url       https://sourceforge.net/projects/s-make/files/
-livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}
+patchfiles-append       001-Makefile-Patch.diff
+
+post-patch {
+                        reinplace -locale C "s|/opt/schily|${prefix}|g" \
+                        ${worksrcpath}/DEFAULTS/Defaults.darwin \
+                        ${worksrcpath}/DEFAULTS/Defaults.mac-os10 \
+                        ${worksrcpath}/DEFAULTS_ENG/Defaults.darwin \
+                        ${worksrcpath}/DEFAULTS_ENG/Defaults.mac-os10 \
+                        ${worksrcpath}/libfind/find.c \
+                        ${worksrcpath}/libfind/find_main.c \
+                        ${worksrcpath}/librscg/scsi-remote.c \
+                        ${worksrcpath}/patch/tests/random/cmptest.sh \
+                        ${worksrcpath}/patch/tests/random/gentest.sh \
+                        ${worksrcpath}/smake/job.c \
+                        ${worksrcpath}/smake/make.c \
+                        ${worksrcpath}/smake/smake.1 \
+                        ${worksrcpath}/TEMPLATES/Defaults.gcc \
+                        ${worksrcpath}/TEMPLATES/Defaults.clang \
+                        ${worksrcpath}/TEMPLATES/Defaults.xcc
+}
+
+proc port_conflict_check {p_port_name p_conflict_ver_min p_conflict_ver_max} {
+    ui_info "Checking for conflict against port: ${p_port_name}"
+
+    if { ![catch {set port_conflict_ver_info [lindex [registry_active ${p_port_name}] 0]}] } {
+        set port_conflict_ver [lindex ${port_conflict_ver_info} 1]_[lindex ${port_conflict_ver_info} 2]
+        ui_info "${p_port_name} active version: ${port_conflict_ver}"
+
+        if { [vercmp ${port_conflict_ver} ${p_conflict_ver_min}] >= 0
+            && [vercmp ${port_conflict_ver} ${p_conflict_ver_max}] <= 0 } {
+
+            ui_info "${p_port_name} conflicts; declare build conflict"
+            conflicts_build-append \
+                ${p_port_name}
+        }
+    }
+}
+
+port_conflict_check     cdrtools 0.0 3.01_1
+
+# https://trac.macports.org/ticket/31616
+compiler.blacklist-append\
+                        llvm-gcc-4.2 macports-llvm-gcc-4.2 {clang < 300}
+
+configure.ldflags-append -lintl
+
+depends_build-append    port:gmake \
+                        port:gettext
+                        
+depends_lib-append      port:gettext-runtime
+
+build.type              gnu
+                        
+build.args-append       INS_BASE="${destroot}${prefix}" \
+                        INS_RBASE="${destroot}${prefix}" \
+                        DEFOSINCDIRS="${prefix}/include" \
+                        CC_OPT=${configure.optflags}
+
+destroot.destdir        INS_BASE="${destroot}${prefix}" \
+                        INS_RBASE="${destroot}${prefix}" \
+                        MANDIR=man \
+                        DEFINSUSR=${install.user} \
+                        DEFINSGRP=${install.group}
+
+# NOTE:  This port first builds a bootstrapped version of smake using gmake.
+#        The final version of smake (and its static associated libraries) are built using
+#        the boostrapped version of smake which does NOT support parallel building.
+#        i.e.  the j flag is ignored by the boostrapped version of smake and
+#              the final version of smake.
+use_parallel_build      no
+
+destroot {
+                        xinstall -m 0755    {*}[glob ${worksrcpath}/smake/OBJ/*/smake] \
+                        ${destroot}${prefix}/bin
+                        
+                        xinstall -m 0644    {*}[glob ${worksrcpath}/smake/OBJ/*/*/smake.1] \
+                        ${destroot}${prefix}/share/man/man1
+                        
+                        xinstall -m 0644    {*}[glob ${worksrcpath}/man/man5/OBJ/*/*/makefiles.5] \
+                        ${destroot}${prefix}/share/man/man5
+                        
+                        xinstall -m 0644    {*}[glob ${worksrcpath}/man/man5/OBJ/*/*/makerules.5] \
+                        ${destroot}${prefix}/share/man/man5
+}

--- a/devel/smake/files/001-Makefile-Patch.diff
+++ b/devel/smake/files/001-Makefile-Patch.diff
@@ -1,0 +1,17 @@
+--- Makefile.orig	2016-06-28 17:22:59.000000000 -0400
++++ Makefile	2023-05-15 15:53:20.000000000 -0400
+@@ -5,9 +5,9 @@
+ # as possible. Smake first looks for 'SMakefile' and thus the 
+ # command 'psmake/smake $@' will use 'SMakefile' to read rules.
+ #
+-.PHONY: all clean clobber distclean install ibins depend rmdep config TAGS tags tests rmtarget relink
++.PHONY: all smake
++
++all smake:
++	@echo "NOTICE: Using bootstrap 'Makefile' to run 'Gmake.smake' script"
++	sh ./Gmake.smake
+ 
+-all man lint clean clobber distclean install installman ibins depend rmdep config TAGS tags tests rmtarget relink:
+-	@echo "NOTICE: Using bootstrap 'Makefile' to make '$@'"
+-	cd psmake && sh ./MAKE-all
+-	./psmake/smake -r $@

--- a/devel/smake/files/Gmake.smake
+++ b/devel/smake/files/Gmake.smake
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+##########################################################################################
+#
+# Script to build smake and related man pages
+#
+# Author:   Robert Kennedy
+# EMAIL:    amtor@hotmail.com
+# GitHub:   RobK88
+#
+# Copyright 2023 Robert Kennedy
+#
+# License:  CDDL or GPL 2+ (Your choice)
+#
+##########################################################################################
+# 
+# Make Bootstrapped smake using gmake
+cd psmake && ./MAKE-all
+
+# Build smake dependencies using bootstrapped version of smake
+cd ../libschily && ../psmake/smake
+
+# Build final smake using bootstrapped version of smake
+cd ../smake && ../psmake/smake
+
+# Build manpages
+cd ../man && ../psmake/smake


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

smake:  Update to 1.7

* Add Modeline for editors at the top of the Portfile
* Delete tabs in Portfile
* Add "makefile 1.0" PortGroup
* Add "conflicts_build 1.0" PortGroup
* Add "codeberg 1.0" PortGroup
* Add "muniversal 1.1" PortGroup statement
* Add "codeberg.setup" after name
* Update version from 1.2.5 to 1.7-${codeberg.version}
* Add revision number
* Delete "platforms darwin" statement
* Add myself as a maintainer
* Modify long_description
* Update master_sites
* Add and update checksums
* Remove "use_bzip2"
* Create new bash script, Gmake.smake, for building the smake binary and man pages
* Add post-extract section to copy Gmake.smake into the ${worksrcpath)
* Add patchfile to patch Makefile to run Gmake.smake script
* Add post-patch block to replace "/opt/Schily" with "${prefix}" in the source files
* Add "port_conflict_check" procedure
* Add "port_conflict_check" against cdrtools versions 0 to 3.01_1
* Update "compiler.blacklist"
* Change "compiler.blacklist" to "compiler.blacklist-append"
* Remove "use_configure no"
* Add -lintl to configure.ldflags-append
* Add build dependency - port:gmake
* Add build dependency - port:gettext-runtime
* Add library dependency - port:gettext-runtime
* Change build.args to build.args-append and update the build args
* Add CC_OPT to build.args-append
* Add note regarding disabling parallel builds
* Delete destroot.args
* Update destroot.destdir
* Delete post-destroot
* Add destroot{} code block to manually move smake binary and man pages into ${destroot}
* Delete livecheck related statements

CLOSES:  https://trac.macports.org/ticket/67405

**IMPORTANT - PLEASE READ:**  This PR for `smake` will not build if the old version of `cdrtools`, version 3.01, currently in the MacPorts repo has been installed and is active. To address this issue, a procedure called `port_conflict_check` has been added which checks whether `cdrtools`, version 3.01_1 or earlier has been installed. (Thanks to macsguy for the code).  Once `smake` is built, `cdrtools` can be activated again.

FYI -- The old version of `cdrtools`, version 3.01, in the MacPorts repo installs OLD libschily header files and libraries. It is the existence of these old header files and libraries which prevents this updated port for star from building successfully. So the previous version of `cdrtools` must be uninstalled or deactivated first.

A new updated port for `cdrtools` has been submitted which no longer installs the libshily header files and libraries since they are not needed to run the binaries.  Please see https://github.com/macports/macports-ports/pull/18741 

**Note:**  Once this PR for `smake` has been merged, the Pull Requests for `star` and `cdrtools` can be finalized.
Please see:

(star)          https://github.com/macports/macports-ports/pull/18616
(cdrtools)   https://github.com/macports/macports-ports/pull/18741

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
