### PR TITLE
libtorrent-rasterbar: use boost181 where intrinsics in multiprecision is fixed

### DIFF
--- a/net/libtorrent-rasterbar/Portfile
+++ b/net/libtorrent-rasterbar/Portfile
@@ -8,8 +8,13 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
+# Earlier Boost has broken intrinsics includes.
+# Fixed in: https://github.com/boostorg/multiprecision/commit/28b314828ddd06b3e2e3586758b398fc29ceeb89
+# See also: https://github.com/arvidn/libtorrent/issues/7042
+boost.version       1.81
+
 github.setup        arvidn libtorrent 2.0.9 v
-revision            1
+revision            2
 name                libtorrent-rasterbar
 license             BSD
 categories          net


### PR DESCRIPTION
#### Description

In earlier Boost versions `multiprecision` lib has a bug in intrinsics headers which results in pulling in x86 intrinsics on a number of non-x86 platforms (for example, ppc and ppc64 on MacOS, ppc64le on Linux) in certain configurations.
This has been fixed in upstream Boost in 1.81.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
