### PR TITLE
R, caffe, ipopt, py-pytorch: allow be used with OpenBLAS-devel

### DIFF
--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -187,7 +187,7 @@ variant builtin_lapack conflicts accelerate atlas openblas description {build us
 }
 
 variant openblas conflicts builtin_lapack accelerate atlas description {build using the BLAS and Lapack in the OpenBLAS port} {
-    depends_lib-append      port:OpenBLAS
+    depends_lib-append      path:lib/libopenblas.dylib:OpenBLAS
     configure.args-delete   --enable-BLAS-shlib
     configure.args-append   --with-blas="-L${prefix}/lib -lopenblas" --with-lapack
 }

--- a/math/caffe/Portfile
+++ b/math/caffe/Portfile
@@ -111,7 +111,7 @@ variant cudnn description {Use cuDNN} {
 }
 
 variant openblas description {Use OpenBLAS} {
-    depends_lib-append port:OpenBLAS
+    depends_lib-append path:lib/libopenblas.dylib:OpenBLAS
     patchfiles-append  patch-openblas.diff
 }
 

--- a/math/ipopt/Portfile
+++ b/math/ipopt/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  f710f4895e2ebcf8382bc87c8e13f8bb4a281644 \
                     sha256  f5972bf5b368e3bf83bd3c9f9e6c8b0b5e4a82077e22192dc548574118292cc0 \
                     size    1851016
 
-depends_lib-append  port:OpenBLAS \
+depends_lib-append  path:lib/libopenblas.dylib:OpenBLAS \
                     port:mumps \
                     port:scalapack
 

--- a/python/py-pytorch/Portfile
+++ b/python/py-pytorch/Portfile
@@ -103,7 +103,7 @@ if {${name} ne ${subport}} {
         port:eigen3 \
         port:gmp \
         port:mpfr \
-        port:OpenBLAS \
+        path:lib/libopenblas.dylib:OpenBLAS \
         path:lib/opencv4/libopencv_core.dylib:opencv4 \
         port:zmq \
         port:zstd \


### PR DESCRIPTION
#### Description

A trivial PR which allows to use OpenBLAS-devel at some missed ports.

I've skip CI because this PR touches py-pytorch which never will be built in githuib timeout time anyway.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->