### PR TITLE
proj9: update to 9.2.1

### DIFF
--- a/gis/proj9/Portfile
+++ b/gis/proj9/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 set realname        proj
 name                ${realname}9
-version             9.2.0
+version             9.2.1
 revision            0
 categories-append   gis
 license             MIT
@@ -21,14 +21,14 @@ long_description    PROJ is a generic coordinate transformation software \
                     includes cartographic projections as well as \
                     geodetic transformations.
 
-homepage            https://proj4.org/
-master_sites        http://download.osgeo.org/proj/
+homepage            https://proj.org/
+master_sites        https://download.osgeo.org/proj/
 
 distname            ${realname}-${version}
 
-checksums           rmd160  58488912e9ec88386ad9b634f98b6eaf21e85646 \
-                    sha256  dea816f5aa732ae6b2ee3977b9bdb28b1d848cf56a1aad8faf6708b89f0ed50e \
-                    size    5521397
+checksums           rmd160  79b86eef17ef8cabd93f468f3bb0456aad08c4c9 \
+                    sha256  15ebf4afa8744b9e6fccb5d571fc9f338dc3adcf99907d9e62d1af815d4971a1 \
+                    size    5536575
 
 compiler.cxx_standard 2011
 
@@ -44,7 +44,7 @@ cmake.install_prefix ${prefix}/lib/proj9
 configure.args-append \
                     -DENABLE_CURL=ON \
                     -DENABLE_TIFF=OFF \
-                    -DPROJ_LIB_ENV_VAR_TRIED_LAST=OFF
+                    -DPROJ_DATA_ENV_VAR_TRIED_LAST=OFF
 
 variant tiff description {Enable TIFF I/O} {
     depends_lib-append      port:tiff


### PR DESCRIPTION
In addition update URLs and renamed compiler flag.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Update proj9 to version 9.2.1.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.6 21G646 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
