### PR TITLE
gallery-dl: updated to 1.25.3

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        mikf gallery-dl 1.25.4 v
+github.setup        mikf gallery-dl 1.25.5 v
 github.tarball_from releases
 distname            gallery_dl-${github.version}
 
@@ -12,9 +12,9 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  bba4157beeb78882720ee15df99e7be3ec788d10 \
-                    sha256  e31d178d7ae21002564a66c68c15b16795895bdaee184f7056b7596137bac04e \
-                    size    541137
+checksums           rmd160  b366bb039010d169b0ed63ffae9183d92a6ba6db \
+                    sha256  205cca54722e659d962e4db766acb1bf0c57178e5fd8efd502a43f8fdf31e1a8 \
+                    size    547516
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites


### PR DESCRIPTION
#### Description

gallery-dl: updated to 1.25.3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement


###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3 14E222b


###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
