### PR TITLE
watchman, folly, fbthrift, fb303, proxygen, wangle, fizz, & edencommon: update to 2023.05.15.00

### DIFF
--- a/devel/edencommon/Portfile
+++ b/devel/edencommon/Portfile
@@ -11,11 +11,11 @@ PortGroup           legacysupport 1.1
 # O_CLOEXEC
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        facebookexperimental edencommon 2023.01.30.00 v
+github.setup        facebookexperimental edencommon 2023.05.15.00 v
 revision            0
-checksums           rmd160  dbc4bea07cad4d320b9421b6f8f5420eacd592c1 \
-                    sha256  9b582c472b718fc0a0f762b2ac3ab317f7e0ea4991929b84fad082b6c1dcbf68 \
-                    size    144694
+checksums           rmd160  2c47fb75bfdcf2d0e24c7fb1266882180f85913f \
+                    sha256  faa599ef131aaa252971f971a7dc56db297ccb62c24c462e405e162b46c6c45e \
+                    size    146561
 
 categories          devel
 license             BSD

--- a/devel/fatal/Portfile
+++ b/devel/fatal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        facebook fatal 2023.01.02.00 v
+github.setup        facebook fatal 2023.05.15.00 v
 revision            0
 categories          devel
 license             BSD

--- a/devel/fb303/Portfile
+++ b/devel/fb303/Portfile
@@ -8,12 +8,12 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
-github.setup        facebook fb303 2023.01.30.00 v
+github.setup        facebook fb303 2023.05.15.00 v
 epoch               1
 revision            0
-checksums           rmd160  b768e496113e24de3976dd016d3452810d53c18c \
-                    sha256  e11ec912767a5bcd76fce60860db7886ee2cd4dcb13df424e3618b3f80351fc1 \
-                    size    241146
+checksums           rmd160  b85ccd3043de74b3486e3c1d7c86f9834ec8db10 \
+                    sha256  8aba581414461149e5be21f2d7ee40f7e6c62922a23c73524bf2e7d677aac355 \
+                    size    243377
 
 categories          devel
 license             Apache-2

--- a/devel/fbthrift/Portfile
+++ b/devel/fbthrift/Portfile
@@ -8,11 +8,11 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
-github.setup        facebook fbthrift 2023.01.30.00 v
+github.setup        facebook fbthrift 2023.05.15.00 v
 revision            0
-checksums           rmd160  e227dbc53aee905d043342d36de57e52ac11c145 \
-                    sha256  66c785a116b52d36cc113b9e639471bd89ca67bdd422f85fad1e44dfa98d7a8f \
-                    size    13408656
+checksums           rmd160  d39ba8a3d574bccfa34541b3d46afd7e40a9bbb8 \
+                    sha256  c939d9e97b0cfde6e8f1ad35ae481300a542d7f7dcfe4461981efc39135dbfa5 \
+                    size    13837302
 
 categories          devel
 license             Apache-2

--- a/devel/fizz/Portfile
+++ b/devel/fizz/Portfile
@@ -11,11 +11,11 @@ PortGroup           legacysupport 1.1
 # O_CLOEXEC
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        facebookincubator fizz 2023.01.30.00 v
+github.setup        facebookincubator fizz 2023.05.15.00 v
 revision            0
-checksums           rmd160  913b61c9b0785e95e0427b4c17a74bfdc065b7b1 \
-                    sha256  53f3b99bbd4e01fbebbdeaaf044ff32b55021b1808c4d458161bacef0de3db9e \
-                    size    649001
+checksums           rmd160  52bc1b0451ff1c2e3da601b589a4629a27370f59 \
+                    sha256  468eca89b75b632ae16f06d4f3e3fb50d8ca145cce64d6c48260997df7770114 \
+                    size    654780
 
 categories          devel
 license             BSD

