### PR TITLE
micronaut: update to 3.9.3

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 3.9.1 v
+github.setup    micronaut-projects micronaut-starter 3.9.3 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  3cf825f6675e06a7177be5606c6fc2c7a1ce4ce0 \
-                sha256  ebe6d5c8b1680a0075b6df38258ff539f0e4f2a61721c43118b4fa3bea5a60c4 \
-                size    20262460
+checksums       rmd160  019a25aa40f10a43d3dfad6e9f4470a1897dbfda \
+                sha256  f45fcb2c25418711777719085ce17da6027cc25bd42a4a03d722117345fc6773 \
+                size    20262868
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 3.9.3.

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?