### PR TITLE
libavif/libheif: enable aom for earlier systems; unbreak build with gcc

### DIFF
--- a/multimedia/libavif/Portfile
+++ b/multimedia/libavif/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 
 github.setup            AOMediaCodec libavif 0.11.1 v
-revision                0
+revision                1
 
 checksums               rmd160  97a8d07f4fe8ce185e376629ea6e5fce4bc92d11 \
                         sha256  0eb49965562a0e5e5de58389650d434cff32af84c34185b6c9b7b2fccae06d4e \
@@ -41,19 +41,14 @@ configure.args-append   -DAVIF_ENABLE_WERROR:BOOL=OFF \
                         -DAVIF_CODEC_SVT:BOOL=ON
 
 platform darwin {
-    if { ${os.major} < 11 } {
-        # TODO: Disable rav1e on 10.6, due to issues with cargo-c; re-enable once fixed
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        # TODO: Disable rav1e on <10.6, due to issues with cargo-c; enable if fixed.
+        # Do not enable on PPC until Rust is fixed or it becomes possible to build with gccrs.
         # See: https://trac.macports.org/ticket/65434
         depends_lib-delete \
                         port:rav1e
         configure.args-delete \
                         -DAVIF_CODEC_RAV1E:BOOL=ON
-    }
-    if { ${os.major} < 10 } {
-        depends_lib-delete \
-                        port:aom
-        configure.args-delete \
-                        -DAVIF_CODEC_AOM:BOOL=ON
     }
 }
 

--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -6,7 +6,7 @@ PortGroup                   cmake 1.1
 PortGroup                   compiler_blacklist_versions 1.0
 
 github.setup                strukturag libheif 1.16.2 v
-revision                    0
+revision                    1
 
 checksums                   rmd160  47615c2fa85ee1163bd4ad787aedd44b90f71d4f \
                             sha256  7f97e4205c0bd9f9b8560536c8bd2e841d1c9a6d610401eb3eb87ed9cdfe78ea \
@@ -47,9 +47,10 @@ compiler.cxx_standard       2011
 compiler.blacklist-append   {clang < 700}
 
 platform darwin {
-    if { ${os.major} >= 10 } {
+    if {${os.major} >= 10 && [string match *clang* ${configure.compiler}]} {
         # Fix for error: non-portable path to file <DAV1D/xxx.h> and <AOM/xxx.h>
         # https://trac.macports.org/ticket/67404
+        # Flags are Clang-specific, they break build with GCC.
         configure.cxxflags-append \
                             -Wno-nonportable-include-path \
                             -Wno-error=nonportable-include-path \
@@ -57,20 +58,13 @@ platform darwin {
                             -Wno-error=unknown-warning-option
     }
 
-    if {${os.major} < 11} {
-        # TODO: Disable rav1e on 10.6, due to issues with cargo-c; re-enable once fixed
+    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
+        # TODO: Disable rav1e on <10.6, due to issues with cargo-c; enable if fixed.
+        # Do not enable on PPC until Rust is fixed or it becomes possible to build with gccrs.
         # See: https://trac.macports.org/ticket/65434
         depends_lib-delete      port:rav1e
         configure.args-append \
                                 -DWITH_RAV1E:BOOL=OFF
-    }
-    if {${os.major} < 10 || (${os.major} == 10 && ${build_arch} eq "ppc")} {
-        # https://trac.macports.org/ticket/62619
-        # aom does not build on 10.6 Rosetta too
-        depends_lib-delete      port:aom
-        configure.args-append \
-                                -DWITH_AOM_DECODER:BOOL=OFF \
-                                -DWITH_AOM_ENCODER:BOOL=OFF
     }
 }
 


### PR DESCRIPTION
#### Description

1. `aom` has been fixed for `ppc` since then and enabled in `ffmpeg` etc.
2. Flags added to `libheif` recently to fix clang builds break build with gcc. Make them compiler-specific.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
