### PR TITLE
miniflux: update to 2.0.45

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.44
+go.setup            github.com/miniflux/v2 2.0.45
 go.package          miniflux.app
 name                miniflux
 revision            0
@@ -16,9 +16,9 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  79f41ee1dd72c61fb1da47dbd3aa0d9d79948f6d \
-                        sha256  9e3f01b417e24bb77695446da2af1f707cf3c2c8c8e8eb1f56340a7cd6567a70 \
-                        size    574445
+                        rmd160  dcf7756cd48f51b74319c9f6b90568bad62fb40f \
+                        sha256  9196a05bfb0c6630f4b5b6ecba84e520ad321786debabb5c767684d75d4277ad \
+                        size    580612
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
@@ -49,35 +49,35 @@ go.vendors          mvdan.cc/xurls \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
                     golang.org/x/text \
-                        lock    v0.9.0 \
-                        rmd160  024cee280ecc35a165fe05f6cb43f745be776cf7 \
-                        sha256  c84b520575096154588a99123b775d5ccbc66e492a6d22aaa75a5dd8572634ab \
-                        size    8356818 \
+                        lock    v0.10.0 \
+                        rmd160  5a436563b2063896e98976f9d30e74051a024888 \
+                        sha256  73558470c5d1e4c49244b4519c77f4b0dc5988ec8138f89963cbc9fc2aa91a15 \
+                        size    8358210 \
                     golang.org/x/term \
-                        lock    v0.8.0 \
-                        rmd160  4ad52ddb467af2722834a7c9330616d97dc9fdb3 \
-                        sha256  5dc93dd1d75d29a136b2c18dbacc8a244067f8a8d585c93ae28d5144efe12c45 \
-                        size    14800 \
-                    golang.org/x/sys \
-                        lock    v0.8.0 \
-                        rmd160  e678fbf405f6f2de2dd29b0a8b71baec9f1f1321 \
-                        sha256  8c0922a390cb8c22c340d69aa24ecf3cd923b30ca28dc96965d32d4b3a4e917d \
-                        size    1436856 \
-                    golang.org/x/oauth2 \
-                        lock    v0.7.0 \
-                        rmd160  7cc03af8875a7394bf2f017dc8b6ceeab0b0f7bf \
-                        sha256  19fc8f8eba76cfb58ab6fe0dc857e03f3aaa4cfd92c28ee60d555fe6b7efeb1e \
-                        size    87771 \
-                    golang.org/x/net \
                         lock    v0.9.0 \
-                        rmd160  978560e0c375a9f678822da49eee99ac3c6cd141 \
-                        sha256  4709176f14c6f0a6cee42ada89c7fef5af41455e21c7d30372bf80d9d1fc1114 \
-                        size    1244630 \
+                        rmd160  7d57f52bf0195a21d9628f7d04b202b6426bfa21 \
+                        sha256  7628c777f684cd13619c91b2b007c27e6d678fcfee3c6e1a6741a418a5c907d6 \
+                        size    14799 \
+                    golang.org/x/sys \
+                        lock    v0.9.0 \
+                        rmd160  2cc3f76a07816bf45247088a57f093ee1dfebd00 \
+                        sha256  138197a232bf1882aeb8865e8263afc6e7dc3b34e632361098ea3506c13f6791 \
+                        size    1440217 \
+                    golang.org/x/oauth2 \
+                        lock    v0.9.0 \
+                        rmd160  adb437da22c0f7ffd377d9c743f25c45456f935f \
+                        sha256  1920ba51b2dbed56e8e12708939e85c205b56fed329754f5e2f0ab9dbad05f98 \
+                        size    88643 \
+                    golang.org/x/net \
+                        lock    v0.11.0 \
+                        rmd160  3a7e9ec93e351ad5dd322e0668c5249bb72dbd1d \
+                        sha256  d8f2473a61f0c3d55f7a1ef159ed6b16479323a5e4e35ec1e81fe790aa918042 \
+                        size    1284069 \
                     golang.org/x/crypto \
-                        lock    v0.8.0 \
-                        rmd160  cdd6ae8112a74f12233909e54b4f454a1ba4f8ab \
-                        sha256  6aaa7fdbd09f9a3cb2400892e114594a71d1f2a88a10e253feb41af313b1f6f8 \
-                        size    1634989 \
+                        lock    v0.10.0 \
+                        rmd160  f3e7f723fa805570142bcb6fc2a7c168f32b1a50 \
+                        sha256  c43ab957e80b3d449442d11ecd9e06d64d9962cf8a632652e6d408f55d844c9d \
+                        size    1785065 \
                     github.com/yuin/goldmark \
                         lock    v1.5.4 \
                         rmd160  7e428750043e781507d94e54431c488a2e07110a \
