### PR TITLE
gdb-apple: update to 2831

### DIFF
--- a/devel/gdb-apple/Portfile
+++ b/devel/gdb-apple/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem      1.0
 PortGroup       muniversal 1.0
+PortGroup       github 1.0
 
+github.setup    apple-oss-distributions gdb 2831 gdb-
 name            gdb-apple
-version         1824
-revision        1
+revision        0
 categories      devel
 license         GPL-2+
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -26,19 +27,15 @@ Pascal (and many other languages). Those programs might be executing on \
 the same machine as GDB (native) or on another machine (remote). GDB \
 can run on most popular UNIX and Microsoft Windows variants.
 
-homepage        http://opensource.apple.com/source/gdb
 platforms       darwin
 supported_archs x86_64 i386 ppc
 
 # xm.h can be created out of order
 use_parallel_build no
 
-distname        gdb-${version}
-master_sites    http://opensource.apple.com/tarballs/gdb
-
-checksums       rmd160  90290c3950dd06c1691a477b9ee302c00b681ed1 \
-                sha256  d25b056a826015e1e0ea338b9b8f03e40dce3ff4696faf95df259ae1a42698da \
-                size    18298209
+checksums       rmd160  086f823e5eb3cdfed0d72c48679913e5bc73a832 \
+                sha256  38006f9bf50df23dd1b76231b362d5e7af800c44c0f9216a7ceb5eb121c5f432 \
+                size    17960818
 
 depends_build   port:gettext port:zlib port:flex port:texinfo
 
@@ -58,6 +55,12 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
         patchfiles-append \
                 patch-macosx-nat-info.c.diff \
                 patch-include-libiberty.h.diff
+
+        post-patch {
+            # https://trac.macports.org/ticket/67370
+            reinplace "s/.__dr/.dr/" \
+                ${worksrcpath}/gdb/macosx/i386-macosx-nat-exec.c
+        }
     }
 }
 


### PR DESCRIPTION
#### Description

Move to the official GitHub repo (where the original tarball redirects), update the version, and include an i386 fix.

Tested on Tiger/PPC.

Closes: https://trac.macports.org/ticket/67370

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
