### PR TITLE
hypre: move to cmake, fix mpich variant

### DIFF
--- a/math/hypre/Portfile
+++ b/math/hypre/Portfile
@@ -1,43 +1,100 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           mpi 1.0
 PortGroup           muniversal 1.0
 
 github.setup        hypre-space hypre 2.28.0 v
-revision            0
+revision            1
 categories          math
 license             LGPL-2.1
-maintainers         nomaintainer
-description         hypre is a linear solver
-long_description    hypre is a library for solving large, sparse linear \
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         HYPRE is a linear solver
+long_description    HYPRE is a library for solving large, sparse linear \
                     systems of equations on massively parallel computers.
 
 checksums           rmd160  51362fd724a779448feb1b919d2707d64ffebd50 \
                     sha256  b66f10fbb342c8156318dd2ff1897390278d19ac2e8c65213dac2fb04d70cc57 \
                     size    6805685
 
-worksrcdir          ${distname}/src
+cmake.source_dir    ${worksrcpath}/src
 
 depends_build-append \
                     port:grep
 
-mpi.setup
+# Only some components need this, but ensure we use a compiler that builds everything:
+compiler.cxx_standard 2017
 
-configure.args      --with-blas --with-lapack --without-superlu \
-                    --without-fei --without-mli
+configure.args-append \
+                    -DCMAKE_INSTALL_INCLUDEDIR=${prefix}/include/HYPRE \
+                    -DHYPRE_BUILD_EXAMPLES=OFF \
+                    -DHYPRE_BUILD_TESTS=OFF \
+                    -DHYPRE_ENABLE_SHARED=ON \
+                    -DHYPRE_ENABLE_BIGINT=OFF \
+                    -DHYPRE_ENABLE_MIXEDINT=OFF \
+                    -DHYPRE_ENABLE_SINGLE=OFF \
+                    -DHYPRE_ENABLE_LONG_DOUBLE=OFF \
+                    -DHYPRE_ENABLE_COMPLEX=OFF \
+                    -DHYPRE_ENABLE_HOPSCOTCH=OFF \
+                    -DHYPRE_ENABLE_HYPRE_BLAS=ON \
+                    -DHYPRE_ENABLE_HYPRE_LAPACK=ON \
+                    -DHYPRE_ENABLE_FEI=OFF \
+                    -DHYPRE_ENABLE_ONEMKLSPARSE=OFF \
+                    -DHYPRE_ENABLE_ONEMKLBLAS=OFF \
+                    -DHYPRE_ENABLE_ONEMKLRAND=OFF \
+                    -DHYPRE_USING_HOST_MEMORY=ON \
+                    -DHYPRE_WITH_CALIPER=OFF \
+                    -DHYPRE_WITH_CUDA=OFF \
+                    -DHYPRE_WITH_GPU_AWARE_MPI=OFF \
+                    -DHYPRE_WITH_MPI=ON \
+                    -DHYPRE_WITH_OPENMP=OFF \
+                    -DHYPRE_WITH_SUPERLU=OFF \
+                    -DHYPRE_WITH_DSUPERLU=OFF \
+                    -DHYPRE_WITH_SYCL=OFF \
+                    -DHYPRE_WITH_UMPIRE=OFF
 
 if {![mpi_variant_isset]} {
-    configure.args-append \
-                    --without-MPI
+    configure.args-replace \
+                    -DHYPRE_WITH_MPI=ON -DHYPRE_WITH_MPI=OFF
+} else {
+    if {${os.platform} eq "darwin" && ${os.arch} eq "powerpc"} {
+        mpi.setup   require \
+                    -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5 \
+                    -clang -fortran
+    } else {
+        mpi.setup   require \
+                    -gcc44 -gcc45 -gcc46 -gcc47 -gcc48 -gcc49 -gcc5
+    }
 }
 
-# --disable-dependency-tracking is not recognized.
-configure.universal_args-delete --disable-dependency-tracking
+variant longindex description {Build with 64-bit ints} {
+    configure.args-replace \
+                    -DHYPRE_ENABLE_BIGINT=OFF -DHYPRE_ENABLE_BIGINT=ON
+}
 
-destroot.destdir    prefix=${destroot}${prefix}
+variant openmp description {Build with OpenMP} {
+    compiler.openmp_version 3.0
+    configure.args-replace \
+                    -DHYPRE_WITH_OPENMP=OFF -DHYPRE_WITH_OPENMP=ON
 
-variant longindex description {Build with 64 bit ints} {
-  configure.args-append   --enable-bigint
+    if {[string match *clang* ${configure.compiler}]} {
+        configure.ldflags-append \
+                    -L${prefix}/lib/libomp -lomp
+    }
+}
+
+default_variants    +openmp
+
+# FIXME: tests target is broken: https://github.com/hypre-space/hypre/issues/928
+variant tests description {Enable testing} {
+    configure.pre_args-replace \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+
+    configure.args-replace \
+                    -DHYPRE_BUILD_TESTS=OFF -DHYPRE_BUILD_TESTS=ON
+
+    test.run        yes
 }


### PR DESCRIPTION
#### Description

Turned out `hypre` MPICH variant was broken: it did nothing. See: https://github.com/mfem/mfem/issues/3720#issuecomment-1593591891

Move to CMake, fix MPICH, add options. Claim maintainership (I use this port for my ports).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
