### PR TITLE
p5-lingua-ja-moji: new port (version 0.59)

### DIFF
--- a/perl/p5-lingua-ja-moji/Portfile
+++ b/perl/p5-lingua-ja-moji/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Lingua-JA-Moji 0.59
+revision            0
+
+license             {Artistic-1 GPL}
+maintainers         {raf.org:raf @macportsraf} openmaintainer
+description         Lingua::JA::Moji - Handle many kinds of Japanese characters
+long_description    {*}${description}
+platforms           {darwin any}
+supported_archs     noarch
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-convert-moji \
+                    port:p${perl5.major}-json-parse
+}
+
+checksums           rmd160 9f65a65769b2f4dddb4a1712b6113761f4635662 \
+                    sha256 896cad9a5a01b30daf0f483dabe312119a5cd794490f4f25677a484f9988c2e4 \
+                    size 61446
+


### PR DESCRIPTION
#### Description

CPAN perl module Lingua::JA::Moji - Handle many kinds of Japanese characters

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
