### PR TITLE
Bring Common Lisp to MacPorts

### DIFF
--- a/lisp/cl-babel/Portfile
+++ b/lisp/cl-babel/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        cl-babel babel 0.5.0 v
+name                cl-babel
+revision            0
+
+checksums           rmd160  806d0c709ad1566b1068ac7926c789a17e5efde3 \
+                    sha256  e68081896e3cd0d652f56869657074fdc3ca1423c775a2eec2245772572730e6 \
+                    size    248658
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Babel is a charset encoding/decoding library, not unlike GNU libiconv, written in pure Common Lisp.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-hu.dwim.stefil \
+                    port:cl-trivial-features \
+                    port:cl-trivial-gray-streams

--- a/lisp/cl-cffi/Portfile
+++ b/lisp/cl-cffi/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        cffi cffi 0.24.1 v
+name                cl-cffi
+revision            0
+
+checksums           rmd160  efbe4f1c7577943db8bdd6fc5a7c9672737d5551 \
+                    sha256  4025586fc921b2a1ebbe3c8ebec90ae5afc5aba142d97ea22f3951e155449993 \
+                    size    254471
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         The Common Foreign Function Interface
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-babel \
+                    port:cl-bordeaux-threads \
+                    port:cl-rt \
+                    port:cl-trivial-features

--- a/lisp/cl-chipz/Portfile
+++ b/lisp/cl-chipz/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-chipz
+version             20220213.git82a17d3
+revision            0
+
+homepage            https://cliki.net/chipz
+
+master_sites        debian:c/${name}/
+worksrcdir          ${distname}
+distname            ${name}_${version}
+use_xz              yes
+extract.suffix      .orig.tar.xz
+
+checksums           rmd160  03a1d2e5d945e171eff52b1cf72422affbd71103 \
+                    sha256  de8b287a4d1a31564e9cc9545943c698cefdb9fe64769db39b94a5b96460f561 \
+                    size    31540
+
+categories-append   archive devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         decompress DEFLATE and BZIP2 data in Common Lisp
+
+long_description    {*}${description}

--- a/lisp/cl-drakma/Portfile
+++ b/lisp/cl-drakma/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        edicl drakma 2.0.9 v
+name                cl-drakma
+revision            0
+
+checksums           rmd160  3a063ec650d945db7d1cdb0afaa07bdfe56746da \
+                    sha256  386313fd1dfbf55805bcb06f4352396c811c9f8d198f3be068cb927d81e711f2 \
+                    size    74723
+
+categories-append   www devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Yet another Lisp markup language
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-base64 \
+                    port:cl-chipz \
+                    port:cl-chunga \
+                    port:cl-flexi-streams \
+                    port:cl-plus-ssl \
+                    port:cl-ppcre \
+                    port:cl-puri

--- a/lisp/cl-fad/Portfile
+++ b/lisp/cl-fad/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        edicl cl-fad 0.7.6 v
+revision            0
+
+checksums           rmd160  96ec808ce43def568aaccc874f517f9a56e7a6d0 \
+                    sha256  b98876f8dd2effc7fb1d4628558edc34a6cdfa665f8d0a817a1078e85959508c \
+                    size    24769
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Portable pathname library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-bordeaux-threads

--- a/lisp/cl-hu.dwim.asdf/Portfile
+++ b/lisp/cl-hu.dwim.asdf/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        hu-dwim hu.dwim.asdf 4796e2833ad39f3e375a99c632de9f5973fd353f
+name                cl-hu.dwim.asdf
+version             20211203
+revision            0
+
+checksums           rmd160  e5b66f81f67fd6d3bc9b11759619583455c531bd \
+                    sha256  fee6b7bc095c540d5b8685cf2321a8d28d558b25406dd51f7b250bcaaa2b9cc7 \
+                    size    6759
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         ASDF extensions used by most of hu.dwim projects.
+
+long_description    {*}${description}
+
+post-extract {
+    # NOTE: seems that system hu.dwim.presentation dissapeared in history
+    file delete ${worksrcpath}/hu.dwim.asdf.documentation.asd
+}

