### PR TITLE
py-awscli2: update to 2.11.27

### DIFF
--- a/python/py-awscli2/Portfile
+++ b/python/py-awscli2/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 PortGroup           github 1.0
 
 name                py-awscli2
-github.setup        aws aws-cli 2.11.22
+github.setup        aws aws-cli 2.11.27
 revision            0
 
 categories          python devel
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  874e4d21d809c45fc66376bccc10abf0aa0c6a61 \
-                    sha256  5e2465953a74af75ad89dc8362b9003055127f920a5398d1ceb5c40ae4d4e806 \
-                    size    13342084
+checksums           rmd160  979cb4f8156232032b41b99e0764baaa0fa3dbbe \
+                    sha256  508f1ea6c959f434318aecb209ed9ddfd925c57c19f8e915b159ec6ae0026c42 \
+                    size    13447441
 
 python.versions     38 39 310 311
 python.pep517       yes

--- a/python/py-awscrt/Portfile
+++ b/python/py-awscrt/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-awscrt
 # This is only used by awscli2. Bump when Amazon bumps
 # their pinned version in awscli2's setup.cfg.
-version             0.16.18
+version             0.16.19
 revision            0
 
 categories-append   devel
@@ -19,9 +19,9 @@ long_description    {*}${description}
 
 homepage            https://aws.amazon.com/cli/
 
-checksums           rmd160  e82288c028f78bbdd6024c344d4ff12af63fd9d8 \
-                    sha256  d29cbfabd10cebc98609f7a7757e45795ad8aaa31ba47870a7950b68f2a5c281 \
-                    size    28486531
+checksums           rmd160  8c3d2d71a7f5c9b4efba32a42bace3450b8b2e07 \
+                    sha256  f514febfd9cc2b7afa3d3906cf786189a34837e321cd1fb719fbef00a78f2d65 \
+                    size    28488666
 
 python.versions     38 39 310 311
 


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.4 22F66 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
