### PR TITLE
toot: update to 0.36.0

### DIFF
--- a/net/toot/Portfile
+++ b/net/toot/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        ihabunek toot 0.28.0
+github.setup        ihabunek toot 0.36.0
 github.tarball_from archive
 revision            0
 
@@ -19,11 +19,11 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 platforms           darwin
 
-checksums           rmd160  1a37dbb29f5eeb091842ab4122f5c94bed386f17 \
-                    sha256  398d567761a71cf29702b80ae61c5502201570206341ae8a82ca364f78b9054b \
-                    size    605965
+checksums           rmd160  2dfb0fb86bfb0e3ef53e641703d4c4aef45e62ff \
+                    sha256  0aa554154d3a784e5e2345a8a2df9a90b877de6d888419194968807c942c7d73 \
+                    size    893951
 
-python.default_version      39
+python.default_version 311
 
 test.run            yes
 test.env-append     PYTHONPATH=${worksrcpath}/build/lib


### PR DESCRIPTION
#### Description

updated package version and bumped python default version

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?