### PR TITLE
ecl: disable any attempt to use on ppc and i386

### DIFF
--- a/_resources/port1.0/group/common_lisp-1.0.tcl
+++ b/_resources/port1.0/group/common_lisp-1.0.tcl
@@ -26,7 +26,8 @@ options common_lisp.sbcl
 default common_lisp.sbcl        yes
 
 options common_lisp.ecl
-default common_lisp.ecl         yes
+# ECL doesn't support i386 and PPC, as an easy way enable it only on 10.7+
+default common_lisp.ecl         [expr { ${os.platform} eq "darwin" && ${os.major} >= 11 }]
 
 options common_lisp.clisp
 default common_lisp.clisp       yes

--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -25,6 +25,10 @@ checksums           rmd160  631b9427edef67ea3cac91da2031ac4629a6dd33 \
                     sha256  b15a75dcf84b8f62e68720ccab1393f9611c078fcd3afdd639a1086cad010900 \
                     size    7875088
 
+# ECL seems doesn't support i386 and PowerPC
+# See: https://gitlab.com/embeddable-common-lisp/ecl/-/issues/705
+supported_archs     arm64 x86_64
+
 configure.ccache    no
 use_parallel_build  no
 universal_variant   no


### PR DESCRIPTION
#### Description

ECL seems that doesn't support i386 and PowerPC.

See: https://gitlab.com/embeddable-common-lisp/ecl/-/issues/705

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->