### PR TITLE
google-cloud-sdk: update to 431.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             430.0.0
+version             431.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  42337bd78b58a6c1297f2d4ca0c18a9e9ba55a13 \
-                    sha256  fe930ced8f747f0081a5bc8d2299063d29988660d28ecc7ea1211f5bcae128d6 \
-                    size    104627845
+    checksums       rmd160  41c2c9e4c387c0673ba7878d2a3e4c88443c9865 \
+                    sha256  494ba4f304d41a2edb2adfa9e8e4e437003e1a469576930e4aac6f7e2dae6936 \
+                    size    104709537
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  15275ce5aef2ac48ddfc975270332fbeea81c4f3 \
-                    sha256  4ce63d6d18d87cd3055ccd85f2a6ea8897487fa212326fdec2d1b5d6b59ca92f \
-                    size    124905675
+    checksums       rmd160  76d819236a270497b64cc80bf04d8644fdee9d92 \
+                    sha256  e3c3a82638ae2d44969af19472f15163695a8fa35d6cc9199cc744ab72e8aa51 \
+                    size    124990246
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  fa8bfe8d0ce3b59195a37f1c0e80754cd92a0894 \
-                    sha256  03fa355695554e5178f59b218350c2bd22936ec8abba0b5d5a841a6fdd40956e \
-                    size    122026291
+    checksums       rmd160  069f688b4ffcd0d322aceb0355c06b31f685e955 \
+                    sha256  4a8374c069336db6e090304d047b42fee93482dcc05e0ce37c0965694af1f2de \
+                    size    122112119
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 431.0.0.

###### Tested on

macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?