### PR TITLE
sshdo: new port (version 1.1.1)

### DIFF
--- a/security/sshdo/Portfile
+++ b/security/sshdo/Portfile
@@ -1,0 +1,70 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        raforg sshdo c27b4a0
+version             1.1.1
+revision            0
+
+description         controls which commands may be executed via incoming ssh
+long_description    {*}${description}. \
+                    \n\nsshdo provides an easily configurable way of controlling which \
+                    commands may be executed via incoming ssh connections by specific \
+                    users and specific keys. Training mode allows a key to be used for \
+                    any command, while logging them. Then sshdo can learn from the logs \
+                    to know what commands to allow. It can also unlearn commands that \
+                    are no longer in use. This mitigates against private ssh key compromise \
+                    with very little effort.
+license             GPL-2+
+categories          security
+supported_archs     noarch
+platforms           {darwin any}
+maintainers         {raf.org:raf @macportsraf} openmaintainer
+
+homepage            https://raf.org/sshdo/
+checksums           rmd160  e597acb80e58da62d0432ab3638eddda813ed653 \
+                    sha256  edd8b082c508390d597b728fb8ad6c4f6c432672406e0b395ae4617e2e57b0d9 \
+                    size    76694
+
+
+# Any of Python 2.6, 2.7, or 3.3+ will do.
+# Update the python3 version every year or so.
+set python_branch   3.11
+set python_version  [string map {. {}} ${python_branch}]
+depends_lib-append  port:python${python_version}
+
+# Note: Not a GNU autoconf configure script
+use_configure       yes
+configure.args      --prefix="${prefix}" \
+                    --etcdir="${prefix}"/etc \
+                    --with-python="${prefix}"/bin/python${python_branch} \
+                    --enable-mangz
+build {}
+
+test.run            yes
+
+destroot.keepdirs   ${destroot}${prefix}/etc/sshdoers.d
+
+notes {
+    sshdo relies on syslog messages to learn and unlearn policy.
+
+    On recent macOS systems with the unified logging system,\
+    syslog messages don't look the same as elsewhere, and they no\
+    longer appear in /var/log/system.log where sshdo expects them,\
+    so you'll need to use the log(1) command to feed log messages\
+    into sshdo via its standard input (stdin). See man sshdo.
+
+    Use the following command as the basis for your log queries:
+
+        log show --style syslog --info --predicate '
+            process == "Python" and
+            composedMessage contains "type=" and
+            composedMessage contains "user=" and
+            composedMessage contains "command="
+        ' | sed -E -e 's/Python/sshdo/' -e 's/: \([^)]+\)/:/'
+
+    You will also need to incorporate the appropriate time range\
+    into the search criteria (e.g., --last 7d). See man log.
+}


### PR DESCRIPTION
#### Description

sshdo - controls which commands may be executed via incoming ssh

sshdo provides an easily configurable way of controlling which commands may be executed via incoming ssh connections by specific users and specific keys. Training mode allows a key to be used for any command, while logging them. Then sshdo can learn from the logs to know what commands to allow. It can also unlearn commands that are no longer in use. This mitigates against private ssh key compromise with very little effort.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

macOS 10.6.8 10K549 i386
Xcode 3.2.6 10M2518

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
