### PR TITLE
codemod: new port

### DIFF
--- a/devel/codemod/Portfile
+++ b/devel/codemod/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+name                codemod
+github.setup        personalcomputer codemod 55a92a8ef237568302173e45bc282a0f8d1f2fad
+revision            0
+categories          devel python
+
+platforms           {darwin any}
+supported_archs     noarch
+license             Apache-2
+maintainers         nomaintainer
+
+description         A tool to assist with large-scale codebase refactors
+long_description    A tool/library to assist with large-scale codebase refactors that can be partially automated but still require human oversight and occasional intervention. Codemod was developed at Facebook and released as open source.
+
+homepage            https://github.com/personalcomputer/codemod
+
+checksums           rmd160  39b8461ab9e16c68a8605fb18a1e8b6c46242bd2 \
+                    sha256  dc72368bc95fab74373f700a32682d12d308828215c973674c06d63da3494dbb \
+                    size    17756
+
+python.versions     311
+
+depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

New submission for [codemod](https://github.com/personalcomputer/codemod) port.
To be noted, this is not the official repo but instead the repository of someone who forked and added a few maintenance patches since the facebook repo is now archived.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 21G531 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
