### PR TITLE
wireshark3: build with python311

### DIFF
--- a/net/wireshark3/Portfile
+++ b/net/wireshark3/Portfile
@@ -167,7 +167,7 @@ variant chmodbpf description {Enable Wireshark to access macOS capture devices} 
     depends_run             port:wireshark-chmodbpf
 }
 
-set pythons_suffixes {36 37 38 39 310}
+set pythons_suffixes {36 37 38 39 310 311}
 
 set pythons_ports {}
 foreach py_ver_nodot ${pythons_suffixes} {
@@ -195,7 +195,7 @@ foreach py_ver_nodot ${pythons_suffixes} {
 ## if no python3* variant is specified, add +python310
 ## XYZZY: it would be better to detect which python3* is already installed and use that...
 if {!${python_isset}} {
-    default_variants-append +python310
+    default_variants-append +python311
 }
 
 


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3 22E252 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
