### PR TITLE
mochiweb: update to 3.1.2, fix a broken port

### DIFF
--- a/erlang/mochiweb/Portfile
+++ b/erlang/mochiweb/Portfile
@@ -4,10 +4,9 @@ PortSystem      1.0
 PortGroup       github 1.0
 
 epoch           20111014
-github.setup    mochi mochiweb 2.7.0 v
+github.setup    mochi mochiweb 3.1.2 v
 categories      erlang www
 license         MIT
-platforms       darwin
 maintainers     nomaintainer
 supported_archs noarch
 
@@ -17,25 +16,30 @@ long_description \
     ${description}
 
 depends_lib     port:erlang
+depends_build-append \
+                port:rebar3
 
-checksums       rmd160  deffa504702f58ecb9dd0de2149d50b374356bde \
-                sha256  4f76cbc1bb81ed1f99e6993589568bb9711584de48c679d9f967975e0dcd7d7c
+checksums       rmd160  aa1eff1f10195a4672a04274a2f1033c12db1ddd \
+                sha256  c213519dbc09e1e99cd72d5c1f333e841a7fbb58b06416898bf9eb0de7f39533 \
+                size    137877
 
-use_configure no
+use_configure   no
 build.target-append edoc
 
 set libdir ${prefix}/lib/erlang/lib/${name}
 
 destroot {
     xinstall -d ${destroot}${libdir}
-    copy ${worksrcpath}/ebin ${destroot}${libdir}/ebin
+    copy ${worksrcpath}/_build/default/lib/${name}/ebin ${destroot}${libdir}/ebin
+    copy ${worksrcpath}/include ${destroot}${libdir}/include
     copy ${worksrcpath}/scripts ${destroot}${libdir}/scripts
     copy ${worksrcpath}/src ${destroot}${libdir}/src
 
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
-    xinstall -m 644 -W ${worksrcpath} CHANGES.md LICENSE README ${destroot}${docdir}
+    xinstall -m 644 -W ${worksrcpath} CHANGES.md LICENSE README.md ${destroot}${docdir}
     copy ${worksrcpath}/doc ${destroot}${docdir}/html
+    copy ${worksrcpath}/examples ${destroot}${docdir}
     xinstall -m 644 ${filespath}/README.MacPorts ${destroot}${docdir}
     reinplace s:@PREFIX@:${prefix}: ${destroot}${docdir}/README.MacPorts
 }


### PR DESCRIPTION
#### Description

Forgotten port broken across the board: https://ports.macports.org/port/mochiweb/details
Update and fix it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
