### PR TITLE
ruby-build: Update to 20230608

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230512 v
+github.setup        rbenv ruby-build 20230608 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  683783c09f12adf5b33d409c9039ce2976131b6d \
-                    sha256  2c97d16b3d49fcd47256afc8d85ae296b1287bf479b94d78d93cba1bdca0a6e0 \
-                    size    79490
+checksums           rmd160  b000237eaa1d9a5edf5634e090464a93bc64b626 \
+                    sha256  bb194fe1bb350576f3037d464adf61f028fe53f400edfb474c9f21563f5656f3 \
+                    size    79516
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Upstream changelog:

```
- Add JRuby 9.4.3.0 by @headius in #2203
```

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?