### PR TITLE
rawhide: new port (version 3.2)

### DIFF
--- a/sysutils/rawhide/Portfile
+++ b/sysutils/rawhide/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           legacysupport 1.0
+
+name                rawhide
+version             3.2
+
+description         (rh) find files using pretty C expressions
+long_description    {*}${description} \
+                    \n\nRawhide (rh) lets you search for files on the command line using \
+                    expressions and user-defined functions in a mini-language inspired by C. \
+                    It's like find(1), but more fun to use. Search criteria can be very \
+                    readable and self-explanatory and/or very concise and typeable, and you can \
+                    create your own lexicon of search terms. The output can include lots of \
+                    detail, like ls(1).
+homepage            https://raf.org/rawhide/
+license             GPL-3+
+categories          sysutils
+depends_lib         port:pcre2 port:libmagic
+maintainers         {raf.org:raf @macportsraf} openmaintainer
+revision            0
+
+github.setup        raforg ${name} ${version} v
+github.tarball_from releases
+checksums           rmd160 685df5c44c4b6ef7ba27817fc1ea92949f81d388 \
+                    sha256 73d0f755ec3edb07c714255a4fb2a47b52b6225815fc39c5719b8330f94530ce \
+                    size 283346
+
+use_configure       yes
+configure.args      --macports
+build.target        rh
+# Need openat, fdopendir, fstatat, faccessat, unlinkat, readlinkat.
+# POSIX 2008, but they didn't make it into macOS until later.
+# But note: This compiles, but doesn't work, on macos-10.6.8. :-(
+legacysupport.newest_darwin_requires_legacy 13
+
+test.run            yes
+test.target         test
+
+livecheck.type      regex
+livecheck.url       ${homepage}download/
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}
+


### PR DESCRIPTION
#### Description

rawhide - (rh) finds files using pretty C expressions

An alternative to GNU find(1) that's fun to use. As well as the usual file search criteria, files can be searched by the contents of access control lists (ACL), the names and values of extended attributes (EA), and special file flags (e.g. immutable, append-only), and by file type description and MIME type (via libmagic). There are lots of options for output, including JSON.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
