### PR TITLE
google-cloud-sdk: update to 435.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             434.0.0
+version             435.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  c2a04c9b39459e0dbc08ca6d81938f85865e9fac \
-                    sha256  026fccdeaeee2258da79cb93934aa00f7bb68ec2dab349630fdc0e7917103d0d \
-                    size    100374368
+    checksums       rmd160  54466922cc99b5c0fe03c597768c8ca03f9bbd9d \
+                    sha256  d4b439847cdef3c7d3e7b3a184ecb51557247812665bfe7e4540de39996425f9 \
+                    size    100486137
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  f61ea422b933ca93ce960853b9f08501dd3ee98a \
-                    sha256  6e3a4c20d5abf79b8b5f3aaa9f3288774cf98b825de26c2d7d631ffdf783c83b \
-                    size    120645905
+    checksums       rmd160  30ff10bb202505c18786077c341300a59ec34a02 \
+                    sha256  e77614ae832c4b2ea625e9efe39f0b5780146ced798e01bcdf48d12778f8f638 \
+                    size    120762227
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  aba21efcf4e4566ff3b7fb9ad036278dacb9c893 \
-                    sha256  be5f1abd8ed8ee3c63ed38c6a75db887635142576e059d94e1cbaa5b49e551b7 \
-                    size    117766953
+    checksums       rmd160  52c4760e7b1998ef7960823e2ad6ef569ec4888d \
+                    sha256  02fe7816e67f43caf6f1d8d7859dc16426064112551cf02875ee3d5e21b47442 \
+                    size    117882396
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 435.0.0.

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?