### PR TITLE
softhsm: fix segment violation at application end

### DIFF
--- a/security/softhsm/Portfile
+++ b/security/softhsm/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                softhsm
 version             2.6.1
-revision            1
+revision            2
 categories          security
 platforms           darwin
 license             BSD
@@ -22,6 +22,10 @@ master_sites        http://dist.opendnssec.org/source/
 checksums           rmd160  73b116b9513d1afcd241431e967a582de1cb737f \
                     sha256  61249473054bcd1811519ef9a989a880a7bdcc36d317c9c25457fc614df475f2 \
                     size 1066766
+
+patchfiles          0001-Issue-548-Don-t-clean-up-engines-after-OpenSSL-has-a.patch \
+                    0002-Fix-OPENSSL_cleanup-detection-without-using-our-own-.patch \
+                    0003-mouse07410-OSSLCryptoFactory.patch
 
 depends_build       port:libtool port:pkgconfig port:cppunit
 depends_lib         path:lib/libssl.dylib:openssl \

--- a/security/softhsm/files/0001-Issue-548-Don-t-clean-up-engines-after-OpenSSL-has-a.patch
+++ b/security/softhsm/files/0001-Issue-548-Don-t-clean-up-engines-after-OpenSSL-has-a.patch
@@ -1,0 +1,128 @@
+From c2cc0652b4c4829fc6ba186469f4e324af77dfe8 Mon Sep 17 00:00:00 2001
+From: David Woodhouse <dwmw2@infradead.org>
+Date: Mon, 4 May 2020 17:36:22 +0100
+Subject: [PATCH 1/2] Issue #548: Don't clean up engines after OpenSSL has
+ already shut down
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+As of 1.1.0, OpenSSL registers its own atexit() handler to call
+OPENSSL_cleanup(). If our own code subsequently tries to, for example,
+unreference an ENGINE, then it'll crash or deadlock with a use after
+free.
+
+Fix it by registering a callback with OPENSSL_atexit() to be called when
+OPENSSL_cleanup() is called. It sets a flag which prevents any further
+touching of OpenSSL objects — which would otherwise happen fairly much
+immediately thereafter when our own OSSLCryptoFactory destructor gets
+called by the C++ runtime's own atexit() handler.
+
+Fixes: #548
+
+diff --git src/lib/crypto/OSSLCryptoFactory.cpp src/lib/crypto/OSSLCryptoFactory.cpp
+index 32daca2..81d080a 100644
+--- src/lib/crypto/OSSLCryptoFactory.cpp
++++ src/lib/crypto/OSSLCryptoFactory.cpp
+@@ -77,6 +77,7 @@ bool OSSLCryptoFactory::FipsSelfTestStatus = false;
+ 
+ static unsigned nlocks;
+ static Mutex** locks;
++static bool ossl_shutdown;
+ 
+ // Mutex callback
+ void lock_callback(int mode, int n, const char* file, int line)
+@@ -101,6 +102,26 @@ void lock_callback(int mode, int n, const char* file, int line)
+ 	}
+ }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++void ossl_factory_shutdown(void)
++{
++	/*
++	 * As of 1.1.0, OpenSSL registers its own atexit() handler
++	 * to call OPENSSL_cleanup(). If our own atexit() handler
++	 * subsequently tries to, for example, unreference an
++	 * ENGINE, then it'll crash or deadlock with a use-after-free.
++	 *
++	 * This hook into the OpenSSL_atexit() handlers will get called
++	 * when OPENSSL_cleanup() is called, and sets a flag which
++	 * prevents any further touching of OpenSSL objects — which
++	 * would otherwise happen fairly much immediately thereafter
++	 * when our own OSSLCryptoFactory destructor gets called by
++	 * the C++ runtime's own atexit() handler.
++	 */
++	ossl_shutdown = true;
++}
++#endif
++
+ // Constructor
+ OSSLCryptoFactory::OSSLCryptoFactory()
+ {
+@@ -119,6 +140,9 @@ OSSLCryptoFactory::OSSLCryptoFactory()
+ 		CRYPTO_set_locking_callback(lock_callback);
+ 		setLockingCallback = true;
+ 	}
++#else
++	// Mustn't dereference engines after OpenSSL itself has shut down
++	OPENSSL_atexit(ossl_factory_shutdown);
+ #endif
+ 
+ #ifdef WITH_FIPS
+@@ -226,31 +250,35 @@ err:
+ // Destructor
+ OSSLCryptoFactory::~OSSLCryptoFactory()
+ {
+-#ifdef WITH_GOST
+-	// Finish the GOST engine
+-	if (eg != NULL)
++	// Don't do this if OPENSSL_cleanup() has already happened
++	if (!ossl_shutdown)
+ 	{
+-		ENGINE_finish(eg);
+-		ENGINE_free(eg);
+-		eg = NULL;
+-	}
++#ifdef WITH_GOST
++		// Finish the GOST engine
++		if (eg != NULL)
++		{
++			ENGINE_finish(eg);
++			ENGINE_free(eg);
++			eg = NULL;
++		}
+ #endif
+ 
+-	// Finish the rd_rand engine
+-	ENGINE_finish(rdrand_engine);
+-	ENGINE_free(rdrand_engine);
+-	rdrand_engine = NULL;
++		// Finish the rd_rand engine
++		ENGINE_finish(rdrand_engine);
++		ENGINE_free(rdrand_engine);
++		rdrand_engine = NULL;
+ 
++		// Recycle locks
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++		if (setLockingCallback)
++		{
++			CRYPTO_set_locking_callback(NULL);
++		}
++#endif
++	}
+ 	// Destroy the one-and-only RNG
+ 	delete rng;
+ 
+-	// Recycle locks
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+-	if (setLockingCallback)
+-	{
+-		CRYPTO_set_locking_callback(NULL);
+-	}
+-#endif
+ 	for (unsigned i = 0; i < nlocks; i++)
+ 	{
+ 		MutexFactory::i()->recycleMutex(locks[i]);
+-- 
+2.40.1
+

--- a/security/softhsm/files/0002-Fix-OPENSSL_cleanup-detection-without-using-our-own-.patch
+++ b/security/softhsm/files/0002-Fix-OPENSSL_cleanup-detection-without-using-our-own-.patch
@@ -1,0 +1,93 @@
+From 2793f3cafb3ea22fe61ad4fc1c626c8121cd4124 Mon Sep 17 00:00:00 2001
+From: David Woodhouse <dwmw2@infradead.org>
+Date: Wed, 13 May 2020 13:13:34 +0100
+Subject: [PATCH 2/2] Fix OPENSSL_cleanup() detection without using our own
+ atexit() handler
+
+We can't register our own atexit() or OPENSSL_atexit() handler because
+there's no way to unregister it when the SoftHSM DSO is unloaded. This
+causes the crash reported at https://bugzilla.redhat.com/1831086#c8
+
+Instead of using that method to set a flag showing that OPENSSL_cleanup()
+has occurred, instead test directly by calling OPENSSL_init_crypto() for
+something that *would* do nothing, but will fail if OPENSSL_cleanup()
+has indeed been run already.
+
+Fixes: c2cc0652b4 "Issue #548: Don't clean up engines after OpenSSL
+                   has already shut down"
+
+diff --git src/lib/crypto/OSSLCryptoFactory.cpp src/lib/crypto/OSSLCryptoFactory.cpp
+index 81d080a..ace4bcb 100644
+--- src/lib/crypto/OSSLCryptoFactory.cpp
++++ src/lib/crypto/OSSLCryptoFactory.cpp
+@@ -77,7 +77,6 @@ bool OSSLCryptoFactory::FipsSelfTestStatus = false;
+ 
+ static unsigned nlocks;
+ static Mutex** locks;
+-static bool ossl_shutdown;
+ 
+ // Mutex callback
+ void lock_callback(int mode, int n, const char* file, int line)
+@@ -102,26 +101,6 @@ void lock_callback(int mode, int n, const char* file, int line)
+ 	}
+ }
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+-void ossl_factory_shutdown(void)
+-{
+-	/*
+-	 * As of 1.1.0, OpenSSL registers its own atexit() handler
+-	 * to call OPENSSL_cleanup(). If our own atexit() handler
+-	 * subsequently tries to, for example, unreference an
+-	 * ENGINE, then it'll crash or deadlock with a use-after-free.
+-	 *
+-	 * This hook into the OpenSSL_atexit() handlers will get called
+-	 * when OPENSSL_cleanup() is called, and sets a flag which
+-	 * prevents any further touching of OpenSSL objects — which
+-	 * would otherwise happen fairly much immediately thereafter
+-	 * when our own OSSLCryptoFactory destructor gets called by
+-	 * the C++ runtime's own atexit() handler.
+-	 */
+-	ossl_shutdown = true;
+-}
+-#endif
+-
+ // Constructor
+ OSSLCryptoFactory::OSSLCryptoFactory()
+ {
+@@ -140,9 +119,6 @@ OSSLCryptoFactory::OSSLCryptoFactory()
+ 		CRYPTO_set_locking_callback(lock_callback);
+ 		setLockingCallback = true;
+ 	}
+-#else
+-	// Mustn't dereference engines after OpenSSL itself has shut down
+-	OPENSSL_atexit(ossl_factory_shutdown);
+ #endif
+ 
+ #ifdef WITH_FIPS
+@@ -250,7 +226,21 @@ err:
+ // Destructor
+ OSSLCryptoFactory::~OSSLCryptoFactory()
+ {
+-	// Don't do this if OPENSSL_cleanup() has already happened
++	bool ossl_shutdown = false;
++
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++	// OpenSSL 1.1.0+ will register an atexit() handler to run
++	// OPENSSL_cleanup(). If that has already happened we must
++	// not attempt to free any ENGINEs because they'll already
++	// have been destroyed and the use-after-free would cause
++	// a deadlock or crash.
++	//
++	// Detect that situation because reinitialisation will fail
++	// after OPENSSL_cleanup() has run.
++	(void)ERR_set_mark();
++	ossl_shutdown = !OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_RDRAND, NULL);
++	(void)ERR_pop_to_mark();
++#endif
+ 	if (!ossl_shutdown)
+ 	{
+ #ifdef WITH_GOST
+-- 
+2.40.1
+

--- a/security/softhsm/files/0003-mouse07410-OSSLCryptoFactory.patch
+++ b/security/softhsm/files/0003-mouse07410-OSSLCryptoFactory.patch
@@ -1,0 +1,21 @@
+diff --git src/lib/crypto/OSSLCryptoFactory.cpp src/lib/crypto/OSSLCryptoFactory.cpp
+index ace4bcb..b5456d4 100644
+--- src/lib/crypto/OSSLCryptoFactory.cpp
++++ src/lib/crypto/OSSLCryptoFactory.cpp
+@@ -175,6 +175,7 @@ OSSLCryptoFactory::OSSLCryptoFactory()
+ 			    OPENSSL_INIT_LOAD_CRYPTO_STRINGS |
+ 			    OPENSSL_INIT_ADD_ALL_CIPHERS |
+ 			    OPENSSL_INIT_ADD_ALL_DIGESTS |
++			    OPENSSL_INIT_NO_ATEXIT |
+ 			    OPENSSL_INIT_LOAD_CONFIG, NULL);
+ #endif
+ 
+@@ -238,7 +239,7 @@ OSSLCryptoFactory::~OSSLCryptoFactory()
+ 	// Detect that situation because reinitialisation will fail
+ 	// after OPENSSL_cleanup() has run.
+ 	(void)ERR_set_mark();
+-	ossl_shutdown = !OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_RDRAND, NULL);
++	ossl_shutdown = !OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_RDRAND | OPENSSL_INIT_NO_ATEXIT, NULL);
+ 	(void)ERR_pop_to_mark();
+ #endif
+ 	if (!ossl_shutdown)


### PR DESCRIPTION
Fix a segmentation violation at application termination through a combination of a couple of commits cherry-picked from upstream post-2.6.1 and a contribution from mouse07410 directed at the same issue.

Closes: https://trac.macports.org/ticket/64036

#### Description

The SEGV in question has been seen in a couple of circumstances, as mentioned in the ticket. One is in the face of multiple OpenSSL engines and the other is through use of the PKCS11 bridge from Java. This has been largely fixed upstream (although this includes an additional contribution which may also help in the first problem case).

I believe the issue wasn't always apparent, but appeared when some changes were made to the underlying OpenSSL implementation.

There seems little chance that the upstream project will see another release soon, or perhaps ever. This patch gets the MacPorts version back to functionality; the only alternative for users would be to build from the upstream development branch sources themselves.

###### Type(s)

<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.4 22F66 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
