### PR TITLE
ecCodes: update to 2.30.2

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -5,7 +5,7 @@ PortGroup cmake     1.1
 PortGroup compilers 1.0
 
 name                ecCodes
-version             2.30.0
+version             2.30.2
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
@@ -18,9 +18,9 @@ homepage            https://confluence.ecmwf.int/display/ECC
 master_sites        https://confluence.ecmwf.int/download/attachments/45757960
 distname            eccodes-${version}-Source
 
-checksums           rmd160  f89e1ce6cc9dd256da8e8a5736095aca3e373826 \
-                    sha256  b3dc9389d05841a2e9c957aa520988a54c2605163de64b7e73c084aaed1fc3c4 \
-                    size    11961739
+checksums           rmd160  8bc64e6d2caf56d141fd5826e9e00d54dd6fecb5 \
+                    sha256  39b95e4221b116dc818656d04c82884055d48aebaa2990c259ea8cdffda42582 \
+                    size    11963700
 
 long_description \
     ecCodes is a package developed by ECMWF which provides an application programming interface and \


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.30.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4 22F66 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
