### PR TITLE
gnuplot, libcerf: update to latest versions

### DIFF
--- a/math/gnuplot/Portfile
+++ b/math/gnuplot/Portfile
@@ -6,7 +6,7 @@ PortGroup           xcodeversion    1.0
 PortGroup           wxWidgets       1.0
 
 name                gnuplot
-version             5.4.6
+version             5.4.8
 revision            0
 
 categories          math science
@@ -30,9 +30,9 @@ homepage            http://gnuplot.sourceforge.net/
 master_sites        sourceforge:project/gnuplot/gnuplot/${version}
 dist_subdir         ${name}/${version}
 
-checksums           rmd160  e8e0518fbc24a57963dee02a087d6dc3aed51f56 \
-                    sha256  02fc27918200ed64d8f0c3b84fe81b95b59cd47ad99f270939ae497c19f27419 \
-                    size    5655661
+checksums           rmd160  a469a3089502de08244c78ee6e9f0d7e810bb701 \
+                    sha256  931279c7caad1aff7d46cb4766f1ff41c26d9be9daf0bcf0c79deeee3d91f5cf \
+                    size    5684061
 
 depends_build       port:pkgconfig
 

--- a/math/libcerf/Portfile
+++ b/math/libcerf/Portfile
@@ -5,7 +5,7 @@ PortGroup           gitlab 1.0
 PortGroup           cmake 1.1
 
 gitlab.instance     https://jugit.fz-juelich.de
-gitlab.setup        mlz libcerf 2.1 v
+gitlab.setup        mlz libcerf 2.3 v
 revision            0
 
 categories          math
@@ -17,9 +17,9 @@ long_description    The libcerf library is a self-contained numeric library that
                     an efficient and accurate implementation of complex error functions, \
                     along with Dawson, Faddeeva, and Voigt functions.
 
-checksums           rmd160  4fcfb848fad1a7d787b6a9d37cfc394c1ae31705 \
-                    sha256  4ab7b5669e2f519cb3c932d18a1cb1449b6131ab49fe5a96d6732a846dd1c389 \
-                    size    66385
+checksums           rmd160  f60b6fb827d41e03a83d006e8aac73e4c2ae8eb3 \
+                    sha256  02fea3714894fd9577ed5eb48221f470dc3eda3713e16b49b7df3eb3ecc7978b \
+                    size    81061
 
 test.run            yes
 test.cmd            ctest


### PR DESCRIPTION
#### Description
- update `gnuplot` to 5.4.8
- update `libcerf` to 2.3

###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3.1 14E300c


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
