### PR TITLE
New openjdk versions

### DIFF
--- a/java/openjdk17-bootstrap/Portfile
+++ b/java/openjdk17-bootstrap/Portfile
@@ -10,26 +10,26 @@ platforms           darwin
 supported_archs     x86_64 arm64
 license             GPL-2+
 maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
-description         OpenJDK 17 Boot JDK
-long_description    OpenJDK 17 Boot JDK to bootstrap Openjdk17 port
-homepage            https://jdk.java.net/
+description         OpenJDK ${version} Boot JDK
+long_description    OpenJDK ${version} Boot JDK to bootstrap Openjdk${version} port
+homepage            https://openjdk.java.net/
 master_sites        https://download.java.net/java/GA/jdk${version}/0d483333a00540d886896bac774ff48b/${build}/GPL/
 
 if {${configure.build_arch} eq "x86_64"} {
     checksums           rmd160  22047e850be0cfafb6d16a9bf6d08914ca724c9a \
                         sha256  18e11cf9bbc6f584031e801b11ae05a233c32086f8e1b84eb8a1e9bb8e1f5d90 \
                         size    184007871
-    distname            openjdk-17_macos-x64_bin
+    distname            openjdk-${version}_macos-x64_bin
 } elseif {${configure.build_arch} eq "arm64"} {
     checksums           rmd160  fbcfd2cc8d00322902f7c8c257985e43130d097a \
                         sha256  b5bf6377aabdc935bd72b36c494e178b12186b0e1f4be50f35134daa33bda052 \
                         size    181735146
-    distname            openjdk-17_macos-aarch64_bin
+    distname            openjdk-${version}_macos-aarch64_bin
 }
 
 use_xcode           no
 use_configure    no
-worksrcdir          jdk-17.jdk
+worksrcdir          jdk-${version}.jdk
 
 build {}
 

--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 
 name                openjdk17
 # https://github.com/openjdk/jdk17u/tags
-version             17.0.7
-set build 7
-revision            1
+version             17.0.8
+set build 3
+revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -16,12 +16,12 @@ long_description    JDK 17 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk17u/archive/refs/tags
-distname            jdk-${version}-ga
+distname            jdk-${version}+${build}
 worksrcdir          jdk17u-[string map {+ -} ${distname}]
 
-checksums           rmd160  ffd3f5eeb5d45a6321b3ed61239e01ff5ae72a35 \
-                    sha256  8024cc0c1e516870b8407bce60c1e67e6572a736518baa3682178937af3fe5a7 \
-                    size    105568148
+checksums           rmd160  a842cc00e74064faf239d0df710b1ef0a0f2a1e2 \
+                    sha256  1547e64f8818de595b228f46454390669aa4bd2850ea53da27f0189ccbdf0e10 \
+                    size    105731315
 
 depends_lib         port:freetype
 depends_build       port:openjdk17-bootstrap \

--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -24,10 +24,10 @@ checksums           rmd160  ffd3f5eeb5d45a6321b3ed61239e01ff5ae72a35 \
                     size    105568148
 
 depends_lib         port:freetype
-depends_build       port:autoconf \
+depends_build       port:openjdk17-bootstrap \
+                    port:autoconf \
                     port:gmake \
-                    port:bash \
-                    port:openjdk17-bootstrap
+                    port:bash
 
 patchfiles          8305995-Footprint-regression-from-JDK-8224957.patch
 
@@ -54,8 +54,8 @@ configure.args      --with-debug-level=release \
                     --with-freetype=system \
                     --with-freetype-include=${prefix}/include/freetype2 \
                     --with-freetype-lib=${prefix}/lib \
-                    --disable-precompiled-headers \
                     --disable-warnings-as-errors \
+                    --disable-precompiled-headers \
                     --with-vendor-name="MacPorts" \
                     --with-vendor-url="https://www.macports.org" \
                     --with-vendor-bug-url="${bug_url}" \

--- a/java/openjdk18-bootstrap/Portfile
+++ b/java/openjdk18-bootstrap/Portfile
@@ -10,8 +10,8 @@ platforms           darwin
 supported_archs     x86_64 arm64
 license             GPL-2+
 maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
