### PR TITLE
vtm: update to 0.9.9m

### DIFF
--- a/sysutils/vtm/Portfile
+++ b/sysutils/vtm/Portfile
@@ -6,7 +6,7 @@ PortGroup               cmake 1.1
 PortGroup               legacysupport 1.1
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            netxs-group vtm 0.9.9k v
+github.setup            netxs-group vtm 0.9.9m v
 github.tarball_from     archive
 revision                0
 
@@ -19,9 +19,9 @@ description             Monotty Desktopio - text-based desktop environment \
 long_description        ${name} is a terminal multiplexer with window manager \
                         and session sharing.
 
-checksums               rmd160  bc0dda8088e5141521d08f147b67502021425010 \
-                        sha256  8bc0ed4a1b737e59bf3e038fcd25ca966aea55598f8b9434c08ae7ef02c7f522 \
-                        size    1376825
+checksums               rmd160  30b65c527665889b974860487b66fb258dba332e \
+                        sha256  916c184e95457b9d1175bc44e0f6f047b4171a045c5c149bf3706a7d7e94e57f \
+                        size    1382938
 
 # Requires a compiler with full C++20 support
 compiler.cxx_standard   2020
@@ -31,10 +31,7 @@ compiler.blacklist-append \
 
 # Needed for std::filesystem and std::atomic_notify_all
 legacysupport.newest_darwin_requires_legacy 19
-# Use MacPorts libcxx only with Clang
-if {[string match *clang* ${configure.compiler}]} {
-    legacysupport.use_mp_libcxx yes
-}
+legacysupport.use_mp_libcxx yes
 
 if {[variant_isset debug]} {
     cmake.build_type    Debug


### PR DESCRIPTION
* fix legacysupport workaround

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
