### PR TITLE
HiGHS: new port in math

### DIFF
--- a/math/HiGHS/Portfile
+++ b/math/HiGHS/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               compilers 1.0
+PortGroup               github 1.0
+
+github.setup            ERGO-Code HiGHS 1.5.1 v
+revision                0
+categories              math
+maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
+license                 MIT
+description             Linear optimization software
+long_description        HiGHS is a high performance serial and parallel solver for large scale sparse linear optimization problems.
+homepage                https://ergo-code.github.io
+checksums               rmd160  a1cb86dcba22650f159e2d43c96d57134e1dcb9e \
+                        sha256  a582123390cf27bead083465cf0f5fa9399d0e6ac7c26f99d717d07d0fe09f5c \
+                        size    1829863
+
+if {${os.major} < 13} {
+    # Lion+ (with Xcode 4.1+) have git; earlier need to bring their own.
+    # On 10.8.5 git fetch fails with ssl error.
+    depends_build-append    port:git
+    git.cmd                 ${prefix}/bin/git
+}
+
+depends_lib-append      port:zlib
+
+platform darwin {
+    patchfiles          0001-CMakeLists-use-CMAKE_OSX_ARCHITECTURE-not-CMAKE_SYST.patch
+}
+
+compiler.cxx_standard   2011
+# Until non_lazy_ptr bug is fixed.
+compiler.blacklist      macports-gcc-12
+compilers.setup         require_fortran
+
+configure.args-append   -DBUILD_TESTING=ON \
+                        -DFORTRAN=ON \
+                        -DSHARED=ON
+
+if {[string match *gcc* ${configure.compiler}]} {
+    # ___atomic_fetch_add_8, ___atomic_compare_exchange_8, ___atomic_store_8, ___atomic_load_8, ___atomic_fetch_xor_8
+    # https://github.com/ERGO-Code/HiGHS/issues/1294
+    configure.ldflags-append -latomic
+}
+
+test.run                yes

--- a/math/HiGHS/files/0001-CMakeLists-use-CMAKE_OSX_ARCHITECTURE-not-CMAKE_SYST.patch
+++ b/math/HiGHS/files/0001-CMakeLists-use-CMAKE_OSX_ARCHITECTURE-not-CMAKE_SYST.patch
@@ -1,0 +1,29 @@
+From 864554a200ed1fbceab5a10d7ad47de280d019b9 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 17 May 2023 23:16:56 +0800
+Subject: [PATCH] CMakeLists: use CMAKE_OSX_ARCHITECTURE, not
+ CMAKE_SYSTEM_PROCESSOR
+
+---
+ CMakeLists.txt | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git CMakeLists.txt CMakeLists.txt
+index d36d192bf..b3e36e99f 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -132,10 +132,8 @@ enable_cxx_compiler_flag_if_supported("-Wno-format-truncation")
+ enable_cxx_compiler_flag_if_supported("-pedantic")
+ endif()
+ 
+-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86\_64|i686)")
++if(CMAKE_OSX_ARCHITECTURE MATCHES "^(x86\_64|i686)")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mpopcnt")
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64|powerpc64)")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mpopcntd")
+ else()
+   message("FLAG_MPOPCNT_SUPPORTED is not available on this architecture")
+ endif()
+-- 
+2.40.0
+


### PR DESCRIPTION
#### Description

New port: https://github.com/ERGO-Code/HiGHS

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

