### PR TITLE
crystal: update to 1.8.2

### DIFF
--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        crystal-lang crystal 1.8.0
+github.setup        crystal-lang crystal 1.8.2
 github.tarball_from archive
 revision            0
 categories          lang
@@ -40,13 +40,13 @@ master_sites-append https://github.com/crystal-lang/${name}/releases/download/${
 distfiles-append    ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  10a34f556ae2acaee55a315ee218256bb439d6dd \
-                    sha256  6353c3b3ca5a1ed6c8b3ee80e5141d130856ebc736c30d1684661001279c2fe1 \
-                    size    3169681 \
+                    rmd160  1edb7e53346a08bb13059623b23e44bba0594b82 \
+                    sha256  6e722e3239a8c467ba42a8838916788a4795b0ceaa2d1e2e98616cedeb540605 \
+                    size    3171583 \
                     ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix} \
-                    rmd160  00f12ba4b74f668264b110106477392415bc426c \
-                    sha256  08a6dc8873ce53af1ba603045a145fefe23f803c6badaa2b4d7e02c666d342d0 \
-                    size    57516167
+                    rmd160  a4647e9838b3210d9670c7d1d0abe09112646672 \
+                    sha256  58ebc5289ed2dbedf80fd0d36fadffeff634b4801a4d739d42737e4b56140e38 \
+                    size    57525607
 
 patchfiles          patch-static.diff
 


### PR DESCRIPTION
###### Tested on
macOS 13.3.1 22E772610a x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?