### PR TITLE
nco: update to 5.1.6

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.1.5
-revision            1
+github.setup        nco nco 5.1.6
+revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \
@@ -21,9 +21,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  77ebf8a14d6a47b262e3251569fa90e6fab0f488 \
-                    sha256  b35352f667fcca77051dbfb2b41b7c546fcb2f7932dcd96c503932bad1ef13ab \
-                    size    6457325
+checksums           rmd160  7b8e220e2a4f3f8d672540a3c360dec18b43657a \
+                    sha256  446dd96dbe0a4e9055f6d477c0551d6973a88b669b3519f68e4f96d640684037 \
+                    size    6463847
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description

Simple update to upstream version 5.1.6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4 22F66 x86_64
Command Line Tools 14.3.0.0.1.1679647830


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
