### PR TITLE
latte-int: enable all programs, install into libexec; lrslib: install into libexec

### DIFF
--- a/devel/cddlib/Portfile
+++ b/devel/cddlib/Portfile
@@ -25,3 +25,7 @@ post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/libexec/${name}
     move ${destroot}${prefix}/bin ${destroot}${prefix}/libexec/${name}
 }
+
+notes "
+The ${name} binary files are now installed into ${prefix}/libexec/${name}/bin
+"

--- a/math/latte-int/Portfile
+++ b/math/latte-int/Portfile
@@ -6,7 +6,7 @@ PortGroup               github 1.0
 github.setup            latte-int latte 1_7_6 version_
 name                    latte-int
 version                 [string map {_ .} ${github.version}]
-revision                1
+revision                2
 
 categories              math
 license                 GPL-2
@@ -38,8 +38,25 @@ depends_lib-append      port:4ti2 \
                         port:lrslib \
                         port:ntl
 
-configure.env           PATH=$env(PATH):${prefix}/libexec/cddlib/bin
+configure.env-append    PATH=${prefix}/libexec/cddlib/bin:=${prefix}/libexec/lrslib/bin:$env(PATH)
+
+configure.args-append   --disable-experiments \
+                        --enable-database \
+                        --enable-programmer-helper
+
+variant experimental description {Enable support for experimental features} {
+    configure.args-replace \
+                        --disable-experiments \
+                        --enable-experiments
+}
+
+default_variants-append +experimental
 
 post-destroot {
-    move ${destroot}${prefix}/bin/count ${destroot}${prefix}/bin/latte-count
+    xinstall -m 755 -d ${destroot}${prefix}/libexec/${name}
+    move ${destroot}${prefix}/bin ${destroot}${prefix}/libexec/${name}
 }
+
+notes "
+The ${name} binary files are now installed into ${prefix}/libexec/${name}/bin
+"

--- a/math/lrslib/Portfile
+++ b/math/lrslib/Portfile
@@ -7,7 +7,7 @@ PortGroup               compiler_blacklist_versions 1.0
 
 name                    lrslib
 version                 7.2
-revision                2
+revision                3
 
 categories              math
 license                 GPL-2+
@@ -79,8 +79,17 @@ build.target            single all-shared
 destroot.env-append     {*}${build.env}
 
 post-destroot {
-    file copy ${worksrcpath}/lrs1 ${worksrcpath}/lrs2 ${destroot}${prefix}/bin
+    foreach f {lrs1 lrs2 lrsmp redund redund1 redund2} {
+        file copy ${worksrcpath}/$f ${destroot}${prefix}/bin
+    }
+
+    xinstall -m 755 -d ${destroot}${prefix}/libexec/${name}
+    move ${destroot}${prefix}/bin ${destroot}${prefix}/libexec/${name}
 }
+
+notes "
+The ${name} binary files are now installed into ${prefix}/libexec/${name}/bin
+"
 
 livecheck.type          regex
 livecheck.version       ${distfile_version}

--- a/math/polymake/Portfile
+++ b/math/polymake/Portfile
@@ -6,7 +6,7 @@ PortGroup               boost 1.0
 PortGroup               perl5 1.0
 
 github.setup            polymake polymake 4.10 V
-revision                0
+revision                1
 categories              math
 license                 GPL-2+
 

--- a/math/sympol/Portfile
+++ b/math/sympol/Portfile
@@ -8,7 +8,7 @@ PortGroup               github 1.0
 github.setup            tremlin SymPol 0.1.9 v
 github.tarball_from     tarball
 name                    sympol
-revision                0
+revision                1
 categories              math science
 license                 GPL-2
 maintainers             {@catap korins.ky:kirill} openmaintainer


### PR DESCRIPTION
#### Description

Here I've avoid a conflict of programs name by installing it into livexec.

Seems that it should be the standard behaviour for math ports because it usually has conflicts in their names :)

The same idea is used for cddlib to which I've added a note.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.3 21G419 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->