### PR TITLE
zmap: update to version 3.0.0-RC2

### DIFF
--- a/net/zmap/Portfile
+++ b/net/zmap/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.0
 PortGroup           github 1.0
 
-github.setup        zmap zmap 3.0.0-beta1 v
+github.setup        zmap zmap 3.0.0-RC2 v
 
 categories          net
 license             apache-2
@@ -16,9 +16,9 @@ long_description    designed for Internet-wide network surveys capable of \
                     a 10GbE connection.
 homepage            https://zmap.io/
 
-checksums           rmd160  4b30c0f33c5e4503a89dcb37808c50075373c4f4 \
-                    sha256  61787bd59cb23183a8b5424a148b95812d8254d6249c2d4efb31cbebff9ca383 \
-                    size    154851
+checksums           rmd160  9ef9b3293de156a76e9e13652cfc46b4321c9b85 \
+                    sha256  0e256d3b62c4ec2f51367c6036aefd99eef6ce6b0b6bcda858223c5a29fda77a \
+                    size    156242
 
 depends_build-append port:byacc \
                     port:flex \
@@ -29,12 +29,21 @@ depends_build-append port:byacc \
 depends_lib-append  port:gmp \
                     port:libdnet \
                     port:libpcap \
-                    port:json-c \
                     port:libunistring \
 
+default_variants +release
 
 variant redis description {Add Redis support} {
     depends_lib-append port:redis
     depends_lib-append port:hiredis
     configure.args-append -DWITH_REDIS=ON
+}
+
+variant json description {Add JSON support} {
+    depends_lib-append port:json-c
+    configure.args-append -DWITH_JSON=ON
+}
+
+variant release description {turns off debug symbols and performance impacting defaults } {
+configure.args-append -DENABLE_DEVELOPMENT=OFF -DENABLE_LOG_TRACE=OF
 }


### PR DESCRIPTION
 * add default_variants +release to turn off debugging and improve performance.
 * break out json-c dependency into an optional variant.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
