### PR TITLE
symfony-cli: update to 5.5.6

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.5.5
+version             5.5.6
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  80de03e5d64f461f7b20e215fcbef396c070901b \
-                        sha256  5c32e34519871b95f65940543c0dc6186190b0d081b7859ad2425af9a59cfb47 \
-                        size    252773
+    checksums           rmd160  8bd33c27b430c1edf565be90cfa4b99ecac862ac \
+                        sha256  3ef88eb0e55540732c162001e698469d1ee196e206c4a8d3155bde120b6d3c1f \
+                        size    252822
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  6408e448db3c3e0c565bc4bfe6078587e148da37 \
-                        sha256  2529b6e34087ef1914580aa87f8d5b16502fb220c2dc7ed90e974961bebcac48 \
-                        size    10958295
+    checksums           rmd160  de37abbda157bbac5e6163162c2c935457838679 \
+                        sha256  2e6c80a7ff70c0b74e3851ffc82823710cf7362ed49f06b1d8f16b646f111d58 \
+                        size    10977711
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.5.6

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
