### PR TITLE
transmission: install .torrent utils with +daemon

### DIFF
--- a/net/transmission/Portfile
+++ b/net/transmission/Portfile
@@ -5,7 +5,7 @@ PortGroup       github 1.0
 PortGroup       xcode 1.0
 
 github.setup    transmission transmission 4.0.3
-revision        1
+revision        2
 categories      net aqua
 maintainers     {khindenburg @kurthindenburg} openmaintainer
 license         MIT GPL-2
@@ -74,6 +74,9 @@ post-patch {
 variant daemon description {Builds headless daemon} {
     xcode.target-append transmission-daemon
     xcode.target-append transmission-remote
+    xcode.target-append transmission-create
+    xcode.target-append transmission-edit
+    xcode.target-append transmission-show
 }
 
 destroot {
@@ -83,16 +86,13 @@ destroot {
 
     if {[variant_isset daemon]} {
         xinstall -m 755 -W ${worksrcpath}/build/${xcode.configuration} \
-        transmission-daemon transmission-remote \
+        transmission-daemon transmission-remote transmission-create transmission-edit transmission-show \
         ${destroot}${prefix}/bin
 
-        xinstall -m 644 -W ${worksrcpath}/daemon \
-        transmission-daemon.1 \
-        ${destroot}${prefix}/share/man/man1
-        
-        xinstall -m 644 -W ${worksrcpath}/utils \
-        transmission-remote.1 \
-        ${destroot}${prefix}/share/man/man1
+        xinstall -m 644 -W ${worksrcpath} \
+            daemon/transmission-daemon.1 \
+            utils/transmission-remote.1 utils/transmission-create.1 utils/transmission-edit.1 utils/transmission-show.1 \
+            ${destroot}${prefix}/share/man/man1
    }
 }
 


### PR DESCRIPTION
Transmission includes three utils for working with .torrent metainfo files: transmission-create, transmission-edit, and transmission-show. Transmission.xcodeproj includes these utils as targets, so this commit simply builds and installs them with the +daemon variant.

Since transmission-daemon and transmission-remote are most likely being used in a headless environment, it seems sensible to me to also include the utils for working with .torrent files themselves, especially since the Transmission GUI includes similar functionality.

Maybe it makes more sense to create an additional variant for these utils, but either way I think there should be a way to install them via MacPorts.

#### Description

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?