### PR TITLE
strumpack: build dynamic lib, fix mpi variant

### DIFF
--- a/math/strumpack/Portfile
+++ b/math/strumpack/Portfile
@@ -2,14 +2,13 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           compilers 1.0
 PortGroup           github 1.0
 PortGroup           linear_algebra 1.0
 PortGroup           mpi 1.0
 
 github.setup        pghysels STRUMPACK 7.1.3 v
 name                strumpack
-revision            0
+revision            1
 categories          math science
 license             BSD
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -28,7 +27,7 @@ depends_build-append    port:util-linux
 
 compiler.cxx_standard   2014
 compiler.openmp_version 4.5
-compilers.choose        fc f90 cxx
+compilers.choose        fc f90 cc cxx
 compilers.setup         require_fortran
 
 # Do not dump all headers into a generic include:
@@ -60,9 +59,9 @@ pre-configure {
 configure.env-append \
                     GETOPT=${prefix}/bin/getopt
 
-# MPICH version builds but tests performance is questionable. For now, do not use it.
 # In order to enable Bpack, Parmetis, Zfp etc., MPICH-based build is a requirement.
 configure.args-append \
+                    -DBUILD_SHARED_LIBS=ON \
                     -DSTRUMPACK_COUNT_FLOPS=OFF \
                     -DSTRUMPACK_MESSAGE_COUNTER=OFF \
                     -DSTRUMPACK_TASK_TIMERS=OFF \
@@ -91,8 +90,19 @@ if {[string match *clang* ${configure.compiler}]} {
                     -lomp
 }
 
+# MPICH version builds but tests performance is questionable.
 if {[mpi_variant_isset]} {
     PortGroup       active_variants 1.1
+
+    # A hack until mpich-default is enabled for PPC:
+    if {${os.platform} eq "darwin" && ${os.arch} eq "powerpc"} {
+        mpi.setup   require_fortran \
+                    -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5 \
+                    -clang -fortran
+    } else {
+        mpi.setup   require_fortran \
+                    -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5
+    }
 
     depends_lib-append \
                     port:bpack \


### PR DESCRIPTION
#### Description

Build dylib. Fix mpi.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
