### PR TITLE
fx: update to 24.1.0

### DIFF
--- a/sysutils/fx/Portfile
+++ b/sysutils/fx/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/antonmedv/fx 24.0.0
+go.setup            github.com/antonmedv/fx 24.1.0
 revision            0
 categories          sysutils textproc
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -13,9 +13,9 @@ description         Terminal JSON viewer
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  948050663d3ff3b6ee2168298ab47cbb0cf8875a \
-                        sha256  de166d4bf1d38be9e7736b1a93267b7debe65206ff7cb53097565993690d880f \
-                        size    1033494
+                        rmd160  da3c3980df5e374dbc90c6c933b8dc9993171b03 \
+                        sha256  7d14aead97bebec110f26dafa4936e33e0e6420b082082ae46fb1077435f7d86 \
+                        size    1037219
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    9f266ea9e77c \
@@ -33,20 +33,25 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  98ec7bd0dc7d4bcee7dcafe02efab29f14dc392f43b227e517beef064e9b6369 \
                         size    32368 \
                     golang.org/x/text \
-                        lock    v0.3.7 \
-                        rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
-                        sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
-                        size    8356115 \
+                        lock    v0.9.0 \
+                        rmd160  024cee280ecc35a165fe05f6cb43f745be776cf7 \
+                        sha256  c84b520575096154588a99123b775d5ccbc66e492a6d22aaa75a5dd8572634ab \
+                        size    8356818 \
                     golang.org/x/term \
-                        lock    e5f449aeb171 \
-                        rmd160  815a83a4b9782102c3877cf61ee45ab5f8f89f4f \
-                        sha256  825a85ed3b123e641b82daecec59a33954393371b3f5e59dc90742a9ec46622f \
-                        size    14976 \
+                        lock    v0.7.0 \
+                        rmd160  274df54dd21ae86085bb2c69ca8bef482406c49c \
+                        sha256  95b59b2c7b3aed7949f0f0b1317eac3fc379a20f5ccb72ed0b23671b50732291 \
+                        size    14808 \
                     golang.org/x/sys \
-                        lock    988cb79eb6c6 \
-                        rmd160  2a811d9ad19b374e9fa643a4b36cff0759f8c973 \
-                        sha256  61e5f6e725d3a5ad7b647ddc01cfeae284330a078846982aced0a2e2ec3b5eb5 \
-                        size    1303231 \
+                        lock    v0.7.0 \
+                        rmd160  06b7e1f7f518376deaad92ca77d2d54b8a6807ec \
+                        sha256  82e99ca5ba1b5fddecc2dfef4b08e6cc1137ffe5eb41d0e0232fbdd8124e1ebf \
+                        size    1435346 \
+                    golang.org/x/sync \
+                        lock    v0.1.0 \
+                        rmd160  bf68702d961107a225cce561701852f129f16a3d \
+                        sha256  50a67a11e715a61c022f218604adc63e61684de5f5db2330741077439c4ce68f \
+                        size    19355 \
                     github.com/stretchr/testify \
                         lock    v1.7.1 \
                         rmd160  9e07f7d6890b8598706260ece5db26a7b12b5b2a \
@@ -58,50 +63,60 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  ccd0e3ec65e987ddb9719f0e1db82aee660db3bfcfc7bd031bcccc1df0d1fc85 \
                         size    123139 \
                     github.com/rivo/uniseg \
-                        lock    v0.2.0 \
-                        rmd160  33577def583aa2db50b69ca601e5d29ab201ebc4 \
-                        sha256  2832965221246272462a03ffc8e159c94d8f534827f660f1ac4fc77e5ccd644c \
-                        size    44037 \
+                        lock    v0.4.4 \
+                        rmd160  00ed48c772088197112a0732fe3c7cd90ec8c94e \
+                        sha256  c80468291b3a3df4d56d48f1335564a3813fb7e6d5588a8502949fd9d67a704a \
+                        size    453472 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
                         sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
                         size    11409 \
                     github.com/muesli/termenv \
-                        lock    44cd13922739 \
-                        rmd160  e31c6ee43ba7a1b5b523da9e4ae4986868175857 \
-                        sha256  51ddb46438edd4eda1564f6743d6b710bd010a1623ad331de11c11423b42d6a4 \
-                        size    412111 \
+                        lock    v0.15.1 \
+                        rmd160  1690f2e21976342a1471af9d7839ec2a6ccdfaf7 \
+                        sha256  5e4d47dca1ea8b6b0ea967ba689aa571b6482bc9fc050725553f77a203ff02c7 \
+                        size    422678 \
                     github.com/muesli/reflow \
                         lock    v0.3.0 \
                         rmd160  8941f9c5aa79468e9280c3727c7eafa4f00f748d \
                         sha256  67ed2e1490730fc629238aa847fdd863acefda8b0d35d689bbd88ced8c0f80ca \
                         size    21257 \
