### PR TITLE
esptool, py-ecdsa, py-pyaes: add python 3.11 variant

### DIFF
--- a/cross/esptool/Portfile
+++ b/cross/esptool/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  09b3e981bbebdeccf85b0453ff504d9d999ad0f6 \
                     size    252178
 revision            0
 
-python.versions     310
+python.versions     310 311
 
 depends_build-append \
     port:py${python.version}-setuptools \

--- a/python/py-ecdsa/Portfile
+++ b/python/py-ecdsa/Portfile
@@ -11,7 +11,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-pyaes/Portfile
+++ b/python/py-pyaes/Portfile
@@ -14,7 +14,7 @@ maintainers         nomaintainer
 description         Pure-Python Implementation of the AES block-cipher and common modes of operation
 long_description    {*}${description}
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 homepage            https://github.com/ricmoo/pyaes
 


### PR DESCRIPTION
#### Description

Add python 3.11 variants for esptool, py-ecdsa and py-pyaes

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E772610a arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
