### PR TITLE
AtomicParsley, -devel: set cxx_standard 2011, unbreak build

### DIFF
--- a/multimedia/AtomicParsley-devel/Portfile
+++ b/multimedia/AtomicParsley-devel/Portfile
@@ -32,6 +32,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 16} {
     patchfiles-append   patch-use-deprecated.diff
 }
 
+compiler.cxx_standard 2011
+
 post-patch {
     reinplace "s|$\{\PACKAGE_VERSION\}\|${version}|g" ${worksrcpath}/CMakeLists.txt
     reinplace "s|$\{\BUILD_INFO\}\|${cmake.build_type}|g" ${worksrcpath}/CMakeLists.txt

--- a/multimedia/AtomicParsley/Portfile
+++ b/multimedia/AtomicParsley/Portfile
@@ -31,6 +31,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 16} {
     patchfiles-append   patch-use-deprecated.diff
 }
 
+compiler.cxx_standard 2011
+
 post-patch {
     reinplace "s|$\{\PACKAGE_VERSION\}\|${version}|g" ${worksrcpath}/CMakeLists.txt
     reinplace "s|$\{\BUILD_INFO\}\|${cmake.build_type}|g" ${worksrcpath}/CMakeLists.txt


### PR DESCRIPTION
#### Description

I thought this has been fixed already, but apparently no. It uses `nullptr`, so should use C++11.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
