### PR TITLE
p5-convert-moji: new port (version 0.11)

### DIFF
--- a/perl/p5-convert-moji/Portfile
+++ b/perl/p5-convert-moji/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Convert-Moji 0.11
+revision            0
+
+license             {Artistic-1 GPL}
+maintainers         {raf.org:raf @macportsraf} openmaintainer
+description         Convert::Moji - Convert between alphabets
+long_description    {*}${description}
+platforms           {darwin any}
+supported_archs     noarch
+
+checksums           rmd160 6de41f99c29e842a301f0b7693772855e84b19e7 \
+                    sha256 28de563d202fc7cfa229cb7122c9a784a30a3210eb2fe5e6009cfca2130e85d5 \
+                    size 8954
+


### PR DESCRIPTION
#### Description

CPAN Perl module: Convert::Moji - Convert between alphabets

This is a prerequisite of another module I want to add.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
