### PR TITLE
MoltenVK: Update to v1.2.4

### DIFF
--- a/graphics/MoltenVK/Portfile
+++ b/graphics/MoltenVK/Portfile
@@ -3,14 +3,12 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        KhronosGroup MoltenVK 1.1.9 v
-epoch               1
-revision            1
+github.setup        KhronosGroup MoltenVK 1.2.4 v
+github.tarball_from releases
 
-set sdkversion      1.3.211.0
 categories          graphics
-maintainers         {ryandesign @ryandesign} openmaintainer
-platforms           macosx
+maintainers         {@gcenx gmail.com:gcenx83} openmaintainer
+platforms           {macosx any >= 15}
 license             Apache-2
 
 # MoltenVK would build for i386, but it uses Metal which only works on x86_64 and arm64
@@ -22,29 +20,21 @@ long_description    ${name} is an implementation of the high-performance, \
                     industry-standard Vulkan graphics and compute API, that \
                     runs on Apple's Metal graphics framework.
 
-distname            vulkansdk-macos-${sdkversion}
-use_dmg             yes
+dist_subdir         ${name}/${version}
+distname            MoltenVK-macos
+use_tar             yes
 
-# url only works for the latest avalible SDK, older versions will 404
-master_sites        https://sdk.lunarg.com/sdk/download/${sdkversion}/mac/
-
-checksums           sha256  bfe654af00030b6e65521f834f0830f15e18c828594226865f15c92a9ea68363 \
-                    rmd160  3674f67b37f7bcc1746d55c3baa975d0cca9dbaa \
-                    size    275553243
-
-depends_build       port:p7zip
-depends_skip_archcheck p7zip
+checksums           sha256  168462e4b26a31184497ac7c4a6393708fe23ee4d90da347f00372ed09460714 \
+                    rmd160  c5b41ac440db29e524c01063c9f3cf8554ccbc4a \
+                    size    46776320
 
 variant universal   {}
 use_configure       no
 
-build {
-    # bypass the installer that requires macOS 10.13
-    system "${prefix}/bin/7z x -aoa ${worksrcpath}/InstallVulkan.app/Contents/Resources/installer.dat -o${workpath}/VulkanSDK"
-}
+build {}
 
 destroot {
-    set output_dir ${workpath}/VulkanSDK
+    set output_dir ${workpath}/MoltenVK
 
     # Xcode11 and later are required to use "xcframework"
     # Headers currently break build due to Xcode 12 ProcessXCFramework bug:
@@ -53,27 +43,70 @@ destroot {
         file copy ${output_dir}/MoltenVK/MoltenVK.xcframework ${destroot}${frameworks_dir}
     }
 
-    file copy ${output_dir}/macOS/bin/MoltenVKShaderConverter ${destroot}${prefix}/bin
-    file attributes ${destroot}${prefix}/bin/MoltenVKShaderConverter -permissions +x
-    file copy ${output_dir}/macOS/lib/libMoltenVK.dylib ${destroot}${prefix}/lib
+    file copy ${output_dir}/MoltenVK/dylib/macOS/libMoltenVK.dylib ${destroot}${prefix}/lib
 
     # vulkan and vk_video are provided via vulkan-headers
     file copy ${output_dir}/MoltenVK/include/MoltenVK ${destroot}${prefix}/include
 
-    if {(![variant_isset universal])} {
+    if {![variant_isset universal] || ![variant_exists universal]} {
         system -W ${destroot}${prefix}/lib "lipo -thin ${configure.build_arch} libMoltenVK.dylib -o libMoltenVK.dylib 2> /dev/null"
     }
 }
 
-platform darwin {
-    if {${os.major} < 16} {
-        archive_sites
-        distfiles
-        depends_build
-        known_fail  yes
-        pre-fetch {
-            ui_error "${subport} @${version} requires macOS Sierra or later"
-            return -code error "incompatible OS X version"
+if {${subport} eq ${name}} {
+    PortGroup           stub 1.0
+    version             1.0
+    epoch               2
+    if {${os.major} < 17} {
+        depends_run     port:MoltenVK-1.1.9
+    } else {
+        depends_run     port:MoltenVK-latest
+    }
+}
+
+# GitHub artifacts deployment target is 10.13 (Xcode14+)
+subport MoltenVK-latest {
+    platforms           {macosx any >= 17}
+    conflicts           MoltenVK-1.1.9
+}
+
+subport MoltenVK-1.1.9 {
+    github.setup        KhronosGroup MoltenVK 1.1.9 v
+
+    conflicts           MoltenVK-latest
+    set sdkversion      1.3.211.0
+
+    distname            vulkansdk-macos-${sdkversion}
+    use_dmg             yes
+    use_tar             no
+
+    # url only works for the latest avalible SDK, older versions will 404
+    master_sites        https://sdk.lunarg.com/sdk/download/${sdkversion}/mac/
+
+    checksums           sha256  bfe654af00030b6e65521f834f0830f15e18c828594226865f15c92a9ea68363 \
+                        rmd160  3674f67b37f7bcc1746d55c3baa975d0cca9dbaa \
+                        size    275553243
+
+    depends_build       port:p7zip
+    depends_skip_archcheck p7zip
+
+    build {
+        # bypass the installer that requires macOS 10.13
+        system "${prefix}/bin/7z x -aoa ${worksrcpath}/InstallVulkan.app/Contents/Resources/installer.dat -o${workpath}/VulkanSDK"
+    }
+
+    destroot {
+        set output_dir ${workpath}/VulkanSDK
+
+        file copy ${output_dir}/macOS/bin/MoltenVKShaderConverter ${destroot}${prefix}/bin
+        file attributes ${destroot}${prefix}/bin/MoltenVKShaderConverter -permissions +x
+        file copy ${output_dir}/macOS/lib/libMoltenVK.dylib ${destroot}${prefix}/lib
+
+        # vulkan and vk_video are provided via vulkan-headers
+        file copy ${output_dir}/MoltenVK/include/MoltenVK ${destroot}${prefix}/include
+
+        if {![variant_isset universal] || ![variant_exists universal]} {
+            system -W ${destroot}${prefix}/lib "lipo -thin ${configure.build_arch} libMoltenVK.dylib -o libMoltenVK.dylib 2> /dev/null"
         }
     }
 }


### PR DESCRIPTION
#### Description

As MoltenVK repo now provides prebuilt artifacts that support macOS High Sierra and later lets make use of them.

For macOS Sierra & OS X El Capitan fallback to the VulkanSDK that provided MoltenVK v1.1.9 and by making use of `darwin any` the package built on 10.12 buildbot will be usable for 10.11.

<br>

While not ideal this gets some version of MoltenVK on all supported systems, the reason the MoltenVK repo artifacts are 10.13 is due to changes in Xcode14.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E772610a x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
