### PR TITLE
miniflux: update to 2.0.44

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.43
+go.setup            github.com/miniflux/v2 2.0.44
 go.package          miniflux.app
 name                miniflux
 revision            0
@@ -16,21 +16,21 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  cdfbb717d04d5c41ff8503b047a70ebcd1884748 \
-                        sha256  62f8f09cab6f436014491597fd7bda9b67cd81c6072beacbf4062a460af752a5 \
-                        size    587052
+                        rmd160  79f41ee1dd72c61fb1da47dbd3aa0d9d79948f6d \
+                        sha256  9e3f01b417e24bb77695446da2af1f707cf3c2c8c8e8eb1f56340a7cd6567a70 \
+                        size    574445
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
-                        lock    v2.4.0 \
-                        rmd160  7273a8af3153a595e51a8631a103749bc8d18da2 \
-                        sha256  eca62cdf7aeb8edb0effeedb68cb160fc3440e9f8c061e735d738b3cd2afb7ec \
-                        size    26252 \
+                        lock    v2.5.0 \
+                        rmd160  1c5194b0a550dd6d0d16c992ddff8cf426a91d13 \
+                        sha256  91f69cb1acb9df8637d000f20a8c6d1bd1af15b090cf60a03766d8feede43a35 \
+                        size    27573 \
                     gopkg.in/yaml.v3 \
-                        lock    9f266ea9e77c \
-                        rmd160  06dca2ede07b2f31c515b4711fbebc1d5359b5e4 \
-                        sha256  e70dd42fb30b7b2d0129c5cdf0e079caaf5602cab24081fdac830ec01204fa59 \
-                        size    86890 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
                     gopkg.in/square/go-jose.v2 \
                         lock    v2.6.0 \
                         rmd160  56e581a46f0364551657e2b7698bd022973e9d7c \
@@ -38,10 +38,10 @@ go.vendors          mvdan.cc/xurls \
                         size    310376 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.28.1 \
-                        rmd160  b6e8eb6d53889424dd6b451c20ac9b72de99a639 \
-                        sha256  0bf41d25ed04a6a4ac9d9cb33031b50718a64ca76b0e9853dabdade80ee34f3b \
-                        size    1281110 \
+                        lock    v1.30.0 \
+                        rmd160  80cc9e6edacb19c225de4f8c07f3c5f79ac9e84a \
+                        sha256  d4ac2c8ff456abc74679f4f37cc8d7aac195684f7698d2030fc5bfe14243b5fa \
+                        size    1299719 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
                         lock    v1.6.7 \
@@ -49,35 +49,35 @@ go.vendors          mvdan.cc/xurls \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
                     golang.org/x/text \
-                        lock    v0.8.0 \
-                        rmd160  46b8c9c9db41ffd579687f8c383b7d4134768744 \
-                        sha256  8e761ba6cd7022babf21ac86de9611c9682c499e048f7305d0b339104c2472aa \
-                        size    8360208 \
+                        lock    v0.9.0 \
+                        rmd160  024cee280ecc35a165fe05f6cb43f745be776cf7 \
+                        sha256  c84b520575096154588a99123b775d5ccbc66e492a6d22aaa75a5dd8572634ab \
+                        size    8356818 \
                     golang.org/x/term \
-                        lock    v0.6.0 \
-                        rmd160  cb472da6ed94fc7801534c41cea8c7db352800f1 \
-                        sha256  57ce8bc9922a775392a237a3c127dc76469edd9580fff38a08837f718d207da8 \
-                        size    14796 \
-                    golang.org/x/sys \
-                        lock    v0.6.0 \
-                        rmd160  eed022d31d3cd2b2a5c7d1bad325b6667db1d831 \
-                        sha256  28b3d661c0b094ccb133bb2f30a2db8fcd64be036f4fc42ee6c2ab4b00867bd3 \
-                        size    1435230 \
-                    golang.org/x/oauth2 \
-                        lock    v0.6.0 \
-                        rmd160  366ba3c2430d9c5b14d6c9a20665baa4018008e9 \
-                        sha256  1f3362a4cca627bac5a0d79c676d770e27a3d9129bcbd3f2d9610d14ad0d3fab \
-                        size    86662 \
-                    golang.org/x/net \
                         lock    v0.8.0 \
