### PR TITLE
gallery-dl: update to 1.25.6, add man pages

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        mikf gallery-dl 1.25.5 v
+github.setup        mikf gallery-dl 1.25.6 v
 github.tarball_from releases
 distname            gallery_dl-${github.version}
 
@@ -12,9 +12,9 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  b366bb039010d169b0ed63ffae9183d92a6ba6db \
-                    sha256  205cca54722e659d962e4db766acb1bf0c57178e5fd8efd502a43f8fdf31e1a8 \
-                    size    547516
+checksums           rmd160  a549a2f28e11c8cefb0fa7f50b7ed8df4cc9884b \
+                    sha256  0824ceff5b7a9482b69d02adaa05aad07026efad2de6d3a183cbfdf7352463f5 \
+                    size    551603
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites
@@ -43,4 +43,9 @@ variant youtubedl description {Add youtube-dl dependency to enable video downloa
 
 variant ytdlp description {Add yt-dlp dependency to enable video downloads} {
      depends_run-append port:yt-dlp
+}
+
+post-destroot {
+    ln -s ${python.prefix}/share/man/man1/gallery-dl.1 ${destroot}${prefix}/share/man/man1/gallery-dl.1
+    ln -s ${python.prefix}/share/man/man5/gallery-dl.conf.5 ${destroot}${prefix}/share/man/man5/gallery-dl.conf.5
 }


### PR DESCRIPTION
#### Description

Updated to v1.25.6, added in `post-destroot` action to install `man` pages

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?


