### PR TITLE
py-jfricas: new port (version 1.0.0)

### DIFF
--- a/python/py-jfricas/Portfile
+++ b/python/py-jfricas/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-jfricas
+version             1.0.0
+revision            0
+
+categories-append   math
+supported_archs     noarch
+license             BSD
+
+maintainers         {@catap korins.ky:kirill} openmaintainer
+
+description         FriCAS Jupyter Kernel.
+long_description    {*}${description}
+
+homepage            http://github.com/fricas/jfricas
+
+checksums           rmd160  5b532a21160c063436c3e161f7300ee541aee17e \
+                    sha256  663f42c0b11077a6195933a175cbde696842c9abf263c0cffdd889ed87db84be \
+                    size    12168
+
+python.versions     37 38 39 310 311
+
+if {${name} ne ${subport}} {
+    post-patch {
+        reinplace "s|^install_kernel_spec()||" ${worksrcpath}/setup.py
+    }
+
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:fricas \
+                    port:cl-hunchentoot \
+                    port:py${python.version}-jupyter \
+                    port:py${python.version}-requests
+
+    post-destroot {
+        set dst ${destroot}${python.prefix}/share/jupyter/kernels/fricas
+        xinstall -d ${dst}
+        xinstall -m 644 ${filespath}/kernel.json ${dst}
+        reinplace "s|%%PYTHON_PREFIX%%|${python.prefix}|g" ${dst}/kernel.json
+
+        # by some reason it is installed with permissions 0640 and 0750, fix it
+        fs-traverse item ${destroot}${python.prefix} {
+            if {[file isfile ${item}]} {
+                file attributes ${item} -permissions 0644
+            } else {
+                file attributes ${item} -permissions 0755
+            }
+        }
+    }
+
+}

--- a/python/py-jfricas/files/kernel.json
+++ b/python/py-jfricas/files/kernel.json
@@ -1,0 +1,12 @@
+{
+  "argv": [
+    "%%PYTHON_PREFIX%%/Resources/Python.app/Contents/MacOS/Python",
+    "-m",
+    "jfricas.fricaskernel",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "FriCAS",
+  "language": "spad",
+  "name": "FriCAS"
+}


### PR DESCRIPTION
#### Description

This is Jupyter kernel for Fricas.

This PR requires https://github.com/macports/macports-ports/pull/18819 to pass CI.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->