### PR TITLE
rocksdb: allow build when ccache installed but configure.ccache=off

### DIFF
--- a/databases/rocksdb/Portfile
+++ b/databases/rocksdb/Portfile
@@ -59,6 +59,15 @@ if {[string match *gcc* ${configure.compiler}]} {
                     -Wno-narrowing
 }
 
+# Build auto-detects ccache if it is installed and attempts to write
+# to CCACHE_DIR, which is not allowed if configure.ccache=off.
+# Set CCACHE_DIR to the build directory instead.
+if {![option configure.ccache]} {
+    configure.env-append   CCACHE_DIR=${workpath}/.ccache
+    build.env-append       CCACHE_DIR=${workpath}/.ccache
+    destroot.env-append    CCACHE_DIR=${workpath}/.ccache
+}
+
 variant jemalloc description "Use jemalloc" {
     depends_lib-append \
                     port:jemalloc


### PR DESCRIPTION
#### Description

If `ccache` installed but not configured, the build breaks down. Borrow an existing fix for that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
