### PR TITLE
clisp: update to 2.50.0-20230212

### DIFF
--- a/lang/clisp/Portfile
+++ b/lang/clisp/Portfile
@@ -4,12 +4,12 @@ PortSystem      1.0
 PortGroup       compiler_blacklist_versions 1.0
 PortGroup       gitlab 1.0
 
-gitlab.setup    gnu-clisp clisp 16b1cd19000ea018ea82a07d08fa3bc5b46ad55b
-version         2.50.0
+gitlab.setup    gnu-clisp clisp 79cbafdbc6337d6dcd8f2dbad69fb7ebf7a46012
+version         2.50.0-20230212
 
 revision        0
 categories      lang
-maintainers     {easieste @easye} openmaintainer
+maintainers     {easieste @easye} {@catap korins.ky:kirill} openmaintainer
 platforms       darwin
 license         GPL-2
 description     The CLISP ANSI Common Lisp Implementation
@@ -27,9 +27,9 @@ long_description        \
 
 homepage        https://clisp.sourceforge.io
 
-checksums       rmd160  95a1293787bfc253e0c8d73197a2a4d8361ad829 \
-                sha256  259592f42620910b6b1c044660136cf1e076e106f56d9bcc77d82fd95692b668 \
-                size    8800864
+checksums       rmd160  92a19ff77f09bc02611f2fd8655bf380f8dc0182 \
+                sha256  1754bf00e967ffdbd3d9bbc5b706990d5caf7fe888d55b0fcb6017281b618ddc \
+                size    9005356
 
 depends_lib     port:readline   \
                 port:gettext    \
@@ -37,10 +37,12 @@ depends_lib     port:readline   \
                 port:ffcall
          
 universal_variant     no
-use_bzip2             yes
 
-# Enable a subset of architectures due to inline-asm
-supported_archs ppc i386 x86_64
+patchfiles      patch-macports-xdg-data-dir.diff
+
+post-patch {
+    reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/modules/asdf/asdf.lisp
+}
 
 # Works with Xcode 7.0 and macports-clang-3.4
 # Failed in Lion (https://trac.macports.org/ticket/33344)
@@ -56,17 +58,28 @@ if {${os.platform} eq "darwin" && ${os.major} >= 11} {
 configure.cc-append  ${configure.cc_archflags}
 configure.args      --with-libiconv-prefix=${prefix} \
                     --with-libreadline-prefix=${prefix} \
-                    --with-libsigsegv-prefix=${prefix}
+                    --with-libsigsegv-prefix=${prefix} \
+                    --with-libffcall-prefix=${prefix} \
+                    --with-readline \
+                    --with-dynamic-ffi \
+                    --with-module=asdf
 
 platform darwin {
     configure.args-append \
                     --disable-rpath
 }
 
+variant threads description {add multithreading support} {
+    # NOTE: by unknown reason threads might be unstable
+    # See: https://gitlab.com/gnu-clisp/clisp/-/issues/43
+    configure.args-append \
+                    --with-threads=POSIX_THREADS
+}
+
 use_parallel_build  no
 build.dir           ${worksrcpath}/src
 build.cmd           "ulimit -s 16384 && make"
-build.target 
+build.target
 
 test.run            yes
 test.target         check

--- a/lang/clisp/files/patch-macports-xdg-data-dir.diff
+++ b/lang/clisp/files/patch-macports-xdg-data-dir.diff
@@ -1,0 +1,11 @@
+--- modules/asdf/asdf.lisp
++++ modules/asdf/asdf.lisp
+@@ -7186,7 +7186,7 @@ also \"Configuration DSL\"\) in the ASDF manual."
+             (or (remove nil (getenv-absolute-directories "XDG_DATA_DIRS"))
+                 (os-cond
+                  ((os-windows-p) (mapcar 'get-folder-path '(:appdata :common-appdata)))
+-                 (t (mapcar 'parse-unix-namestring '("/usr/local/share/" "/usr/share/")))))))
++                 (t (mapcar 'parse-unix-namestring '("@@PREFIX@@/share/" "/usr/local/share/" "/usr/share/")))))))
+ 
+   (defun xdg-config-dirs (&rest more)
+     "The preference-ordered set of additional base paths to search for configuration files.


### PR DESCRIPTION
#### Description

I've also enabled asdf, and this update includes fixes for build on arm64.

Thus, I've hardcode MacPorts XDG_DATA_DIRS and add myself as co-maintainer.

Threads? It is unstable but let keep it as variant.

And seems that `dynamic-ffi` works fine with last version of libffcall.

See: https://github.com/macports/macports-ports/pull/16496

Closes: https://trac.macports.org/ticket/27837

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

macOS 13.3.1 22E261 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->