@@ -89,20 +89,20 @@ go.vendors          mvdan.cc/xurls \
                         sha256  4d7559e4d965a056e8dc4c32f852a23451ad47cd639123bc7a4bf7268ff94861 \
                         size    3248 \
                     github.com/tdewolff/test \
-                        lock    v1.0.7 \
-                        rmd160  2ed22bbdbe37e41a47c72b0723f119aca5b05378 \
-                        sha256  ec3d36b70718e240d985ffb44998ff043680dbaf8800abb8acabd509ad3c06a5 \
-                        size    2949 \
+                        lock    v1.0.9 \
+                        rmd160  6b9a086f0d9479d652817a3a0fb074a00bd075d5 \
+                        sha256  38f2a2130a529983eb487812a4f577000c6894a80f126f7377fc08f88d02da57 \
+                        size    3089 \
                     github.com/tdewolff/parse \
-                        lock    v2.6.5 \
-                        rmd160  da41b43201a259b16f31cc3f98b3f075fdc0142f \
-                        sha256  cf43970b52d797dfe041e357df348bb1e7e407b5cd4bbcadd1f1310b8832a83f \
-                        size    104778 \
+                        lock    v2.6.6 \
+                        rmd160  0f1f426a750662d5da5d71e94f2b4695022cbc2e \
+                        sha256  6fbe7ffc7d2a7bb64586b6582f00325c292625e51fc27282b15bdae545bcef90 \
+                        size    104809 \
                     github.com/tdewolff/minify \
-                        lock    v2.12.5 \
-                        rmd160  462386a770743a1eacadb6f8cf50f6e9aadd4685 \
-                        sha256  cf0db1d207def082990b406145dfc58b42ae68b6e19894a3422ab282eae3bb1e \
-                        size    7008959 \
+                        lock    v2.12.7 \
+                        rmd160  79fb17402eb3cd6e5bccac075c6c3a75e7a77415 \
+                        sha256  d1a9e47ff59fd04c4bc87421cda4f956f032607ff98c10239a63f671569bf4b8 \
+                        size    7029578 \
                     github.com/stretchr/testify \
                         lock    v1.8.0 \
                         rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
@@ -114,10 +114,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  7d433ce89160e19d0375617b62e84bc4efce07e02428c09f2dacb7dcf6e6cfce \
                         size    18598 \
                     github.com/prometheus/procfs \
-                        lock    v0.9.0 \
-                        rmd160  a91ed9844868c593a4faf7e6cac47ea4f6443d6f \
-                        sha256  618278b47243204e55efa66074d047b020d2d80b106805299505473938d318c2 \
-                        size    220424 \
+                        lock    v0.10.1 \
+                        rmd160  7457d5314a0fb2e66c81200391866d0fa2a2f230 \
+                        sha256  2cc061359b6bcedb03bac1f3b14b9f1ff1ffdfdbbfb3bad99231c8a56ce7fa87 \
+                        size    226705 \
                     github.com/prometheus/common \
                         lock    v0.42.0 \
                         rmd160  2edad904e117e7e4776ce7a5370333e20f576a80 \
@@ -129,10 +129,10 @@ go.vendors          mvdan.cc/xurls \
                         sha256  54817b98ddf4cde06a2f122c6d811d37ce25cc4f74d0a32bebf5620389c08c00 \
                         size    14955 \
                     github.com/prometheus/client_golang \
-                        lock    v1.15.1 \
-                        rmd160  1fd6bc3b066dc9f1c0a03f18e19aeecfb0fcd0b1 \
-                        sha256  bffdc705ca85c03a6c8c7eb33437fbeb7712d15c5eb4788230da4cbf11d7f96a \
-                        size    264632 \
+                        lock    v1.16.0 \
+                        rmd160  ad0170daf3d6fd4e32623bdb80c6230fdd511c58 \
+                        sha256  884d73dd250c539bc3a784b4d8abce9381d63820737734371c858c4a87da12c7 \
+                        size    1102658 \
                     github.com/pquerna/cachecontrol \
                         lock    v0.1.0 \
                         rmd160  e819f8dcacadd42bbe783a3c1810f17f3e43fa95 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.45)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
