### PR TITLE
psi: update to 1.5, fix build for 10.14+

### DIFF
--- a/net/psi/Portfile
+++ b/net/psi/Portfile
@@ -6,14 +6,13 @@ name                psi
 version             1.5
 revision            0
 categories          net chat
-maintainers         {rowue @rowue}
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         jabber-based instant messaging client
-long_description \
-    Psi is a capable Jabber client aimed at experienced users.  Its design \
-    goals are simplicity and stability.
+long_description    Psi is a capable Jabber client aimed at experienced users. \
+                    Its design goals are simplicity and stability.
 license             GPL-2+
 
-homepage            https://psi-im.org/
+homepage            https://psi-im.org
 master_sites        sourceforge
 use_xz              yes
 

--- a/net/psi/Portfile
+++ b/net/psi/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                psi
-version             1.4
-revision            1
+version             1.5
+revision            0
 categories          net chat
 maintainers         {rowue @rowue}
 description         jabber-based instant messaging client
@@ -13,15 +13,13 @@ long_description \
     goals are simplicity and stability.
 license             GPL-2+
 
-platforms           darwin
-
 homepage            https://psi-im.org/
 master_sites        sourceforge
 use_xz              yes
 
-checksums           rmd160  2f047baa0e2af16c949f6bb33667124253e231e4 \
-                    sha256  761934c1c62daf69215f085ba24d7f9cd4db05ef0ad735383d68fb03d21571ad \
-                    size    2119840
+checksums           rmd160  fbea608528f90d90b3acf76014e1a6312e39d340 \
+                    sha256  3167350fd43fab4dc948cb5179ca10159a7aa318472d1a8a7617e41f5aa8b5b7 \
+                    size    2125104
 
 compiler.cxx_standard   2011
 
@@ -40,6 +38,10 @@ if {${os.major} < 13} {
     patchfiles-append \
                      patch-os-compat.diff
 }
+if {${os.major} > 17} {
+    patchfiles-append \
+                     patch-xcode11.diff
+}
 
 depends_lib-append   port:libidn \
                      port:minizip \
@@ -57,6 +59,8 @@ universal_variant    no
 
 # Qt provides it's own optimization flag
 configure.optflags
+
+# FIXME: older systems need a fix-up: https://github.com/psi-im/psi/issues/719
 
 variant qt4 conflicts qt5 description "build Qt4 version of ${name}" {
     PortGroup qt4 1.0

--- a/net/psi/files/patch-xcode11.diff
+++ b/net/psi/files/patch-xcode11.diff
@@ -1,0 +1,29 @@
+# https://github.com/psi-im/psi/commit/73cd894861345ee7cca10e4296e455efa85c0f1d
+
+--- src/CocoaUtilities/CocoaTrayClick.cpp.orig	2020-09-06 15:44:34.000000000 +0800
++++ src/CocoaUtilities/CocoaTrayClick.cpp	2023-06-22 02:36:05.000000000 +0800
+@@ -28,6 +28,9 @@
+ 
+ //#define DEBUG_OUTPUT
+ 
++typedef objc_object* (*object_type)(struct objc_object *self, SEL _cmd);
++object_type objc_msgSendObject = (object_type)objc_msgSend;
++
+ bool dockClickHandler(id /*self*/, SEL /*_cmd*/, ...)
+ {
+ 	CocoaTrayClick::instance()->emitTrayClicked();
+@@ -47,11 +50,11 @@
+ 	: QObject(qApp)
+ {
+ 	Class cls = objc_getClass("NSApplication");
+-	objc_object *appInst = objc_msgSend((objc_object*)cls, sel_registerName("sharedApplication"));
++	objc_object *appInst = objc_msgSendObject((objc_object*)cls, sel_registerName("sharedApplication"));
+ 
+ 	if(appInst != NULL) {
+-		objc_object* delegate = objc_msgSend(appInst, sel_registerName("delegate"));
+-		Class delClass = (Class)objc_msgSend(delegate,  sel_registerName("class"));
++		objc_object* delegate = objc_msgSendObject(appInst, sel_registerName("delegate"));
++		Class delClass = (Class)objc_msgSendObject(delegate, sel_registerName("class"));
+ 		SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
+ 		if (class_getInstanceMethod(delClass, shouldHandle)) {
+ 			if (class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:")) {


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
