### PR TITLE
beets-devel: update to 20230512; beets-beetcamp: update to 0.17.1

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -39,13 +39,13 @@ if {$subport eq $name} {
 subport ${name}-devel {
     conflicts       $name
 
-    github.setup    beetbox beets 8fc3ddee2702d0612c5340700f876d78c3e06bbc
-    version         20230507
+    github.setup    beetbox beets 9527a07767629c1ceb99c2cd681b78172a7272a0
+    version         20230512
     revision        0
 
-    checksums       rmd160  cbeea2e628e4cac0d7973530410100f8aa2e8bba \
-                    sha256  985bd3ee0c0ec93841b5744788243a9c6672ed19c5b1f4f273b55445ac74239a \
-                    size    1867919
+    checksums       rmd160  47a9819099086969bdec29b3d3589410fb948ec3 \
+                    sha256  436410b7b886af13288d28c3a1b0ca1a95a8cb3096cdc709fdb6837f1a309b99 \
+                    size    1867798
 
     depends_build-append \
                     port:py${python.version}-sphinx

--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -232,7 +232,7 @@ subport ${name}-barcode {
 
 subport ${name}-beetcamp {
     python.rootname beetcamp
-    version         0.16.3
+    version         0.17.1
     revision        0
 
     license         GPL-2
@@ -243,9 +243,13 @@ subport ${name}-beetcamp {
 
     homepage        https://github.com/snejus/beetcamp
 
-    checksums       rmd160  e9545400eb9cb36987f159ab973107932b3ed575 \
-                    sha256  b58433c33f1aaee50673866614d9e32189b313f035de12a354c7c4a9432aa765 \
-                    size    43079
+    checksums       rmd160  8f0dd6bc7bca3f146c2699c6a8cf5b3719a8ec74 \
+                    sha256  e0dfe23703e2a029c71e56ca48d22712ab71403f221610355f5a132e67aece44 \
+                    size    43529
+
+    python.pep517   yes
+    python.pep517_backend \
+                    poetry
 
     depends_lib-append \
                     port:py${python.version}-cached-property \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->