### PR TITLE
qca: fix build for < 10.7

### DIFF
--- a/devel/qca/Portfile
+++ b/devel/qca/Portfile
@@ -51,6 +51,10 @@ switch ${Qt_Major} {
                         patch-qca221-ossl.diff \
                         qt4/patch-installname.diff \
                         qt4/patch-cmakeminver.diff
+        if {${os.platform} eq "darwin" && ${os.major} < 11} {
+            patchfiles-append \
+                        patch-unbreak-qca_systemstore.diff
+        }
         configure.args-append \
                         -DQT4_BUILD:BOOL=ON
     }

--- a/devel/qca/files/patch-unbreak-qca_systemstore.diff
+++ b/devel/qca/files/patch-unbreak-qca_systemstore.diff
@@ -1,0 +1,18 @@
+Reverts a breaking commit: https://github.com/KDE/qca/commit/f223ce03d4b94ffbb093fc8be5adf8d968f54434
+
+--- a/src/qca_systemstore_mac.cpp.orig	2019-04-24 20:58:14.000000000 +0800
++++ b/src/qca_systemstore_mac.cpp	2023-06-20 04:09:17.000000000 +0800
+@@ -39,9 +39,10 @@
+ 	for(int n = 0; n < CFArrayGetCount(anchors); ++n)
+ 	{
+ 		SecCertificateRef cr = (SecCertificateRef)CFArrayGetValueAtIndex(anchors, n);
+-		CFDataRef derRef = SecCertificateCopyData(cr);
+-		QByteArray der((const char *)CFDataGetBytePtr(derRef), CFDataGetLength(derRef));
+-		CFRelease(derRef);
++		CSSM_DATA cssm;
++		SecCertificateGetData(cr, &cssm);
++		QByteArray der(cssm.Length, 0);
++		memcpy(der.data(), cssm.Data, cssm.Length);
+ 
+ 		Certificate cert = Certificate::fromDER(der, 0, provider);
+ 		if(!cert.isNull())


### PR DESCRIPTION
#### Description

Turned out, it is upstream has broken it with one commit.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
