### PR TITLE
cl-gobject-introspection: new port

### DIFF
--- a/lisp/cl-gobject-introspection/Portfile
+++ b/lisp/cl-gobject-introspection/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        andy128k cl-gobject-introspection c4fef07
+github.tarball_from archive
+version             0.3
+revision            0
+
+categories-append   devel
+license             BSD
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         Common Lisp bindings to gobject-introspection
+
+long_description    {*}${description}
+
+checksums           rmd160  cc755a29d9d427d981789549c96752ff01db2a04 \
+                    sha256  6e722716371be5d7c46ac7ef9c8f2fd6ea237a18908f62dc8d349b68126a2454 \
+                    size    86821
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-cffi \
+                    port:cl-iterate \
+                    port:cl-trivial-garbage \
+                    port:gobject-introspection


### PR DESCRIPTION
#### Description

[Common Lisp bindings to gobject-introspection](https://github.com/andy128k/cl-gobject-introspection)

###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3 14E222b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?