### PR TITLE
sbcl: fix build on 10.6 i386; update to 2.2.5

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -41,39 +41,49 @@ checksums       rmd160  95a02d7a489137602ebba333b83bfc1d9eb794be \
                 sha256  89c90720cf9d05dbcd90d690e381a2514c0f1807159e0d7222220c5a8c2d5186 \
                 size    7474392
 
-if {${os.major} < 10} {
-    # 1.3.9 is the last version of SBCL which can be build before 10.6
-    version     1.3.9
-    revision    0
-    epoch       1
+platform darwin {
 
-    checksums   rmd160  d0da4fd941890372f3558bafb18433497c67c0ee \
-                sha256  af0f09d4379113dfd5aa255279cb3df9cb9cac0bcd65369cc43dd857ca51de6e \
-                size    5758174
+    if {${os.major} < 10} {
+        # 1.3.9 is the last version of SBCL which can be build before 10.6
+        version     1.3.9
+        revision    0
+        epoch       1
 
-} elseif {${build_arch} eq "ppc"} {
-    # 2.2.2 is the last version of SBCL with ppc-Darwin
-    version     2.2.2
-    revision    0
-    epoch       1
+        checksums   rmd160  d0da4fd941890372f3558bafb18433497c67c0ee \
+                    sha256  af0f09d4379113dfd5aa255279cb3df9cb9cac0bcd65369cc43dd857ca51de6e \
+                    size    5758174
 
-    checksums   rmd160  4960ccd562302f3223e2db7d32b9ecc50cf76536 \
-                sha256  8790dbbe97711dce14bb823125ce5b185b0073cf2f3cbf37bdd1ad380e7950f6 \
-                size    6716272
+    } elseif {${configure.build_arch} eq "ppc"} {
+        # 2.2.2 is the last version of SBCL with ppc-Darwin
+        version     2.2.2
+        revision    0
+        epoch       1
 
-} elseif {${build_arch} eq "i386"} {
-    # 2.2.4 is the last version of SBCL with i386-Darwin
-    version     2.2.4
-    revision    0
-    epoch       1
+        checksums   rmd160  4960ccd562302f3223e2db7d32b9ecc50cf76536 \
+                    sha256  8790dbbe97711dce14bb823125ce5b185b0073cf2f3cbf37bdd1ad380e7950f6 \
+                    size    6716272
 
-    checksums   rmd160  2df788b7b6ebe35bf37c3264aeb06aef4f3416c3 \
-                sha256  fcdd251cbc65f7f808ed0ad77246848d1be166aa69a17f7499600184b7a57202 \
-                size    7030086
+        universal_variant  no
 
-    patchfiles-append \
-                patch-i386-missed-context.diff \
-                patch-i386-old-preprocessor.diff
+    } elseif {${configure.build_arch} eq "i386"} {
+        # 2.2.5 is the last version of SBCL support of with i386-Darwin
+        version     2.2.5
+        revision    0
+        epoch       1
+
+        checksums   rmd160  55225af6c20d39db1b158b7c07685ff6e3a8d5bf \
+                    sha256  8584b541370fd6ad6e58d3f97982077dfcab240f30d4e9b18f15da91c2f13ed1 \
+                    size    7029912
+
+        patchfiles-append \
+                    patch-i386-mask-out-O_LARGEFILE-in-fcntl-1-test.diff \
+                    patch-i386-revert-OS_THREAD_STACK.diff \
+                    patch-i386-old-preprocessor.diff \
+                    patch-i386-contrib-sb-posix-posix-tests.lisp.diff \
+                    patch-i386-missed-context.diff
+
+        universal_variant  no
+    }
 }
 
 platform darwin powerpc {
@@ -175,8 +185,11 @@ variant threads description {Enable multi-threaded runtime using the Mach pthrea
 
 variant fancy conflicts threads description {Configure SBCL compilation with all available compatible options (including threading).} {
     build.args-append   --fancy
+    # Before 2.2.6 it ueses lz to compress core
+    depends_lib-append  port:zlib
     # As of version 2.2.6, zstd is used for core compression.
     if {[vercmp ${version} 2.2.6] >= 0} {
+        depends_lib-delete  port:zlib
         depends_lib-append  port:zstd
         patchfiles-append   patch-config-darwin-${build_arch}.diff
 

--- a/lang/sbcl/files/patch-i386-contrib-sb-posix-posix-tests.lisp.diff
+++ b/lang/sbcl/files/patch-i386-contrib-sb-posix-posix-tests.lisp.diff
@@ -1,0 +1,20 @@
+diff --git contrib/sb-posix/posix-tests.lisp contrib/sb-posix/posix-tests.lisp
+index 7c94a430d..b32a41893 100644
+--- contrib/sb-posix/posix-tests.lisp
++++ contrib/sb-posix/posix-tests.lisp
+@@ -341,6 +341,7 @@
+             (,mode (sb-posix::stat-mode ,stat)))
+        ,@body)))
+ 
++#-(and darwin x86)
+ (deftest stat-mode.1
+   (with-stat-mode (mode *test-directory*)
+     (sb-posix:s-isreg mode))
+@@ -357,6 +358,7 @@
+     (sb-posix:s-ischr mode))
+   nil)
+ 
++#-(and darwin x86)
+ (deftest stat-mode.4
+   (with-stat-mode (mode *test-directory*)
+     (sb-posix:s-isblk mode))

--- a/lang/sbcl/files/patch-i386-mask-out-O_LARGEFILE-in-fcntl-1-test.diff
+++ b/lang/sbcl/files/patch-i386-mask-out-O_LARGEFILE-in-fcntl-1-test.diff
@@ -1,0 +1,18 @@
+See:
+ - https://github.com/sbcl/sbcl/commit/bebec0fb89ceefde0f1d584da439989bc12ad17d
+ - https://github.com/sbcl/sbcl/commit/cc425f4be3125c3ba48418cc76bc1d3d3260a431
+ - https://github.com/sbcl/sbcl/commit/306beeae30de474fb46c3efd31e8e2ea5acb65fb
+
+diff --git contrib/sb-posix/posix-tests.lisp contrib/sb-posix/posix-tests.lisp
+index a75d91646..962fbb452 100644
+--- contrib/sb-posix/posix-tests.lisp
++++ contrib/sb-posix/posix-tests.lisp
+@@ -434,7 +434,7 @@
+ 
+ ;; O_LARGEFILE is always set on 64-bit *nix platforms even though the whole
+ ;; flag makes no sense.
+-#-win32
++#-(or (and darwin x86) win32)
+ (deftest fcntl.1
+     (let ((fd (sb-posix:open "/dev/null" sb-posix::o-nonblock)))
+       (logtest (sb-posix:fcntl fd sb-posix::f-getfl)

--- a/lang/sbcl/files/patch-i386-missed-context.diff
+++ b/lang/sbcl/files/patch-i386-missed-context.diff
@@ -1,4 +1,4 @@
-See: https://github.com/sbcl/sbcl/blob/sbcl-1.3.9/src/runtime/x86-bsd-os.c#L113-L128
+See: https://github.com/sbcl/sbcl/commit/3bf3c33f9e291f2edbdfe8ba7c57128586923e41
 
 diff --git src/runtime/x86-darwin-os.h src/runtime/x86-darwin-os.h
 index 7ff303b96..cf6487815 100644

--- a/lang/sbcl/files/patch-i386-revert-OS_THREAD_STACK.diff
+++ b/lang/sbcl/files/patch-i386-revert-OS_THREAD_STACK.diff
@@ -1,0 +1,17 @@
+See:
+ - https://github.com/sbcl/sbcl/commit/e3490371ab2207d5280084df0c76aee1a14879c2
+ - https://github.com/sbcl/sbcl/commit/c7590d3d7e73a4da203b71493a9cb353d8280f1c
+
+diff --git src/cold/shared.lisp src/cold/shared.lisp
+index c0b32fc6c..4e0f92b56 100644
+--- src/cold/shared.lisp
++++ src/cold/shared.lisp
+@@ -285,7 +285,7 @@
+           (push :compact-symbol sb-xc:*features*))
+         (when (target-featurep '(:and :sb-thread (:not :win32)))
+           (push :pauseless-threadstart sb-xc:*features*))
+-        (when (target-featurep '(:and :sb-thread (:or :darwin :openbsd)))
++        (when (target-featurep '(:and :sb-thread (:or (:and :darwin (:not :x86)) :openbsd)))
+           (push :os-thread-stack sb-xc:*features*))
+         (when (target-featurep '(:and :x86 :int4-breakpoints))
+           ;; 0xCE is a perfectly good 32-bit instruction,


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

as `port install sbcl build_arch=i386`

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->