### PR TITLE
openal-soft: fix a patch

### DIFF
--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 14
 
 name                    openal-soft
 version                 1.23.1
-revision                0
+revision                1
 checksums               rmd160  5ca2531cc9e7476d122ddc9ab3a1b3e568d62175 \
                         sha256  796f4b89134c4e57270b7f0d755f0fa3435b90da437b745160a49bd41c845b21 \
                         size    699330
@@ -52,7 +52,8 @@ compiler.blacklist-append {clang < 900}
 
 # See: https://github.com/kcat/openal-soft/pull/851
 patchfiles-append       0001-Define-__STDC_FORMAT_MACROS-on-systems-that-need-it.patch \
-                        0002-threads-do-not-use-libdispatch-where-it-is-not-prese.patch
+                        0002-threads-do-not-use-libdispatch-where-it-is-not-prese.patch \
+                        patch-cinttypes.diff
 
 configure.args-append   -DALSOFT_EXAMPLES=OFF \
                         -DALSOFT_UTILS=ON \

--- a/audio/openal-soft/files/patch-cinttypes.diff
+++ b/audio/openal-soft/files/patch-cinttypes.diff
@@ -1,0 +1,55 @@
+# https://github.com/kcat/openal-soft/commit/6752d5516c8b30fe7db559c7f3a1423705d2a4fd
+
+--- al/source.cpp.orig	2023-04-12 03:46:23.000000000 +0800
++++ al/source.cpp	2023-06-29 15:13:22.000000000 +0800
+@@ -27,11 +27,11 @@
+ #include <atomic>
+ #include <cassert>
+ #include <chrono>
++#include <cinttypes>
+ #include <climits>
+ #include <cmath>
+ #include <cstdint>
+ #include <functional>
+-#include <inttypes.h>
+ #include <iterator>
+ #include <limits>
+ #include <memory>
+
+--- alc/backends/coreaudio.cpp.orig	2023-04-12 03:46:23.000000000 +0800
++++ alc/backends/coreaudio.cpp	2023-06-29 15:12:58.000000000 +0800
+@@ -22,7 +22,7 @@
+ 
+ #include "coreaudio.h"
+ 
+-#include <inttypes.h>
++#include <cinttypes>
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+
+--- alc/backends/sndio.cpp.orig	2023-04-12 03:46:23.000000000 +0800
++++ alc/backends/sndio.cpp	2023-06-29 15:12:20.000000000 +0800
+@@ -22,8 +22,8 @@
+ 
+ #include "sndio.h"
+ 
++#include <cinttypes>
+ #include <functional>
+-#include <inttypes.h>
+ #include <poll.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+
+--- utils/uhjencoder.cpp.orig	2023-04-12 03:46:23.000000000 +0800
++++ utils/uhjencoder.cpp	2023-06-29 15:11:54.000000000 +0800
+@@ -25,8 +25,8 @@
+ #include "config.h"
+ 
+ #include <array>
++#include <cinttypes>
+ #include <cstring>
+-#include <inttypes.h>
+ #include <memory>
+ #include <stddef.h>
+ #include <string>


### PR DESCRIPTION
#### Description

A small but necessary fix to the patch. What was overlooked is that CMakeLists check uses `cinttypes`, while the code uses `inttypes.h`, and this does not work as intended with GCC, which does not need `__STDC_FORMAT_MACROS` with the first, but does need with the second header.
Reported to upstream also: https://github.com/kcat/openal-soft/commit/118c729680d6664f793f8d88ff0b7548137847d3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
