### PR TITLE
ngtcp2: fixes for Apple and Big-endian from upstream

### DIFF
--- a/net/ngtcp2/Portfile
+++ b/net/ngtcp2/Portfile
@@ -7,17 +7,19 @@ PortGroup               openssl 1.0
 
 openssl.branch          1.1
 
-github.setup            ngtcp2 ngtcp2 0.15.0 v
-revision                0
+# Until next release use commit due to: https://github.com/ngtcp2/ngtcp2/issues/805
+github.setup            ngtcp2 ngtcp2 edf5c7630555ddded7050b1dde7a5cc34b1c7451
+version                 0.15.0
+revision                1
 categories              net devel
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
 license                 MIT
 description             ngtcp2 project is an effort to implement RFC9000 QUIC protocol
 long_description        {*}${description}
 homepage                https://nghttp2.org/ngtcp2
-checksums               rmd160  d3e04fd585e0a9090efe62007499fad5fd658bea \
-                        sha256  676139dc1058774d1856206419063073783130ff468be4811c68b0726e8483fb \
-                        size    588266
+checksums               rmd160  88ba59c7c369e0fd4d4a5cacc317790e135ef3e4 \
+                        sha256  4bbd24552df2d9c9402a9a55e46484a467021b1589d86513139b346a89e17c6f \
+                        size    590494
 
 depends_lib-append      path:lib/pkgconfig/gnutls.pc:gnutls \
                         port:cunit \
@@ -30,7 +32,8 @@ patchfiles              patch-examples.diff
 
 compiler.cxx_standard   2017
 
-configure.args-append   -DENABLE_GNUTLS:BOOL=ON \
+configure.args-append   -DENABLE_EXAMPLES:BOOL=OFF \
+                        -DENABLE_GNUTLS:BOOL=ON \
                         -DENABLE_JEMALLOC:BOOL=ON \
                         -DENABLE_OPENSSL:BOOL=ON \
                         -DENABLE_SHARED_LIB:BOOL=ON \
@@ -43,6 +46,5 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
                         -DENABLE_JEMALLOC:BOOL=ON -DENABLE_JEMALLOC:BOOL=OFF
 }
 
-# FIXME: several tests fail on ppc: https://github.com/ngtcp2/ngtcp2/issues/805
 test.run                yes
 test.target             check


### PR DESCRIPTION
#### Description

Fixes earlier errors on Big-endian.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
