### PR TITLE
danectl: new port (version 0.8.4)

### DIFF
--- a/security/danectl/Portfile
+++ b/security/danectl/Portfile
@@ -1,0 +1,89 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+PortGroup        makefile 1.0
+
+name             danectl
+version          0.8.4
+revision         0
+
+categories       security
+license          GPL-2+
+maintainers      {raf.org:raf @macportsraf} openmaintainer
+description      DNSSEC DANE implementation manager
+long_description {*}${description}. \
+                 \n\nDANE is \"DNS-based Authentication of Named Entities\". \
+                 It means securely letting the world know in advance what \
+                 your public encryption keys are by publishing them as \
+                 DNS records (TLSA, SSHFP, OPENPGPKEY, SMIMEA) in your \
+                 DNSSEC-enabled internet domain zone. This is the simplest \
+                 and most secure way to let the world know what keys to \
+                 expect when connecting to your servers. This can apply to \
+                 TLS keys, SSH host keys, and OpenPGP and S/MIME keys. \
+                 This makes it possible to prevent impersonation or \
+                 man-in-the-middle attacks. It's mostly used with mail \
+                 servers. Eventually, it could render certificate \
+                 authorities unnecessary. DNSSEC has become very easy.
+depends_lib      port:libidn2
+supported_archs  noarch
+platforms        any
+
+default_variants +tlsa +sshfp +openpgpkey +smimea
+
+variant tlsa description {Add TLSA support for TLS servers} {
+    depends_run-append \
+        port:certbot \
+        port:openssl \
+        port:coreutils
+}
+
+variant sshfp description {Add SSHFP support for ssh servers} {
+    depends_run-append \
+        port:openssh
+}
+
+variant openpgpkey description {Add OPENPGPKEY support for GnuPG keys} {
+    depends_run-append \
+        port:gnupg2
+}
+
+variant smimea description {Add SMIMEA support for S/MIME keys} {
+    # Suppress a port lint warning about port:openssl appearing twice
+    if {![variant_isset tlsa]} {
+        depends_run-append \
+            port:openssl
+    }
+}
+
+homepage         https://raf.org/${name}/
+master_sites     ${homepage}download/ \
+                 https://web.archive.org/web/20230718143137/${homepage}download/ \
+                 https://github.com/raforg/${name}/releases/download/v${version}/ \
+                 https://codeberg.org/raforg/${name}/releases/download/v${version}/
+checksums        rmd160  ce7b310967bcc81678a9cd3e1bf890df90cb7ae2 \
+                 sha256  179730da7e8d7b68f62b92292b7bc883922fa5cb8361eba22666a1fa6886e10e \
+                 size    56860
+
+post-patch {
+    # Set the installation prefix
+    # Suppress a reinplace runtime warning when ${prefix} is /usr/local (unlikely)
+    if {![string match /usr/local ${prefix}]} {
+        reinplace -W ${worksrcpath} "s|/usr/local|${prefix}|g" Makefile
+    }
+    # Certbot is definitely a macports port (tlsa variant dependency)
+    reinplace -W ${worksrcpath} "s|/etc/letsencrypt|${prefix}/etc/letsencrypt|g" danectl danectl.1
+    # Assume apache2 or nginx would also be macports ports, if present
+    reinplace -W ${worksrcpath} "s|/etc/apache2|${prefix}/etc/apache2|g" danectl danectl.1
+    reinplace -W ${worksrcpath} "s|/etc/nginx|${prefix}/etc/nginx|g" danectl danectl.1
+    # Don't require users to put ${prefix}/libexec/gnubin in their $PATH
+    reinplace -W ${worksrcpath} "s|sha256sum|gsha256sum|g" danectl danectl.1
+}
+
+build {}
+
+test.run            yes
+
+livecheck.type      regex
+livecheck.url       ${homepage}download/
+livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}
+


### PR DESCRIPTION
#### Description

DNSSEC DANE implementation manager

DANE is "DNS-based Authentication of Named Entities".  It means securely letting the world know in advance what  your public encryption keys are by publishing them as  DNS records (TLSA, SSHFP, OPENPGPKEY, SMIMEA) in your  DNSSEC-enabled internet domain zone. This is the simplest  and most secure way to let the world know what keys to expect when connecting to your servers. This can apply to  TLS keys, SSH host keys, and OpenPGP and S/MIME keys. This makes it possible to prevent impersonation or  man-in-the-middle attacks. It's mostly used with mail  servers. Eventually, it could render certificate  authorities unnecessary. DNSSEC has become very easy.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
