### PR TITLE
w3m: fix build with GCC 4.2

### DIFF
--- a/www/w3m/Portfile
+++ b/www/w3m/Portfile
@@ -32,6 +32,7 @@ checksums           rmd160  724e6a776c6e0aa5dd3ea8bfd92a9ec718328dc9 \
 
 subport w3m-devel {
     PortGroup       obsolete 1.0
+
     replaced_by     w3m
     version         20220429
     revision        0
@@ -44,6 +45,10 @@ configure.args      --with-gc=${prefix} \
                     --with-libiconv-prefix=${prefix} \
                     --with-libintl-prefix=${prefix} \
                     --disable-image
+
+# Fix build with GCC 4.2
+configure.cflags-append     -std=c99
+build.args                  WARNINGS=-Wall
 
 post-destroot {
    xinstall -d ${destroot}${prefix}/share/doc/w3m


### PR DESCRIPTION
###### Description

Fixes: https://trac.macports.org/ticket/67546

###### Type(s)

- [x] bugfix

###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?