### PR TITLE
sfeed: update to 1.8

### DIFF
--- a/net/sfeed/Portfile
+++ b/net/sfeed/Portfile
@@ -5,7 +5,7 @@ PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 name                sfeed
-version             1.6
+version             1.8
 revision            0
 license             ISC
 
@@ -18,9 +18,9 @@ homepage            https://git.codemadness.org/${name}/
 
 master_sites        https://codemadness.org/releases/${name}/
 
-checksums           rmd160  c9371705f2c6e8ad15eadeac0b5e3202e3233d2c \
-                    sha256  bfd6d24ce98619726aa411a7a0d969806ad08a73c9adc3a8d04508e00eea6aea \
-                    size    65239
+checksums           rmd160  4335f02db9b2b3adbe9d77e1f1681624b494c8be \
+                    sha256  173cffaee785110a73c7e02822d7a8de10307e8a2351fca17eebfdb9483ac7b3 \
+                    size    67335
 
 depends_lib-append  port:ncurses
 


### PR DESCRIPTION
#### Description
[Changelog](https://git.codemadness.org/sfeed/)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?