### PR TITLE
devel/libssh: revbump to 0.10.5, resolves build error mentioned in ht…

### DIFF
--- a/devel/libssh/Portfile
+++ b/devel/libssh/Portfile
@@ -5,15 +5,15 @@ PortGroup           cmake 1.1
 
 name                libssh
 epoch               1
-version             0.10.4
+version             0.10.5
 revision            0
 set major           [join [lrange [split ${version} .] 0 1] .]
 master_sites        https://www.libssh.org/files/${major}
 use_xz              yes
 
-checksums           rmd160  51499309fa8a317ee71522e97da4231fa0394580 \
-                    sha256  07392c54ab61476288d1c1f0a7c557b50211797ad00c34c3af2bbc4dbc4bd97d \
-                    size    554920
+checksums           rmd160  36319c6c1df88d9f00f1a6b2b94ba669fbff8865 \
+                    sha256  b60e2ff7f367b9eee2b5634d3a63303ddfede0e6a18dfca88c44a8770e7e4234 \
+                    size    557776
 
 categories          devel security net
 platforms           darwin


### PR DESCRIPTION
#### Description
devel/libssh: revbump to 0.10.5, resolves build error mentioned in https://trac.macports.org/ticket/67499

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4 22F66 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
