### PR TITLE
sbcl: fix build on i386

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -70,6 +70,9 @@ if {${os.major} < 10} {
     checksums   rmd160  2df788b7b6ebe35bf37c3264aeb06aef4f3416c3 \
                 sha256  fcdd251cbc65f7f808ed0ad77246848d1be166aa69a17f7499600184b7a57202 \
                 size    7030086
+
+    patchfiles-append \
+                patch-i386-missed-context.diff
 }
 
 platform darwin powerpc {
@@ -135,7 +138,7 @@ build.args-append \
 if {${build_arch} eq "i386"} {
     build.args-append \
                 --arch=x86
-} elseif {${build_arch} eq "i386"} {
+} elseif {${build_arch} eq "x86_64"} {
     build.args-append \
                 --arch=x86-64
 } else {

--- a/lang/sbcl/files/patch-i386-missed-context.diff
+++ b/lang/sbcl/files/patch-i386-missed-context.diff
@@ -1,0 +1,26 @@
+See: https://github.com/sbcl/sbcl/blob/sbcl-1.3.9/src/runtime/x86-bsd-os.c#L113-L128
+
+diff --git src/runtime/x86-darwin-os.h src/runtime/x86-darwin-os.h
+index 7ff303b96..cf6487815 100644
+--- src/runtime/x86-darwin-os.h
++++ src/runtime/x86-darwin-os.h
+@@ -19,7 +19,9 @@ void set_data_desc_addr(data_desc_t* desc, void* addr);
+  */
+ #if __DARWIN_UNIX03
+ 
+-#define CONTEXT_ADDR_FROM_STEM(stem) &context->uc_mcontext->__ss.__##stem
++#define CONTEXT_ADDR_FROM_STEM(stem) (os_context_register_t*)&context->uc_mcontext->__ss.__##stem
++#define OS_CONTEXT_PC(context) context->uc_mcontext->__ss.__eip
++
+ #define EIP __eip
+ #define ESP __esp
+ #define EBP __ebp
+@@ -42,6 +44,8 @@ void set_data_desc_addr(data_desc_t* desc, void* addr);
+ #else
+ 
+ #define CONTEXT_ADDR_FROM_STEM(stem) &context->uc_mcontext->ss.stem
++#define OS_CONTEXT_PC(context) context->uc_mcontext->ss.eip
++
+ #define EIP eip
+ #define ESP esp
+ #define EBP ebp


### PR DESCRIPTION
#### Description

This is a kind of blind fix. I haven't got access to 10.6 i386 and tested it on 10.5 i386;

unfortunately, 2.2.4 requires a few more patches to be build with all features on 10.5 and not all of them ready.

Anyway, base version are ready and had allowed make this fix.
 
With quite big probabibility it will build on buildbot :)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->