### PR TITLE
ruby-build: Update to 20230615

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230614 v
+github.setup        rbenv ruby-build 20230615 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  dba9ebfc8c7929a6c1fae7d570c3372e5def5cfa \
-                    sha256  d29105bd92395d1f67e050c1fd10586bd90599b18e1499efa14addeb1334c0d6 \
-                    size    79989
+checksums           rmd160  21894bad49a1421fcc4a5790085f0c55d0ccb595 \
+                    sha256  5407ebc6431b4d6708a10bf817e70d84131574309766a5eea7c49fce48d611b7 \
+                    size    80376
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Upstream changelog:

```
- Print a message about the new distribution and license when installing
  TruffleRuby 23.0 by @eregon in #2209
```

This new message is:

> TruffleRuby+GraalVM 23.0 and later installed by ruby-build use the
> faster Oracle GraalVM distribution Oracle GraalVM uses the GFTC license,
> which is free for development and production use, see
> https://medium.com/graalvm/161527df3d76


###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?