### PR TITLE
skaffold: update to 2.5.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.4.1 v
+github.setup        GoogleContainerTools skaffold 2.5.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  8c61e96ad5c48b9e576fbbf191d0e6d08941e4cb \
-                    sha256  f1b81fa4c16fef0f827d629a64667e45e6e5e3b7445104c75e7033d35def73ed \
-                    size    59590206
+checksums           rmd160  a4b80e08d71a81781b9c4760063c3793d6ad1731 \
+                    sha256  caeb91c6f9fd940e58d8eeef910820ca48c582919e2ba9b76fabf08d0d8ddf8c \
+                    size    59954655
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.5.0.

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?