### PR TITLE
google-cloud-sdk: update to 434.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             433.0.1
+version             434.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  846602bedbe62e7492a8be57d755a0b06783e9e6 \
-                    sha256  28367032ce48847c92488f7142ee1c9040c473016684281c1c8b39c97812d2d1 \
-                    size    100368548
+    checksums       rmd160  c2a04c9b39459e0dbc08ca6d81938f85865e9fac \
+                    sha256  026fccdeaeee2258da79cb93934aa00f7bb68ec2dab349630fdc0e7917103d0d \
+                    size    100374368
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  421bcd9cd0d9aa7496d202a01ccd88df338ffe1e \
-                    sha256  bac4acc2876f0d410b1429e4543128464b6808d3dc53fbbe70dfed0c017100c0 \
-                    size    120642630
+    checksums       rmd160  f61ea422b933ca93ce960853b9f08501dd3ee98a \
+                    sha256  6e3a4c20d5abf79b8b5f3aaa9f3288774cf98b825de26c2d7d631ffdf783c83b \
+                    size    120645905
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  5de4a0e026e8341ac76e4a02b5b2cb91d7f64735 \
-                    sha256  3e4f3dd8bdb3c2efff9befb1363468cde8fce382e0fbf5f03e7772d87cb632f4 \
-                    size    117764783
+    checksums       rmd160  aba21efcf4e4566ff3b7fb9ad036278dacb9c893 \
+                    sha256  be5f1abd8ed8ee3c63ed38c6a75db887635142576e059d94e1cbaa5b49e551b7 \
+                    size    117766953
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 434.0.0.

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?