### PR TITLE
soundtouch: unbreak the port on  < 10.7

### DIFF
--- a/audio/soundtouch/Portfile
+++ b/audio/soundtouch/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           codeberg 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 codeberg.setup      soundtouch soundtouch 2.3.2
 categories          audio multimedia
@@ -26,7 +27,11 @@ checksums           rmd160  57c876f09ddac0cdca51411705b92064e9da6d95 \
 use_autoreconf      yes
 autoreconf.args     -fvi
 
-configure.args      --disable-silent-rules \
+# cc1plus: error: invalid option argument '-Ofast'
+compiler.blacklist-append {*gcc-[34].*} {clang < 500}
+
+configure.args-append \
+                    --disable-silent-rules \
                     --disable-static \
                     --enable-shared
 


### PR DESCRIPTION
#### Description

@catap @herbygillot Not sure how Macports on 10.6.8 buildbots pick clang-11: https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/155600/steps/install-port/logs/stdio
For me it picks gcc-4.2, and if that is blacklisted without blacklisting old clang, it picks llvm-g++-4.2, both of which fail at configure due to unsupported `-Ofast`.
Anyway, blacklist those explicitly.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
