### PR TITLE
cl-iterate: new port

### DIFF
--- a/lisp/cl-iterate/Portfile
+++ b/lisp/cl-iterate/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           common_lisp 1.0
+
+gitlab.instance     https://gitlab.common-lisp.net
+gitlab.setup        iterate iterate 1.5.3
+name                cl-iterate
+revision            0
+
+categories-append   devel
+license             MIT
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         ITERATE macro library for Common Lisp
+
+long_description    {*}${description}
+
+homepage            https://iterate.common-lisp.dev/
+
+checksums           rmd160  6da2c2444e7ec8b33bcdef7fa60c0bfe62a09aae \
+                    sha256  61d57d4196586333a437ac4516e87500c823498e2e34b71296384c8b404dcd8e \
+                    size    297681


### PR DESCRIPTION
#### Description

[ITERATE macro library for Common Lisp](https://iterate.common-lisp.dev/)

###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3 14E222b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?