### PR TITLE
spring-boot-cli: update to 3.1.1

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.1.0
+version         3.1.1
 revision        0
 
 categories      java
@@ -30,15 +30,15 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  6e0f11183abc213369da33afc80784085925e240 \
-                sha256  cdc8e4baf7747bb18f862941c094bd163274144ffbacc75bde791fd37ae82865 \
-                size    5141514
+checksums       rmd160  d612027d37bbad985738a3e95a80e869d519e30e \
+                sha256  2c473b35e1c88ce6cf12a20d6d1835890ed3b66a5d27428ddaf5670180ad5d03 \
+                size    5144586
 
 worksrcdir      spring-${version}
 
 use_configure   no
 
-java.version    1.8+
+java.version    17+
 java.fallback   openjdk17
 
 build {}


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.1.1, and fix minimum Java version.

###### Tested on

macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?