### PR TITLE
py-paho-mqtt: update to 1.6.1

### DIFF
--- a/python/py-paho-mqtt/Portfile
+++ b/python/py-paho-mqtt/Portfile
@@ -4,11 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-paho-mqtt
-version             1.5.1
+version             1.6.1
 revision            0
 
-# Eclipse Public License v1.0 / Eclipse Distribution License v1.0
-license             unknown
+license             {EPL-2 EDL-1}
 maintainers         {mojca @mojca} openmaintainer
 
 description         MQTT version 3.1/3.1.1 client class
@@ -16,11 +15,11 @@ long_description    Eclipse Paho MQTT Python client library
 
 homepage            https://eclipse.org/paho
 
-checksums           rmd160  16be65b419a07bfa3584881b7dd75e2332ebd534 \
-                    sha256  9feb068e822be7b3a116324e01fb6028eb1d66412bf98595ae72698965cb1cae \
-                    size    101757
+checksums           rmd160  d6bccf7fdb166109d901a63fafc99432c195ef68 \
+                    sha256  2a8291c81623aec00372b5a85558a372c747cbca8e9934dfe218638b8eefc26f \
+                    size    99373
 
-python.versions     37 38 39
+python.versions     37 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/eclipse/paho.mqtt.python/blob/v1.6.1/ChangeLog.txt)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
