### PR TITLE
zfp: update to upstream, fix tests on 32-bit

### DIFF
--- a/science/zfp/Portfile
+++ b/science/zfp/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        LLNL zfp f15d00720e454cd70206a85d7013d8240ad38585
-version             2023.02.11
+github.setup        LLNL zfp 300e77d12f25d3eaa4ba9461d937fb17a71d45f6
+version             2023.04.30
 revision            0
 categories          science devel
 license             BSD
@@ -14,14 +15,14 @@ description         zfp is a compressed format for representing multi-dimensiona
 long_description    {*}${description}
 homepage            https://zfp.llnl.gov
 
-checksums           rmd160  cac426354ae3f5f7ffd15442d044a0dbad876bba \
-                    sha256  d9ceb27be5a8591c204b2599e60f178edeaf0139da24aeee5d3f1768fe3cc3e2 \
-                    size    504306
+checksums           rmd160  6427229673f288ae8e3d8ca0d90ec8264ab4c9dd \
+                    sha256  69754125d2b25f5a35574aac20af32dea2c17f7268fcb6cc26d0e1205467bf74 \
+                    size    504422
 
-compiler.c_standard 1999
 # index.hpp: error: integer constant is too large for ‘unsigned long’ type
 compiler.blacklist-append \
-                    *gcc-4.*
+                    {clang < 400} *gcc-4.*
+compiler.c_standard 1999
 
 configure.args-append \
                     -DBUILD_EXAMPLES=OFF \
@@ -44,6 +45,17 @@ variant openmp description {use OpenMP} {
     }
 }
 
-# Note, that tests are likely to fail on 32-bit platforms due to insufficient precision:
-# https://github.com/LLNL/zfp/issues/205
+# See: https://github.com/LLNL/zfp/issues/205
+if {${configure.build_arch} in [list i386 ppc]} {
+    configure.args-append \
+                    -DZFP_INT64='long long' \
+                    -DZFP_INT64_SUFFIX=ll \
+                    -DZFP_UINT64='unsigned long long' \
+                    -DZFP_UINT64_SUFFIX=ull
+}
+
 test.run            yes
+# Drop once someone finally removes this from cmake PG:
+configure.pre_args-replace \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF


### PR DESCRIPTION
#### Description

Update and a fix from upstream for 32-bit compilation and tests.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
