### PR TITLE
lagrange: update to 1.16.5

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.16.4 v
+gitea.setup         gemini lagrange 1.16.5 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  9e18c7a169109de3c585fe5c6a380c9c16ff8d51 \
-                    sha256  f1d73da15b85cc8ff267c76a68823bebf951effbfb0e17b8cf5a1a908d2492e6 \
-                    size    7543124
+checksums           rmd160  43a9c2409827880199fc7eae5c4ecebb259c8414 \
+                    sha256  ee3f8dfc772b6c829d51fd7ae42abec73eff0c60dac74a93f7f283ac7ef42b65 \
+                    size    7543696
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/skyjake/lagrange/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
