### PR TITLE
HiGHS: avoid Apple clangs on <= 10.11

### DIFF
--- a/math/HiGHS/Portfile
+++ b/math/HiGHS/Portfile
@@ -31,8 +31,10 @@ platform darwin {
 }
 
 compiler.cxx_standard   2011
-# Until non_lazy_ptr bug is fixed.
-compiler.blacklist      macports-gcc-12
+# Apple clang on 10.11 and below fails.
+# gcc12 excluded until non_lazy_ptr bug is fixed.
+compiler.blacklist-append \
+                        {clang < 900} macports-gcc-12
 compilers.setup         require_fortran
 
 configure.args-append   -DBUILD_TESTING=ON \


### PR DESCRIPTION
#### Description

The build fails on <= 10.11 atm, wherever Apple clangs are used: https://ports.macports.org/port/HiGHS/details
Blacklist `{clang < 900}`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
