### PR TITLE
darwin-xtools: use 2.2.4 on PPC (x86 unchanged)

### DIFF
--- a/devel/darwin-xtools/Portfile
+++ b/devel/darwin-xtools/Portfile
@@ -4,13 +4,36 @@ PortSystem                  1.0
 PortGroup                   cmake 1.1
 PortGroup                   github 1.0
 
-set xtools_version          6446947f3e99db52a40b30a38f36b9ae33492aea
-set libyaml_version         0.2.5
+if {${os.arch} eq "powerpc"} {
+    set xtools_version      6f6c04e8b25497851f6a5979a6e96023fffe22df
+    github.setup            iains darwin-xtools ${xtools_version}
+    version                 2.2.4
 
-github.setup                iains darwin-xtools ${xtools_version}
+    checksums               ${name}-${xtools_version}.tar.gz \
+                            rmd160  07dd50453b93f90ea4806fd8c12be3acb91c2fbd \
+                            sha256  7568104068614b8e8b1cb72fcc01219f78f90a0d14d95c255be78e2c0a899d62 \
+                            size    2932788
+} else {
+    set xtools_version      6446947f3e99db52a40b30a38f36b9ae33492aea
+    github.setup            iains darwin-xtools ${xtools_version}
+    version                 3.3.0
+
+    checksums               ${name}-${xtools_version}.tar.gz \
+                            rmd160  18d99473a012f4fa48464aadd078921a25bdc322 \
+                            sha256  9167b67e128f616cef079bbeda4b116fe0d41fe54784fff85826420daae23f5f \
+                            size    2958759
+}
+
+set libyaml_version         0.2.5
+set libyaml_distfile        ${libyaml_version}.tar.gz
+distfiles-append            ${libyaml_distfile}:libyaml
+checksums-append            ${libyaml_distfile} \
+                            rmd160  7fe42b7d7bb0dd07aedee6c775c43fd35bb5cf3e \
+                            sha256  fa240dbf262be053f3898006d502d514936c818e422afdcf33921c63bed9bf2e \
+                            size    85055
+
 github.tarball_from         archive
 
-version                     3.3.0
 revision                    0
 epoch                       0
 
@@ -25,18 +48,6 @@ license                     {APSL-2 Apache-2}
 homepage                    https://github.com/iains/darwin-xtools
 
 master_sites-append         https://github.com/yaml/libyaml/archive/refs/tags:libyaml
-
-set libyaml_distfile        ${libyaml_version}.tar.gz
-distfiles-append            ${libyaml_distfile}:libyaml
-
-checksums                   ${name}-${xtools_version}.tar.gz \
-                            rmd160  18d99473a012f4fa48464aadd078921a25bdc322 \
-                            sha256  9167b67e128f616cef079bbeda4b116fe0d41fe54784fff85826420daae23f5f \
-                            size    2958759 \
-                            ${libyaml_distfile} \
-                            rmd160  7fe42b7d7bb0dd07aedee6c775c43fd35bb5cf3e \
-                            sha256  fa240dbf262be053f3898006d502d514936c818e422afdcf33921c63bed9bf2e \
-                            size    85055
 
 patchfiles-append           0001-ld64-unwinddump-include-stdlib-for-exit-3.patch \
                             0002-ld64-archive_file-fix-compilation-without-LTO_SUPPOR.patch \
@@ -53,6 +64,10 @@ patchfiles-append           0001-ld64-unwinddump-include-stdlib-for-exit-3.patch
                             0013-libyaml-add-the-way-to-include-it.patch \
                             0014-cctools-removed-redundant-implementation-of-get_toc_.patch \
                             0015-tapilite-fix-build-by-clang.patch
+
+platform darwin powerpc {
+    patchfiles-append       0016-Minor-fix-ups-for-ppc.patch
+}
 
 post-extract {
     ln -s ${workpath}/libyaml-${libyaml_version} ${worksrcpath}/libyaml

--- a/devel/darwin-xtools/files/0016-Minor-fix-ups-for-ppc.patch
+++ b/devel/darwin-xtools/files/0016-Minor-fix-ups-for-ppc.patch
@@ -1,0 +1,43 @@
+From b7e635efd894116530e4fc15847de0aab5915b7e Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Thu, 18 May 2023 02:51:49 +0800
+Subject: [PATCH] Minor fix-ups for ppc
+
+---
+ cctools/misc/strings.c  | 6 +++++-
+ ld64/src/ld/Options.cpp | 2 +-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git cctools/misc/strings.c cctools/misc/strings.c
+index e8d62a7..93d8fea 100644
+--- cctools/misc/strings.c
++++ cctools/misc/strings.c
+@@ -354,7 +354,11 @@ void *cookie)
+ 	 * If the ofile is not an object file then process it without reguard
+ 	 * to sections.
+ 	 */
+-	if(ofile->object_addr == NULL || ofile->member_type == OFILE_LLVM_BITCODE){
++	if(ofile->object_addr == NULL
++#ifdef LTO_SUPPORT
++           || ofile->member_type == OFILE_LLVM_BITCODE
++#endif /* LTO_SUPPORT */
++           ){
+ 	    if(ofile->file_type == OFILE_FAT && ofile->arch_flag.cputype != 0){
+ 		if(ofile->fat_header->magic == FAT_MAGIC_64){
+ 		    addr = ofile->file_addr +
+diff --git ld64/src/ld/Options.cpp ld64/src/ld/Options.cpp
+index 0ab643d..be01832 100644
+--- ld64/src/ld/Options.cpp
++++ ld64/src/ld/Options.cpp
+@@ -1704,7 +1704,7 @@ uint32_t Options::parseVersionNumber32(const char* versionString)
+ 			z = strtoul(&end[1], &end, 10);
+ 		}
+ 	}
+-	if ( (*end != '\0') || (x > 0xffff) || (y > 0xff) || (z > 0xff) )
++	if ( (x > 0xffff) || (y > 0xff) || (z > 0xff) )
+ 		throwf("malformed 32-bit x.y.z version number: %s", versionString);
+ 
+ 	return (x << 16) | ( y << 8 ) | z;
+-- 
+2.40.1
+


### PR DESCRIPTION
#### Description

3.3.0 does not work on PPC. Use 2.2.4 branch (which is in fact the default one in Iain’s repo).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
