### PR TITLE
flock: fix build with gcc-4.2

### DIFF
--- a/sysutils/flock/Portfile
+++ b/sysutils/flock/Portfile
@@ -1,23 +1,32 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-
 PortGroup           github 1.0
 
 github.setup        discoteq flock 0.4.0 v
 github.tarball_from releases
 revision            0
 
-
 categories          sysutils
-platforms           darwin
 license             ISC
 maintainers         {langly.org:kenneth.ostby @langly} \
                     openmaintainer
-description         Flock for darwin
+description         Flock for Darwin
 long_description    This utility manages flock locks from within shell scripts or the command line.
 homepage            https://github.com/discoteq/flock
 
 checksums           sha256  c98617f1f29d2fee64b59496a147b3d17b496324a76a007c4bf5ff6b5853b7f7 \
                     rmd160  fa9080a21e2c3ca0ba5db6a301a8ccf890ac2f41 \
                     size    143473
+
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake
+
+if {[string match *gcc-4.* ${configure.compiler}]} {
+    # cc1: error: unrecognized command line option "-Wtype-limits"
+    patchfiles      patch-gcc-4.diff
+}

--- a/sysutils/flock/files/patch-gcc-4.diff
+++ b/sysutils/flock/files/patch-gcc-4.diff
@@ -1,0 +1,10 @@
+--- Makefile.am.orig	2018-05-07 01:02:27.000000000 +0800
++++ Makefile.am	2023-06-09 08:37:22.000000000 +0800
+@@ -32,7 +32,6 @@
+ 	-Wmissing-declarations \
+ 	-Wmissing-prototypes \
+ 	-Wredundant-decls \
+-	-Wtype-limits \
+ 	-Wunused-parameter \
+ 	-Wnested-externs \
+ 	-Wpointer-arith \


### PR DESCRIPTION
#### Description

Fix the build on < 10.7 with old Xcode gcc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
