### PR TITLE
qt5*: use qt5 PG to set QMAKE_MAC_SDK

### DIFF
--- a/aqua/phantomjs-qt/Portfile
+++ b/aqua/phantomjs-qt/Portfile
@@ -361,41 +361,10 @@ foreach {module module_info} [array get modules] {
                     ${worksrcpath}/mkspecs/common/gcc-base.conf
             }
 
-            platform darwin {
-                # qt calls xcrun to find the SDK to use, so make sure this call will succeed
-
-                ui_debug "phantomjs-qt Portfile: the initial SDK value is: macosx${configure.sdk_version}"
-                # first try for a system-specific SDK
-                if {[string first . ${configure.sdk_version}] == -1 && ${configure.sdkroot} ne ""} {
-                    # xcrun doesn't like major version only (e.g. macosx11), try to find a full version
-                    set sdks [lsort -command vercmp -decreasing [glob -nocomplain [file rootname ${configure.sdkroot}]*.sdk]]
-                    configure.sdk_version [string map {MacOSX ""} [file rootname [file tail [lindex $sdks 0]]]]
-                    ui_debug "using possibly more specific SDK version: ${configure.sdk_version}"
-                }
-                ui_debug "phantomjs-qt Portfile: testing for system-specific SDK:"
-                if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
-
-                    ui_debug "phantomjs-qt Portfile: system-specific SDK was not found, looking for generic SDK."
-                    # if no specific sdk found, check for a generic macosx sdk
-                    if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
-                        pre-fetch {
-                            ui_error "${subport}: no usable SDK can be found"
-                            return -code error "no usable SDK can be found"
-                        }
-                    } else {
-                        ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} was not found"
-                        configure.sdk_version
-                    }
-                } else {
-                    ui_debug "phantomjs-qt Portfile: system-specific SDK was found."
-                }
-                ui_debug "phantomjs-qt Portfile: the final SDK value is: macosx${configure.sdk_version}"
-            }
-
             # respect configure.sdk_version
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_MAC_SDK__|macosx${configure.sdk_version}|g" \
+                    "s|__MACPORTS_MAC_SDK__|${qt5.mac_sdk}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
             }
 

--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1199,41 +1199,10 @@ foreach {module module_info} [array get modules] {
                     ${worksrcpath}/mkspecs/common/gcc-base.conf
             }
 
-            if { ${os.platform} eq "darwin" } {
-                # qt calls xcrun to find the SDK to use, so make sure this call will succeed
-
-                ui_debug "qt5 Portfile: the initial SDK value is: macosx${configure.sdk_version}"
-                # first try for a system-specific SDK
-                if {[string first . ${configure.sdk_version}] == -1 && ${configure.sdkroot} ne ""} {
-                    # xcrun doesn't like major version only (e.g. macosx11), try to find a full version
-                    set sdks [lsort -command vercmp -decreasing [glob -nocomplain [file rootname ${configure.sdkroot}]*.sdk]]
-                    configure.sdk_version [string map {MacOSX ""} [file rootname [file tail [lindex $sdks 0]]]]
-                    ui_debug "using possibly more specific SDK version: ${configure.sdk_version}"
-                }
-                ui_debug "qt5 Portfile: testing for system-specific SDK:"
-                if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
-
-                    ui_debug "qt5 Portfile: system-specific SDK was not found, looking for generic SDK."
-                    # if no specific sdk found, check for a generic macosx sdk
-                    if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
-                        pre-fetch {
-                            ui_error "${subport}: no usable SDK can be found"
-                            return -code error "no usable SDK can be found"
-                        }
-                    } else {
-                        ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} was not found"
-                        configure.sdk_version
-                    }
-                } else {
-                    ui_debug "qt5 Portfile: system-specific SDK was found."
-                }
-                ui_debug "qt5 Portfile: the final SDK value is: macosx${configure.sdk_version}"
-            }
-
             # respect configure.sdk_version
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_MAC_SDK__|macosx${configure.sdk_version}|g" \
+                    "s|__MACPORTS_MAC_SDK__|${qt5.mac_sdk}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
             }
 

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -987,7 +987,7 @@ foreach {module module_info} [array get modules] {
             # respect configure.sdk_version
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_MAC_SDK__|[qt5pg::qmake_mac_sdk]|g" \
+                    "s|__MACPORTS_MAC_SDK__|${qt5.mac_sdk}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
             }
 

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -994,7 +994,7 @@ foreach {module module_info} [array get modules] {
             # respect configure.sdk_version
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_MAC_SDK__|[qt5pg::qmake_mac_sdk]|g" \
+                    "s|__MACPORTS_MAC_SDK__|${qt5.mac_sdk}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
             }
 

