### PR TITLE
spirv-tools: use `legacysupport.use_mp_libcxx` on Mojave and older to support `<filesystem>`

### DIFF
--- a/graphics/spirv-tools/Portfile
+++ b/graphics/spirv-tools/Portfile
@@ -3,18 +3,19 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           legacysupport 1.1
 
 github.setup        KhronosGroup SPIRV-Tools 1.3.250.0 sdk-
-github.tarball_from archive
 name                spirv-tools
-revision            0
+revision            1
 
 categories          graphics
 license             Apache-2
 maintainers         {judaew @judaew} openmaintainer
 
-description         Various SPIRV tools
-long_description    SPIRV assembler, binary module parser, disassembler, validator, and optimizer
+description         various SPIR-V tools
+long_description    SPIR-V assembler, binary module parser, \
+                    disassembler, validator, and optimizer
 homepage            https://vulkan.lunarg.com
 
 checksums           SPIRV-Tools-1.3.250.0.tar.gz \
@@ -45,6 +46,18 @@ checksums           SPIRV-Tools-1.3.250.0.tar.gz \
                     rmd160  3cc69cf8d8120f8671344bcf0703faf4c96ceaae \
                     sha256  08b9525e0b5716125f45a1347bd890bfe255e4bd79ad8fe0998f2c3e4c93ac51 \
                     size    452918
+
+compiler.cxx_standard 2017
+# Need to use MacPorts libc++ (and MacPorts Clang) on macOS 10.14 Mojave
+# and older, because Apple Clang only added support for the
+# C++17 <filesystem> library starting in Xcode 11 (clang-1100) for
+# macOS 10.15+.
+#
+# References:
+# * https://stackoverflow.com/a/55353263
+# * https://developer.apple.com/documentation/xcode-release-notes/xcode-11-release-notes
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx yes
 
 set py_ver          3.11
 set py_ver_nodot    [string map {. {}} ${py_ver}]


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Need to use MacPorts `libc++` (and MacPorts Clang) on macOS 10.14 Mojave and older, because Apple Clang only added support for the C++17 `<filesystem>` library starting in Xcode 11 (clang-1100) for macOS 10.15+. This PR fixes the MacPorts builds for 10.14 and older.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
