### PR TITLE
supertuxkart: fix build on 10.8-10.10

### DIFF
--- a/games/supertuxkart/Portfile
+++ b/games/supertuxkart/Portfile
@@ -77,9 +77,6 @@ if { ${os.platform} eq "darwin" && ${os.major} <= 10 } {
 }
 
 if { ${os.platform} eq "darwin" && ${os.major} <= 14 } {
-    # MoltenVK.mm:14:41: error: use of undeclared identifier 'NSAppKitVersionNumber10_10_Max'
-    configure.cppflags-append -DNSAppKitVersionNumber10_10_Max=1349
-
     # No Metal, https://trac.macports.org/ticket/67263
     patchfiles-append patch-supertuxkart-no-metal.diff
     configure.args-append -DDLOPEN_MOLTENVK=ON

--- a/games/supertuxkart/files/patch-supertuxkart-no-metal.diff
+++ b/games/supertuxkart/files/patch-supertuxkart-no-metal.diff
@@ -1,14 +1,21 @@
-Undefining __OBJC__ prevents Metal headers from being included.
-Supertuxkart will fall back to OpenGL at run-time.
+Patch to work on 10.10 and earlier (and only those systems).
+The undef prevents Metal from being imported; the defines fill in for
+NSApplication.h, which otherwise has a conflicting type with IOSurfaceRef.
+
+See: https://trac.macports.org/ticket/67263
 
 --- lib/irrlicht/source/Irrlicht/MoltenVK.mm.orig
 +++ lib/irrlicht/source/Irrlicht/MoltenVK.mm
-@@ -1,6 +1,8 @@
+@@ -1,9 +1,11 @@
  #include "MoltenVK.h"
  #include "SDL_vulkan.h"
 +#undef __OBJC__
  #include "vulkan_wrapper.h"
-+#define __OBJC__
  
  #include <dlfcn.h>
- #import <AppKit/NSApplication.h>
+-#import <AppKit/NSApplication.h>
++extern const double NSAppKitVersionNumber;
++#define NSAppKitVersionNumber10_10_Max 1349
+ 
+ #ifdef DLOPEN_MOLTENVK
+ PFN_vkGetMoltenVKConfigurationMVK vkGetMoltenVKConfigurationMVK = NULL;


### PR DESCRIPTION
#### Description

`supertuxkart` has build failures with 10.8-10.10, see e.g.

https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/225778

Attempt to work around the issue by not importing NSApplication.h.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