+                    github.com/muesli/cancelreader \
+                        lock    v0.2.2 \
+                        rmd160  cbc757f0d680959cea46000a5dd74e63ddbb8a15 \
+                        sha256  33f793cd6fbf7733ed7cba381920606b4917ba472148f85a5fd0965477146fc8 \
+                        size    9431 \
                     github.com/muesli/ansi \
-                        lock    c9f0611b6c70 \
-                        rmd160  b4e973867b185963dba064fdda31cbc3df37e4e9 \
-                        sha256  69b20c11994dd2f52dbe30d14e6fcc6596b1bcf09f5ead5339ce55a1950dd411 \
-                        size    5129 \
+                        lock    276c6243b2f6 \
+                        rmd160  bbc37c92ce2b54f538eb0d5f32edefd7074d540a \
+                        sha256  0b4beac5757eb25d0c45f9f931e2b241168e16c2bd58d21e5aafce7e33c669ee \
+                        size    5249 \
                     github.com/mazznoer/csscolorparser \
-                        lock    v0.1.2 \
-                        rmd160  01441e6effb91474c7b8808070cf29639bfa44fd \
-                        sha256  98f5363394be83080e5637de4896e0543d5f33fdcf465150dc80c8ff5501ceaa \
-                        size    16615 \
+                        lock    v0.1.3 \
+                        rmd160  68a19be8e6a1cfbda5cb7927577bef04aa759967 \
+                        sha256  d3ccbf24b19886eb4390de3c6372f3b26c36d908a096b2d57e51fd4fd5dcc52a \
+                        size    16990 \
                     github.com/mazznoer/colorgrad \
-                        lock    v0.8.1 \
-                        rmd160  72fc0d973c9b546c63213e125037d70588e98301 \
-                        sha256  6ed9d0793de7a9d2351e5b3959fd6178566bf8493f5f29258fe95aad361172cf \
-                        size    192552 \
+                        lock    v0.9.1 \
+                        rmd160  4ed70bc1592bdd76889ad27cce3a3c8058697689 \
+                        sha256  fb118206dbb004f59aedaf3ff3e8c31cf7ecde5b0b910c863286669e148050f6 \
+                        size    208255 \
                     github.com/mattn/go-runewidth \
-                        lock    v0.0.13 \
-                        rmd160  e177edb4dc4702ae2b23704934ff31cc6561bbd0 \
-                        sha256  dcd3ccbd956a6f53bc106b79489d0303a237c21d858d23250e3e1d7284b72b86 \
-                        size    17363 \
-                    github.com/mattn/go-isatty \
                         lock    v0.0.14 \
-                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
-                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
-                        size    4705 \
+                        rmd160  7186117475d80aff012960b61daefd53c7efeca6 \
+                        sha256  71e68e76e460aff1af8b58453a5a7b2278c42f6659c8c7b4321907bdf14ee6eb \
+                        size    18269 \
+                    github.com/mattn/go-localereader \
+                        lock    v0.0.1 \
+                        rmd160  7afdbbc0f4978c6f54c25df0d86ff3c66db19ce2 \
+                        sha256  75a68e82a83b37aee40ad81dfcfce54d2f999945282bb198add16a49b8ec7f46 \
+                        size    1738 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.18 \
+                        rmd160  b857a1d7ca02887106419c1a8b32364f1526fd4f \
+                        sha256  b91360b8bf6d2b635db2e16241b171ab9704ddc0cbcb8173b421ad2099a9ec45 \
+                        size    4676 \
                     github.com/lucasb-eyer/go-colorful \
                         lock    v1.2.0 \
                         rmd160  a4183d0625e6c94474942cdc544c1061d35c4e34 \
@@ -117,21 +132,26 @@ go.vendors          gopkg.in/yaml.v3 \
                         rmd160  0895c899b9d88b87beccda0a9b4c5c7057e858f0 \
                         sha256  88d8d187ffa4faf0362b48c3d327ad440c7e5fb179ea3247e69269cab128a6b9 \
                         size    10043 \
