### PR TITLE
lirc: allow build on newer systems (Python 3.11 & avoid conflict VERSION file and version header)

### DIFF
--- a/sysutils/lirc/Portfile
+++ b/sysutils/lirc/Portfile
@@ -38,6 +38,11 @@ use_autoreconf      yes
 autoreconf.cmd      ./autogen.sh
 # setting autoreconf.cmd means that autotools build dependencies are not added
 
+post-configure {
+    # avoid confusion with version header file
+    move ${worksrcpath}/VERSION ${worksrcpath}/VERSION.txt
+}
+
 depends_build-append \
                     port:autoconf \
                     port:automake \

--- a/sysutils/lirc/Portfile
+++ b/sysutils/lirc/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
 
 name                lirc

--- a/sysutils/lirc/Portfile
+++ b/sysutils/lirc/Portfile
@@ -27,10 +27,10 @@ checksums           rmd160  998a726823a90ad79bde50fce3bd0417c950ab59 \
 livecheck.distname  LIRC
 
 set lircuser        _lirc
-set pythonbranch    3.6
+set pythonbranch    3.11
 set pythonver       python${pythonbranch}
-set pythonbin       ${prefix}/bin/${pythonver}
-set pymodver        py36
+configure.python    ${prefix}/bin/${pythonver}
+set pymodver        py[join [split ${pythonbranch} .] ""]
 
 compiler.cxx_standard 2011
 
@@ -66,7 +66,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 
 post-patch {
     reinplace -locale C "s|@PREFIX@|${prefix}|g" ${worksrcpath}/lirc_options.conf
-    reinplace -locale C "s|#!/usr/bin/env python3\$|#!${pythonbin}|" \
+    reinplace -locale C "s|#!/usr/bin/env python3\$|#!${configure.python}|" \
         ${worksrcpath}/doc/data2hwdb \
         ${worksrcpath}/doc/data2table \
         ${worksrcpath}/doc/make_rel_symlink.py \
@@ -77,9 +77,6 @@ post-patch {
         ${worksrcpath}/tools/make_rel_symlink.py \
         ${worksrcpath}/tools/pronto2lirc
 }
-
-configure.env-append \
-                    PYTHON=${pythonbin}
 
 # consider variant for X programs (irxevent xmode2)
 configure.args      --without-x --disable-silent-rules


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
