### PR TITLE
GLC_lib: fix build on 10.6: old Xcode gcc-4.* does not support required cxx_standard

### DIFF
--- a/graphics/GLC_lib/Portfile
+++ b/graphics/GLC_lib/Portfile
@@ -9,6 +9,7 @@ platforms           darwin
 name                GLC_lib
 version             2.2.0
 revision            0
+license             LGPL-2.1
 maintainers         nomaintainer
 description         C++ class library that enables the quick creation of an OpenGL application based on QT4.
 long_description    ${description}
@@ -36,8 +37,8 @@ post-patch {
 configure.args      GLC_lib.pro
 
 # https://github.com/laumaya/GLC_lib/issues/30
-compiler.cxx_standard 2003
-configure.cxxflags-append -std=c++03
+compiler.cxx_standard 1998
+configure.cxxflags-append -std=c++98
 
 livecheck.type      regex
 livecheck.url       http://sourceforge.net/api/file/index/project-id/153150/mtime/desc/rss?path=%2Fglc-lib


### PR DESCRIPTION
#### Description

Fix the port on 10.6 (and earlier).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
