### PR TITLE
retdec-devel: update to 20230504

### DIFF
--- a/devel/retdec/Portfile
+++ b/devel/retdec/Portfile
@@ -84,8 +84,6 @@ configure.python    ${prefix}/bin/python${python_branch}
 depends_lib-append   port:libcxx
 configure.cxx_stdlib libc++
 
-patchfiles          yaramod-python.diff
-
 if {${name} eq ${subport}} {
     # 4.0's yara uses std::variant<>, which is broken on macOS <= 10.12
     if {${os.platform} eq "darwin" && ${os.major} <= 16} {
@@ -93,21 +91,36 @@ if {${name} eq ${subport}} {
         configure.cxxflags-append   -nostdinc++ -isystem${prefix}/include/libcxx/v1
         configure.ldflags-append    -L${prefix}/lib/libcxx
     }
+
+    patchfiles      yaramod-python.diff
 }
 
 subport retdec-devel {
     conflicts       $name
 
-    github.setup    avast retdec 5821bbe735262187bd5d48930d0eda8b7b48bba8
-    version         20230404
+    github.setup    avast retdec 407f290c23700a4c8284f0ec773f82297ce6111f
+    version         20230504
     revision        0
     epoch           1
 
+    set yaramod_version \
+                    aa06dd408c492a8f4488774caf2ee105ccc23ab5
+
+    array set deps_cmake_checksums { \
+                    rmd160  5f5124b900777b3ab7cadbea8e096b0df9bc957c \
+                    sha256  1db6cdb279b9f6b52fddbc7391c4548656a8e780a37ba59ba479c6f3b654d6d5 \
+                    size    2022 \
+                    }
+
     checksums-append \
                     ${distname}${extract.suffix} \
-                    rmd160  b8de5e6483fb24890826025326bfddd8916f5646 \
-                    sha256  163c9e5889a354ddf9eaef51e40474728c0c8f163ca2da83f97fbacbbeef8bbe \
-                    size    27197443
+                    rmd160  fcc873f9c84eaff4a556c3e9d9f6d6ce67192b0e \
+                    sha256  80389d02c4080cdbf7d877b560b5fa7116f3190afe86280851d96749bbed978f \
+                    size    27197793 \
+                    ${yaramod_version}${extract.suffix} \
+                    rmd160  eab0a12e77f24be097e8f97f768fa02574a23c31 \
+                    sha256  f9c75eb93c379ab4e1a80f28a678d54531b1bbc1de2725438b3f54be11332ee9 \
+                    size    962598
 }
 
 master_sites-append https://github.com/capstone-engine/capstone/archive/refs/tags:capstone \
@@ -185,6 +198,7 @@ post-patch {
         ${worksrcpath}/support/CMakeLists.txt
 
 }
+
 post-destroot {
     set support_pkg_path ${destroot}${prefix}/share/${name}/support
     xinstall -d -m 0755 ${support_pkg_path}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->