### PR TITLE
protobuf-c: Update required C++ version from 2011 to 2014

### DIFF
--- a/devel/protobuf-c/Portfile
+++ b/devel/protobuf-c/Portfile
@@ -34,7 +34,7 @@ depends_build-append \
 depends_lib-append \
                 port:protobuf3-cpp
 
-compiler.cxx_standard 2011
+compiler.cxx_standard 2014
 
 # error: constexpr constructor never produces a constant expression [-Winvalid-constexpr]
 compiler.blacklist-append {clang < 900}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Closes: https://trac.macports.org/ticket/67476

A sub-dependency of `protobuf-c`, `abseil`, recently [announced](https://github.com/abseil/abseil-cpp/releases/tag/20230125.3) that they're now requiring C++ 14 or higher to compile.

This port no longer builds successfully with the outdated Portfile.

Because protobuf-c is a dependency for Postgis 3.0, that port also fails to build without this change.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.6
Xcode 14.2 

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
