### PR TITLE
json2tsv: update to 1.1

### DIFF
--- a/textproc/json2tsv/Portfile
+++ b/textproc/json2tsv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                json2tsv
-version             1.0
+version             1.1
 revision            0
 license             MIT
 
@@ -17,9 +17,9 @@ homepage            https://codemadness.org/json2tsv.html
 
 master_sites        https://codemadness.org/releases/${name}/
 
-checksums           rmd160  8c27844d009f343d2aa82139a5de7edab8df1a5c \
-                    sha256  04e6a60d6b33603a8a19d28e94038b63b17d49c65a0495cd761cf7f22616de9b \
-                    size    8551
+checksums           rmd160  406b62d3e3828bd319f8bbae9df12e109112389d \
+                    sha256  eebe7e6286558af0aa0db7c552a4c1ff1e350eb662ec665155c2611990a9c34a \
+                    size    8687
 
 makefile.override   PREFIX
 


### PR DESCRIPTION
#### Description
[Changelog](https://git.codemadness.org/json2tsv/log.html)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.6 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
