### PR TITLE
xlsclients: update to 1.1.5

### DIFF
--- a/x11/xlsclients/Portfile
+++ b/x11/xlsclients/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                xlsclients
-version             1.1.4
+version             1.1.5
 categories          x11
 license             X11
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -14,16 +14,20 @@ platforms           darwin
 
 homepage            https://www.x.org/
 master_sites        xorg:individual/app/
-use_bzip2           yes
+use_xz              yes
 
-checksums           rmd160  b26f2e0818e3b1486c222b6015cc9e528cab4328 \
-                    sha256  773f2af49c7ea2c44fba4213bee64325875c1b3c9bc4bbcd8dac9261751809c1 \
-                    size    130586
+checksums           rmd160  ae78c25834cecb7f93e1adeda71342d716ae523e \
+                    sha256  68baee57e70250ac4a7759fb78221831f97d88bc8e51dcc2e64eb3f8ca56bae3 \
+                    size    125552
 
 depends_build       port:pkgconfig
 
 depends_lib         port:xorg-libxcb port:xorg-xcb-util
 
+configure.args-append --disable-silent-rules
+
+configure.checks.implicit_function_declaration.whitelist-append strchr
+
 livecheck.type      regex
-livecheck.regex     ${name}-(\[\\d.\]+)${extract.suffix}
+livecheck.regex     ${name}-(\[\\d.\]+\\d)
 livecheck.url       https://xorg.freedesktop.org/archive/individual/app/?C=M&O=D


### PR DESCRIPTION
Disable silent rules

Implicit declaration of `strchr` is intentionally done by autoconf

Exclude distfile extension from livecheck

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.6
Xcode 14.2
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
