### PR TITLE
xmlto: clean up port

### DIFF
--- a/textproc/xmlto/Portfile
+++ b/textproc/xmlto/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xmlto
 version             0.0.28
-revision            5
+revision            6
 categories          textproc
 license             GPL-2+
 installs_libs       no
@@ -30,37 +30,25 @@ checksums           rmd160  acba3cc9ff46505ae49b91108c611646aeac2b5d \
 
 depends_build       port:util-linux
 
-depends_run         path:libexec/coreutils/libstdbuf.so:coreutils \
-                    port:docbook-xml \
+depends_run         port:docbook-xml \
                     port:docbook-xsl-nons \
-                    path:libexec/gnubin/find:findutils \
                     port:fop \
-                    port:grep \
-                    port:gsed \
                     port:libpaper \
                     port:libxml2 \
                     port:libxslt \
-                    port:links \
+                    port:w3m \
                     port:util-linux
 
 patchfiles          searchpath_local.patch \
                     xml-catalog.patch
 
-configure.args      --mandir=${prefix}/share/man \
-                    --with-webbrowser=any
-
 configure.env-append \
-    FIND=${prefix}/bin/gfind \
     GETOPT=${prefix}/bin/getopt \
     PAPER_CONF=${prefix}/bin/paperconf \
-    TAIL=${prefix}/bin/gtail \
     XMLLINT=${prefix}/bin/xmllint \
-    XMLTEX=${prefix}/bin/xmltex \
-    DBLATEX=${prefix}/bin/dblatex \
+    XSLTPROC=${prefix}/bin/xsltproc \
     FOP=${prefix}/bin/fop \
-    GREP=${prefix}/bin/ggrep \
-    SED=${prefix}/bin/gsed \
-    LINKS=${prefix}/bin/links
+    W3M=${prefix}/bin/w3m
 
 build.env-append    XML_CATALOG_FILES=${prefix}/etc/xml/catalog
 
@@ -73,6 +61,9 @@ post-destroot {
         NEWS README ${destroot}${docdir}
     xinstall -m 0644 {*}[glob ${worksrcpath}/doc/*] ${destroot}${docdir}
 }
+
+test.run            yes
+test.target         check
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]


### PR DESCRIPTION
#### Description

- Remove redundant dependencies
- Add test
- Use w3m instead of links
- Fix xsltproc path

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3 14E222b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?