### PR TITLE
qtimageformats ports: revbump for tiff 4.5.0; qt513-qtwebengine-docs: fix build

### DIFF
--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -297,7 +297,7 @@ array set modules {
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtlocation {

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -1664,6 +1664,8 @@ foreach {module module_info} [array get modules] {
                 configure.args-append QMAKE_LINK=${configure.cxx}
                 # see https://trac.macports.org/ticket/59294
                 use_xcode yes
+                # see https://trac.macports.org/ticket/61924
+                patchfiles-append patch-qtwebengine_sdk.diff
             } elseif { ${module} eq "qtwebkit" } {
                 post-extract {
                     # without this file, the makefile ${worksrcpath}/qtwebkit/Source/WebCore/Makefile.WebCore.Target

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -282,7 +282,7 @@ array set modules {
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtlocation {

--- a/aqua/qt53/Portfile
+++ b/aqua/qt53/Portfile
@@ -228,7 +228,7 @@ array set modules {
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtlocation {

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -255,7 +255,7 @@ array set modules {
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 5"
+        "revision 6"
         "License: "
     }
     qtlocation {

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -261,7 +261,7 @@ array set modules {
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtlocation {

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -308,7 +308,7 @@ array set modules {
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtlocation {

--- a/aqua/qt58/Portfile
+++ b/aqua/qt58/Portfile
@@ -291,7 +291,7 @@ array set modules {
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtlocation {

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -295,7 +295,7 @@ array set modules {
         {"Qt Image Formats"}
         ""
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtlocation {


### PR DESCRIPTION
#### Description

See https://trac.macports.org/ticket/61924#comment:9 regarding qt513-qtwebengine-docs

Fix `rev-upgrade` error for qtimageformats ports due to tiff now having libtiff.6.dylib:
```
--->  Scanning binaries for linking errors
Could not open /opt/local/lib/libtiff.5.dylib: Error opening or reading file (referenced from /opt/local/libexec/qt5/plugins/imageformats/libqtiff.dylib)
--->  Found 1 broken file, matching files to ports       
--->  Found 1 broken port, determining rebuild order
You can always run 'port rev-upgrade' again to fix errors.
The following ports will be rebuilt: qt513-qtimageformats @5.13.2
Continue? [Y/n]:
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
qt513-qtwebengine-docs:
macOS 12.6.6
Xcode 14.2
SDK 13.1

qtimageformats ports: untested (no known/reported build failures)


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
