### PR TITLE
zmap: submission new Portfile ZMap version 3.0.0 beta1

### DIFF
--- a/net/zmap/Portfile
+++ b/net/zmap/Portfile
@@ -4,11 +4,9 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 
-name                zmap
 github.setup        zmap zmap 3.0.0-beta1 v
 
 categories          net
-platforms           darwin
 license             apache-2
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 
@@ -22,14 +20,13 @@ checksums           rmd160  4b30c0f33c5e4503a89dcb37808c50075373c4f4 \
                     sha256  61787bd59cb23183a8b5424a148b95812d8254d6249c2d4efb31cbebff9ca383 \
                     size    154851
 
-depends_build       port:byacc \
+depends_build-append port:byacc \
                     port:flex \
                     port:gengetopt \
-                    port:pkgconfig
+                    port:pkgconfig \
+                    port:cmake
 
-depends_build-append port:cmake
-
-depends_lib         port:gmp \
+depends_lib-append  port:gmp \
                     port:libdnet \
                     port:libpcap \
                     port:json-c \

--- a/net/zmap/Portfile
+++ b/net/zmap/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.0
+PortGroup           github 1.0
+
+name                zmap
+github.setup        zmap zmap 3.0.0-beta1 v
+
+categories          net
+platforms           darwin
+license             apache-2
+maintainers         {@artkiver gmail.com:artkiver} openmaintainer
+
+description         ZMap is a fast network scanner
+long_description    designed for Internet-wide network surveys capable of \
+                    scanning the entire IPv4 address space in 5 minutes from \
+                    a 10GbE connection.
+homepage            https://zmap.io/
+
+checksums           rmd160  4b30c0f33c5e4503a89dcb37808c50075373c4f4 \
+                    sha256  61787bd59cb23183a8b5424a148b95812d8254d6249c2d4efb31cbebff9ca383 \
+                    size    154851
+
+depends_build       port:byacc \
+                    port:flex \
+                    port:gengetopt \
+                    port:pkgconfig
+
+depends_build-append port:cmake
+
+depends_lib         port:gmp \
+                    port:libdnet \
+                    port:libpcap \
+                    port:json-c \
+                    port:libunistring \
+
+
+variant redis description {Add Redis support} {
+    depends_lib-append port:redis
+    depends_lib-append port:hiredis
+    configure.args-append -DWITH_REDIS=ON
+}


### PR DESCRIPTION
 * closes https://trac.macports.org/ticket/42895
 * closes https://trac.macports.org/ticket/41986

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
