### PR TITLE
beets-devel: update to 20230606; beets-alternatives: update to 0.11.0

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -128,8 +128,8 @@ if {${name} eq ${subport} || "${name}-devel" eq ${subport}} {
 }
 
 subport ${name}-alternatives {
-    version         0.10.2.post1
-    revision        1
+    version         0.11.0
+    revision        0
 
     license         MIT
 
@@ -137,11 +137,19 @@ subport ${name}-alternatives {
     long_description \
                     {*}${description}
 
+    distfiles       [string map {- _} ${subport}]-${version}${extract.suffix}
+
     homepage        https://www.github.com/geigerzaehler/beets-alternatives
 
-    checksums       rmd160  832db7cf388d766671184b53e9d2a9ce2a578e7e \
-                    sha256  2ad1213b9a395233082062860a8ba165c29a4125624f7cd9a3a749ee15600bd6 \
-                    size    10943
+    checksums       rmd160  e9d5d9f79b4b677849764b66f78eb00615ffb53a \
+                    sha256  b9380301cf728864442038e1aeed5324645c7223a4b77711fd3ddbdd62c1900d \
+                    size    13757
+
+    extract.rename  yes
+
+    python.pep517   yes
+    python.pep517_backend \
+                    poetry
 }
 
 subport ${name}-amazon {

--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -39,16 +39,19 @@ if {$subport eq $name} {
 subport ${name}-devel {
     conflicts       $name
 
-    github.setup    beetbox beets 9527a07767629c1ceb99c2cd681b78172a7272a0
-    version         20230512
+    github.setup    beetbox beets 0c3f428a601cb40c5fd463791df6229d51b0635e
+    version         20230606
     revision        0
 
-    checksums       rmd160  47a9819099086969bdec29b3d3589410fb948ec3 \
-                    sha256  436410b7b886af13288d28c3a1b0ca1a95a8cb3096cdc709fdb6837f1a309b99 \
-                    size    1867798
+    checksums       rmd160  2abb8bd24e470e7fc789f861118f0185b640d3fd \
+                    sha256  367506f9c269aea252474c770d498fee0ed41b01be39eda3bea5edd3f278bff9 \
+                    size    1869560
 
     depends_build-append \
                     port:py${python.version}-sphinx
+
+    depends_lib-append \
+                    port:py${python.version}-typing_extensions
 
     post-build {
         system -W ${worksrcpath} "make -C docs SPHINXBUILD=${python.prefix}/bin/sphinx-build BUILDDIR=../ man"


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->