### PR TITLE
pika: update to 0.16.0

### DIFF
--- a/devel/pika/Portfile
+++ b/devel/pika/Portfile
@@ -12,7 +12,7 @@ PortGroup           mpi 1.0
 legacysupport.use_mp_libcxx                 yes
 legacysupport.newest_darwin_requires_legacy 18
 
-github.setup        pika-org pika 0.15.1
+github.setup        pika-org pika 0.16.0
 revision            0
 categories          devel parallel
 license             Boost-1
@@ -20,9 +20,9 @@ maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         C++ library for concurrency and parallelism
 long_description    pika is a C++ library for concurrency and parallelism. \
                     It implements senders/receivers for CPU thread pools, MPI and CUDA.
-checksums           rmd160  faad11882520cb4de35b41dc3606bc3a0407c3b2 \
-                    sha256  b68b87cf956ad1448f5c2327a72ba4d9fb339ecabeabb0a87b8ea819457e293b \
-                    size    1252949
+checksums           rmd160  79d62c88fd2acd90725bd7decc91ef0dea10c6ce \
+                    sha256  59f2baec91cc9bf71ca96d21d0da1ec0092bf59da106efa51789089e0d7adcbb \
+                    size    1243996
 github.tarball_from archive
 
 # Prefer a version with libcontext working across all archs (ppc64 is still not fixed):


### PR DESCRIPTION
#### Description

Simple update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
