### PR TITLE
darwin-xtools: fix universal build on legacy OS

### DIFF
--- a/devel/darwin-xtools/Portfile
+++ b/devel/darwin-xtools/Portfile
@@ -3,11 +3,14 @@
 PortSystem                  1.0
 PortGroup                   cmake 1.1
 PortGroup                   github 1.0
+PortGroup                   muniversal 1.0
 
 if {${os.arch} eq "powerpc"} {
     set xtools_version      6f6c04e8b25497851f6a5979a6e96023fffe22df
     github.setup            iains darwin-xtools ${xtools_version}
     version                 2.2.4
+    revision                1
+    epoch                   1
 
     checksums               ${name}-${xtools_version}.tar.gz \
                             rmd160  07dd50453b93f90ea4806fd8c12be3acb91c2fbd \
@@ -17,6 +20,8 @@ if {${os.arch} eq "powerpc"} {
     set xtools_version      6446947f3e99db52a40b30a38f36b9ae33492aea
     github.setup            iains darwin-xtools ${xtools_version}
     version                 3.3.0
+    revision                1
+    epoch                   0
 
     checksums               ${name}-${xtools_version}.tar.gz \
                             rmd160  18d99473a012f4fa48464aadd078921a25bdc322 \
@@ -33,9 +38,6 @@ checksums-append            ${libyaml_distfile} \
                             size    85055
 
 github.tarball_from         archive
-
-revision                    0
-epoch                       0
 
 platforms                   darwin
 categories                  devel
@@ -87,13 +89,45 @@ configure.ldflags-delete  -L${prefix}/lib
 
 compiler.cxx_standard       2011
 
+merger_arch_flag            yes
+merger_arch_compiler        yes
+merger_must_run_binaries    yes
+
 if {${os.platform} eq "darwin" && ${os.major} < 12} {
     depends_build-append    port:gcc10-bootstrap
     depends_skip_archcheck-append \
                             gcc10-bootstrap
 
-    configure.cc            ${prefix}/libexec/gcc10-bootstrap/bin/gcc
-    configure.cxx           ${prefix}/libexec/gcc10-bootstrap/bin/g++
+    # Leopard is the first macOS which supports Roseta
+    # See: https://trac.macports.org/ticket/67284
+    if {${os.major} > 8} {
+        pre-configure {
+            file mkdir ${workpath}/bins
+
+            set gcc [open "${workpath}/bins/gcc" w 0755]
+            puts ${gcc} "#!/bin/sh"
+            puts ${gcc} "arch -arch $\{BUILD_ARCH:-${build_arch}\} ${prefix}/libexec/gcc10-bootstrap/bin/gcc \"\$@\""
+            close ${gcc}
+
+            set gxx [open "${workpath}/bins/g++" w 0755]
+            puts ${gxx} "#!/bin/sh"
+            puts ${gxx} "arch -arch $\{BUILD_ARCH:-${build_arch}\} ${prefix}/libexec/gcc10-bootstrap/bin/g++ \"\$@\""
+            close ${gxx}
+        }
+
+        configure.cc        ${workpath}/bins/gcc
+        configure.cxx       ${workpath}/bins/g++
+
+        if {[variant_exists universal] && [variant_isset universal]} {
+            foreach arch ${universal_archs_supported} {
+                lappend merger_configure_env(${arch}) BUILD_ARCH=${arch}
+                lappend merger_build_env(${arch}) BUILD_ARCH=${arch}
+            }
+        }
+    } else {
+        configure.cc        ${prefix}/libexec/gcc10-bootstrap/bin/gcc
+        configure.cxx       ${prefix}/libexec/gcc10-bootstrap/bin/g++
+    }
 
     # prevent it from linking against gcc's libstdc++.6.dylib and libgcc_s.1.1.dylib
     configure.ldflags-append \


### PR DESCRIPTION
#### Description

I've also increased epoch for powerpc version which is mandatory since it was downgraded before.

Closes: https://trac.macports.org/ticket/67480

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->