### PR TITLE
py-re2: build as C++14

### DIFF
--- a/python/py-re2/Portfile
+++ b/python/py-re2/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        facebook pyre2 1.0.7 v
-revision            2
+revision            3
 name                py-re2
 
 categories-append   devel
@@ -28,11 +28,15 @@ if {${name} ne ${subport}} {
     depends_lib-append \
                     port:re2
 
-    compiler.cxx_standard   2011
+    compiler.cxx_standard   2014
     # hack to use proper compiler and stdlib
     configure.cc        ${configure.cxx}
     configure.cflags    {*}${configure.cxxflags}
     python.add_cflags   yes
+
+    post-patch {
+        reinplace "s|-std=c\+\+11|-std=c++14|g" ${worksrcpath}/setup.py
+    }
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}


### PR DESCRIPTION
The re2 upgrade at 8d9008694fb2 brings it to version 2023-06-01, which requires Abseil, added as a dependency in 60e55a7069d6. [Abseil enforces a C++14 minimum via an #error in one of its headers](https://github.com/abseil/abseil-cpp/blob/71ffb09f8c27849c7e92595b5ac883b1ec45b95e/absl/base/policy_checks.h#L68), and that header is visible to the py-re2 build. This was addressed for re2 itself in d7242bf8674b.

Fixes: https://trac.macports.org/ticket/67548

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4 22F66 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@herbygillot