### PR TITLE
qd: update to 2.3.23

### DIFF
--- a/devel/qd/Portfile
+++ b/devel/qd/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup           compilers 1.0
 
 name                qd
-version             2.3.17
+version             2.3.23
 categories          devel math
 platforms           darwin
 license             LBNL-BSD
@@ -21,16 +21,15 @@ long_description \
     statements and (for Fortran-90 programs) read/write statements need to \
     be changed. PSLQ and numerical quadrature programs are included.
 
-homepage        http://crd.lbl.gov/~dhbailey/mpdist/
+homepage        https://www.davidhbailey.com/dhbsoftware/
 master_sites    ${homepage}
 
 compilers.choose    cxx fc
 compilers.setup     -gfortran
 
-checksums \
-        md5     5e17dbeaff328ce312ccadccdb669592 \
-        sha1    e49295182c7424c644cc618cd205cb27b8909f53 \
-        rmd160  aff0765dd4323ff3c7096ac65b4d6197c8b3372d
+checksums           rmd160  1c91693392f3597a9ccabe340be0fb1d0adcfa30 \
+                    sha256  b3eaf41ce413ec08f348ee73e606bd3ff9203e411c377c3c0467f89acf69ee26 \
+                    size    781558
 
 if {[fortran_variant_isset]} {
     configure.args-append   --enable-fortran
@@ -46,4 +45,3 @@ post-build {
 livecheck.type      regex
 livecheck.url       ${homepage}
 livecheck.regex     {qd-(\d+(?:\.\d+)*).tar.gz}
-


### PR DESCRIPTION
#### Description

Forgotten port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
