### PR TITLE
pdfjam: update to 3.04

### DIFF
--- a/textproc/pdfjam/Portfile
+++ b/textproc/pdfjam/Portfile
@@ -1,30 +1,30 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               github 1.0
 
-name                    pdfjam
-version                 2.08
+github.setup            rrthomas pdfjam 3.04 v
 categories              textproc pdf
 maintainers             {gmail.com:jjstickel @jjstickel}
 license                 GPL-2
 platforms               any
-homepage                http://www2.warwick.ac.uk/fac/sci/statistics/staff/academic-research/firth/software/pdfjam
-master_sites            ${homepage}
-extract.suffix          .tgz
-distname                ${name}_[join [split ${version} .] {}]
-worksrcdir              ${name}
 supported_archs         noarch
 use_configure           no
 
-description             A few PDF manipulation tools.
+description             pdfjam is a shell-script front end to the LaTeX 'pdfpages' package
 
 long_description \
-    PDFjam is a small collection of shell scripts which provide a  \
-    simple interface to some of the functionality of the excellent \
-    pdfpages package (by Andreas Matthias) for pdfLaTeX.
+    The pdfjam package makes available the pdfjam shell script that provides a simple interface to much of the \
+    functionality of the excellent pdfpages package (by Andreas Matthias) for LaTeX. \
+    The pdfjam script takes one or more PDF files (and/or JPG/PNG graphics files) as input, \
+    and produces one or more PDF files as output. \
+    It is useful for joining files together, selecting pages, reducing several source pages onto one output page, etc.
 
-checksums               sha1    981b504ef96369a203f85fefb42d4ea0d1194493 \
-                        rmd160  98452c703d3d799e8562763d2d828aa64e63b893
+github.tarball_from     releases
+
+checksums               rmd160  c21641ccd20efbc8d360c6858c9e9ebeec8a8c5d \
+                        sha256  15f060e63b9d12e628ae1c5662b8a662158e2fc86f24b2ee5ecd2a13bb28955d \
+                        size    123125
 
 depends_run \
     bin:pdflatex:texlive-latex \
@@ -34,23 +34,17 @@ post-patch {
     reinplace "s|/usr/local|${prefix}|g" \
         ${worksrcpath}/bin/pdfjam \
         ${worksrcpath}/man1/pdfjam.1 \
-        ${worksrcpath}/PDFjam-README.html
+        ${worksrcpath}/README.md
 }
 
 build {}
 
 destroot {
-    delete ${destroot}${prefix}/bin ${destroot}${prefix}/share/man/man1
-    copy ${worksrcpath}/bin ${destroot}${prefix}/bin
-    copy ${worksrcpath}/man1 ${destroot}${prefix}/share/man/man1
-
+    xinstall -m 755 ${worksrcpath}/bin/pdfjam ${destroot}${prefix}/bin/pdfjam
+    xinstall -m 644 ${worksrcpath}/man1/pdfjam.1 ${destroot}${prefix}/share/man/man1/pdfjam.1
     xinstall -m 644 ${worksrcpath}/pdfjam.conf ${destroot}${prefix}/etc/pdfjam.conf.sample
 
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 -W ${worksrcpath} COPYING PDFjam-README.html VERSION \
+    xinstall -m 644 -W ${worksrcpath} COPYING README.md VERSION \
        ${destroot}${prefix}/share/doc/${name}
 }
-
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     "<strong>(\[0-9.\]+)</strong>:"


### PR DESCRIPTION
#### Description

* This MR updates `pdfjam` from version 2.x to 3.x.
* Note that the `pdfjam` wrapper scripts were [dropped in pdfjam 3.02](https://github.com/rrthomas/pdfjam#-wrapper-scripts-no-longer-included-here). If those are required by `texlive-bin-extra`, then a port for the unmaintained [pdfjam-extras](https://github.com/rrthomas/pdfjam-extras) may need to be created and added as a dependency to `texlive-bin-extra`.

Closes https://trac.macports.org/ticket/66411

###### Tested on

macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?