### PR TITLE
net/wireshark4: revbump to 4.0.6

### DIFF
--- a/net/wireshark4/Portfile
+++ b/net/wireshark4/Portfile
@@ -30,12 +30,12 @@ if { ${os.platform} eq "darwin" && ${os.major} < 16 } {
     }
 }
 
-version         4.0.5
+version         4.0.6
 revision        0
 
-checksums       sha256  71b67346935fea4968c68efcae0371c06b30770d6396419c10bc443aac196b29 \
-                sha1    2a0d489480b1a6dd002487b4ba3a8172f58402d9 \
-                size    41401932
+checksums       sha256  0079097a1b17ebc7250a73563f984c13327dac5016b7d53165810fbcca4bd884 \
+                sha1    a60b6f8063df2a711932ba869ae86e6476087cf0 \
+                size    41583088
 
 livecheck.type  regex
 livecheck.url   ${homepage}download.html


### PR DESCRIPTION
#### Description
net/wireshark4: revbump to 4.0.6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4 22F66 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
