### PR TITLE
boost181: fix fiber for powerpc

### DIFF
--- a/devel/boost181/Portfile
+++ b/devel/boost181/Portfile
@@ -111,6 +111,9 @@ patchfiles-append patch-revert-lib-name-tagged.diff
 # https://github.com/boostorg/context/pull/215
 patchfiles-append patch-boost-context-asm.diff
 
+# https://github.com/boostorg/fiber/pull/306
+patchfiles-append patch-fix-fiber.diff
+
 # Availability.h -> AvailabilityMacros.h on Tiger
 # The attempted fix:
 # https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
@@ -179,15 +182,11 @@ if {[string match *gcc* ${configure.compiler}]} {
 }
 
 # Boost's PPC32 ASM code in the context module was only recently fixed (see
-# patch above). PPC64 is still broken, and the Fiber module won't compile with
-# GCC7. Conditionally disable pending further investigation.
+# patch above). PPC64 is still broken.
 platform darwin {
     if {${build_arch} eq "ppc64"} {
         configure.args-append   --without-libraries=context \
                                 --without-libraries=coroutine
-    }
-    if {${build_arch} eq "ppc"} {
-        configure.args-append   --without-libraries=fiber
     }
 }
 
@@ -375,7 +374,7 @@ subport ${name}-numpy {
 
 if {$subport eq $name} {
 
-    revision 5
+    revision 6
 
     patchfiles-append patch-disable-numpy-extension.diff
 

--- a/devel/boost181/files/patch-fix-fiber.diff
+++ b/devel/boost181/files/patch-fix-fiber.diff
@@ -1,0 +1,14 @@
+--- boost/fiber/detail/cpu_relax.hpp.orig	2022-12-08 09:02:41.000000000 +0800
++++ boost/fiber/detail/cpu_relax.hpp	2023-05-14 19:32:43.000000000 +0800
+@@ -59,7 +59,11 @@
+ //               processors
+ // extended mnemonics (available with POWER7)
+ // yield   ==   or 27, 27, 27
++# if defined(__POWERPC__)
++# define cpu_relax() asm volatile ("or r27,r27,r27" ::: "memory");
++# else
+ # define cpu_relax() asm volatile ("or 27,27,27" ::: "memory");
++# endif
+ #elif BOOST_ARCH_X86
+ # if BOOST_COMP_MSVC || BOOST_COMP_MSVC_EMULATED
+ #  define cpu_relax() YieldProcessor();


### PR DESCRIPTION
#### Description

@mascguy @evanmiller Turned out it is the same silly bug which was fixed for a dozen of ports already. Eh.
https://github.com/boostorg/fiber/pull/306

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
