### PR TITLE
yubikey-manager: bump rev and use python 3.11

### DIFF
--- a/security/yubikey-manager/Portfile
+++ b/security/yubikey-manager/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                yubikey-manager
 version             5.1.1
-revision            0
+revision            1
 categories-prepend  security
 platforms           darwin
 license             BSD
@@ -24,7 +24,7 @@ checksums           rmd160  a6cd5f34060817698f4d73c32938a1c0312c36b8 \
                     sha256  684102affd4a0d29611756da263c22f8e67226e80f65c5460c8c5608f9c0d58d \
                     size    168752
 
-python.default_version 310
+python.default_version 311
 
 python.pep517           yes
 python.pep517_backend   poetry


### PR DESCRIPTION
#### Description

yubikey-manager: bump rev and use python 3.11

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4 22F66 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`? trace mode failed; without successful
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
