### PR TITLE
gtest(patch): Add gtest version to CMakeLists

### DIFF
--- a/devel/gtest/Portfile
+++ b/devel/gtest/Portfile
@@ -7,7 +7,7 @@ PortGroup       cmake 1.1
 PortGroup       legacysupport 1.1
 
 github.setup    google googletest 1.12.1 release-
-revision        0
+revision        1
 
 name            gtest
 categories      devel
@@ -27,6 +27,14 @@ long_description \
 checksums       rmd160  3991930354c07c75875fba519d7aa6b12eba21a8 \
                 sha256  a28fa459c227d0bd97acc9c18503870b24eabaa69056c7f637144747c469e66a \
                 size    854915
+
+patchfiles      patch-add-gtest-version.diff
+
+post-patch {
+    reinplace "s,@@GOOGLETEST_VERSION@@,${version},g" \
+        ${worksrcpath}/googlemock/CMakeLists.txt \
+        ${worksrcpath}/googletest/CMakeLists.txt
+}
 
 legacysupport.newest_darwin_requires_legacy 14
 legacysupport.use_mp_libcxx yes

--- a/devel/gtest/Portfile
+++ b/devel/gtest/Portfile
@@ -6,8 +6,9 @@ PortGroup       compiler_blacklist_versions 1.0
 PortGroup       cmake 1.1
 PortGroup       legacysupport 1.1
 
-github.setup    google googletest 1.12.1 release-
-revision        1
+github.setup    google googletest 1.13.0 v
+github.tarball_from archive
+revision        0
 
 name            gtest
 categories      devel
@@ -24,9 +25,9 @@ long_description \
                 fatal and non-fatal failures, various options for \
                 running the tests, and XML test report generation.
 
-checksums       rmd160  3991930354c07c75875fba519d7aa6b12eba21a8 \
-                sha256  a28fa459c227d0bd97acc9c18503870b24eabaa69056c7f637144747c469e66a \
-                size    854915
+checksums       rmd160  a9c9160e28d4d2573f07235f05e25ae1cad8f261 \
+                sha256  ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363 \
+                size    862871
 
 patchfiles      patch-add-gtest-version.diff
 
@@ -43,7 +44,15 @@ compiler.cxx_standard   2014
 cmake.set_cxx_standard  yes
 
 configure.optflags      -g
-configure.args-append   -Dgtest_build_tests=ON
+configure.args-append   -Dgtest_build_tests=ON \
+                        -DBUILD_SHARED_LIBS=OFF
+
+# Tests are broken for shared libs, see
+# https://github.com/google/googletest/issues/3442
+variant shared_libs description "Build dynamic library" {
+configure.args-replace  -DBUILD_SHARED_LIBS=OFF \
+                        -DBUILD_SHARED_LIBS=ON
+}
 
 # Prevent MacPorts headers from being used. They're not needed since
 # googletest has no dependencies, and if a different version of googletest

--- a/devel/gtest/files/patch-add-gtest-version.diff
+++ b/devel/gtest/files/patch-add-gtest-version.diff
@@ -1,0 +1,20 @@
+--- googlemock/CMakeLists.txt.orig	2023-05-19 12:51:24.000000000 +0300
++++ googlemock/CMakeLists.txt	2023-05-19 12:52:53.512783464 +0300
+@@ -38,6 +38,7 @@
+ # Language "C" is required for find_package(Threads).
+ cmake_minimum_required(VERSION 3.5)
+ cmake_policy(SET CMP0048 NEW)
++set(GOOGLETEST_VERSION @@GOOGLETEST_VERSION@@)
+ project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
+ 
+ if (COMMAND set_up_hermetic_build)
+--- googletest/CMakeLists.txt.orig	2023-05-19 12:53:24.000000000 +0300
++++ googletest/CMakeLists.txt	2023-05-19 12:53:32.354596104 +0300
+@@ -48,6 +48,7 @@
+ 
+ cmake_minimum_required(VERSION 3.5)
+ cmake_policy(SET CMP0048 NEW)
++set(GOOGLETEST_VERSION @@GOOGLETEST_VERSION@@)
+ project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
+ 
+ if (POLICY CMP0063) # Visibility


### PR DESCRIPTION
#### Description

See https://trac.macports.org/ticket/67449 (reported by @barracuda156).

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E772610a x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
