### PR TITLE
pciutils: update to 3.10.0, set license to GPL-2+

### DIFF
--- a/sysutils/pciutils/Portfile
+++ b/sysutils/pciutils/Portfile
@@ -4,10 +4,10 @@ PortSystem                  1.0
 PortGroup                   makefile 1.0
 
 name                        pciutils
-version                     3.9.0
+version                     3.10.0
 revision                    0
 categories                  sysutils
-license                     GPL-2
+license                     GPL-2+
 maintainers                 {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 description                 a collection of programs for inspecting and manipulating configuration of PCI devices
 long_description            The PCI Utilities are {*}${description}, \
@@ -17,9 +17,9 @@ long_description            The PCI Utilities are {*}${description}, \
 homepage                    https://mj.ucw.cz/sw/pciutils
 master_sites                https://mj.ucw.cz/download/linux/pci/
 
-checksums                   rmd160  7c9586966a97623eaed71fb7218ab22b2001e406 \
-                            sha256  8953a785b2e3af414434b8fdcbfb75c90758819631001e60dd3afb89b22b2331 \
-                            size    908219
+checksums                   rmd160  60f163c428c483b93199b76ba5e99cf9153ce1b3 \
+                            sha256  7deabe38ae5fa88a96a8c4947975cf31c591506db546e9665a10dddbf350ead0 \
+                            size    931711
 
 patchfiles-append           patch-shared_library.diff
 


### PR DESCRIPTION
#### Description

* update to 3.10.0
* set license to GPL-2+ ; see https://github.com/pciutils/pciutils/issues/149 and https://github.com/pciutils/pciutils/commit/6182921907ef3cc31be3394eb468b24bcd3955a8

This updated `license` will allow `qt6-qtwebengine` to be distributable. 

Closes: https://trac.macports.org/ticket/67602


###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3.1 14E300c
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?