### PR TITLE
kokkos-devel: update to 2023.06.15, use tarball_from archive, since Github keeps breaking checksums

### DIFF
--- a/devel/kokkos/Portfile
+++ b/devel/kokkos/Portfile
@@ -18,14 +18,15 @@ checksums                   rmd160  b73fbb7e3cc532545100412415bcb602414f7656 \
                             size    2305267
 
 subport kokkos-devel {
-    github.setup            kokkos kokkos 63d695ce53674978c33d6d0a32a0007f173452c4
-    version                 2023.06.11
+    github.setup            kokkos kokkos 3163aefc027b7bad62367eadd9602e5fd56ebbcd
+    version                 2023.06.15
     conflicts               kokkos
     maintainers-append      {@barracuda156 gmail.com:vital.had}
-    checksums               rmd160  7305b47448488d9c2b0aa2566f8e893ed6403998 \
-                            sha256  e80bde1568aea1b9e46510c2ce41103c583bbdfaadf18da472cc22900e5c6846 \
-                            size    2328288
+    checksums               rmd160  c392dde84df9addbfdc8ff38a0f8cf0655d74c11 \
+                            sha256  5714c1244aabde1033ff3f9dbfcf3192635fba967ba25466dafdb5a0374f864f \
+                            size    2326967
     git.branch              develop
+    github.tarball_from     archive
     # 32-bit support added in: https://github.com/kokkos/kokkos/pull/5916
 }
 


### PR DESCRIPTION
#### Description

Primary reason for a second update in a row is that Github again broken checksums. Use `tarball_from archive` in a hope to fix these recurring breakages.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
