### PR TITLE
R: small follow-up on today’s packages

### DIFF
--- a/R/R-AnnotationDbi/Portfile
+++ b/R/R-AnnotationDbi/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor AnnotationDbi 1.62.0
+R.setup             github Bioconductor AnnotationDbi f754ee6b67de7ef14e02f5a14df740e4a6cefa8f
+version             1.63.1
 revision            0
 maintainers         nomaintainer
 license             Artistic-2
 description         Manipulation of SQLite-based annotations in Bioconductor
 long_description    {*}${description}
-checksums           rmd160  0669f6dbc063523c8aa957b45af9dbb4b072675b \
-                    sha256  dc1fea5e9952215cd78985ce8303213bcb7967112f417dd58392b1d75b50087a \
-                    size    4359322
+checksums           rmd160  4fcc294f8837aad00100d3500531b044a3c8eb8d \
+                    sha256  9dd07a7d6284f41772bd5a646bd451a4b085cae1a8a9045904c58fdd0bcb6a5d \
+                    size    3931735
 supported_archs     noarch
 
 depends_lib-append  port:R-Biobase \

--- a/R/R-KEGGREST/Portfile
+++ b/R/R-KEGGREST/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor KEGGREST 1.40.0
+R.setup             github Bioconductor KEGGREST b810cd1e0899690b151166925898384ba80768c1
+version             1.41.0
 revision            0
 maintainers         nomaintainer
 license             Artistic-2
 description         Client-side REST access to the Kyoto Encyclopedia of Genes and Genomes (KEGG)
 long_description    {*}${description}
-checksums           rmd160  90bc3a50b40f9abddc6279c8fa010e3a28688c7a \
-                    sha256  6b2d9875de2fe11fadbe2a7321d5c12b736514112d743b5002988d887899bafe \
-                    size    21823
+checksums           rmd160  198d492a273fd540fd5c053017e7e16bab5304b4 \
+                    sha256  027f1eb1c90aec8105d6f1b6925b7bdad973b72b8bf69a7433daeaa9f7712286 \
+                    size    15027
 supported_archs     noarch
 
 depends_lib-append  port:R-Biostrings \

--- a/R/R-ebTobit/Portfile
+++ b/R/R-ebTobit/Portfile
@@ -19,7 +19,3 @@ depends_lib-append  port:R-Rcpp \
                     port:R-RcppParallel
 
 compilers.setup     require_fortran
-
-depends_test-append port:R-REBayes
-
-test.run            yes

--- a/R/R-gpboost/files/patch-unbreak-openmp.diff
+++ b/R/R-gpboost/files/patch-unbreak-openmp.diff
@@ -4,7 +4,7 @@
  if test `uname -s` = "Darwin"
  then
      OPENMP_CXXFLAGS='-Xclang -fopenmp'
-+if clang --version | grep -i "clang" > dev/null; then
++if clang --version | grep -i "clang" >/dev/null; then
      OPENMP_LIB='-lomp'
 +fi
      ac_pkg_openmp=no

--- a/R/R-lightgbm/files/patch-unbreak-openmp.diff
+++ b/R/R-lightgbm/files/patch-unbreak-openmp.diff
@@ -4,7 +4,7 @@
  if test `uname -s` = "Darwin"
  then
      OPENMP_CXXFLAGS='-Xclang -fopenmp'
-+if clang --version | grep -i "clang" > dev/null; then
++if clang --version | grep -i "clang" >/dev/null; then
      OPENMP_LIB='-lomp'
 -
 +fi

--- a/R/R-manynet/Portfile
+++ b/R/R-manynet/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran snlab-ch manynet 0.1.1
+revision            0
+categories-append   math
+maintainers         nomaintainer
+license             MIT
+description         Many ways to make, manipulate and map myriad networks
+long_description    {*}${description}
+checksums           rmd160  3f9e26f811d99dd664802e0bb930ce54b20927fb \
+                    sha256  72a4c6d418e2a42c719aeddbde7259399f81e1468ad1f3bfd8a99abc4d9364cc \
+                    size    1506707
+supported_archs     noarch
+
+depends_lib-append  port:R-dplyr \
+                    port:R-ggplot2 \
+                    port:R-ggraph \
+                    port:R-igraph \
+                    port:R-network \
+                    port:R-tidygraph

--- a/R/R-migraph/Portfile
+++ b/R/R-migraph/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran snlab-ch migraph 0.13.2
+R.setup             cran snlab-ch migraph 1.0.0
 revision            0
 categories-append   math
 maintainers         nomaintainer
@@ -11,22 +11,19 @@ license             MIT
 description         Tools for multimodal network analysis
 long_description    {*}${description}
 homepage            https://snlab-ch.github.io/migraph
-checksums           rmd160  a1adee96c7671988401a8fb3a2d9d6839a5376c3 \
-                    sha256  fb6cc2561fb66577d2e6e10078ac2509049310b6877d968c7b4f985e59d1e51a \
-                    size    2234221
+checksums           rmd160  d6feff09eeb1dc8392a5ed7392d8efee99278c87 \
+                    sha256  4c0c10fef89b5eb8a028c5d1f51eb4920340bc156eb48ce7be4dbcc0b3cae972 \
+                    size    2085991
 supported_archs     noarch
 
-depends_lib-append  port:R-BiocManager \
-                    port:R-dplyr \
+depends_lib-append  port:R-dplyr \
                     port:R-furrr \
                     port:R-future \
                     port:R-generics \
-                    port:R-ggforce \
                     port:R-ggplot2 \
-                    port:R-ggraph \
                     port:R-igraph \
+                    port:R-manynet \
                     port:R-network \
-                    port:R-patchwork \
                     port:R-pillar \
                     port:R-purrr \
                     port:R-rlang \

--- a/R/R-tibble/Portfile
+++ b/R/R-tibble/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github tidyverse tibble 3.2.1.9004 v
+R.setup             github tidyverse tibble 3.2.1.9005 v
 revision            0
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
 description         Modern re-imagining of the data frame
 long_description    {*}${description}
 homepage            https://tibble.tidyverse.org
-checksums           rmd160  81ab843073f39acf2ad0500b7d4c04e970f059e1 \
-                    sha256  e02e316a1de2d4a737d9b11759e9d62e19a3943bd5eb650379f71d34963cfa74 \
-                    size    1231651
+checksums           rmd160  e163ac4309dba3efc752b6c1f9fcd826c8f6cf17 \
+                    sha256  352d65b5c90fe3e21cfa4e4d031ccb2c27324671bd82cfcb0b58157e09aa6204 \
+                    size    1231669
 
 depends_lib-append  port:R-fansi \
                     port:R-lifecycle \


### PR DESCRIPTION
#### Description

Few updates that did not fit.
A fix to one port, where a missing test dependency was overlooked.
Correct a minor typo in a patch (inconsequential, the patch is working as is, but this fix removes a warning).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
