### PR TITLE
clamav-legacy: version for older systems; clamav: improvements to portfile

### DIFF
--- a/sysutils/clamav-legacy/Portfile
+++ b/sysutils/clamav-legacy/Portfile
@@ -2,37 +2,38 @@
 
 PortSystem              1.0
 PortGroup               cmake 1.1
-PortGroup               legacysupport 1.0
+PortGroup               legacysupport 1.1
+PortGroup               openssl 1.0
 
-name                    clamav
-conflicts               clamav-legacy
-version                 1.1.0
+name                    clamav-legacy
+set realname            clamav
+conflicts               clamav
+version                 0.104.4
+revision                0
 categories              sysutils
-platforms               {darwin > 10}
-maintainers             {geeklair.net:dluke @danielluke}
-description             ClamAV antivirus software
+platforms               {darwin < 11}
+maintainers             nomaintainer
+description             ClamAV anti-virus software adapted to older MacOS
 license                 {GPL-2 OpenSSLException}
 
 long_description        Clam AntiVirus is a GPL anti-virus toolkit for UNIX. \
                         The main purpose of this software is the integration \
-                        with mail servers (attachment scanning).
+                        with mail servers (attachment scanning). This port supports \
+                        old Macs with Mac OS X 10.4–10.6 (Tiger, Leopard, Snow Leopard).
 
 homepage                https://www.clamav.net
 master_sites            https://www.clamav.net/downloads/production
-checksums               rmd160  0f3a5b5a5306bc041b6865188a94104b55f8b3b8 \
-                        sha256  a30020d99cd467fa5ea0efbd6f4f182efebf62a9fc62fc4a3a7b2cc3f55e6b74 \
-                        size    47793733
+distname                ${realname}-${version}
+checksums               rmd160  9158544048971e28c71ebf60ea39b42afcb8ce04 \
+                        sha256  8ac32e910aa744cc7f921c5122ba523ef1ffbbbf94545f94fc4a976b502be74b \
+                        size    12027448
 
 # Disable tests to avoid extra dependencies
 configure.args-append   -DENABLE_TESTS=OFF
 
-depends_build-append    bin:git:git \
-                        port:cargo \
-                        port:pkgconfig \
-                        port:rust
+depends_build-append    port:pkgconfig
 
-depends_lib-append      path:lib/libssl.dylib:openssl \
-                        port:bzip2 \
+depends_lib-append      port:bzip2 \
                         port:curl \
                         port:json-c \
                         port:libiconv \
@@ -41,6 +42,28 @@ depends_lib-append      path:lib/libssl.dylib:openssl \
                         port:ncurses \
                         port:pcre2 \
                         port:zlib
