### PR TITLE
Replace opensource.apple.com/tarballs to macports_distfiles

### DIFF
--- a/devel/CoreOSMakefiles/Portfile
+++ b/devel/CoreOSMakefiles/Portfile
@@ -12,10 +12,15 @@ long_description        These are some makefiles which are required to build \
                         implies MAKEFILEPATH=${prefix}/share/Makefiles
 
 homepage                http://opensource.apple.com/source/${name}/
-master_sites            http://opensource.apple.com/tarballs/${name}/
+master_sites            https://github.com/apple-oss-distributions/${name}/archive
 
-checksums               rmd160  ab3816588c11c9c9ef6720717d323846d69ebefe \
-                        sha256  6b8a9521bb65a2868181696f12515eb4c2498fb05a8f28075e29cb1eda67bae6
+checksums               rmd160  aa7a5724907a0719ea6c1c39c96ad2a11adaec56 \
+                        sha256  b8bf4c3fa727d71615665322bb22813eda15962544df5238cc37aa606bda276c \
+                        size    17200
+
+# handle stealth update; remove with next version change
+dist_subdir             ${name}/${version}_1
+worksrcdir              ${name}-${distname}
 
 supported_archs         noarch
 use_configure           no

--- a/devel/bootstrap_cmds/Portfile
+++ b/devel/bootstrap_cmds/Portfile
@@ -7,16 +7,16 @@ epoch                   1
 categories              devel
 maintainers             nomaintainer
 homepage                http://opensource.apple.com/source/${name}/
-master_sites            http://opensource.apple.com/tarballs/${name}/
+master_sites            https://github.com/apple-oss-distributions/${name}/archive
 license                 APSL-2
 installs_libs           no
 description             Darwin Core OS Bootstrap Commands
 long_description        Bootstrapping tools like the Mach Interface \
                         Generator (MIG) required to build the XNU kernel.
 
-checksums               rmd160  4b8304d058d2b8953e938b09aaeb979c88f98355 \
-                        sha256  e56cc6fade7b5ebbbacb77f2015bad7efc3313bf9a9245f3852f013d73502703 \
-                        size    108971
+checksums               rmd160  f297049f1f8e43d1d53ba1d47d268e81f1ba1e0f \
+                        sha256  c119228064f6e3f12dc22c38b9966aa36d9e89b78405e139fc2e75df399f62e3 \
+                        size    108737
 
 xcode.target            migcom
 xcode.destroot.path     ${prefix}/bin
@@ -27,8 +27,9 @@ patchfiles              cc_fallback.patch
 if {${os.major} < 12} {
     version         80
     revision        5
-    checksums       rmd160  072e399562eb021e4fa0cd66132153afcc02f417 \
-                    sha256  2ae65cd2ca6f0f684b25aad46a649aeb95a774d06a8287c59962fba42900a2fc
+    checksums       rmd160  772c9bf34e1f65ca5850b2cbc604504e60b8f117 \
+                    sha256  446cb2090064496a0ee9043415d8e9bf6b1695d2cfffc4e2b31b4975ed02d914 \
+                    size    279127
 
     supported_archs i386 ppc
     xcode.project   migcom.tproj/migcom.xcodeproj
@@ -64,6 +65,10 @@ if {${os.major} < 12} {
     }
 
 }
+
+# handle stealth update; remove with next version change
+dist_subdir             ${name}/${version}_1
+worksrcdir              ${name}-${distname}
 
 livecheck.type          regex
 livecheck.regex         "${name}-(\[\\d.\]+)"

--- a/devel/bsdmake/Portfile
+++ b/devel/bsdmake/Portfile
@@ -21,7 +21,7 @@ long_description \
 
 homepage       http://opensource.apple.com/
                # see also http://www.freebsd.org/cgi/cvsweb.cgi/src/usr.bin/make/
-master_sites   http://opensource.apple.com/tarballs/${name}
+master_sites   https://github.com/apple-oss-distributions/${name}/archive
 
 checksums      rmd160  1f08d49704391725cc304c455ead7e48103fd8cf \
                sha256  096f333f94193215931a9fab86b9bca0713fbd22ec465bf55510067b53940e62 \

