### PR TITLE
openal-soft: fix build for older systems

### DIFF
--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -50,6 +50,10 @@ compiler.thread_local_storage   yes
 # https://github.com/kcat/openal-soft/issues/703
 compiler.blacklist-append {clang < 900}
 
+# See: https://github.com/kcat/openal-soft/pull/851
+patchfiles-append       0001-Define-__STDC_FORMAT_MACROS-on-systems-that-need-it.patch \
+                        0002-threads-do-not-use-libdispatch-where-it-is-not-prese.patch
+
 configure.args-append   -DALSOFT_EXAMPLES=OFF \
                         -DALSOFT_UTILS=ON \
                         -DALSOFT_NO_CONFIG_UTIL=ON \

--- a/audio/openal-soft/files/0001-Define-__STDC_FORMAT_MACROS-on-systems-that-need-it.patch
+++ b/audio/openal-soft/files/0001-Define-__STDC_FORMAT_MACROS-on-systems-that-need-it.patch
@@ -1,0 +1,37 @@
+From 118c729680d6664f793f8d88ff0b7548137847d3 Mon Sep 17 00:00:00 2001
+From: Chris Robinson <chris.kcat@gmail.com>
+Date: Sat, 27 May 2023 09:38:12 -0700
+Subject: [PATCH 1/2] Define __STDC_FORMAT_MACROS on systems that need it
+
+---
+ CMakeLists.txt | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git CMakeLists.txt CMakeLists.txt
+index eeef181f..0bc8f2e2 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -186,6 +186,20 @@ set(LIB_VERSION_NUM ${LIB_MAJOR_VERSION},${LIB_MINOR_VERSION},${LIB_REVISION},0)
+ set(EXPORT_DECL "")
+ 
+ 
++# Some systems erroneously require the __STDC_FORMAT_MACROS macro to be defined
++# to get the fixed-width integer type formatter macros.
++check_cxx_source_compiles("#include <cinttypes>
++#include <cstdio>
++int main()
++{
++    int64_t i64{};
++    std::printf(\"%\" PRId64, i64);
++}"
++HAVE_STDC_FORMAT_MACROS)
++if(NOT HAVE_STDC_FORMAT_MACROS)
++    set(CPP_DEFS ${CPP_DEFS} __STDC_FORMAT_MACROS)
++endif()
++
+ if(NOT WIN32)
+     # Check if _POSIX_C_SOURCE and _XOPEN_SOURCE needs to be set for POSIX functions
+     check_symbol_exists(posix_memalign stdlib.h HAVE_POSIX_MEMALIGN_DEFAULT)
+-- 
+2.40.1
+

--- a/audio/openal-soft/files/0002-threads-do-not-use-libdispatch-where-it-is-not-prese.patch
+++ b/audio/openal-soft/files/0002-threads-do-not-use-libdispatch-where-it-is-not-prese.patch
@@ -1,0 +1,55 @@
+From cd781b1511d437816aac65f89646bd80dbf7c040 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sun, 28 May 2023 14:28:00 +0800
+Subject: [PATCH 2/2] threads: do not use libdispatch where it is not present
+ (#851)
+
+Fixes: https://github.com/kcat/openal-soft/issues/850
+---
+ common/threads.cpp | 3 ++-
+ common/threads.h   | 7 ++++++-
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git common/threads.cpp common/threads.cpp
+index 136c4813..76a13d9d 100644
+--- common/threads.cpp
++++ common/threads.cpp
+@@ -128,7 +128,8 @@ void althrd_setname(const char *name [[maybe_unused]])
+ #endif
+ }
+ 
+-#ifdef __APPLE__
++/* Do not try using libdispatch on systems where it is absent. */
++#if defined(__APPLE__) && ((MAC_OS_X_VERSION_MIN_REQUIRED > 1050) && !defined(__ppc__))
+ 
+ namespace al {
+ 
+diff --git common/threads.h common/threads.h
+index 59fccd12..2592e5b0 100644
+--- common/threads.h
++++ common/threads.h
+@@ -15,7 +15,12 @@
+ #endif
+ 
+ #if defined(__APPLE__)
++#include <AvailabilityMacros.h>
++#if (MAC_OS_X_VERSION_MIN_REQUIRED > 1050) && !defined(__ppc__)
+ #include <dispatch/dispatch.h>
++#else
++#include <semaphore.h> /* Fallback option for Apple without a working libdispatch */
++#endif
+ #elif !defined(_WIN32)
+ #include <semaphore.h>
+ #endif
+@@ -27,7 +32,7 @@ namespace al {
+ class semaphore {
+ #ifdef _WIN32
+     using native_type = void*;
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && ((MAC_OS_X_VERSION_MIN_REQUIRED > 1050) && !defined(__ppc__))
+     using native_type = dispatch_semaphore_t;
+ #else
+     using native_type = sem_t;
+-- 
+2.40.1
+


### PR DESCRIPTION
#### Description

Merged to upstream now, so opening the PR.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