-                        rmd160  9fad54bb4c2f96a60e6d5126ff16ffa4064b1844 \
-                        sha256  8e2ecc9dc226234900b728b1b340e096675a27b3724298ce964d21a276f5bc05 \
-                        size    1244466 \
-                    golang.org/x/crypto \
+                        rmd160  4ad52ddb467af2722834a7c9330616d97dc9fdb3 \
+                        sha256  5dc93dd1d75d29a136b2c18dbacc8a244067f8a8d585c93ae28d5144efe12c45 \
+                        size    14800 \
+                    golang.org/x/sys \
+                        lock    v0.8.0 \
+                        rmd160  e678fbf405f6f2de2dd29b0a8b71baec9f1f1321 \
+                        sha256  8c0922a390cb8c22c340d69aa24ecf3cd923b30ca28dc96965d32d4b3a4e917d \
+                        size    1436856 \
+                    golang.org/x/oauth2 \
                         lock    v0.7.0 \
-                        rmd160  88543af3c42d0c465ee8b4144b4dbf7e54c204e8 \
-                        sha256  e25aba4438946c18a951fe4d7921af122f9408f828a0f0e289b23a9a19e5752d \
-                        size    1634536 \
+                        rmd160  7cc03af8875a7394bf2f017dc8b6ceeab0b0f7bf \
+                        sha256  19fc8f8eba76cfb58ab6fe0dc857e03f3aaa4cfd92c28ee60d555fe6b7efeb1e \
+                        size    87771 \
+                    golang.org/x/net \
+                        lock    v0.9.0 \
+                        rmd160  978560e0c375a9f678822da49eee99ac3c6cd141 \
+                        sha256  4709176f14c6f0a6cee42ada89c7fef5af41455e21c7d30372bf80d9d1fc1114 \
+                        size    1244630 \
+                    golang.org/x/crypto \
+                        lock    v0.8.0 \
+                        rmd160  cdd6ae8112a74f12233909e54b4f454a1ba4f8ab \
+                        sha256  6aaa7fdbd09f9a3cb2400892e114594a71d1f2a88a10e253feb41af313b1f6f8 \
+                        size    1634989 \
                     github.com/yuin/goldmark \
                         lock    v1.5.4 \
                         rmd160  7e428750043e781507d94e54431c488a2e07110a \
@@ -104,35 +104,35 @@ go.vendors          mvdan.cc/xurls \
                         sha256  cf0db1d207def082990b406145dfc58b42ae68b6e19894a3422ab282eae3bb1e \
                         size    7008959 \
                     github.com/stretchr/testify \
-                        lock    v1.7.0 \
-                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
-                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
-                        size    91096 \
+                        lock    v1.8.0 \
+                        rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
+                        sha256  9b51f07d72fd2d88a76cd89fb8863fc69812e364d28d0a97f6eacf9cd974c71d \
+                        size    97622 \
                     github.com/rylans/getlang \
                         lock    9e7f44ff8aa0 \
                         rmd160  f1a0fc33eb1e627f0609029369b367ba76098409 \
                         sha256  7d433ce89160e19d0375617b62e84bc4efce07e02428c09f2dacb7dcf6e6cfce \
                         size    18598 \
                     github.com/prometheus/procfs \
-                        lock    v0.8.0 \
-                        rmd160  0cd72a082087a0c3dd922a362316063f79364968 \
-                        sha256  4047304194f7f2cf99f627a1dae661ec0b3037f34aa07cd4d359e82015debc64 \
-                        size    194848 \
+                        lock    v0.9.0 \
+                        rmd160  a91ed9844868c593a4faf7e6cac47ea4f6443d6f \
+                        sha256  618278b47243204e55efa66074d047b020d2d80b106805299505473938d318c2 \
+                        size    220424 \
                     github.com/prometheus/common \
-                        lock    v0.37.0 \
-                        rmd160  4b9ab33f6ebadf18c84de43be89633d0adf967d9 \
-                        sha256  ed4d3dbcb57018812d44094380bb26c0c331ef6d99d4df13b4ed907aa221bc47 \
-                        size    148974 \
+                        lock    v0.42.0 \
+                        rmd160  2edad904e117e7e4776ce7a5370333e20f576a80 \
+                        sha256  a2b612d24ec08d26b143de507e49e2b5773b2cf93bc548f2e623029edb364364 \
+                        size    130561 \
                     github.com/prometheus/client_model \
                         lock    v0.3.0 \
                         rmd160  a0b906835c5e39f188c88e71d319eac4a240567d \
                         sha256  54817b98ddf4cde06a2f122c6d811d37ce25cc4f74d0a32bebf5620389c08c00 \
                         size    14955 \
                     github.com/prometheus/client_golang \
