### PR TITLE
lrslib: fix build on 32bit system

### DIFF
--- a/math/lrslib/Portfile
+++ b/math/lrslib/Portfile
@@ -2,16 +2,15 @@
 
 PortSystem              1.0
 PortGroup               makefile 1.0
+PortGroup               muniversal 1.1
+PortGroup               compiler_blacklist_versions 1.0
 
 name                    lrslib
 version                 7.2
-revision                1
+revision                2
 
 categories              math
 license                 GPL-2+
-
-# lrslib requires __int128 aka long long
-supported_archs         arm64 ppc64 x86_64
 
 maintainers             {@catap korins.ky:kirill} openmaintainer
 
@@ -42,8 +41,22 @@ post-extract {
     move ${worksrcpath}/makefile ${worksrcpath}/Makefile
 }
 
+compiler.blacklist-append \
+                    *gcc-3.* *gcc-4.* {clang < 500}
+
+patchfiles-append   patch-override-CC.diff
+
+# Follow the instruction to build in 32bit mode on 32bit arch
+if { ${configure.build_arch} in [list i386 ppc] } {
+    patchfiles-append \
+                    patch-build-32bit-mode.diff
+}
+
 platform darwin {
     post-patch {
+        # Use MacPorts prefix instead /usr/local
+        reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/Makefile
+
         # Darwin requires different arguments to build dynamic libraries
         reinplace "s|-shared -Wl,-soname=|-dynamiclib -install_name ${prefix}/lib/|" ${worksrcpath}/Makefile
 

--- a/math/lrslib/files/patch-build-32bit-mode.diff
+++ b/math/lrslib/files/patch-build-32bit-mode.diff
@@ -1,0 +1,35 @@
+diff --git Makefile Makefile
+index 217b4c2..ae6dff0 100644
+--- Makefile
++++ Makefile
+@@ -45,12 +45,12 @@ mpicxx=mpicc
+ 
+ # for 32 bit machines
+ 
+-# BITS=
+-# MPLRSOBJ2=
++BITS=
++MPLRSOBJ2=
+ 
+ # for 64 bit machines
+-BITS=-DB128
+-MPLRSOBJ2=lrslib2-mplrs.o lrslong2-mplrs.o
++# BITS=-DB128
++# MPLRSOBJ2=lrslib2-mplrs.o lrslong2-mplrs.o
+ 
+ 
+ LRSOBJ=lrs.o lrslong1.o lrslong2.o lrslib1.o lrslib2.o lrslibgmp.o lrsgmp.o lrsdriver.o
+@@ -216,11 +216,11 @@ SOMINOR ?=.0.0
+ SHLIB ?=$(SONAME)$(SOMINOR)
+ SHLINK ?=liblrs.so
+ 
+-SHLIBOBJ2=lrslib2-shr.o lrslong2-shr.o
++# SHLIBOBJ2=lrslib2-shr.o lrslong2-shr.o
+ 
+ # for 32 bit machines
+ 
+-# SHLIBOBJ2=
++SHLIBOBJ2=
+ 
+ SHLIBOBJ=lrslong1-shr.o lrslib1-shr.o  \
+ 	lrslibgmp-shr.o lrsgmp-shr.o lrsdriver-shr.o \

--- a/math/lrslib/files/patch-override-CC.diff
+++ b/math/lrslib/files/patch-override-CC.diff
@@ -1,0 +1,13 @@
+diff --git Makefile Makefile
+index 217b4c2..de6a48c 100644
+--- Makefile
++++ Makefile
+@@ -6,7 +6,7 @@
+ # add -DSIGNALS if your compiler does *not* support <signal.h> <unistd.h>
+ 
+ #try uncommenting next line if cc is the default C compiler
+-CC = gcc      # or gcc7
++CC ?= gcc      # or gcc7
+ 
+ default: lrs lrsgmp lrsnash checkpred inedel 
+ 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

as `lrslib +universal` which produces:

```
/opt/local/lib/liblrs.dylib: Mach-O universal binary with 2 architectures
/opt/local/lib/liblrs.dylib (for architecture ppc7400):	Mach-O dynamically linked shared library ppc
/opt/local/lib/liblrs.dylib (for architecture i386):	Mach-O dynamically linked shared library i386

```


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->