### PR TITLE
folly and friends: fix for pre-Big Sur systems

### DIFF
--- a/devel/edencommon/Portfile
+++ b/devel/edencommon/Portfile
@@ -11,8 +11,10 @@ PortGroup           legacysupport 1.1
 # O_CLOEXEC
 legacysupport.newest_darwin_requires_legacy 10
 
+boost.version       1.81
+
 github.setup        facebookexperimental edencommon 2023.05.15.00 v
-revision            0
+revision            1
 checksums           rmd160  2c47fb75bfdcf2d0e24c7fb1266882180f85913f \
                     sha256  faa599ef131aaa252971f971a7dc56db297ccb62c24c462e405e162b46c6c45e \
                     size    146561

--- a/devel/fb303/Portfile
+++ b/devel/fb303/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  b85ccd3043de74b3486e3c1d7c86f9834ec8db10 \
 categories          devel
 license             Apache-2
 
-maintainers         nomaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 
 description         fb303 is a base Thrift service and a common set of functionality for querying stats, options, and other information from a service.
 long_description    {*}${description}

--- a/devel/fb303/Portfile
+++ b/devel/fb303/Portfile
@@ -8,9 +8,11 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
+boost.version       1.81
+
 github.setup        facebook fb303 2023.05.15.00 v
 epoch               1
-revision            0
+revision            1
 checksums           rmd160  b85ccd3043de74b3486e3c1d7c86f9834ec8db10 \
                     sha256  8aba581414461149e5be21f2d7ee40f7e6c62922a23c73524bf2e7d677aac355 \
                     size    243377

--- a/devel/fbthrift/Portfile
+++ b/devel/fbthrift/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  d39ba8a3d574bccfa34541b3d46afd7e40a9bbb8 \
 categories          devel
 license             Apache-2
 
-maintainers         nomaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 
 description         Facebook's branch of Apache Thrift, including a new C++ server.
 long_description    {*}${description}

--- a/devel/fbthrift/Portfile
+++ b/devel/fbthrift/Portfile
@@ -40,6 +40,17 @@ depends_lib-append  port:fizz \
 
 patchfiles          patch-cpp2.diff
 
+# Keep until breaking changes in Folly are fixed:
+platform darwin {
+    if {${os.major} < 20} {
+        patchfiles-append \
+                    0001-Revert-Update-methods-to-dcheck-ToSend-Received-OrEm.patch \
+                    0002-Revert-Per-request-telemetry-5-x-Implement-writeStar.patch \
+                    0003-Revert-Extract-FDs-from-otherMetadata-when-pack-make.patch \
+                    0004-Revert-Use-AsyncFdSocket-when-accepting-Unix-socket-.patch
+    }
+}
+
 # Fix error: invalid output constraint '=@ccc' in asm
 compiler.blacklist-append \
                     {clang < 1200}

--- a/devel/fbthrift/Portfile
+++ b/devel/fbthrift/Portfile
@@ -8,8 +8,10 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
+boost.version       1.81
+
 github.setup        facebook fbthrift 2023.05.15.00 v
-revision            0
+revision            1
 checksums           rmd160  d39ba8a3d574bccfa34541b3d46afd7e40a9bbb8 \
                     sha256  c939d9e97b0cfde6e8f1ad35ae481300a542d7f7dcfe4461981efc39135dbfa5 \
                     size    13837302

--- a/devel/fbthrift/files/0001-Revert-Update-methods-to-dcheck-ToSend-Received-OrEm.patch
+++ b/devel/fbthrift/files/0001-Revert-Update-methods-to-dcheck-ToSend-Received-OrEm.patch
@@ -1,0 +1,27 @@
+From 54be3719e26d21758a4e2a2199f42124419c91f6 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 17 May 2023 16:16:44 +0800
+Subject: [PATCH 1/4] Revert "Update methods to
+ `dcheck{ToSend,Received}OrEmpty()`"
+
+This reverts commit df79893d4b66e97e9778df8aeea4f712e09a780f.
+---
+ thrift/lib/cpp2/transport/rocket/PayloadUtils.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git thrift/lib/cpp2/transport/rocket/PayloadUtils.h thrift/lib/cpp2/transport/rocket/PayloadUtils.h
+index 9cc7c21cd0..6751a2b351 100644
+--- thrift/lib/cpp2/transport/rocket/PayloadUtils.h
++++ thrift/lib/cpp2/transport/rocket/PayloadUtils.h
+@@ -187,7 +187,7 @@ rocket::Payload packWithFds(
+   auto ret = apache::thrift::rocket::detail::makePayload(
+       *metadata, std::move(serializedPayload));
+   if (numFds) {
+-    ret.fds = std::move(fds.dcheckToSendOrEmpty());
++    ret.fds = std::move(fds.dcheckToSend());
+   }
+   return ret;
+ }
+-- 
+2.40.1
+

