### PR TITLE
openexr: ensure struct is packed on PPC systems

### DIFF
--- a/graphics/openexr/Portfile
+++ b/graphics/openexr/Portfile
@@ -6,7 +6,7 @@ PortGroup                       github 1.0
 PortGroup                       legacysupport 1.1
 
 github.setup                    AcademySoftwareFoundation openexr 3.1.7 v
-revision                        3
+revision                        4
 
 categories                      graphics
 license                         BSD
@@ -33,6 +33,13 @@ legacysupport.newest_darwin_requires_legacy 10
 # Use posix compat fallback for now, which performs much better.
 patchfiles-append               patch-fix-endian.diff \
                                 patch-darwin-no-libdispatch.diff
+
+if { (!(${universal_possible} && [variant_isset universal]) && ${configure.build_arch} eq "ppc")
+     ||
+     ((${universal_possible} && [variant_isset universal]) && "ppc" in ${configure.universal_archs}) } {
+    # see description in patch file; bug in GCC 7?
+    patchfiles-append           patch-ensure_pack.diff
+}
 
 depends_build-append            port:pkgconfig
 depends_lib-append              port:imath \

--- a/graphics/openexr/files/patch-ensure_pack.diff
+++ b/graphics/openexr/files/patch-ensure_pack.diff
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <stdint.h>
+
+#pragma pack(push, 1)
+
+/* struct from OpenEXR; should be packed with the pragma directive  */
+typedef struct
+{
+    uint32_t x_size;
+    uint32_t y_size;
+    uint8_t  level_and_round;
+} exr_attr_tiledesc_t;
+
+/* same struct but reordered */
+typedef struct
+{
+    uint8_t  level_and_round;
+    uint32_t x_size;
+    uint32_t y_size;
+} new1_exr_attr_tiledesc_t;
+
+/* same as first struct but with packed forced */
+typedef struct
+{
+    uint32_t x_size;
+    uint32_t y_size;
+    uint8_t  level_and_round;
+} __attribute__((packed, aligned(1))) new2_exr_attr_tiledesc_t;
+
+#pragma pack(pop)
+
+int main() {
+    std::cout << sizeof(exr_attr_tiledesc_t) << " "
+              << sizeof(new1_exr_attr_tiledesc_t) << " "
+              << sizeof(new2_exr_attr_tiledesc_t) << "\n";
+
+    return 0;
+}
+
+
+On Mac OS X Leopart (10.5),
+    `g++-mp-7 main.cxx && ./a.out` gives: 12 9 9
+    `g++ main.cxx && ./a.out`      gives: 9  9 9
+    `g++-mp-7 main.cxx && ./a.out` gives: 9  9 9
+
+    `g++* -arch ppc64 && ./a.out`  gives: 9 9 9
+
+OpenEXR requires this struct to be packed, so 9 is the correct result.
+It not clear what effects there would be in reordering, so force packed with __attribute__.
+
+--- src/lib/OpenEXRCore/openexr_attr.h.orig	2023-03-28 08:25:15.000000000 -0700
++++ src/lib/OpenEXRCore/openexr_attr.h	2023-05-13 06:48:03.000000000 -0700
+@@ -274,7 +274,7 @@
+     uint32_t x_size;
+     uint32_t y_size;
+     uint8_t  level_and_round;
+-} exr_attr_tiledesc_t;
++} __attribute__((packed, aligned(1))) exr_attr_tiledesc_t;
+ 
+ /** @brief Macro to access type of tiling from packed structure. */
+ #define EXR_GET_TILE_LEVEL_MODE(tiledesc)                                      \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