-description         OpenJDK 18 Boot JDK
-long_description    OpenJDK 18 Boot JDK to bootstrap Openjdk17 port
+description         OpenJDK ${version} Boot JDK
+long_description    OpenJDK ${version} Boot JDK to bootstrap Openjdk${version} port
 homepage            https://openjdk.java.net/
 master_sites        https://download.java.net/java/GA/jdk${version}/43f95e8614114aeaa8e8a5fcf20a682d/${build}/GPL/
 
@@ -19,17 +19,17 @@ if {${configure.build_arch} eq "x86_64"} {
     checksums           rmd160  7cfc98587bfc1d209cf58e973cf42b1af361d27b \
                         sha256  527b61b4265caf45cdcbacfcf8fbcd0b4b280bede1eff32a5b252d855ff0534b \
                         size    185375922
-    distname            openjdk-18_macos-x64_bin
+    distname            openjdk-${version}_macos-x64_bin
 } elseif {${configure.build_arch} eq "arm64"} {
     checksums           rmd160  8d36e7f1f202ac7e998ad837b41d98e2d4ed9a60 \
                         sha256  6880a5b512d1c1df5013a04b2cef4e1261e881d7f246ea5483ffeb728b30b2f1 \
                         size    183221810
-    distname            openjdk-18_macos-aarch64_bin
+    distname            openjdk-${version}_macos-aarch64_bin
 }
 
 use_xcode           no
 use_configure    no
-worksrcdir          jdk-18.jdk
+worksrcdir          jdk-${version}.jdk
 
 build {}
 

--- a/java/openjdk18/Portfile
+++ b/java/openjdk18/Portfile
@@ -40,7 +40,7 @@ use_configure    yes
 configure.cmd       ${prefix}/bin/bash configure
 configure.pre_args  --prefix=${tpath}
 set bug_url "https://trac.macports.org/newticket?port=${name}"
-# default configure args 
+# default configure args
 configure.args      --with-debug-level=release \
                     --with-native-debug-symbols=none \
                     --with-version-string=${version}+${build} \
@@ -54,8 +54,8 @@ configure.args      --with-debug-level=release \
                     --with-freetype-lib=${prefix}/lib \
                     --disable-warnings-as-errors \
                     --disable-precompiled-headers \
-                    --with-vendor-name="OpenJDK Porters Group" \
-                    --with-vendor-url="${homepage}" \
+                    --with-vendor-name="MacPorts" \
+                    --with-vendor-url="https://www.macports.org" \
                     --with-vendor-bug-url="${bug_url}" \
                     --with-vendor-vm-bug-url="${bug_url}" \
                     --with-conf-name=release

--- a/java/openjdk19-bootstrap/Portfile
+++ b/java/openjdk19-bootstrap/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                openjdk19-bootstrap
+version             19
+set build           36
+categories          java devel
+platforms           darwin
+supported_archs     x86_64 arm64
+license             GPL-2+
+maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
+description         OpenJDK ${version} Boot JDK
+long_description    OpenJDK ${version} Boot JDK to bootstrap Openjdk${version} port
+homepage            https://openjdk.java.net/
+master_sites        https://download.java.net/java/GA/jdk${version}/877d6127e982470ba2a7faa31cc93d04/${build}/GPL/
+
+if {${configure.build_arch} eq "x86_64"} {
+    checksums           rmd160  d69263ad5a95431ea6f44138e7c81f6367e3b597 \
+                        sha256  bfd33f5b2590fd552ae2d9231340c6b4704a872f927dce1c52860b78c49a5a11 \
+                        size    192323254
+    distname            openjdk-${version}_macos-x64_bin
+} elseif {${configure.build_arch} eq "arm64"} {
+    checksums           rmd160  ab7a706471109466c270a3b219f55736b6743970 \
+                        sha256  6691c199fdc6d71826f37d89d2e1a2089ba8bdd98b7001c1d4e8d5d01d6b022b \
+                        size    190416515
+    distname            openjdk-${version}_macos-aarch64_bin
+}
+
+use_xcode           no
+use_configure    no
+worksrcdir          jdk-${version}.jdk
+
+build {}
+
+set path /Library/Java/JavaVirtualMachines/${name}
+destroot {
+    xinstall -m 755 -d ${destroot}${path}
+    copy ${worksrcpath}/Contents ${destroot}${path}
+}
+destroot.violate_mtree      yes

