### PR TITLE
McBopomofo: provide versions for <10.8; fix build for >20

### DIFF
--- a/aqua/McBopomofo/Portfile
+++ b/aqua/McBopomofo/Portfile
@@ -4,7 +4,6 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        openvanilla McBopomofo 0.9.11
 categories          aqua
 platforms           darwin
 maintainers         nomaintainer
@@ -15,21 +14,55 @@ long_description    OpenVanilla McBopomofo 小麥注音輸入法
 
 homepage            https://mcbopomofo.openvanilla.org/
 
-checksums           rmd160  c201c4c176f0ee205c3587cf93b441128ca241ab \
+if {${os.major} > 11} {
+    github.setup    openvanilla McBopomofo 0.9.11
+    checksums       rmd160  c201c4c176f0ee205c3587cf93b441128ca241ab \
                     sha256  203c925e72990c41b45bc948214becc20f6410ec00dd8caa6abc0bbcb58e2d7a \
                     size    2868560
+} elseif {${os.major} == 11} {
+    github.setup    openvanilla McBopomofo 0.9.10
+    checksums       rmd160  04ecfcc546ca4e5cdf615d91a626cdef7ad7ebb1 \
+                    sha256  23f37e1de13b2a14a770d1bdef16b7dc3e1cc953d2fc420f2436867ba6c20ac5 \
+                    size    2866643
+} elseif {${os.major} == 10 && ${build_arch} ne "ppc"} {
+    github.setup    openvanilla McBopomofo 0.9.9
+    checksums       rmd160  66e855dd7dcf13aa785d037270f6a72953373ee5 \
+                    sha256  ff4972a51a78134b6b8e036a345253656044f1538ef237f6a342b5ec5cd701f3 \
+                    size    2871281
+} elseif {${os.major} == 9 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+    # https://github.com/openvanilla/McBopomofo/issues/349
+    github.setup    openvanilla McBopomofo 4c239a2a5fe10610d63473727a71f9b30077667c
+    version         0.9.9.1
+    checksums       rmd160  f0459b10993f3afae4450f0781f664e9eb974f10 \
+                    sha256  20428feaaa43749377d4b931c5190c9dc317843cc839d8ac694cc30d384e2d1c \
+                    size    3174055
+    git.branch      leopard-support
+    macosx_deployment_target 10.5
+}
 
-patchfiles          patch-no-werror.diff \
-                    patch-includes.diff
+patchfiles          patch-includes.diff
+
+if {${os.major} > 9 && ${build_arch} ne "ppc"} {
+    # Not needed on leopard-support branch since already implemented with upstream:
+    patchfiles-append \
+                    patch-no-werror.diff
+}
 
 # Don't build McBopomofoInstaller
 xcode.target        Data McBopomofo
+
+destroot.violate_mtree yes
 
 destroot.pre_args   -IDECustomDerivedDataLocation=${worksrcpath}/DerivedData \
                     -UseNewBuildSystem=NO
 
 post-destroot {
     xinstall -d "${destroot}/Library/Input Methods"
-    move "${destroot}${applications_dir}/McBopomofo.app" \
-         "${destroot}/Library/Input Methods/McBopomofo.app"
+    if {[vercmp $xcodeversion 4.2] >= 0} {
+        move "${destroot}${applications_dir}/McBopomofo.app" \
+            "${destroot}/Library/Input Methods/McBopomofo.app"
+    } else {
+        copy "${worksrcpath}/build/UninstalledProducts/McBopomofo.app" \
+            "${destroot}/Library/Input Methods/McBopomofo.app"
+    }
 }

--- a/aqua/McBopomofo/Portfile
+++ b/aqua/McBopomofo/Portfile
@@ -53,8 +53,12 @@ xcode.target        Data McBopomofo
 
 destroot.violate_mtree yes
 
-destroot.pre_args   -IDECustomDerivedDataLocation=${worksrcpath}/DerivedData \
+destroot.pre_args   -IDECustomDerivedDataLocation=${worksrcpath}/DerivedData
+
+if {[vercmp ${xcodeversion} 10.0] >= 0} {
+    destroot.pre_args-append \
                     -UseNewBuildSystem=NO
+}
 
 post-destroot {
     xinstall -d "${destroot}/Library/Input Methods"

--- a/aqua/McBopomofo/Portfile
+++ b/aqua/McBopomofo/Portfile
@@ -60,6 +60,19 @@ if {[vercmp ${xcodeversion} 10.0] >= 0} {
                     -UseNewBuildSystem=NO
 }
 
+if {${os.platform} eq "darwin" && ${os.major} >= 21} {
+    # No /usr/bin/python, use python3
+    configure.python \
+                    /usr/bin/python3
+    post-patch {
+        fs-traverse f ${worksrcpath}/Source/Data/bin {
+            if {[string match *.py ${f}]} {
+                reinplace -q "s|/usr/bin/env python$|${configure.python}|" ${f}
+            }
+        }
+    }
+}
+
 post-destroot {
     xinstall -d "${destroot}/Library/Input Methods"
     if {[vercmp $xcodeversion 4.2] >= 0} {


### PR DESCRIPTION
#### Description

Fixed for newer macOS too, where it is also broken currently: https://ports.macports.org/port/McBopomofo/details

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
