### PR TITLE
parallel-hashmap: depend on git on <= 10.9

### DIFF
--- a/devel/parallel-hashmap/Portfile
+++ b/devel/parallel-hashmap/Portfile
@@ -17,6 +17,15 @@ checksums               rmd160  1efbfaa5fb4c65c146de0c895b68c2bb0afc6967 \
                         size    2048486
 installs_libs           no
 
+platform darwin {
+    if {${os.major} < 14} {
+        # Lion+ (with Xcode 4.1+) have git; earlier need to bring their own.
+        # On 10.9 git fetch fails with ssl error.
+        depends_build-append    port:git
+        git.cmd                 ${prefix}/bin/git
+    }
+}
+
 # https://github.com/greg7mdp/parallel-hashmap/issues/192
 # https://github.com/greg7mdp/parallel-hashmap/pull/193
 patchfiles-append       0001-Warn-on-4-byte-char-not-err-out.patch \


### PR DESCRIPTION
#### Description

One more fix needed, otherwise 10.9 and earlier fail if Git is not installed: https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/231890/steps/install-port/logs/stdio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