--- a/aqua/qt53/Portfile
+++ b/aqua/qt53/Portfile
@@ -849,41 +849,10 @@ foreach {module module_info} [array get modules] {
                     ${worksrcpath}/mkspecs/common/gcc-base.conf
             }
 
-            platform darwin {
-                # qt calls xcrun to find the SDK to use, so make sure this call will succeed
-
-                ui_debug "qt53 Portfile: the initial SDK value is: macosx${configure.sdk_version}"
-                # first try for a system-specific SDK
-                if {[string first . ${configure.sdk_version}] == -1 && ${configure.sdkroot} ne ""} {
-                    # xcrun doesn't like major version only (e.g. macosx11), try to find a full version
-                    set sdks [lsort -command vercmp -decreasing [glob -nocomplain [file rootname ${configure.sdkroot}]*.sdk]]
-                    configure.sdk_version [string map {MacOSX ""} [file rootname [file tail [lindex $sdks 0]]]]
-                    ui_debug "using possibly more specific SDK version: ${configure.sdk_version}"
-                }
-                ui_debug "qt53 Portfile: testing for system-specific SDK:"
-                if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
-
-                    ui_debug "qt53 Portfile: system-specific SDK was not found, looking for generic SDK."
-                    # if no specific sdk found, check for a generic macosx sdk
-                    if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
-                        pre-fetch {
-                            ui_error "${subport}: no usable SDK can be found"
-                            return -code error "no usable SDK can be found"
-                        }
-                    } else {
-                        ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} was not found"
-                        configure.sdk_version
-                    }
-                } else {
-                    ui_debug "qt53 Portfile: system-specific SDK was found."
-                }
-                ui_debug "qt53 Portfile: the final SDK value is: macosx${configure.sdk_version}"
-            }
-
             # respect configure.sdk_version
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_MAC_SDK__|macosx${configure.sdk_version}|g" \
+                    "s|__MACPORTS_MAC_SDK__|${qt5.mac_sdk}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
             }
 

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -856,41 +856,10 @@ foreach {module module_info} [array get modules] {
                     ${worksrcpath}/mkspecs/common/gcc-base.conf
             }
 
-            platform darwin {
-                # qt calls xcrun to find the SDK to use, so make sure this call will succeed
-
-                ui_debug "qt55 Portfile: the initial SDK value is: macosx${configure.sdk_version}"
-                # first try for a system-specific SDK
-                if {[string first . ${configure.sdk_version}] == -1 && ${configure.sdkroot} ne ""} {
-                    # xcrun doesn't like major version only (e.g. macosx11), try to find a full version
-                    set sdks [lsort -command vercmp -decreasing [glob -nocomplain [file rootname ${configure.sdkroot}]*.sdk]]
-                    configure.sdk_version [string map {MacOSX ""} [file rootname [file tail [lindex $sdks 0]]]]
-                    ui_debug "using possibly more specific SDK version: ${configure.sdk_version}"
-                }
-                ui_debug "qt55 Portfile: testing for system-specific SDK:"
-                if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
-
-                    ui_debug "qt55 Portfile: system-specific SDK was not found, looking for generic SDK."
-                    # if no specific sdk found, check for a generic macosx sdk
-                    if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
-                        pre-fetch {
-                            ui_error "${subport}: no usable SDK can be found"
-                            return -code error "no usable SDK can be found"
-                        }
-                    } else {
-                        ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} was not found"
-                        configure.sdk_version
-                    }
-                } else {
-                    ui_debug "qt55 Portfile: system-specific SDK was found."
-                }
-                ui_debug "qt55 Portfile: the final SDK value is: macosx${configure.sdk_version}"
-            }
-
             # respect configure.sdk_version
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_MAC_SDK__|macosx${configure.sdk_version}|g" \
+                    "s|__MACPORTS_MAC_SDK__|${qt5.mac_sdk}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
             }
 

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -901,41 +901,10 @@ foreach {module module_info} [array get modules] {
                     ${worksrcpath}/mkspecs/common/gcc-base.conf
             }
 
