### PR TITLE
asciidoctor: update to 2.0.20

### DIFF
--- a/textproc/asciidoctor/Portfile
+++ b/textproc/asciidoctor/Portfile
@@ -5,9 +5,11 @@ PortGroup           ruby 1.0
 
 # The version of Ruby chosen here works across all OS versions and CPU
 # architectures.  Don't change it without preserving this property.
-ruby.setup          asciidoctor 2.0.18 gem {} rubygems ruby30
+# The choice of Ruby versions doesn't affect clients.
+#
+ruby.setup          asciidoctor 2.0.20 gem {} rubygems ruby30
 name                asciidoctor
-revision            2
+revision            0
 
 # Prevent addition of the ruby interpreter version number as suffix to command line tools
 ruby.link_binaries_suffix
@@ -30,9 +32,12 @@ long_description    Asciidoctor is a fast, open source, Ruby-based \
                     content written in AsciiDoc.
 homepage            https://asciidoctor.org/
 
-checksums           rmd160  4d9e064700d6a198be3ce9c91ed86c2012824b87 \
-                    sha256  bbd1e1d16deed8db94bf9624b9f4474fac32d9ca7225d377f076c08d9adde387 \
-                    size    280064
+checksums           rmd160  e75d63c088cfba353283b93a314f774386e1080a \
+                    sha256  835eabd445e4ae88f56a5f4e07593c3612b2be72eb661c612c3a8e1e17c57479 \
+                    size    281600
+
+# Use normal distfile location, instead of 'ruby'.
+dist_subdir         ${name}
 
 post-destroot {
     set man1 ${destroot}${prefix}/share/man/man1


### PR DESCRIPTION
Also fixes confusing nonstandard distfile location.

TESTED:
Built on 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-10.15 x86_64, and 11.x-13.x arm64.  Compared ntpsec manpage builds on all of the above except 10.5 x86_64 (due to ntpsec issue).  Identical except for asciidoctor version and build date.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.7 20G1345, arm64, Xcode 13.2.1 13C100
macOS 12.6.6 21G646, arm64, Xcode 14.2 14C18
macOS 13.4 22F66, arm64, Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [N/A] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
