### PR TITLE
clang_dependency PG: switch to clang-11-bootstrap

### DIFF
--- a/_resources/port1.0/group/clang_dependency-1.0.tcl
+++ b/_resources/port1.0/group/clang_dependency-1.0.tcl
@@ -1,14 +1,45 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 # This portgroup is to help prevent circular dependencies for ports that
-# recent clang builds depend on, by blacklisting all 5+ clang compilers.
+# recent clang builds depend on, switching it to clang-11-bootstrap
 
-# call this if an older clang version depends on the port
-proc clang_dependency.extra_versions {versions} {
-    global prefix
-    foreach ver $versions {
-        compiler.blacklist-append macports-clang-${ver}
+proc clang_dependency.clang_bootstrap {} {
+    global os.platform os.major prefix configure.compiler
+
+    # When MacPorts decided to use MacPorts clang replace it to
+    # clang-11-bootstrap when it possible, to break circular dependencies.
+    if {[regexp {macports-clang-(.*)} ${configure.compiler} -> clang_v]} {
+
+        # detects when decided clang is already installed
+        if {![catch {lindex [registry_active clang-${clang_v}] 0}]} {
+            ui_debug "${configure.compiler} is installed, do not replace by clang-11-bootstrap"
+            return
+        }
+
+        # clang-11-bootstrap can build clang up to 15,
+        # future clang / llvm may requires future patches.
+        if {[vercmp ${clang_v} 15] >= 0} {
+            ui_debug "clang-11-bootstrap can't replace ${configure.compiler}"
+            return
+        }
+
+        ui_debug "Replace ${configure.compiler} by clang-11-bootstrap"
+
+        depends_build-delete    port:clang-${clang_v}
+        depends_build-append    port:clang-11-bootstrap
+        depends_skip_archcheck-append \
+                                clang-11-bootstrap
+        configure.cc            ${prefix}/libexec/clang-11-bootstrap/bin/clang
+        configure.cxx           ${prefix}/libexec/clang-11-bootstrap/bin/clang++
+
+        if {${os.major} < 11} {
+            configure.env-append \
+                                AR=${prefix}/libexec/clang-11-bootstrap/bin/llvm-ar \
+                                RANLIB=${prefix}/libexec/clang-11-bootstrap/bin/llvm-ranlib
+        }
     }
 }
 
-clang_dependency.extra_versions {devel 16 15 14 13 12 11 10 9.0 8.0 7.0 6.0 5.0}
+clang_dependency.clang_bootstrap
+
+port::register_callback clang_dependency.clang_bootstrap

--- a/archivers/xz/Portfile
+++ b/archivers/xz/Portfile
@@ -87,10 +87,6 @@ extract.suffix      .tar.xz
 extract.cmd         \$\{prefix\}/libexec/${subport}/bin/xz
 "
 }
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    # This port is in the dependency chain for clang 3.7 and later
-    clang_dependency.extra_versions 3.7
-}
 
 # the internal "check.h" header conflicts with port check's <check.h>
 configure.cppflags -I${worksrcpath}/src/liblzma/check -I${prefix}/include

--- a/databases/db48/Portfile
+++ b/databases/db48/Portfile
@@ -30,11 +30,6 @@ checksums       md5     f80022099c5742cd179343556179aa8c \
                 sha1    ab36c170dda5b2ceaad3915ced96e41c6b7e493c \
                 rmd160  dd2fcd4c9b857a91e2f491fd4fadb0c51b993a9c
 
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    # This port is in the dependency chain for clang 3.7 and later
-    clang_dependency.extra_versions 3.7
-}
-
 patchfiles      patch-dbinc_atomic.h patch-dist_configure.diff
 
 # Don't link with "-flat_namespace -undefined suppress" on Yosemite and

--- a/databases/gdbm/Portfile
+++ b/databases/gdbm/Portfile
@@ -29,11 +29,6 @@ checksums           rmd160  8a9e35d4e0eae3e7927b0f1fdb627ebfe7e4179b \
                     sha256  74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd \
                     size    1115854
 
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    # This port is in the dependency chain for clang 3.7 and later
-    clang_dependency.extra_versions 3.7
-}
-
 # https://trac.macports.org/ticket/63393
 patchfiles-append   patch-gdbm.h-tiger-stdio-no-offt.diff
 

