### PR TITLE
poppler qt5 ports: require Qt 5.8

### DIFF
--- a/graphics/poppler-devel/Portfile
+++ b/graphics/poppler-devel/Portfile
@@ -116,7 +116,9 @@ default_variants-append +boost
 subport ${name}-qt5 {
     PortGroup qt5 1.0
 
-    qt5.min_version 5.5.0
+    # Builds with Qt 5.8 (requires toSecsSinceEpoch and fromSecsSinceEpoch)
+    # despite CMakeLists.txt in poppler 23.01 saying 5.12 is required
+    qt5.min_version 5.8
 
     configure.env-append \
                     MOCQT5=${qt_bins_dir}/moc

--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -116,7 +116,9 @@ default_variants-append +boost
 subport ${name}-qt5 {
     PortGroup qt5 1.0
 
-    qt5.min_version 5.5.0
+    # Builds with Qt 5.8 (requires toSecsSinceEpoch and fromSecsSinceEpoch)
+    # despite CMakeLists.txt in poppler 23.01 saying 5.12 is required
+    qt5.min_version 5.8
 
     configure.env-append \
                     MOCQT5=${qt_bins_dir}/moc


### PR DESCRIPTION
Needed since poppler 21.04, even though poppler claims to require newer Qt; poppler 23.01 and later say 5.12 is required
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
