### PR TITLE
libhv: new port

### DIFF
--- a/devel/libhv/Portfile
+++ b/devel/libhv/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+github.setup        ithewei libhv 1.3.1 v
+github.tarball_from archive
+revision            0
+
+categories          devel
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+
+license             BSD
+
+description         A c/c++ network library for developing TCP/UDP/SSL/HTTP/WebSocket/MQTT client/server
+long_description    {*}${description}
+
+checksums           rmd160  27c3bb6613ede4ae8ce5c685b7987a41eeed70b0 \
+                    sha256  da4757c3520854cf2081f796733f7bc023651d60baab448a06fcf66435a859be \
+                    size    880367
+
+compiler.cxx_standard 2011
+
+configure.args-append \
+                    -DENABLE_UDS=ON \
+                    -DWITH_MQTT=ON \
+                    -DWITH_CURL=ON \
+                    -DWITH_NGHTTP2=ON \
+                    -DWITH_OPENSSL=ON \
+                    -DWITH_KCP=ON
+
+depends_build-append \
+                    port:curl


### PR DESCRIPTION
#### Description
[**libhv**](https://github.com/ithewei/libhv) - a c/c++ network library for developing TCP/UDP/SSL/HTTP/WebSocket/MQTT client/server.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
