### PR TITLE
tk: Backport fix for ttk::ThemeChanged error

### DIFF
--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.1
 
 name                tk
 version             8.6.13
-revision            0
+revision            1
 categories          x11
 license             Tcl/Tk
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -38,6 +38,9 @@ build.dir          ${configure.dir}
 # see https://trac.macports.org/ticket/57594
 # for upstream report, see https://core.tcl-lang.org/tcl/tktview?name=ad393071c2
 patchfiles-append   patch-dyld_fallback_library_path.diff
+
+# Fix for https://core.tcl-lang.org/tk/info/310c74ecf4
+patchfiles-append   fix-themechanged-error.patch
 
 # https://github.com/tcltk/tk/commit/b0cb1a48cb0c4a0118d45e8804476a6b4ab502c8
 # this is the only code that fails on OSX 10.6, so enable it for 10.7 or newer only; see also

--- a/x11/tk/files/fix-themechanged-error.patch
+++ b/x11/tk/files/fix-themechanged-error.patch
@@ -1,0 +1,120 @@
+From https://core.tcl-lang.org/tk/info/b1876b9ebc4b
+
+Index: generic/tkInt.h
+==================================================================
+--- generic/tkInt.h
++++ generic/tkInt.h
+@@ -1090,14 +1090,15 @@
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+ 
+ /*
+- * Themed widget set init function:
++ * Themed widget set init function, and handler called when Tk is destroyed.
+  */
+ 
+ MODULE_SCOPE int	Ttk_Init(Tcl_Interp *interp);
++MODULE_SCOPE void	Ttk_TkDestroyedHandler(Tcl_Interp *interp);
+ 
+ /*
+  * Internal functions shared among Tk modules but not exported to the outside
+  * world:
+  */
+
+Index: generic/tkWindow.c
+==================================================================
+--- generic/tkWindow.c
++++ generic/tkWindow.c
+@@ -1619,10 +1619,11 @@
+ 	    TkBindFree(winPtr->mainPtr);
+ 	    TkDeleteAllImages(winPtr->mainPtr);
+ 	    TkFontPkgFree(winPtr->mainPtr);
+ 	    TkFocusFree(winPtr->mainPtr);
+ 	    TkStylePkgFree(winPtr->mainPtr);
++	    Ttk_TkDestroyedHandler(winPtr->mainPtr->interp);
+ 
+ 	    /*
+ 	     * When embedding Tk into other applications, make sure that all
+ 	     * destroy events reach the server. Otherwise the embedding
+ 	     * application may also attempt to destroy the windows, resulting
+
+Index: generic/ttk/ttkTheme.c
+==================================================================
+--- generic/ttk/ttkTheme.c
++++ generic/ttk/ttkTheme.c
+@@ -401,12 +401,10 @@
+     Cleanup *cleanupList;		/* Cleanup records */
+     Ttk_ResourceCache cache;		/* Resource cache */
+     int themeChangePending;		/* scheduled ThemeChangedProc call? */
+ } StylePackageData;
+ 
+-static void ThemeChangedProc(void *);	/* Forward */
+-
+ /* Ttk_StylePkgFree --
+  *	Cleanup procedure for StylePackageData.
+  */
+ static void Ttk_StylePkgFree(
+     ClientData clientData,
+@@ -415,17 +413,10 @@
+     StylePackageData *pkgPtr = (StylePackageData *)clientData;
+     Tcl_HashSearch search;
+     Tcl_HashEntry *entryPtr;
+     Cleanup *cleanup;
+ 
+-    /*
+-     * Cancel any pending ThemeChanged calls:
+-     */
+-    if (pkgPtr->themeChangePending) {
+-	Tcl_CancelIdleCall(ThemeChangedProc, pkgPtr);
+-    }
+-
+     /*
+      * Free themes.
+      */
+     entryPtr = Tcl_FirstHashEntry(&pkgPtr->themeTable, &search);
+     while (entryPtr != NULL) {
+@@ -484,11 +475,11 @@
+  *
+  */
+ void Ttk_RegisterCleanup(
+     Tcl_Interp *interp, ClientData clientData, Ttk_CleanupProc *cleanupProc)
+ {
+-    StylePackageData *pkgPtr = (StylePackageData *)GetStylePackageData(interp);
++    StylePackageData *pkgPtr = GetStylePackageData(interp);
+     Cleanup *cleanup = (Cleanup *)ckalloc(sizeof(*cleanup));
+ 
+     cleanup->clientData = clientData;
+     cleanup->cleanupProc = cleanupProc;
+     cleanup->next = pkgPtr->cleanupList;
+@@ -528,10 +519,29 @@
+     if (!pkgPtr->themeChangePending) {
+ 	Tcl_DoWhenIdle(ThemeChangedProc, pkgPtr);
+ 	pkgPtr->themeChangePending = 1;
+     }
+ }
++
++/* Ttk_TkDestroyedHandler --
++ *	See bug [310c74ecf440]: idle calls to ThemeChangedProc()
++ *	need to be canceled when Tk is destroyed, since the interp
++ *	may still be active afterward; canceling them from
++ *	Ttk_StylePkgFree() would be too late.
++ */
++void Ttk_TkDestroyedHandler(
++    Tcl_Interp* interp)
++{
++    StylePackageData* pkgPtr = GetStylePackageData(interp);
++
++    /*
++     * Cancel any pending ThemeChanged calls:
++     */
++    if (pkgPtr->themeChangePending) {
++	Tcl_CancelIdleCall(ThemeChangedProc, pkgPtr);
++    }
++}
+ 
+ /*
+  * Ttk_CreateTheme --
+  *	Create a new theme and register it in the global theme table.
+  *
+


### PR DESCRIPTION
#### Description

This fixes a race condition which is difficult to reproduce, and an annoyance mainly to Tkinter users (e.g. https://github.com/python/cpython/issues/71383)
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.5
Xcode 14.2
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