-            platform darwin {
-                # qt calls xcrun to find the SDK to use, so make sure this call will succeed
-
-                ui_debug "qt56 Portfile: the initial SDK value is: macosx${configure.sdk_version}"
-                # first try for a system-specific SDK
-                if {[string first . ${configure.sdk_version}] == -1 && ${configure.sdkroot} ne ""} {
-                    # xcrun doesn't like major version only (e.g. macosx11), try to find a full version
-                    set sdks [lsort -command vercmp -decreasing [glob -nocomplain [file rootname ${configure.sdkroot}]*.sdk]]
-                    configure.sdk_version [string map {MacOSX ""} [file rootname [file tail [lindex $sdks 0]]]]
-                    ui_debug "using possibly more specific SDK version: ${configure.sdk_version}"
-                }
-                ui_debug "qt56 Portfile: testing for system-specific SDK:"
-                if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
-
-                    ui_debug "qt56 Portfile: system-specific SDK was not found, looking for generic SDK."
-                    # if no specific sdk found, check for a generic macosx sdk
-                    if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
-                        pre-fetch {
-                            ui_error "${subport}: no usable SDK can be found"
-                            return -code error "no usable SDK can be found"
-                        }
-                    } else {
-                        ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} was not found"
-                        configure.sdk_version
-                    }
-                } else {
-                    ui_debug "qt56 Portfile: system-specific SDK was found."
-                }
-                ui_debug "qt56 Portfile: the final SDK value is: macosx${configure.sdk_version}"
-            }
-
             # respect configure.sdk_version
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_MAC_SDK__|macosx${configure.sdk_version}|g" \
+                    "s|__MACPORTS_MAC_SDK__|${qt5.mac_sdk}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
             }
 

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -971,41 +971,10 @@ foreach {module module_info} [array get modules] {
                     ${worksrcpath}/mkspecs/common/gcc-base.conf
             }
 
-            platform darwin {
-                # qt calls xcrun to find the SDK to use, so make sure this call will succeed
-
-                ui_debug "qt57 Portfile: the initial SDK value is: macosx${configure.sdk_version}"
-                # first try for a system-specific SDK
-                if {[string first . ${configure.sdk_version}] == -1 && ${configure.sdkroot} ne ""} {
-                    # xcrun doesn't like major version only (e.g. macosx11), try to find a full version
-                    set sdks [lsort -command vercmp -decreasing [glob -nocomplain [file rootname ${configure.sdkroot}]*.sdk]]
-                    configure.sdk_version [string map {MacOSX ""} [file rootname [file tail [lindex $sdks 0]]]]
-                    ui_debug "using possibly more specific SDK version: ${configure.sdk_version}"
-                }
-                ui_debug "qt57 Portfile: testing for system-specific SDK:"
-                if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
-
-                    ui_debug "qt57 Portfile: system-specific SDK was not found, looking for generic SDK."
-                    # if no specific sdk found, check for a generic macosx sdk
-                    if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
-                        pre-fetch {
-                            ui_error "${subport}: no usable SDK can be found"
-                            return -code error "no usable SDK can be found"
-                        }
-                    } else {
-                        ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} was not found"
-                        configure.sdk_version
-                    }
-                } else {
-                    ui_debug "qt57 Portfile: system-specific SDK was found."
-                }
-                ui_debug "qt57 Portfile: the final SDK value is: macosx${configure.sdk_version}"
-            }
-
             # respect configure.sdk_version
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_MAC_SDK__|macosx${configure.sdk_version}|g" \
+                    "s|__MACPORTS_MAC_SDK__|${qt5.mac_sdk}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
             }
 

--- a/aqua/qt58/Portfile
+++ b/aqua/qt58/Portfile
@@ -972,41 +972,10 @@ foreach {module module_info} [array get modules] {
                     ${worksrcpath}/mkspecs/common/gcc-base.conf
             }
 
