### PR TITLE
httping: Update to 2.9

### DIFF
--- a/net/httping/Portfile
+++ b/net/httping/Portfile
@@ -1,34 +1,41 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        folkertvanheusden HTTPing 2.9 v
+revision            0
+checksums           rmd160  49891c45e04e92aa83ea22038ea1c32b55f04c59 \
+                    sha256  37da3c89b917611d2ff81e2f6c9e9de39d160ef0ca2cb6ffec0bebcb9b45ef5d \
+                    size    83674
 
 name                httping
-version             2.5
-revision            2
 categories          net www
-license             {GPL-2 OpenSSLException}
+# License is unclear. Source file headers say AGPL 3 with OpenSSL exception as
+# they did in version 2.5 and was confirmed in license.txt but in 2.9 (there
+# don't appear to have been any 2.6, 2.7, or 2.8 releases) license.txt was
+# deleted and the new LICENSE file says GPL 3. This may be a mistake from when
+# the new repository was created.
+license             {AGPL-3 OpenSSLException}
 maintainers         nomaintainer
-platforms           darwin
 
 description         Ping-like tool for http-requests
 
 long_description    Give it an url, and it will show you how long it takes to \
                     connect, send a request and retrieve the reply (only the headers).
 
-homepage            https://web.archive.org/web/20201108093618/https://www.vanheusden.com/httping/
-master_sites        ${homepage}
-
-checksums           rmd160  f0154ece513637c3334dc2852a9435292996f00a \
-                    sha256  3e895a0a6d7bd79de25a255a1376d4da88eb09c34efdd0476ab5a907e75bfaf8
+github.tarball_from archive
 
 depends_lib         port:fftw-3 \
                     port:gettext \
                     port:ncurses \
                     path:lib/libssl.dylib:openssl
 
-extract.suffix      .tgz
+installs_libs       no
 
 patchfiles          patch-configure.diff
+patchfiles-append   unistd.patch
+patchfiles-append   LOCALEDIR.patch
 
 configure.pre_args
 configure.universal_args
@@ -38,6 +45,6 @@ configure.args      --with-fftw3 \
                     --with-tfo
 configure.ldflags-append -lintl
 
-destroot.args       PREFIX=${prefix}
+build.args          PREFIX=${prefix}
 
-livecheck.type      none
+destroot.args       {*}${build.args}

--- a/net/httping/files/LOCALEDIR.patch
+++ b/net/httping/files/LOCALEDIR.patch
@@ -1,0 +1,35 @@
+--- Makefile.orig	2022-10-29 14:34:27.000000000 -0500
++++ Makefile	2023-05-31 15:10:22.000000000 -0500
+@@ -30,7 +30,8 @@
+ 
+ TARGET=httping
+ 
+-LOCALEDIR=/usr/share/locale
++PREFIX?=/usr
++LOCALEDIR=$(PREFIX)/share/locale
+ 
+ DEBUG=yes
+ WFLAGS=-Wall -W -Wextra -pedantic -D_FORTIFY_SOURCE=2
+@@ -39,7 +40,6 @@
+ LDFLAGS+=-lm
+ 
+ PACKAGE=$(TARGET)-$(VERSION)
+-PREFIX?=/usr
+ BINDIR=$(PREFIX)/bin
+ MANDIR=$(PREFIX)/share/man
+ DOCDIR=$(PREFIX)/share/doc/$(TARGET)
+@@ -121,10 +121,10 @@
+ 	$(STRIP) $(DESTDIR)/$(BINDIR)/$(TARGET)
+ endif
+ ifneq ($(NO_GETTEXT),yes)
+-	mkdir -p $(DESTDIR)/$(PREFIX)/share/locale/nl/LC_MESSAGES
+-	cp nl.mo $(DESTDIR)/$(PREFIX)/share/locale/nl/LC_MESSAGES/httping.mo
+-	mkdir -p $(DESTDIR)/$(PREFIX)/share/locale/ru/LC_MESSAGES
+-	cp ru.mo $(DESTDIR)/$(PREFIX)/share/locale/ru/LC_MESSAGES/httping.mo
++	mkdir -p $(DESTDIR)$(LOCALEDIR)/nl/LC_MESSAGES
++	cp nl.mo $(DESTDIR)$(LOCALEDIR)/nl/LC_MESSAGES/httping.mo
++	mkdir -p $(DESTDIR)$(LOCALEDIR)/ru/LC_MESSAGES
++	cp ru.mo $(DESTDIR)$(LOCALEDIR)/ru/LC_MESSAGES/httping.mo
+ endif
+ 
+ 

--- a/net/httping/files/patch-configure.diff
+++ b/net/httping/files/patch-configure.diff
@@ -1,5 +1,5 @@
---- configure.orig	2015-02-10 02:17:38.000000000 -0600
-+++ configure	2015-09-17 08:15:10.000000000 -0500
+--- configure.orig	2022-10-29 14:34:27.000000000 -0500
++++ configure	2023-05-31 14:56:26.000000000 -0500
 @@ -1,7 +1,8 @@
  #! /bin/sh
  
@@ -9,7 +9,7 @@
 +FILE="`mktemp "$TMPDIR/httping.XXXXXX"`"
 +FILE2="`mktemp "$TMPDIR/httping.XXXXXX"`"
  
- echo \*\*\* HTTPing v`grep VERSION version | cut -d = -f 2` \(`echo $Revision$ | awk '{ print $2; }'`\) configure script \*\*\*
+ echo \*\*\* HTTPing v`grep VERSION version | cut -d = -f 2` configure script \*\*\*
  echo
 @@ -86,6 +87,9 @@
  fi

--- a/net/httping/files/unistd.patch
+++ b/net/httping/files/unistd.patch
@@ -1,0 +1,13 @@
+Fix:
+error: unknown type name 'useconds_t'
+https://github.com/folkertvanheusden/HTTPing/commit/aad3c275686344fe9a235faeac4ee3832f3aa8d5
+--- nc.c.orig
++++ nc.c
+@@ -8,6 +8,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <sys/ioctl.h>
++#include <unistd.h>
+ 
+ #include <ncurses.h>
+ 


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/67541

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.4 21G526 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