--- a/lisp/cl-hu.dwim.stefil/Portfile
+++ b/lisp/cl-hu.dwim.stefil/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        hu-dwim hu.dwim.stefil 7a172486ea51c5d38836e5b209d7135014506d19
+name                cl-hu.dwim.stefil
+version             20211211
+revision            0
+
+checksums           rmd160  9d7785239dd33a9264352dbe57de0819000506e8 \
+                    sha256  5e172b6287aaded52b7aa4f6eb58e24d0dd9672856bd0f06ddcce33266fbac5d \
+                    size    23588
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Common Lisp testing framework blending into normal Slime development.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-hu.dwim.asdf
+
+post-extract {
+    # NOTE: hu.dwim.stefil+swank*.asd is broken
+    file delete ${worksrcpath}/hu.dwim.stefil+swank.asd
+    file delete ${worksrcpath}/hu.dwim.stefil+hu.dwim.def.asd
+    file delete ${worksrcpath}/hu.dwim.stefil+hu.dwim.def+swank.asd
+}

--- a/lisp/cl-hunchentoot/Portfile
+++ b/lisp/cl-hunchentoot/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        edicl hunchentoot 1.3.0 v
+name                cl-hunchentoot
+revision            0
+
+checksums           rmd160  8a4e854d83de6071ffa89d26c960106ddce6a916 \
+                    sha256  8392b539e1df484c946828beb906cf3db52991ab63f5547aadfe93d0268fa890 \
+                    size    272403
+
+categories-append   www devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Web server written in Common Lisp
+
+long_description    Hunchentoot is a web server written in Common Lisp and at \
+                    the same time a toolkit for building dynamic websites.
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-base64 \
+                    port:cl-bordeaux-threads \
+                    port:cl-chunga \
+                    port:cl-drakma \
+                    port:cl-fad \
+                    port:cl-flexi-streams \
+                    port:cl-md5 \
+                    port:cl-plus-ssl \
+                    port:cl-ppcre \
+                    port:cl-rfc2388 \
+                    port:cl-trivial-backtrace \
+                    port:cl-usocket \
+                    port:cl-who

--- a/lisp/cl-md5/Portfile
+++ b/lisp/cl-md5/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        pmai md5 2.0.5 release-
+name                cl-md5
+revision            0
+
+checksums           rmd160  a918ff5158170bc7a52ef934a778360ef80f2901 \
+                    sha256  274104fdfe4e2ce4340e57c4a9e5b3d7f705f5311da48f1365aebc8678bd08b1 \
+                    size    16194
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Common Lisp implementation of the MD5 Message-Digest Algorithm (RFC 1321)
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-flexi-streams

--- a/lisp/cl-plus-ssl/Portfile
+++ b/lisp/cl-plus-ssl/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        cl-plus-ssl cl-plus-ssl 85b4bdae8947dde2091287f23cdc5c4730518e77
+version             20230522
+revision            0
+
+checksums           rmd160  7c6250d65d65304ed12f57d2ff7a64c58022008e \
+                    sha256  abcbd01bcee2ae4be52897b43c7eb340706790e98334a98989a941323d3fbe8d \
+                    size    93557
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A Common Lisp interface to OpenSSL / LibreSSL
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-bordeaux-threads \
+                    port:cl-cffi \
+                    port:cl-flexi-streams \
+                    port:cl-trivial-features \
+                    port:cl-trivial-garbage \
+                    port:cl-trivial-gray-streams \
+                    port:cl-trivial-sockets \
+                    port:cl-usocket
+
+post-extract {
+    # NOTE: cl-coveralls requires a lot of ports and useless here
+    reinplace {s|(:feature (:or :sbcl :ccl) :cl-coveralls)||} ${worksrcpath}/cl+ssl.test.asd
+}

--- a/lisp/cl-puri/Portfile
+++ b/lisp/cl-puri/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-puri
+version             1.5.7.2
+revision            0
+
+homepage            https://cliki.net/puri
+
+master_sites        debian:c/${name}/
+worksrcdir          ${distname}
+distname            ${name}_${version}
+extract.suffix      .orig.tar.gz
+
+checksums           rmd160  4662eaf1926607f2dbf0d258ac842269a141fdc1 \
+                    sha256  36821e005b289a002070e63e479c89d8c10401dcb7446275f11545214a4a82cf \
+                    size    26923
+
+categories-append   www devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Portable URI Library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-ptester