+
+# older systems support
+post-extract {
+    platform darwin {
+        # use linux version of openssl cert util on systems < 10.7 that don't support the macOS version
+        # ./common/linux/cert_util_linux.c -> ./common/mac/cert_util_mac.m
+        # passes all tests. See: https://trac.macports.org/ticket/59168
+
+        ui_msg  "replacing mac security with linux security"
+        delete  ${worksrcpath}/common/mac/cert_util_mac.m
+        copy    ${worksrcpath}/common/linux/cert_util_linux.c \
+                ${worksrcpath}/common/mac/cert_util_mac.m
+
+        # remove two switchs not supported by the older gcc versions often used on these systems
+        reinplace "s/-Wno-logical-op-parentheses//g" ${worksrcpath}/libclamunrar/CMakeLists.txt
+        reinplace "s/-Wno-dangling-else//g" ${worksrcpath}/libclamunrar/CMakeLists.txt
+    }
+}
+
+platform darwin 8 {
+    configure.args-append   -DOPTIMIZE=OFF
+}
 
 variant clamav_milter description {Build with libmilter support} {
     depends_lib-append      port:libmilter
@@ -59,7 +82,7 @@ variant tests description {Enable running 'port test'} {
 
     depends_test-append \
                     port:check \
-                    port:py310-pytest
+                    port:py311-pytest
 
     configure.args-delete \
                     -DENABLE_TESTS=OFF

--- a/sysutils/clamav/Portfile
+++ b/sysutils/clamav/Portfile
@@ -1,74 +1,70 @@
-PortSystem 1.0
-PortGroup legacysupport 1.0
-PortGroup cmake 1.1
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name			clamav
-version		 	1.1.0
-categories		sysutils
-maintainers	 	{geeklair.net:dluke @danielluke}
-description	 	clamav antivirus software
-license			{GPL-2 OpenSSLException}
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               legacysupport 1.0
 
-long_description	Clam AntiVirus is a GPL anti-virus toolkit for UNIX. The \
-			main purpose of this software is the integration with mail \
-			servers (attachment scanning).
+name                    clamav
+version                 1.1.0
+categories              sysutils
+maintainers             {geeklair.net:dluke @danielluke}
+description             ClamAV antivirus software
+license                 {GPL-2 OpenSSLException}
 
-homepage		http://www.clamav.net
-master_sites		http://www.clamav.net/downloads/production
-checksums	rmd160	0f3a5b5a5306bc041b6865188a94104b55f8b3b8 \
-		sha256	a30020d99cd467fa5ea0efbd6f4f182efebf62a9fc62fc4a3a7b2cc3f55e6b74 \
-		size	47793733
+long_description        Clam AntiVirus is a GPL anti-virus toolkit for UNIX. \
+                        The main purpose of this software is the integration \
+                        with mail servers (attachment scanning).
 
-platforms		darwin
+homepage                https://www.clamav.net
+master_sites            https://www.clamav.net/downloads/production
+checksums               rmd160  0f3a5b5a5306bc041b6865188a94104b55f8b3b8 \
+                        sha256  a30020d99cd467fa5ea0efbd6f4f182efebf62a9fc62fc4a3a7b2cc3f55e6b74 \
+                        size    47793733
 
 # Disable tests to avoid extra dependencies
-configure.args-append	-DENABLE_TESTS=OFF
+configure.args-append   -DENABLE_TESTS=OFF
 
-use_parallel_build	yes
+depends_build-append    bin:git:git \
+                        port:cargo \
+                        port:pkgconfig \
+                        port:rust
 
-depends_build		path:bin/cmake:cmake \
-			port:pkgconfig \
-			bin:git:git \
-			port:rust \
-			port:cargo
+depends_lib-append      path:lib/libssl.dylib:openssl \
+                        port:bzip2 \
+                        port:curl \
+                        port:json-c \
+                        port:libiconv \
+                        port:libtool \
+                        port:libxml2 \
+                        port:ncurses \
+                        port:pcre2 \
+                        port:zlib
 
-depends_lib		port:libiconv \
-			port:zlib \
-			port:bzip2 \
-			port:ncurses \
-			path:lib/libssl.dylib:openssl \
-			port:pcre2 \
-			port:libxml2 \
-			port:curl \
-			port:json-c \
-			port:libtool
-
-## older systems support
+# older systems support
 post-extract {
- if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        # use linux version of openssl cert util on systems < 10.7 that don't support the macOS version
+        # ./common/linux/cert_util_linux.c -> ./common/mac/cert_util_mac.m
+        # passes all tests. See: https://trac.macports.org/ticket/59168
 
-	# use linux version of openssl cert util on systems < 10.7 that don't support the macOS version
-	# ./common/linux/cert_util_linux.c -> ./common/mac/cert_util_mac.m
-	# passes all tests. See: https://trac.macports.org/ticket/59168
+        ui_msg  "replacing mac security with linux security"
+        delete  ${worksrcpath}/common/mac/cert_util_mac.m
+        copy    ${worksrcpath}/common/linux/cert_util_linux.c \
+                ${worksrcpath}/common/mac/cert_util_mac.m
 
-	ui_msg	"replacing mac security with linux security"
-	delete	${worksrcpath}/common/mac/cert_util_mac.m
-	copy	${worksrcpath}/common/linux/cert_util_linux.c \
-		${worksrcpath}/common/mac/cert_util_mac.m
-
-	# remove two switchs not supported by the older gcc versions often used on these systems
-	reinplace "s/-Wno-logical-op-parentheses//g"	${worksrcpath}/libclamunrar/CMakeLists.txt
-	reinplace "s/-Wno-dangling-else//g"		${worksrcpath}/libclamunrar/CMakeLists.txt
- }
+        # remove two switchs not supported by the older gcc versions often used on these systems
+        reinplace "s/-Wno-logical-op-parentheses//g" ${worksrcpath}/libclamunrar/CMakeLists.txt
+        reinplace "s/-Wno-dangling-else//g" ${worksrcpath}/libclamunrar/CMakeLists.txt
+    }
 }
 
 platform darwin 8 {
-	configure.args-append	-DOPTIMIZE=OFF
+    configure.args-append   -DOPTIMIZE=OFF
 }
 
-variant clamav_milter description {build with libmilter support} {
-	depends_lib-append port:libmilter
-	configure.args-append	-DENABLE_MILTER=ON
+variant clamav_milter description {Build with libmilter support} {
+    depends_lib-append      port:libmilter
+    configure.args-append   -DENABLE_MILTER=ON
 }
 
 pre-test {
@@ -79,21 +75,23 @@ pre-test {
 }
 
 variant tests description {Enable running 'port test'} {
-	ui_msg "Tests run using the installed version of this port."
+    ui_msg "Tests run using the installed version of this port."
 
-	depends_test	port:check \
-			port:py310-pytest
+    depends_test-append \
+                    port:check \
+                    port:py310-pytest
 
-	configure.args-delete	-DENABLE_TESTS=OFF
-	configure.pre_args-replace	-DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
-					-DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+    configure.args-delete \
+                    -DENABLE_TESTS=OFF
+    configure.pre_args-replace \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
-
-	test.run yes
-	test.cmd ctest
-	test.target --rerun-failed --output-on-failure
+    test.run        yes
+    test.cmd        ctest
+    test.target     --rerun-failed --output-on-failure
 }
 
-livecheck.type		regex
-livecheck.url		http://www.clamav.net/downloads
-livecheck.regex		${name}-(\\d+.\\d+.\\d+)${extract.suffix}
+livecheck.type      regex
+livecheck.url       https://www.clamav.net/downloads
+livecheck.regex     ${name}-(\\d+.\\d+.\\d+)${extract.suffix}


### PR DESCRIPTION
#### Description

See commits.

@ballapete I have set you as a maintainer, since there is an old draft of the port by you: https://trac.macports.org/ticket/64613
If you are not interested, please let us know, I will set the port to nomaintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
