### PR TITLE
parallel-hashmap: new port in devel

### DIFF
--- a/devel/parallel-hashmap/Portfile
+++ b/devel/parallel-hashmap/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+
+github.setup            greg7mdp parallel-hashmap 1.3.11 v
+revision                0
+categories              devel
+license                 Apache-2
+maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
+description             A family of header-only, very fast and memory-friendly hashmap and btree containers
+long_description        {*}${description}
+homepage                https://greg7mdp.github.io/parallel-hashmap
+checksums               rmd160  1efbfaa5fb4c65c146de0c895b68c2bb0afc6967 \
+                        sha256  8d132cff02946f0a0b5a0cfb5716c61eac72645e637e663be891bef41a9c43fa \
+                        size    2048486
+installs_libs           no
+
+# https://github.com/greg7mdp/parallel-hashmap/issues/192
+# https://github.com/greg7mdp/parallel-hashmap/pull/193
+patchfiles-append       0001-Warn-on-4-byte-char-not-err-out.patch \
+                        0002-Unbreak-build-on-Apple-with-GCC-do-not-use-clangism.patch
+
+compiler.cxx_standard   2011
+
+configure.args-append   -DPHMAP_INSTALL=ON \
+                        -DPHMAP_BUILD_TESTS=ON \
+                        -DPHMAP_BUILD_EXAMPLES=OFF
+
+# https://github.com/greg7mdp/parallel-hashmap/issues/191
+configure.cxxflags-append \
+                         -I${worksrcpath}
+
+test.run                 yes

--- a/devel/parallel-hashmap/files/0001-Warn-on-4-byte-char-not-err-out.patch
+++ b/devel/parallel-hashmap/files/0001-Warn-on-4-byte-char-not-err-out.patch
@@ -1,0 +1,25 @@
+From 0e534ee7e0ea9aae89f015e3d86bb81b485ffb16 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 May 2023 20:03:36 +0800
+Subject: [PATCH 1/2] Warn on 4-byte char, not err out
+
+---
+ parallel_hashmap/phmap_config.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git parallel_hashmap/phmap_config.h parallel_hashmap/phmap_config.h
+index 744de18..0505e8d 100644
+--- parallel_hashmap/phmap_config.h
++++ parallel_hashmap/phmap_config.h
+@@ -100,7 +100,7 @@
+ #endif
+ 
+ #if CHAR_BIT != 8
+-    #error "phmap assumes CHAR_BIT == 8."
++    #warning "phmap assumes CHAR_BIT == 8."
+ #endif
+ 
+ // phmap currently assumes that an int is 4 bytes. 
+-- 
+2.40.0
+

--- a/devel/parallel-hashmap/files/0002-Unbreak-build-on-Apple-with-GCC-do-not-use-clangism.patch
+++ b/devel/parallel-hashmap/files/0002-Unbreak-build-on-Apple-with-GCC-do-not-use-clangism.patch
@@ -1,0 +1,26 @@
+From 47ee627eab1663a76ae4066b4f7df8fef6a16c9d Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 May 2023 20:04:53 +0800
+Subject: [PATCH 2/2] Unbreak build on Apple with GCC: do not use clangism
+
+Fixes: https://github.com/greg7mdp/parallel-hashmap/issues/192
+---
+ parallel_hashmap/phmap_config.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git parallel_hashmap/phmap_config.h parallel_hashmap/phmap_config.h
+index 0505e8d..06385f5 100644
+--- parallel_hashmap/phmap_config.h
++++ parallel_hashmap/phmap_config.h
+@@ -154,7 +154,7 @@
+ // -------------------------------------------------------------------
+ #ifdef PHMAP_HAVE_THREAD_LOCAL
+     #error PHMAP_HAVE_THREAD_LOCAL cannot be directly set
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && !defined(__GNUC__)
+     #if __has_feature(cxx_thread_local) && \
+         !(TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)
+         #define PHMAP_HAVE_THREAD_LOCAL 1
+-- 
+2.40.0
+


### PR DESCRIPTION
#### Description

New port: https://github.com/greg7mdp/parallel-hashmap

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

```
--->  Testing parallel-hashmap
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_parallel-hashmap/parallel-hashmap/work/build" && /usr/bin/make test 
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_parallel-hashmap/parallel-hashmap/work/build
      Start  1: test_compressed_tuple
 1/18 Test  #1: test_compressed_tuple ...............   Passed    0.08 sec
      Start  2: test_container_memory
 2/18 Test  #2: test_container_memory ...............   Passed    0.04 sec
      Start  3: test_hash_policy_testing
 3/18 Test  #3: test_hash_policy_testing ............   Passed    0.04 sec
      Start  4: test_node_hash_policy
 4/18 Test  #4: test_node_hash_policy ...............   Passed    0.04 sec
      Start  5: test_raw_hash_set
 5/18 Test  #5: test_raw_hash_set ...................   Passed    1.11 sec
      Start  6: test_raw_hash_set_allocator
 6/18 Test  #6: test_raw_hash_set_allocator .........   Passed    0.05 sec
      Start  7: test_flat_hash_set
 7/18 Test  #7: test_flat_hash_set ..................   Passed    0.14 sec
      Start  8: test_flat_hash_map
 8/18 Test  #8: test_flat_hash_map ..................   Passed    0.55 sec
      Start  9: test_node_hash_map
 9/18 Test  #9: test_node_hash_map ..................   Passed    0.14 sec
      Start 10: test_node_hash_set
10/18 Test #10: test_node_hash_set ..................   Passed    0.14 sec
      Start 11: test_parallel_flat_hash_map
11/18 Test #11: test_parallel_flat_hash_map .........   Passed    0.57 sec
      Start 12: test_parallel_flat_hash_set
12/18 Test #12: test_parallel_flat_hash_set .........   Passed    0.15 sec
      Start 13: test_parallel_node_hash_map
13/18 Test #13: test_parallel_node_hash_map .........   Passed    0.56 sec
      Start 14: test_parallel_node_hash_set
14/18 Test #14: test_parallel_node_hash_set .........   Passed    0.23 sec
      Start 15: test_parallel_flat_hash_map_mutex
15/18 Test #15: test_parallel_flat_hash_map_mutex ...   Passed    0.68 sec
      Start 16: test_dump_load
16/18 Test #16: test_dump_load ......................   Passed    0.04 sec
      Start 17: test_erase_if
17/18 Test #17: test_erase_if .......................   Passed    0.06 sec
      Start 18: test_btree
18/18 Test #18: test_btree ..........................   Passed   20.50 sec

100% tests passed, 0 tests failed out of 18

Total Test time (real) =  25.29 sec
```