### PR TITLE
pyinfra: update to 2.9, use Python 3.12

### DIFF
--- a/python/py-bcrypt/Portfile
+++ b/python/py-bcrypt/Portfile
@@ -11,7 +11,6 @@ categories-append   devel
 license             Apache-2
 
 python.versions     27 35 36 37 38 39 310 311 312
-python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -41,6 +40,8 @@ if {${name} ne ${subport}} {
                             port:py${python.version}-six
     } else {
         PortGroup           rust 1.0
+
+        python.pep517       yes
 
         depends_build-append \
                             port:py${python.version}-setuptools-rust

--- a/python/py-configparser/Portfile
+++ b/python/py-configparser/Portfile
@@ -12,8 +12,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 37 38 39 310
-python.pep517       yes
+python.versions     27 37 38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-ntlm-auth/Portfile
+++ b/python/py-ntlm-auth/Portfile
@@ -6,12 +6,13 @@ PortGroup           python 1.0
 name                py-ntlm-auth
 version             1.5.0
 revision            0
+
 categories-append   security
 platforms           {darwin any}
 license             MIT
 supported_archs     noarch
 
-python.versions     39 310
+python.versions     39 310 311 312
 
 maintainers         nomaintainer
 
@@ -27,10 +28,3 @@ homepage            https://github.com/jborean93/ntlm-auth
 checksums           rmd160  898989eefc29be237d1fc5dda4bbd3f4f574f355 \
                     sha256  c9667d361dc09f6b3750283d503c689070ff7d89f2f6ff0d38088d5436ff8543 \
                     size    28872
-
-if {${name} ne ${subport}} {
-    depends_build-append  \
-                    port:py${python.version}-setuptools
-
-    livecheck.type      none
-}

--- a/python/py-paramiko/Portfile
+++ b/python/py-paramiko/Portfile
@@ -11,8 +11,7 @@ license             LGPL-2.1+
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 37 38 39 310 311
-python.pep517       yes
+python.versions     27 37 38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-pynacl/Portfile
+++ b/python/py-pynacl/Portfile
@@ -11,7 +11,7 @@ revision            1
 categories-append   devel
 license             Apache-2
 
-python.versions     27 36 37 38 39 310 311
+python.versions     27 36 37 38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-pyspnego/Portfile
+++ b/python/py-pyspnego/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pyspnego
+version             0.10.2
+revision            0
+
+categories-append
+supported_archs     noarch
+platforms           {darwin any}
+license             MIT
+maintainers         nomaintainer
+
+description         Windows Negotiate Authentication Client and Server
+long_description    {*}${description}
+
+homepage            https://github.com/jborean93/pyspnego
+
+checksums           rmd160  087c07c815ab4191cce92348e9042dc52097d672 \
+                    sha256  9a22c23aeae7b4424fdb2482450d3f8302ac012e2644e1cfe735cf468fcd12ed \
+                    size    222036
+
+python.versions     39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-cryptography
+}

--- a/python/py-pywinrm/Portfile
+++ b/python/py-pywinrm/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pywinrm
-version             0.4.1
+version             0.4.3
 revision            0
 categories-append   devel net
 platforms           {darwin any}
 license             MIT
 supported_archs     noarch
 
-python.versions     39 310
+python.versions     39 310 311 312
 
 maintainers         nomaintainer
 
@@ -24,18 +24,13 @@ long_description    pywinrm is a Python client for the Windows Remote \
                     commands on target Windows machines from any machine that \
                     can run Python.
 
-checksums           rmd160  dea754437a44cea1e9d83219003188ffeed10622 \
-                    sha256  4ede5c6c85b53780ad0dbf9abef2fa2ea58f44c82256a84a63eae5f1205cea81 \
-                    size    36391
+checksums           rmd160  65d3dbb02b9422ea7e546ead00592bc4084ed603 \
+                    sha256  995674bf5ac64b2562c9c56540473109e530d36bde10c262d5a5296121ad5565 \
+                    size    38356
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
-
     depends_lib-append  port:py${python.version}-requests \
                         port:py${python.version}-requests_ntlm \
                         port:py${python.version}-six \
                         port:py${python.version}-xmltodict
-
-    livecheck.type      none
 }

--- a/python/py-requests_ntlm/Portfile
+++ b/python/py-requests_ntlm/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-requests_ntlm
-version             1.1.0
+version             1.2.0
 revision            0
 categories-append   devel security net
 platforms           {darwin any}
 license             ISC
 supported_archs     noarch
 
-python.versions     39 310
+python.versions     39 310 311 312
 
 maintainers         nomaintainer
 
@@ -22,17 +22,12 @@ description         NTLM authentication support for Requests
 long_description    This package allows for HTTP NTLM authentication using \
                     the requests library.
 
-checksums           rmd160  0632a5263f2a48b69f4f7d819cfd6dd962478bf7 \
-                    sha256  9189c92e8c61ae91402a64b972c4802b2457ce6a799d658256ebf084d5c7eb71 \
-                    size    5183
+checksums           rmd160  ff08a9276b73a417603f26e7a9572254807cbc4f \
+                    sha256  33c285f5074e317cbdd338d199afa46a7c01132e5c111d36bd415534e9b916a8 \
+                    size    6851
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
-
     depends_lib-append  port:py${python.version}-cryptography \
-                        port:py${python.version}-ntlm-auth \
+                        port:py${python.version}-pyspnego \
                         port:py${python.version}-requests
-
-    livecheck.type      none
 }

--- a/sysutils/pyinfra/Portfile
+++ b/sysutils/pyinfra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                pyinfra
-version             2.4
+version             2.9
 revision            0
 
 homepage            https://pyinfra.com
@@ -29,16 +29,13 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 supported_archs     noarch
 platforms           {darwin any}
 
-checksums           rmd160  834561c988a329df8351ba0d2d4d8e3212be70b1 \
-                    sha256  1f236920442e2a5556b11135690ca787d5e80d648e12ab5da1cf3112738da651 \
-                    size    181078
+checksums           rmd160  e85034ef049e922614f87335f424c89e3b6173c3 \
+                    sha256  35ca4cac87c6ef952e10f568973307ab040bf5240ac4832f53e16f6d4b5b9bc4 \
+                    size    203128
 
-python.default_version      310
-
-depends_lib-append  port:py${python.version}-setuptools
+python.default_version  312
 
 depends_run-append  port:py${python.version}-click          \
-                    port:py${python.version}-colorama       \
                     port:py${python.version}-configparser   \
                     port:py${python.version}-dateutil       \
                     port:py${python.version}-distro         \
@@ -46,12 +43,11 @@ depends_run-append  port:py${python.version}-click          \
                     port:py${python.version}-jinja2         \
                     port:py${python.version}-paramiko       \
                     port:py${python.version}-pywinrm        \
-                    port:py${python.version}-six            \
                     port:py${python.version}-yaml
 
 test.run            yes
+python.test_framework
 
-test.env-append     PYTHONPATH=${worksrcpath}/build/lib
 test.cmd            ${python.bin}
 test.pre_args       -m ${name}
 test.args           --help


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
