### PR TITLE
glslang: fix build on 10.9 Mavericks and older

### DIFF
--- a/graphics/glslang/Portfile
+++ b/graphics/glslang/Portfile
@@ -34,4 +34,16 @@ depends_build-append    port:python${py_ver_nodot}
 configure.python        ${prefix}/bin/python${py_ver}
 configure.args-append   -DPYTHON_EXECUTABLE:FILEPATH=${configure.python}
 
+# This patch has been submitted upstream:
+# https://github.com/KhronosGroup/glslang/pull/3243
+# This patch applies to glslang version 12.2.0. When the patch gets
+# integrated into the upstream code for a future release, then this
+# patch should get removed when updating this port.
+if {${os.platform} eq "darwin" && ${os.major} <= 13} {
+    post-patch {
+        reinplace {/CMAKE_CXX_COMPILER_ID.*AppleClang/,/--no-undefined/s/else()/elseif(NOT APPLE)/} \
+            ${worksrcpath}/CMakeLists.txt
+    }
+}
+
 configure.args-append   -DENABLE_GLSLANG_INSTALL=ON


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This PR fixes linking errors when building on 10.9 Mavericks and older.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 12F2560 x86_64
Xcode 5.1.1 5B1008

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
