### PR TITLE
openexr: fix defines in libdispatch-related patch

### DIFF
--- a/graphics/openexr/Portfile
+++ b/graphics/openexr/Portfile
@@ -6,7 +6,7 @@ PortGroup                       github 1.0
 PortGroup                       legacysupport 1.1
 
 github.setup                    AcademySoftwareFoundation openexr 3.1.7 v
-revision                        1
+revision                        2
 
 categories                      graphics
 license                         BSD

--- a/graphics/openexr/files/patch-darwin-no-libdispatch.diff
+++ b/graphics/openexr/files/patch-darwin-no-libdispatch.diff
@@ -14,7 +14,7 @@
  #   if ILMTHREAD_HAVE_POSIX_SEMAPHORES
  #      include <semaphore.h>
 -#   elif defined(__APPLE__)
-+#   elif defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
++#   elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
  #      include <dispatch/dispatch.h>
  #   elif (defined (_WIN32) || defined (_WIN64))
  #      ifdef NOMINMAX
@@ -23,7 +23,7 @@
  	mutable sem_t _semaphore;
  
 -#elif defined(__APPLE__)
-+#elif defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
++#elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
 +
  	mutable dispatch_semaphore_t _semaphore;
  
@@ -39,7 +39,7 @@
 +#    include <AvailabilityMacros.h>
 +
 +// No libdispatch prior to 10.6, and no support for it on any ppc.
-+#if __MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
  
  #include "IlmThreadSemaphore.h"
  #include "Iex.h"
@@ -66,7 +66,7 @@
 -#if ( !(ILMTHREAD_HAVE_POSIX_SEMAPHORES) && !defined (__APPLE__) && !defined (_WIN32) && !defined (_WIN64) )
 +#    if (!(ILMTHREAD_HAVE_POSIX_SEMAPHORES) && !defined(_WIN32) && !defined(_WIN64) && \
 +        (!defined(__APPLE__) || (defined(__APPLE__) && \
-+        (__MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || defined(__ppc__)))))
++        (MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || defined(__ppc__)))))
  
  #include "IlmThreadSemaphore.h"
  


### PR DESCRIPTION
See comments to: https://github.com/macports/macports-ports/commit/c1bcfa7090015e6f09e9714e862591c460ef6b39

#### Description

Turned out, old systems do not understand when those defines are prefixed with `__`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
