### PR TITLE
pika: legacysupport.use_mp_libcxx for <10.16 to support filesystem

### DIFF
--- a/devel/pika/Portfile
+++ b/devel/pika/Portfile
@@ -8,7 +8,9 @@ PortGroup           legacysupport 1.1
 PortGroup           mpi 1.0
 
 # clock_gettime
-legacysupport.newest_darwin_requires_legacy 15
+# On <10.15 built-in libc++ has no support for std::filesystem
+legacysupport.use_mp_libcxx                 yes
+legacysupport.newest_darwin_requires_legacy 18
 
 github.setup        pika-org pika 0.15.0
 revision            0
@@ -81,9 +83,7 @@ platform powerpc {
 }
 
 # https://github.com/pika-org/pika/issues/584
-if {${os.platform} eq "darwin" && ${os.major} <= 19 && ${cxx_stdlib} eq "libc++"} {
-    configure.ldflags-append -lc++fs
-} elseif {${cxx_stdlib} eq "libstdc++" && [string match macports-gcc* ${configure.compiler}]} {
+if {${cxx_stdlib} eq "libstdc++" && [string match macports-gcc* ${configure.compiler}]} {
     set gcc_v [
         string range ${configure.compiler} [
             string length macports-gcc-


### PR DESCRIPTION
#### Description

Another attempt to fix `pika` on Catalina and earlier with Clang. Fix borrowed from `poac` port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
