### PR TITLE
duckdb: fix build with gcc

### DIFF
--- a/databases/duckdb/Portfile
+++ b/databases/duckdb/Portfile
@@ -40,3 +40,12 @@ compiler.cxx_standard 2011
 depends_build-append \
                     port:pkgconfig \
                     port:zstd
+
+if {[string match *gcc* ${configure.compiler}]} {
+    # Without the following setting, the build fails miserably at linking with every possible symbol undefined.
+    # Undefined symbols: __ZNK6duckdb5Value14GetValueUnsafeItEET_v, __ZN6duckdb11LogicalType3MAPES0_S0_ etc.
+    configure.args-append \
+                    -DEXTENSION_STATIC_BUILD=TRUE
+    configure.ldflags-append \
+                    -latomic
+}


### PR DESCRIPTION
#### Description

@herbygillot I have found a fix for it. Turns out, it needs the same setting which is used on Linux (apparently for the same reason).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
