### PR TITLE
lagrange: update to 1.16.0

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.15.9 v
+gitea.setup         gemini lagrange 1.16.0 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  0e329da804b62db2229f81a83de04314886bbf0e \
-                    sha256  cec02289d88cd23d46da5dda2ea0b8c6369c2336c8e289a77fb8154253214f9f \
-                    size    7527354
+checksums           rmd160  e5548c5074b9a929bb29bd4371c2f2a0d3a9573c \
+                    sha256  a5f1ef1b76c0099cf1b68bc9d7d15e8b86661d3f39d5fabf607b24de00dc7198 \
+                    size    7533319
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
