### PR TITLE
py-beancount: add python3.11 variant

### DIFF
--- a/python/py-beancount/Portfile
+++ b/python/py-beancount/Portfile
@@ -21,7 +21,7 @@ long_description    A double-entry bookkeeping computer language that lets \
                     them, and provides a basic web interface.
 homepage            http://furius.ca/beancount/
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-bottle/Portfile
+++ b/python/py-bottle/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-bottle
-version             0.12.18
+version             0.12.25
 revision            1
 
 categories-append   devel
@@ -22,9 +22,9 @@ long_description    Bottle is a fast, simple and lightweight WSGI micro web-fram
 
 homepage            https://bottlepy.org/
 
-checksums           rmd160  a34d7d5c77e3a65a9763323c5fe94edc85fc2c97 \
-                    sha256  0819b74b145a7def225c0e83b16a4d5711fde751cd92bae467a69efce720f69e \
-                    size    71557
+checksums           rmd160  2a7943553cc3c58d977b943d01fb38d67ec7a220 \
+                    sha256  e1a9c94970ae6d710b3fb4526294dfeb86f2cb4a81eff3a4b98dc40fb0e5e021 \
+                    size    74231
 
 python.versions     27 37 38 39 310
 

--- a/python/py-bottle/Portfile
+++ b/python/py-bottle/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-bottle
 version             0.12.25
-revision            1
+revision            0
 
 categories-append   devel
 platforms           {darwin any}
@@ -26,7 +26,7 @@ checksums           rmd160  2a7943553cc3c58d977b943d01fb38d67ec7a220 \
                     sha256  e1a9c94970ae6d710b3fb4526294dfeb86f2cb4a81eff3a4b98dc40fb0e5e021 \
                     size    74231
 
-python.versions     27 37 38 39 310
+python.versions     27 37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-google-api-core/Portfile
+++ b/python/py-google-api-core/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  ab449c2446ea350362fdb4d56bb8e50c3b62f4f6 \
                     sha256  b0fa577e512f0c8e063386b974718b8614586a798c5894ed34bedf256d9dae24 \
                     size    122056
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-google-api/Portfile
+++ b/python/py-google-api/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  9b5160018ac3a3482d86459d2bb51552e1b7fc60 \
                     sha256  facbe8e25ea9d07241299bf7704f53dec154ad3dc52fec2ea23ca6d6e5f6b392 \
                     size    7873449
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-google-auth-httplib2/Portfile
+++ b/python/py-google-auth-httplib2/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  989b8175d45cfa889ea9279a2991f33d38b0d063 \
                     sha256  a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac \
                     size    10895
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-google-auth/Portfile
+++ b/python/py-google-auth/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  471d535f41aa69f225e62bd74af1779a5fdbed04 \
                     sha256  ad160fc1ea8f19e331a16a14a79f3d643d813a69534ba9611d2c80dc10439dad \
                     size    188477
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-googleapis-common-protos/Portfile
+++ b/python/py-googleapis-common-protos/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  85f98a686621cdaaec8f635b460a860492b750c7 \
                     sha256  4007500795bcfc269d279f0f7d253ae18d6dc1ff5d5a73613ffe452038b1ec5f \
                     size    132706
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-magic/Portfile
+++ b/python/py-magic/Portfile
@@ -12,7 +12,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 37 38 39 310
+python.versions     27 37 38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-uritemplate/Portfile
+++ b/python/py-uritemplate/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  8c97f14d50a4e668825ee672672d39a2bc469351 \
                     sha256  4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
                     size    273898
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.3 22E252 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
