### PR TITLE
ntpsec: Add variants for Python versions.

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 
 name                ntpsec
 version             1.2.2
-revision            0
+revision            1
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -36,26 +36,74 @@ if { ${os.platform} eq "darwin" && ${os.major} < 10 } {
     supported_archs     i386 ppc
 }
 
-# To avoid breaking any code that uses our Python package, keep the Python
-# version at 2.7 until we add variants for Python versions.  The upstream
-# code itself works with 2.6, 2.7, and 3.3+.
-python.versions     27
+# ntpsec requires Python 2.6, 2.7, or 3.3+.
+# We skip 2.6 and 3.3, but keep 2.7 and 3.4+.
+# Some variants may force a more restricted list.
+#
+set pythons_suffixes {27 34 35 36 37 38 39 310 311}
 
-# Note that the upstream --python option may not work correctly, so waf
-# must be run with the target Python version.  The waf PortGroup doesn't
-# currently allow selecting its Python version, but since it's hard-coded
-# for 2.7, we can ignore this for now.
+set pythons_ports {}
+foreach s ${pythons_suffixes} {
+    lappend pythons_ports python${s}
+}
 
-# Also note that the new ffi-based Python client library doesn't work properly
+foreach s ${pythons_suffixes} {
+    set p python${s}
+    set v [string index ${s} 0].[string range ${s} 1 99]
+    set i [lsearch -exact ${pythons_ports} ${p}]
+    set c [lreplace ${pythons_ports} ${i} ${i}]
+    variant ${p} description "Build ${name} to use Python ${v}" conflicts {*}${c} ""
+}
+
+# Default to +python27
+#
+# Since this port provides Python modules that may be used by users, changing
+# the Python version may break existing user code.  Since earlier versions of
+# this port had no pythonXX variant, there is no established default variant
+# to avoid such a switch on an upgrade.  Hence, the default should remain at
+# +python27 for a while.
+#
+set pyver_no_dot "27"
+
+foreach s ${pythons_suffixes} {
+    if {[variant_isset python${s}]} {
+        set pyver_no_dot ${s}
+    }
+}
+default_variants +python${pyver_no_dot}
+
+# make sure some python variant is selected
+set pyver_no_dot ""
+foreach s ${pythons_suffixes} {
+    if {[variant_isset python${s}]} {
+        set pyver_no_dot ${s}
+    }
+}
+pre-fetch {
+    if {${pyver_no_dot} eq ""} {
+        ui_error "\n\nYou must select one of the Python variants (+pythonXY).\n"
+    return -code error "Invalid Python variant selection"
+    }
+}
+
+python.version          ${pyver_no_dot}
+waf.python_branch       ${python.branch}
+
+# Avoid treating python311+ differently from earlier versions.
+# In particular, avoid clobbering destroot.target and adding superfluous
+# dependencies.
+python.pep517       no
+
+# Note that the new ffi-based Python client library doesn't work properly
 # on the Mac, so we use the old extension-based version.
 
 openssl.branch      3
 # NOTE: doesn't work with libressl
 
 depends_build-append port:bison port:pkgconfig
-depends_lib-append  port:python${python.version}
+#depends_lib-append  port:python${pyver_no_dot}
 
-# Consolidated patchfile, based on GitHub/fhgwwight/macports-releases
+# Consolidated patchfile, based on GitHub/fhgwright/macports-releases
 patchfiles          patch-allfixes.diff
 
 use_configure       yes
@@ -68,6 +116,7 @@ configure.args      --alltests \
                     --pyshebang=${python.bin} \
                     --pythondir=${python.pkgd} \
                     --pythonarchdir=${python.pkgd}
+
 # Make sure we use waf, not setup.py for build
 build.cmd           ${waf.python} ./waf
 destroot.cmd        ${build.cmd}
@@ -75,6 +124,8 @@ destroot.cmd        ${build.cmd}
 # Although the normal build procedure includes the tests, we also allow
 # them separately so that "port test" works.
 test.run            yes
+# Avoid unnecessary dependency on pyXX-test
+python.test_framework
 # Override the python portgroup's inappropriate test.cmd
 test.cmd            ${build.cmd}
 test.target         check
@@ -111,6 +162,10 @@ post-destroot {
     destroot.keepdirs \
         ${destroot}${prefix}/var/db \
         ${destroot}${prefix}/var/run
+
+    # The install script inappropriately installs the runtests program
+    # See https://gitlab.com/NTPsec/ntpsec/-/issues/786
+    delete "${destroot}${prefix}/bin/runtests"
 }
 post-activate {
     if {![file exists ${prefix}/etc/ntp.conf]} {


### PR DESCRIPTION
This implements pythonXY variants to allow choosing the Python version.  The default remains +python27 for now, as noted.

Having subports for each Python version would be better, but is more work, so for now only one version at a time can be selected.

Closes: https://trac.macports.org/ticket/63955

Also removes the erroneously installed 'runtests' program.

Also removes the unnecessary dependency on py-test.

This gets a revbump due to the 'runtests' removal, as well as due to the registry update for the new variants.

TESTED:
Built and ran tests with all variants on 10.4-10.5 ppc, 10.4-10.6 i386, 10.6-10.15 x86_64, and 11.x-13.x arm64.  Successful except where pythonXY was unavailable or broken on the OS/CPU combination.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.7 20G1345, arm64, Xcode 13.2.1 13C100
macOS 12.6.6 21G646, arm64, Xcode 14.2 14C18
macOS 13.4 22F66, arm64, Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
