### PR TITLE
simplotask: new port

### DIFF
--- a/sysutils/simplotask/Portfile
+++ b/sysutils/simplotask/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/umputun/spot 1.8.1 v
+name                simplotask
+revision            0
+categories          sysutils
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+license             MIT
+
+description         A tool for effortless deployment and configuration management
+long_description    {*}${description}
+homepage            https://simplotask.com
+
+build.cmd           make
+build.pre_args-append \
+                    REV=v${version}
+build.args          build
+
+checksums           rmd160  5c6a5f657ee05a45c80395e571dc216371135b11 \
+                    sha256  135b97bfa837f5da30c79b1eda93f8e1f6ed9e0c2a847ccab73d6535ca5ece10 \
+                    size    32388760
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/.bin/spot ${destroot}${prefix}/bin
+    xinstall -m 0755 ${worksrcpath}/.bin/spot-secrets ${destroot}${prefix}/bin
+
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 ${worksrcpath}/spot.1 \
+        ${destroot}${prefix}/share/man/man1/
+}


### PR DESCRIPTION
#### Description
**[Spot](https://simplotask.com/)** (aka simplotask) is a powerful and easy-to-use tool for effortless deployment and configuration management.

Named as `simplotask` since [spot](https://github.com/macports/macports-ports/blob/master/science/spot) package already exists.

https://github.com/umputun/spot/issues/94

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
