### PR TITLE
libxc{,4}: fix homepage, master_sites, livecheck; mirror distfiles in shared dir 'libxc'; pin livecheck to ver major

### DIFF
--- a/science/libxc/Portfile
+++ b/science/libxc/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 
 name                libxc
+set my_name         libxc
 version             2.2.3
 revision            1
 # HORTON cannot use version 3 yet. There is also libxc4 port.
 categories          science
-platforms           darwin
 license             LGPL-3+
 maintainers         {dstrubbe @dstrubbe}
 
@@ -22,11 +22,14 @@ long_description    Libxc is a library of exchange-correlation functionals \
                     correlation functionals that can be used by all the \
                     ETSF codes and also other codes.
 
-homepage            http://www.tddft.org/programs/octopus/wiki/index.php/Libxc
-master_sites        http://www.tddft.org/programs/octopus/download/libxc
+homepage            https://www.tddft.org/programs/libxc/
+master_sites        https://www.tddft.org/programs/libxc/down.php?file=${version}
+distname            ${my_name}-${version}
+dist_subdir         ${my_name}
 
 checksums           rmd160  28e7d96c49aebfc4d7b7d16edc91565bc2fd8eea \
-                    sha256  2f2b00b77a75c7fe8fe3f3ae70700cf28a09ff8d0ce791e47980ff7f9cde68e7
+                    sha256  2f2b00b77a75c7fe8fe3f3ae70700cf28a09ff8d0ce791e47980ff7f9cde68e7 \
+                    size    734714
 
 compilers.choose    fc
 compilers.setup     require_fortran
@@ -38,5 +41,5 @@ test.run            yes
 test.target         check
 
 livecheck.type      regex
-livecheck.url       http://www.tddft.org/programs/octopus/wiki/index.php/Libxc:download
-livecheck.regex     ${name} (\[0-9.\]+)
+livecheck.url       http://www.tddft.org/programs/libxc/download/previous
+livecheck.regex     "${my_name}-(2\.\[0-9\.\]+).tar.gz"

--- a/science/libxc4/Portfile
+++ b/science/libxc4/Portfile
@@ -4,7 +4,9 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 
 name                libxc4
+set my_name         libxc
 version             4.3.4
+revision            0
 categories          science
 platforms           darwin
 license             LGPL-3+
@@ -19,14 +21,14 @@ long_description    Libxc is a library of exchange-correlation functionals \
                     correlation functionals that can be used by all the \
                     ETSF codes and also other codes.
 
-homepage            http://www.tddft.org/programs/libxc/
-master_sites        http://www.tddft.org/programs/octopus/download/libxc/${version}
+homepage            https://www.tddft.org/programs/libxc/
+master_sites        https://www.tddft.org/programs/libxc/down.php?file=${version}
+distname            ${my_name}-${version}
+dist_subdir         ${my_name}
 
 checksums           rmd160  48b4249e4ffa513e9c9c99e64bcc14c5d8ec7cc3 \
                     sha256  a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337 \
                     size    15602575
-
-distname            libxc-${version}
 
 compilers.choose    fc
 compilers.setup     require_fortran -g95
@@ -39,4 +41,4 @@ test.target         check
 
 livecheck.type      regex
 livecheck.url       http://www.tddft.org/programs/libxc/download/previous
-livecheck.regex     libxc-(\[0-9.\]+).tar.gz
+livecheck.regex     "${my_name}-(4\.\[0-9\.\]+).tar.gz"


### PR DESCRIPTION
### Description

* The URLs for `master_sites` are no longer valid; update to current location
* Update `homepage`
* Pin `livecheck` to major version
* Mirror distfiles in shared dir `libxc`