--- a/devel/fbthrift/files/0002-Revert-Per-request-telemetry-5-x-Implement-writeStar.patch
+++ b/devel/fbthrift/files/0002-Revert-Per-request-telemetry-5-x-Implement-writeStar.patch
@@ -1,0 +1,360 @@
+From bbd9e317ffc9d990ea281aacac36cb495d5dcb66 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 17 May 2023 16:17:12 +0800
+Subject: [PATCH 2/4] Revert "Per-request telemetry (5/x): Implement
+ writeStarting() and add raw byte offset to write events"
+
+This reverts commit 8e2d236c882857c0e42bd2a403f7660bb3fcf349.
+---
+ .../rocket/server/RocketServerConnection.cpp  | 33 +++----
+ .../rocket/server/RocketServerConnection.h    |  5 +-
+ .../server/RocketServerConnectionObserver.h   | 12 +--
+ .../transport/rocket/test/network/Mocks.h     |  6 +-
+ .../rocket/test/network/RocketNetworkTest.cpp | 87 ++++++-------------
+ 5 files changed, 41 insertions(+), 102 deletions(-)
+
+diff --git thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.cpp thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.cpp
+index 438c25d3c5..966fbaa0ed 100644
+--- thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.cpp
++++ thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.cpp
+@@ -155,6 +155,16 @@ void RocketServerConnection::flushWrites(
+   DestructorGuard dg(this);
+   DVLOG(10) << fmt::format("write: {} B", writes->computeChainDataLength());
+ 
++  if (auto observerContainer = getObserverContainer();
++      observerContainer && observerContainer->numObservers()) {
++    for (const auto& writeEvent : context.writeEvents) {
++      observerContainer->invokeInterfaceMethodAllObservers(
++          [&](auto observer, auto observed) {
++            observer->writeReady(observed, writeEvent);
++          });
++    }
++  }
++
+   inflightWritesQueue_.push_back(std::move(context));
+   socket_->writeChain(this, std::move(writes));
+ }
+@@ -736,24 +746,6 @@ void RocketServerConnection::closeWhenIdle() {
+       "Closing due to imminent shutdown"));
+ }
+ 
+-void RocketServerConnection::writeStarting() noexcept {
+-  DestructorGuard dg(this);
+-  DCHECK(!inflightWritesQueue_.empty());
+-  auto& context = inflightWritesQueue_.front();
+-  DCHECK(!context.writeEventsContext.startRawByteOffset.has_value());
+-  context.writeEventsContext.startRawByteOffset = socket_->getRawBytesWritten();
+-
+-  if (auto observerContainer = getObserverContainer();
+-      observerContainer && observerContainer->numObservers()) {
+-    for (const auto& writeEvent : context.writeEvents) {
+-      observerContainer->invokeInterfaceMethodAllObservers(
+-          [&](auto observer, auto observed) {
+-            observer->writeStarting(observed, writeEvent);
+-          });
+-    }
+-  }
+-}
+-
+ void RocketServerConnection::writeSuccess() noexcept {
+   DestructorGuard dg(this);
+   DCHECK(!inflightWritesQueue_.empty());
+@@ -763,16 +755,13 @@ void RocketServerConnection::writeSuccess() noexcept {
+        --processingCompleteCount) {
+     frameHandler_->requestComplete();
+   }
+-  DCHECK(!context.writeEventsContext.endRawByteOffset.has_value());
+-  context.writeEventsContext.endRawByteOffset = socket_->getRawBytesWritten();
+ 
+   if (auto observerContainer = getObserverContainer();
+       observerContainer && observerContainer->numObservers()) {
+     for (const auto& writeEvent : context.writeEvents) {
+       observerContainer->invokeInterfaceMethodAllObservers(
+           [&](auto observer, auto observed) {
+-            observer->writeSuccess(
+-                observed, writeEvent, context.writeEventsContext);
++            observer->writeSuccess(observed, writeEvent);
+           });
+     }
+   }
+diff --git thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.h thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.h
+index 68e9240c98..7fc092bc48 100644
+--- thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.h
++++ thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.h
+@@ -118,7 +118,6 @@ class RocketServerConnection final
+   void close(folly::exception_wrapper ew);
+ 
+   // AsyncTransport::WriteCallback implementation
+-  void writeStarting() noexcept final;
+   void writeSuccess() noexcept final;
+   void writeErr(
+       size_t bytesWritten,
+@@ -299,7 +298,7 @@ class RocketServerConnection final
+    * @return             Attached observers of type T.
+    */
+   template <typename T = Observer>
+-  std::vector<T*> findObservers() const {
++  std::vector<T*> findObservers() {
+     if (auto list = getObserverContainer()) {
+       return list->findObservers<T>();
+     }
+@@ -353,8 +352,6 @@ class RocketServerConnection final
+     std::vector<apache::thrift::MessageChannel::SendCallbackPtr> sendCallbacks;
+     // the WriteEvent objects associated with each write in the batch
+     std::vector<RocketServerConnectionObserver::WriteEvent> writeEvents;
+-    // the raw byte offset at the beginning and end of the inflight write
+-    RocketServerConnectionObserver::WriteEventBatchContext writeEventsContext;
+   };
+   // The size of the queue is equal to the total number of inflight writes to
+   // the underlying transport, i.e., writes for which the
+diff --git thrift/lib/cpp2/transport/rocket/server/RocketServerConnectionObserver.h thrift/lib/cpp2/transport/rocket/server/RocketServerConnectionObserver.h
+index eee8bde872..19bd9aad13 100644
+--- thrift/lib/cpp2/transport/rocket/server/RocketServerConnectionObserver.h
++++ thrift/lib/cpp2/transport/rocket/server/RocketServerConnectionObserver.h
+@@ -31,13 +31,6 @@ class RocketServerConnectionObserver {
+     WriteEvents = 1,
+   };
+ 
+-  struct WriteEventBatchContext {
+-    // the raw byte offset at the beginning of the batch of writes
+-    folly::Optional<size_t> startRawByteOffset;
+-    // the raw byte offset at the end of the batch of writes
+-    folly::Optional<size_t> endRawByteOffset;
+-  };
+-
+   struct WriteEvent {
+     // the stream id of the write
+     const StreamId streamId;
+@@ -60,7 +53,7 @@ class RocketServerConnectionObserver {
+    * writeReady() is invoked when a new response is ready to be written to
+    * the underlying transport
+    */
+-  virtual void writeStarting(
++  virtual void writeReady(
+       RocketServerConnection* /* connection */,
+       const WriteEvent& /* writeEvent */) {}
+ 
+@@ -70,8 +63,7 @@ class RocketServerConnectionObserver {
+    */
+   virtual void writeSuccess(
+       RocketServerConnection* /* connection */,
+-      const WriteEvent& /* writeEvent */,
+-      const WriteEventBatchContext& /* writeEventBatchContext */) {}
++      const WriteEvent& /* writeEvent */) {}
+ };
+ 
+ } // namespace rocket
+diff --git thrift/lib/cpp2/transport/rocket/test/network/Mocks.h thrift/lib/cpp2/transport/rocket/test/network/Mocks.h
+index dd1d87f3f0..be0e999ef8 100644
+--- thrift/lib/cpp2/transport/rocket/test/network/Mocks.h
++++ thrift/lib/cpp2/transport/rocket/test/network/Mocks.h
+@@ -31,15 +31,13 @@ class MockRocketServerConnectionObserver
+   using RocketServerConnection::ManagedObserver::ManagedObserver;
+   MOCK_METHOD(
+       void,
+-      writeStarting,
++      writeReady,
+       (RocketServerConnection*, const WriteEvent&),
+       (override));
+   MOCK_METHOD(
+       void,
+       writeSuccess,
+-      (RocketServerConnection*,
+-       const WriteEvent&,
+-       const WriteEventBatchContext&),
++      (RocketServerConnection*, const WriteEvent&),
+       (override));
+ };
+ 
+diff --git thrift/lib/cpp2/transport/rocket/test/network/RocketNetworkTest.cpp thrift/lib/cpp2/transport/rocket/test/network/RocketNetworkTest.cpp
+index a220506a77..a405f09af8 100644
+--- thrift/lib/cpp2/transport/rocket/test/network/RocketNetworkTest.cpp
++++ thrift/lib/cpp2/transport/rocket/test/network/RocketNetworkTest.cpp
+@@ -1397,25 +1397,12 @@ TEST_F(RocketNetworkTest, ObserverIsNotInstalledWhenFlagIsFalse) {
+   });
+ }
+ 
+-MATCHER_P3(WriteStartingMatcher, id, bytes, offset, "") {
++MATCHER_P3(WriteEventMatcher, id, bytes, offset, "") {
+   return arg.streamId == StreamId(id) &&
+       arg.totalBytesInWrite == (size_t)bytes &&
+       arg.batchOffset == (size_t)offset;
+ }
+ 
+-MATCHER_P3(WriteSuccessMatcher, id, bytes, offset, "") {
+-  return arg.streamId == StreamId(id) &&
+-      arg.totalBytesInWrite == (size_t)bytes &&
+-      arg.batchOffset == (size_t)offset;
+-}
+-
+-MATCHER_P2(WriteEventContextMatcher, startRawOffset, endRawOffset, "") {
+-  return arg.startRawByteOffset.has_value() &&
+-      arg.startRawByteOffset.value() == startRawOffset &&
+-      arg.endRawByteOffset.has_value() &&
+-      arg.endRawByteOffset.value() == endRawOffset;
+-}
+-
+ TEST_F(RocketNetworkTest, ObserverIsNotifiedOnWriteSuccessRequestResponse) {
+   THRIFT_FLAG_SET_MOCK(enable_rocket_connection_observers, true);
+   this->withClient([&](RocketTestClient& client) {
+@@ -1443,21 +1430,19 @@ TEST_F(RocketNetworkTest, ObserverIsNotifiedOnWriteSuccessRequestResponse) {
+     constexpr size_t kSetupFrameSize(14);
+     constexpr size_t kSetupFrameStreamId(0);
+ 
+-    // send a request and check the event notifications when the
+-    // response is ready and written to the socket
++    // send a request and check the event notifications when the response is
++    // ready and written to the socket
+     {
+       constexpr folly::StringPiece kMetadata("metadata");
+       constexpr folly::StringPiece kData("data");
+-      const unsigned int startOffsetBatch1 = 0;
+-      const unsigned int endOffsetBatch1 = kSetupFrameSize + 24;
+ 
+-      // responses to setup frame (stream id = 0) and to the first
+-      // request (stream id = 1) are batched together
++      // responses to setup frame (stream id = 0) and to the first request
++      // (stream id = 1) are batched together
+       EXPECT_CALL(
+           *observer,
+-          writeStarting(
++          writeReady(
+               _,
+-              WriteStartingMatcher(
++              WriteEventMatcher(
+                   kSetupFrameStreamId /* streamId */,
+                   kSetupFrameSize /* totalBytesWritten */,
+                   0 /* batchOffset */)));
+@@ -1465,18 +1450,15 @@ TEST_F(RocketNetworkTest, ObserverIsNotifiedOnWriteSuccessRequestResponse) {
+           *observer,
+           writeSuccess(
+               _,
+-              WriteSuccessMatcher(
++              WriteEventMatcher(
+                   kSetupFrameStreamId /* streamId */,
+                   kSetupFrameSize /* totalBytesWritten */,
+-                  0 /* batchOffset */),
+-              WriteEventContextMatcher(
+-                  startOffsetBatch1 /* startRawByteOffset */,
+-                  endOffsetBatch1 /* endRawByteOffset */)));
++                  0 /* batchOffset */)));
+       EXPECT_CALL(
+           *observer,
+-          writeStarting(
++          writeReady(
+               _,
+-              WriteStartingMatcher(
++              WriteEventMatcher(
+                   kSetupFrameStreamId + 1 /* streamId */,
+                   24 /* totalBytesWritten */,
+                   kSetupFrameSize /* batchOffset */)));
+@@ -1484,13 +1466,10 @@ TEST_F(RocketNetworkTest, ObserverIsNotifiedOnWriteSuccessRequestResponse) {
+           *observer,
+           writeSuccess(
+               _,
+-              WriteSuccessMatcher(
++              WriteEventMatcher(
+                   kSetupFrameStreamId + 1 /* streamId */,
+                   24 /* totalBytesWritten */,
+-                  kSetupFrameSize /* batchOffset */),
+-              WriteEventContextMatcher(
+-                  startOffsetBatch1 /* startRawByteOffset */,
+-                  endOffsetBatch1 /* endRawByteOffset */)));
++                  kSetupFrameSize /* batchOffset */)));
+ 
+       client.sendRequestResponseSync(
+           Payload::makeFromMetadataAndData(kMetadata, kData),
+@@ -1503,16 +1482,11 @@ TEST_F(RocketNetworkTest, ObserverIsNotifiedOnWriteSuccessRequestResponse) {
+     {
+       constexpr folly::StringPiece kNewMetadata("new_metadata");
+       constexpr folly::StringPiece kNewData("new_data");
+-      const unsigned int startOffsetBatch2 =
+-          kSetupFrameSize + 24 /* 24 is the size of the first response */;
+-      const unsigned int endOffsetBatch2 =
+-          startOffsetBatch2 + 32 /* 32 is the size of the second response */;
+-
+       EXPECT_CALL(
+           *observer,
+-          writeStarting(
++          writeReady(
+               _,
+-              WriteStartingMatcher(
++              WriteEventMatcher(
+                   kSetupFrameStreamId + 3 /* streamId */,
+                   32 /* totalBytesWritten */,
+                   0 /* batchOffset */)));
+@@ -1520,13 +1494,10 @@ TEST_F(RocketNetworkTest, ObserverIsNotifiedOnWriteSuccessRequestResponse) {
+           *observer,
+           writeSuccess(
+               _,
+-              WriteSuccessMatcher(
++              WriteEventMatcher(
+                   kSetupFrameStreamId + 3 /* streamId */,
+                   32 /* totalBytesWritten */,
+-                  0 /* batchOffset */),
+-              WriteEventContextMatcher(
+-                  startOffsetBatch2 /* startRawByteOffset */,
+-                  endOffsetBatch2 /* endRawByteOffset */)));
++                  0 /* batchOffset */)));
+ 
+       client.sendRequestResponseSync(
+           Payload::makeFromMetadataAndData(kNewMetadata, kNewData),
+@@ -1575,14 +1546,12 @@ TEST_F(RocketNetworkTest, ObserverIsNotifiedOnWriteSuccessRequestStream) {
+     constexpr folly::StringPiece kMetadata("metadata");
+     const auto data =
+         folly::to<std::string>("generate:", kNumRequestedPayloads);
+-    const unsigned int startOffsetBatch = 0;
+-    const unsigned int endOffsetBatch = kSetupFrameSize + 16;
+ 
+     EXPECT_CALL(
+         *observer,
+-        writeStarting(
++        writeReady(
+             _,
+-            WriteStartingMatcher(
++            WriteEventMatcher(
+                 kSetupFrameStreamId /* streamId */,
+                 kSetupFrameSize /* totalBytesWritten */,
+                 0 /* batchOffset */)));
+@@ -1590,18 +1559,15 @@ TEST_F(RocketNetworkTest, ObserverIsNotifiedOnWriteSuccessRequestStream) {
+         *observer,
+         writeSuccess(
+             _,
+-            WriteSuccessMatcher(
++            WriteEventMatcher(
+                 kSetupFrameStreamId /* streamId */,
+                 kSetupFrameSize /* totalBytesWritten */,
+-                0 /* batchOffset */),
+-            WriteEventContextMatcher(
+-                startOffsetBatch /* startRawByteOffset */,
+-                endOffsetBatch /* endRawByteOffset */)));
++                0 /* batchOffset */)));
+     EXPECT_CALL(
+         *observer,
+-        writeStarting(
++        writeReady(
+             _,
+-            WriteStartingMatcher(
++            WriteEventMatcher(
+                 kSetupFrameStreamId + 1 /* streamId */,
+                 16 /* totalBytesWritten */,
+                 kSetupFrameSize /* batchOffset */)));
+@@ -1609,13 +1575,10 @@ TEST_F(RocketNetworkTest, ObserverIsNotifiedOnWriteSuccessRequestStream) {
+         *observer,
+         writeSuccess(
+             _,
+-            WriteSuccessMatcher(
++            WriteEventMatcher(
+                 kSetupFrameStreamId + 1 /* streamId */,
+                 16 /* totalBytesWritten */,
+-                kSetupFrameSize /* batchOffset */),
+-            WriteEventContextMatcher(
+-                startOffsetBatch /* startRawByteOffset */,
+-                endOffsetBatch /* endRawByteOffset */)));
++                kSetupFrameSize /* batchOffset */)));
+ 
+     auto stream = client.sendRequestStreamSync(
+         Payload::makeFromMetadataAndData(kMetadata, folly::StringPiece{data}));
+-- 
+2.40.1
+

--- a/devel/fbthrift/files/0003-Revert-Extract-FDs-from-otherMetadata-when-pack-make.patch
+++ b/devel/fbthrift/files/0003-Revert-Extract-FDs-from-otherMetadata-when-pack-make.patch
@@ -1,0 +1,476 @@
+From 1c313b21a94a7769a8e69daf0e22ca2c9fc8a74e Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 17 May 2023 16:17:34 +0800
+Subject: [PATCH 3/4] Revert "Extract FDs from `otherMetadata` when `pack`
+ makes the payload"
+
+This reverts commit 68198fbee27bb8404e961015e05830f20e0bdbba.
+---
+ thrift/lib/cpp2/CMakeLists.txt                |  1 -
+ thrift/lib/cpp2/async/RocketClientChannel.cpp | 13 ++---
+ thrift/lib/cpp2/async/StreamCallbacks.h       |  3 -
+ .../transport/rocket/FdSocketMetadata.cpp     | 51 -----------------
+ .../cpp2/transport/rocket/FdSocketMetadata.h  | 36 ------------
+ .../cpp2/transport/rocket/PayloadUtils.cpp    |  6 --
+ .../lib/cpp2/transport/rocket/PayloadUtils.h  | 39 ++-----------
+ thrift/lib/cpp2/transport/rocket/Types.h      |  3 -
+ .../rocket/server/RocketThriftRequests.cpp    |  2 +-
+ .../rocket/test/FdSocketMetadataTest.cpp      | 55 -------------------
+ .../thrift/util/ExceptionUtilTest.java        | 12 ++--
+ thrift/lib/thrift/RpcMetadata.thrift          |  3 -
+ 12 files changed, 17 insertions(+), 207 deletions(-)
+ delete mode 100644 thrift/lib/cpp2/transport/rocket/FdSocketMetadata.cpp
+ delete mode 100644 thrift/lib/cpp2/transport/rocket/FdSocketMetadata.h
+ delete mode 100644 thrift/lib/cpp2/transport/rocket/test/FdSocketMetadataTest.cpp
+
+diff --git thrift/lib/cpp2/CMakeLists.txt thrift/lib/cpp2/CMakeLists.txt
+index 9adf60ff54..5b15464285 100644
+--- thrift/lib/cpp2/CMakeLists.txt
++++ thrift/lib/cpp2/CMakeLists.txt
+@@ -274,7 +274,6 @@ add_library(
+   transport/core/ThriftClient.cpp
+   transport/core/ThriftClientCallback.cpp
+   transport/core/ThriftRequest.cpp
+-  transport/rocket/FdSocketMetadata.cpp
+   transport/rocket/PayloadUtils.cpp
+   transport/rocket/Types.cpp
+   transport/rocket/client/RequestContext.cpp
+diff --git thrift/lib/cpp2/async/RocketClientChannel.cpp thrift/lib/cpp2/async/RocketClientChannel.cpp
+index c22256efb8..71dfd6ab14 100644
+--- thrift/lib/cpp2/async/RocketClientChannel.cpp
++++ thrift/lib/cpp2/async/RocketClientChannel.cpp
+@@ -49,7 +49,6 @@
+ #include <thrift/lib/cpp2/transport/core/RpcMetadataUtil.h>
+ #include <thrift/lib/cpp2/transport/core/ThriftClientCallback.h>
+ #include <thrift/lib/cpp2/transport/core/TryUtil.h>
+-#include <thrift/lib/cpp2/transport/rocket/FdSocketMetadata.h>
+ #include <thrift/lib/cpp2/transport/rocket/PayloadUtils.h>
+ #include <thrift/lib/cpp2/transport/rocket/RocketException.h>
+ #include <thrift/lib/cpp2/transport/rocket/client/RocketClient.h>
+@@ -814,8 +813,7 @@ void RocketClientChannel::sendRequestStream(
+   auto buf = std::move(request.buffer);
+   setCompression(metadata, buf->computeChainDataLength());
+ 
+-  auto payload = rocket::packWithFds(
+-      &metadata, std::move(buf), rocket::releaseFdsFromMetadata(metadata));
++  auto payload = rocket::pack(metadata, std::move(buf));
+   assert(metadata.name_ref());
+   return rocket::RocketClient::sendRequestStream(
+       std::move(payload),
+@@ -856,8 +854,7 @@ void RocketClientChannel::sendRequestSink(
+   auto buf = std::move(request.buffer);
+   setCompression(metadata, buf->computeChainDataLength());
+ 
+-  auto payload = rocket::packWithFds(
+-      &metadata, std::move(buf), rocket::releaseFdsFromMetadata(metadata));
++  auto payload = rocket::pack(metadata, std::move(buf));
+   assert(metadata.name_ref());
+   return rocket::RocketClient::sendRequestSink(
+       std::move(payload),
+@@ -924,8 +921,7 @@ void RocketClientChannel::sendSingleRequestNoResponse(
+     RequestRpcMetadata&& metadata,
+     std::unique_ptr<folly::IOBuf> buf,
+     RequestClientCallback::Ptr cb) {
+-  auto requestPayload = rocket::packWithFds(
+-      &metadata, std::move(buf), rocket::releaseFdsFromMetadata(metadata));
++  auto requestPayload = rocket::pack(metadata, std::move(buf));
+   const bool isSync = cb->isSync();
+   SingleRequestNoResponseCallback callback(std::move(cb));
+ 
+@@ -945,8 +941,7 @@ void RocketClientChannel::sendSingleRequestSingleResponse(
+     std::unique_ptr<folly::IOBuf> buf,
+     RequestClientCallback::Ptr cb) {
+   const auto requestSerializedSize = buf->computeChainDataLength();
+-  auto requestPayload = rocket::packWithFds(
+-      &metadata, std::move(buf), rocket::releaseFdsFromMetadata(metadata));
++  auto requestPayload = rocket::pack(metadata, std::move(buf));
+   const auto requestWireSize = requestPayload.dataSize();
+   const auto requestMetadataAndPayloadSize =
+       requestPayload.metadataAndDataSize();
+diff --git thrift/lib/cpp2/async/StreamCallbacks.h thrift/lib/cpp2/async/StreamCallbacks.h
+index efc2c9349d..41a3d852c1 100644
+--- thrift/lib/cpp2/async/StreamCallbacks.h
++++ thrift/lib/cpp2/async/StreamCallbacks.h
+@@ -26,7 +26,6 @@
+ #include <folly/Utility.h>
+ #include <folly/io/IOBuf.h>
+ #include <folly/io/async/EventBase.h>
+-#include <folly/io/async/fdsock/SocketFds.h>
+ 
+ #include <thrift/lib/cpp/TApplicationException.h>
+ #include <thrift/lib/cpp/transport/THeader.h>
+@@ -42,7 +41,6 @@ struct FirstResponsePayload {
+ 
+   std::unique_ptr<folly::IOBuf> payload;
+   ResponseRpcMetadata metadata;
+-  folly::SocketFds fds;
+ };
+ 
+ struct StreamPayload {
+@@ -74,7 +72,6 @@ struct StreamPayload {
+   StreamPayloadMetadata metadata;
+   // OrderedHeader is sent as a PAYLOAD frame with an empty payload
+   bool isOrderedHeader;
+-  folly::SocketFds fds;
+ };
+ 
+ struct HeadersPayload {
+diff --git thrift/lib/cpp2/transport/rocket/FdSocketMetadata.cpp thrift/lib/cpp2/transport/rocket/FdSocketMetadata.cpp
+deleted file mode 100644
+index fb1540e4ab..0000000000
+--- thrift/lib/cpp2/transport/rocket/FdSocketMetadata.cpp
++++ /dev/null
+@@ -1,51 +0,0 @@
+-/*
+- * Copyright (c) Meta Platforms, Inc. and affiliates.
+- *
+- * Licensed under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License.
+- * You may obtain a copy of the License at
+- *
+- *     http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software
+- * distributed under the License is distributed on an "AS IS" BASIS,
+- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- * See the License for the specific language governing permissions and
+- * limitations under the License.
+- */
+-
+-#include <folly/Conv.h>
+-#include <folly/File.h>
+-#include <folly/String.h>
+-
+-#include "FdSocketMetadata.h"
+-
+-namespace apache {
+-namespace thrift {
+-namespace rocket {
+-
+-folly::SocketFds releaseFdsFromMetadata(RequestRpcMetadata& metadata) {
+-  if (!metadata.otherMetadata()) {
+-    return folly::SocketFds{};
+-  }
+-  auto& otherMetadata = *metadata.otherMetadata();
+-  auto it = otherMetadata.find("__UNSAFE_FDS_FOR_REQUEST__");
+-  if (it == otherMetadata.end()) {
+-    return folly::SocketFds{};
+-  }
+-
+-  folly::SocketFds::ToSend fds;
+-  std::vector<folly::StringPiece> fdStrVec;
+-  folly::split(",", it->second, fdStrVec);
+-  for (const auto& fdStr : fdStrVec) {
+-    fds.emplace_back(
+-        std::make_shared<folly::File>(folly::to<int>(fdStr), /*ownsFd*/ false));
+-  }
+-  otherMetadata.erase(it);
+-
+-  return fds.size() ? folly::SocketFds{std::move(fds)} : folly::SocketFds{};
+-}
+-
+-} // namespace rocket
+-} // namespace thrift
+-} // namespace apache
+diff --git thrift/lib/cpp2/transport/rocket/FdSocketMetadata.h thrift/lib/cpp2/transport/rocket/FdSocketMetadata.h
+deleted file mode 100644
+index 41137eb3f4..0000000000
+--- thrift/lib/cpp2/transport/rocket/FdSocketMetadata.h
++++ /dev/null
+@@ -1,36 +0,0 @@
+-/*
+- * Copyright (c) Meta Platforms, Inc. and affiliates.
+- *
+- * Licensed under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License.
+- * You may obtain a copy of the License at
+- *
+- *     http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software
+- * distributed under the License is distributed on an "AS IS" BASIS,
+- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- * See the License for the specific language governing permissions and
+- * limitations under the License.
+- */
+-
+-#pragma once
+-
+-#include <folly/io/async/fdsock/SocketFds.h>
+-#include <thrift/lib/cpp2/transport/rocket/Types.h>
+-#include <thrift/lib/thrift/gen-cpp2/RpcMetadata_types.h>
+-
+-namespace apache {
+-namespace thrift {
+-namespace rocket {
+-
+-// Remove the temporary proof-of-concept "plumbing key" from the headers.
+-// Instead, update the metadata with the number of FDs being sent.
+-//
+-// For the real deal, we will want to plumb through proper C++ objects
+-// representing FD ownership.
+-folly::SocketFds releaseFdsFromMetadata(RequestRpcMetadata&);
+-
+-} // namespace rocket
+-} // namespace thrift
+-} // namespace apache
+diff --git thrift/lib/cpp2/transport/rocket/PayloadUtils.cpp thrift/lib/cpp2/transport/rocket/PayloadUtils.cpp
+index 82a87adb1f..e172a0a1f4 100644
+--- thrift/lib/cpp2/transport/rocket/PayloadUtils.cpp
++++ thrift/lib/cpp2/transport/rocket/PayloadUtils.cpp
+@@ -24,12 +24,6 @@ namespace detail {
+ template <class Metadata>
+ Payload makePayload(
+     const Metadata& metadata, std::unique_ptr<folly::IOBuf> data) {
+-  DCHECK(
+-      !metadata.otherMetadata() ||
+-      !metadata.otherMetadata()->contains("__UNSAFE_FDS_FOR_REQUEST__"))
+-      << "Not implemented: attaching FDs via "
+-      << "otherMetadata[__UNSAFE_FDS_FOR_REQUEST__] on this code path";
+-
+   CompactProtocolWriter writer;
+   // Default is to leave some headroom for rsocket headers
+   size_t serSize = metadata.serializedSizeZC(&writer);
+diff --git thrift/lib/cpp2/transport/rocket/PayloadUtils.h thrift/lib/cpp2/transport/rocket/PayloadUtils.h
+index 6751a2b351..9aa0941e68 100644
+--- thrift/lib/cpp2/transport/rocket/PayloadUtils.h
++++ thrift/lib/cpp2/transport/rocket/PayloadUtils.h
+@@ -157,48 +157,21 @@ inline std::unique_ptr<folly::IOBuf> packCompact(
+   return std::move(data);
+ }
+ 
+-// NB: Populates `metadata.numFds` if `fds` is nonempty.
+ template <typename Payload, typename Metadata>
+-rocket::Payload packWithFds(
+-    Metadata* metadata, Payload&& payload, folly::SocketFds fds) {
++rocket::Payload pack(const Metadata& metadata, Payload&& payload) {
+   auto serializedPayload = packCompact(std::forward<Payload>(payload));
+-  if (auto compress = metadata->compression_ref()) {
++  if (auto compress = metadata.compression_ref()) {
+     apache::thrift::rocket::detail::compressPayload(
+         serializedPayload, *compress);
+   }
+-  auto numFds = fds.size();
+-  if (numFds) {
+-    // When received, the request will know to retrieve this many FDs.
+-    //
+-    // NB: The receiver could more confidently assert that the right FDs are
+-    // associated with the right request if we could:
+-    //  - Additionally store the "socket sequence number" of these FDs into
+-    //    the metadata here.
+-    //  - Have `AsyncFdSocket::writeIOBufsWithFds` check, via a token
+-    //    object, that the sequence number chosen at parse-time matches the
+-    //    actual write order).
+-    // Unfortunately, implementing this check would require adding
+-    // considerable plumbing to Rocket, so we skip it in favor of asserting
+-    // we got the right # of FDs, and documenting the correct FD+data
+-    // ordering invariant in the client & server code that interacts with
+-    // the socket.
+-    metadata->numFds() = numFds;
+-  }
+-  auto ret = apache::thrift::rocket::detail::makePayload(
+-      *metadata, std::move(serializedPayload));
+-  if (numFds) {
+-    ret.fds = std::move(fds.dcheckToSend());
+-  }
+-  return ret;
++  return apache::thrift::rocket::detail::makePayload(
++      metadata, std::move(serializedPayload));
+ }
+ 
+ template <class T>
+ rocket::Payload pack(T&& payload) {
+-  auto metadata = std::forward<T>(payload).metadata;
+-  return packWithFds(
+-      &metadata,
+-      std::forward<T>(payload).payload,
+-      std::forward<T>(payload).fds);
++  return pack(
++      std::forward<T>(payload).metadata, std::forward<T>(payload).payload);
+ }
+ } // namespace rocket
+ } // namespace thrift
+diff --git thrift/lib/cpp2/transport/rocket/Types.h thrift/lib/cpp2/transport/rocket/Types.h
+index 891dbe661a..650d3537a4 100644
+--- thrift/lib/cpp2/transport/rocket/Types.h
++++ thrift/lib/cpp2/transport/rocket/Types.h
+@@ -23,7 +23,6 @@
+ 
+ #include <folly/Range.h>
+ #include <folly/io/IOBuf.h>
+-#include <folly/io/async/fdsock/SocketFds.h>
+ 
+ namespace apache {
+ namespace thrift {
+@@ -142,8 +141,6 @@ class Payload {
+ 
+   bool hasData() const { return buffer_ != nullptr; }
+ 
+-  folly::SocketFds fds;
+-
+  private:
+   std::unique_ptr<folly::IOBuf> buffer_;
+   size_t metadataSize_{0};
+diff --git thrift/lib/cpp2/transport/rocket/server/RocketThriftRequests.cpp thrift/lib/cpp2/transport/rocket/server/RocketThriftRequests.cpp
+index 48502cf221..e99598ef77 100644
+--- thrift/lib/cpp2/transport/rocket/server/RocketThriftRequests.cpp
++++ thrift/lib/cpp2/transport/rocket/server/RocketThriftRequests.cpp
+@@ -470,7 +470,7 @@ void ThriftServerRequestResponse::sendThriftResponse(
+   }
+ 
+   context_.sendPayload(
+-      packWithFds(&metadata, std::move(data), folly::SocketFds{}),
++      pack(metadata, std::move(data)),
+       Flags().next(true).complete(true),
+       std::move(cb));
+ }
+diff --git thrift/lib/cpp2/transport/rocket/test/FdSocketMetadataTest.cpp thrift/lib/cpp2/transport/rocket/test/FdSocketMetadataTest.cpp
+deleted file mode 100644
+index 71fe08942d..0000000000
+--- thrift/lib/cpp2/transport/rocket/test/FdSocketMetadataTest.cpp
++++ /dev/null
+@@ -1,55 +0,0 @@
+-/*
+- * Copyright (c) Meta Platforms, Inc. and affiliates.
+- *
+- * Licensed under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License.
+- * You may obtain a copy of the License at
+- *
+- *     http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software
+- * distributed under the License is distributed on an "AS IS" BASIS,
+- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- * See the License for the specific language governing permissions and
+- * limitations under the License.
+- */
+-
+-#include <folly/portability/GTest.h>
+-
+-#include <thrift/lib/cpp2/transport/rocket/FdSocketMetadata.h>
+-
+-using namespace apache::thrift;
+-
+-TEST(FdSocketMetadata, ReleaseFdsFromMetadataEmpty) {
+-  RequestRpcMetadata emptyMeta;
+-  EXPECT_TRUE(rocket::releaseFdsFromMetadata(emptyMeta).empty());
+-  EXPECT_EQ(RequestRpcMetadata{}, emptyMeta); // no changes
+-
+-  RequestRpcMetadata noMagicKey;
+-  noMagicKey.otherMetadata() = {};
+-  EXPECT_TRUE(rocket::releaseFdsFromMetadata(noMagicKey).empty());
+-  RequestRpcMetadata alsoNoMagicKey;
+-  alsoNoMagicKey.otherMetadata() = {};
+-  EXPECT_EQ(alsoNoMagicKey, noMagicKey);
+-}
+-
+-TEST(FdSocketMetadata, ReleaseFdsFromMetadata) {
+-  RequestRpcMetadata meta;
+-  meta.otherMetadata() = {
+-      {"__UNSAFE_FDS_FOR_REQUEST__", "2,0,1"},
+-      {"OtherKeysAreNotDeleted", "whew"},
+-  };
+-  auto fds = rocket::releaseFdsFromMetadata(meta);
+-
+-  RequestRpcMetadata noMagicKey;
+-  noMagicKey.otherMetadata() = {{"OtherKeysAreNotDeleted", "whew"}};
+-  EXPECT_EQ(noMagicKey, meta);
+-
+-  EXPECT_EQ(3, fds.size());
+-  auto sendFds = fds.releaseToSend();
+-  EXPECT_TRUE(fds.empty());
+-  EXPECT_EQ(3, sendFds.size());
+-  EXPECT_EQ(2, sendFds[0]->fd());
+-  EXPECT_EQ(0, sendFds[1]->fd());
+-  EXPECT_EQ(1, sendFds[2]->fd());
+-}
+diff --git thrift/lib/java/runtime/src/test/java/com/facebook/thrift/util/ExceptionUtilTest.java thrift/lib/java/runtime/src/test/java/com/facebook/thrift/util/ExceptionUtilTest.java
+index aed59b46e0..fb2240ee43 100644
+--- thrift/lib/java/runtime/src/test/java/com/facebook/thrift/util/ExceptionUtilTest.java
++++ thrift/lib/java/runtime/src/test/java/com/facebook/thrift/util/ExceptionUtilTest.java
+@@ -75,7 +75,7 @@ public class ExceptionUtilTest {
+ 
+     ResponseRpcMetadata metadata =
+         new ResponseRpcMetadata(
+-            Collections.singletonMap("ex", "x"), 0L, 0, null, null, null, 0, null, null);
++            Collections.singletonMap("ex", "x"), 0L, 0, null, null, null, 0, null);
+ 
+     ClientResponsePayload responsePayload =
+         ClientResponsePayload.createException(myExp, metadata, null, false);
+@@ -90,7 +90,7 @@ public class ExceptionUtilTest {
+ 
+     ResponseRpcMetadata metadata =
+         new ResponseRpcMetadata(
+-            Collections.singletonMap("ex", "3"), 0L, 0, null, null, null, 0, null, null);
++            Collections.singletonMap("ex", "3"), 0L, 0, null, null, null, 0, null);
+ 
+     ClientResponsePayload responsePayload =
+         ClientResponsePayload.createException(myExp, metadata, null, false);
+@@ -106,7 +106,7 @@ public class ExceptionUtilTest {
+ 
+     ResponseRpcMetadata metadata =
+         new ResponseRpcMetadata(
+-            Collections.singletonMap("ex", "3"), 0L, 0, null, null, null, 0, null, null);
++            Collections.singletonMap("ex", "3"), 0L, 0, null, null, null, 0, null);
+ 
+     ClientResponsePayload responsePayload =
+         ClientResponsePayload.createException(myExp, metadata, null, false);
+@@ -121,7 +121,7 @@ public class ExceptionUtilTest {
+ 
+     ResponseRpcMetadata metadata =
+         new ResponseRpcMetadata(
+-            Collections.singletonMap("ex", "4"), 0L, 0, null, null, null, 0, null, null);
++            Collections.singletonMap("ex", "4"), 0L, 0, null, null, null, 0, null);
+ 
+     ClientResponsePayload responsePayload =
+         ClientResponsePayload.createException(myExp, metadata, null, false);
+@@ -135,7 +135,7 @@ public class ExceptionUtilTest {
+     MyException myExp = new MyException("my exception");
+ 
+     ResponseRpcMetadata metadata =
+-        new ResponseRpcMetadata(Collections.emptyMap(), 0L, 0, null, null, null, 0, null, null);
++        new ResponseRpcMetadata(Collections.emptyMap(), 0L, 0, null, null, null, 0, null);
+ 
+     ClientResponsePayload responsePayload =
+         ClientResponsePayload.createException(myExp, metadata, null, false);
+@@ -149,7 +149,7 @@ public class ExceptionUtilTest {
+ 
+     ResponseRpcMetadata metadata =
+         new ResponseRpcMetadata(
+-            Collections.singletonMap("ex", "5"), 0L, 0, null, null, null, 0, null, null);
++            Collections.singletonMap("ex", "5"), 0L, 0, null, null, null, 0, null);
+ 
+     ClientResponsePayload responsePayload =
+         ClientResponsePayload.createException(myExp, metadata, null, false);
+diff --git thrift/lib/thrift/RpcMetadata.thrift thrift/lib/thrift/RpcMetadata.thrift
+index 35f7a7f21f..d560de2eae 100644
+--- thrift/lib/thrift/RpcMetadata.thrift
++++ thrift/lib/thrift/RpcMetadata.thrift
+@@ -187,7 +187,6 @@ struct RequestRpcMetadata {
+   // Thrift is typically used within a larger framework.
+   // This field is for storing framework-specific metadata.
+   20: optional IOBufPtr frameworkMetadata;
+-  21: optional i32 numFds; // Linux currently limits this to SCM_MAX_FD.
+ }
+ 
+ struct ErrorClassification {
+@@ -285,7 +284,6 @@ struct ResponseRpcMetadata {
+   9: optional i32 streamId;
+   // Set on a sampled basis for tracking queueing times.
+   10: optional QueueMetadata queueMetadata;
+-  11: optional i32 numFds; // Linux currently limits this to SCM_MAX_FD.
+ }
+ 
+ enum ResponseRpcErrorCategory {
+@@ -386,7 +384,6 @@ struct StreamPayloadMetadata {
+   // Metadata describing the type of stream payload. MUST be set for protocol
+   // version 8+.
+   3: optional PayloadMetadata payloadMetadata;
+-  4: optional i32 numFds; // Linux currently limits this to SCM_MAX_FD.
+ }
+ 
+ // Setup metadata sent from the client to the server at the time
+-- 
+2.40.1
+

--- a/devel/fbthrift/files/0004-Revert-Use-AsyncFdSocket-when-accepting-Unix-socket-.patch
+++ b/devel/fbthrift/files/0004-Revert-Use-AsyncFdSocket-when-accepting-Unix-socket-.patch
@@ -1,0 +1,77 @@
+From 872d5c59ed7a55f4f19af7b1296f014206946616 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 17 May 2023 16:54:15 +0800
+Subject: [PATCH 4/4] Revert "Use `AsyncFdSocket` when accepting Unix socket
+ connections"
+
+This reverts commit 7631d8f859447ffc24bb9022a72f1419a4db66d3.
+---
+ thrift/lib/cpp2/server/Cpp2Worker.cpp | 18 ------------------
+ thrift/lib/cpp2/server/Cpp2Worker.h   |  5 -----
+ 2 files changed, 23 deletions(-)
+
+diff --git thrift/lib/cpp2/server/Cpp2Worker.cpp thrift/lib/cpp2/server/Cpp2Worker.cpp
+index 24662548a7..9225600db5 100644
+--- thrift/lib/cpp2/server/Cpp2Worker.cpp
++++ thrift/lib/cpp2/server/Cpp2Worker.cpp
+@@ -26,11 +26,9 @@
+ #include <folly/io/async/AsyncSSLSocket.h>
+ #include <folly/io/async/AsyncSocket.h>
+ #include <folly/io/async/EventBaseLocal.h>
+-#include <folly/io/async/fdsock/AsyncFdSocket.h>
+ #include <folly/portability/Sockets.h>
+ #include <thrift/lib/cpp/async/TAsyncSSLSocket.h>
+ #include <thrift/lib/cpp/concurrency/Util.h>
+-#include <thrift/lib/cpp2/Flags.h>
+ #include <thrift/lib/cpp2/async/ResponseChannel.h>
+ #include <thrift/lib/cpp2/security/extensions/ThriftParametersContext.h>
+ #include <thrift/lib/cpp2/server/Cpp2Connection.h>
+@@ -42,10 +40,6 @@
+ #include <wangle/acceptor/SSLAcceptorHandshakeHelper.h>
+ #include <wangle/acceptor/UnencryptedAcceptorHandshakeHelper.h>
+ 
+-// DANGER: If you disable this overly broadly, this can completely break
+-// workloads that rely on passing FDs over Unix sockets + Thrift.
+-THRIFT_FLAG_DEFINE_bool(enable_server_async_fd_socket, /* default = */ true);
+-
+ namespace apache {
+ namespace thrift {
+ 
+@@ -198,18 +192,6 @@ void Cpp2Worker::plaintextConnectionReady(
+       server_->getObserverShared());
+ }
+ 
+-folly::AsyncSocket::UniquePtr Cpp2Worker::makeNewAsyncSocket(
+-    folly::EventBase* base, int fd, const folly::SocketAddress* peerAddress) {
+-  if (THRIFT_FLAG(enable_server_async_fd_socket) &&
+-      peerAddress->getFamily() == AF_UNIX) {
+-    VLOG(4) << "Enabling AsyncFdSocket"; // peerAddress is always anonymous
+-    // Enable passing FDs over Unix sockets, see `man cmsg`.
+-    return folly::AsyncSocket::UniquePtr(new folly::AsyncFdSocket(
+-        base, folly::NetworkSocket::fromFd(fd), peerAddress));
+-  }
+-  return Acceptor::makeNewAsyncSocket(base, fd, peerAddress);
+-}
+-
+ void Cpp2Worker::useExistingChannel(
+     const std::shared_ptr<HeaderServerChannel>& serverChannel) {
+   folly::SocketAddress address;
+diff --git thrift/lib/cpp2/server/Cpp2Worker.h thrift/lib/cpp2/server/Cpp2Worker.h
+index 951a62019e..0275f7caed 100644
+--- thrift/lib/cpp2/server/Cpp2Worker.h
++++ thrift/lib/cpp2/server/Cpp2Worker.h
+@@ -390,11 +390,6 @@ class Cpp2Worker : public IOWorkerContext,
+   mutable folly::F14NodeMap<AsyncProcessorFactory*, PerServiceMetadata>
+       perServiceMetadata_;
+ 
+-  folly::AsyncSocket::UniquePtr makeNewAsyncSocket(
+-      folly::EventBase* base,
+-      int fd,
+-      const folly::SocketAddress* peerAddress) override;
+-
+   folly::AsyncSSLSocket::UniquePtr makeNewAsyncSSLSocket(
+       const std::shared_ptr<folly::SSLContext>& ctx,
+       folly::EventBase* base,
+-- 
+2.40.1
+

--- a/devel/fizz/Portfile
+++ b/devel/fizz/Portfile
@@ -11,8 +11,10 @@ PortGroup           legacysupport 1.1
 # O_CLOEXEC
 legacysupport.newest_darwin_requires_legacy 10
 
+boost.version       1.81
+
 github.setup        facebookincubator fizz 2023.05.15.00 v
-revision            0
+revision            1
 checksums           rmd160  52bc1b0451ff1c2e3da601b589a4629a27370f59 \
                     sha256  468eca89b75b632ae16f06d4f3e3fb50d8ca145cce64d6c48260997df7770114 \
                     size    654780

--- a/devel/fizz/Portfile
+++ b/devel/fizz/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  52bc1b0451ff1c2e3da601b589a4629a27370f59 \
 
 categories          devel
 license             BSD
-maintainers         nomaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 
 description         Fizz is a TLS 1.3 implementation
 long_description    {*}${description}

--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -71,6 +71,20 @@ cmake.generator     Ninja
 
 patchfiles-append   patch-older-systems.diff
 
+# This is a temporary revert of breaking commits until this can be properly fixed.
+# See: https://github.com/macports/macports-ports/commit/03289e4611ed4b387ce916214c7c6a6a105e25e0
+platform darwin {
+    if {${os.major} < 20} {
+        patchfiles-append \
+                    0001-Revert-Update-methods-to-dcheck-ToSend-Received-OrEm.patch \
+                    0002-Revert-Add-popNextReceivedFds-using-ReadAncillaryDat.patch \
+                    0003-Revert-Change-cloneToSendFrom-to-DFATAL-instead-of-C.patch \
+                    0004-Revert-Add-const-to-help-with-thread-safety.patch \
+                    0005-Revert-Unit-tests.patch \
+                    0006-Revert-writeChainWithFds-using-SendMsgParamsCallback.patch
+    }
+}
+
 configure.args-append   -DBUILD_SHARED_LIBS=ON \
                         -DFOLLY_USE_JEMALLOC=0
 

--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -10,6 +10,8 @@ PortGroup           legacysupport 1.1
 
 legacysupport.newest_darwin_requires_legacy 19
 
+boost.version       1.81
+
 if {[string match *clang* ${configure.compiler}]} {
     # Don't use libcxx with gcc.
     legacysupport.use_mp_libcxx yes
@@ -19,7 +21,7 @@ if {[string match *clang* ${configure.compiler}]} {
 # upgrade without also upgrading its dependents, as listed by:
 # port list rdepends:folly
 github.setup        facebook folly 2023.05.15.00 v
-revision            0
+revision            1
 checksums           rmd160  562d4877fba3842d2f0fd2733c4e1e0ad2c56773 \
                     sha256  fffd8a800f0840875b11d867225499d8ddff5917e7280a787a9d298e42acb1ba \
                     size    3832144

--- a/devel/folly/files/0001-Revert-Update-methods-to-dcheck-ToSend-Received-OrEm.patch
+++ b/devel/folly/files/0001-Revert-Update-methods-to-dcheck-ToSend-Received-OrEm.patch
@@ -1,0 +1,35 @@
+From 746e0e38b8853f55c4b4310afb517faa1899b623 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 17 May 2023 14:37:00 +0800
+Subject: [PATCH 1/6] Revert "Update methods to
+ `dcheck{ToSend,Received}OrEmpty()`"
+
+This reverts commit ace41c041175402779b1c05981b5dd7a48a4ee46.
+---
+ folly/io/async/fdsock/SocketFds.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git folly/io/async/fdsock/SocketFds.h folly/io/async/fdsock/SocketFds.h
+index 965bdb5ac..620a5dd0a 100644
+--- folly/io/async/fdsock/SocketFds.h
++++ folly/io/async/fdsock/SocketFds.h
+@@ -83,12 +83,12 @@ class SocketFds final {
+     DCHECK(!ptr_);
+     return *this;
+   }
+-  SocketFds& dcheckReceivedOrEmpty() {
+-    DCHECK(!ptr_ || std::holds_alternative<Received>(*ptr_));
++  SocketFds& dcheckReceived() {
++    DCHECK(std::holds_alternative<Received>(*ptr_));
+     return *this;
+   }
+-  SocketFds& dcheckToSendOrEmpty() {
+-    DCHECK(!ptr_ || std::holds_alternative<ToSend>(*ptr_));
++  SocketFds& dcheckToSend() {
++    DCHECK(std::holds_alternative<ToSend>(*ptr_));
+     return *this;
+   }
+ 
+-- 
+2.40.1
+

--- a/devel/folly/files/0002-Revert-Add-popNextReceivedFds-using-ReadAncillaryDat.patch
+++ b/devel/folly/files/0002-Revert-Add-popNextReceivedFds-using-ReadAncillaryDat.patch
@@ -1,0 +1,282 @@
+From d7a0a0e96bcbdfad5819fd12eff9307f40ddd298 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 17 May 2023 14:38:31 +0800
+Subject: [PATCH 2/6] Revert "Add `popNextReceivedFds` using
+ `ReadAncillaryDataCallback`"
+
+This reverts commit 185e3b2b18fca08f4ce7f58bd2cc50e53c1a3a3d.
+---
+ folly/io/async/AsyncSocket.cpp          |   7 +-
+ folly/io/async/fdsock/AsyncFdSocket.cpp | 114 +-----------------------
+ folly/io/async/fdsock/AsyncFdSocket.h   |  54 +----------
+ 3 files changed, 6 insertions(+), 169 deletions(-)
+
+diff --git folly/io/async/AsyncSocket.cpp folly/io/async/AsyncSocket.cpp
+index 696b18729..8339b586b 100644
+--- folly/io/async/AsyncSocket.cpp
++++ folly/io/async/AsyncSocket.cpp
+@@ -2513,22 +2513,17 @@ AsyncSocket::ReadResult AsyncSocket::performReadMsg(
+     bytes = netops_->recv(
+         fd_, msg.msg_iov[0].iov_base, msg.msg_iov[0].iov_len, MSG_DONTWAIT);
+   } else {
+-    int recvFlags = 0;
+     if (readAncillaryDataCallback_) {
+       auto buf = readAncillaryDataCallback_->getAncillaryDataCtrlBuffer();
+       msg.msg_control = buf.data();
+       msg.msg_controllen = buf.size();
+-#if defined(__linux__)
+-      // On BSD / MacOS, `AsyncFdSocket` has to do 2 extra `fcntl`s per FD.
+-      recvFlags |= MSG_CMSG_CLOEXEC;
+-#endif
+     } else {
+       msg.msg_control = nullptr;
+       msg.msg_controllen = 0;
+     }
+ 
+     // `msg.msg_iov*` were set by the caller, we're ready.
+-    bytes = netops::recvmsg(fd_, &msg, recvFlags);
++    bytes = netops::recvmsg(fd_, &msg, 0);
+ 
+     // KEY INVARIANT: If `bytes > 0`, we must proceed to `ancillaryData` --
+     // no error branches must interrupt this flow.  The reason is that
+diff --git folly/io/async/fdsock/AsyncFdSocket.cpp folly/io/async/fdsock/AsyncFdSocket.cpp
+index 24ce50111..d8cadc038 100644
+--- folly/io/async/fdsock/AsyncFdSocket.cpp
++++ folly/io/async/fdsock/AsyncFdSocket.cpp
+@@ -22,8 +22,7 @@ AsyncFdSocket::AsyncFdSocket(EventBase* evb)
+     : AsyncSocket(evb)
+ #if !defined(_WIN32)
+       ,
+-      sendMsgCob_(evb),
+-      readAncillaryDataCob_(this) {
++      sendMsgCob_(evb) {
+   setUpCallbacks();
+ }
+ #else
+@@ -44,8 +43,7 @@ AsyncFdSocket::AsyncFdSocket(
+     : AsyncSocket(evb, fd, /* zeroCopyBufId */ 0, peerAddress)
+ #if !defined(_WIN32)
+       ,
+-      sendMsgCob_(evb),
+-      readAncillaryDataCob_(this) {
++      sendMsgCob_(evb) {
+   setUpCallbacks();
+ }
+ #else
+@@ -99,7 +97,6 @@ void AsyncFdSocket::writeChainWithFds(
+ 
+ void AsyncFdSocket::setUpCallbacks() noexcept {
+   AsyncSocket::setSendMsgParamCB(&sendMsgCob_);
+-  AsyncSocket::setReadAncillaryDataCB(&readAncillaryDataCob_);
+ }
+ 
+ void AsyncFdSocket::releaseIOBuf(
+@@ -202,113 +199,6 @@ void AsyncFdSocket::FdSendMsgParamsCallback::destroyFdsForWriteTag(
+           << nh.mapped().size() << " FDs for tag " << writeTag;
+ }
+ 
+-namespace {
+-
+-// Logs and returns `false` on error.
+-bool receiveFdsFromCMSG(
+-    const struct ::cmsghdr& cmsg, std::vector<folly::File>* fds) noexcept {
+-  if (cmsg.cmsg_len < CMSG_LEN(sizeof(int))) {
+-    LOG(ERROR) << "Got truncated SCM_RIGHTS message: length=" << cmsg.cmsg_len;
+-    return false;
+-  }
+-  const size_t dataLength = cmsg.cmsg_len - CMSG_LEN(0);
+-
+-  const size_t numFDs = dataLength / sizeof(int);
+-  if ((dataLength % sizeof(int)) != 0) {
+-    LOG(ERROR) << "Non-integer number of file descriptors: size=" << dataLength;
+-    return false;
+-  }
+-
+-  const auto* data = reinterpret_cast<const int*>(CMSG_DATA(&cmsg));
+-  for (size_t n = 0; n < numFDs; ++n) {
+-    auto fd = data[n];
+-
+-// On Linux, `AsyncSocket` sets `MSG_CMSG_CLOEXEC` for us.
+-#if !defined(__linux__)
+-    int flags = ::fcntl(fd, F_GETFD);
+-    // On error, "fail open" by leaving the FD unmodified.
+-    if (UNLIKELY(flags == -1)) {
+-      PLOG(ERROR) << "FdReadAncillaryDataCallback F_GETFD";
+-    } else if (UNLIKELY(-1 == ::fcntl(fd, F_SETFD, flags | FD_CLOEXEC))) {
+-      PLOG(ERROR) << "FdReadAncillaryDataCallback F_SETFD";
+-    }
+-#endif // !Linux
+-
+-    fds->emplace_back(fd, /*owns_fd*/ true);
+-  }
+-
+-  return true;
+-}
+-
+-// Logs and returns `false` on error.
+-bool receiveFds(struct ::msghdr& msg, std::vector<folly::File>* fds) noexcept {
+-  struct ::cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+-  while (cmsg) {
+-    if (cmsg->cmsg_level != SOL_SOCKET) {
+-      LOG(ERROR) << "Unexpected cmsg_level=" << cmsg->cmsg_level;
+-      return false;
+-    } else if (cmsg->cmsg_type != SCM_RIGHTS) {
+-      LOG(ERROR) << "Unexpected cmsg_type=" << cmsg->cmsg_type;
+-      return false;
+-    } else {
+-      if (!receiveFdsFromCMSG(*cmsg, fds)) {
+-        return false;
+-      }
+-    }
+-    cmsg = CMSG_NXTHDR(&msg, cmsg);
+-  }
+-  return true;
+-}
+-
+-} // namespace
+-
+-void AsyncFdSocket::enqueueFdsFromAncillaryData(struct ::msghdr& msg) noexcept {
+-  eventBase_->dcheckIsInEventBaseThread();
+-
+-  if (msg.msg_flags & MSG_CTRUNC) {
+-    AsyncSocketException ex(
+-        AsyncSocketException::INTERNAL_ERROR,
+-        "Got MSG_CTRUNC because the `AsyncFdSocket` buffer was too small");
+-    AsyncSocket::failRead(__func__, ex);
+-    return;
+-  }
+-
+-  std::vector<folly::File> fds;
+-  if (!receiveFds(msg, &fds)) {
+-    AsyncSocketException ex(
+-        AsyncSocketException::INTERNAL_ERROR,
+-        "Failed to read FDs from msghdr.msg_control");
+-    AsyncSocket::failRead(__func__, ex);
+-    return;
+-  }
+-
+-  // Don't waste queue space with empty FD lists since we match FDs only to
+-  // requests that claim to include FDs.
+-  if (fds.empty()) {
+-    return;
+-  }
+-
+-  VLOG(4) << "this=" << this << ", enqueueFdsFromAncillaryData() got "
+-          << fds.size() << " FDs, prev queue size " << fdsQueue_.size();
+-  fdsQueue_.emplace(std::move(fds));
+-}
+-
+ #endif // !Windows
+ 
+-std::optional<SocketFds::Received> AsyncFdSocket::popNextReceivedFds() {
+-#if defined(_WIN32)
+-  return std::nullopt;
+-#else
+-  eventBase_->dcheckIsInEventBaseThread();
+-
+-  DCHECK_EQ(&readAncillaryDataCob_, getReadAncillaryDataCallback());
+-  if (fdsQueue_.empty()) {
+-    return std::nullopt;
+-  }
+-  auto fds = std::move(fdsQueue_.front());
+-  fdsQueue_.pop();
+-  return fds;
+-#endif // !Windows
+-}
+-
+ } // namespace folly
+diff --git folly/io/async/fdsock/AsyncFdSocket.h folly/io/async/fdsock/AsyncFdSocket.h
+index 65e43dcff..d72d086ac 100644
+--- folly/io/async/fdsock/AsyncFdSocket.h
++++ folly/io/async/fdsock/AsyncFdSocket.h
+@@ -16,8 +16,6 @@
+ 
+ #pragma once
+ 
+-#include <optional>
+-
+ #include <folly/io/async/AsyncSocket.h>
+ #include <folly/io/async/fdsock/SocketFds.h>
+ 
+@@ -27,9 +25,9 @@ namespace folly {
+  * Intended for use with Unix sockets. Unlike regular `AsyncSocket`:
+  *  - Can send FDs via `writeChainWithFds` using socket ancillary data (see
+  *    `man cmsg`).
+- *  - Whenever handling regular reads, concurrently attempts to receive FDs
+- *    included in incoming ancillary data.  Groups of received FDs are
+- *    enqueued to be retrieved via `popNextReceivedFds`.
++ *  - Always attempts to receive FDs included in incoming ancillary data.
++ *    Groups of received FDs are enqueued to be retrieved via
++ *    `popNextReceivedFds`.
+  *  - The "read ancillary data" and "sendmsg params" callbacks are built-in
+  *    are NOT customizable.
+  *
+@@ -95,24 +93,9 @@ class AsyncFdSocket : public AsyncSocket {
+       SocketFds::ToSend,
+       WriteFlags flags = WriteFlags::NONE);
+ 
+-  /**
+-   * This socket will look for file descriptors in the ancillary data (`man
+-   * cmsg`) of each incoming read.
+-   *   - FDs are kept in an internal queue, to be retrieved via this call.
+-   *   - FDs are marked with FD_CLOEXEC upon receipt, although on non-Linux
+-   *     platforms there is a short race window before this happens.
+-   *   - Empty lists of FDs (0 FDs with this message) are not stored in the
+-   *     queue.
+-   *   - Returns `std::nullopt` if the queue is empty.
+-   */
+-  std::optional<SocketFds::Received> popNextReceivedFds();
+-
+   void setSendMsgParamCB(SendMsgParamsCallback*) override {
+     LOG(DFATAL) << "AsyncFdSocket::setSendMsgParamCB is forbidden";
+   }
+-  void setReadAncillaryDataCB(ReadAncillaryDataCallback*) override {
+-    LOG(DFATAL) << "AsyncFdSocket::setReadAncillaryDataCB is forbidden";
+-  }
+ 
+ // This uses no ancillary data callbacks on Windows, they wouldn't compile.
+ #if !defined(_WIN32)
+@@ -166,40 +149,9 @@ class AsyncFdSocket : public AsyncSocket {
+     WriteTagToFds writeTagToFds_;
+   };
+ 
+-  class FdReadAncillaryDataCallback : public ReadAncillaryDataCallback {
+-   public:
+-    explicit FdReadAncillaryDataCallback(AsyncFdSocket* socket)
+-        : socket_(socket) {}
+-
+-    void ancillaryData(struct ::msghdr& msg) noexcept override {
+-      socket_->enqueueFdsFromAncillaryData(msg);
+-    }
+-
+-    folly::MutableByteRange getAncillaryDataCtrlBuffer() noexcept override {
+-      // Not checking thread because `ancillaryData()` will follow.
+-      return folly::MutableByteRange(ancillaryDataCtrlBuffer_);
+-    }
+-
+-   private:
+-    // Max number of fds in a single `sendmsg` / `recvmsg` message
+-    // Defined as SCM_MAX_FD in linux/include/net/scm.h
+-    static constexpr size_t kMaxFdsPerSocketMsg{253};
+-
+-    AsyncFdSocket* socket_;
+-    std::array<uint8_t, CMSG_SPACE(sizeof(int) * kMaxFdsPerSocketMsg)>
+-        ancillaryDataCtrlBuffer_;
+-  };
+-
+-  friend class FdReadAncillaryDataCallback;
+-
+-  void enqueueFdsFromAncillaryData(struct ::msghdr& msg) noexcept;
+-
+   void setUpCallbacks() noexcept;
+ 
+   FdSendMsgParamsCallback sendMsgCob_;
+-  std::queue<SocketFds::Received>
+-      fdsQueue_; // must outlive readAncillaryDataCob_
+-  FdReadAncillaryDataCallback readAncillaryDataCob_;
+ #endif // !Windows
+ };
+ 
+-- 
+2.40.1
+

--- a/devel/folly/files/0003-Revert-Change-cloneToSendFrom-to-DFATAL-instead-of-C.patch
+++ b/devel/folly/files/0003-Revert-Change-cloneToSendFrom-to-DFATAL-instead-of-C.patch
@@ -1,0 +1,37 @@
+From 738fd9e20c79b63654e66669fd7d10e1d17ccfa9 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 17 May 2023 14:39:26 +0800
+Subject: [PATCH 3/6] Revert "Change cloneToSendFrom to DFATAL instead of
+ CHECK"
+
+This reverts commit 1f23eee52218d7de99c585444e84c279fb794d0d.
+---
+ folly/io/async/fdsock/SocketFds.h | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git folly/io/async/fdsock/SocketFds.h folly/io/async/fdsock/SocketFds.h
+index 620a5dd0a..53707371f 100644
+--- folly/io/async/fdsock/SocketFds.h
++++ folly/io/async/fdsock/SocketFds.h
+@@ -96,15 +96,10 @@ class SocketFds final {
+   // `SocketFds` that are known to be in this state.
+   //  - Invariant: `other` must be `ToSend`.
+   //  - Cost: Cloning copies a vector into a new heap allocation.
+-  void cloneToSendFromOrDfatal(const SocketFds& other) {
++  void cloneToSendFrom(const SocketFds& other) {
+     if (!other.empty()) {
+-      auto* fds = std::get_if<ToSend>(other.ptr_.get());
+-      if (UNLIKELY(fds == nullptr)) {
+-        LOG(DFATAL) << "SocketFds was in 'received' state, not cloning";
+-        ptr_.reset();
+-      } else {
+-        ptr_ = std::make_unique<FdsVariant>(*fds);
+-      }
++      auto* fds = CHECK_NOTNULL(std::get_if<ToSend>(other.ptr_.get()));
++      ptr_ = std::make_unique<FdsVariant>(*fds);
+     }
+   }
+ 
+-- 
+2.40.1
+

--- a/devel/folly/files/0004-Revert-Add-const-to-help-with-thread-safety.patch
+++ b/devel/folly/files/0004-Revert-Add-const-to-help-with-thread-safety.patch
@@ -1,0 +1,30 @@
+From 3139135e63e36d6147f6a785dc9fa0874188cb13 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 17 May 2023 14:39:45 +0800
+Subject: [PATCH 4/6] Revert "Add `const` to help with thread-safety"
+
+This reverts commit b492dbfb3ee6f1d151b9e5a978ebfec618946073.
+---
+ folly/io/async/fdsock/SocketFds.h | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git folly/io/async/fdsock/SocketFds.h folly/io/async/fdsock/SocketFds.h
+index 53707371f..f160d78cb 100644
+--- folly/io/async/fdsock/SocketFds.h
++++ folly/io/async/fdsock/SocketFds.h
+@@ -48,11 +48,7 @@ namespace folly {
+ class SocketFds final {
+  public:
+   using Received = std::vector<folly::File>;
+-  // These `shared_ptr`s are commonly be shared across threads -- and there
+-  // is no locking -- so `const` ensures thread-safety.  Therefore, if
+-  // you're going to put your `File` into a `ToSend`, it's best to first
+-  // make your own copy `const`, too.
+-  using ToSend = std::vector<std::shared_ptr<const folly::File>>;
++  using ToSend = std::vector<std::shared_ptr<folly::File>>;
+ 
+  private:
+   using FdsVariant = std::variant<Received, ToSend>;
+-- 
+2.40.1
+

--- a/devel/folly/files/0005-Revert-Unit-tests.patch
+++ b/devel/folly/files/0005-Revert-Unit-tests.patch
@@ -1,0 +1,330 @@
+From 94e534b75df21628aaedbf098374c03444c7ede6 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 17 May 2023 14:40:42 +0800
+Subject: [PATCH 5/6] Revert "Unit tests"
+
+This reverts commit 872c0332cea1cc8ca3bf8d0727e734654d855a3f.
+---
+ .../async/fdsock/test/AsyncFdSocketTest.cpp   | 291 ------------------
+ folly/io/async/test/AsyncSocketTest.h         |   3 +-
+ 2 files changed, 1 insertion(+), 293 deletions(-)
+ delete mode 100644 folly/io/async/fdsock/test/AsyncFdSocketTest.cpp
+
+diff --git folly/io/async/fdsock/test/AsyncFdSocketTest.cpp folly/io/async/fdsock/test/AsyncFdSocketTest.cpp
+deleted file mode 100644
+index 9fce1d5d4..000000000
+--- folly/io/async/fdsock/test/AsyncFdSocketTest.cpp
++++ /dev/null
+@@ -1,291 +0,0 @@
+-/*
+- * Copyright (c) Meta Platforms, Inc. and affiliates.
+- *
+- * Licensed under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License.
+- * You may obtain a copy of the License at
+- *
+- *     http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software
+- * distributed under the License is distributed on an "AS IS" BASIS,
+- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- * See the License for the specific language governing permissions and
+- * limitations under the License.
+- */
+-
+-#include <folly/io/async/fdsock/AsyncFdSocket.h>
+-#include <folly/io/async/test/AsyncSocketTest.h>
+-#include <folly/portability/GMock.h> // for matchers like HasSubstr
+-#include <folly/portability/GTest.h>
+-
+-using namespace folly;
+-
+-// `AsyncFdSocket` is just a stub on Windows because its CMSG macros are busted
+-#if !defined(_WIN32)
+-
+-std::string getFdProcMagic(int fd) {
+-  char magic[PATH_MAX];
+-  PCHECK(
+-      -1 !=
+-      ::readlink(
+-          fmt::format("/proc/{}/fd/{}", getpid(), fd).c_str(),
+-          magic,
+-          PATH_MAX));
+-  return std::string(magic);
+-}
+-
+-void checkFdsMatch(
+-    const folly::SocketFds::ToSend& sFds,
+-    const folly::SocketFds::Received& rFds) {
+-  EXPECT_EQ(sFds.size(), rFds.size());
+-  for (size_t i = 0; i < rFds.size(); ++i) {
+-    const auto& sfd = sFds[i]->fd();
+-    const auto& rfd = rFds[i].fd();
+-
+-    // We should always receive with FD_CLOEXEC enabled
+-    int flags = ::fcntl(rfd, F_GETFD);
+-    PCHECK(-1 != flags);
+-    EXPECT_TRUE(flags & FD_CLOEXEC) << "Actual flags:" << flags;
+-
+-    // Check that the two FDs appear identical in `/proc/PID/fd/FD`
+-    CHECK_EQ(getFdProcMagic(sfd), getFdProcMagic(rfd));
+-  }
+-}
+-
+-folly::SocketFds::ToSend makeFdsToSend(size_t n) {
+-  folly::SocketFds::ToSend sendFds;
+-  while (sendFds.size() != n) {
+-    std::array<int, 2> rawSendFds;
+-    // Don't set FD_CLOEXEC here so it is extra-clear that the socket did it
+-    // (even though FD_CLOEXEC on this FD isn't coupled with its copy).
+-    PCHECK(0 == ::pipe(rawSendFds.data()));
+-
+-    for (int fd : rawSendFds) {
+-      auto f = std::make_shared<folly::File>(fd, /*ownsFd*/ true);
+-      if (sendFds.size() < n) { // handle odd `n`
+-        sendFds.emplace_back(std::move(f));
+-      }
+-    }
+-  }
+-  CHECK_EQ(n, sendFds.size());
+-  return sendFds;
+-}
+-
+-struct AsyncFdSocketTest : public testing::Test {
+-  AsyncFdSocketTest()
+-      : AsyncFdSocketTest{[]() {
+-          std::array<NetworkSocket, 2> fds;
+-          PCHECK(0 == netops::socketpair(AF_UNIX, SOCK_STREAM, 0, fds.data()));
+-          for (int i = 0; i < 2; ++i) {
+-            PCHECK(0 == netops::set_socket_non_blocking(fds[i])) << i;
+-          }
+-          return fds;
+-        }()} {}
+-
+-  explicit AsyncFdSocketTest(std::array<NetworkSocket, 2> fds)
+-      : sendSock_{&evb_, fds[0]}, recvSock_{&evb_, fds[1]} {
+-    recvSock_.setReadCB(&rcb_);
+-  }
+-
+-  EventBase evb_;
+-
+-  WriteCallback wcb_;
+-  AsyncFdSocket sendSock_;
+-
+-  ReadCallback rcb_; // NB: `~AsyncSocket` calls `rcb.readEOF`
+-  AsyncFdSocket recvSock_;
+-};
+-
+-TEST_F(AsyncFdSocketTest, FailNoData) {
+-  sendSock_.writeChainWithFds(&wcb_, IOBuf::create(0), makeFdsToSend(1));
+-  EXPECT_THAT(wcb_.exception.what(), testing::HasSubstr("least 1 data byte"));
+-}
+-
+-TEST_F(AsyncFdSocketTest, FailTooManyFds) {
+-  char data = 'a'; // Need >= 1 data byte to send ancillary data.
+-  sendSock_.writeChainWithFds(
+-      &wcb_, IOBuf::wrapBuffer(&data, sizeof(data)), makeFdsToSend(254));
+-  EXPECT_EQ(EINVAL, wcb_.exception.getErrno());
+-}
+-
+-struct AsyncFdSocketSimpleRoundtripTest
+-    : public AsyncFdSocketTest,
+-      public testing::WithParamInterface<int> {};
+-
+-TEST_P(AsyncFdSocketSimpleRoundtripTest, WithNumFds) {
+-  int numFds = GetParam();
+-  char data = 'a'; // Need >= 1 data byte to send ancillary data.
+-
+-  auto sendFds = makeFdsToSend(numFds);
+-
+-  sendSock_.writeChainWithFds(
+-      &wcb_, IOBuf::wrapBuffer(&data, sizeof(data)), sendFds);
+-  evb_.loopOnce();
+-
+-  rcb_.verifyData(&data, sizeof(data));
+-  rcb_.clearData();
+-
+-  auto recvFds = recvSock_.popNextReceivedFds();
+-  if (0 == numFds) {
+-    EXPECT_FALSE(recvFds.has_value());
+-  } else {
+-    checkFdsMatch(sendFds, *recvFds);
+-  }
+-}
+-
+-// Round-trip & verify various numbers of FDs with 1 byte of data.
+-INSTANTIATE_TEST_SUITE_P(
+-    VaryFdCount,
+-    AsyncFdSocketSimpleRoundtripTest,
+-    testing::Values(1, 0, 2, 253, 0, 3)); // 253 is the Linux max
+-
+-struct WriteCountedAsyncFdSocket : public AsyncFdSocket {
+-  using AsyncFdSocket::AsyncFdSocket;
+-  AsyncSocket::WriteResult sendSocketMessage(
+-      const iovec* vec,
+-      size_t count,
+-      WriteFlags flags,
+-      WriteRequestTag writeTag) override {
+-    ++numWrites_;
+-    return AsyncSocket::sendSocketMessage(vec, count, flags, writeTag);
+-  }
+-  size_t numWrites_{0};
+-};
+-
+-// This test exists because without `FdSendMsgParamsCallback::wroteBytes`,
+-// we would be sending the same FDs repeatedly, whenever the data to be
+-// written didn't fit in the `sendmsg` buffer and got sent in several
+-// batches.
+-TEST_F(AsyncFdSocketTest, MultiPartSend) {
+-  auto sendFds = makeFdsToSend(1);
+-
+-  WriteCountedAsyncFdSocket sendSock{&evb_, sendSock_.detachNetworkSocket()};
+-
+-  // Find the socket's "send" buffer size
+-  socklen_t sendBufSize;
+-  socklen_t sizeOfSendBufSize = sizeof(sendBufSize);
+-  PCHECK(
+-      0 ==
+-      netops::getsockopt(
+-          sendSock.getNetworkSocket(),
+-          SOL_SOCKET,
+-          SO_SNDBUF,
+-          &sendBufSize,
+-          &sizeOfSendBufSize));
+-  ASSERT_EQ(sizeof(sendBufSize), sizeOfSendBufSize);
+-
+-  // Make the message too big for one `sendmsg`.
+-  int numSendParts = 3;
+-  std::string data(numSendParts * sendBufSize, 'x');
+-  sendSock.writeChainWithFds(
+-      &wcb_, IOBuf::wrapBuffer(data.data(), data.size()), sendFds);
+-
+-  // FDs are sent with the first send & received by the first receive
+-  evb_.loopOnce();
+-  checkFdsMatch(sendFds, *recvSock_.popNextReceivedFds());
+-  EXPECT_EQ(1, sendSock.numWrites_);
+-
+-  // Receive the rest of the data.
+-  while (rcb_.dataRead() < data.size()) {
+-    evb_.loopOnce();
+-  }
+-  rcb_.verifyData(data.data(), data.size());
+-  rcb_.clearData();
+-  EXPECT_EQ(numSendParts, sendSock.numWrites_);
+-
+-  // There are no more data or FDs
+-  evb_.loopOnce(EVLOOP_NONBLOCK);
+-  EXPECT_EQ(0, rcb_.dataRead()) << "Leftover reads";
+-  EXPECT_FALSE(recvSock_.popNextReceivedFds().has_value()) << "Extra FDs";
+-}
+-
+-struct AsyncFdSocketSequenceRoundtripTest
+-    : public AsyncFdSocketTest,
+-      public testing::WithParamInterface<int> {};
+-
+-TEST_P(AsyncFdSocketSequenceRoundtripTest, WithDataSize) {
+-  size_t dataSize = GetParam();
+-
+-  // The default `ReadCallback` has special-snowflake buffer management
+-  // that's annoying for this test.  Secondarily, this exercises the
+-  // "ReadVec" path.
+-  ReadvCallback rcb(128, 3);
+-  // Avoid `readEOF` use-after-stack-scope in `~AsyncSocket`.
+-  SCOPE_EXIT { recvSock_.setReadCB(nullptr); };
+-  recvSock_.setReadCB(&rcb);
+-
+-  std::queue<std::tuple<int, std::string, folly::SocketFds::ToSend>> sentQueue;
+-
+-  // Enqueue several writes before attempting reads
+-  char msgFirstByte = 0; // The first byte of each data message is different.
+-  for (auto numFds : {0, 1, 0, 0, 2, 253, 253, 0, 5}) {
+-    // All but the first bytes are 255, while the first byte is a counter.
+-    std::string data(dataSize, '\377');
+-    CHECK_LT(msgFirstByte, 254); // Don't collide with 255, don't overflow
+-    data[0] = ++msgFirstByte;
+-
+-    auto sendFds = makeFdsToSend(numFds);
+-
+-    sendSock_.writeChainWithFds(
+-        &wcb_, IOBuf::wrapBuffer(data.data(), data.size()), sendFds);
+-
+-    sentQueue.push({msgFirstByte, std::move(data), std::move(sendFds)});
+-  }
+-
+-  // Read from the socket, and check that any batches of FDs arrive with the
+-  // first byte of the matching data.
+-  bool checkedFds{false};
+-  // The max expected steps is ~3k: 1234567 / (3 * 128)
+-  for (int i = 0; i < 10000 && !sentQueue.empty(); ++i) {
+-    evb_.loopOnce(EVLOOP_NONBLOCK);
+-    size_t dataRead = rcb.buf_->computeChainDataLength();
+-    if (!dataRead) {
+-      continue;
+-    }
+-
+-    if (!checkedFds) {
+-      checkedFds = true;
+-
+-      // Ensure that FDs arrive with the first byte of the associated data
+-      ASSERT_EQ(std::get<0>(sentQueue.front()), rcb.buf_->data()[0]);
+-
+-      const auto& sendFds = std::get<2>(sentQueue.front());
+-      if (!sendFds.empty()) {
+-        auto recvFds = recvSock_.popNextReceivedFds();
+-        checkFdsMatch(sendFds, *recvFds);
+-      }
+-    }
+-
+-    // Move on to the next data chunk
+-    if (dataRead >= std::get<1>(sentQueue.front()).size()) {
+-      ASSERT_TRUE(checkedFds);
+-      checkedFds = false;
+-
+-      auto [firstByte, expectedData, _fds] = sentQueue.front();
+-      auto& buf = rcb.buf_;
+-
+-      // Check that the entire data string is as expected.
+-      ASSERT_EQ(firstByte, buf->data()[0]);
+-      buf->coalesce();
+-      ASSERT_GE(buf->length(), expectedData.size());
+-      ASSERT_EQ(
+-          0, memcmp(expectedData.data(), buf->data(), expectedData.size()));
+-      buf->trimStart(expectedData.size());
+-
+-      sentQueue.pop();
+-    }
+-  }
+-  EXPECT_TRUE(sentQueue.empty()) << "Stuck reading?";
+-  evb_.loopOnce(EVLOOP_NONBLOCK);
+-  EXPECT_EQ(0, rcb.buf_->computeChainDataLength()) << "Leftover reads";
+-  EXPECT_FALSE(recvSock_.popNextReceivedFds().has_value()) << "Extra FDs";
+-}
+-
+-// Vary the data size to (hopefully) get a variety of chunking behaviors.
+-INSTANTIATE_TEST_SUITE_P(
+-    VaryDataSize,
+-    AsyncFdSocketSequenceRoundtripTest,
+-    testing::Values(1, 12, 123, 1234, 12345, 123456, 1234567));
+-
+-#endif // !Windows
+diff --git folly/io/async/test/AsyncSocketTest.h folly/io/async/test/AsyncSocketTest.h
+index 1dcaaf23f..27f3c6d0c 100644
+--- folly/io/async/test/AsyncSocketTest.h
++++ folly/io/async/test/AsyncSocketTest.h
+@@ -258,12 +258,11 @@ class ReadvCallback : public folly::AsyncTransport::ReadCallback {
+     CHECK_EQ(data, tmp);
+   }
+ 
+-  std::unique_ptr<folly::IOBuf> buf_;
+-
+  private:
+   StateEnum state_;
+   folly::AsyncSocketException exception_;
+   folly::IOBufIovecBuilder queue_;
++  std::unique_ptr<folly::IOBuf> buf_;
+   const size_t len_;
+ };
+ 
+-- 
+2.40.1
+

--- a/devel/folly/files/0006-Revert-writeChainWithFds-using-SendMsgParamsCallback.patch
+++ b/devel/folly/files/0006-Revert-writeChainWithFds-using-SendMsgParamsCallback.patch
@@ -1,0 +1,539 @@
+From 2d3a6253989cc93e8f8e5c83e567694f2c588b1a Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 17 May 2023 14:40:59 +0800
+Subject: [PATCH 6/6] Revert "`writeChainWithFds` using
+ `SendMsgParamsCallback`"
+
+This reverts commit 62eeb799779cbc24b622ec8ce3501c7969d60bae.
+---
+ folly/io/async/AsyncSocket.h            |   2 +-
+ folly/io/async/fdsock/AsyncFdSocket.cpp | 204 ------------------------
+ folly/io/async/fdsock/AsyncFdSocket.h   | 158 ------------------
+ folly/io/async/fdsock/SocketFds.h       | 126 ---------------
+ 4 files changed, 1 insertion(+), 489 deletions(-)
+ delete mode 100644 folly/io/async/fdsock/AsyncFdSocket.cpp
+ delete mode 100644 folly/io/async/fdsock/AsyncFdSocket.h
+ delete mode 100644 folly/io/async/fdsock/SocketFds.h
+
+diff --git folly/io/async/AsyncSocket.h folly/io/async/AsyncSocket.h
+index 9ff04ea6c..e65f1ba23 100644
+--- folly/io/async/AsyncSocket.h
++++ folly/io/async/AsyncSocket.h
+@@ -1657,7 +1657,7 @@ class AsyncSocket : public AsyncSocketTransport {
+   bool containsZeroCopyBuf(folly::IOBuf* ptr);
+   void releaseZeroCopyBuf(uint32_t id);
+ 
+-  virtual void releaseIOBuf(
++  void releaseIOBuf(
+       std::unique_ptr<folly::IOBuf> buf, ReleaseIOBufCallback* callback);
+ 
+   ReadCode processZeroCopyRead();
+diff --git folly/io/async/fdsock/AsyncFdSocket.cpp folly/io/async/fdsock/AsyncFdSocket.cpp
+deleted file mode 100644
+index d8cadc038..000000000
+--- folly/io/async/fdsock/AsyncFdSocket.cpp
++++ /dev/null
+@@ -1,204 +0,0 @@
+-/*
+- * Copyright (c) Meta Platforms, Inc. and affiliates.
+- *
+- * Licensed under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License.
+- * You may obtain a copy of the License at
+- *
+- *     http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software
+- * distributed under the License is distributed on an "AS IS" BASIS,
+- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- * See the License for the specific language governing permissions and
+- * limitations under the License.
+- */
+-
+-#include "AsyncFdSocket.h"
+-
+-namespace folly {
+-
+-AsyncFdSocket::AsyncFdSocket(EventBase* evb)
+-    : AsyncSocket(evb)
+-#if !defined(_WIN32)
+-      ,
+-      sendMsgCob_(evb) {
+-  setUpCallbacks();
+-}
+-#else
+-{
+-}
+-#endif
+-
+-AsyncFdSocket::AsyncFdSocket(
+-    EventBase* evb,
+-    const folly::SocketAddress& address,
+-    uint32_t connectTimeout)
+-    : AsyncFdSocket(evb) {
+-  connect(nullptr, address, connectTimeout);
+-}
+-
+-AsyncFdSocket::AsyncFdSocket(
+-    EventBase* evb, NetworkSocket fd, const folly::SocketAddress* peerAddress)
+-    : AsyncSocket(evb, fd, /* zeroCopyBufId */ 0, peerAddress)
+-#if !defined(_WIN32)
+-      ,
+-      sendMsgCob_(evb) {
+-  setUpCallbacks();
+-}
+-#else
+-{
+-}
+-#endif
+-
+-void AsyncFdSocket::writeChainWithFds(
+-    WriteCallback* callback,
+-    std::unique_ptr<folly::IOBuf> buf,
+-    SocketFds::ToSend fds,
+-    WriteFlags flags) {
+-#if defined(_WIN32)
+-  DCHECK(fds.empty()) << "AsyncFdSocket cannot send FDs on Windows";
+-#else
+-  DCHECK_EQ(&sendMsgCob_, getSendMsgParamsCB());
+-
+-  if (buf->empty() && !fds.empty()) {
+-    DestructorGuard dg(this);
+-    AsyncSocketException ex(
+-        AsyncSocketException::BAD_ARGS,
+-        withAddr("Cannot send FDs without at least 1 data byte"));
+-    return failWrite(__func__, callback, 0, ex);
+-  }
+-
+-  if (!sendMsgCob_.registerFdsForWriteTag(
+-          WriteRequestTag{buf.get()},
+-          std::move(fds) // discarded on error
+-          )) {
+-    // Careful: this has no unittest coverage because I don't have a good
+-    // idea for how to cause this in a meaningful way.  Should this be
+-    // a DCHECK? Plans that don't work:
+-    //  - Creating two `unique_ptr` from the same raw pointer would be
+-    //    bad news bears for the test.
+-    //  - IOBuf recycling via getReleaseIOBufCallback() shouldn't be
+-    //    possible either, since we unregister the tag in our `releaseIOBuf`
+-    //    override below before releasing the IOBuf.
+-    DestructorGuard dg(this);
+-    AsyncSocketException ex(
+-        AsyncSocketException::BAD_ARGS,
+-        withAddr("Buffer was already owned by this socket"));
+-    return failWrite(__func__, callback, 0, ex);
+-  }
+-#endif // !Windows
+-
+-  writeChain(callback, std::move(buf), flags);
+-}
+-
+-// The callbacks aren't defined on Windows -- the CMSG macros don't compile
+-#if !defined(_WIN32)
+-
+-void AsyncFdSocket::setUpCallbacks() noexcept {
+-  AsyncSocket::setSendMsgParamCB(&sendMsgCob_);
+-}
+-
+-void AsyncFdSocket::releaseIOBuf(
+-    std::unique_ptr<folly::IOBuf> buf, ReleaseIOBufCallback* callback) {
+-  sendMsgCob_.destroyFdsForWriteTag(WriteRequestTag{buf.get()});
+-  AsyncSocket::releaseIOBuf(std::move(buf), callback);
+-}
+-
+-std::pair<
+-    size_t,
+-    AsyncFdSocket::FdSendMsgParamsCallback::WriteTagToFds::iterator>
+-AsyncFdSocket::FdSendMsgParamsCallback::getCmsgSizeAndFds(
+-    const AsyncSocket::WriteRequestTag& writeTag) noexcept {
+-  auto it = writeTagToFds_.find(writeTag);
+-  if (it == writeTagToFds_.end()) {
+-    return std::make_pair(0, it);
+-  }
+-  return std::make_pair(CMSG_SPACE(sizeof(int) * it->second.size()), it);
+-}
+-
+-void AsyncFdSocket::FdSendMsgParamsCallback::getAncillaryData(
+-    folly::WriteFlags,
+-    void* data,
+-    const WriteRequestTag& writeTag,
+-    const bool /*byteEventsEnabled*/) noexcept {
+-  eventBase_->dcheckIsInEventBaseThread();
+-
+-  auto [cmsgSpace, fdsIt] = getCmsgSizeAndFds(writeTag);
+-  CHECK_NE(0, cmsgSpace);
+-  const auto& fds = fdsIt->second;
+-
+-  // NOT checking `fds.size() < SCM_MAX_FD` here because there's no way to
+-  // propagate the error to the caller, and ultimately the write will fail
+-  // out with EINVAL anyway.  The front-end that accepts FDs should check
+-  // this instead.  If there is a debuggability issue, do add a LOG(ERROR).
+-
+-  ::msghdr msg{}; // Discarded, we just need to populate `data`
+-
+-  msg.msg_control = data;
+-  msg.msg_controllen = cmsgSpace;
+-  struct ::cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+-  CHECK_NOTNULL(cmsg);
+-
+-  cmsg->cmsg_len = CMSG_LEN(sizeof(int) * fds.size());
+-  cmsg->cmsg_level = SOL_SOCKET;
+-  cmsg->cmsg_type = SCM_RIGHTS;
+-
+-  auto* outFds = reinterpret_cast<int*>(CMSG_DATA(cmsg));
+-  for (size_t n = 0; n < fds.size(); ++n) {
+-    outFds[n] = fds[n]->fd();
+-  }
+-
+-  VLOG(4) << "this=" << this << ", getAncillaryData() sending " << fds.size()
+-          << " FDs";
+-}
+-
+-uint32_t AsyncFdSocket::FdSendMsgParamsCallback::getAncillaryDataSize(
+-    folly::WriteFlags,
+-    const WriteRequestTag& writeTag,
+-    const bool /*byteEventsEnabled*/) noexcept {
+-  // Not checking thread because `getAncillaryData` will follow.
+-
+-  // Due to the unfortunate design of the callback API, this will run
+-  // again in `getAncillaryData`, let's pray for CPU caches here.
+-  auto [size, _] = getCmsgSizeAndFds(writeTag);
+-  return size;
+-}
+-
+-void AsyncFdSocket::FdSendMsgParamsCallback::wroteBytes(
+-    const WriteRequestTag& writeTag) noexcept {
+-  auto nh = writeTagToFds_.extract(writeTag);
+-  if (nh.empty()) {
+-    // `AsyncSocket` will only call `wroteBytes` if `getAncillaryDataSize`
+-    // returned a nonzero value, so we'll never get here.
+-    LOG(DFATAL) << "wroteBytes without a matching `getAncillaryData`?";
+-  } else {
+-    VLOG(5) << "this=" << this << ", FdSendMsgParamsCallback::wroteBytes() on "
+-            << nh.mapped().size() << " FDs for tag " << writeTag;
+-  }
+-}
+-
+-bool AsyncFdSocket::FdSendMsgParamsCallback::registerFdsForWriteTag(
+-    WriteRequestTag writeTag, SocketFds::ToSend&& fds) {
+-  VLOG(5) << "this=" << this << ", registerFdsForWriteTag() on " << fds.size()
+-          << " FDs for tag " << writeTag;
+-  if (writeTag.empty()) {
+-    return false; // no insertion, error: we require a nonempty tag
+-  }
+-  auto [it, inserted] = writeTagToFds_.try_emplace(writeTag, std::move(fds));
+-  return inserted;
+-}
+-
+-void AsyncFdSocket::FdSendMsgParamsCallback::destroyFdsForWriteTag(
+-    WriteRequestTag writeTag) noexcept {
+-  auto nh = writeTagToFds_.extract(writeTag);
+-  if (nh.empty()) {
+-    return; // Not every write has FDs; also, `wroteBytes` clears them.
+-  }
+-  VLOG(5) << "this=" << this << ", destroyFdsForWriteTag() on "
+-          << nh.mapped().size() << " FDs for tag " << writeTag;
+-}
+-
+-#endif // !Windows
+-
+-} // namespace folly
+diff --git folly/io/async/fdsock/AsyncFdSocket.h folly/io/async/fdsock/AsyncFdSocket.h
+deleted file mode 100644
+index d72d086ac..000000000
+--- folly/io/async/fdsock/AsyncFdSocket.h
++++ /dev/null
+@@ -1,158 +0,0 @@
+-/*
+- * Copyright (c) Meta Platforms, Inc. and affiliates.
+- *
+- * Licensed under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License.
+- * You may obtain a copy of the License at
+- *
+- *     http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software
+- * distributed under the License is distributed on an "AS IS" BASIS,
+- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- * See the License for the specific language governing permissions and
+- * limitations under the License.
+- */
+-
+-#pragma once
+-
+-#include <folly/io/async/AsyncSocket.h>
+-#include <folly/io/async/fdsock/SocketFds.h>
+-
+-namespace folly {
+-
+-/**
+- * Intended for use with Unix sockets. Unlike regular `AsyncSocket`:
+- *  - Can send FDs via `writeChainWithFds` using socket ancillary data (see
+- *    `man cmsg`).
+- *  - Always attempts to receive FDs included in incoming ancillary data.
+- *    Groups of received FDs are enqueued to be retrieved via
+- *    `popNextReceivedFds`.
+- *  - The "read ancillary data" and "sendmsg params" callbacks are built-in
+- *    are NOT customizable.
+- *
+- * Implementation limitation: Unlike regular `AsyncSocket`, this currently
+- * does not automatically send socket timestamping events.  This could
+- * easily be added, but seems of limited utility for Unix sockets.
+- */
+-class AsyncFdSocket : public AsyncSocket {
+- public:
+-  using UniquePtr = std::unique_ptr<AsyncSocket, Destructor>;
+-
+-  /**
+-   * Create a new unconnected AsyncSocket.
+-   *
+-   * connect() must later be called on this socket to establish a connection.
+-   */
+-  explicit AsyncFdSocket(EventBase* evb);
+-
+-  /**
+-   * Create a new AsyncSocket and begin the connection process.
+-   *
+-   * Unlike `AsyncSocket`, lacks `useZeroCopy` since Unix sockets do not
+-   * support zero-copy.
+-   */
+-  AsyncFdSocket(
+-      EventBase* evb,
+-      const folly::SocketAddress& address,
+-      uint32_t connectTimeout = 0);
+-
+-  /**
+-   * Create a AsyncSocket from an already connected socket file descriptor.
+-   *
+-   * Unlike `AsyncSocket`, lacks `zeroCopyBufId` since Unix sockets do not
+-   * support zero-copy.
+-   */
+-  AsyncFdSocket(
+-      EventBase* evb,
+-      NetworkSocket fd,
+-      const folly::SocketAddress* peerAddress = nullptr);
+-
+-  /**
+-   * `AsyncSocket::writeChain` analog that passes FDs as ancillary data over
+-   * the socket (see `man cmsg`).
+-   *
+-   * Invariants:
+-   *  - Max FDs per IOBuf: `SCM_MAX_FD` from include/net/scm.h, 253 for
+-   *    effectively all of Linux history.
+-   *  - FDs are received no earlier than the first data byte of the IOBuf,
+-   *    and no later than the last data byte. More specifically:
+-   *     - The currently implemented behavior is that FDs arrive precisely
+-   *       with the first data byte.  This was efficient and good enough for
+-   *       Thrift Rocket transport, where each message knows whether it
+-   *       expects FDs, and FDs are sent with the last data fragment of each
+-   *       message.
+-   *     - In other conceivable designs, it could be useful to pass FDs
+-   *       with the last data byte instead, which could be implemented as an
+-   *       optional write flag. In Thrift Rocket, this would minimize the
+-   *       buffering of FDs by the receiver, at the cost of more syscalls.
+-   */
+-  void writeChainWithFds(
+-      WriteCallback*,
+-      std::unique_ptr<folly::IOBuf>,
+-      SocketFds::ToSend,
+-      WriteFlags flags = WriteFlags::NONE);
+-
+-  void setSendMsgParamCB(SendMsgParamsCallback*) override {
+-    LOG(DFATAL) << "AsyncFdSocket::setSendMsgParamCB is forbidden";
+-  }
+-
+-// This uses no ancillary data callbacks on Windows, they wouldn't compile.
+-#if !defined(_WIN32)
+- protected:
+-  void releaseIOBuf(
+-      std::unique_ptr<folly::IOBuf>, ReleaseIOBufCallback*) override;
+-
+- private:
+-  class FdSendMsgParamsCallback : public SendMsgParamsCallback {
+-   public:
+-    explicit FdSendMsgParamsCallback(folly::EventBase* evb) : eventBase_(evb) {}
+-
+-    void getAncillaryData(
+-        folly::WriteFlags,
+-        void* data,
+-        const WriteRequestTag&,
+-        const bool byteEventsEnabled) noexcept override;
+-
+-    uint32_t getAncillaryDataSize(
+-        folly::WriteFlags,
+-        const WriteRequestTag&,
+-        const bool byteEventsEnabled) noexcept override;
+-
+-    void wroteBytes(const WriteRequestTag&) noexcept override;
+-
+-   protected:
+-    friend class AsyncFdSocket;
+-
+-    // Returns true on success, false if the tag was already registered, or
+-    // has a null IOBuf* (both are usage error).  The FDs are discarded on
+-    // error.
+-    bool registerFdsForWriteTag(WriteRequestTag, SocketFds::ToSend&&);
+-
+-    // Called from `releaseIOBuf()` above, once we're sure that an IOBuf
+-    // will not be used for a write any more.  This is a good time to
+-    // discard the FDs associated with this write.
+-    //
+-    // CAREFUL: This may be invoked for IOBufs that never had a
+-    // corresponding `getAncillaryData*` call.
+-    void destroyFdsForWriteTag(WriteRequestTag) noexcept;
+-
+-   private:
+-    using WriteTagToFds =
+-        std::unordered_map<WriteRequestTag, SocketFds::ToSend>;
+-
+-    std::pair<size_t, WriteTagToFds::iterator> getCmsgSizeAndFds(
+-        const WriteRequestTag& writeTag) noexcept;
+-
+-    const folly::EventBase* eventBase_; // only for dcheckIsInEventBaseThread
+-
+-    WriteTagToFds writeTagToFds_;
+-  };
+-
+-  void setUpCallbacks() noexcept;
+-
+-  FdSendMsgParamsCallback sendMsgCob_;
+-#endif // !Windows
+-};
+-
+-} // namespace folly
+diff --git folly/io/async/fdsock/SocketFds.h folly/io/async/fdsock/SocketFds.h
+deleted file mode 100644
+index f160d78cb..000000000
+--- folly/io/async/fdsock/SocketFds.h
++++ /dev/null
+@@ -1,126 +0,0 @@
+-/*
+- * Copyright (c) Meta Platforms, Inc. and affiliates.
+- *
+- * Licensed under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License.
+- * You may obtain a copy of the License at
+- *
+- *     http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software
+- * distributed under the License is distributed on an "AS IS" BASIS,
+- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- * See the License for the specific language governing permissions and
+- * limitations under the License.
+- */
+-
+-#pragma once
+-
+-#include <memory>
+-#include <variant>
+-#include <glog/logging.h>
+-
+-#include <folly/File.h>
+-
+-namespace folly {
+-
+-/**
+- * Represents an ordered collection of file descriptors. This union type
+- * either contains:
+- *  - FDs to be sent on a socket -- with shared ownership, since the sender
+- *    may still need them, OR
+- *  - FDs just received, with sole ownership.
+- *
+- * This hides the variant of containers behind a `unique_ptr` so that the
+- * normal / fast path, which is not passing FDs, is as light as possible,
+- * adding just 8 bytes for a pointer.
+- *
+- * == Rationale ==
+- *
+- * In order to send FDs over Unix sockets, Thrift plumbs them through a
+- * variety of classes.  Many of these can be used both for send & receive
+- * operations (THeader, StreamPayload, etc).
+- *
+- * This is especially useful in regular Thrift request-response handler
+- * methods, where the same THeader is used for consuming the received FDs,
+- * and sending back FDs with the response -- necessarily in that order.
+- */
+-class SocketFds final {
+- public:
+-  using Received = std::vector<folly::File>;
+-  using ToSend = std::vector<std::shared_ptr<folly::File>>;
+-
+- private:
+-  using FdsVariant = std::variant<Received, ToSend>;
+-
+- public:
+-  SocketFds() = default;
+-  SocketFds(SocketFds&& other) = default;
+-  template <class T>
+-  explicit SocketFds(T fds) {
+-    ptr_ = std::make_unique<FdsVariant>(std::move(fds));
+-  }
+-
+-  SocketFds& operator=(SocketFds&& other) = default;
+-
+-  bool empty() const { return !ptr_; }
+-
+-  size_t size() const {
+-    if (empty()) {
+-      return 0;
+-    }
+-    return std::visit([](auto&& v) { return v.size(); }, *ptr_);
+-  }
+-
+-  // These methods help ensure the right kind of data is being plumbed or
+-  // overwritten:
+-  //   fds.dcheckEmpty() = otherFds.dcheck{Received,ToSend}();
+-  SocketFds& dcheckEmpty() {
+-    DCHECK(!ptr_);
+-    return *this;
+-  }
+-  SocketFds& dcheckReceived() {
+-    DCHECK(std::holds_alternative<Received>(*ptr_));
+-    return *this;
+-  }
+-  SocketFds& dcheckToSend() {
+-    DCHECK(std::holds_alternative<ToSend>(*ptr_));
+-    return *this;
+-  }
+-
+-  // Since ownership of `ToSend` FDs is shared, it is permissible to clone
+-  // `SocketFds` that are known to be in this state.
+-  //  - Invariant: `other` must be `ToSend`.
+-  //  - Cost: Cloning copies a vector into a new heap allocation.
+-  void cloneToSendFrom(const SocketFds& other) {
+-    if (!other.empty()) {
+-      auto* fds = CHECK_NOTNULL(std::get_if<ToSend>(other.ptr_.get()));
+-      ptr_ = std::make_unique<FdsVariant>(*fds);
+-    }
+-  }
+-
+-  Received releaseReceived() {
+-    auto fds = std::move(*CHECK_NOTNULL(std::get_if<Received>(ptr_.get())));
+-    // NB: In the case of a Thrift server handler method that is receiving
+-    // and then sending back FDs using the same `SocketFds` object, this
+-    // deallocation (and subsequent allocation) could be avoided, e.g. by:
+-    //  - Without changing the API by having an additional `std::monostate`
+-    //    representing the variant being empty. This has the downside of
+-    //    holding on to allocations unnecessarily in other cases.
+-    //  - By adding `std::pair<Received, ToSend&> releaseReceivedAndSend()`.
+-    //    This complicates the user experience.
+-    ptr_.reset();
+-    return fds;
+-  }
+-
+-  ToSend releaseToSend() {
+-    auto fds = std::move(*CHECK_NOTNULL(std::get_if<ToSend>(ptr_.get())));
+-    ptr_.reset();
+-    return fds;
+-  }
+-
+- private:
+-  std::unique_ptr<FdsVariant> ptr_;
+-};
+-
+-} // namespace folly
+-- 
+2.40.1
+

--- a/devel/folly/files/patch-older-systems.diff
+++ b/devel/folly/files/patch-older-systems.diff
@@ -256,7 +256,7 @@ index 88f00150f..3f882b473 100644
    return 0;
  }
  
-+#if defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 101100
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101100
  FOLLY_ATTR_WEAK int clock_gettime(clockid_t clk_id, struct timespec* ts) {
    switch (folly::to_underlying(clk_id)) {
      case CLOCK_REALTIME: {
@@ -272,7 +272,7 @@ index 88f00150f..3f882b473 100644
        res->tv_nsec = time_t(perSec * kNsPerSec);
        return 0;
      }
-+#if defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 101100
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101100
      case CLOCK_PROCESS_CPUTIME_ID:
      case CLOCK_THREAD_CPUTIME_ID: {
        DWORD adj, timeIncrement;
@@ -294,7 +294,7 @@ index 88f00150f..3f882b473 100644
        duration_to_ts(now, tp);
        return 0;
      }
-+#if defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 101100
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 101100
      case CLOCK_PROCESS_CPUTIME_ID: {
        if (!GetProcessTimes(
                GetCurrentProcess(),

--- a/devel/proxygen/Portfile
+++ b/devel/proxygen/Portfile
@@ -11,8 +11,10 @@ PortGroup           legacysupport 1.1
 # O_CLOEXEC
 legacysupport.newest_darwin_requires_legacy 10
 
+boost.version       1.81
+
 github.setup        facebook proxygen 2023.05.15.00 v
-revision            0
+revision            1
 categories          devel
 license             BSD
 maintainers         nomaintainer

--- a/devel/proxygen/Portfile
+++ b/devel/proxygen/Portfile
@@ -17,7 +17,7 @@ github.setup        facebook proxygen 2023.05.15.00 v
 revision            1
 categories          devel
 license             BSD
-maintainers         nomaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Collection of C++ HTTP libraries including an easy to use HTTP server
 long_description    This project comprises the core C++ HTTP abstractions used at Facebook. \
                     Internally, it is used as the basis for building many HTTP servers, proxies and clients. \

--- a/devel/wangle/Portfile
+++ b/devel/wangle/Portfile
@@ -8,8 +8,10 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
+boost.version       1.81
+
 github.setup        facebook wangle 2023.05.15.00 v
-revision            0
+revision            1
 checksums           rmd160  b5ef4200a7b85716de20c20a9d3421a064765be2 \
                     sha256  2b12abd6c17319ec6f648bdcb4f6516e08044282aa77aad455447b3a01c2b22f \
                     size    341329

--- a/devel/wangle/Portfile
+++ b/devel/wangle/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  b5ef4200a7b85716de20c20a9d3421a064765be2 \
 
 categories          devel
 license             BSD
-maintainers         nomaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 
 description         Wangle is a framework providing a set of common \
                     client/server abstractions for building services in a \

--- a/sysutils/watchman/Portfile
+++ b/sysutils/watchman/Portfile
@@ -7,8 +7,10 @@ PortGroup           boost 1.0
 PortGroup           rust 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
+boost.version       1.81
+
 github.setup        facebook watchman 2023.05.15.00 v
-revision            0
+revision            1
 
 categories          sysutils
 maintainers         {danchr @danchr} openmaintainer


### PR DESCRIPTION
#### Description

@mascguy @herbygillot @danchr 
Provisionally this should fix build for `folly` and friends.

Disclaimer: I cannot test `edencommon` and `watchman`, those require stuff that is broken for PPC. Others build fine for me on 10.6 now.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
