### PR TITLE
cl-ppcre: added missed test dependency

### DIFF
--- a/lisp/cl-ppcre/Portfile
+++ b/lisp/cl-ppcre/Portfile
@@ -22,6 +22,8 @@ long_description    CL-PPCRE is a fast, portable, thread-safe regular expression
 
 github.tarball_from archive
 
+depends_test-append port:cl-flexi-streams
+
 # broke cyclic dependencies:
 #  - cl-unicode depends on cl-ppcre
 #  - cl-ppcre-unicode depends cl-unicode

--- a/lisp/cl-unicode/Portfile
+++ b/lisp/cl-unicode/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
 github.setup        edicl cl-unicode 0.1.6 v
-revision            0
+revision            1
 
 checksums           rmd160  9ef3cff28569de8b0801f8c0bc2e5cfb9303d5a0 \
                     sha256  58935b7117eb9e4591eb55a64dc6a3a95e0dbcf0bb340fc5b95c28a6cf14e3b1 \
@@ -23,3 +23,14 @@ long_description    {*}${description}
 
 depends_lib-append  port:cl-flexi-streams \
                     port:cl-ppcre
+
+post-destroot {
+    # Some times this files aren't included into into archive, let fail when it
+    # happened to prevent making broken shipment.
+    foreach f {lists.lisp hash-tables.lisp methods.lisp} {
+        if {![file exists ${destroot}/${common_lisp.prefix}/source/cl-unicode/$f]} {
+            ui_error "${name} should produce ${f}."
+            return -code error "missing ${f}"
+        }
+    }
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->