--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -18,11 +18,11 @@ if {[string match *clang* ${configure.compiler}]} {
 # NB: Facebook does not do API stabiilty, apparently, so please don't
 # upgrade without also upgrading its dependents, as listed by:
 # port list rdepends:folly
-github.setup        facebook folly 2023.01.30.00 v
+github.setup        facebook folly 2023.05.15.00 v
 revision            0
-checksums           rmd160  b5170cc7a49851456dfae482c058bb6a1be5137f \
-                    sha256  2f4b6da55d1009807ad3072655d680b31beb3c25b987a6e1dc32c30f6aac648a \
-                    size    3789531
+checksums           rmd160  562d4877fba3842d2f0fd2733c4e1e0ad2c56773 \
+                    sha256  fffd8a800f0840875b11d867225499d8ddff5917e7280a787a9d298e42acb1ba \
+                    size    3832144
 
 categories          devel
 license             Apache-2

--- a/devel/proxygen/Portfile
+++ b/devel/proxygen/Portfile
@@ -11,7 +11,7 @@ PortGroup           legacysupport 1.1
 # O_CLOEXEC
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        facebook proxygen 2023.01.30.00 v
+github.setup        facebook proxygen 2023.05.15.00 v
 revision            0
 categories          devel
 license             BSD
@@ -23,9 +23,9 @@ long_description    This project comprises the core C++ HTTP abstractions used a
                     Future releases will provide simple client APIs as well. The framework supports \
                     HTTP/1.1, SPDY/3, SPDY/3.1, HTTP/2 and HTTP/3. The goal is to provide a simple, \
                     performant and modern C++ HTTP library.
-checksums           rmd160  38e65661b1d131f35f8c84b54c13e0e1ec0b1fc8 \
-                    sha256  f6b42ec0733a5cbdc3d2710af014418df0821c2a584e557bc92026ade088ac0b \
-                    size    1092738
+checksums           rmd160  51ffa8ffdb7be5e1488001d8e809d7b5979021b3 \
+                    sha256  e476d1065d076a6360b2cc489b8b7d17ce498d092cd31bc080712b1e856b747c \
+                    size    1135276
 github.tarball_from archive
 
 patchfiles          patch-tcpinfo.diff

--- a/devel/wangle/Portfile
+++ b/devel/wangle/Portfile
@@ -8,11 +8,11 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
-github.setup        facebook wangle 2023.01.30.00 v
+github.setup        facebook wangle 2023.05.15.00 v
 revision            0
-checksums           rmd160  40c00b74d7064f0f11971e0e3edd12dee30af267 \
-                    sha256  03e981ffca04aa11605eb129a9a1efdf4fd0828ac83b814852ca8caf3b8694fa \
-                    size    339206
+checksums           rmd160  b5ef4200a7b85716de20c20a9d3421a064765be2 \
+                    sha256  2b12abd6c17319ec6f648bdcb4f6516e08044282aa77aad455447b3a01c2b22f \
+                    size    341329
 
 categories          devel
 license             BSD

--- a/sysutils/watchman/Portfile
+++ b/sysutils/watchman/Portfile
@@ -7,7 +7,7 @@ PortGroup           boost 1.0
 PortGroup           rust 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        facebook watchman 2023.01.30.00 v
+github.setup        facebook watchman 2023.05.15.00 v
 revision            0
 
 categories          sysutils
@@ -48,7 +48,8 @@ configure.env-append \
 patch.pre_args      -p1
 patchfiles          0001-revert-optionset-move.patch \
                     0002-cmake-rust-build-target.patch \
-                    0003-no-tests.patch
+                    0003-no-tests.patch \
+                    0004-cmake-rust-build-offline.patch
 
 post-patch {
     reinplace "s,/usr/bin,${prefix}," CMakeLists.txt
@@ -68,116 +69,124 @@ compiler.cxx_standard \
                     2017
 
 checksums           ${distname}${extract.suffix}  \
-                    rmd160  1232b1beaea84798f925190212bfbd641646e979 \
-                    sha256  5b8fb29a92fd3428e90bf330792311191455779175a1f3b7365e165541c7f6b5 \
-                    size    3810912
+                    rmd160  8e29a018137fa2a90d31d42a80ba8d8bac87bd44 \
+                    sha256  99492beb2a89a22feb89336dd789938d615f5e3019143a74f325875b9058c7ae \
+                    size    3963951
 
 cargo.crates \
-    ahash                            0.3.8  e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217 \
+    ahash                            0.8.3  2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f \
     ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
-    anyhow                          1.0.68  2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61 \
+    anyhow                          1.0.71  9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8 \
     atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
     autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
-    bytes                            1.3.0  dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c \
-    cc                              1.0.79  50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f \
+    bytes                            1.4.0  89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     clap                            2.34.0  a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c \
-    const-random                    0.1.15  368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e \
-    const-random-macro              0.1.15  9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb \
-    core-foundation-sys              0.8.3  5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc \
+    core-foundation-sys              0.8.4  e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa \
     crossbeam                        0.8.2  2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c \
-    crossbeam-channel                0.5.6  c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521 \
-    crossbeam-deque                  0.8.2  715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc \
-    crossbeam-epoch                 0.9.13  01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a \
+    crossbeam-channel                0.5.8  a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200 \
+    crossbeam-deque                  0.8.3  ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef \
+    crossbeam-epoch                 0.9.14  46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695 \
     crossbeam-queue                  0.3.8  d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add \
-    crossbeam-utils                 0.8.14  4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f \
-    crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
+    crossbeam-utils                 0.8.15  3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b \
     duct                            0.13.6  37ae3fc31835f74c2a7ceda3aeede378b0ae2e74c8f1c36559fcc9ae2a4e7d3e \
     either                           1.8.1  7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91 \
     futures                         0.1.31  3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678 \
-    futures                         0.3.26  13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84 \
-    futures-channel                 0.3.26  2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5 \
-    futures-core                    0.3.26  ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608 \
-    futures-executor                0.3.26  e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e \
-    futures-io                      0.3.26  bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531 \
-    futures-macro                   0.3.26  95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70 \
-    futures-sink                    0.3.26  f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364 \
-    futures-task                    0.3.26  dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366 \
-    futures-util                    0.3.26  9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1 \
-    getrandom                        0.2.8  c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31 \
+    futures                         0.3.28  23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40 \
+    futures-channel                 0.3.28  955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2 \
+    futures-core                    0.3.28  4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c \
+    futures-executor                0.3.28  ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0 \
+    futures-io                      0.3.28  4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964 \
+    futures-macro                   0.3.28  89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72 \
+    futures-sink                    0.3.28  f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e \
+    futures-task                    0.3.28  76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65 \
+    futures-util                    0.3.28  26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533 \
+    getrandom                        0.2.9  c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4 \
     heck                             0.3.3  6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c \
     hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
     hermit-abi                       0.2.6  ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7 \
-    itoa                             1.0.5  fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440 \
+    itoa                             1.0.6  453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6 \
     jwalk                            0.6.2  5dbcda57db8b6dc067e589628b7348639014e793d9e8137d8cf215e8b133a0bd \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.139  201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79 \
+    libc                           0.2.144  2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1 \
     lock_api                         0.4.9  435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df \
     log                             0.4.17  abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e \
     maplit                           1.0.2  3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d \
     memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
     memoffset                        0.6.5  5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce \
-    memoffset                        0.7.1  5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4 \
-    mio                              0.8.5  e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de \
-    nix                             0.23.2  8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c \
-    ntapi                            0.4.0  bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc \
+    memoffset                        0.8.0  d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1 \
+    mio                              0.8.6  5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9 \
+    nix                             0.25.1  f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4 \
+    ntapi                            0.4.1  e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4 \
     num_cpus                        1.15.0  0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b \
-    once_cell                       1.17.0  6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66 \
-    os_pipe                          1.1.2  c6a252f1f8c11e84b3ab59d7a488e48e4478a93937e027076638c49536204639 \
+    once_cell                       1.17.1  b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3 \
+    os_pipe                          1.1.4  0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177 \
     parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
-    parking_lot_core                 0.9.6  ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf \
+    parking_lot_core                 0.9.7  9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521 \
     pin-project-lite                 0.2.9  e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116 \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
-    proc-macro-hack               0.5.20+deprecated  dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068 \
-    proc-macro2                     1.0.50  6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2 \
-    quote                           1.0.23  8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b \
-    rayon                            1.6.1  6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7 \
-    rayon-core                      1.10.2  356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b \
+    proc-macro2                     1.0.57  c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16 \
+    quote                           1.0.27  8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500 \
+    rayon                            1.7.0  1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b \
+    rayon-core                      1.11.0  4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d \
     redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
-    ryu                             1.0.12  7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde \
+    ryu                             1.0.13  f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041 \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
-    serde                          1.0.152  bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb \
-    serde_derive                   1.0.152  af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e \
-    serde_json                      1.0.91  877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883 \
+    serde                          1.0.163  2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2 \
+    serde_bytes                     0.11.9  416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294 \
+    serde_derive                   1.0.163  8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e \
+    serde_json                      1.0.96  057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1 \
     shared_child                     1.0.0  b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef \
-    signal-hook-registry             1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
-    slab                             0.4.7  4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef \
+    signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
+    slab                             0.4.8  6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d \
     smallvec                        1.10.0  a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0 \
-    socket2                          0.4.7  02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd \
+    socket2                          0.4.9  64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662 \
     strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
     structopt                       0.3.26  0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10 \
     structopt-derive                0.4.18  dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0 \
-    syn                            1.0.107  1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5 \
+    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+    syn                             2.0.16  a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01 \
     sysinfo                         0.26.9  5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5 \
     tabular                          0.2.0  d9a2882c514780a1973df90de9d68adcd8871bacc9a6331c3f28e6d2ff91a3d1 \
     textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
-    thiserror                       1.0.38  6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0 \
-    thiserror-impl                  1.0.38  1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f \
-    tiny-keccak                      2.0.2  2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237 \
-    tokio                           1.25.0  c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af \
-    tokio-macros                     1.8.2  d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8 \
+    thiserror                       1.0.40  978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac \
+    thiserror-impl                  1.0.40  f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f \
+    tokio                           1.28.1  0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105 \
+    tokio-macros                     2.1.0  630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e \
     tokio-util                      0.6.10  36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507 \
-    unicode-ident                    1.0.6  84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc \
-    unicode-segmentation            1.10.0  0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a \
+    tracing                         0.1.37  8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8 \
+    tracing-core                    0.1.31  0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a \
+    unicode-ident                    1.0.8  e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4 \
+    unicode-segmentation            1.10.1  1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36 \
     unicode-width                   0.1.10  c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b \
     vec_map                          0.8.2  f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191 \
     version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
-    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows-sys                     0.42.0  5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7 \
-    windows_aarch64_gnullvm         0.42.1  8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608 \
-    windows_aarch64_msvc            0.42.1  4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7 \
-    windows_i686_gnu                0.42.1  de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640 \
-    windows_i686_msvc               0.42.1  bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605 \
-    windows_x86_64_gnu              0.42.1  c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45 \
-    windows_x86_64_gnullvm          0.42.1  628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463 \
-    windows_x86_64_msvc             0.42.1  447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd
+    windows-sys                     0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-targets                 0.42.2  8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
+    windows-targets                 0.48.0  7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5 \
+    windows_aarch64_gnullvm         0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
+    windows_aarch64_gnullvm         0.48.0  91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc \
+    windows_aarch64_msvc            0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
+    windows_aarch64_msvc            0.48.0  b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3 \
+    windows_i686_gnu                0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
+    windows_i686_gnu                0.48.0  622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241 \
+    windows_i686_msvc               0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
+    windows_i686_msvc               0.48.0  4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00 \
+    windows_x86_64_gnu              0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
+    windows_x86_64_gnu              0.48.0  ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1 \
+    windows_x86_64_gnullvm          0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
+    windows_x86_64_gnullvm          0.48.0  7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953 \
+    windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
+    windows_x86_64_msvc             0.48.0  1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a
 
 cmake.generator     Ninja
 

--- a/sysutils/watchman/files/0004-cmake-rust-build-offline.patch
+++ b/sysutils/watchman/files/0004-cmake-rust-build-offline.patch
@@ -1,0 +1,26 @@
+--- ./build/fbcode_builder/CMake/RustStaticLibrary.cmake.orig	2023-05-16 04:58:25.000000000 -0400
++++ ./build/fbcode_builder/CMake/RustStaticLibrary.cmake	2023-05-16 04:59:14.000000000 -0400
+@@ -122,9 +122,9 @@
+   set(rust_staticlib "${CMAKE_CURRENT_BINARY_DIR}/${target_dir}/${staticlib_name}")
+ 
+   if(DEFINED ARG_FEATURES)
+-    set(cargo_flags build $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name} --features ${ARG_FEATURES})
++    set(cargo_flags build --offline $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name} --features ${ARG_FEATURES})
+   else()
+-    set(cargo_flags build $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name})
++    set(cargo_flags build --offline $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name})
+   endif()
+   if(USE_CARGO_VENDOR)
+     set(extra_cargo_env "CARGO_HOME=${RUST_CARGO_HOME}")
+@@ -193,9 +193,9 @@
+   endif()
+ 
+   if(DEFINED ARG_FEATURES)
+-    set(cargo_flags build $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name} --features ${ARG_FEATURES})
++    set(cargo_flags build --offline $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name} --features ${ARG_FEATURES})
+   else()
+-    set(cargo_flags build $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name})
++    set(cargo_flags build --offline $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name})
+   endif()
+   if(USE_CARGO_VENDOR)
+     set(extra_cargo_env "CARGO_HOME=${RUST_CARGO_HOME}")


### PR DESCRIPTION
Update `watchman` to 2023.05.15.00, as well other FB libraries, including:

- folly
- edencommon
- fizz
- folly
- wangle
- fbthrift
- fb303
- proxygen

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