--- a/lisp/cl-rfc2388/Portfile
+++ b/lisp/cl-rfc2388/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        jdz rfc2388 591bcf7e77f2c222c43953a80f8c297751dc0c4e
+name                cl-rfc2388
+version             20180830
+revision            0
+
+checksums           rmd160  62151a2febcb8914dabef61aa9895b5a9248affb \
+                    sha256  4061d8a198aeb96a5dcb3049cec13a7976a3a29d69c264106d49b1c79ec1054c \
+                    size    12676
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         An implementation of RFC 2388 in Common Lisp
+
+long_description    {*}${description}

--- a/lisp/cl-split-sequence/Portfile
+++ b/lisp/cl-split-sequence/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-split-sequence
+version             2.0.1
+revision            0
+
+homepage            https://tracker.debian.org/cl-split-sequence
+
+master_sites        debian:c/${name}/
+worksrcdir          split-sequence-${version}
+distname            ${name}_${version}
+extract.suffix      .orig.tar.gz
+
+checksums           rmd160  9a0b28137663780355dd64a4e7f79164191bf9a4 \
+                    sha256  e5d0efe5bebc9566ad9f84f2c247fc5f6e5bd06e05ac0127b04654da8a7da59b \
+                    size    12078
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Common Lisp package to split a sequence of objects
+
+long_description    {*}${description}

--- a/lisp/cl-trivial-features/Portfile
+++ b/lisp/cl-trivial-features/Portfile
@@ -33,3 +33,13 @@ if {${name} eq ${subport}} {
         file delete ${worksrcpath}/trivial-features-tests.asd
     }
 }
+
+subport cl-trivial-features-tests {
+    depends_lib-append  \
+                    port:cl-cffi \
+                    port:cl-trivial-features
+
+    post-extract {
+        file delete ${worksrcpath}/trivial-features.asd
+    }
+}

--- a/lisp/cl-trivial-sockets/Portfile
+++ b/lisp/cl-trivial-sockets/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        usocket trivial-sockets 0.4 v
+name                cl-trivial-sockets
+revision            0
+
+checksums           rmd160  f0482423460d4ec83455bc60715a864dd0c9f49f \
+                    sha256  ff9102c35833ab4343161c5965abcf858e293a49da9de7f2e4c77c9f5c26bdfe \
+                    size    11697
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A trivial networking library for undemanding Internet applications
+
+long_description    {*}${description}

--- a/lisp/cl-usocket/Portfile
+++ b/lisp/cl-usocket/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        usocket usocket 0.8.6 v
+name                cl-usocket
+revision            0
+
+checksums           rmd160  4c4d3bf26a29e4d2fa713b5e4352c69bbb43eca8 \
+                    sha256  1d51fc1dd0a9ea3d369690d391a56e372e8a351211ace36e1546c3e13a0c1c8f \
+                    size    93823
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A Common Lisp interface to OpenSSL / LibreSSL
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-rt \
+                    port:cl-split-sequence

--- a/lisp/cl-who/Portfile
+++ b/lisp/cl-who/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        edicl cl-who 1.1.4 v
+revision            0
+
+checksums           rmd160  dfde7e9ff65b1268c5abe9cf929e098c1945e5e5 \
+                    sha256  c66e011f36b7499c73b2dbd257cc543ec891cac5c5eec61b0bc70409b75699a3 \
+                    size    24803
+
+categories-append   www devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Yet another Lisp markup language
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-flexi-streams


### PR DESCRIPTION
#### Description

I've bring a brand new port group to manage Common Lisp packages in a debian way.

Some packages are fetching from Debian because it is maintaned by Debian Lisp Team.

The goal of this PR is bring hunchentoot to MacPorts.

This PR works on SBCL, and support another lisp can be includes by fixing lisps :)

It was tested by https://gist.github.com/catap/6d392f3cf17353599649a24a39d75c3b as:
```
> sudo port install cl-hunchentoot cl-drakma sbcl
...
> sbcl --script /tmp/demo-hunchentoot.lisp
...
127.0.0.1 - [2023-05-26 18:12:33] "GET /foo HTTP/1.1" 200 5 "-" "Drakma/2.0.9 (SBCL 2.3.4; Darwin; 21.6.0; http://weitz.de/drakma/)"
```

Thus, almost all ports has tests :)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->