### PR TITLE
lua-lpeg: Add patch to build dylib; neovim-devel: Update to 2023-06-24

### DIFF
--- a/editors/neovim-devel/Portfile
+++ b/editors/neovim-devel/Portfile
@@ -4,10 +4,10 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            neovim neovim 3ac952d4e27f4e2454332a730310316fe13fd4a3
+github.setup            neovim neovim cc624fac683ce6dbd01f10781817cd654cceed38
 name                    neovim-devel
-version                 20230423
-revision                1
+version                 20230624
+revision                0
 categories              editors
 maintainers             {l2dy @l2dy} {judaew @judaew} \
                         openmaintainer
@@ -23,9 +23,9 @@ long_description \
 
 homepage                https://neovim.io
 
-checksums               rmd160  d83f207445e5cc8fec0fdfbe8470192a839b734b \
-                        sha256  3a75236a9d21ad21abe066e048b57241dbca0b7022eb19a2abdf79fb016a73d6 \
-                        size    11577661
+checksums               rmd160  ef610730c4bcd2fa09983313a5517ffcca804f4b \
+                        sha256  1bca456ba8e99af7176fff4605d11b518b310ab45dcf01d60ae6c5109008c14e \
+                        size    11745918
 
 depends_build-append    port:pkgconfig
 

--- a/lua/lua-lpeg/Portfile
+++ b/lua/lua-lpeg/Portfile
@@ -5,11 +5,11 @@ PortGroup           luarocks_org 1.0
 
 name                lua-lpeg
 version             1.0.2
-revision            0
+revision            1
 epoch               1
 luarocks.rock       lpeg-${version}-1.src.rock
 license             MIT
-maintainers         gmail.com:andremm openmaintainer
+maintainers         {judaew @judaew} gmail.com:andremm openmaintainer
 
 description         Parsing Expression Grammars For Lua
 long_description    {*}${description}.
@@ -19,5 +19,15 @@ checksums           rmd160  459e9e52c88de576b8ef4c44dafc582d3d53814e \
                     size    72725
 
 luarocks.worksrcdir lpeg-${version}
-
 luarocks.uploader   gvvaughan
+
+patchfiles          patch-makefile-add-dylib.diff
+
+post-build {
+    system -W ${worksrcpath} "make PREFIX=${prefix} LUADIR=${prefix}/include/lua${lua.version} lpeg.dylib"
+}
+
+post-destroot {
+    xinstall -m 0755 ${worksrcpath}/lpeg.dylib \
+        ${destroot}${prefix}/lib/lua/${lua.version}/lpeg.dylib
+}

--- a/lua/lua-lpeg/Portfile
+++ b/lua/lua-lpeg/Portfile
@@ -9,7 +9,7 @@ revision            1
 epoch               1
 luarocks.rock       lpeg-${version}-1.src.rock
 license             MIT
-maintainers         {judaew @judaew} gmail.com:andremm openmaintainer
+maintainers         {judaew @judaew} openmaintainer
 
 description         Parsing Expression Grammars For Lua
 long_description    {*}${description}.

--- a/lua/lua-lpeg/files/patch-makefile-add-dylib.diff
+++ b/lua/lua-lpeg/files/patch-makefile-add-dylib.diff
@@ -1,0 +1,22 @@
+--- makefile.orig	2019-03-11 16:08:29.000000000 +0200
++++ makefile	2023-06-25 01:12:10.669704347 +0300
+@@ -1,5 +1,6 @@
+ LIBNAME = lpeg
+ LUADIR = ../lua/
+++PREFIX =
+ 
+ COPT = -O2 -DNDEBUG
+ # COPT = -g
+@@ -36,7 +37,10 @@
+ 	$(MAKE) lpeg.so "DLLFLAGS = -bundle -undefined dynamic_lookup"
+ 
+ lpeg.so: $(FILES)
+-	env $(CC) $(DLLFLAGS) $(FILES) -o lpeg.so
++	env $(CC) -bundle -undefined dynamic_lookup $(FILES) -o lpeg.so
++
++lpeg.dylib: $(FILES)
++	env $(CC) -dynamiclib -Wl,-undefined,dynamic_lookup,-install_name,$(PREFIX)/lib/lua/5.1/lpeg.dylib $(FILES) -o lpeg.dylib
+ 
+ $(FILES): makefile
+ 
+


### PR DESCRIPTION
#### Description

Neovim now uses lua-lpeg for runtime. By default, Lpeg is compiled with the `-share` flag, which creating a bundle library. Neovim tries to link the bunlde library with the dylib library, which results in the following error:

```
:info:build ld: can't link with bundle (MH_BUNDLE) only dylibs (MH_DYLIB) file '/opt/local/lib/lua/5.1/lpeg.so' for architecture x86_64
:info:build clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The patch adds the dylib library (with the `-dynamiclib`) in addition to the bundle library (`lpeg.so` and `lpeg.dylib`). Thus, the linker selects `lpeg.dylib` for building and Neovim builds and work correctly.

See https://github.com/neovim/neovim/issues/24124.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4 22F66 x86_64
Xcode 15.0 15A5160n

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