--- a/databases/sqlite3/Portfile
+++ b/databases/sqlite3/Portfile
@@ -37,11 +37,6 @@ depends_lib         port:libedit \
                     port:ncurses \
                     port:zlib
 
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    # This port is in the dependency chain for clang 3.7 and later
-    clang_dependency.extra_versions 3.7
-}
-
 if {${subport} ne "${name}-tools"} {
     configure.checks.implicit_function_declaration.whitelist-append strchr
 

--- a/devel/cmake-bootstrap/Portfile
+++ b/devel/cmake-bootstrap/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           clang_dependency 1.0
 PortGroup           muniversal 1.0
 
 name                cmake-bootstrap

--- a/devel/gettext/Portfile
+++ b/devel/gettext/Portfile
@@ -26,11 +26,6 @@ if {${subport} in "${name} ${name}-tools-libs"} {
     compiler.blacklist-append   {clang >= 600 < 700}
 }
 
-# Also needed by later clangs.
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    clang_dependency.extra_versions 3.7
-}
-
 patch.dir               ${worksrcpath}
 
 configure.args-append   ac_cv_prog_AWK=/usr/bin/awk \

--- a/devel/gperf/Portfile
+++ b/devel/gperf/Portfile
@@ -25,10 +25,5 @@ installs_libs   no
 
 configure.args  --infodir=${prefix}/share/info
 
-# Also needed by later clangs.
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    clang_dependency.extra_versions 3.7
-}
-
 test.run        yes
 test.target     check

--- a/devel/libedit/Portfile
+++ b/devel/libedit/Portfile
@@ -28,11 +28,6 @@ checksums           rmd160  fe125a8fc1881c86a551cbda966b02d9591807fa \
 
 depends_lib         port:ncurses
 
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    # This port is required by clang 3.7 and later
-    clang_dependency.extra_versions 3.7
-}
-
 # rename man files to avoid conflict with readline
 patchfiles-append   doc__Makefile.in.patch
 

--- a/devel/ncurses/Portfile
+++ b/devel/ncurses/Portfile
@@ -23,11 +23,6 @@ checksums       rmd160 a8b6ef8fe778c87ffdd3e0f3199c156c47b8dc39 \
 # hex.diff from https://opensource.apple.com/source/ncurses/ncurses-57/patches.applied/
 patchfiles      hex.diff
 
-# Also needed by later clangs.
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    clang_dependency.extra_versions 3.7
-}
-
 configure.cppflags
 configure.ldflags
 configure.args  --enable-widec \

--- a/devel/pkgconfig/Portfile
+++ b/devel/pkgconfig/Portfile
@@ -35,11 +35,6 @@ patchfiles          patch-glib-configure.diff \
 
 set docdir          ${prefix}/share/doc/${name}
 
-# Also needed by later clangs.
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    clang_dependency.extra_versions 3.7
-}
-
 conflicts_build     libuuid
 
 # garray.c:1808: internal compiler error: Abort trap

--- a/devel/readline/Portfile
+++ b/devel/readline/Portfile
@@ -48,11 +48,6 @@ checksums        ${patchname}-001 \
                  sha256  3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35 \
                  size    3043952
 
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    # This port is in the dependency chain for clang 3.7 and later
-    clang_dependency.extra_versions 3.7
-}
-
 configure.args  --with-curses
 configure.universal_args-delete --disable-dependency-tracking
 configure.checks.implicit_function_declaration.whitelist-append strchr

--- a/lang/python27/Portfile
+++ b/lang/python27/Portfile
@@ -104,10 +104,6 @@ subport ${name}-bootstrap {
                         built by the full ${name} port: gdbm, hashlib, locale, sqlite3, ssl"
     }
 }
-# Also needed by later clangs.
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    clang_dependency.extra_versions 3.7
-}
 
 configure.args-append \
                     --enable-framework=${frameworks_dir} \

--- a/textproc/libiconv/Portfile
+++ b/textproc/libiconv/Portfile
@@ -32,11 +32,6 @@ depends_skip_archcheck  perf
 
 patchfiles              patch-src-Makefile.in-darwin.diff
 
-# Also needed by later clangs.
-if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
-    clang_dependency.extra_versions 3.7
-}
-
 configure.checks.implicit_function_declaration.whitelist-append strchr
 configure.cmd-prepend   mv Makefile.devel Makefile.devel.orig \
                         && sed -E {"s|^(CFLAGS *=).*|\1 $CFLAGS|"} < Makefile.devel.orig \


### PR DESCRIPTION
#### Description

Instead of blacklisting all clangs I've enforced to use clang-11-bootstrap on all systems which ships with something older which can't be used by system to build port which is kept inside clang bootstrap cycle.

Anyway, I've replaced compiler only if desire one isn't available and if desired was MacPorts clang in accepted list of versions.

This dramatically decrease number of compilers which needs to be build on old system.

Thus, clang-11-bootstrap contains all necessary patches to be able to build LLVM/Clang up to 15 (tested), and probably 16 (untested).

P.S. I've used this approach on my test machines for almost a year, and seems that it works very well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->