### PR TITLE
afscompress: Update to 1.7.3

### DIFF
--- a/sysutils/afscompress/Portfile
+++ b/sysutils/afscompress/Portfile
@@ -1,16 +1,14 @@
-# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-
 PortSystem           1.0
 PortGroup            cmake 1.1
 PortGroup            github 1.0
 
-github.setup         RJVB afsctool 1.7.2
+github.setup         RJVB afsctool 1.7.3 v
+revision             0
 set lzfse_version    e634ca58b4821d9f3d560cdc6df5dec02ffc93fd
 
 name                 afscompress
-revision             1
 categories           sysutils
-platforms            darwin
+platforms            {darwin >= 10}
 license              GPL-3
 maintainers          {@ylluminarious orbitalimpact.com:georgedp} openmaintainer
 description          A fork of brkirch's afsctool utility, featuring several improvements.
@@ -29,13 +27,14 @@ long_description     AFSC (Apple File System Compression) tool is a utility that
     to specify an arbitrary (though positive :)) number of threads that will \
     compress the specified files in parallel.
 
+github.tarball_from  archive
 master_sites-append  https://github.com/lzfse/lzfse/archive/:lzfse
 distfiles-append     ${lzfse_version}.tar.gz:lzfse
 
 checksums            afsctool-${version}.tar.gz \
-                     sha256  cc4ca89af59cede79c32722d92bdb805d4cb93a9e9117e8e23b83eda1aa93ca7 \
-                     rmd160  9237a055a04c83f1203865ac5231680f9e86b288 \
-                     size    111841 \
+                     sha256  5776ff5aaf05c513bead107536d9e98e6037019a0de8a1435cc9da89ea8d49b8 \
+                     rmd160  73726e9e114443cfdc5daa373ded16b182d7d020 \
+                     size    111816 \
                      ${lzfse_version}.tar.gz \
                      sha256  ca98aa6644d44500e3315858daa747ce15bd06d49e3edb12a5458e5525e8ebdb \
                      rmd160  2a571ba71473d3e46b3e82f2c212d2867a207c63 \
@@ -46,19 +45,12 @@ depends_build-append port:pkgconfig
 depends_lib-append   port:sparsehash \
                      port:zlib
 
-universal_variant    yes
-
-pre-fetch {
-    if {${os.platform} eq "darwin" && ${os.major} < 10} {
-        ui_error "${name} is only compatible with Mac OS X 10.6 or later; earlier versions lack support for HFS compression."
-        return -code error "incompatible Mac OS X version"
-    }
-}
-
 post-extract {
     file delete -force ${worksrcpath}/src/private/lzfse
     ln -s ${workpath}/lzfse-${lzfse_version} ${worksrcpath}/src/private/lzfse
 }
+
+patchfiles           version.patch
 
 compiler.cxx_standard  2011
 

--- a/sysutils/afscompress/files/version.patch
+++ b/sysutils/afscompress/files/version.patch
@@ -1,0 +1,12 @@
+Fix version.
+https://github.com/RJVB/afsctool/commit/ab3716682ff1d6d5fb05df73a81166e03c71160e
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -1,6 +1,6 @@
+ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+ 
+-project(afsctool VERSION 1.7.2)
++project(afsctool VERSION 1.7.3)
+ set(afsctool_FULL_VERSION "${afsctool_VERSION_MAJOR}.${afsctool_VERSION_MINOR}.${afsctool_VERSION_PATCH}.${afsctool_VERSION_TWEAK}")
+ 
+ include(CheckTypeSize)


### PR DESCRIPTION
#### Description

afscompress: Update to 1.7.3

Set supported OS versions in platforms variable rather than doing it manually.

Remove "universal_variant yes" which is the default.

Remove modeline because the whitespace does not conform to it.

Use "github.tarball_from archive" so that the worksrcdir does not have to be changed with each update as of MacPorts 2.8.1.

Closes: https://trac.macports.org/ticket/67650

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.4 21G526 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
