### PR TITLE
graphite2: use py311

### DIFF
--- a/graphics/graphite2/Portfile
+++ b/graphics/graphite2/Portfile
@@ -31,7 +31,7 @@ extract.suffix      .tgz
 compiler.cxx_standard \
                     2011
 
-set py_ver          3.10
+set py_ver          3.11
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 test.run            yes


### PR DESCRIPTION
### Description

- Migrate port to py311; no other changes