### PR TITLE
Fix livechecks on lisp ports

### DIFF
--- a/lisp/cl-alexandria/Portfile
+++ b/lisp/cl-alexandria/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           gitlab 1.0
 PortGroup           common_lisp 1.0
 
-gitlab.setup        alexandria alexandria 1.4 v
 gitlab.instance     https://gitlab.common-lisp.net
+gitlab.setup        alexandria alexandria 1.4 v
 name                cl-alexandria
 revision            0
 

--- a/lisp/cl-base64/Portfile
+++ b/lisp/cl-base64/Portfile
@@ -28,3 +28,6 @@ long_description    {*}${description}
 
 depends_test-append port:cl-kmrcl \
                     port:cl-ptester
+
+livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
+livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)

--- a/lisp/cl-chipz/Portfile
+++ b/lisp/cl-chipz/Portfile
@@ -26,3 +26,6 @@ license             MIT
 description         decompress DEFLATE and BZIP2 data in Common Lisp
 
 long_description    {*}${description}
+
+livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
+livecheck.regex     ${name}_(\\d+(?:\\.git\[^-.\]+)*)

--- a/lisp/cl-hu.dwim.asdf/Portfile
+++ b/lisp/cl-hu.dwim.asdf/Portfile
@@ -25,3 +25,6 @@ post-extract {
     # NOTE: seems that system hu.dwim.presentation dissapeared in history
     file delete ${worksrcpath}/hu.dwim.asdf.documentation.asd
 }
+
+github.livecheck.branch \
+                    main

--- a/lisp/cl-hu.dwim.stefil/Portfile
+++ b/lisp/cl-hu.dwim.stefil/Portfile
@@ -30,3 +30,6 @@ post-extract {
     file delete ${worksrcpath}/hu.dwim.stefil+hu.dwim.def.asd
     file delete ${worksrcpath}/hu.dwim.stefil+hu.dwim.def+swank.asd
 }
+
+github.livecheck.branch \
+                    main

--- a/lisp/cl-kmrcl/Portfile
+++ b/lisp/cl-kmrcl/Portfile
@@ -27,3 +27,6 @@ description         General Utilities for Common Lisp Programs
 long_description    {*}${description}
 
 depends_test-append port:cl-rt
+
+livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
+livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)

--- a/lisp/cl-ptester/Portfile
+++ b/lisp/cl-ptester/Portfile
@@ -26,3 +26,6 @@ license             LLGPL
 description         Test suite for Common Lisp programs
 
 long_description    {*}${description}
+
+livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
+livecheck.regex     ${name}_(\\d+(?:\\.git\[^-.\]+)*)

--- a/lisp/cl-puri/Portfile
+++ b/lisp/cl-puri/Portfile
@@ -27,3 +27,6 @@ description         Portable URI Library for Common Lisp
 long_description    {*}${description}
 
 depends_lib-append  port:cl-ptester
+
+livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
+livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)

--- a/lisp/cl-rt/Portfile
+++ b/lisp/cl-rt/Portfile
@@ -26,3 +26,6 @@ license             MIT
 description         Common Lisp regression tester from MIT
 
 long_description    {*}${description}
+
+livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
+livecheck.regex     ${name}_(\\d+(?:\\.git\[^-.\]+)*)

--- a/lisp/cl-split-sequence/Portfile
+++ b/lisp/cl-split-sequence/Portfile
@@ -25,3 +25,6 @@ license             MIT
 description         Common Lisp package to split a sequence of objects
 
 long_description    {*}${description}
+
+livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
+livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Tested as `port livecheck 'cl-*'`

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->