### PR TITLE
openjdk11-openj9: update to 11.0.19

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      11.0.18
+version      11.0.19
 revision     0
 
-set build    10
-set openj9_version 0.36.1
+set build    7
+set openj9_version 0.38.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 11
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  1c0e76941d53095695903bb61415f76536f26155 \
-                 sha256  ef18ff9bcd8dc0955fc3f69a43953373d3681aed9465ec561085a034a23f866b \
-                 size    204802374
+    checksums    rmd160  c6fddfbfc170379b88f760c59a260b012e3b3794 \
+                 sha256  49ff29804ac94ffaee88df4886afc084c66bb58123c64e1e7e4f1b795b3b8ced \
+                 size    205020791
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  abff799d46d78772bf0417374b110c4d13e4f939 \
-                 sha256  8f6e4ea6dbb19f605e4acae9b056779aacc2ae483ff1a724f90317da88d8a77e \
-                 size    199015288
+    checksums    rmd160  45040f39063eeec32943ea4c52a15a048792124e \
+                 sha256  7027c65226d7146fb7402dec1b399f0d6574a31e3a4abc3dbe95e8798e6d9251 \
+                 size    199179197
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.19.

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?