### PR TITLE
apache-arrow: disable mimalloc on old systems (CI fail on py*-grpcio)

### DIFF
--- a/devel/apache-arrow/Portfile
+++ b/devel/apache-arrow/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           boost 1.0
+PortGroup           active_variants 1.1
 
 boost.version       1.81
 
@@ -142,7 +143,7 @@ configure.args-append \
                     -DARROW_S3:BOOL=OFF \
                     -DARROW_SUBSTRAIT:BOOL=OFF \
                     -DARROW_USE_CCACHE:BOOL=ON \
-                    -DARROW_TENSORFLOW:BOOL=ON \
+                    -DARROW_TENSORFLOW:BOOL=OFF \
                     -DARROW_UTF8PROC_USE_SHARED:BOOL=ON \
                     -DARROW_WITH_BROTLI:BOOL=ON \
                     -DARROW_WITH_BZ2:BOOL=ON \
@@ -177,6 +178,12 @@ destroot.target     install
 if {${name} eq ${subport}} {
     configure.args-append \
                     -DARROW_BUILD_UTILITIES:BOOL=ON
+
+    variant tensorflow description {Build with tensorflow support enabled} {
+        configure.args-replace \
+                    -DARROW_TENSORFLOW:BOOL=OFF \
+                    -DARROW_TENSORFLOW:BOOL=ON
+    }
 }
 
 # lib[^[:space:]]+
@@ -220,18 +227,11 @@ if {[string match "py*" ${subport}]} {
                     port:py${python.version}-wheel
 
     depends_lib-append \
+                    port:apache-arrow \
                     port:py${python.version}-brotli \
                     port:py${python.version}-cython \
                     port:py${python.version}-pycares \
-                    port:py${python.version}-numpy \
-                    path:${python.pkgd}/tensorflow:py${python.version}-tensorflow
-
-    # py-tensorflow-macos requires minimum macOS 12.0 and Python 3.8
-    if {${os.major} >= 21 && ${python.version} >= 38} {
-        depends_lib-replace \
-                    path:${python.pkgd}/tensorflow:py${python.version}-tensorflow \
-                    path:${python.pkgd}/tensorflow:py${python.version}-tensorflow-macos
-    }
+                    port:py${python.version}-numpy
 
     depends_test-append \
                     port:py${python.version}-cffi \
@@ -321,7 +321,24 @@ if {[string match "py*" ${subport}]} {
                     PYARROW_WITH_PARQUET=1 \
                     PYARROW_WITH_PLASMA=1 \
                     PYARROW_WITH_S3=0 \
+                    PYARROW_WITH_TENSORFLOW=0
+
+    variant tensorflow description {Build with tensorflow support enabled} {
+        require_active_variants apache-arrow tensorflow
+
+        build.env-replace \
+                    PYARROW_WITH_TENSORFLOW=0 \
                     PYARROW_WITH_TENSORFLOW=1
+
+        # py-tensorflow-macos requires minimum macOS 12.0 and Python 3.8
+        if {${os.major} >= 21 && ${python.version} >= 38} {
+            depends_lib-append \
+                    path:${python.pkgd}/tensorflow:py${python.version}-tensorflow-macos
+        } else {
+            depends_lib-append \
+                    path:${python.pkgd}/tensorflow:py${python.version}-tensorflow
+        }
+    }
 
     build.dir       ${worksrcpath}/python
     build.cmd       ${python.bin} setup.py --no-user-cfg
@@ -369,4 +386,11 @@ if {[string match "py*" ${subport}]} {
     livecheck.type      none
 } else {
     github.livecheck.regex {([0-9.]+)}
+}
+
+if { ![variant_isset tensorflow] } {
+    notes-append "\
+- ${subport} is now built with tensorflow support disabled by default.\
+To enable it, install the port with '+tensorflow'.\
+"
 }

--- a/devel/apache-arrow/Portfile
+++ b/devel/apache-arrow/Portfile
@@ -84,6 +84,8 @@ depends_lib-append \
 
 # https://github.com/apache/arrow/pull/35046
 patchfiles-append   patch-io_util.diff
+# https://github.com/apache/arrow/issues/35833
+patchfiles-append   patch-absl-ver.diff
 
 # Remove incorrect make dependency on SDK that cmake adds on some systems
 # See https://github.com/grpc/grpc/issues/24902
@@ -152,6 +154,12 @@ configure.args-append \
                     -DgRPC_ROOT:PATH=${prefix} \
                     -Djemalloc_SOURCE:STRING=SYSTEM \
                     -DRE2_SOURCE:STRING=SYSTEM
+
+if {${os.platform} eq "darwin" && ${os.major} < 12} {
+    # arrow downloads mimalloc version which is broken for < 10.8 due to missing MACH_TASK_BASIC_INFO_COUNT etc.
+    configure.args-replace \
+                    -DARROW_MIMALLOC:BOOL=ON -DARROW_MIMALLOC:BOOL=OFF
+}
 
 # Build auto-detects cache if it is installed and a part of it attempts
 # to write to CCACHE_DIR which is not allow if configure.ccache=off.

--- a/devel/apache-arrow/files/patch-absl-ver.diff
+++ b/devel/apache-arrow/files/patch-absl-ver.diff
@@ -1,0 +1,11 @@
+--- cpp/cmake_modules/ThirdpartyToolchain.cmake.orig	2023-04-21 16:37:41.000000000 +0800
++++ cpp/cmake_modules/ThirdpartyToolchain.cmake	2023-06-01 23:10:20.000000000 +0800
+@@ -2823,7 +2823,7 @@
+       # 20211102 or later. We need to update
+       # ARROW_ABSL_REQUIRED_LTS_VERSIONS list when new Abseil LTS is
+       # released.
+-      set(ARROW_ABSL_REQUIRED_LTS_VERSIONS 20211102 20220623)
++      set(ARROW_ABSL_REQUIRED_LTS_VERSIONS 20230125 20220623 20211102)
+       foreach(_VERSION ${ARROW_ABSL_REQUIRED_LTS_VERSIONS})
+         find_package(absl ${_VERSION})
+         if(absl_FOUND)


### PR DESCRIPTION
#### Description

@mascguy Need one more fix for 12.0.0 on old systems.

1. `mimalloc` is not a default component of `apache-arrow` anyway, but we have it enabled. However it does not build now with `arrow` 12.0.0 on old systems due to a number of issues. Disable for now, until properly fixed across the board (I will enable it back once fixed). 

P. S. One issue is `MACH_TASK_BASIC_INFO`, which we fixed in `arrow` itself, but it popped up in `mimalloc`. Since `arrow` downloads `mimalloc` during the build, I am not too sure how to patch it. However even that is done, it still fails due to a few obscure linking errors (besides easily fixable atomics): https://trac.macports.org/ticket/67220 
In fact, a large part of what fails I have fixed and it was merged in master in https://github.com/microsoft/mimalloc/commit/56fde8459abd0ad6362f042f152c3c7c4944ca71 – but `arrow` uses an older `mimalloc` without these fixes.

2. Give another try to `R-arrow` – v. 11 did not build with Clang last time I tried (GCC build was fine), possibly due to version mismatch (?). Now versions match precisely, so try again. If it fails, I will drop the commit for it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
