### PR TITLE
Revert "ci: Combine grep and cut into a single sed"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,8 @@ jobs:
 
           portlist=$( \
             git -C ports/ diff --name-only --diff-filter=AM macports/master...@ \
-              | sed -En 's,^[^._/][^/]*/([^/]+)/(Portfile$|files/),\1,p' \
+              | grep -E '^[^._/][^/]*/[^/]+/(Portfile$|files/)' \
+              | cut -d/ -f2 \
               | sort -u \
               | tr '\n' ' ' \
               | sed 's/ $//')


### PR DESCRIPTION
#### Description

This change causes added or modified patch files in the files directory to be interpreted as port names. See

  https://github.com/macports/macports-ports/commit/99d77366d2598857e1545d61a3bbd224677704d4

for discussion. Examples for pull requests that do not work correctly because of this change are

 - https://github.com/macports/macports-ports/pull/18068
 - https://github.com/macports/macports-ports/pull/19004

This reverts commit f3efbc9e1caeb0e041bc1e868ea01654b730bee8.

See: https://xkcd.com/1691/

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
https://github.com/macports/macports-ports/pull/19004

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
