### PR TITLE
scrcpy: Update to 2.0

### DIFF
--- a/multimedia/scrcpy/Portfile
+++ b/multimedia/scrcpy/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           meson 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        Genymobile scrcpy 1.25 v
+github.setup        Genymobile scrcpy 2.0 v
 revision            0
 
 categories          multimedia
@@ -24,13 +24,15 @@ extract.only        ${distfiles}
 distfiles-append    ${name}-server-v${version}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  f44a661318638456ea2477adde079d873c35d35f \
-                    sha256  78d7b2dcecc527dec3e391a6ca022a411a1f7b9b582875aaf329f22e489cb521 \
-                    size    345630 \
+                    rmd160  5991a252ef7883bf907becf121cbdd84c8baeb90 \
+                    sha256  ed6e86f8df82454252f9d1da7f918e1e1ecab09e06c1a537c86a70b21af7489b \
+                    size    375926 \
                     ${name}-server-v${version} \
-                    rmd160  ece066a6d2a86cc1daac5d4eba6367af8c4ad539 \
-                    sha256  ce0306c7bbd06ae72f6d06f7ec0ee33774995a65de71e0a83813ecb67aec9bdb \
-                    size    42151
+                    rmd160  32ee7d41e1e0e393d1c96b9d645d31cbd2626caa \
+                    sha256  9e241615f578cd690bb43311000debdecf6a9c50a7082b001952f18f6f21ddc2 \
+                    size    52867
+
+patchfiles          6b769675fa68e60c9765022e43c4d7b1e329353a.patch
 
 depends_build-append \
                     port:pkgconfig
@@ -51,10 +53,3 @@ compiler.c_standard 2011
 # Work around cfm: fatal error: 'stdatomic.h' file not found
 # https://trac.macports.org/ticket/60429
 compiler.blacklist-append {clang < 700}
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}/share/${name}
-
-    xinstall -m 644 ${workpath}/build/server/${name}-server ${destroot}${prefix}/share/${name}
-    xinstall -m 755 ${workpath}/build/app/${name} ${destroot}${prefix}/bin
-}

--- a/multimedia/scrcpy/files/6b769675fa68e60c9765022e43c4d7b1e329353a.patch
+++ b/multimedia/scrcpy/files/6b769675fa68e60c9765022e43c4d7b1e329353a.patch
@@ -1,0 +1,54 @@
+From 6b769675fa68e60c9765022e43c4d7b1e329353a Mon Sep 17 00:00:00 2001
+From: Ruoyu Zhong <zhongruoyu@outlook.com>
+Date: Sun, 12 Mar 2023 14:23:35 +0800
+Subject: [PATCH] Fix an "expected expression" error
+
+In C, a label can only be followed by a statement, not a declaration.
+An error in `app/src/screen.c` violated this, and led to a build error
+with an error message similar to the one below:
+
+    ../app/src/screen.c:821:13: error: expected expression
+                bool ok = sc_screen_init_size(screen);
+                ^
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.0.0/include/stdbool.h:15:14: note: expanded from macro 'bool'
+    #define bool _Bool
+                 ^
+    ../app/src/screen.c:822:18: error: use of undeclared identifier 'ok'
+                if (!ok) {
+                     ^
+    2 errors generated.
+
+This could be fixed by introducing a new block (or compound statement;
+as is already being done in the next `case`). That is a statement.
+
+Fixes #3785 <https://github.com/Genymobile/scrcpy/issues/3785>
+PR #3787 <https://github.com/Genymobile/scrcpy/pull/3787>
+
+Signed-off-by: Ruoyu Zhong <zhongruoyu@outlook.com>
+Signed-off-by: Romain Vimont <rom@rom1v.com>
+Upstream-Status: Backport [https://github.com/Genymobile/scrcpy/commit/6b769675fa68e60c9765022e43c4d7b1e329353a]
+---
+ app/src/screen.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/app/src/screen.c b/app/src/screen.c
+index f74fd8a54..b00b0d051 100644
+---  ./app/src/screen.c
++++  ./app/src/screen.c
+@@ -816,7 +816,7 @@ sc_screen_handle_event(struct sc_screen *screen, SDL_Event *event) {
+     bool relative_mode = sc_screen_is_relative_mode(screen);
+ 
+     switch (event->type) {
+-        case SC_EVENT_SCREEN_INIT_SIZE:
++        case SC_EVENT_SCREEN_INIT_SIZE: {
+             // The initial size is passed via screen->frame_size
+             bool ok = sc_screen_init_size(screen);
+             if (!ok) {
+@@ -824,6 +824,7 @@ sc_screen_handle_event(struct sc_screen *screen, SDL_Event *event) {
+                 return false;
+             }
+             return true;
++        }
+         case SC_EVENT_NEW_FRAME: {
+             bool ok = sc_screen_update_frame(screen);
+             if (!ok) {


### PR DESCRIPTION
#### Description

Needed a backport from master to fix a build failure.

Upstream now has an install target, so drop the manual destroot phase. This also gives us a manpage, and completions for the bash and zsh shells.

Closes: https://trac.macports.org/ticket/67564

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
