### PR TITLE
edid-decode: new Portfile

### DIFF
--- a/sysutils/edid-decode/Portfile
+++ b/sysutils/edid-decode/Portfile
@@ -1,0 +1,19 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+PortSystem              1.0
+PortGroup               makefile 1.0
+
+name                    edid-decode
+version                 20230616
+categories              sysutils
+maintainers             @wwalexander openmaintainer
+license                 MIT
+description             Decode EDID data in human-readable format
+long_description        edid-decode decodes EDID monitor description data in human-readable format
+set domain              linuxtv.org
+homepage                https://git.${domain}/${name}.git
+fetch.type              git
+git.url                 git://${domain}/${name}.git
+git.branch              a31e680
+
+destroot.args-append    bindir=${prefix}/bin \
+                        mandir=${prefix}/share/man


### PR DESCRIPTION
This commit adds a port for the edid-decode utility, which decodes binary EDID monitor description data. There doesn't appear to be any tags or branches to pin versions to, so I'm just using commit SHAs.

#### Description

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
