### PR TITLE
netcdf-fortran: update to 4.6.1

### DIFF
--- a/science/netcdf-fortran/Portfile
+++ b/science/netcdf-fortran/Portfile
@@ -19,7 +19,7 @@ PortGroup                   github 1.0
 #        I/O feature disabled. Abort.
 mpi.enforce_variant         netcdf
 
-github.setup                Unidata netcdf-fortran 4.6.0 v
+github.setup                Unidata netcdf-fortran 4.6.1 v
 revision                    0
 maintainers                 {takeshi @tenomoto} openmaintainer
 categories                  science
@@ -36,9 +36,11 @@ long_description \
     This software package provides Fortran application interfaces \
     for accessing netCDF data.
 
-checksums           rmd160  dbd86f8e6495a5b4329b3ddc6ee65b1233f42369 \
-                    sha256  d9b51d69c028ad54738cb758919078c3bd7e816b259ba0f5ec378c9d88d5b2b7 \
-                    size    2044291
+checksums           rmd160  12bf9c7ba84f60f77e7d77e069e9365bfd3c4659 \
+                    sha256  921be559e162d90370faecba7d60fa12dc4534600807a519520c277de5e7691c \
+                    size    2046635
+
+patchfiles          patch-nf03_test4-Makefile.in.diff
 
 compilers.choose    f77 f90 fc
 mpi.setup           require_fortran

--- a/science/netcdf-fortran/files/patch-nf03_test4-Makefile.in.diff
+++ b/science/netcdf-fortran/files/patch-nf03_test4-Makefile.in.diff
@@ -1,0 +1,13 @@
+# This patch is needed to make the tests run to completion.
+# Without this the global netcdf4.inc file is used instead of the local one.
+--- nf03_test4/Makefile.in	2023-05-19 22:19:16
++++ nf03_test4/Makefile.in	2023-05-23 16:00:05
+@@ -733,7 +733,7 @@
+ valgrind_tools = @valgrind_tools@
+ 
+ # Find the .mod files for netcdf-4.
+-AM_FCFLAGS = -I$(top_builddir)/fortran
++AM_CPPFLAGS = -I$(top_builddir)/fortran
+ 
+ # All tests need to link to fortran library.
+ LDADD = ${top_builddir}/fortran/libnetcdff.la


### PR DESCRIPTION
#### Description

Simple update to upstream version 4.6.1.
Also includes a new patch that applies only to testing. It avoids that the compilation of the test programs takes the global (system-wide) netcdf include files instead of the local ones coming with the distribution.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E772610a x86_64
Command Line Tools 14.3.0.0.1.1679647830


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