-            platform darwin {
-                # qt calls xcrun to find the SDK to use, so make sure this call will succeed
-
-                ui_debug "qt58 Portfile: the initial SDK value is: macosx${configure.sdk_version}"
-                # first try for a system-specific SDK
-                if {[string first . ${configure.sdk_version}] == -1 && ${configure.sdkroot} ne ""} {
-                    # xcrun doesn't like major version only (e.g. macosx11), try to find a full version
-                    set sdks [lsort -command vercmp -decreasing [glob -nocomplain [file rootname ${configure.sdkroot}]*.sdk]]
-                    configure.sdk_version [string map {MacOSX ""} [file rootname [file tail [lindex $sdks 0]]]]
-                    ui_debug "using possibly more specific SDK version: ${configure.sdk_version}"
-                }
-                ui_debug "qt58 Portfile: testing for system-specific SDK:"
-                if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
-
-                    ui_debug "qt58 Portfile: system-specific SDK was not found, looking for generic SDK."
-                    # if no specific sdk found, check for a generic macosx sdk
-                    if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
-                        pre-fetch {
-                            ui_error "${subport}: no usable SDK can be found"
-                            return -code error "no usable SDK can be found"
-                        }
-                    } else {
-                        ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} was not found"
-                        configure.sdk_version
-                    }
-                } else {
-                    ui_debug "qt58 Portfile: system-specific SDK was found."
-                }
-                ui_debug "qt58 Portfile: the final SDK value is: macosx${configure.sdk_version}"
-            }
-
             # respect configure.sdk_version
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_MAC_SDK__|macosx${configure.sdk_version}|g" \
+                    "s|__MACPORTS_MAC_SDK__|${qt5.mac_sdk}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
             }
 

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -986,41 +986,10 @@ foreach {module module_info} [array get modules] {
                     ${worksrcpath}/mkspecs/common/gcc-base.conf
             }
 
-            platform darwin {
-                # qt calls xcrun to find the SDK to use, so make sure this call will succeed
-
-                ui_debug "qt59 Portfile: the initial SDK value is: macosx${configure.sdk_version}"
-                # first try for a system-specific SDK
-                if {[string first . ${configure.sdk_version}] == -1 && ${configure.sdkroot} ne ""} {
-                    # xcrun doesn't like major version only (e.g. macosx11), try to find a full version
-                    set sdks [lsort -command vercmp -decreasing [glob -nocomplain [file rootname ${configure.sdkroot}]*.sdk]]
-                    configure.sdk_version [string map {MacOSX ""} [file rootname [file tail [lindex $sdks 0]]]]
-                    ui_debug "using possibly more specific SDK version: ${configure.sdk_version}"
-                }
-                ui_debug "qt59 Portfile: testing for system-specific SDK:"
-                if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx${configure.sdk_version} --find ld  > /dev/null 2>@1}]} {
-
-                    ui_debug "qt59 Portfile: system-specific SDK was not found, looking for generic SDK."
-                    # if no specific sdk found, check for a generic macosx sdk
-                    if {[catch {exec -ignorestderr env DEVELOPER_DIR=${configure.developer_dir} /usr/bin/xcrun --sdk macosx --find ld > /dev/null 2>@1}]} {
-                        pre-fetch {
-                            ui_error "${subport}: no usable SDK can be found"
-                            return -code error "no usable SDK can be found"
-                        }
-                    } else {
-                        ui_debug "${subport}: using generic macosx SDK as macosx${configure.sdk_version} was not found"
-                        configure.sdk_version
-                    }
-                } else {
-                    ui_debug "qt59 Portfile: system-specific SDK was found."
-                }
-                ui_debug "qt59 Portfile: the final SDK value is: macosx${configure.sdk_version}"
-            }
-
             # respect configure.sdk_version
             post-patch {
                 reinplace \
-                    "s|__MACPORTS_MAC_SDK__|macosx${configure.sdk_version}|g" \
+                    "s|__MACPORTS_MAC_SDK__|${qt5.mac_sdk}|g" \
                     ${worksrcpath}/mkspecs/common/macx.conf
             }
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
