### PR TITLE
vim: Fix +python3 variant, follow-up to #18475

### DIFF
--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -146,7 +146,12 @@ foreach s ${pythons_suffixes} {
             patchfiles-append       patch-python.diff
         } else {
             configure.args-append   --enable-python3interp --with-python3-command=${prefix}/bin/python${v}
-            patchfiles-append       patch-python3.diff
+            if {[vercmp \"${vim_version}.${vim_patchlevel}\" 9.0.1441] < 0} {
+                ui_info \"Vim patchlevel < 1441, python3 patch needed\"
+                patchfiles-append   patch-python3.diff
+            } else {
+                ui_info \"Vim patchlevel >= 1441, no python3 patch needed\"
+            }
         }
         depends_lib-append      port:${p}
         use_autoconf yes


### PR DESCRIPTION
#### Description

It seems upstream now has a patch that separately tracks `PYTHONFRAMEWORKPREFIX` and adds it as necessary. I tested this by checking the output of `otool -L` on the vim binary and running

```
:py3 print(sys.version_info)
```

in the resulting binary.

The python 2 variants may also have been broken by the recent changes, but I don't use those and python 2 is deprecated anyway. We should probably just remove the python 2 variants from vim.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