--- a/devel/csu/Portfile
+++ b/devel/csu/Portfile
@@ -3,17 +3,17 @@ PortSystem              1.0
 name                    csu
 version                 85
 categories              devel
-platforms               darwin
 maintainers             nomaintainer
 license                 {APSL-1.1 APSL-2}
 description             Common startup and C runtime setup code
-long_description        Common startup and C runtime setup code
+long_description        {*}${description}
 homepage                http://opensource.apple.com/source/Csu/
-master_sites            http://opensource.apple.com/tarballs/Csu/
+master_sites            https://github.com/apple-oss-distributions/Csu/archive
 
 distname                Csu-${version}
-checksums               rmd160  5196472e25fbe87566646d3cfba55f8c20c6d482 \
-                        sha256  f2291d7548da854322acf194a875609bfae96c2481738cf6fd1d89eea9ae057a
+checksums               rmd160  c571588a596ed9c54ae5d27c3b67cca98d5615fe \
+                        sha256  87a6bfb1030455e17128d5803e02815e35a1c8bd8bda7bd7f4141431a4d0eac6 \
+                        size    13389
 
 use_configure           no
 default_variants        +universal
@@ -30,9 +30,14 @@ variant universal {
 platform darwin 9 {
     version             75
     distname            Csu-${version}
-    checksums           rmd160  5ccb1772c638f495f8ab28250ed8203d82b00c13 \
-                        sha256  a038b1f51884bbca68ed9b6d6bfa4ff349658a658bacfb411545eb88dba104bc
+    checksums           rmd160  45daca7a8f32e6dbbe405c91c94b5ead0f3af98f \
+                        sha256  60eef896fd551987ca569190dd809375ccffa3ee3880f61193a5c7eee498118a \
+                        size    8304
 }
+
+# handle stealth update; remove with next version change
+dist_subdir             ${name}/${version}_1
+worksrcdir              Csu-${distname}
 
 livecheck.type          regex
 livecheck.regex         "Csu-(\[\\d.\]+)"

--- a/devel/developer_cmds/Portfile
+++ b/devel/developer_cmds/Portfile
@@ -16,19 +16,19 @@ maintainers             nomaintainer
 conflicts               ctags unifdef
 
 homepage                http://opensource.apple.com/source/${name}/
-master_sites            http://opensource.apple.com/tarballs/${name}/
+master_sites            https://github.com/apple-oss-distributions/${name}/archive
 license                 BSD
 description             A set of general BSD commands for developers
 long_description        Apple's BSD general commands for developers including \
                         the asa utility, ctags, indent, lorder, mkdep, \
                         rpcgen, unifdef and what.
 
-# stealth update
+# handle stealth update; remove with next version change
 dist_subdir             ${name}/${version}_2
+worksrcdir              ${name}-${distname}
 checksums               rmd160  8b33e651e3ee65a421bfebed85cd2442c9aabd3c \
                         sha256  076a83feed92d11df2b958484dac430054133f08ecfefbd9f45c8c810fbd64e6 \
                         size    110943
-extract.rename          yes
 
 # some old versions of sys/cdefs.h don't have __FBSDID
 xcode.build.settings    GCC_PREPROCESSOR_DEFINITIONS='__FBSDID\(s\)= '

--- a/devel/ld64/Portfile
+++ b/devel/ld64/Portfile
@@ -9,45 +9,40 @@ version                 3
 revision                6
 set dyld_version        655.1.1
 categories              devel
-platforms               darwin
 maintainers             {jeremyhu @jeremyhu}
 homepage                http://opensource.apple.com/source/${name}/
-master_sites            http://opensource.apple.com/tarballs/${name} \
-                        http://opensource.apple.com/tarballs/dyld
+master_sites            https://github.com/apple-oss-distributions/${name}/archive/:ld64 \
+                        https://github.com/apple-oss-distributions/dyld/archive/:dyld
 license                 APSL-2
 installs_libs           no
 description             ld64 is the new mach-o linker
 long_description        ld64 combines several object files and libraries, \
                         resolves references, and produces an ouput file.
 
-checksums           dyld-655.1.1.tar.gz \
-                    rmd160  eef3ce30381e5fa23152c637e3bde2d8cf4cde0b \
-                    sha256  8ca6e3cf0263d3f69dfa65e0846e2bed051b0cff92e796352ad178e7e4c92f1d \
-                    size    907171 \
-                    ld64-97-standalone-libunwind-headers.patch \
-                    rmd160  f6da71e097aa61b1055b3fdc12cd39aafed5f492 \
-                    sha256  370d02757ea628b5dd145c099e42fc4eb88cc09cf459a59e32d14bbc9b4a105e \
-                    size    141802 \
-                    ld64-97.17.tar.gz \
-                    rmd160  d52df7d7f741c8bedd29cbac73dbb9db992b4795 \
-                    sha256  02bd46af0809eaa415d096d7d41c3e8e7d80f7d8d181840866fb87f036b4e089 \
-                    size    421947 \
-                    ld64-127.2.tar.gz \
-                    rmd160  8ee709341549a1944732daef6ebab7ef1acfcc6e \
-                    sha256  97b75547b2bd761306ab3e15ae297f01e7ab9760b922bc657f4ef72e4e052142 \
-                    size    496975 \
-                    ld64-236.3.tar.gz \
-                    rmd160  6a3f44aa9ae57a60d2cff5b3d47be7972ad83029 \
-                    sha256  8ef36729b643201081ab45ebd8586ede8f9968bc17614b679a940faa82875ca6 \
-                    size    624400 \
-                    ld64-274.2.tar.gz \
-                    rmd160  16e57faf2b1d3f3808fb8e4b167cf23a14f106b0 \
-                    sha256  175d89c419e99d49a7a5f7e4196d3cef4c9e19cc17a425c332e86df6b516f7d7 \
-                    size    671652 \
-                    ld64-450.3.tar.gz \
-                    rmd160  4d263cff143228e021c438d3c2d1800ff367c895 \
-                    sha256  140619e676e099581771dbad98277850ff731cd23938bed95b4d7171616acca1 \
-                    size    729639
+checksums               dyld-655.1.1.tar.gz \
+                        rmd160  3ce28be9a3eb52777443828853040d4c870a5db2 \
+                        sha256  67326487dd139a82f0da9f43eb91414041551ee54cacf4763052e5aae606f518 \
+                        size    872742 \
+                        ld64-97.17.tar.gz \
+                        rmd160  e9e51b2b219fb094a4744b307fe14badac5d74bd \
+                        sha256  dc609d295365f8f5853b45e8dbcb44ca85e7dbc7a530e6fb5342f81d3c042db5 \
+                        size    418239 \
+                        ld64-127.2.tar.gz \
+                        rmd160  94b1bda67084f52417d3ad465795f4eb26b44b9e \
+                        sha256  acfc5c3340a24ad8696ff22027b121cb3807c75fade7dec48b2b52494698e05f \
+                        size    492334 \
+                        ld64-236.3.tar.gz \
+                        rmd160  1811d7bf9a72949879716976b06c9b52455da990 \
+                        sha256  d88b3bf58fc5cfe7c33babfc9619dbb82a5a4a0b4a5f44aa12b60b6efe642756 \
+                        size    604369 \
+                        ld64-274.2.tar.gz \
+                        rmd160  1dc9dd59ad2c760e2920a40890f9ca614f20cc16 \
+                        sha256  89f5fe683faff0da8990cf881beaa0ca61bd13827d4a75aada423a8693a68714 \
+                        size    674878 \
+                        ld64-450.3.tar.gz \
+                        rmd160  ffbf7b2dcd9826db463c779c6ae920f4a71803d3 \
+                        sha256  7c14d80f1552819e7038e918dde9cc7b2398e08678471221330f173c87cf565a \
+                        size    716654
 
 subport ld64-97 {
     # Xcode 3.2.6
@@ -72,13 +67,13 @@ subport ld64-97 {
         ld64-97-no-ppc-thread_status.patch \
         ld64-97-configured_architectures.patch
 
-    if {${os.major} >= 14} {
-        known_fail yes
-        pre-fetch {
-            ui_error "$subport is not supported on Yosemite or later."
-            error "unsupported platform"
-        }
-    }
+    patch_sites         https://distfiles.macports.org/${name}/
+    checksums-append    ld64-97-standalone-libunwind-headers.patch \
+                        rmd160  f6da71e097aa61b1055b3fdc12cd39aafed5f492 \
+                        sha256  370d02757ea628b5dd145c099e42fc4eb88cc09cf459a59e32d14bbc9b4a105e \
+                        size    141802
+
+    platforms   {darwin < 14}
 }
 
 subport ld64-127 {
@@ -115,13 +110,7 @@ subport ld64-127 {
         PR-29117886.patch \
         ld64-ppc-9610466.patch
 
-    if {${os.major} >= 17} {
-        known_fail yes
-        pre-fetch {
-            ui_error "$subport is not supported on High Sierra or later."
-            error "unsupported platform"
-        }
-    }
+    platforms   {darwin < 17}
 }
 
 subport ld64-236 {
@@ -155,13 +144,8 @@ subport ld64-236 {
         patchfiles-append   ld64-236-hash_set.patch
     }
 
-    if {${os.major} <= 9} {
-        known_fail yes
-        pre-fetch {
-            ui_error "$subport is not supported on Leopard or earlier.  It requires the blocks runtime."
-            error "unsupported platform"
-        }
-    }
+    # requires the blocks runtime
+    platforms   {darwin >= 10}
 }
 
 subport ld64-274 {
@@ -375,7 +359,8 @@ if {${subport} eq ${name}} {
         }
     }
 } else {
-    distfiles           dyld-${dyld_version}.tar.gz ${name}-${version}.tar.gz
+    distfiles           dyld-${dyld_version}.tar.gz:dyld \
+                        ${name}-${version}.tar.gz:ld64
 
     depends_build       path:include/mach-o/arm/reloc.h:libmacho-headers
 
@@ -467,6 +452,8 @@ if {${subport} eq ${name}} {
     }
 
     post-extract {
+        move ${workpath}/ld64-ld64-${version} ${workpath}/ld64-${version}
+        move ${workpath}/dyld-dyld-${dyld_version} ${workpath}/dyld-${dyld_version}
         file copy ${filespath}/${makefile} ${worksrcpath}/Makefile
     }
 
@@ -603,5 +590,8 @@ if {!${universal_possible} || ![variant_isset universal]} {
                 | perl ../bin/result-filter.pl
     test.target
 }
+
+# handle stealth update; remove with next version change
+dist_subdir             ${name}/${version}_1
 
 livecheck.type          none

--- a/devel/libmacho/Portfile
+++ b/devel/libmacho/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+
 name                    libmacho
 version                 949.0.1
 subport ${name}-headers { }
@@ -13,13 +14,16 @@ long_description        {*}${description} \
                         may be needed for newer functionality.
 
 homepage                https://opensource.apple.com/source/cctools/
-master_sites            https://opensource.apple.com/tarballs/cctools/
+master_sites            https://github.com/apple-oss-distributions/cctools/archive/
 
+# handle stealth update; remove with next version change
+dist_subdir             ${name}/${version}_1
 distname                cctools-${version}
+worksrcdir              cctools-${distname}
 
-checksums               rmd160  6412d9c5aea6aadd88cd9abdde6c1383f103b582 \
-                        sha256  830485ac7c563cd55331f643952caab2f0690dfbd01e92eb432c45098b28a5d0 \
-                        size    1968671
+checksums               rmd160  54a8e318087547b827eee4e5dbb21a8f3956402f \
+                        sha256  8b2d8dc371a57e42852fa6102efaf324ef004adf86072bf9957e2ac9005326c1 \
+                        size    1967695
 
 patchfiles              cctools-921-noavx512.patch \
                         cctools-949-libstuff-add-args-c.diff \

--- a/lang/apple-gcc40/Portfile
+++ b/lang/apple-gcc40/Portfile
@@ -3,7 +3,7 @@ PortSystem 1.0
 name			apple-gcc40
 version			5494
 categories		lang
-platforms		darwin
+platforms		{darwin < 13}
 license			GPL-2
 maintainers		nomaintainer
 description		Apple's version of gcc 4.0
@@ -11,24 +11,14 @@ long_description	Apple's version of the GNU compiler collection, \
 			version 4.0. Supports C and Objective-C only.
 
 homepage		http://opensource.apple.com/
-master_sites		http://opensource.apple.com/tarballs/gcc_40
+#master_sites		https://github.com/apple-oss-distributions/gcc/archive/
+# handle stealth update; remove with next version change
+master_sites    macports_distfiles
 distname		gcc_40-${version}
 
 checksums           sha1    07574623e23103cb4024410ca48481fbb5da322e \
                     rmd160  d7a5d15d312b9d7295564cf3862ec63296e769a3 \
                     sha256  86b9c1d48c30042ba23d181a58ceeb3afb850b595206d976f78c985baea4b5ad
-
-platform darwin {
-    if {${os.major} >= 13} {
-        known_fail  yes
-        depends_lib
-        depends_run
-        pre-fetch {
-            ui_error "$name is not supported on Mavericks or later."
-            error "unsupported platform"
-        }
-    }
-}
 
 post-extract { file mkdir ${workpath}/build }
 

--- a/lang/apple-gcc42/Portfile
+++ b/lang/apple-gcc42/Portfile
@@ -7,7 +7,7 @@ version			5666.3
 set gcc_version		4.2.1
 revision		16
 categories		lang
-platforms		darwin
+platforms		{darwin < 16}
 license			{GPL-2+ Permissive}
 maintainers		{jeremyhu @jeremyhu} openmaintainer
 
@@ -28,9 +28,13 @@ if {[variant_isset gpl3]} {
 
 homepage		http://opensource.apple.com/
 master_sites		gnu:/gcc/gcc-${gcc_version}:gnu \
-			http://opensource.apple.com/tarballs/gcc/:apple
+			https://github.com/apple-oss-distributions/gcc/archive/:apple
+
+# handle stealth update; remove with next version change
+dist_subdir     ${name}/${version}_1
 
 distname		gcc-${version}
+worksrcdir		gcc-${distname}
 
 set dcore		${distname}.tar.gz
 set dfort		gcc-fortran-${gcc_version}.tar.bz2
@@ -42,9 +46,11 @@ distfiles               ${dcore}:apple
 checksums           gcc-4.2.1-4.2.4-v2.patch \
                     rmd160  f33804c6f04e853a6248bf4941f4a0ace1e3f30f \
                     sha256  0f22916b8b1c96bafaccbb17b4350530d4ae903475ae934efe76a26b9c35e03f \
+                    size    19024738 \
                     gcc-5666.3.tar.gz \
-                    rmd160  a01d000f89c0e89dd0079dcd202bba7629ba78dc \
-                    sha256  6c46f4376d11ada5be0cfc3894b9296edf574af3c616ab71803ea78edfd7015b
+                    rmd160  6a159f3cb80dc9ce2109edaaa5fea95a995b9fc2 \
+                    sha256  2e9889ce0136f5a33298cf7cce5247d31a5fb1856e6f301423bde4a81a5e7ea6 \
+                    size    19371628
 
 #                    gcc-fortran-4.2.1.tar.bz2 \
 #                    md5     2a91d467b50a404ca0cd3b10b413f9b2 \
@@ -214,17 +220,6 @@ if {![variant_isset bootstrap]} {
         STRIP_FOR_HOST=${prefix}/bin/strip \
         OTOOL=${prefix}/bin/otool \
         OTOOL64=${prefix}/bin/otool
-}
-
-if {${os.platform} eq "darwin" && ${os.major} > 15} {
-    known_fail  yes
-    depends_lib
-    depends_run
-    archive_sites
-    pre-fetch {
-        ui_error "${name} is not supported on OS X versions newer than El Capitan."
-        return -code error {unsupported platform}
-    }
 }
 
 build.args-append \

--- a/lang/llvm-gcc42/Portfile
+++ b/lang/llvm-gcc42/Portfile
@@ -6,7 +6,7 @@ version                 2336.11
 revision                4
 set gcc_version         4.2.1
 categories              lang
-platforms               darwin
+platforms               {darwin < 16}
 license                 {GPL-2+ Permissive}
 maintainers             {jeremyhu @jeremyhu}
 description             llvm-gcc42 is a gcc compiler frontend for llvm
@@ -17,13 +17,17 @@ long_description        llvm-gcc42 integrates the LLVM optimizers and code \
                         compatibility with version 4.2 of GCC.
 
 homepage                http://opensource.apple.com/
-master_sites            http://opensource.apple.com/tarballs/llvmgcc42/
+master_sites            https://github.com/apple-oss-distributions/llvmgcc42/archive/
 
 distname                llvmgcc42-${version}
+worksrcdir              llvmgcc42-${distname}
 
-checksums               md5     046629f7b3ce59bcb32b5116d29c27cd \
-                        sha1    97b82b328780d1b4f261301dc084bb256172ee2a \
-                        rmd160  90e496dc075ebd3daa088f818e52e7ecbb4a182e
+# handle stealth update; remove with next version change
+dist_subdir             ${name}/${version}_1
+
+checksums               sha256  338a736aa6ed71f9127bf9049e15a95102d7118b12293a925cec7f374ebb7bbe \
+                        rmd160  76a9d722f4e990b8fba8c16a59465d9c141f5602 \
+                        size    49017586
 
 depends_lib             port:ld64 port:cctools
 depends_run             port:gcc_select
@@ -36,17 +40,6 @@ variant universal {}
 default_variants-append +universal
 
 supported_archs i386 x86_64
-
-if {${os.platform} eq "darwin" && ${os.major} > 15} {
-    depends_lib
-    depends_run
-    archive_sites
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} is not supported on macOS Sierra or newer."
-        return -code error {unsupported platform}
-    }
-}
 
 select.group    gcc
 select.file     ${filespath}/mp-llvm-gcc42

--- a/sysutils/dtrace/Portfile
+++ b/sysutils/dtrace/Portfile
@@ -8,6 +8,8 @@ version             370.40.1
 categories          sysutils
 maintainers         nomaintainer
 license             APSL-2 CDDL
+# error: An empty identity is not valid when signing a binary for the product type 'Command-line Tool'. (in target 'ctfconvert' from project 'dtrace')
+platforms           {darwin < 22}
 
 description         DTrace support tools
 long_description    The ctfconvert, ctfmerge and ctfdump tools for \
@@ -16,11 +18,11 @@ long_description    The ctfconvert, ctfmerge and ctfdump tools for \
                     these rely on an unpublished private framework.
 
 homepage            http://opensource.apple.com/source/${name}/
-master_sites        http://opensource.apple.com/tarballs/${name}/
+master_sites        https://github.com/apple-oss-distributions/${name}/archive/
 
-checksums           rmd160  5d0f9440b344302f6a8722cd658809818811458f \
-                    sha256  94a3d46a7f06b962e184fbe968ff79c4092e6b89c0414b7f7996245b3ff381a4 \
-                    size    1285649
+checksums           rmd160  2c1375c56ea6b620a791ea154cc8bd56e3ee1003 \
+                    sha256  e1ae4c8163eb5e808b5ad6cf60d812c42f754a75eae2909dcb6df4d0632547e2 \
+                    size    1281877
 
 xcode.destroot.path ${prefix}/bin
 xcode.target        ctfconvert ctfmerge ctfdump
@@ -28,13 +30,19 @@ xcode.target        ctfconvert ctfmerge ctfdump
 # for ppc support
 if {${os.major} == 9} {
     version         48.1
-    checksums       rmd160  530acfb4bb2b69b121e5f461abba2a78ab53bd57 \
-                    sha256  3fdee5d4fcb36a4dae0f877dbe50330bd905cb09b10e70e7a219370a6e30760a
+
+    checksums       rmd160  b909716f534fcfeb0cdc36cb47c78abf76a1b421 \
+                    sha256  25da58051aef4c781684899fb19d3f217b332ef5cfa134d97b396021d8f50cf8 \
+                    size    1858024
 
     depends_build   path:${prefix}/lib/libiberty.a:binutils
     xcode.build.settings    LIBRARY_SEARCH_PATHS='${prefix}/lib'
     xcode.destroot.settings LIBRARY_SEARCH_PATHS='${prefix}/lib'
 }
+
+# handle stealth update; remove with next version change
+dist_subdir         ${name}/${version}_1
+worksrcdir          ${name}-${distname}
 
 livecheck.type      regex
 livecheck.regex     "${name}-(\[\\d.\]+)"


### PR DESCRIPTION
#### Description

Apple moved all sources from opensource.apple.com/tarballs to github, that leads to a different distfiles which hadn't passed checksum.

Unfortunately they hadn't migrated everything, for example some patches for ld64 are missed.

But, we have it inside distfiles => let use distfiles as mirror.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port checksum`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->