### PR TITLE
glslang: require C++17

### DIFF
--- a/graphics/glslang/Portfile
+++ b/graphics/glslang/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           legacysupport 1.1
 
 github.setup        KhronosGroup glslang 12.2.0
 github.tarball_from archive
@@ -24,7 +25,10 @@ checksums           sha256  870d17030fda7308c1521fb2e01a9e93cbe4b130bc8274e90d00
 set py_ver          3.11
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 
-compiler.cxx_standard 2011
+compiler.cxx_standard 2017
+
+# Apple Clang doesn't support C++17 on macOS 10.9 Mavericks and older
+legacysupport.newest_darwin_requires_legacy 13
 
 depends_build-append    port:python${py_ver_nodot}
 configure.python        ${prefix}/bin/python${py_ver}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The `CMakeLists.txt` file wants C++17, but the Portfile is only enforcing C++11. Also, turn on legacy support for macOS < 10.9, because Apple Clang on Mavericks and older doesn't support C++17 at all.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
