### PR TITLE
bzip3: update to 1.3.0

### DIFF
--- a/archivers/bzip3/Portfile
+++ b/archivers/bzip3/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        kspalaiologos bzip3 1.2.1
+github.setup        kspalaiologos bzip3 1.3.0
 github.tarball_from releases
 categories          archivers
 license             LGPL-3+
@@ -13,9 +13,9 @@ maintainers         {@sech1p gmail.com:sech1piam} openmaintainer
 description         A better and stronger spiritual successor to BZip2.
 long_description    {*}${description}
 
-checksums           rmd160  3940e049433a348ccc9fe4f0fcc3fe76cbae37ad \
-                    sha256  bba90d867f53efa4291de1df9c22da1578e1a93ca819e0fc68881da6fcc4149d \
-                    size    399621
+checksums           rmd160  1537f8db5ec4a656bfd8230241b233c5980980e5 \
+                    sha256  29eb1d552b49aa04a13cb153bfb5b751f8e9e1bad7e80dcbd16359d87a7c531f \
+                    size    404720
 
 configure.args      --disable-silent-rules
 


### PR DESCRIPTION
#### Description

bzip3: update to 1.3.0

###### Type(s)

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? 
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