100% of tests pass in Rosetta:
```
[100%] Built target unit_tests
make[1]: Leaving directory `/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_HiGHS/HiGHS/work/build'
/opt/local/bin/cmake -E cmake_progress_start /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_HiGHS/HiGHS/work/build/CMakeFiles 0
make: Leaving directory `/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_HiGHS/HiGHS/work/build'
--->  Testing HiGHS
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_math_HiGHS/HiGHS/work/build" && /usr/bin/make test 
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_math_HiGHS/HiGHS/work/build
        Start   1: capi_unit_tests
  1/148 Test   #1: capi_unit_tests ..................   Passed    0.26 sec
        Start   2: unit-test-build
  2/148 Test   #2: unit-test-build ..................   Passed    3.32 sec
        Start   3: unit_tests_all
  3/148 Test   #3: unit_tests_all ...................   Passed   50.27 sec
        Start   4: 25fv47--presolve=off
  4/148 Test   #4: 25fv47--presolve=off .............   Passed    1.23 sec
        Start   5: 25fv47--presolve=on
  5/148 Test   #5: 25fv47--presolve=on ..............   Passed    1.07 sec
        Start   6: 25fv47--random_seed=1
  6/148 Test   #6: 25fv47--random_seed=1 ............   Passed    1.12 sec
        Start   7: 25fv47--random_seed=2
  7/148 Test   #7: 25fv47--random_seed=2 ............   Passed    1.10 sec
        Start   8: 25fv47--random_seed=3
  8/148 Test   #8: 25fv47--random_seed=3 ............   Passed    1.34 sec
        Start   9: 80bau3b--presolve=off
  9/148 Test   #9: 80bau3b--presolve=off ............   Passed    1.67 sec
        Start  10: 80bau3b--presolve=on
 10/148 Test  #10: 80bau3b--presolve=on .............   Passed    1.33 sec
        Start  11: 80bau3b--random_seed=1
 11/148 Test  #11: 80bau3b--random_seed=1 ...........   Passed    1.39 sec
        Start  12: 80bau3b--random_seed=2
 12/148 Test  #12: 80bau3b--random_seed=2 ...........   Passed    1.30 sec
        Start  13: 80bau3b--random_seed=3
 13/148 Test  #13: 80bau3b--random_seed=3 ...........   Passed    1.33 sec
        Start  14: adlittle--presolve=off
 14/148 Test  #14: adlittle--presolve=off ...........   Passed    0.14 sec
        Start  15: adlittle--presolve=on
 15/148 Test  #15: adlittle--presolve=on ............   Passed    0.16 sec
        Start  16: adlittle--random_seed=1
 16/148 Test  #16: adlittle--random_seed=1 ..........   Passed    0.16 sec
        Start  17: adlittle--random_seed=2
 17/148 Test  #17: adlittle--random_seed=2 ..........   Passed    0.15 sec
        Start  18: adlittle--random_seed=3
 18/148 Test  #18: adlittle--random_seed=3 ..........   Passed    0.15 sec
        Start  19: afiro--presolve=off
 19/148 Test  #19: afiro--presolve=off ..............   Passed    0.12 sec
        Start  20: afiro--presolve=on
 20/148 Test  #20: afiro--presolve=on ...............   Passed    0.12 sec
        Start  21: afiro--random_seed=1
 21/148 Test  #21: afiro--random_seed=1 .............   Passed    0.12 sec
        Start  22: afiro--random_seed=2
 22/148 Test  #22: afiro--random_seed=2 .............   Passed    0.12 sec
        Start  23: afiro--random_seed=3
 23/148 Test  #23: afiro--random_seed=3 .............   Passed    0.12 sec
        Start  24: etamacro--presolve=off
 24/148 Test  #24: etamacro--presolve=off ...........   Passed    0.24 sec
        Start  25: etamacro--presolve=on
 25/148 Test  #25: etamacro--presolve=on ............   Passed    0.28 sec
        Start  26: etamacro--random_seed=1
 26/148 Test  #26: etamacro--random_seed=1 ..........   Passed    0.28 sec
        Start  27: etamacro--random_seed=2
 27/148 Test  #27: etamacro--random_seed=2 ..........   Passed    0.29 sec
        Start  28: etamacro--random_seed=3
 28/148 Test  #28: etamacro--random_seed=3 ..........   Passed    0.28 sec
        Start  29: greenbea--presolve=off
 29/148 Test  #29: greenbea--presolve=off ...........   Passed    3.93 sec
        Start  30: greenbea--presolve=on
 30/148 Test  #30: greenbea--presolve=on ............   Passed    1.82 sec
        Start  31: greenbea--random_seed=1
 31/148 Test  #31: greenbea--random_seed=1 ..........   Passed    1.81 sec
        Start  32: greenbea--random_seed=2
 32/148 Test  #32: greenbea--random_seed=2 ..........   Passed    1.90 sec
        Start  33: greenbea--random_seed=3
 33/148 Test  #33: greenbea--random_seed=3 ..........   Passed    1.68 sec
        Start  34: shell--presolve=off
 34/148 Test  #34: shell--presolve=off ..............   Passed    0.23 sec
        Start  35: shell--presolve=on
 35/148 Test  #35: shell--presolve=on ...............   Passed    0.30 sec
        Start  36: shell--random_seed=1
 36/148 Test  #36: shell--random_seed=1 .............   Passed    0.29 sec
        Start  37: shell--random_seed=2
 37/148 Test  #37: shell--random_seed=2 .............   Passed    0.30 sec
        Start  38: shell--random_seed=3
 38/148 Test  #38: shell--random_seed=3 .............   Passed    0.29 sec
        Start  39: stair--presolve=off
 39/148 Test  #39: stair--presolve=off ..............   Passed    0.28 sec
        Start  40: stair--presolve=on
 40/148 Test  #40: stair--presolve=on ...............   Passed    0.28 sec
        Start  41: stair--random_seed=1
 41/148 Test  #41: stair--random_seed=1 .............   Passed    0.28 sec
        Start  42: stair--random_seed=2
 42/148 Test  #42: stair--random_seed=2 .............   Passed    0.28 sec
        Start  43: stair--random_seed=3
 43/148 Test  #43: stair--random_seed=3 .............   Passed    0.27 sec
        Start  44: standata--presolve=off
 44/148 Test  #44: standata--presolve=off ...........   Passed    0.20 sec
        Start  45: standata--presolve=on
 45/148 Test  #45: standata--presolve=on ............   Passed    0.21 sec
        Start  46: standata--random_seed=1
 46/148 Test  #46: standata--random_seed=1 ..........   Passed    0.21 sec
        Start  47: standata--random_seed=2
 47/148 Test  #47: standata--random_seed=2 ..........   Passed    0.22 sec
        Start  48: standata--random_seed=3
 48/148 Test  #48: standata--random_seed=3 ..........   Passed    0.21 sec
        Start  49: standgub--presolve=off
 49/148 Test  #49: standgub--presolve=off ...........   Passed    0.19 sec
        Start  50: standgub--presolve=on
 50/148 Test  #50: standgub--presolve=on ............   Passed    0.21 sec
        Start  51: standgub--random_seed=1
 51/148 Test  #51: standgub--random_seed=1 ..........   Passed    0.21 sec
        Start  52: standgub--random_seed=2
 52/148 Test  #52: standgub--random_seed=2 ..........   Passed    0.22 sec
        Start  53: standgub--random_seed=3
 53/148 Test  #53: standgub--random_seed=3 ..........   Passed    0.25 sec
        Start  54: standmps--presolve=off
 54/148 Test  #54: standmps--presolve=off ...........   Passed    0.22 sec
        Start  55: standmps--presolve=on
 55/148 Test  #55: standmps--presolve=on ............   Passed    0.27 sec
        Start  56: standmps--random_seed=1
 56/148 Test  #56: standmps--random_seed=1 ..........   Passed    0.28 sec
        Start  57: standmps--random_seed=2
 57/148 Test  #57: standmps--random_seed=2 ..........   Passed    0.26 sec
        Start  58: standmps--random_seed=3
 58/148 Test  #58: standmps--random_seed=3 ..........   Passed    0.25 sec
        Start  59: bgetam--presolve=off
 59/148 Test  #59: bgetam--presolve=off .............   Passed    0.16 sec
        Start  60: bgetam--presolve=on
 60/148 Test  #60: bgetam--presolve=on ..............   Passed    0.19 sec
        Start  61: bgetam--random_seed=1
 61/148 Test  #61: bgetam--random_seed=1 ............   Passed    0.19 sec
        Start  62: bgetam--random_seed=2
 62/148 Test  #62: bgetam--random_seed=2 ............   Passed    0.21 sec
        Start  63: bgetam--random_seed=3
 63/148 Test  #63: bgetam--random_seed=3 ............   Passed    0.19 sec
        Start  64: box1--presolve=off
 64/148 Test  #64: box1--presolve=off ...............   Passed    0.13 sec
        Start  65: box1--presolve=on
 65/148 Test  #65: box1--presolve=on ................   Passed    0.15 sec
        Start  66: box1--random_seed=1
 66/148 Test  #66: box1--random_seed=1 ..............   Passed    0.15 sec
        Start  67: box1--random_seed=2
 67/148 Test  #67: box1--random_seed=2 ..............   Passed    0.14 sec
        Start  68: box1--random_seed=3
 68/148 Test  #68: box1--random_seed=3 ..............   Passed    0.15 sec
        Start  69: ex72a--presolve=off
 69/148 Test  #69: ex72a--presolve=off ..............   Passed    0.15 sec
        Start  70: ex72a--presolve=on
 70/148 Test  #70: ex72a--presolve=on ...............   Passed    0.15 sec
        Start  71: ex72a--random_seed=1
 71/148 Test  #71: ex72a--random_seed=1 .............   Passed    0.15 sec
        Start  72: ex72a--random_seed=2
 72/148 Test  #72: ex72a--random_seed=2 .............   Passed    0.15 sec
        Start  73: ex72a--random_seed=3
 73/148 Test  #73: ex72a--random_seed=3 .............   Passed    0.14 sec
        Start  74: forest6--presolve=off
 74/148 Test  #74: forest6--presolve=off ............   Passed    0.14 sec
        Start  75: forest6--presolve=on
 75/148 Test  #75: forest6--presolve=on .............   Passed    0.18 sec
        Start  76: forest6--random_seed=1
 76/148 Test  #76: forest6--random_seed=1 ...........   Passed    0.25 sec
        Start  77: forest6--random_seed=2
 77/148 Test  #77: forest6--random_seed=2 ...........   Passed    0.15 sec
        Start  78: forest6--random_seed=3
 78/148 Test  #78: forest6--random_seed=3 ...........   Passed    0.15 sec
        Start  79: galenet--presolve=off
 79/148 Test  #79: galenet--presolve=off ............   Passed    0.10 sec
        Start  80: galenet--presolve=on
 80/148 Test  #80: galenet--presolve=on .............   Passed    0.08 sec
        Start  81: galenet--random_seed=1
 81/148 Test  #81: galenet--random_seed=1 ...........   Passed    0.09 sec
        Start  82: galenet--random_seed=2
 82/148 Test  #82: galenet--random_seed=2 ...........   Passed    0.09 sec
        Start  83: galenet--random_seed=3
 83/148 Test  #83: galenet--random_seed=3 ...........   Passed    0.09 sec
        Start  84: gams10am--presolve=off
 84/148 Test  #84: gams10am--presolve=off ...........   Passed    0.13 sec
        Start  85: gams10am--presolve=on
 85/148 Test  #85: gams10am--presolve=on ............   Passed    0.11 sec
        Start  86: gams10am--random_seed=1
 86/148 Test  #86: gams10am--random_seed=1 ..........   Passed    0.12 sec
        Start  87: gams10am--random_seed=2
 87/148 Test  #87: gams10am--random_seed=2 ..........   Passed    0.12 sec
        Start  88: gams10am--random_seed=3
 88/148 Test  #88: gams10am--random_seed=3 ..........   Passed    0.12 sec
        Start  89: refinery--presolve=off
 89/148 Test  #89: refinery--presolve=off ...........   Passed    0.22 sec
        Start  90: refinery--presolve=on
 90/148 Test  #90: refinery--presolve=on ............   Passed    0.24 sec
        Start  91: refinery--random_seed=1
 91/148 Test  #91: refinery--random_seed=1 ..........   Passed    0.24 sec
        Start  92: refinery--random_seed=2
 92/148 Test  #92: refinery--random_seed=2 ..........   Passed    0.23 sec
        Start  93: refinery--random_seed=3
 93/148 Test  #93: refinery--random_seed=3 ..........   Passed    0.24 sec
        Start  94: woodinfe--presolve=off
 94/148 Test  #94: woodinfe--presolve=off ...........   Passed    0.13 sec
        Start  95: woodinfe--presolve=on
 95/148 Test  #95: woodinfe--presolve=on ............   Passed    0.11 sec
        Start  96: woodinfe--random_seed=1
 96/148 Test  #96: woodinfe--random_seed=1 ..........   Passed    0.11 sec
        Start  97: woodinfe--random_seed=2
 97/148 Test  #97: woodinfe--random_seed=2 ..........   Passed    0.11 sec
        Start  98: woodinfe--random_seed=3
 98/148 Test  #98: woodinfe--random_seed=3 ..........   Passed    0.10 sec
        Start  99: small_mip--presolve=off
 99/148 Test  #99: small_mip--presolve=off ..........   Passed    0.16 sec
        Start 100: small_mip--presolve=on
100/148 Test #100: small_mip--presolve=on ...........   Passed    0.10 sec
        Start 101: small_mip--random_seed=1
101/148 Test #101: small_mip--random_seed=1 .........   Passed    0.11 sec
        Start 102: small_mip--random_seed=2
102/148 Test #102: small_mip--random_seed=2 .........   Passed    0.11 sec
        Start 103: small_mip--random_seed=3
103/148 Test #103: small_mip--random_seed=3 .........   Passed    0.11 sec
        Start 104: flugpl--presolve=off
104/148 Test #104: flugpl--presolve=off .............   Passed    0.85 sec
        Start 105: flugpl--presolve=on
105/148 Test #105: flugpl--presolve=on ..............   Passed    1.07 sec
        Start 106: flugpl--random_seed=1
106/148 Test #106: flugpl--random_seed=1 ............   Passed    1.05 sec
        Start 107: flugpl--random_seed=2
107/148 Test #107: flugpl--random_seed=2 ............   Passed    1.12 sec
        Start 108: flugpl--random_seed=3
108/148 Test #108: flugpl--random_seed=3 ............   Passed    1.06 sec
        Start 109: lseu--presolve=off
109/148 Test #109: lseu--presolve=off ...............   Passed    2.24 sec
        Start 110: lseu--presolve=on
110/148 Test #110: lseu--presolve=on ................   Passed    3.34 sec
        Start 111: lseu--random_seed=1
111/148 Test #111: lseu--random_seed=1 ..............   Passed    3.30 sec
        Start 112: lseu--random_seed=2
112/148 Test #112: lseu--random_seed=2 ..............   Passed    5.72 sec
        Start 113: lseu--random_seed=3
113/148 Test #113: lseu--random_seed=3 ..............   Passed    3.03 sec
        Start 114: egout--presolve=off
114/148 Test #114: egout--presolve=off ..............   Passed    0.55 sec
        Start 115: egout--presolve=on
115/148 Test #115: egout--presolve=on ...............   Passed    0.46 sec
        Start 116: egout--random_seed=1
116/148 Test #116: egout--random_seed=1 .............   Passed    0.48 sec
        Start 117: egout--random_seed=2
117/148 Test #117: egout--random_seed=2 .............   Passed    0.51 sec
        Start 118: egout--random_seed=3
118/148 Test #118: egout--random_seed=3 .............   Passed    0.46 sec
        Start 119: gt2--presolve=off
119/148 Test #119: gt2--presolve=off ................   Passed    0.70 sec
        Start 120: gt2--presolve=on
120/148 Test #120: gt2--presolve=on .................   Passed    1.21 sec
        Start 121: gt2--random_seed=1
121/148 Test #121: gt2--random_seed=1 ...............   Passed    0.68 sec
        Start 122: gt2--random_seed=2
122/148 Test #122: gt2--random_seed=2 ...............   Passed    1.49 sec
        Start 123: gt2--random_seed=3
123/148 Test #123: gt2--random_seed=3 ...............   Passed    1.30 sec
        Start 124: rgn--presolve=off
124/148 Test #124: rgn--presolve=off ................   Passed    3.38 sec
        Start 125: rgn--presolve=on
125/148 Test #125: rgn--presolve=on .................   Passed    2.67 sec
        Start 126: rgn--random_seed=1
126/148 Test #126: rgn--random_seed=1 ...............   Passed    4.38 sec
        Start 127: rgn--random_seed=2
127/148 Test #127: rgn--random_seed=2 ...............   Passed    2.16 sec
        Start 128: rgn--random_seed=3
128/148 Test #128: rgn--random_seed=3 ...............   Passed    2.36 sec
        Start 129: bell5--presolve=off
129/148 Test #129: bell5--presolve=off ..............   Passed    6.21 sec
        Start 130: bell5--presolve=on
130/148 Test #130: bell5--presolve=on ...............   Passed    8.47 sec
        Start 131: bell5--random_seed=1
131/148 Test #131: bell5--random_seed=1 .............   Passed   15.27 sec
        Start 132: bell5--random_seed=2
132/148 Test #132: bell5--random_seed=2 .............   Passed    5.52 sec
        Start 133: bell5--random_seed=3
133/148 Test #133: bell5--random_seed=3 .............   Passed    8.13 sec
        Start 134: sp150x300d--presolve=off
134/148 Test #134: sp150x300d--presolve=off .........   Passed    1.93 sec
        Start 135: sp150x300d--presolve=on
135/148 Test #135: sp150x300d--presolve=on ..........   Passed    0.88 sec
        Start 136: sp150x300d--random_seed=1
136/148 Test #136: sp150x300d--random_seed=1 ........   Passed    1.08 sec
        Start 137: sp150x300d--random_seed=2
137/148 Test #137: sp150x300d--random_seed=2 ........   Passed    1.03 sec
        Start 138: sp150x300d--random_seed=3
138/148 Test #138: sp150x300d--random_seed=3 ........   Passed    1.44 sec
        Start 139: p0548--presolve=off
139/148 Test #139: p0548--presolve=off ..............   Passed    2.12 sec
        Start 140: p0548--presolve=on
140/148 Test #140: p0548--presolve=on ...............   Passed    1.93 sec
        Start 141: p0548--random_seed=1
141/148 Test #141: p0548--random_seed=1 .............   Passed    1.83 sec
        Start 142: p0548--random_seed=2
142/148 Test #142: p0548--random_seed=2 .............   Passed    1.49 sec
        Start 143: p0548--random_seed=3
143/148 Test #143: p0548--random_seed=3 .............   Passed    1.49 sec
        Start 144: dcmulti--presolve=off
144/148 Test #144: dcmulti--presolve=off ............   Passed   18.08 sec
        Start 145: dcmulti--presolve=on
145/148 Test #145: dcmulti--presolve=on .............   Passed   12.61 sec
        Start 146: dcmulti--random_seed=1
146/148 Test #146: dcmulti--random_seed=1 ...........   Passed    7.30 sec
        Start 147: dcmulti--random_seed=2
147/148 Test #147: dcmulti--random_seed=2 ...........   Passed   15.59 sec
        Start 148: dcmulti--random_seed=3
148/148 Test #148: dcmulti--random_seed=3 ...........   Passed   11.59 sec

100% tests passed, 0 tests failed out of 148

Total Test time (real) = 265.90 sec
```