### PR TITLE
gdal: unbreak 32-bit build

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -265,6 +265,12 @@ configure.args-append                                        \
 # Always choose internal libjson code (#44098)
 configure.args-append -DGDAL_USE_JSONC_INTERNAL=ON
 
+if {${build_arch} in [list i386 ppc]} {
+    # https://trac.macports.org/ticket/67468
+    configure.args-append \
+                    -DBUILD_WITHOUT_64BIT_OFFSET=ON
+}
+
 pre-configure {
     # see https://trac.macports.org/ticket/56517
     if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/67468

#### Description

Fix 32-bit build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
