### PR TITLE
ecl: fix build on arm64; add myself as co-maintainer

### DIFF
--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -1,24 +1,24 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem      1.0
-PortGroup       compiler_blacklist_versions 1.0
+PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 
-name		    ecl
-version		    21.2.1
-revision        0
-categories	    lang
-license		GPL-2+
-maintainers	{easieste @easye} openmaintainer
-description	Embeddable Common Lisp
-long_description	\
-	ECL (Embeddable Common Lisp) is an interpreter of the 	\
-	Common Lisp language as described in the X3J13 ANSI 	\
-	specification, featuring CLOS (Common Lisp Object 	\
-	System), conditions, loops, etc, plus a translator to 	\
-	C, which can produce standalone executables.
+name                ecl
+version             21.2.1
+revision            1
+categories          lang
+license             GPL-2+
+maintainers         {easieste @easye} {@catap korins.ky:kirill} openmaintainer
+description         Embeddable Common Lisp
+long_description    \
+    ECL (Embeddable Common Lisp) is an interpreter of the     \
+    Common Lisp language as described in the X3J13 ANSI     \
+    specification, featuring CLOS (Common Lisp Object     \
+    System), conditions, loops, etc, plus a translator to     \
+    C, which can produce standalone executables.
 
-platforms	    darwin
-homepage       	https://common-lisp.net/project/ecl/
+platforms           darwin
+homepage            https://ecl.common-lisp.dev/
 
 master_sites        https://common-lisp.net/project/ecl/static/files/release/
 checksums           rmd160  631b9427edef67ea3cac91da2031ac4629a6dd33 \
@@ -26,19 +26,28 @@ checksums           rmd160  631b9427edef67ea3cac91da2031ac4629a6dd33 \
                     size    7875088
 
 configure.ccache    no
-use_parallel_build	no
-universal_variant	no
+use_parallel_build  no
+universal_variant   no
 extract.suffix      .tgz
 
-configure.args          --enable-boehm=included 
+depends_lib-append  port:boehmgc \
+                    port:gmp
+
+configure.args      --enable-boehm=system \
+                    --enable-gmp=system
 
 # ecl-16.1.3 fails in (asdf:test-op :hunchentoot) with an "Illegal
 # Instruction: 4" error This error is an "internal Apple error", so we
-# blacklist the failing versions clang, in favor of gcc.  
+# blacklist the failing versions clang, in favor of gcc.
 compiler.blacklist      { clang < 300 }
 #compiler.whitelist      macports-gcc-4.9
 #compiler.whitelist       cc
 
-livecheck.regex         /${name}-(\[0-9.\]+)${extract.suffix}
+patchfiles          patch-macports-xdg-data-dir.diff
 
+post-patch {
+    reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/contrib/asdf/asdf.lisp
+}
 
+livecheck.url       ${homepage}rss.xml
+livecheck.regex     /${name}-(\[0-9.\]+)${extract.suffix}

--- a/lang/ecl/files/patch-macports-xdg-data-dir.diff
+++ b/lang/ecl/files/patch-macports-xdg-data-dir.diff
@@ -1,0 +1,11 @@
+--- contrib/asdf/asdf.lisp
++++ contrib/asdf/asdf.lisp
+@@ -7188,7 +7188,7 @@ also \"Configuration DSL\"\) in the ASDF manual."
+             (or (remove nil (getenv-absolute-directories "XDG_DATA_DIRS"))
+                 (os-cond
+                  ((os-windows-p) (mapcar 'get-folder-path '(:appdata :common-appdata)))
+-                 (t (mapcar 'parse-unix-namestring '("/usr/local/share/" "/usr/share/")))))))
++                 (t (mapcar 'parse-unix-namestring '("@@PREFIX@@/share/" "/usr/local/share/" "/usr/share/")))))))
+ 
+   (defun xdg-config-dirs (&rest more)
+     "The preference-ordered set of additional base paths to search for configuration files.


### PR DESCRIPTION
#### Description

Also hardcode MacPorts XDG_DATA_DIRS, fix livecheck and update homepage, and made `port lint` happy.

See: https://github.com/macports/macports-ports/pull/16496

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

macOS 13.3.1 22E261 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->