### PR TITLE
reflex: update to 2.5.4-20230523

### DIFF
--- a/devel/reflex/Portfile
+++ b/devel/reflex/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                reflex
-version             2.5.4-20230206
+version             2.5.4-20230523
 revision            0
-checksums           rmd160  0b6d38e64b6cde86217c3d3f0e3fc7202115827b \
-                    sha256  a36ee836e4077fdac5aff280ec89fd97f21fd789c70d42c4501bf9da344df0d4 \
-                    size    476372
+checksums           rmd160  e19c3c3a92f5e8caa416541d7a7e1c10774b5e4e \
+                    sha256  312a21529ec28aa1e24583db4d21ac8ad452574e817cc7df3ed3fb22f0f08224 \
+                    size    480999
 
 set version_date    [lindex [split ${version} -] 1]
 categories          devel


### PR DESCRIPTION
#### Description

update reflex to current release, fixing a race which interferes with this port

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.3.1 22E772610a x86_64

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
