### PR TITLE
openjdk20-graalvm: new submission

### DIFF
--- a/java/openjdk20-graalvm/Portfile
+++ b/java/openjdk20-graalvm/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk20-graalvm
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        darwin
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://github.com/graalvm/graalvm-ce-builds/releases
+supported_archs  x86_64 arm64
+
+version     20.0.1
+revision    0
+
+description  GraalVM Community Edition based on OpenJDK 20
+long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
+                 JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
+
+master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     graalvm-community-jdk-${version}_macos-x64_bin
+    checksums    rmd160  564a8de20455600405b42f91e30b8e0c3a3be3d8 \
+                 sha256  0baffa8076049915c93e97f61ea9528959c6d30e9f03943c71a7b995fc73e36d \
+                 size    295385552
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     graalvm-community-jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  7cf90e8da7a36d66e31f9c7c0675cd190073a07b \
+                 sha256  be18d18f1fb805a0a3185c3eb6f08d6f7c93172025d8c8bd16c2a70b5105e28c \
+                 size    291203447
+}
+
+worksrcdir   graalvm-community-openjdk-${version}+9.1
+
+homepage     https://www.graalvm.org
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set target /Library/Java/JavaVirtualMachines/jdk-20-oracle-graalvm-community.jdk
+set destroot_target ${destroot}${target}
+
+destroot {
+    xinstall -m 755 -d ${destroot_target}
+    copy ${worksrcpath}/Contents ${destroot_target}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${target}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for GraalVM for JDK 20 Community Edition.

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?