--- a/java/openjdk19/Portfile
+++ b/java/openjdk19/Portfile
@@ -1,0 +1,156 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                openjdk19
+# https://github.com/openjdk/jdk19u/tags
+version             19
+set build 7
+revision            0
+categories          java devel
+supported_archs     x86_64 arm64
+license             GPL-2+
+maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
+description         OpenJDK 19
+long_description    JDK 19 builds of OpenJDK, the Open-Source implementation \
+                    of the Java Platform, Standard Edition, and related projects.
+homepage            https://openjdk.java.net/
+master_sites        https://git.openjdk.java.net/jdk19u/archive/refs/tags
+distname            jdk-${version}-ga
+worksrcdir          jdk19u-[string map {+ -} ${distname}]
+
+checksums           rmd160  7480f2e756c0fd13eab9ba710abd00d500c1ec5e \
+                    sha256  06985b43323bc6195f7f47d7b74bb9d90cb95f5361861b3a35e84066ae728c8a \
+                    size    108064378
+
+depends_lib         port:freetype
+depends_build       port:openjdk19-bootstrap \
+                    port:autoconf \
+                    port:gmake \
+                    port:bash
+
+pre-patch {
+    reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4
+    reinplace "s|xmacosx|xwindows|g" ${worksrcpath}/make/autoconf/lib-freetype.m4
+}
+
+patchfiles          763c080fa46b01ac07603792c1d52659e246dd13.patch \
+                    17e3412363bf5263c26d9bf1dfbef1fecc3d11a9.patch
+patch.pre_args      -p1
+
+set tpath /Library/Java
+use_xcode           yes
+use_configure    yes
+configure.cmd       ${prefix}/bin/bash configure
+configure.pre_args  --prefix=${tpath}
+set bug_url "https://trac.macports.org/newticket?port=${name}"
+# default configure args
+configure.args      --with-debug-level=release \
+                    --with-native-debug-symbols=none \
+                    --with-version-string=${version}+${build} \
+                    --with-sysroot=`xcrun --sdk macosx --show-sdk-path` \
+                    --with-extra-cflags="${configure.cflags}" \
+                    --with-extra-cxxflags="${configure.cxxflags}" \
+                    --with-extra-ldflags="${configure.ldflags}" \
+                    --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk19-bootstrap/Contents/Home \
+                    --with-freetype=system \
+                    --with-freetype-include=${prefix}/include/freetype2 \
+                    --with-freetype-lib=${prefix}/lib \
+                    --disable-warnings-as-errors \
+                    --disable-precompiled-headers \
+                    --with-vendor-name="MacPorts" \
+                    --with-vendor-url="https://www.macports.org" \
+                    --with-vendor-bug-url="${bug_url}" \
+                    --with-vendor-vm-bug-url="${bug_url}" \
+                    --with-conf-name=release
+
+
+variant release \
+    conflicts debug optimized \
+    description {OpenJDK with no debug information, all optimizations and no asserts} {
+    configure.args-append   --with-debug-level=release
+}
+
+variant optimized \
+    conflicts debug release \
+    description {OpenJDK with no debug information, all optimizations, no asserts and HotSpot is 'optimized'} {
+    configure.args-append   --with-debug-level=optimized
+}
+
+variant debug \
+    conflicts optimized release \
+    description {OpenJDK with debug information, all optimizations and all asserts} {
+    configure.args-append   --with-debug-level=fastdebug
+    configure.args-delete   --with-native-debug-symbols=none
+}
+
+variant client \
+    conflicts core minimal server zero \
+    description {JVM with normal interpreter, C1 and no C2 compiler} {
+    configure.args-append   --with-jvm-variants=client
+}
+
+variant server \
+    conflicts client core minimal zero \
+    description {JVM with normal interpreter, and a tiered C1/C2 compiler} {
+    configure.args-append   --with-jvm-variants=server
+}
+
+variant minimal \
+    conflicts client core server zero \
+    description {JVM with reduced form of normal interpreter having C1, no C2 compiler and optional features stripped out} {
+    configure.args-append   --with-jvm-variants=minimal
+}
+
+variant core \
+    conflicts client minimal server zero \
+    description {JVM with normal interpreter only and no compiler} {
+    configure.args-append   --with-jvm-variants=core
+}
+
+variant zero \
+    conflicts client core minimal server \
+    description {JVM with C++ based interpreter only, no compiler} {
+    configure.args-append   --with-jvm-variants=zero \
+                            --with-libffi=${prefix} \
+                            --enable-libffi-bundling
+    depends_lib-append         port:libffi
+}
+
+if {![variant_isset debug] && ![variant_isset optimized] && ![variant_isset release]} {
+    default_variants-append +release
+}
+
+if {![variant_isset client] && ![variant_isset core] && ![variant_isset minimal] && ![variant_isset server] && ![variant_isset zero]} {
+    default_variants-append +server
+}
+
+build.type          gnu
+build.target        images
+use_parallel_build  no
+set jdkn jdk-${version}.jdk
+set bundle_dir build/release/images/jdk-bundle/${jdkn}/Contents
+
+test.run            yes
+test.cmd            ${bundle_dir}/Home/bin/java
+test.target         --version
+
+set pathb ${tpath}/JavaVirtualMachines/${name}
+destroot {
+    xinstall -m 755 -d ${destroot}${pathb}
+    copy ${worksrcpath}/${bundle_dir} ${destroot}${pathb}
+}
+destroot.violate_mtree      yes
+
+post-destroot {
+    delete ${worksrcpath}
+}
+
+notes "
+If you want to make ${name} the default JDK, add this to shell profile:
+export JAVA_HOME=${pathb}/Contents/Home
+"
+    
+livecheck.type      regex
+livecheck.url       https://github.com/openjdk/jdk19u/tags
+livecheck.regex     jdk-(19\.\[0-9\.\]+)-ga

