### PR TITLE
re2: update to 2023-06-02

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -674,7 +674,7 @@ array set modules {
         {"Qt WebEngine"}
         "very large and relatively new"
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtwebglplugin {

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -597,7 +597,7 @@ array set modules {
         {"Qt WebEngine"}
         "very large and relatively new"
         "variant overrides: "
-        "revision 8"
+        "revision 9"
         "License: "
     }
     qtwebglplugin {

--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -341,7 +341,7 @@ array set modules {
         {"Qt WebEngine Qt" "Qt PDF"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtwebview {

--- a/devel/Bear/Portfile
+++ b/devel/Bear/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        rizsotto Bear 3.1.1
-revision            3
+revision            4
 checksums           rmd160  66e4698f34c116ff875bd80e15e097fb4fada48f \
                     sha256  b80b81abe8b38cfd7399a074ef97e1c1045875a3e38459c960543e226e309476 \
                     size    127097

--- a/devel/apache-arrow/Portfile
+++ b/devel/apache-arrow/Portfile
@@ -8,7 +8,7 @@ PortGroup           boost 1.0
 boost.version       1.81
 
 github.setup        apache arrow 12.0.0 apache-arrow-
-revision            2
+revision            3
 name                ${github.author}-${github.project}
 
 categories          devel

--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 # NOTE: Also rev-bump 'apache-arrow' when updating this port
 github.setup        grpc grpc 1.48.0 v
-revision            7
+revision            8
 categories          devel
 maintainers         nomaintainer
 license             Apache-2

--- a/devel/re2/Portfile
+++ b/devel/re2/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        google re2 2023-06-01
+github.setup        google re2 2023-06-02
 epoch               1
 revision            0
 
 github.tarball_from archive
-checksums           rmd160 ac85ba5d9881c6c0f194df120b9fda6bfcb576c8 \
-                    sha256 8b4a8175da7205df2ad02e405a950a02eaa3e3e0840947cd598e92dca453199b \
-                    size   396047
+checksums           rmd160 05aba6e61cd336764abad3d35f3a78afd0f04816 \
+                    sha256 4ccdd5aafaa1bcc24181e6dd3581c3eee0354734bb9f3cb4306273ffa434b94f \
+                    size   396296
 
 categories          devel textproc
 maintainers         {gmail.com:herby.gillot @herbygillot} \

--- a/games/warzone2100/Portfile
+++ b/games/warzone2100/Portfile
@@ -39,7 +39,7 @@ if {$subport eq ${name}} {
     PortGroup           legacysupport 1.1
 
     github.setup        Warzone2100 ${name} 4.3.0
-    revision            1
+    revision            2
     github.tarball_from releases
     distname            ${name}_src
     use_xz              yes

--- a/net/mtxclient/Portfile
+++ b/net/mtxclient/Portfile
@@ -8,7 +8,7 @@ PortGroup           boost 1.0
 
 github.setup        Nheko-Reborn mtxclient 0.9.2 v
 epoch               2
-revision            2
+revision            3
 
 checksums           rmd160  4584fdcd4d6632a531343f235ec2258f7ba38204 \
                     sha256  14df722738830510edf8768b24648568d46f392953c9b2f8d1bf749f0c12435d \

--- a/python/py-re2/Portfile
+++ b/python/py-re2/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        facebook pyre2 1.0.7 v
-revision            3
+revision            4
 name                py-re2
 
 categories-append   devel


### PR DESCRIPTION
Another update for `re2`; revbump downstream ports.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
