### PR TITLE
qt511-qtwebengine: set `known_fail yes` on 10.15+

### DIFF
--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -1470,12 +1470,14 @@ foreach {module module_info} [array get modules] {
                 # see https://doc.qt.io/qt-5/qtwebengine-platform-notes.html
                 PortGroup           xcodeversion 1.0
                 minimum_xcodeversions   {15 7.3}
-                if { ${os.platform} eq "darwin" && ${os.major} < 15 } {
-                    pre-fetch {
-                        ui_error "${subport} requires OS X 10.11 or later"
-                        return -code error "incompatible OS version"
-                    }
-                }
+
+                # Has incompatibilities with 10.15 SDK which are fixed in newer chromium:
+                # https://github.com/chromium/chromium/commit/2db1569218f1
+                # https://github.com/chromium/chromium/commit/acd3f7caf5fc
+                # error: typedef redefinition with different types ('struct OpaqueSecTrustRef *' vs 'struct __SecACL *')
+                # error: typedef redefinition with different types ('struct OpaqueSecTrustedApplicationRef *' vs 'struct __SecTrustedApplication *')
+                # error: typedef redefinition with different types ('struct OpaqueSecPolicyRef *' vs 'struct __SecPolicy *')
+                platforms           {macosx >= 15 < 19}
 
                 # UsingTheRightCompiler (https://trac.macports.org/wiki/UsingTheRightCompiler)
                 build.env-append      CXX=${configure.cxx}


### PR DESCRIPTION
See: https://trac.macports.org/ticket/66317

[skip ci]

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
