### PR TITLE
common_lisp: added support ECL and CLISP

### DIFF
--- a/lisp/cl-bordeaux-threads/Portfile
+++ b/lisp/cl-bordeaux-threads/Portfile
@@ -25,3 +25,5 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-global-vars \
                     port:cl-trivial-features \
                     port:cl-trivial-garbage
+
+common_lisp.clisp   threads

--- a/lisp/cl-cffi/Portfile
+++ b/lisp/cl-cffi/Portfile
@@ -33,6 +33,8 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-trivial-features \
                     port:libffi
 
+common_lisp.clisp   threads
+
 post-patch {
     if { ${prefix} ne "/opt/local"} {
         reinplace "s|/opt/local|${prefix}|g" \

--- a/lisp/cl-drakma/Portfile
+++ b/lisp/cl-drakma/Portfile
@@ -27,3 +27,5 @@ depends_lib-append  port:cl-base64 \
                     port:cl-plus-ssl \
                     port:cl-ppcre \
                     port:cl-puri
+
+common_lisp.clisp   threads

--- a/lisp/cl-fad/Portfile
+++ b/lisp/cl-fad/Portfile
@@ -21,3 +21,5 @@ long_description    {*}${description}
 
 depends_lib-append  port:cl-alexandria \
                     port:cl-bordeaux-threads
+
+common_lisp.clisp   threads

--- a/lisp/cl-flexi-streams/Portfile
+++ b/lisp/cl-flexi-streams/Portfile
@@ -21,3 +21,6 @@ description         Flexible bivalent streams for Common Lisp
 long_description    {*}${description}
 
 depends_lib-append  port:cl-trivial-gray-streams
+
+# See: https://gitlab.com/embeddable-common-lisp/ecl/-/issues/648
+common_lisp.ecl     no

--- a/lisp/cl-hunchentoot/Portfile
+++ b/lisp/cl-hunchentoot/Portfile
@@ -35,3 +35,5 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-trivial-backtrace \
                     port:cl-usocket \
                     port:cl-who
+
+common_lisp.clisp   threads

--- a/lisp/cl-kmrcl/Portfile
+++ b/lisp/cl-kmrcl/Portfile
@@ -30,3 +30,11 @@ depends_test-append port:cl-rt
 
 livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
 livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)
+
+# Test :STS.10 failed
+# Form:
+# (KMRCL:SECONDS-TO-CONDENSED-TIME-STRING (+ 0.1 86400 7200 120 50 (* 21 86400))
+#  :DP-DIGITS 1)
+# Expected value: "3w1d2h2m50.1s"
+# Actual value: "3w1d2h2m50.2s".
+common_lisp.clisp   no

--- a/lisp/cl-plus-ssl/Portfile
+++ b/lisp/cl-plus-ssl/Portfile
@@ -35,3 +35,8 @@ post-extract {
     # NOTE: cl-coveralls requires a lot of ports and useless here
     reinplace {s|(:feature (:or :sbcl :ccl) :cl-coveralls)||} ${worksrcpath}/cl+ssl.test.asd
 }
+
+# See: https://github.com/usocket/trivial-sockets/issues/1
+common_lisp.ecl     no
+# Error while trying to load definition for system trivial-sockets from pathname [...]/trivial-sockets.asd: keyword list is not a proper list.
+common_lisp.clisp   no

--- a/lisp/cl-trivial-backtrace/Portfile
+++ b/lisp/cl-trivial-backtrace/Portfile
@@ -22,3 +22,7 @@ description         Portable simple API to work with backtraces in Common Lisp
 long_description    {*}${description}
 
 depends_lib-append  port:cl-lift
+
+# /bin/sh: /usr/bin/clang -arch x86_64: No such file or directory
+# /bin/sh: line 0: exec: /usr/bin/clang -arch x86_64: cannot execute: No such file or directory
+common_lisp.clisp   no

--- a/lisp/cl-trivial-features/Portfile
+++ b/lisp/cl-trivial-features/Portfile
@@ -42,4 +42,7 @@ subport cl-trivial-features-tests {
     post-extract {
         file delete ${worksrcpath}/trivial-features.asd
     }
+
+    # See: https://github.com/trivial-features/trivial-features/issues/23
+    common_lisp.clisp   no
 }

--- a/lisp/cl-trivial-sockets/Portfile
+++ b/lisp/cl-trivial-sockets/Portfile
@@ -19,3 +19,6 @@ license             MIT
 description         A trivial networking library for undemanding Internet applications
 
 long_description    {*}${description}
+
+# See: https://github.com/usocket/trivial-sockets/issues/1
+common_lisp.ecl     no

--- a/lisp/cl-usocket/Portfile
+++ b/lisp/cl-usocket/Portfile
@@ -23,3 +23,5 @@ long_description    {*}${description}
 depends_lib-append  port:cl-bordeaux-threads \
                     port:cl-rt \
                     port:cl-split-sequence
+
+common_lisp.clisp   threads


### PR DESCRIPTION
#### Description

Some ports are uses threads which is variant at CLISP.

A few can't be used with ECL or CLISP.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

as `port test 'cl-*'`

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->