### PR TITLE
warzone2100: update to 4.3.5

### DIFF
--- a/games/warzone2100/Portfile
+++ b/games/warzone2100/Portfile
@@ -38,16 +38,16 @@ if {$subport eq ${name}} {
     PortGroup           cmake 1.1
     PortGroup           legacysupport 1.1
 
-    github.setup        Warzone2100 ${name} 4.3.0
-    revision            1
+    github.setup        Warzone2100 ${name} 4.3.5
+    revision            0
     github.tarball_from releases
     distname            ${name}_src
     use_xz              yes
     dist_subdir         ${name}/${version}
 
-    checksums           rmd160  ead5dccf8860d2096e506d94d41e14eba0ae6fdb \
-                        sha256  417665f4cc678e0cbf2f27905a8fbf0bc51771a0138385abec54d31254582cb3 \
-                        size    320501020
+    checksums           rmd160  653843bdd1ae14d9d23a72d77bbbf0878c17e2f8 \
+                        sha256  01d608f6f9638e14d7c857df40ad339c1bfc207a05daafe7157ad8652a3405c3 \
+                        size    320369492
 
     set port_libfmt     libfmt9
     cmake.module_path-append \


### PR DESCRIPTION
`warzone2100` needed to be rev-bumped because of the `re2` upgrade, but there's a newer version available, so this is the PR for that.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
