### PR TITLE
libfmt10: new port in devel

### DIFF
--- a/devel/libfmt10/Portfile
+++ b/devel/libfmt10/Portfile
@@ -16,7 +16,7 @@ checksums           rmd160  49a1ba4a3612455017eaa80c248c339860b659f1 \
 
 categories          devel
 license             MIT
-maintainers         nomaintainer
+maintainers         {mascguy @mascguy} openmaintainer
 
 description         An open-source formatting library
 long_description    fmt (formerly cppformat) is an open-source formatting library. \

--- a/devel/libfmt10/Portfile
+++ b/devel/libfmt10/Portfile
@@ -1,0 +1,101 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           conflicts_build 1.0
+PortGroup           github 1.0
+
+github.setup        fmtlib fmt 10.0.0
+name                libfmt10
+revision            0
+checksums           rmd160  49a1ba4a3612455017eaa80c248c339860b659f1 \
+                    sha256  ede1b6b42188163a3f2e0f25ad5c0637eca564bd8df74d02e31a311dd6b37ad8 \
+                    size    851582
+
+categories          devel
+license             MIT
+maintainers         nomaintainer
+
+description         An open-source formatting library
+long_description    fmt (formerly cppformat) is an open-source formatting library. \
+                    It can be used as a safe alternative to printf or as a fast \
+                    alternative to C++ IOStreams.
+homepage            https://fmt.dev
+
+github.tarball_from archive
+
+conflicts_build     gtest
+
+#------------------------------------------------------------------------------
+# Path-Related Variables - START
+#------------------------------------------------------------------------------
+
+# The "install name," meaning, the subdirectory name for this port.
+# Should correspond to the major version.
+set port_install_name \
+                    ${subport}
+
+# Define all of our base paths up-front
+set port_install_include \
+                    ${prefix}/include/${port_install_name}
+set port_install_lib \
+                    ${prefix}/lib/${port_install_name}
+
+# Populate CMake options currently available
+cmake.install_rpath \
+                    ${port_install_lib}
+
+configure.args-append \
+                    -DCMAKE_INSTALL_INCLUDEDIR=${port_install_include} \
+                    -DCMAKE_INSTALL_LIBDIR=${port_install_lib} \
+                    -DCMAKE_INSTALL_NAME_DIR=${port_install_lib}
+
+#------------------------------------------------------------------------------
+# Path-Related Variables - END
+#------------------------------------------------------------------------------
+
+cmake.generator     Ninja
+
+# Clear optflags; controlled by project, via cmake build type
+configure.optflags
+
+if {[variant_isset debug]} {
+    cmake.build_type Debug
+} else {
+    cmake.build_type RelWithDebInfo
+}
+
+compiler.cxx_standard 2011
+
+# error: default initialization of an object of const type 'const Answer' without a user-provided default constructor
+# error would be valid except Answer is empty
+compiler.blacklist-append \
+                    {clang < 801}
+
+configure.args-append \
+                    -DBUILD_SHARED_LIBS:BOOL=ON \
+                    -DFMT_DOC:BOOL=OFF \
+                    -DFMT_TEST:BOOL=OFF
+
+# Obsolete port 'libfmt' causes clashes, so deactivate if installed
+pre-activate {
+    if {![catch {set installed [lindex [registry_active libfmt] 0]}]} {
+        registry_deactivate_composite libfmt "" [list ports_nodepcheck 1]
+    }
+}
+
+variant tests description {Enable test support} {
+    configure.pre_args-replace \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+
+    configure.args-replace \
+                    -DFMT_TEST:BOOL=OFF \
+                    -DFMT_TEST:BOOL=ON
+
+    test.run        yes
+}
+
+github.livecheck.regex {(10\.[0-9.]+)}


### PR DESCRIPTION
#### Description

This merely brings new version of `libfmt`. No ports are moved to it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
