### PR TITLE
clisp: do not cache arch flag

### DIFF
--- a/lang/clisp/Portfile
+++ b/lang/clisp/Portfile
@@ -7,7 +7,7 @@ PortGroup       gitlab 1.0
 gitlab.setup    gnu-clisp clisp 79cbafdbc6337d6dcd8f2dbad69fb7ebf7a46012
 version         2.50.0-20230212
 
-revision        0
+revision        1
 categories      lang
 maintainers     {easieste @easye} {@catap korins.ky:kirill} openmaintainer
 platforms       darwin
@@ -49,13 +49,12 @@ post-patch {
 # Assuming {clang < 300}, but please refine if more datapoints become available
 compiler.blacklist {clang < 300}
 
-configure.cflags
+configure.cflags    ${configure.cc_archflags}
 
 if {${os.platform} eq "darwin" && ${os.major} >= 11} {
    configure.cflags-append -Wl,-no_pie
 }
 
-configure.cc-append  ${configure.cc_archflags}
 configure.args      --with-libiconv-prefix=${prefix} \
                     --with-libreadline-prefix=${prefix} \
                     --with-libsigsegv-prefix=${prefix} \

--- a/lisp/cl-trivial-backtrace/Portfile
+++ b/lisp/cl-trivial-backtrace/Portfile
@@ -23,6 +23,6 @@ long_description    {*}${description}
 
 depends_lib-append  port:cl-lift
 
-# /bin/sh: /usr/bin/clang -arch x86_64: No such file or directory
-# /bin/sh: line 0: exec: /usr/bin/clang -arch x86_64: cannot execute: No such file or directory
+# Error while running (BUILD-REPORT) from [...]/lift-standard.config:
+# PROBE-FILE: No file name given: #P"[..]/test-results-2023-05-31-1/"
 common_lisp.clisp   no


### PR DESCRIPTION
#### Description

CLISP caches arch flag and uses it as part of path to compiler, that
leads to an error when it should compile something like cl-cffi:
```
/bin/sh: /usr/bin/clang -arch x86_64: No such file or directory
/bin/sh: line 0: exec: /usr/bin/clang -arch x86_64: cannot execute: No such file or directory
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->