### PR TITLE
git: catch any error when reading ${guidir}/Info

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -234,10 +234,19 @@ post-destroot {
     # Tiger doesn't build the GUI, so check for its existence before mucking with it
     if {[file exists "${destroot}${guidir}"]} {
         # The executable could be "Wish" or "Wish Shell", depending on the OS version
-        set wish_executable [exec defaults read ${destroot}${guidir}/Info CFBundleExecutable]
-        # The system-provided Tk is now deprecated, so use the MacPorts version if available.
-        system "echo exec wish \"'${guidir}/Resources/Scripts/AppMain.tcl'\" '\"$@\"' > \
-            '${destroot}${guidir}/MacOS/${wish_executable}'"
+        try {
+            set wish_executable [exec defaults read ${destroot}${guidir}/Info CFBundleExecutable]
+            set status 0
+        } trap CHILDSTATUS {wish_executable options} {
+            set status [lindex [dict get $options -errorcode] 2]
+        }
+        if {$status == 0} {
+            # The system-provided Tk is now deprecated, so use the MacPorts version if available.
+            system "echo exec wish \"'${guidir}/Resources/Scripts/AppMain.tcl'\" '\"$@\"' > \
+                '${destroot}${guidir}/MacOS/${wish_executable}'"
+        } else {
+            ui_debug "Reading ${guidir}/Info failed: $status $wish_executable"
+        }
     }
 
     file delete -force ${share_path}/contrib


### PR DESCRIPTION
This fixes the destroot error "The domain/default pair of ... does not exist"

closes: https://trac.macports.org/ticket/67106

Catch any errors from reading '${destroot}${guidir}/Info'

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4 22F66 x86_64
Xcode 14.3.1 14E300c


###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
