### PR TITLE
mdds: update to 2.1.1

### DIFF
--- a/devel/ixion/Portfile
+++ b/devel/ixion/Portfile
@@ -4,24 +4,24 @@ PortSystem          1.0
 PortGroup           gitlab 1.0
 PortGroup           boost 1.0
 
-gitlab.setup        ixion ixion 0.17.0
+gitlab.setup        ixion ixion 0.18.1
 revision            0
 
 categories          devel
-platforms           darwin
 license             MIT
 maintainers         {gmail.com:audvare @Tatsh} openmaintainer
 
 description         General purpose formula parser and interpreter.
-long_description    ${description}
+long_description    {*}${description}
 
-depends_build       port:pkgconfig
-depends_lib         port:mdds \
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:mdds \
                     port:spdlog
 
-checksums           rmd160  c4cd1a3364af2a004b1f802394411b8d52329c13 \
-                    sha256  63f3942defc684be82046b9d7454602dadafced9be7b3b60e9e8a5fa63ee91a8 \
-                    size    191134
+checksums           rmd160  bb0b41b1c4dbd4e334049819937b530ed82e4fc5 \
+                    sha256  c2975b0aa9f6e1a76c690928cdaa6f48d414cf6f8cca83c9e8c713dec4da18f0 \
+                    size    203778
 
 compiler.cxx_standard 2017
 

--- a/devel/mdds/Portfile
+++ b/devel/mdds/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           gitlab 1.0
 PortGroup           boost 1.0
 
-gitlab.setup        mdds mdds 2.0.3
+gitlab.setup        mdds mdds 2.1.1
 revision            0
 epoch               1
 
@@ -15,9 +15,9 @@ maintainers         {gmail.com:audvare @Tatsh} openmaintainer
 description         Collection of multi-dimensional data structure and indexing algorithms.
 long_description    {*}${description}
 
-checksums           rmd160  a7530a1b0cedf4a9dc6a4c660557e9f1ff769a0a \
-                    sha256  e84fe995b3d6e0dd80a8d4032489df433d4d5a4bdae836c00ae51dba8401150c \
-                    size    695834
+checksums           rmd160  54635a3819a0b095441418ed91453cc9b5ea5799 \
+                    sha256  06fecb705276a8628e527311cb590c203442f5cbe934d245626cb328458e0e17 \
+                    size    651536
 
 compiler.cxx_standard \
                     2017

--- a/devel/orcus/Portfile
+++ b/devel/orcus/Portfile
@@ -5,25 +5,25 @@ PortGroup           gitlab 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           boost 1.0
 
-gitlab.setup        orcus orcus 0.17.2
+gitlab.setup        orcus orcus 0.18.1
 revision            0
 
 categories          devel
-platforms           darwin
 license             MIT
 maintainers         {gmail.com:audvare @Tatsh} openmaintainer
 
 description         Standalone file import filter library for spreadsheet documents.
 long_description    {*}${description}
 
-depends_build       port:pkgconfig
-depends_lib         port:mdds \
-                    port:zlib \
-                    port:ixion
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:ixion \
+                    port:mdds \
+                    port:zlib
 
-checksums           rmd160  c215eb46c93f2a160a7730e680ed031db3826f36 \
-                    sha256  79fcc2998191fe5853a05edafe97a04d73e45d95d38237ad03500fe266f03503 \
-                    size    7967823
+checksums           rmd160  5b3264f35962e2db5da27e6c34d2a9ac8405edc3 \
+                    sha256  413a1fc00efe40c126eb56dc88912c30f6d7b3d020a7d02db827a6de7058600e \
+                    size    8160360
 
 use_autoreconf      yes
 


### PR DESCRIPTION
#### Description

UPD. Let us rather do it one by one. Existing in Macports [outdated] version of `libetonyek` does not depend on `mdds`. Update `mdds` first.

Both ports are long due to be updated. `mdds` and `liblangtag` are now dependencies for `libetonyek`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
