### PR TITLE
qt5-qtlocation: mapbox-gl-native: patch unique_any.hpp, for std::move

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1607,6 +1607,10 @@ foreach {module module_info} [array get modules] {
                 # do not allow ${prefix}/include/boost to conflict with bundled boost (in bundled mapbox-gl-native)
                 conflicts_build boost
 
+                # https://trac.macports.org/ticket/67417
+                # include/mbgl/util/unique_any.hpp: error: no member named 'move' in namespace 'std'
+                patchfiles-append  patch-qtlocation-mbgl-unique_any.hpp.diff
+
                 # qtlocation uses
                 #    Gypsy (https://gypsy.freedesktop.org/wiki/)
                 #    if they can be found

--- a/aqua/qt5/files/patch-qtlocation-mbgl-unique_any.hpp.diff
+++ b/aqua/qt5/files/patch-qtlocation-mbgl-unique_any.hpp.diff
@@ -1,0 +1,11 @@
+--- src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp.orig	2023-05-13 13:07:39.000000000 -0400
++++ src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp	2023-05-13 13:08:21.000000000 -0400
+@@ -3,6 +3,8 @@
+ #include <typeinfo>
+ #include <type_traits>
+ #include <stdexcept>
++#include <utility> // std::move
++
+ namespace mbgl {
+ namespace util {
+ 


### PR DESCRIPTION
### Description

* Include for `<utility>` missing from: `mbgl/util/unique_any.hpp`
* Fixes: https://trac.macports.org/ticket/67417