### PR TITLE
py-hyrule: submission

### DIFF
--- a/python/py-hyrule/Portfile
+++ b/python/py-hyrule/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-hyrule
+version             0.3.0
+revision            0
+categories-append   devel
+license             MIT
+platforms           {darwin any}
+supported_archs     noarch
+maintainers         nomaintainer
+description         A utility library for the Hy programming language
+long_description    Hyrule is a utility library for the Hy programming \
+                    language. It can be thought of as the Hy equivalent, or addition, \
+                    to Python’s standard library. While intended primarily for Hy \
+                    programs, its functions and classes can be used in Python as with \
+                    any other Python library\; just import hyrule. Hyrule’s macros, on \
+                    the other hand, are only really usable in Hy.
+
+homepage            https://hyrule.readthedocs.io/
+
+checksums           rmd160 635180f049af1e3dd8e0ed0d6da247ed476b8ff1 \
+                    sha256 b65127d94d71aa7c05e7eb1c3e550b389247c66f41af24c73f1fe743d39410b4  \
+                    size   45291
+
+python.versions     38 39 310 311
+
+python.pep517       no
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools \
+                            port:py${python.version}-wheel
+
+    depends_lib-append      port:py${python.version}-hy
+}


### PR DESCRIPTION
#### Description

https://hyrule.readthedocs.io/

Hyrule is a kind of standard library for Hy. Much of the functionality that used to be included with the Hy compiler is now distributed separately in Hyrule. You can use Hy without it, but it's likely that any nontrivial Hy application (if there are any) also would depend on Hyrule. Also, a lot of it is usable and useful in plain Python.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

```none
macOS 12.4 21F79 arm64
Xcode 13.4.1 13F100
```

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all ~~binary~~ files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
[skip notification]
