### PR TITLE
openjdk17-graalvm: update to 17.0.7

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -14,34 +14,29 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-if {${configure.build_arch} eq "arm64"} {
-    # There is no macOS aarch64 build for 22.3.2
-    version 22.3.1
-} else {
-    version 22.3.2
-}
-
-revision     0
+version     17.0.7
+revision    0
+epoch       1
 
 description  GraalVM Community Edition based on OpenJDK 17
 long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
                  JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
 
-master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
+master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
-    distname     graalvm-ce-java17-darwin-amd64-${version}
-    checksums    rmd160  c0dd0bbf1c976a1b89a749d5f28d03befde5f364 \
-                 sha256  470d538e34dc168255ee8ceadca74aab4b028ec6c699c4bd8e0226b0a7d3f155 \
-                 size    261116951
+    distname     graalvm-community-jdk-${version}_macos-x64_bin
+    checksums    rmd160  080bee211eb78ee8187a80daa1427ef6979bab4f \
+                 sha256  7b38776fc9259af5b9b02ffa21d8c7bf3991fa29bc689d6d1a10a305cd8f50af \
+                 size    284463055
 } elseif {${configure.build_arch} eq "arm64"} {
-    distname     graalvm-ce-java17-darwin-aarch64-${version}
-    checksums    rmd160  2243e23de57909f7cb6f88b51d51e623b4f0ca87 \
-                 sha256  e3307c29e71423038960c38a6f8c0525f7c6f430c494d9c16935335c291c7ce1 \
-                 size    258360745
+    distname     graalvm-community-jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  f98daabd32205fd8573d5b401e5372475dd76669 \
+                 sha256  05d9a51786c578cea346760b3ec3af3721780afb850b739407a2a123f5d081fd \
+                 size    280334645
 }
 
-worksrcdir   graalvm-ce-java17-${version}
+worksrcdir   graalvm-community-openjdk-${version}+7.1
 
 homepage     https://www.graalvm.org
 
@@ -94,46 +89,14 @@ by adding the following line to your shell profile:
 "
 
 subport ${name}-native-image {
-    depends_lib        port:${name}
-    description        Native Image component for GraalVM
-    long_description   ${description}
+    description         Former Native Image component for GraalVM
+    long_description    Native Image support is now included in ${name}. Please uninstall ${subport}.
 
-    if {${configure.build_arch} eq "x86_64"} {
-        set jar_file native-image-installable-svm-java17-darwin-amd64-${version}.jar
-        distfiles    ${jar_file}
-        checksums    rmd160  889bbd69a50db60314d2e23d4aa69a6f9c744f74 \
-                     sha256  f3325ba7fbbcb865c3cc38ee531398482344fae2dd364073391568b0e5b0a77a \
-                     size    30685976
-    } elseif {${configure.build_arch} eq "arm64"} {
-        set jar_file native-image-installable-svm-java17-darwin-aarch64-${version}.jar
-        distfiles    ${jar_file}
-        checksums    rmd160  c1fe4d16e586fd7302271c8f2a5f8bd22dd10f81 \
-                     sha256  f69cc832db03db6698b41346bbee0a58ef4a5277971b6f7629d82a8f3ae98726 \
-                     size    30569608
-    }
-
-    set java_home ${target}/Contents/Home
-
-    extract {}
-
+    destroot.violate_mtree no
     destroot {
-        xinstall -d -m 0755 ${destroot}${prefix}/share/java/${subport}
-        file copy ${distpath}/${jar_file} ${destroot}${prefix}/share/java/${subport}
+        file mkdir ${destroot}${prefix}/share/doc
+        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
     }
 
-    post-activate {
-        # Graal Updater doesn't signal errors if the component is already installed.
-        # Unfortunately, we require root privileges to invoke Graal Updater.
-        system "sudo ${java_home}/bin/gu -L install ${prefix}/share/java/${subport}/${jar_file}"
-    }
-
-    post-deactivate {
-        # This helps prevent breakage if the user removed native-image themselves
-        # and wants to deactivate or uninstall this port.
-        if {[regexp {(?i)native-image} [exec ${java_home}/bin/gu list] match]} {
-            system "sudo ${java_home}/bin/gu remove native-image"
-        }
-    }
-
-    notes "The Native Image component of GraalVM has been installed for you"
+    notes "${long_description}"
 }


### PR DESCRIPTION
#### Description

Update to GraalVM for JDK 17 Community 17.0.7. Increased the epoch version due to a versioning change.

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?