### PR TITLE
ghc-bootstrap: support powerpc

### DIFF
--- a/lang/ghc-bootstrap/Portfile
+++ b/lang/ghc-bootstrap/Portfile
@@ -8,7 +8,7 @@ set canonicalname   ghc
 version             7.6.3
 revision            0
 categories          lang haskell
-maintainers         {cal @neverpanic} {@barracuda156 gmail.com:vital.had} openmaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             BSD
 # ppc64 will need cross-compilation, not enabled for now.
 supported_archs     i386 x86_64 ppc
@@ -102,57 +102,24 @@ platform darwin {
         # This is PPC:
         compiler.blacklist-append   *clang*
 
-        # gcc11 and gcc12 do not build it. Restriction to gcc7 is on purpose.
-        # BEGIN gcc variants
+        # Newer gcc do not build it. Restriction to gcc7 is on purpose.
 
-        variant gcc7 conflicts gcc6 gcc49 gcc48 gcc42 description {Compile with gcc 7} {
+        variant gcc7 conflicts gcc42 description {Compile with gcc 7} {
             configure.compiler      macports-gcc-7
             depends_run-append      port:gcc7
             require_active_variants ghc-ppc-bootstrap gcc7
             configure.args-append   --with-gcc=${configure.cc}
         }
 
-        variant gcc6 conflicts gcc7 gcc49 gcc48 gcc42 description {Compile with gcc 6} {
-            configure.compiler      macports-gcc-6
-            depends_run-append      port:gcc6
-            require_active_variants ghc-ppc-bootstrap gcc6
-            configure.args-append   --with-gcc=${configure.cc}
-        }
-
-        variant gcc49 conflicts gcc7 gcc6 gcc48 gcc42 description {Compile with gcc 4.9} {
-            configure.compiler      macports-gcc-4.9
-            depends_run-append      port:gcc49
-            require_active_variants ghc-ppc-bootstrap gcc49
-            configure.args-append   --with-gcc=${configure.cc}
-            # compiler doesn't accept -arch
-            configure.cc_archflags
-            configure.cxx_archflags
-            configure.objc_archflags
-            configure.ld_archflags
-        }
-
-        variant gcc48 conflicts gcc7 gcc6 gcc49 gcc42 description {Compile with gcc 4.8} {
-            configure.compiler      macports-gcc-4.8
-            depends_run-append      port:gcc48
-            require_active_variants ghc-ppc-bootstrap gcc48
-            configure.args-append   --with-gcc=${configure.cc}
-            # compiler doesn't accept -arch
-            configure.cc_archflags
-            configure.cxx_archflags
-            configure.objc_archflags
-            configure.ld_archflags
-        }
-
-        variant gcc42 conflicts gcc7 gcc6 gcc49 gcc48 description {Compile with Xcode gcc 4.2} {
+        variant gcc42 conflicts gcc7 description {Compile with Xcode gcc 4.2} {
             configure.compiler      gcc-4.2
             require_active_variants ghc-ppc-bootstrap gcc42
             configure.args-append   --with-gcc=${configure.cc}
         }
 
-        if {![variant_isset gcc7] && ![variant_isset gcc6] && ![variant_isset gcc49]  && ![variant_isset gcc48] && ![variant_isset gcc42]} {
+        if {![variant_isset gcc7] && ![variant_isset gcc42]} {
             default_variants +gcc42
         }
-        # END gcc variants
     }
 }
 

--- a/lang/ghc-bootstrap/Portfile
+++ b/lang/ghc-bootstrap/Portfile
@@ -5,38 +5,64 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                ghc-bootstrap
 set canonicalname   ghc
-# Note: 7.6.3 doesn't have a i386 darwin version at http://www.haskell.org/ghc/dist/7.6.3
-version             7.6.2
-revision            2
+version             7.6.3
+revision            0
 categories          lang haskell
-maintainers         {cal @neverpanic} openmaintainer
+maintainers         {cal @neverpanic} {@barracuda156 gmail.com:vital.had} openmaintainer
 license             BSD
-platforms           darwin
-supported_archs     i386 x86_64
+# ppc64 will need cross-compilation, not enabled for now.
+supported_archs     i386 x86_64 ppc
 universal_variant   no
 installs_libs       no
 
 description         The Glorious Glasgow Haskell Compilation System
-long_description    \
-                    This is a package that installs a binary \
+long_description    This is a package that installs a binary \
                     bootstrap ghc compiler.
 
-homepage            http://haskell.org/${canonicalname}
+homepage            https://haskell.org/${canonicalname}
 master_sites        ${homepage}/dist/${version}/
-distname            ${canonicalname}-${version}-${build_arch}-apple-darwin
+
+if {${configure.build_arch} in [list ppc ppc64]} {
+    distname        ${canonicalname}-${version}-src
+} else {
+    distname        ${canonicalname}-${version}-${build_arch}-apple-darwin
+}
+
 worksrcdir          ${canonicalname}-${version}
 use_bzip2           yes
 
 checksums           ${canonicalname}-${version}-i386-apple-darwin${extract.suffix} \
-                        rmd160  232b3aa4ed9e2ff09d520f4ae02fa572a671178a \
-                        sha256  c1da502fa7d99f3d87370c65d705a7e8ee4c900fdb62df6f71696c5432047059 \
+                        rmd160  aca3ff527969cfaf1e4ebcbf304dd49e264b0ad7 \
+                        sha256  b212acd6ef99df87a4a6f2fb68b1de35071527889743bbd69b9c9ab2d301b178 \
+                        size    158867690 \
                     ${canonicalname}-${version}-x86_64-apple-darwin${extract.suffix} \
-                        rmd160  b0870a4a292fae7248f9b0be485affa4a5a76a2d \
-                        sha256  eb0dd19bd5a6eede332d58de219437b9c2b186c72a1fc0c60fa1095b0c2d2789
+                        rmd160  2ed57694bcf505e13fa69a7c84a83cb49040ea0c \
+                        sha256  f7a35bea69b6cae798c5f603471a53b43c4cc5feeeeb71733815db6e0a280945 \
+                        size    151929866 \
+                    ${canonicalname}-${version}-src${extract.suffix} \
+                        rmd160  82a673ed38b7cf9a59afeb01057625fc761a822b \
+                        sha256  bd43823d31f6b5d0b2ca7b74151a8f98336ab0800be85f45bb591c9c26aac998 \
+                        size    110763823
 
-post-extract {
-    # Copy clang-wrapper for re-inplace during configure
-    xinstall -m 644 ${filespath}/clang-wrapper ${workpath}/clang-wrapper
+# There are no ready-built binaries of GHC 7.6.x for PPC. We use 7.0.4 to build 7.6.3 from source.
+platform darwin powerpc {
+    PortGroup active_variants 1.1
+
+    depends_build-append \
+                    port:ghc-ppc-bootstrap \
+                    port:libxslt
+
+    depends_lib-append \
+                    port:gmp \
+                    port:libiconv \
+                    port:ncurses
+
+    patchfiles-append \
+                    patch-configure.diff \
+                    patch-utils__mkdirhier__mkdirhier.sh.diff \
+                    patch-includes_HsFFI.h.diff \
+                    validate-settings.diff \
+                    patch-10.6.diff
 }
 
 # Compilation (of the final non-bootstrap GHC, which uses the C compiler
@@ -47,58 +73,227 @@ post-extract {
 # Also avoid LLVM GCC 4.2 and GCC 4.2, which are before MacPorts' clang 3.4
 # in the fallback list on some systems.
 compiler.blacklist-append \
+                    *gcc-4.0 \
                     llvm-gcc-4.2 \
-                    gcc-4.2 \
                     {clang < 503.0.38} \
                     macports-clang-3.3
 
-# ghc needs a build and runtime dependency on the compiler used to build it
-# same is also set in ghc-bootstrap. clang-4.0 works, is needed on older systems anyway
-# also /usr/bin/clang does not work on 10.11, so override it there
-if { ${os.platform} eq "darwin" && ( ${os.major} < 13 || ${os.major} == 15 ) } {
-    compiler.whitelist    macports-clang-8.0
-    depends_run-append    port:clang-8.0
+if {${configure.build_arch} ni [list ppc ppc64]} {
+    # There seems to be no reason to blacklist this, since it should work on every released version of macOS where present,
+    # and has been reported to work, but since the port was set up this way earlier, we retain it.
+    compiler.blacklist-append \
+                    *gcc-4.2
 }
 
-configure.pre_args  --prefix=${prefix}/share/ghc-bootstrap
-configure.args      --with-gcc=${configure.cc}
+platform darwin {
+    if {${configure.build_arch} ni [list ppc ppc64]} {
+        post-extract {
+            # Copy clang-wrapper for re-inplace during configure
+            xinstall -m 644 ${filespath}/clang-wrapper ${workpath}/clang-wrapper
+        }
+        # ghc needs a build and runtime dependency on the compiler used to build it.
+        # Same is also set in ghc-bootstrap. clang-9.0 works, is needed on older systems anyway.
+        # Also /usr/bin/clang does not work on 10.11, so override it there.
+        if {${os.major} < 13 || ${os.major} == 15} {
+            depends_run-append      port:clang-9.0
+            compiler.whitelist      macports-clang-9.0
+        }
+    } else {
+        # This is PPC:
+        compiler.blacklist-append   *clang*
 
-pre-configure {
-    # OK so because this binary has been prebuilt for libraries
-    # in /usr/lib we search these before macports stuff so (hopefully)
-    # weird things don't happen
-    configure.ldflags  -L/usr/lib
-    configure.cppflags -I/usr/include
+        # gcc11 and gcc12 do not build it. Restriction to gcc7 is on purpose.
+        # BEGIN gcc variants
 
-    # patch clang-wrapper and make sure it is used by patching settings.in
-    reinplace "s#@clang@#${configure.cc}#g" ${workpath}/clang-wrapper
-    reinplace "s#@SettingsCCompilerCommand@#${prefix}/share/ghc-bootstrap/libexec/clang-wrapper#g" ${worksrcpath}/settings.in
+        variant gcc7 conflicts gcc6 gcc49 gcc48 gcc42 description {Compile with gcc 7} {
+            configure.compiler      macports-gcc-7
+            depends_run-append      port:gcc7
+            require_active_variants ghc-ppc-bootstrap gcc7
+            configure.args-append   --with-gcc=${configure.cc}
+        }
+
+        variant gcc6 conflicts gcc7 gcc49 gcc48 gcc42 description {Compile with gcc 6} {
+            configure.compiler      macports-gcc-6
+            depends_run-append      port:gcc6
+            require_active_variants ghc-ppc-bootstrap gcc6
+            configure.args-append   --with-gcc=${configure.cc}
+        }
+
+        variant gcc49 conflicts gcc7 gcc6 gcc48 gcc42 description {Compile with gcc 4.9} {
+            configure.compiler      macports-gcc-4.9
+            depends_run-append      port:gcc49
+            require_active_variants ghc-ppc-bootstrap gcc49
+            configure.args-append   --with-gcc=${configure.cc}
+            # compiler doesn't accept -arch
+            configure.cc_archflags
+            configure.cxx_archflags
+            configure.objc_archflags
+            configure.ld_archflags
+        }
+
+        variant gcc48 conflicts gcc7 gcc6 gcc49 gcc42 description {Compile with gcc 4.8} {
+            configure.compiler      macports-gcc-4.8
+            depends_run-append      port:gcc48
+            require_active_variants ghc-ppc-bootstrap gcc48
+            configure.args-append   --with-gcc=${configure.cc}
+            # compiler doesn't accept -arch
+            configure.cc_archflags
+            configure.cxx_archflags
+            configure.objc_archflags
+            configure.ld_archflags
+        }
+
+        variant gcc42 conflicts gcc7 gcc6 gcc49 gcc48 description {Compile with Xcode gcc 4.2} {
+            configure.compiler      gcc-4.2
+            require_active_variants ghc-ppc-bootstrap gcc42
+            configure.args-append   --with-gcc=${configure.cc}
+        }
+
+        if {![variant_isset gcc7] && ![variant_isset gcc6] && ![variant_isset gcc49]  && ![variant_isset gcc48] && ![variant_isset gcc42]} {
+            default_variants +gcc42
+        }
+        # END gcc variants
+    }
 }
 
-build {}
+configure.pre_args      --prefix=${prefix}/share/ghc-bootstrap
 
-post-destroot {
-    # install clang-wrapper to libexec
-    xinstall -d -m 755 ${destroot}${prefix}/share/ghc-bootstrap/libexec
-    xinstall -m 755 ${workpath}/clang-wrapper ${destroot}${prefix}/share/ghc-bootstrap/libexec
+platform darwin {
+    if {${configure.build_arch} ni [list ppc ppc64]} {
+        pre-configure {
+            # OK so because this binary has been prebuilt for libraries in /usr/lib
+            # We search these before macports stuff so (hopefully) weird things don't happen
+            configure.ldflags  -L/usr/lib
+            configure.cppflags -I/usr/include
 
-    # Delete all .dylib files, because their load commands would have to be
-    # fixed or rev-upgrade complains and tries to rebuild the port. However, we
-    # cannot correctly fix all .dylibs, because the have not been built with
-    # -headerpad_max_install_names. Deleting them fixes the problem and GHC
-    # still seems to compile correctly.
+            # patch clang-wrapper and make sure it is used by patching settings.in
+            reinplace "s#@clang@#${configure.cc}#g" ${workpath}/clang-wrapper
+            reinplace "s#@SettingsCCompilerCommand@#${prefix}/share/ghc-bootstrap/libexec/clang-wrapper#g" ${worksrcpath}/settings.in
+        }
 
-    # We also delete all the .html files, because we really don't need the
-    # documentation in a bootstrap port.
+        build {}
+    } else {
+        # Here we ghc-ppc-bootstrap port to build GHC.
+        # The build is quite fragile; do not modify settings unnecessarily.
+        set bootstraproot ${prefix}/share/ghc-ppc-bootstrap
 
-    fs-traverse f ${destroot}${prefix} {
-        if {[file isfile ${f}]} {
-            set ext [file extension ${f}]
-            if {${ext} eq ".html" || ${ext} eq ".dylib"} {
-                delete ${f}
+        configure.args-append \
+                    --with-ghc=${bootstraproot}/bin/ghc \
+                    --with-iconv-includes=${prefix}/include \
+                    --with-iconv-libraries=${prefix}/lib \
+                    --with-gmp-includes=${prefix}/include \
+                    --with-gmp-libraries=${prefix}/lib \
+                    --with-macosx-deployment-target=${macosx_deployment_target}
+
+        # OK so because the bootstrap binary has been prebuilt for libraries
+        # in /usr/lib we search these before macports stuff to prevent
+        # link errors, ghc _should_ actually compile itself in stage2
+        # using paths from the command line arguments
+        compiler.cpath          /usr/include
+        compiler.library_path   /usr/lib
+    }
+}
+
+platform darwin {
+    if {${configure.build_arch} ni [list ppc ppc64]} {
+        post-destroot {
+            # install clang-wrapper to libexec
+            xinstall -d -m 755 ${destroot}${prefix}/share/ghc-bootstrap/libexec
+            xinstall -m 755 ${workpath}/clang-wrapper ${destroot}${prefix}/share/ghc-bootstrap/libexec
+
+            # Delete all .dylib files, because their load commands would have to be
+            # fixed or rev-upgrade complains and tries to rebuild the port. However,
+            # we cannot correctly fix all .dylibs, because the have not been built
+            # with -headerpad_max_install_names. Deleting them fixes the problem
+            # and GHC still seems to compile correctly.
+
+            # We also delete all the .html files, because we really don't need
+            # the documentation in a bootstrap port.
+
+            fs-traverse f ${destroot}${prefix} {
+                if {[file isfile ${f}]} {
+                    set ext [file extension ${f}]
+                    if {${ext} eq ".html" || ${ext} eq ".dylib"} {
+                        delete ${f}
+                    }
+                }
             }
+        }
+    } else {
+        post-destroot {
+            set prefixlib   ${prefix}/share/ghc-bootstrap/lib/${worksrcdir}
+            set destlib     ${destroot}/${prefixlib}
+            set libver      ${canonicalname}${version}
+
+            variable libs [ list                               \
+                            libHSrts-${libver}.dylib           \
+                            libHSrts_debug-${libver}.dylib     \
+                            libHSrts_thr-${libver}.dylib       \
+                            libHSrts_thr_debug-${libver}.dylib ]
+
+            system "install_name_tool -id ${prefixlib}/libffi.dylib ${destlib}/libffi.dylib"
+
+            foreach lib $libs {
+              regexp -line {[^[:space:]]*/libffi.*\.dylib} [exec otool -L ${destlib}/${lib}] oldlib
+              system "install_name_tool -change ${oldlib} ${prefixlib}/libffi.dylib ${destlib}/$lib"
+            }
+        }
+
+        pre-activate {
+            # Legacy port deactivation hack added 2012-12-08
+            if {![catch {set platform_ghc_installed [lindex [registry_active hs-platform-ghc] 0]}]} {
+                # hs-platform-ghc is installed and active
+                # force deactivation
+                registry_deactivate_composite hs-platform-ghc "" [list ports_nodepcheck 1]
+            }
+            # Legacy port deactivation hack added 2013-08-11, hs-process is provided by base
+            if {![catch {set hs_process_installed [lindex [registry_active hs-process] 0]}]} {
+                # hs-process is installed and active
+                # force deactivation
+                registry_deactivate_composite hs-process "" [list ports_nodepcheck 1]
+            }
+            # Legacy port deactivation hack added 2013-08-14, hs-template-haskell is provided by base
+            if {![catch {set hs_template_haskell_installed [lindex [registry_active hs-template-haskell] 0]}]} {
+                # hs-template-haskell is installed and active
+                # force deactivation
+                registry_deactivate_composite hs-template-haskell "" [list ports_nodepcheck 1]
+            }
+        }
+
+        post-activate {
+            set libprefix "${prefix}/share/ghc-bootstrap/lib/${canonicalname}-${version}"
+            set packageconfd "${libprefix}/package.conf.d"
+            set deletefiles [list]
+
+            # files that were not correctly unregistered due to --force missing in the haskell portgroup,
+            # leaving package registrations of packages that still had dependents in place
+
+            # added 2013-12-14
+            lappend deletefiles "${packageconfd}/Cabal-1.16.0.3-*.conf"
+            lappend deletefiles "${packageconfd}/cereal-0.3.5.2-*.conf"
+            lappend deletefiles "${packageconfd}/cpphs-1.16-*.conf"
+            lappend deletefiles "${packageconfd}/entropy-0.2.2.2-*.conf"
+            lappend deletefiles "${packageconfd}/highlighting-kate-0.5.3.9-*.conf"
+            lappend deletefiles "${packageconfd}/language-c-0.3.2.1-*.conf"
+            lappend deletefiles "${packageconfd}/nats-0.1-*.conf"
+            lappend deletefiles "${packageconfd}/primitive-0.5.0.1-*.conf"
+            lappend deletefiles "${packageconfd}/semigroups-0.11-*.conf"
+            lappend deletefiles "${packageconfd}/semigroups-0.9.2-*.conf"
+            lappend deletefiles "${packageconfd}/template-haskell-2.8.0.0-10af654f73a6befd48e3430f5bf44c21.conf"
+            lappend deletefiles "${packageconfd}/uniplate-1.6.10-*.conf"
+
+            fs-traverse file $packageconfd {
+                foreach pattern $deletefiles {
+                    if {[string match $pattern $file]} {
+                        ui_debug "Removing remnant package registration file ${file}"
+                        delete $file
+                    }
+                }
+            }
+
+            catch {system "${prefix}/share/ghc-bootstrap/bin/ghc-pkg -v recache"}
         }
     }
 }
 
-livecheck.type      none
+livecheck.type     none

--- a/lang/ghc-bootstrap/files/patch-10.6.diff
+++ b/lang/ghc-bootstrap/files/patch-10.6.diff
@@ -1,0 +1,13 @@
+--- configure.orig	2013-04-19 06:47:00.000000000 +0800
++++ configure	2022-10-17 14:25:49.000000000 +0800
+@@ -4024,6 +4024,10 @@
+             fi
+         fi
+     fi
++    if test "$HostArch" = "powerpc"
++    then
++        SplitObjsBroken=YES
++    fi
+ fi
+ 
+ 

--- a/lang/ghc-bootstrap/files/patch-configure.diff
+++ b/lang/ghc-bootstrap/files/patch-configure.diff
@@ -1,0 +1,87 @@
+--- configure.orig	2013-04-19 06:47:00.000000000 +0800
++++ configure	2022-02-19 18:24:14.000000000 +0800
+@@ -5965,6 +5965,11 @@
+         IGNORE_LINKER_LD_FLAGS="$IGNORE_LINKER_LD_FLAGS -arch x86_64"
+         CPPFLAGS="$CPPFLAGS -m64"
+         ;;
++    powerpc-apple-darwin)
++        CFLAGS="$CFLAGS -m32"
++        LDFLAGS="$LDFLAGS -m32"
++        CPPFLAGS="$CPPFLAGS -m32"
++        ;;
+     alpha-*)
+         # For now, to suppress the gcc warning "call-clobbered
+         # register used for global register variable", we simply
+@@ -6022,6 +6027,12 @@
+         CONF_LD_LINKER_OPTS_STAGE0="$CONF_LD_LINKER_OPTS_STAGE0 -arch x86_64"
+         CONF_CPP_OPTS_STAGE0="$CONF_CPP_OPTS_STAGE0 -m64"
+         ;;
++    powerpc-apple-darwin)
++        CONF_CC_OPTS_STAGE0="$CONF_CC_OPTS_STAGE0 -m32"
++        CONF_GCC_LINKER_OPTS_STAGE0="$CONF_GCC_LINKER_OPTS_STAGE0 -m32"
++        CONF_LD_LINKER_OPTS_STAGE0="$CONF_LD_LINKER_OPTS_STAGE0 -arch ppc"
++        CONF_CPP_OPTS_STAGE0="$CONF_CPP_OPTS_STAGE0 -m32"
++        ;;
+     alpha-*)
+         # For now, to suppress the gcc warning "call-clobbered
+         # register used for global register variable", we simply
+@@ -6079,6 +6090,12 @@
+         CONF_LD_LINKER_OPTS_STAGE1="$CONF_LD_LINKER_OPTS_STAGE1 -arch x86_64"
+         CONF_CPP_OPTS_STAGE1="$CONF_CPP_OPTS_STAGE1 -m64"
+         ;;
++    powerpc-apple-darwin)
++        CONF_CC_OPTS_STAGE1="$CONF_CC_OPTS_STAGE1 -m32"
++        CONF_GCC_LINKER_OPTS_STAGE1="$CONF_GCC_LINKER_OPTS_STAGE1 -m32"
++        CONF_LD_LINKER_OPTS_STAGE1="$CONF_LD_LINKER_OPTS_STAGE1 -arch ppc"
++        CONF_CPP_OPTS_STAGE1="$CONF_CPP_OPTS_STAGE1 -m32"
++        ;;
+     alpha-*)
+         # For now, to suppress the gcc warning "call-clobbered
+         # register used for global register variable", we simply
+@@ -6137,6 +6154,12 @@
+         CONF_LD_LINKER_OPTS_STAGE2="$CONF_LD_LINKER_OPTS_STAGE2 -arch x86_64"
+         CONF_CPP_OPTS_STAGE2="$CONF_CPP_OPTS_STAGE2 -m64"
+         ;;
++    powerpc-apple-darwin)
++        CONF_CC_OPTS_STAGE2="$CONF_CC_OPTS_STAGE2 -m32"
++        CONF_GCC_LINKER_OPTS_STAGE2="$CONF_GCC_LINKER_OPTS_STAGE2 -m32"
++        CONF_LD_LINKER_OPTS_STAGE2="$CONF_LD_LINKER_OPTS_STAGE2 -arch ppc"
++        CONF_CPP_OPTS_STAGE2="$CONF_CPP_OPTS_STAGE2 -m32"
++        ;;
+     alpha-*)
+         # For now, to suppress the gcc warning "call-clobbered
+         # register used for global register variable", we simply
+@@ -10945,8 +10968,6 @@
+ 
+ 
+ 
+-
+-
+ for ac_func in __mingw_vfprintf
+ do :
+   ac_fn_c_check_func "$LINENO" "__mingw_vfprintf" "ac_cv_func___mingw_vfprintf"
+@@ -10971,7 +10992,7 @@
+ then
+     BUILD_DOCBOOK_HTML=NO
+ else
+-    BUILD_DOCBOOK_HTML=YES
++    BUILD_DOCBOOK_HTML=NO
+ fi
+ 
+ 
+@@ -10980,13 +11001,12 @@
+     BUILD_DOCBOOK_PS=NO
+     BUILD_DOCBOOK_PDF=NO
+ else
+-    BUILD_DOCBOOK_PS=YES
+-    BUILD_DOCBOOK_PDF=YES
++    BUILD_DOCBOOK_PS=NO
++    BUILD_DOCBOOK_PDF=NO
+ fi
+ 
+ 
+ 
+-
+ dir=base
+ LIBRARY_base_VERSION=`grep -i "^version:" libraries/${dir}/base.cabal | sed "s/.* //"`
+ 

--- a/lang/ghc-bootstrap/files/patch-includes_HsFFI.h.diff
+++ b/lang/ghc-bootstrap/files/patch-includes_HsFFI.h.diff
@@ -1,0 +1,31 @@
+diff --git includes/HsFFI.h includes/HsFFI.h
+index 652fbea..a21811e 100644
+--- includes/HsFFI.h
++++ includes/HsFFI.h
+@@ -21,7 +21,7 @@ extern "C" {
+ #include "stg/Types.h"
+
+ /* get limits for integral types */
+-#ifdef HAVE_STDINT_H
++#if defined HAVE_STDINT_H && !defined USE_INTTYPES_H_FOR_RTS_PROBES_D
+ /* ISO C 99 says:
+  * "C++ implementations should define these macros only when
+  * __STDC_LIMIT_MACROS is defined before <stdint.h> is included."
+diff --git rts/RtsProbes.d rts/RtsProbes.d
+index 13f40f8..226f881 100644
+--- rts/RtsProbes.d
++++ rts/RtsProbes.d
+@@ -6,6 +6,12 @@
+  *
+  * ---------------------------------------------------------------------------*/
+
++#ifdef __APPLE__ && __MACH__
++# if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
++#  define USE_INTTYPES_H_FOR_RTS_PROBES_D
++# endif
++#endif
++
+ #include "HsFFI.h"
+ #include "rts/EventLogFormat.h"
+
+

--- a/lang/ghc-bootstrap/files/patch-utils__mkdirhier__mkdirhier.sh.diff
+++ b/lang/ghc-bootstrap/files/patch-utils__mkdirhier__mkdirhier.sh.diff
@@ -1,0 +1,8 @@
+--- utils/mkdirhier/mkdirhier.sh.orig	2013-11-14 21:57:42.000000000 +0100
++++ utils/mkdirhier/mkdirhier.sh	2013-11-14 21:57:49.000000000 +0100
+@@ -1,4 +1,4 @@
+ #!/bin/sh
+ 
+-mkdir -p ${1+"$@"}
++gmkdir -p ${1+"./$@"}
+ 

--- a/lang/ghc-bootstrap/files/validate-settings.diff
+++ b/lang/ghc-bootstrap/files/validate-settings.diff
@@ -1,0 +1,11 @@
+--- mk/validate-settings.mk.orig	2013-04-19 05:22:46.000000000 +0800
++++ mk/validate-settings.mk	2022-02-19 18:41:53.000000000 +0800
+@@ -5,7 +5,7 @@
+ SRC_CC_WARNING_OPTS =
+ SRC_HC_WARNING_OPTS =
+ 
+-HADDOCK_DOCS    = YES
++HADDOCK_DOCS    = NO
+ 
+ # Debian doesn't turn -Werror=unused-but-set-variable on by default, so
+ # we turn it on explicitly for consistency with other users

--- a/lang/ghc-ppc-bootstrap/Portfile
+++ b/lang/ghc-ppc-bootstrap/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                ghc-ppc-bootstrap
 set canonicalname   ghc
 version             7.0.4
-revision            0
+revision            1
 categories          lang haskell
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             BSD
@@ -14,7 +14,7 @@ universal_variant   no
 installs_libs       no
 
 description         The Glorious Glasgow Haskell Compilation System
-long_description    This is a package that installs a binary bootstrap ghc compiler.
+long_description    This is a package that installs a binary bootstrap GHC compiler.
 
 homepage            https://haskell.org/${canonicalname}
 master_sites        https://downloads.haskell.org/ghc/7.0.4/krabby/
@@ -28,6 +28,37 @@ checksums           rmd160  38cc042793d2b4f4a6b901c6bb7f6a1f6959cce8 \
 depends_extract     port:xar
 
 worksrcdir          ${canonicalname}-${version}
+
+# BEGIN gcc variants
+# Newer gcc does not build ghc-bootstrap, so no point making variants here as well.
+variant gcc7 conflicts gcc6 gcc49 gcc48 gcc42 description {Compile with gcc 7} {
+    configure.compiler      macports-gcc-7
+    depends_run-append      port:gcc7
+}
+
+variant gcc6 conflicts gcc7 gcc49 gcc48 gcc42 description {Compile with gcc 6} {
+    configure.compiler      macports-gcc-6
+    depends_run-append      port:gcc6
+}
+
+variant gcc49 conflicts gcc7 gcc6 gcc48 gcc42 description {Compile with gcc 4.9} {
+    configure.compiler      macports-gcc-4.9
+    depends_run-append      port:gcc49
+}
+
+variant gcc48 conflicts gcc7 gcc6 gcc49 gcc42 description {Compile with gcc 4.8} {
+    configure.compiler      macports-gcc-4.8
+    depends_run-append      port:gcc48
+}
+
+variant gcc42 conflicts gcc7 gcc6 gcc49 gcc48 description {Compile with Xcode gcc 4.2} {
+    configure.compiler      gcc-4.2
+}
+
+if {![variant_isset gcc7] && ![variant_isset gcc6] && ![variant_isset gcc49] && ![variant_isset gcc48] & ![variant_isset gcc42]} {
+    default_variants +gcc42
+}
+# END gcc variants
 
 extract {
     system -W ${workpath} "mkdir -p ${worksrcpath}/pkg"

--- a/lang/ghc-ppc-bootstrap/Portfile
+++ b/lang/ghc-ppc-bootstrap/Portfile
@@ -29,36 +29,19 @@ depends_extract     port:xar
 
 worksrcdir          ${canonicalname}-${version}
 
-# BEGIN gcc variants
-# Newer gcc does not build ghc-bootstrap, so no point making variants here as well.
-variant gcc7 conflicts gcc6 gcc49 gcc48 gcc42 description {Compile with gcc 7} {
+# Newer gcc does not build ghc-bootstrap, so no point making variants here for those.
+variant gcc7 conflicts gcc42 description {Compile with gcc 7} {
     configure.compiler      macports-gcc-7
     depends_run-append      port:gcc7
 }
 
-variant gcc6 conflicts gcc7 gcc49 gcc48 gcc42 description {Compile with gcc 6} {
-    configure.compiler      macports-gcc-6
-    depends_run-append      port:gcc6
-}
-
-variant gcc49 conflicts gcc7 gcc6 gcc48 gcc42 description {Compile with gcc 4.9} {
-    configure.compiler      macports-gcc-4.9
-    depends_run-append      port:gcc49
-}
-
-variant gcc48 conflicts gcc7 gcc6 gcc49 gcc42 description {Compile with gcc 4.8} {
-    configure.compiler      macports-gcc-4.8
-    depends_run-append      port:gcc48
-}
-
-variant gcc42 conflicts gcc7 gcc6 gcc49 gcc48 description {Compile with Xcode gcc 4.2} {
+variant gcc42 conflicts gcc7 description {Compile with Xcode gcc 4.2} {
     configure.compiler      gcc-4.2
 }
 
-if {![variant_isset gcc7] && ![variant_isset gcc6] && ![variant_isset gcc49] && ![variant_isset gcc48] & ![variant_isset gcc42]} {
+if {![variant_isset gcc7] && ![variant_isset gcc42]} {
     default_variants +gcc42
 }
-# END gcc variants
 
 extract {
     system -W ${workpath} "mkdir -p ${worksrcpath}/pkg"


### PR DESCRIPTION
#### Description

`ghc-bootstrap` looks like an unused port and has not been updated forever. It has utility for PPC though, since the latest version of GHC that builds so far for PPC is 7.6.3 – I update Intel binaries from 7.6.2 to 7.6.3 along.
For the most part I simply restore what existed earlier for 7.6.x when those were actually built, with needed additions to support building for ppc.

It may or may not build on 10.6 PPC (if anyone cares), but it should build on 10.5.8 reproducibly.

Subsequent versions of GHC are pretty broken until something like 7.10+, but those need a later GHC to build. This is still much better than ever existed either officially or in Macports.

P. S. I have found some unofficial bootstrap binaries of GHC 7.6.3 online, however they are not meant to be installed (since they lack needed libraries), but just used to build GHC. I.e. they are not the same kind of binaries which are used in this port for Intel, so we need to build stuff from scratch.

Some discussion of the matter, somewhat dated: https://trac.macports.org/ticket/64698

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.1.4

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
