### PR TITLE
grep: fix for year2038 for 32-bit archs builds

### DIFF
--- a/sysutils/grep/Portfile
+++ b/sysutils/grep/Portfile
@@ -42,6 +42,13 @@ configure.env   PATH=/usr/bin:$env(PATH)
 configure.args  --disable-silent-rules \
                 --program-prefix=g
 
+if {${build_arch} in [list i386 ppc]} {
+    # error: this system appears to support timestamps after mid-January 2038,
+    # but no mechanism for enabling wide 'time_t' was detected.
+    configure.args-append \
+                --disable-year2038
+}
+
 platform darwin 8 {
     # Work around some /usr/include/sys/signal.h brokenness
     configure.cflags-append -D_MCONTEXT64_T -D_UCONTEXT64_T


### PR DESCRIPTION
#### Description

Apparently when the OS is detected as 64-bit, but the build is for 32-bit arch, configure breaks down. GNU folks keep breaking ports by this 2038 check, eh.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
