### PR TITLE
openjdk8-openj9: update to 8u372

### DIFF
--- a/java/openjdk8-openj9/Portfile
+++ b/java/openjdk8-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64
 
-version      8u362
+version      8u372
 revision     0
 
-set build    09
-set openj9_version 0.36.0
+set build    07
+set openj9_version 0.38.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 8
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -29,9 +29,9 @@ master_sites https://github.com/ibmruntimes/semeru8-binaries/releases/download/j
 distname     ibm-semeru-open-jdk_x64_mac_${version}b${build}_openj9-${openj9_version}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  c24af0f736208ae8ff10e2f5f950892c823fdf3a \
-             sha256  ce4e07b5af6ad236365dde5736ac95965c736415f0ec52ff94d8f90fc664387d \
-             size    129530104
+checksums    rmd160  dd01680436b22bc6ae34b6762cc9da3c8bb135d3 \
+             sha256  f80452d92b236ebeadf727f66a675519fc6fb724ead4cdc8158c9dfdd3ea6eb3 \
+             size    129597136
 
 homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
 


### PR DESCRIPTION
#### Description

Update to IBM Semeru 8u372.

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?