### PR TITLE
cdrtools:  update to version 3.02

### DIFF
--- a/sysutils/cdrtools/Portfile
+++ b/sysutils/cdrtools/Portfile
@@ -1,98 +1,194 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
+PortSystem              1.0
+PortGroup               makefile 1.0
+PortGroup               compiler_blacklist_versions 1.0
+PortGroup               conflicts_build 1.0
+PortGroup               codeberg 1.0
 
-name                cdrtools
-version             3.01
-revision            1
-categories          sysutils
-# listing all these licenses is somewhat redundant when taken as a whole,
-# but different separable components are licensed differently
-license             CDDL-1 BSD LGPL-2.1 GPL-2+ GPL-2
-platforms           darwin
-conflicts           dvdrtools
+name                    cdrtools
+codeberg.setup          schilytools schilytools 2023-04-19
+version                 3.02-${codeberg.version}
+revision                0
+categories              sysutils audio
+conflicts               dvdrtools
+maintainers             {hotmail.com:amtor @RobK88} \
+                        openmaintainer
+license                 CDDL-1 LGPL-2.1 GPL-2+ GPL-2
 
-description         ISO 9660 filesystem and CD creation tools
-long_description    The cdrtools software includes programs to create \
-                    and/or extract ISO 9660 filesystems, verify their \
-                    integrity, and write them to a disc.
-homepage            http://cdrecord.org
-maintainers         nomaintainer
-master_sites        sourceforge:project/cdrtools
+description             ISO 9660 filesystem and CD creation tools
+long_description        The cdrtools software includes programs to create \
+                        and/or extract ISO 9660 filesystems, verify their \
+                        integrity, and write them to a disc.
 
-checksums           rmd160  3696b1bc502905cbe7c06e492b42d2ffe2dba982 \
-                    sha256  ed282eb6276c4154ce6a0b5dee0bdb81940d0cbbfc7d03f769c4735ef5f5860f \
-                    size    2087416
+checksums               rmd160  e154278ecbe7d778bc1d6766ed163c9963b1cc82 \
+                        sha256  a4270cdcca5dd69c0114079277b06e5efad260b0a099c9c09d31e16e99a23ff5 \
+                        size    5896292
 
