### PR TITLE
py-tables: update to 3.8.0

### DIFF
--- a/python/py-tables/Portfile
+++ b/python/py-tables/Portfile
@@ -5,13 +5,11 @@ PortGroup           python 1.0
 PortGroup           mpi 1.0
 
 name                py-tables
-version             3.6.1
-revision            5
+version             3.8.0
 categories-append   science
-platforms           darwin
 license             BSD
 
-python.versions     27 36 37 38 39
+python.versions     27 35 36 37 38 39 310 311
 
 maintainers         nomaintainer
 
@@ -20,78 +18,93 @@ long_description    PyTables is a package for managing hierarchical datasets \
                     and designed to efficiently and easily cope with \
                     extremely large amounts of data
 
-homepage            https://pytables.github.io/
+homepage            http://www.pytables.org/
 
-checksums           rmd160  05833282f4c44e48f6f39afada9cb2684aa3249a \
-                    sha256  49a972b8a7c27a8a173aeb05f67acb45fe608b64cd8e9fa667c0962a60b71b49 \
-                    size    4641089
+checksums           md5 83b2e54523cd83f7a9efbfbb8aa37227 \
+                    rmd160 dfdd6649c665416e919e221084c18c24421d74e8 \
+                    sha256 34f3fa2366ce20b18f1df573a77c1d27306ce1f2a41d9f9eff621b5192ea8788
 
 mpi.setup
 
 if {${name} ne ${subport}} {
     # Last version that supports python 2.7
-    if {${python.version} eq 27} {
-        version        3.5.2
-        revision       7
-        distname       ${python.rootname}-${version}
-        checksums      rmd160  9e5aa9f3b270888c853eb5f30cd6461a362bb1c1 \
-                       sha256  b220e32262bab320aa41d33125a7851ff898be97c0de30b456247508e2cc33c2 \
-                       size    7825372
+    if {${python.version} == 27} {
+        version     3.5.2
+        revision    7
+        checksums   rmd160 9e5aa9f3b270888c853eb5f30cd6461a362bb1c1 \
+                    sha256 b220e32262bab320aa41d33125a7851ff898be97c0de30b456247508e2cc33c2 \
+                    size   7825372
+    } elseif {${python.version} == 35} {
+        version     3.6.1
+        revision    5
+        checksums   md5 fe8daa05dd05f9ab07698c30ee48a029 \
+                    rmd160 05833282f4c44e48f6f39afada9cb2684aa3249a \
+                    sha256 49a972b8a7c27a8a173aeb05f67acb45fe608b64cd8e9fa667c0962a60b71b49
+    } elseif {${python.version} <= 37} {
+        version     3.7.0
+        revision    0
+        checksums   md5 d67a870ee90748a260e3ab3d6774533a \
+                    rmd160 19f19a990839ac70ceb0a3c779c56fa7b764ef76 \
+                    sha256 e92a887ad6f2a983e564a69902de4a7645c30069fc01abd353ec5da255c5e1fe
     }
 
-    build.target        build_ext
-    build.args          --inplace \
-                        --hdf5=${prefix} \
-                        --bzip2=${prefix} \
-                        --lzo=${prefix} \
-                        --blosc=${prefix}
-
-    destroot.args       --hdf5=${prefix} \
-                        --bzip2=${prefix} \
-                        --lzo=${prefix} \
-                        --blosc=${prefix}
-
-    pre-destroot {
-        # need to wrap this in a pre-destroot phase so that ${mpi.cc} expands to the right value
-        if {[mpi_variant_isset]} {
-            destroot.cmd       env CC=${mpi.cc} ${destroot.cmd}
+    if {${python.version} >= 36} {
+        python.pep517   yes
+        if {${python.version} >= 38} {
+            patchfiles  pyproject.toml.patch
+        }
+        # https://trac.macports.org/ticket/67136
+        post-patch {
+            reinplace "s|oldest-supported-numpy|numpy|" ${worksrcpath}/pyproject.toml
         }
     }
+
+    build.env-append    BLOSC_DIR=${prefix} \
+                        BZIP2_DIR=${prefix} \
+                        HDF5_DIR=${prefix} \
+                        LZO_DIR=${prefix}
+    destroot.env-append BLOSC_DIR=${prefix} \
+                        BZIP2_DIR=${prefix} \
+                        HDF5_DIR=${prefix} \
+                        LZO_DIR=${prefix}
+
     depends_build-append \
-                        port:py${python.version}-cython
+                        port:py${python.version}-cython \
+                        port:py${python.version}-setuptools
 
     mpi.enforce_variant hdf5
     depends_lib-append  port:hdf5 \
                         port:py${python.version}-numpy \
                         port:py${python.version}-numexpr \
-                        port:py${python.version}-cython \
                         port:zlib \
                         port:bzip2 \
                         port:lzo2 \
                         port:blosc
 
-    post-extract {
-        # Fix permissions
-        fs-traverse item ${worksrcpath} {
-            if {[file isdirectory ${item}]} {
-                file attributes ${item} -permissions a+rx
-            } elseif {[file isfile ${item}]} {
-                file attributes ${item} -permissions a+r
-            }
-        }
+    if {${python.version} >= 38} {
+        depends_lib-append  port:py${python.version}-blosc2 \
+                            port:py${python.version}-cpuinfo
 
-        file rename ${worksrcpath}/src/utils.h ${worksrcpath}/src/xxx_utils.h
+        build.env-append    BLOSC2_DIR=${python.prefix}
+        destroot.env-append BLOSC2_DIR=${python.prefix}
     }
 
     post-patch {
-        delete {*}[glob ${worksrcpath}/tables/*.c]
+        file rename ${worksrcpath}/src/utils.h ${worksrcpath}/src/xxx_utils.h
+        set cfiles [glob -nocomplain -directory ${worksrcpath}/tables *.c]
+        if {$cfiles ne ""} {
+            delete {*}$cfiles
+        }
         reinplace -q {s:utils\.h:xxx_utils.h:} {*}[glob ${worksrcpath}/{src,tables}/*.{c,pxd,pyx}]
     }
 
-    post-destroot    {
+    post-destroot {
         xinstall -m 755 -d ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 644 -W ${worksrcpath} LICENSE.txt README.rst \
-            RELEASE_NOTES.txt THANKS VERSION \
+        set docfiles [list LICENSE.txt README.rst THANKS]
+        if {${python.version} <= 35} {
+            lappend docfiles RELEASE_NOTES.txt VERSION
+        }
+        xinstall -m 644 -W ${worksrcpath} {*}${docfiles} \
             ${destroot}${prefix}/share/doc/${subport}
     }
 

--- a/python/py-tables/files/pyproject.toml.patch
+++ b/python/py-tables/files/pyproject.toml.patch
@@ -1,0 +1,15 @@
+--- pyproject.toml.orig	2022-12-23 21:42:14
++++ pyproject.toml	2023-05-27 16:39:26
+@@ -2,10 +2,10 @@
+ requires = [
+     "setuptools >=42.0",
+     "wheel",
+-    "oldest-supported-numpy",
++    "numpy",
+     "packaging",
+     "py-cpuinfo",
+     "Cython >=0.29.21",
+-    "blosc2 ~=2.0.0"
++    "blosc2 >=2.0.0,!=2.2.1,!=2.2.2"
+ ]
+ build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Keeping at latest supported versions for 27 through 37, which still have dependents.

Closes: https://trac.macports.org/ticket/66624
Closes: https://trac.macports.org/ticket/64482
