### PR TITLE
gdb-apple: fix build in Rosetta

### DIFF
--- a/devel/gdb-apple/Portfile
+++ b/devel/gdb-apple/Portfile
@@ -6,7 +6,7 @@ PortGroup       github 1.0
 
 github.setup    apple-oss-distributions gdb 2831 gdb-
 name            gdb-apple
-revision        0
+revision        1
 categories      devel
 license         GPL-2+
 maintainers     {jeremyhu @jeremyhu} openmaintainer
@@ -37,7 +37,7 @@ checksums       rmd160  086f823e5eb3cdfed0d72c48679913e5bc73a832 \
                 sha256  38006f9bf50df23dd1b76231b362d5e7af800c44c0f9216a7ceb5eb121c5f432 \
                 size    17960818
 
-depends_build   port:gettext port:zlib port:flex port:texinfo
+depends_build   port:gettext port:zlib port:flex
 
 depends_lib     port:libiconv port:ncurses port:sqlite3
 

--- a/devel/gdb-apple/Portfile
+++ b/devel/gdb-apple/Portfile
@@ -86,6 +86,13 @@ configure.args \
     --program-suffix=-apple \
     --disable-werror
 
+platform darwin 10 powerpc {
+    # Need to force the buildsystem use correct settings in Rosetta.
+    configure.args-append \
+        --build=powerpc-apple-darwin${os.major} \
+        --enable-serial-build-configure
+}
+
 build.args \
     MAKEINFO="/usr/bin/makeinfo" \
     LEXLIB="${prefix}/lib/libfl.a"

--- a/devel/gdb-apple/Portfile
+++ b/devel/gdb-apple/Portfile
@@ -107,15 +107,10 @@ post-destroot {
         system "chmod g+s ${destroot}${prefix}/bin/*-apple"
     }
 
-    foreach info [glob -tails -directory ${destroot}${prefix}/share/info g*] {
-        move ${destroot}${prefix}/share/info/${info} ${destroot}${prefix}/share/info/apple-${info}
-    }
-
     delete {*}[glob ${destroot}${prefix}/lib/*.{,l}a]
     delete {*}[glob ${destroot}${prefix}/bin/{addr2line,ar,c*filt,nm,objcopy,objdump,ranlib,readelf,size,strings,strip}-apple]
     delete {*}[glob ${destroot}${prefix}/*darwin*]
     delete {*}[glob ${destroot}${prefix}/include/*.h]
-    delete {*}[glob ${destroot}${prefix}/share/info/{annotate,bfd,stabs}.info]
     delete {*}[glob ${destroot}${prefix}/share/locale/*/LC_MESSAGES/{bfd,binutils,opcodes}.mo]
 }
 

--- a/devel/gdb-apple/Portfile
+++ b/devel/gdb-apple/Portfile
@@ -94,11 +94,11 @@ platform darwin 10 powerpc {
 }
 
 build.args \
-    MAKEINFO="/usr/bin/makeinfo" \
+    MAKEINFO="/usr/bin/true" \
     LEXLIB="${prefix}/lib/libfl.a"
 
 destroot.args \
-    MAKEINFO="/usr/bin/makeinfo" \
+    MAKEINFO="/usr/bin/true" \
     LEXLIB="${prefix}/lib/libfl.a"
 
 post-destroot {


### PR DESCRIPTION
#### Description

Otherwise Rosetta misdetects arch and sets wrong target.

UPD. macos-13 CI failure is unrelated, and it also fails with existing version of the port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

P. S. For the record, this does not fix the build on 10.6 PPC, since its early Xcode lacks a symbol in `DebugSymbols.framework`. However I think the framework can be borrowed from a later Xcode, since `ppc` slice is there.