### PR TITLE
paramonte: do not install test binary

### DIFF
--- a/math/paramonte/Portfile
+++ b/math/paramonte/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
-PortGroup           mpi 1.0
 PortGroup           linear_algebra 1.0
+PortGroup           mpi 1.0
 
 # Using commit since release is broken: https://github.com/cdslaborg/paramonte/issues/20
 github.setup        cdslaborg paramonte 08b5ee74e1dc9045fca8fd7d94e3bbc979a3c425
 version             1.5.1
-revision            0
+revision            1
 categories          math science fortran
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -69,3 +69,9 @@ test.cmd-prepend    DYLD_LIBRARY_PATH=${prefix}/lib/libgcc:${cmake.build_dir}/ob
 # Yeah, it is a mess: data files are placed into bin, while a binary is sitting in obj. Eh.
 test.dir            ${cmake.build_dir}/test/bin
 test.target
+
+# Given how oddly everything is placed, rather not move things around and get new errors
+# but trash a test binary here, otherwise it gets installed.
+post-destroot {
+    delete ${destroot}${prefix}/var/macports/build
+}


### PR DESCRIPTION
#### Description

I vaguely recall fixing this, but here we are.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
