### PR TITLE
icu-devel{,-docs}: update to 73.2

### DIFF
--- a/devel/icu-devel/Portfile
+++ b/devel/icu-devel/Portfile
@@ -23,8 +23,8 @@ set my_name         icu
 # Please confirm that all ports and its subport can be build. To find the list, use:
 #  port file all | sort -u | xargs grep -El ':icu( |$)' | rev | cut -d / -f 2 | rev | xargs port info --name --subport | cut -d : -f 2 | tr ',' ' ' | grep -v '\-\-' | tr ' ' '\n' | sort -u
 
-version             73.1
-revision            2
+version             73.2
+revision            0
 epoch               1
 subport             ${name}-docs         { revision 0 }
 subport             ${name}-lx           { revision 0 }
@@ -67,9 +67,9 @@ if {${subport} eq ${name} || ${subport} eq "${name}-lx"} {
     worksrcdir          icu/source
 
     # please also update the icu-docs checksums at the bottom of the Portfile
-    checksums           rmd160  0ff3bac0a432a0685c649884ee978f39bc71af57 \
-                        sha256  a457431de164b4aa7eca00ed134d00dfbf88a77c6986a10ae7774fc076bb8c45 \
-                        size    26512935
+    checksums           rmd160  d8ff2467ab4785ca27910050fbac642d3985a3fd \
+                        sha256  818a80712ed3caacd9b652305e01afc7fa167e6f2e94996da44b90c2ab604ce1 \
+                        size    26519906
 
     # use full pathnames to libraries in tools
     patchfiles-append   patch-i18n-formatted_string_builder.h.diff
@@ -106,12 +106,12 @@ if {${subport} eq ${name} || ${subport} eq "${name}-lx"} {
         }
         foreach dir ${dirs} {
             # Remove architecture-specific differences to allow merging. (See footnote 3).
-            reinplace {s| -DSIZEOF_VOID_P=[48]||g}              ${dir}/config/Makefile.inc \
-                                                                ${dir}/config/icu-config
-            reinplace -E {s| -arch +[^ ]+||g}                   ${dir}/config/pkgdata.inc
-            reinplace {s|host=\".*\"|host=\"\"|g}               ${dir}/config/icu-config
-            reinplace {s|host_alias=\".*\"|host_alias=\"\"|g}   ${dir}/config/icu-config
-            reinplace {s|host_cpu=\".*\"|host_cpu=\"\"|g}       ${dir}/config/icu-config
+            reinplace -q {s| -DSIZEOF_VOID_P=[48]||g}               ${dir}/config/Makefile.inc \
+                                                                    ${dir}/config/icu-config
+            reinplace -q -E {s| -arch +[^ ]+||g}                    ${dir}/config/pkgdata.inc
+            reinplace -q {s|host=\".*\"|host=\"\"|g}                ${dir}/config/icu-config
+            reinplace -q {s|host_alias=\".*\"|host_alias=\"\"|g}    ${dir}/config/icu-config
+            reinplace -q {s|host_cpu=\".*\"|host_cpu=\"\"|g}        ${dir}/config/icu-config
         }
     }
 
@@ -184,9 +184,9 @@ if {${subport} eq "${name}-docs"} {
 
     use_zip                 yes
     distname                icu4c-[string map {. _} [string map {.rc rc} ${version}]]-docs
-    checksums               rmd160  fe544d809270eee6d5aa7b15c714ef23db31e4a9 \
-                            sha256  296dbf8113f4269ec0e057c3c2148e758137dad92672706996e100d01f628617 \
-                            size    8516388
+    checksums               rmd160  bb3829f8c7ede7f6e427a7fd052f1fcf89de77c7 \
+                            sha256  99d74b537961fa7eba2a3db8735e77060fc5ee1e8ce865d3ab53de6425285614 \
+                            size    8517399
 
     extract.dir             ${worksrcpath}/doc/html
     use_configure           no


### PR DESCRIPTION
#### Description

This is planned and minor update of icu. It doesn't change API and quite safe.

Anyway, to be on very safe side I've updated only `icu-devel` port, and will update `icu` in 1 week that makes a room to test it by anyone who uses `icu-devel` as main port.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->