### PR TITLE
R: revbump ICU dependents to unbreak them; update a few packages

### DIFF
--- a/R/R-Cairo/Portfile
+++ b/R/R-Cairo/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran s-u Cairo 1.6-0
-revision            2
+revision            3
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             {GPL-2 GPL-3}
 description         R graphics device using cairo graphics library

--- a/R/R-Cairo/Portfile
+++ b/R/R-Cairo/Portfile
@@ -20,6 +20,7 @@ depends_build-append \
 depends_lib-append  path:lib/pkgconfig/cairo.pc:cairo \
                     path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     path:lib/pkgconfig/harfbuzz-icu.pc:harfbuzz-icu \
+                    path:lib/pkgconfig/icu-uc.pc:icu \
                     port:freetype \
                     port:tiff
 

--- a/R/R-XML/Portfile
+++ b/R/R-XML/Portfile
@@ -17,7 +17,8 @@ checksums           rmd160  fd272764d33a34ad65ce16ea3af22e87fe09328f \
 
 depends_build-append \
                     port:pkgconfig
-depends_lib-append  port:libxml2
+depends_lib-append  path:lib/pkgconfig/icu-uc.pc:icu \
+                    port:libxml2
 
 patchfiles          patch-cc.diff
 

--- a/R/R-XML/Portfile
+++ b/R/R-XML/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran cran XML 3.99-0.14
-revision            1
+revision            2
 categories-append   devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             BSD

--- a/R/R-apollo/Portfile
+++ b/R/R-apollo/Portfile
@@ -3,18 +3,20 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran cran apollo 0.2.8
-revision            1
+R.setup             cran cran apollo 0.2.9
+revision            0
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-2
 description         Tools for choice model estimation and application
 long_description    {*}${description}
-checksums           rmd160  3ffbee2eec8176b01912e64a3ac30661103864f8 \
-                    sha256  5a2c7ae2287e094a76abe5e721ccf65101711050fab58facb16a3237c0503889 \
-                    size    469152
+checksums           rmd160  648a4e59a27f5044bd079be8a938d1ba79ba5687 \
+                    sha256  a3e6ff3427bb5bc0105fae050145324feb83891d464e3a6d9394201b2831d11c \
+                    size    508443
 
-depends_lib-append  port:R-coda \
+depends_lib-append  port:R-bgw \
+                    port:R-cli \
+                    port:R-coda \
                     port:R-Deriv \
                     port:R-matrixStats \
                     port:R-maxLik \

--- a/R/R-ggdist/Portfile
+++ b/R/R-ggdist/Portfile
@@ -3,28 +3,29 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github mjskay ggdist 3.2.1 v
-revision            1
+R.setup             github mjskay ggdist 3.3.0 v
+revision            0
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
-license             GPL-3
+license             GPL-3+
 description         Visualizations of distributions and uncertainty
 long_description    {*}${description}
 homepage            https://mjskay.github.io/ggdist
-checksums           rmd160  9b049fa16dedfebe247d617ff770ff18b7363711 \
-                    sha256  666df8c895c0782c64b1bda52ce7edac91b18f1b30c88b6c842a0fe85bda2dd2 \
-                    size    24237781
+checksums           rmd160  5788428bf230afe03464099d7d124904b51ee950 \
+                    sha256  908f37806806035d3053d42ca9f447b320edb3d42ba2c088c444b89617046422 \
+                    size    24515665
 github.tarball_from archive
 supported_archs     noarch
 
-depends_lib-append  port:R-distributional \
+depends_lib-append  port:R-cli \
+                    port:R-distributional \
                     port:R-dplyr \
                     port:R-ggplot2 \
                     port:R-glue \
-                    port:R-HDInterval \
                     port:R-numDeriv \
                     port:R-quadprog \
                     port:R-rlang \
+                    port:R-scales \
                     port:R-tibble \
                     port:R-tidyselect \
                     port:R-vctrs \

--- a/R/R-igraph/Portfile
+++ b/R/R-igraph/Portfile
@@ -17,7 +17,8 @@ checksums           rmd160  f08c692969e9b5a38c334c558937eb036f65cb64 \
                     sha256  7d5300adb1a25a6470cada8630e35ef416181147ab624d5a0a8d3552048c4ae5 \
                     size    3308627
 
-depends_lib-append  port:glpk \
+depends_lib-append  path:lib/pkgconfig/icu-uc.pc:icu \
+                    port:glpk \
                     port:gmp \
                     port:libxml2 \
                     port:R-cpp11 \

--- a/R/R-igraph/Portfile
+++ b/R/R-igraph/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran igraph igraph 1.4.2
-revision            1
+revision            2
 maintainers         {gmail.com:szhorvat @szhorvat} {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-2+
 description         Network Analysis and Visualization

--- a/R/R-nimble/Portfile
+++ b/R/R-nimble/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran nimble-dev nimble 0.13.1
-revision            1
+R.setup             cran nimble-dev nimble 0.13.2
+revision            0
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             BSD
 description         The base NIMBLE package for R
 long_description    {*}${description}
 homepage            https://R-nimble.org
-checksums           rmd160  28f2d363a80fbd6a56a5032491abb58dddc2a870 \
-                    sha256  dc70caab64a8a4e44fb13fa6d67f6f2a0453fa684669e24718758bb2a8cf8530 \
-                    size    2149097
+checksums           rmd160  a9208ffaed9d6dfc1ad9a5271593d2fac4fac6f6 \
+                    sha256  64907e899a2c6338956f397f5669df2c98c1a65238d0fcc83a14495aa6985f60 \
+                    size    2161913
 
 depends_lib-append  port:R-coda \
                     port:R-igraph \

--- a/R/R-stringi/Portfile
+++ b/R/R-stringi/Portfile
@@ -13,3 +13,9 @@ homepage            https://stringi.gagolewski.com
 checksums           rmd160  ad412812453ed9a60cd896fe182c5ee3f4624c93 \
                     sha256  f900c3f44f2b453a5b2e7bab331e22effd0425aa68453cbab35f262ec4aa6fb4 \
                     size    86700964
+
+# ICU is an optional dependency, but it is linked to, if available.
+# Make it consistent. Anyway, R itself requires ICU installed.
+depends_lib-append  path:lib/pkgconfig/icu-uc.pc:icu
+
+test.run            yes

--- a/R/R-stringi/Portfile
+++ b/R/R-stringi/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             github gagolews stringi 1.7.12 v
-revision            1
+revision            2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             BSD
 description         Fast and portable character string processing in R (with the Unicode ICU).

--- a/R/R-xml2/Portfile
+++ b/R/R-xml2/Portfile
@@ -19,7 +19,8 @@ checksums           rmd160  8eed5336ccde723a2025bcc2edab27a5ed451699 \
 
 depends_build-append \
                     port:pkgconfig
-depends_lib-append  port:libxml2
+depends_lib-append  path:lib/pkgconfig/icu-uc.pc:icu \
+                    port:libxml2
 
 depends_test-append port:R-covr \
                     port:R-curl \

--- a/R/R-xml2/Portfile
+++ b/R/R-xml2/Portfile
@@ -5,7 +5,7 @@ PortGroup           R 1.0
 
 # Revert to GitHub once updated there.
 R.setup             cran r-lib xml2 1.3.4
-revision            0
+revision            1
 categories-append   devel textproc
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT


### PR DESCRIPTION
#### Description

Revbumping R packages depending on ICU/libxml2 was forgotten during a recent update of ICU. In result, they broke down.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