--- a/java/openjdk19/files/17e3412363bf5263c26d9bf1dfbef1fecc3d11a9.patch
+++ b/java/openjdk19/files/17e3412363bf5263c26d9bf1dfbef1fecc3d11a9.patch
@@ -1,0 +1,25 @@
+From 17e3412363bf5263c26d9bf1dfbef1fecc3d11a9 Mon Sep 17 00:00:00 2001
+From: Xue-Lei Andrew Fan <xuelei@openjdk.org>
+Date: Wed, 9 Nov 2022 17:36:12 +0000
+Subject: [PATCH] 8296615: use of undeclared identifier 'IPV6_DONTFRAG'
+
+Reviewed-by: michaelm
+---
+ src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c b/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
+index 296a4fd73072..762aa54cb058 100644
+--- a/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
++++ b/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
+@@ -38,6 +38,10 @@
+ #define IP_DONTFRAG             28
+ #endif
+ 
++#ifndef IPV6_DONTFRAG
++#define IPV6_DONTFRAG           62
++#endif
++
+ #include "jni_util.h"
+ 
+ /*

--- a/java/openjdk19/files/763c080fa46b01ac07603792c1d52659e246dd13.patch
+++ b/java/openjdk19/files/763c080fa46b01ac07603792c1d52659e246dd13.patch
@@ -1,0 +1,35 @@
+From 763c080fa46b01ac07603792c1d52659e246dd13 Mon Sep 17 00:00:00 2001
+From: Man Cao <manc@openjdk.org>
+Date: Fri, 7 Oct 2022 23:50:17 +0000
+Subject: [PATCH] 8290900: Build failure with Clang 14+ due to function warning
+ attribute
+
+Backport-of: 0599a05f8c7e26d4acae0b2cc805a65bdd6c6f67
+---
+ src/hotspot/share/utilities/compilerWarnings_gcc.hpp | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+index 83ec0e0f12f..8cf0ad571f0 100644
+--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
++++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+@@ -69,7 +69,10 @@
+ 
+ #endif // clang/gcc version check
+ 
+-#if (__GNUC__ >= 10) || (defined(__clang_major__) && (__clang_major__ >= 14))
++#if (__GNUC__ >= 10)
++// TODO: Re-enable warning attribute for Clang once
++// https://github.com/llvm/llvm-project/issues/56519 is fixed and released.
++// || (defined(__clang_major__) && (__clang_major__ >= 14))
+ 
+ // Use "warning" attribute to detect uses of "forbidden" functions.
+ //
+@@ -92,6 +95,6 @@
+   __VA_ARGS__                                           \
+   PRAGMA_DIAG_POP
+ 
+-#endif // gcc10+ or clang14+
++#endif // gcc10+
+ 
+ #endif // SHARE_UTILITIES_COMPILERWARNINGS_GCC_HPP

--- a/java/openjdk20-bootstrap/Portfile
+++ b/java/openjdk20-bootstrap/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                openjdk20-bootstrap
+version             20
+set build           36
+categories          java devel
+platforms           darwin
+supported_archs     x86_64 arm64
+license             GPL-2+
+maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
+description         OpenJDK ${version} Boot JDK
+long_description    OpenJDK ${version} Boot JDK to bootstrap Openjdk${version} port
+homepage            https://openjdk.java.net/
+master_sites        https://download.java.net/java/GA/jdk${version}/bdc68b4b9cbc4ebcb30745c85038d91d/${build}/GPL/
+
+if {${configure.build_arch} eq "x86_64"} {
+    checksums           rmd160  54d754bdb6ca6b152d6a1602ee3c1c55d6c939e2 \
+                        sha256  47cf960d9bb89dbe987535a389f7e26c42de7c984ef5108612d77c81aa8cc6a4 \
+                        size    194328775
+    distname            openjdk-${version}_macos-x64_bin
+} elseif {${configure.build_arch} eq "arm64"} {
+    checksums           rmd160  723284f11a4a4ae47fa207c6b5497f586eff5852 \
+                        sha256  d020f5c512c043cfb7119a591bc7e599a5bfd76d866d939f5562891d9db7c9b3 \
+                        size    191881541
+    distname            openjdk-${version}_macos-aarch64_bin
+}
+
+use_xcode           no
+use_configure    no
+worksrcdir          jdk-${version}.jdk
+
+build {}
+
+set path /Library/Java/JavaVirtualMachines/${name}
+destroot {
+    xinstall -m 755 -d ${destroot}${path}
+    copy ${worksrcpath}/Contents ${destroot}${path}
+}
+destroot.violate_mtree      yes
+    

--- a/java/openjdk20/Portfile
+++ b/java/openjdk20/Portfile
@@ -1,0 +1,152 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                openjdk20
+# https://github.com/openjdk/jdk20u/tags
+version             20.0.1
+set build 9
+revision            0
+categories          java devel
+supported_archs     x86_64 arm64
+license             GPL-2+
+maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
+description         OpenJDK 20
+long_description    JDK 20 builds of OpenJDK, the Open-Source implementation \
+                    of the Java Platform, Standard Edition, and related projects.
+homepage            https://openjdk.java.net/
+master_sites        https://git.openjdk.java.net/jdk20u/archive/refs/tags
+distname            jdk-${version}-ga
+worksrcdir          jdk20u-[string map {+ -} ${distname}]
+
+checksums           rmd160  dc2fb313f073b95429356eea469ef27ec47d99f2 \
+                    sha256  ced1915490f6831cd53bbf84281e8bd6b0c5e3fe6ab7c04e3428df1f32343a1e \
+                    size    109446355
+
+depends_lib         port:freetype
+depends_build       port:openjdk20-bootstrap \
+                    port:autoconf \
+                    port:gmake \
+                    port:bash
+
+pre-patch {
+    reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4
+    reinplace "s|xmacosx|xwindows|g" ${worksrcpath}/make/autoconf/lib-freetype.m4
+}
+
+set tpath /Library/Java
+use_xcode           yes
+use_configure    yes
+configure.cmd       ${prefix}/bin/bash configure
+configure.pre_args  --prefix=${tpath}
+set bug_url "https://trac.macports.org/newticket?port=${name}"
+# default configure args
+configure.args      --with-debug-level=release \
+                    --with-native-debug-symbols=none \
+                    --with-version-string=${version}+${build} \
+                    --with-sysroot=`xcrun --sdk macosx --show-sdk-path` \
+                    --with-extra-cflags="${configure.cflags}" \
+                    --with-extra-cxxflags="${configure.cxxflags}" \
+                    --with-extra-ldflags="${configure.ldflags}" \
+                    --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk20-bootstrap/Contents/Home \
+                    --with-freetype=system \
+                    --with-freetype-include=${prefix}/include/freetype2 \
+                    --with-freetype-lib=${prefix}/lib \
+                    --disable-warnings-as-errors \
+                    --disable-precompiled-headers \
+                    --with-vendor-name="MacPorts" \
+                    --with-vendor-url="https://www.macports.org" \
+                    --with-vendor-bug-url="${bug_url}" \
+                    --with-vendor-vm-bug-url="${bug_url}" \
+                    --with-conf-name=release
+
+
+variant release \
+    conflicts debug optimized \
+    description {OpenJDK with no debug information, all optimizations and no asserts} {
+    configure.args-append   --with-debug-level=release
+}
+
+variant optimized \
+    conflicts debug release \
+    description {OpenJDK with no debug information, all optimizations, no asserts and HotSpot is 'optimized'} {
+    configure.args-append   --with-debug-level=optimized
+}
+
+variant debug \
+    conflicts optimized release \
+    description {OpenJDK with debug information, all optimizations and all asserts} {
+    configure.args-append   --with-debug-level=fastdebug
+    configure.args-delete   --with-native-debug-symbols=none
+}
+
+variant client \
+    conflicts core minimal server zero \
+    description {JVM with normal interpreter, C1 and no C2 compiler} {
+    configure.args-append   --with-jvm-variants=client
+}
+
+variant server \
+    conflicts client core minimal zero \
+    description {JVM with normal interpreter, and a tiered C1/C2 compiler} {
+    configure.args-append   --with-jvm-variants=server
+}
+
+variant minimal \
+    conflicts client core server zero \
+    description {JVM with reduced form of normal interpreter having C1, no C2 compiler and optional features stripped out} {
+    configure.args-append   --with-jvm-variants=minimal
+}
+
+variant core \
+    conflicts client minimal server zero \
+    description {JVM with normal interpreter only and no compiler} {
+    configure.args-append   --with-jvm-variants=core
+}
+
+variant zero \
+    conflicts client core minimal server \
+    description {JVM with C++ based interpreter only, no compiler} {
+    configure.args-append   --with-jvm-variants=zero \
+                            --with-libffi=${prefix} \
+                            --enable-libffi-bundling
+    depends_lib-append         port:libffi
+}
+
+if {![variant_isset debug] && ![variant_isset optimized] && ![variant_isset release]} {
+    default_variants-append +release
+}
+
+if {![variant_isset client] && ![variant_isset core] && ![variant_isset minimal] && ![variant_isset server] && ![variant_isset zero]} {
+    default_variants-append +server
+}
+
+build.type          gnu
+build.target        images
+use_parallel_build  no
+set jdkn jdk-${version}.jdk
+set bundle_dir build/release/images/jdk-bundle/${jdkn}/Contents
+
+test.run            yes
+test.cmd            ${bundle_dir}/Home/bin/java
+test.target         --version
+
+set pathb ${tpath}/JavaVirtualMachines/${name}
+destroot {
+    xinstall -m 755 -d ${destroot}${pathb}
+    copy ${worksrcpath}/${bundle_dir} ${destroot}${pathb}
+}
+destroot.violate_mtree      yes
+
+post-destroot {
+    delete ${worksrcpath}
+}
+
+notes "
+If you want to make ${name} the default JDK, add this to shell profile:
+export JAVA_HOME=${pathb}/Contents/Home
+"
+    
+livecheck.type      regex
+livecheck.url       https://github.com/openjdk/jdk20u/tags
+livecheck.regex     jdk-(20\.\[0-9\.\]+)-ga


### PR DESCRIPTION
#### Description

Added some new openjdk versions, and cleaned up the older ones so it's easier to update them to newer versions. (openjdk19 has nitpick warnings, but these are intentional–it just happens to have a version number of just "19" at the moment.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4 22F5059b
Xcode 14.3 14E222b 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
