### PR TITLE
audacious-*: removed unnecessary dependency on qt5

### DIFF
--- a/multimedia/audacious-core/Portfile
+++ b/multimedia/audacious-core/Portfile
@@ -7,7 +7,7 @@ set real_name       audacious
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
 version             3.10.1
-revision            0
+revision            1
 
 license             BSD
 categories          multimedia
@@ -69,8 +69,6 @@ post-destroot {
 
 variant qt5 description {Add Qt5 support} {
     PortGroup   qt5 1.0
-
-    qt5.depends_component   qt5
 
     configure.args-replace  --disable-qt \
                             --enable-qt

--- a/multimedia/audacious-plugins/Portfile
+++ b/multimedia/audacious-plugins/Portfile
@@ -6,7 +6,7 @@ name                audacious-plugins
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
 version             3.10.1
-revision            4
+revision            5
 
 # FIXME: probably more licenses involved here...
 license             BSD GPL-2+
@@ -309,8 +309,7 @@ variant sdl2 conflicts sdl1 ffmpeg description {Add SDL audio output via libsdl2
 variant qt5 description {Add Qt5 support} {
     PortGroup   qt5 1.0
 
-    qt5.depends_component   qtmultimedia \
-                            qt5
+    qt5.depends_component   qtmultimedia
 
     configure.args-replace  --disable-qt \
                             --enable-qt


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