+                    github.com/google/pprof \
+                        lock    00490a63f317 \
+                        rmd160  5bb0872c7fa1aa80e5a7097b5017de7c0956dece \
+                        sha256  a958c8a1eb12aa9f98990d979f1d6e40e8e5a70d1af2ff04d5f8f188bb650681 \
+                        size    2950468 \
                     github.com/go-sourcemap/sourcemap \
                         lock    v2.1.3 \
                         rmd160  5c0ca4bf07713d7a1fe3d18f20383a43b72238e3 \
                         sha256  3012001cf5d369398deda6feb4b8ef7806680ace0909615262089e4276235c45 \
                         size    6481 \
                     github.com/dop251/goja \
-                        lock    e1eca0b61fa9 \
-                        rmd160  c527122b5356cd6b4c30ff5a11c945d7d9d9bf30 \
-                        sha256  d73b4468cc75217ffb3b631dbaaed7f2e6adab1e1b6a9802e7a6182bc0cd9fb0 \
-                        size    341742 \
+                        lock    623f9dda9079 \
+                        rmd160  5db110e9865852dce52fb39576b6f261e525f239 \
+                        sha256  df77835a41f491a3b755d4785cd8d3d3efca715ede2283b2929dce48b115aa24 \
+                        size    385313 \
                     github.com/dlclark/regexp2 \
-                        lock    a2a8dda75c91 \
-                        rmd160  b98117d8ee923adf0b36bc66bbfac667d5b211a3 \
-                        sha256  21a5736eb79dfb44f2fa6b2f4254759121adf6715e55c53e702eba44e7aef849 \
-                        size    206229 \
+                        lock    v1.9.0 \
+                        rmd160  3f727c63e8fb4b41e29e7cc2a66d0aeb38ecc0fb \
+                        sha256  45592040e3033f256efbc751ee46998f030f6e46cb59242c47b4e4ea74472872 \
+                        size    211846 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.0 \
                         rmd160  0303eae19a01f38fe314921fd965e4d09b9ef3ad \
@@ -143,20 +163,25 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  a032c6f2eecefbeb998ef96bb92f65423552f8e0ac7c410ec0f8c5829af704ea \
                         size    13726 \
                     github.com/charmbracelet/lipgloss \
-                        lock    v0.5.0 \
-                        rmd160  a63f508c630e9b9700102538cb65e4732130f914 \
-                        sha256  2df51ce2b10fc945cf69c21be3b3bbf141f90f7350bcc16d5d3998824b365f44 \
-                        size    27292 \
+                        lock    v0.7.1 \
+                        rmd160  20031658ad1c3014a263c16e63ff6fed5e006efb \
+                        sha256  e2c1a68bc9976546889d914ef04fd44ed9803e69d7db0365bbb74586bb954ae7 \
+                        size    40825 \
                     github.com/charmbracelet/bubbletea \
-                        lock    v0.20.0 \
-                        rmd160  320e5a00f7ee43bed9e58a048dc100733740156b \
-                        sha256  6870f707dd15f420cb149d4babb2a4055aeb1336003a731ab0ff30661f533d27 \
-                        size    65945 \
+                        lock    v0.23.2 \
+                        rmd160  1432e930fa2009366732e06b915ff29caa050fe9 \
+                        sha256  cdfbeacc2d31f9afbf6518e05719cdbf55698b27f302cf237a50eb1a88d62162 \
+                        size    2164184 \
                     github.com/charmbracelet/bubbles \
-                        lock    v0.10.3 \
-                        rmd160  4a380ad8fc02cf6917e01dd52b522695fe6cb936 \
-                        sha256  e4c30269e1a865a7320544969141c8b6b73f8dc92d8b3c077af6603a337d0603 \
-                        size    35716 \
+                        lock    v0.15.0 \
+                        rmd160  0e32c1af3c2b8a84b260f21bbd5a1b44ba94422b \
+                        sha256  8f0f21d13dbcb61df3902cd1b5216a34d09382edefee446304627d2fc548a7dd \
+                        size    55529 \
+                    github.com/aymanbagabas/go-osc52 \
+                        lock    v2.0.1 \
+                        rmd160  8669f2bdcf2704bbc8df6af7e5fd396215737b9b \
+                        sha256  0904dc990e2f1e5bbe290e02f418940def4168b63e36914e3bf76ff2ac1fb2a5 \
+                        size    5889 \
                     github.com/atotto/clipboard \
                         lock    v0.1.4 \
                         rmd160  cda277fa418bc6cdb42b3a2e6c3637473bdd12e3 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/antonmedv/fx/compare/24.0.0...24.1.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.5 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
