### PR TITLE
gtk2, gtk3, babl, gegl: debug variants

### DIFF
--- a/gnome/gtk2-devel/Portfile
+++ b/gnome/gtk2-devel/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 PortGroup           muniversal 1.0
 PortGroup           xcodeversion 1.0
+PortGroup           debug 1.0
 
 name                gtk2-devel
 conflicts           gtk2

--- a/gnome/gtk2/Portfile
+++ b/gnome/gtk2/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 PortGroup           muniversal 1.0
 PortGroup           xcodeversion 1.0
+PortGroup           debug 1.0
 
 name                gtk2
 conflicts           gtk2-devel

--- a/gnome/gtk3-devel/Portfile
+++ b/gnome/gtk3-devel/Portfile
@@ -7,6 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.1
 PortGroup           meson 1.0
+PortGroup           debug 1.0
 
 name                gtk3-devel
 conflicts           gtk3

--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -7,6 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.1
 PortGroup           meson 1.0
+PortGroup           debug 1.0
 
 name                gtk3
 conflicts           gtk3-devel

--- a/graphics/babl-devel/Portfile
+++ b/graphics/babl-devel/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           meson 1.0
+PortGroup           debug 1.0
 
 name                babl-devel
 conflicts           babl

--- a/graphics/babl/Portfile
+++ b/graphics/babl/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           meson 1.0
+PortGroup           debug 1.0
 
 name                babl
 conflicts           babl-devel

--- a/graphics/gegl-devel/Portfile
+++ b/graphics/gegl-devel/Portfile
@@ -5,6 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           meson 1.0
 PortGroup           legacysupport 1.0
+PortGroup           debug 1.0
 
 name                gegl-devel
 conflicts           gegl

--- a/graphics/gegl/Portfile
+++ b/graphics/gegl/Portfile
@@ -5,6 +5,7 @@ PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           meson 1.0
 PortGroup           legacysupport 1.0
+PortGroup           debug 1.0
 
 name                gegl
 conflicts           gegl-devel


### PR DESCRIPTION
These dependencies to gimp2 and gimp3 need debug variants so that
gimp doesn't need to separately maintain ports and can build
debugoptimized versions into the release.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
