### PR TITLE
libimobiledevice: Add libimobiledevice-glue-devel

### DIFF
--- a/devel/libimobiledevice-glue/Portfile
+++ b/devel/libimobiledevice-glue/Portfile
@@ -43,3 +43,19 @@ pre-configure {
 configure.cmd       ./autogen.sh
 
 configure.args      --disable-silent-rules
+
+subport libimobiledevice-glue-devel {
+    github.setup    libimobiledevice libimobiledevice-glue 214bafdde6a1434ead87357afe6cb41b32318495
+    version         20230512
+    revision        0
+
+    checksums       rmd160  ec1dc6bbed16a63917a4053ecaae4d2ecb98d932 \
+                    sha256  6be77b9b51a07fc89d41b29e2e65ada1bab72a7c9a0bebeb279030167decef4e \
+                    size    43281
+
+    conflicts       libimobiledeviceglue
+
+    depends_lib-replace port:libplist port:libplist-devel
+
+    livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
+}

--- a/devel/libirecovery/Portfile
+++ b/devel/libirecovery/Portfile
@@ -56,6 +56,8 @@ subport libirecovery-devel {
 
     conflicts       libirecovery
 
+    depends_lib-replace port:libimobiledevice-glue port:libimobiledevice-glue-devel
+
     livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
 }
 


### PR DESCRIPTION
#### Description

Fixes https://github.com/macports/macports-ports/pull/18683#issuecomment-1558750058.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5 22G5027e
Xcode 14.3.1 14E300c 

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