-                        lock    v1.14.0 \
-                        rmd160  9f502ae011c53f72a9cba178310ffeed13d67a4a \
-                        sha256  81e046e141f490525685ab27ce96b089ebb48640641da3e64d169611c42e2717 \
-                        size    236365 \
+                        lock    v1.15.1 \
+                        rmd160  1fd6bc3b066dc9f1c0a03f18e19aeecfb0fcd0b1 \
+                        sha256  bffdc705ca85c03a6c8c7eb33437fbeb7712d15c5eb4788230da4cbf11d7f96a \
+                        size    264632 \
                     github.com/pquerna/cachecontrol \
                         lock    v0.1.0 \
                         rmd160  e819f8dcacadd42bbe783a3c1810f17f3e43fa95 \
@@ -154,25 +154,25 @@ go.vendors          mvdan.cc/xurls \
                         sha256  96ecd3f6db41b69df8ea8ae4eff694b2fc1916c40bef88e488fed3241ce3a31e \
                         size    26592 \
                     github.com/lib/pq \
-                        lock    v1.10.7 \
-                        rmd160  2d1613378f35b0f27c085769cacb6eca1be07f84 \
-                        sha256  8958d528b808839874ec50e0704a4e1ee43609a69bfdd659b1b9abe40a18fea7 \
-                        size    111537 \
+                        lock    v1.10.9 \
+                        rmd160  beb0e233773f49d8d08ee991abf23bc8febf69d0 \
+                        sha256  08610bf0370b202bee369b7303c3085e02c7f6fdfd42a3f58e8f033088151eea \
+                        size    114528 \
                     github.com/gorilla/mux \
                         lock    v1.8.0 \
                         rmd160  0671fd049b24cb4c682168aef4e176793dd624a7 \
                         sha256  b94c995107eaf9f5bcaa0a29629fb6c23bab9ec0606071c09070e143fdf323fa \
                         size    45524 \
                     github.com/google/go-cmp \
-                        lock    v0.5.8 \
-                        rmd160  8335ed233b7f0de3539ff5c88b2eb1400480a806 \
-                        sha256  a1b3d227b1d4a6c224f4597228e7380ac5dd4b886fe91644ba88ca0292b5f121 \
-                        size    104650 \
+                        lock    v0.5.9 \
+                        rmd160  9832ae80123461baed8aa20e830199c0e21e337b \
+                        sha256  3058d20d61f03aa05fca0fc07acb8c50850c68086998c542857aec7ad1529482 \
+                        size    104431 \
                     github.com/golang/protobuf \
-                        lock    v1.5.2 \
-                        rmd160  9924f66e6525b49769f4ef61f7196387185b2f9b \
-                        sha256  d7b5f7c44e324b3f510fec1b79de20bd8d7537229b23ad7236769cf3974ce0c7 \
-                        size    171736 \
+                        lock    v1.5.3 \
+                        rmd160  b4e09ad842f6dcd3aea36b28ec64d6d9563fd1d8 \
+                        sha256  12e830fab630cabd279fca57e7089eeb1556e2c22b58eee64bb21bd3c8dfc706 \
+                        size    171856 \
                     github.com/go-telegram-bot-api/telegram-bot-api \
                         lock    v4.6.4 \
                         rmd160  80821ad149f661570509a35adcf2d1d73fcf0c10 \
@@ -189,10 +189,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  cb7f8f625e511034f24505efeee92be610f2cbd957114d9c591aea9f29afa22c \
                         size    24141 \
                     github.com/cespare/xxhash \
-                        lock    v2.1.2 \
-                        rmd160  aa8f44c877aeb7a980aba19d9d84e6b20e52560d \
-                        sha256  4bc66a9c435d9fa48cc9f8cb72c402a863943d594c1b1f8b5f421541c58150d2 \
-                        size    11252 \
+                        lock    v2.2.0 \
+                        rmd160  17d6143308fd7f2ccf9b885b19a2445a612ce013 \
+                        sha256  d491baceb567c1fcc6eae97991816169f798ac2bfc9f62224bd6ad63b1a4e60e \
+                        size    12348 \
                     github.com/beorn7/perks \
                         lock    v1.0.1 \
                         rmd160  c6c5c7fd2132f01925c7fccd9d27c9d7a80f2adb \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.44)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
