### PR TITLE
glib2-devel: remove legacysupport, fix Tiger

### DIFF
--- a/devel/glib2-devel/Portfile
+++ b/devel/glib2-devel/Portfile
@@ -6,16 +6,13 @@ PortGroup                   clang_dependency 1.0
 PortGroup                   meson 1.0
 PortGroup                   muniversal 1.0
 
-# to get past the aligned memory access error
-PortGroup                   legacysupport 1.1
-
 # Please keep the glib2 and glib2-devel ports as similar as possible.
 
 name                        glib2-devel
 conflicts                   glib2
 set my_name                 glib
 version                     2.76.2
-revision                    1
+revision                    2
 epoch                       0
 checksums                   rmd160  537272ca0c11b2a056b07a9d4dc089815402375a \
                             sha256  24f3847857b1d8674cdb0389a36edec0f13c666cd3ce727ecd340eb9da8aca9e \
@@ -40,6 +37,8 @@ master_sites                gnome:sources/${my_name}/${branch}/
 
 patchfiles-append           libintl.patch \
                             patch-gio-tests-meson.build.diff \
+                            patch-glib_gmem.c.diff \
+                            patch-glib_gspawn.c.diff \
                             patch-glib_gunicollate.c.diff \
                             patch-gio_xdgmime_xdgmime.c.diff \
                             patch-get-launchd-dbus-session-address.diff \
@@ -193,6 +192,9 @@ platform darwin {
 }
 
 platform darwin 8 {
+    # https://trac.macports.org/ticket/67307
+    configure.cflags-append -D__DARWIN_NON_CANCELABLE=1
+
     # meson on Tiger cannot use rpaths, so we workaround with this to find dylibs
     foreach my_phase {build test destroot} {
         ${my_phase}.env-append  "DYLD_LIBRARY_PATH=${build_dir}/glib:${build_dir}/gobject:${build_dir}/gio:${build_dir}/gthread:${build_dir}/gmodule"

--- a/devel/glib2-devel/files/patch-glib_gmem.c.diff
+++ b/devel/glib2-devel/files/patch-glib_gmem.c.diff
@@ -1,0 +1,12 @@
+--- glib/gmem.c.orig	2023-05-14 09:57:50.000000000 -0400
++++ glib/gmem.c	2023-05-14 09:59:39.000000000 -0400
+@@ -679,7 +679,8 @@
+ #elif defined(HAVE_MEMALIGN)
+   res = memalign (alignment, real_size);
+ #else
+-# error "This platform does not have an aligned memory allocator."
++  /* malloc is 16-byte aligned; otherwise page alignment will do */
++  res = alignment <= 16 ? malloc(real_size) : valloc(real_size);
+ #endif
+ 
+   TRACE (GLIB_MEM_ALLOC((void*) res, (unsigned int) real_size, 0, 0));

--- a/devel/glib2-devel/files/patch-glib_gspawn.c.diff
+++ b/devel/glib2-devel/files/patch-glib_gspawn.c.diff
@@ -1,0 +1,32 @@
+libproc.h isn't available on older systems
+
+--- meson.build.orig	2023-05-13 23:04:36.000000000 -0400
++++ meson.build	2023-05-13 23:04:51.000000000 -0400
+@@ -350,6 +350,7 @@
+   'fstab.h',
+   'grp.h',
+   'inttypes.h',
++  'libproc.h',
+   'limits.h',
+   'locale.h',
+   'mach/mach_time.h',
+--- glib/gspawn.c.orig	2023-05-13 23:05:53.000000000 -0400
++++ glib/gspawn.c	2023-05-13 23:06:23.000000000 -0400
+@@ -70,7 +70,7 @@
+ #include "glibintl.h"
+ #include "glib-unix.h"
+ 
+-#ifdef __APPLE__
++#ifdef HAVE_LIBPROC_H
+ #include <libproc.h>
+ #include <sys/proc_info.h>
+ #endif
+@@ -1544,7 +1544,7 @@
+   if (open_max < 0)
+     open_max = 4096;
+ 
+-#if defined(__APPLE__)
++#if defined(HAVE_LIBPROC_H)
+   /* proc_pidinfo isn't documented as async-signal-safe but looking at the implementation
+    * in the darwin tree here:
+    *


### PR DESCRIPTION
#### Description

glib2 currently doesn't build on Tiger, see https://trac.macports.org/ticket/67307#comment:19

In addition to the missing symbol, there's a conflict between `legacysupport` (which was added for `posix_memalign`) and the way that this Portfile works around Tiger's lack of rpath. Legacysupport's `DYLD_LIBRARY_PATH` overrides the Portfile's, leading to a failed build.

Finally, Tiger lacks `proc_pidinfo`.

To work around these issues:

* Define `__DARWIN_NON_CANCELABLE` to prevent the missing symbol error
* Remove legacysupport in favor of a 2-line patch
* Add a test for the `libproc.h` header

Basic tests pass but I see some failures in the collation tests – likely unrelated.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
