### PR TITLE
ffcall: fix build when cross-compiling

### DIFF
--- a/devel/ffcall/Portfile
+++ b/devel/ffcall/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           muniversal 1.1
 
 name                ffcall
 version             2.4
@@ -13,7 +14,6 @@ long_description    ffcall is a collection of four libraries which can \
                     be used to build foreign function call interfaces \
                     in embedded interpreters.
 homepage            https://www.gnu.org/software/libffcall/
-platforms           darwin
 distname            libffcall-${version}
 checksums           rmd160  b5f5b9c3447eb67cb4c827ac993035e81aa8ee93 \
                     sha256  8ef69921dbdc06bc5bb90513622637a7b83a71f31f5ba377be9d8fd8f57912c2 \
@@ -28,6 +28,20 @@ configure.checks.implicit_function_declaration.whitelist-append strchr
 # configure accepts --infodir, although there is no info pages (yet?).
 configure.args      --mandir=${prefix}/share/man \
                     --infodir=${prefix}/share/info
+
+foreach arch {arm64 x86_64 i386 ppc ppc64} {
+    # `libtool` compiles assembly with CC but without any way to set compiler flags
+    # this is a problem if ${configure.build_arch} is not the same as the compiler default architecture
+    # and for universal builds
+    configure.args.${arch}-append \
+                    CC="${configure.cc} -arch ${arch}"
+}
+
+# https://trac.macports.org/ticket/65736
+platform darwin 10 powerpc {
+    configure.args-append \
+                    --build=powerpc-apple-darwin${os.major}
+}
 
 use_parallel_build  no
 


### PR DESCRIPTION
No revbump since port either build correctly or not at all. Fixes https://trac.macports.org/ticket/65736

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
