### PR TITLE
libiodbc: update to 3.52.16

### DIFF
--- a/devel/libiodbc/Portfile
+++ b/devel/libiodbc/Portfile
@@ -4,10 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           active_variants 1.1
 
-github.setup        openlink iODBC 3.52.15 v
+github.setup        openlink iODBC 3.52.16 v
+github.tarball_from releases
 #override name (keep it lowercase)
 name                libiodbc
-revision            2
+revision            0
 categories          devel
 maintainers         {snc @nerdling} openmaintainer
 license             BSD
@@ -15,26 +16,27 @@ description         Independent Open DataBase Connectivity
 long_description    iODBC is the acronym for Independent Open DataBase Connectivity, \
                     an Open Source platform independent implementation of both the \
                     ODBC and X/Open specifications.
-platforms           darwin
 
-checksums           rmd160  60a54f0f032e98c3dd56190044202e7d942a9eeb \
-                    sha256  40c96973dfa02725f3e338eeed2f735e662eeb59de43a58ec871a34dc64c698d \
-                    size    659032
+distname            ${name}-${version}
 
-depends_build-append    port:automake \
-                        port:autoconf \
-                        port:libtool
+checksums           rmd160  5b8a762b5df534f2a10a61fa80ddfe4144bed8cf \
+                    sha256  3898b32d07961360f6f2cf36db36036b719a230e476469258a80f32243e845fa \
+                    size    1086850
 
-patchfiles-append   patch-iodbcinst-unicode.h.diff
+patchfiles-append   patch-iodbcinst-unicode.h.diff patch-mac-link-inclibs.diff
 
 configure.args-append   --disable-libodbc
 
 variant libodbc description {install extra libodbc.a library} {
-    configure.args-replace --disable-libodbc --enable-libodbc
-    conflicts           unixODBC
+    configure.args-replace  --disable-libodbc --enable-libodbc
+    configure.args-delete   --includedir=${prefix}/include/${name}
+    conflicts               unixODBC
 }
 
-variant x11 {
+variant x11 conflicts gui {
+    depends_build-append \
+                        port:pkgconfig
+
     depends_lib-append  port:atk \
                         path:lib/pkgconfig/cairo.pc:cairo \
                         port:fontconfig \
@@ -62,11 +64,61 @@ variant x11 {
     configure.args-delete   --disable-gui
 }
 
-default_variants +x11 +libodbc
+build.args
 
-pre-configure {
-    system -W ${worksrcpath} "sh ./autogen.sh"
+variant gui conflicts x11 description {install admin GUI} {
+    post-patch {
+        reinplace "s|@IODBC_VERSION@|${version}|" \
+            ${worksrcpath}/mac/iodbc-config.macos
+        reinplace "s|/usr/local/iODBC|${prefix}|" \
+            ${worksrcpath}/mac/iodbc-config.macos \
+            ${worksrcpath}/mac/link-inclibs.sh
+        reinplace "s|/Applications|${applications_dir}|" \
+            {*}[glob ${worksrcpath}/mac/*/*/project.pbxproj] \
+            {*}[glob ${worksrcpath}/mac/*/*/*/project.pbxproj]
+        reinplace "s|/Library/Application Support/iODBC/bin|${prefix}/bin|" \
+            ${worksrcpath}/mac/iODBCtest/iODBCtest.xcodeproj/project.pbxproj \
+            ${worksrcpath}/mac/iODBCtestw/iODBCtestw.xcodeproj/project.pbxproj
+        reinplace -E "s|(\[ \")])/Library/Frameworks|\\1${frameworks_dir}|" \
+            ${worksrcpath}/mac/GNUmakefile \
+            ${worksrcpath}/mac/link-inclibs.sh \
+            {*}[glob ${worksrcpath}/mac/*/*/project.pbxproj] \
+            {*}[glob ${worksrcpath}/mac/*/*/*/project.pbxproj]
+        reinplace -E "s|(MACOSX_DEPLOYMENT_TARGET) = 10.9|\\1 = ${macosx_deployment_target}|" \
+            {*}[glob ${worksrcpath}/mac/*/*/project.pbxproj] \
+            {*}[glob ${worksrcpath}/mac/*/*/*/project.pbxproj]
+    }
+
+    use_xcode           yes
+    build.dir           ${worksrcpath}/mac
+    build.args          MODEL="Deployment -IDECustomDerivedDataLocation=${workpath}/DerivedData"
+
+    platform darwin {
+        if {${os.major} >= 19} {
+            build.args-append   IODBC_32BIT=x86_64
+        }
+    }
+
+    destroot.args       {*}${build.args}
+
+    post-destroot {
+        copy ${worksrcpath}/man/iodbc-config.1 \
+            ${worksrcpath}/man/iodbctest.1 \
+            ${worksrcpath}/man/iodbctestw.1 \
+            ${destroot}${prefix}/share/man/man1
+
+        if {[variant_isset libodbc]} {
+            ln -s libiodbc.dylib ${destroot}${prefix}/lib/libodbc.dylib
+        } else {
+            xinstall -d ${destroot}${prefix}/include/${name}
+            move {*}[glob ${destroot}${prefix}/include/*.h] \
+                ${destroot}${prefix}/include/${name}
+        }
+    }
 }
+
+default_variants +gui +libodbc
+
 configure.args-append   --disable-gui \
                         --includedir=${prefix}/include/${name} \
                         --with-iodbc-inidir=${prefix}/etc

--- a/devel/libiodbc/files/patch-mac-link-inclibs.diff
+++ b/devel/libiodbc/files/patch-mac-link-inclibs.diff
@@ -1,0 +1,17 @@
+--- mac/link-inclibs.sh.orig	2023-06-21 23:48:02
++++ mac/link-inclibs.sh	2023-06-22 00:07:13
+@@ -80,14 +80,7 @@
+ INST_FW="/opt/local/Library/Frameworks/iODBCinst.framework"
+ 
+ 
+-#
+-#  Remove old installation
+-#
+-if [ -d "$PREFIX" ] ; then
+-  rm -rf "$PREFIX"
+-fi
+ 
+-
+ #
+ #  Create new directory structure
+ #


### PR DESCRIPTION
#### Description

Clean up Portfile and build GUI using macOS-specific Makefile.

The GTK version fails to build.
    
Closes: https://trac.macports.org/ticket/67661

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?