### PR TITLE
plumed: update to v2.9.0

### DIFF
--- a/science/plumed/Portfile
+++ b/science/plumed/Portfile
@@ -6,7 +6,7 @@ PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           debug 1.0
 
-github.setup        plumed plumed2 2.8.2 v
+github.setup        plumed plumed2 2.9.0 v
 name                plumed
 revision            0
 
@@ -26,9 +26,9 @@ platforms           darwin
 
 homepage            http://www.plumed.org/
 
-checksums           rmd160  bd559220606cf4e03ddfbb2f0c83d66e29065a56 \
-                    sha256  2f84812d3502ce5ac5ca5c3459fe78fc99d857ab8266390881b529e0f6e830ee \
-                    size    108129430
+checksums           rmd160  af05bf43a7df583cf21c7cb2374cceea7dfe4066 \
+                    sha256  63e01c425c59e4921429fb79d03710b5d115e47fc8025a165477c6807cbf0014 \
+                    size    116844795
 
 # Disable additional features.
 # --disable-doc:          Do not create documentation, and avoid searching for Doxygen.
@@ -112,15 +112,15 @@ pre-configure {
 # plumed-devel subport
 # This subport installs the developer version
 subport plumed-devel {
-    github.setup        plumed plumed2 897ae1d053140f3a4fa1d0da1ab688642733fa2e
-    version             2.9-20230313
+    github.setup        plumed plumed2 b10067f646c3a957618fd0dfcc3bc0a74c9d45c6
+    version             2.10-20230525
     revision            0
     description         ${description} (development version)
     long_description    ${long_description} (development version)
     conflicts plumed
-    checksums           rmd160  45568c335bb76cfd0b64e0c25dde6fd2a03dba6b \
-                        sha256  77b743c1a370fd40199d143bdd867f6b89a2967539c84569781e806bf0a74990 \
-                        size    116285876
+    checksums           rmd160  bc4ef71db62a35b276b2d2fc2aaec03184d825e2 \
+                        sha256  df9731de2f755367ebe94cf6f240c940a9a885cd1427734e342b0ca9e635d777 \
+                        size    116645604
 }
 
 # Allow running tests from MacPorts


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E772610a x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`? **NO. On my machine the -t flag is not working. In particular, the tar.gz file cannot be extracted properly. I don't know how to fix this.**
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