-use_bzip2           yes
+patch {
+                        reinplace -locale C "s|-noclobber| |g" \
+                        ${worksrcpath}/cdrecord/Makefile.dfl
 
-depends_build       port:smake
-
-depends_lib         port:gettext
-
-patchfiles          patch-include_schily_sha2.h
-patchfiles-append   mkisofs.c.patch
-post-patch {
-    reinplace -locale C "s|/opt/schily|${prefix}|g" \
-        ${worksrcpath}/DEFAULTS/Defaults.darwin \
-        ${worksrcpath}/DEFAULTS/Defaults.mac-os10 \
-        ${worksrcpath}/DEFAULTS_ENG/Defaults.darwin \
-        ${worksrcpath}/DEFAULTS_ENG/Defaults.mac-os10 \
-        ${worksrcpath}/libfind/find.c \
-        ${worksrcpath}/libfind/find_main.c \
-        ${worksrcpath}/librscg/scsi-remote.c \
-        ${worksrcpath}/TEMPLATES/Defaults.gcc
+                        reinplace -locale C "s|/opt/schily|${prefix}|g" \
+                        ${worksrcpath}/btcflash/btcflash.1 \
+                        ${worksrcpath}/cdda2wav/cdda2wav.1 \
+                        ${worksrcpath}/cdrecord/cdrecord.1 \
+                        ${worksrcpath}/DEFAULTS/Defaults.darwin \
+                        ${worksrcpath}/DEFAULTS/Defaults.mac-os10 \
+                        ${worksrcpath}/DEFAULTS_ENG/Defaults.darwin \
+                        ${worksrcpath}/DEFAULTS_ENG/Defaults.mac-os10 \
+                        ${worksrcpath}/libfind/find.c \
+                        ${worksrcpath}/libfind/find_main.c \
+                        ${worksrcpath}/librscg/scsi-remote.c \
+                        ${worksrcpath}/mkisofs/diag/isoinfo.8 \
+                        ${worksrcpath}/patch/tests/random/cmptest.sh \
+                        ${worksrcpath}/patch/tests/random/gentest.sh \
+                        ${worksrcpath}/readcd/readcd.1 \
+                        ${worksrcpath}/rmt/rmt.1 \
+                        ${worksrcpath}/rscsi/default-rscsi.sample \
+                        ${worksrcpath}/rscsi/rscsi.1 \
+                        ${worksrcpath}/scgskeleton/scgskeleton.1 \
+                        ${worksrcpath}/sformat/datio.c \
+                        ${worksrcpath}/smake/job.c \
+                        ${worksrcpath}/smake/make.c \
+                        ${worksrcpath}/sunpro/Make/bin/make/common/misc.cc \
+                        ${worksrcpath}/sunpro/Make/bin/make/common/read2.cc \
+                        ${worksrcpath}/TEMPLATES/Defaults.gcc \
+                        ${worksrcpath}/TEMPLATES/Defaults.clang \
+                        ${worksrcpath}/TEMPLATES/Defaults.xcc \
+                        ${worksrcpath}/ved/ved.h
 }
 
-use_configure       no
+proc port_conflict_check {p_port_name p_conflict_ver_min p_conflict_ver_max} {
+    ui_info "Checking for conflict against port: ${p_port_name}"
 
-# hangs the same way as smake itself with both llvm-gcc-4.2 and Xcode 4.1's clang
-# https://trac.macports.org/ticket/30310
-compiler.blacklist  llvm-gcc-4.2 macports-llvm-gcc-4.2 {clang < 300}
+    if { ![catch {set port_conflict_ver_info [lindex [registry_active ${p_port_name}] 0]}] } {
+        set port_conflict_ver [lindex ${port_conflict_ver_info} 1]_[lindex ${port_conflict_ver_info} 2]
+        ui_info "${p_port_name} active version: ${port_conflict_ver}"
 
-configure.cflags-append \
-                    -DNO_SCANSTACK \
-                    -Wno-error=implicit-function-declaration
+        if { [vercmp ${port_conflict_ver} ${p_conflict_ver_min}] >= 0
+            && [vercmp ${port_conflict_ver} ${p_conflict_ver_max}] <= 0 } {
 
-build.cmd           smake
-build.args          CC=${configure.cc} \
-                    COPTX="${configure.cflags} [get_canonical_archflags cc]" \
-                    DEFOSINCDIRS=${prefix}/include \
-                    LDOPTX="${configure.ldflags} [get_canonical_archflags ld]" \
-                    LDPATH=
-
-# smake does not support -j
-# Set build.jobs to -1 to disable MacPorts from adding the -j flag
-build.jobs          -1
-
-post-build {
-    # The build script doesn't notice when a program fails to build, so
-    # we must verify it ourselves. See
-    # https://trac.macports.org/ticket/34823
-    set progs {btcflash cdda2wav cdrecord devdump isodebug isodump isoinfo isovfy mkisofs readcd scgcheck scgskeleton}
-    fs-traverse path ${worksrcpath} {
-        if {[file isfile ${path}] && [string match {*/OBJ/*} ${path}]} {
-            set file [file tail ${path}]
-            set prog_index [lsearch ${progs} ${file}]
-            if {${prog_index} != -1} {
-                set progs [lreplace ${progs} ${prog_index} ${prog_index}]
-            }
+            ui_info "${p_port_name} conflicts; declare build conflict"
+            conflicts_build-append \
+                ${p_port_name}
         }
     }
-    if {[llength ${progs}] > 0} {
-        ui_error "The following programs did not build: [join ${progs} {, }]"
-        return -code error "build failed"
-    }
 }
 
-destroot.args       DEFINSUSR=${install.user} \
-                    DEFINSGRP=${install.group} \
-                    INS_BASE=${prefix}
+port_conflict_check     cdrtools 0.0 3.01_1
+
+universal_variant       no
+
+compiler.blacklist-append \
+                        llvm-gcc-4.2 macports-llvm-gcc-4.2 {clang < 300}
+
+configure.ldflags-append -lintl
+
+depends_build-append    port:smake \
+                        port:gettext
+
+depends_lib-append      port:gettext-runtime \
+                        port:libiconv
+
+build.cmd               smake
+
+#
+# Must specify INS_BASE and INS_RBASE in both the build and destroot phases
+#
+
+build.args-append       INS_BASE="${destroot}${prefix}" \
+                        INS_RBASE="${destroot}${prefix}" \
+                        DEFOSINCDIRS="${prefix}/include" \
+                        CC_OPT=${configure.optflags}
+
+destroot.destdir        INS_BASE="${destroot}${prefix}" \
+                        INS_RBASE="${destroot}${prefix}" \
+                        MANDIR=man \
+                        DEFINSUSR=${install.user} \
+                        DEFINSGRP=${install.group}
+
+#
+# smake does not support parallel building
+# i.e. smake does not support the -j flag
+#
+use_parallel_build      no
 
 post-destroot {
-    move ${destroot}/etc/default ${destroot}${prefix}/etc/
-}
+                        set keepPrograms  [ list    ${destroot}${prefix}/bin/btcflash \
+                                                    ${destroot}${prefix}/bin/cdda2mp3 \
+                                                    ${destroot}${prefix}/bin/cdda2ogg \
+                                                    ${destroot}${prefix}/bin/cdda2wav \
+                                                    ${destroot}${prefix}/bin/cdrecord \
+                                                    ${destroot}${prefix}/bin/devdump \
+                                                    ${destroot}${prefix}/bin/isodebug \
+                                                    ${destroot}${prefix}/bin/isodump \
+                                                    ${destroot}${prefix}/bin/isoinfo \
+                                                    ${destroot}${prefix}/bin/isovfy \
+                                                    ${destroot}${prefix}/bin/mkhybrid \
+                                                    ${destroot}${prefix}/bin/mkisofs \
+                                                    ${destroot}${prefix}/bin/readcd \
+                                                    ${destroot}${prefix}/bin/scgcheck \
+                                                    ${destroot}${prefix}/bin/scgskeleton ]
 
-livecheck.url       http://sourceforge.net/projects/cdrtools/files/
-livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
+                        set allPrograms [ glob ${destroot}${prefix}/bin/* ]
+                        foreach f $allPrograms {
+                            if { [ lsearch $keepPrograms $f ] == -1 } {
+                                delete $f
+                            }
+                        }
+
+                        set keepPrograms  [ list ${destroot}${prefix}/sbin/rscsi ]
+                        set allPrograms [ glob ${destroot}${prefix}/sbin/* ]
+                        foreach f $allPrograms {
+                            if { [ lsearch $keepPrograms $f ] == -1 } {
+                                delete $f
+                            }
+                        }
+
+                        set keepDocs [ list ${destroot}${prefix}/share/doc/cdda2wav \
+                                            ${destroot}${prefix}/share/doc/cdrecord \
+                                            ${destroot}${prefix}/share/doc/libparanoia \
+                                            ${destroot}${prefix}/share/doc/mkisofs \
+                                            ${destroot}${prefix}/share/doc/rscsi \
+                                            ${destroot}${prefix}/share/doc/mkisofs ]
+                        set allDocs [ glob -type d ${destroot}${prefix}/share/doc/* ]
+                        foreach f $allDocs {
+                            if { [ lsearch $keepDocs $f ] == -1 } {
+                                delete $f
+                            }
+                        }
+
+                        delete  ${destroot}${prefix}/etc/sformat.dat \
+                                ${destroot}${prefix}/etc/termcap \
+                                ${destroot}${prefix}/etc/default/rmt \
+                                ${destroot}${prefix}/etc/default/star
+
+                        set keepMan1Pages [ list \
+                                            ${destroot}${prefix}/share/man/man1/btcflash.1 \
+                                            ${destroot}${prefix}/share/man/man1/cdda2mp3.1 \
+                                            ${destroot}${prefix}/share/man/man1/cdda2ogg.1 \
+                                            ${destroot}${prefix}/share/man/man1/cdda2wav.1 \
+                                            ${destroot}${prefix}/share/man/man1/cdrecord.1 \
+                                            ${destroot}${prefix}/share/man/man1/readcd.1 \
+                                            ${destroot}${prefix}/share/man/man1/rscsi.1 \
+                                            ${destroot}${prefix}/share/man/man1/scgcheck.1 \
+                                            ${destroot}${prefix}/share/man/man1/scgskeleton.1 ]
+                        set allMan1Pages [ glob ${destroot}${prefix}/share/man/man1/* ]
+                        foreach f $allMan1Pages {
+                            if { [ lsearch $keepMan1Pages $f ] == -1 } {
+                                delete $f
+                            }
+                        }
+
+                        delete  ${destroot}${prefix}/share/man/help \
+                                ${destroot}${prefix}/share/man/man3 \
+                                ${destroot}${prefix}/share/man/man5 \
+                                ${destroot}${prefix}/share/man/man8/sformat.8
+
+                        delete  ${destroot}${prefix}/share/lib \
+                                ${destroot}${prefix}/lib \
+                                ${destroot}${prefix}/include
+
+                        delete  ${destroot}${prefix}/ccs ${destroot}${prefix}/xpg4
+}


### PR DESCRIPTION
#### Description
cdrtools:  update to version 3.02

* Reformat Portfile
* Add "makefile 1.0" PortGroup
* Add "conflicts_build 1.0" PortGroup
* Add "codeberg 1.0" PortGroup
* Add codeberg.setup after name
* Update version to 3.02-${codeberg.version}
* Add revision number
* Add audio to categories
* Add myself as a maintainer
* Remove BSD license
* Remove homepage
* Remove master_sites
* Update the checksums
* Remove "use_bzip2"
* Delete the patch files - patch-include_schily_sha2.h and mkisofs.c.patch
* Add patch block to delete "-noclobber" flag in cdrecord/Makefile.dfl
* Add patch block to replace "/opt/schily" with "${prefix}" in the source code files
* Add "port_conflict_check" procedure
* Add "port_conflict_check" procedure call to check against build conflicts with cdrtools versions 0 to 3.01_1
* Remove "use_configure no"
* Add "universal_variant no" to Portfile
* Change compiler.blacklist to compiler.backlist-append
* Remove "configure.cflags-append"
* Add "-lintl" to configure.ldflags-append
* Change depends_build to depends_build-append
* Change depends_lib to depends_lib-append
* Remove build dependency - port:smake
* Add build dependency - port:smake
* Add build dependency - port:gettext
* Add build dependency - port:libiconv
* Add library dependency - port:gettext-runtime
* Add library dependency - port:libiconv
* Change build.cmd to smake
* Delete "build.jobs -1" from the Portfile
* Add "use_parallel_build      no"
* Add note regarding the disabling of parallel builds
* Remove CC, COPTX, LDOPTX and LDPATH from build.args
* Change build.args to build.args-append
* Add INS_BASE, INS_RBASE, CC_OPT to build.args-append in the Portfile
* Remove post-build {} code block
* Add INS_RBASE to destroot.destdir in the Portfile
* Reformat post-distroot code block
* Fix post-destroot block to delete unnecessary binaries, manpages and docs
* Delete livecheck related statements

**IMPORTANT - PLEASE READ:**  This PR for `cdrtools` will not build if the old version of `cdrtools`, version 3.01, currently in the MacPorts repo has been installed and is active. To address this issue, a procedure called `port_conflict_check` has been added which checks whether `cdrtools`, version 3.01_1 or earlier has been installed. (Thanks to @mascguy for the code).  Once `smake` is built, `cdrtools` can be activated again.

FYI -- The old version of `cdrtools`, version 3.01, in the MacPorts repo installs OLD libschily header files and libraries. It is the existence of these old header files and libraries which prevents this updated port for `cdrtools` from building successfully. So the previous version of `cdrtools` must be uninstalled or deactivated first.

This PR for `cdrtools` no longer installs the libshily header files and libraries since they are not needed to run the binaries.  

Please see the following related Pull Requests:

(smake)  https://github.com/macports/macports-ports/pull/18655
(star)      https://github.com/macports/macports-ports/pull/18616

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
