### PR TITLE
dia: fix overlinking of icu

### DIFF
--- a/gnome/dia/Portfile
+++ b/gnome/dia/Portfile
@@ -5,7 +5,7 @@ PortGroup           active_variants 1.1
 
 name                dia
 version             0.97.3
-revision            6
+revision            7
 checksums           rmd160  a984efa1663cc154f4394060af37fab146f99175 \
                     sha256  22914e48ef48f894bb5143c5efc3d01ab96e0a0cde80de11058d3b4301377d34 \
                     size    5548500

--- a/gnome/dia/files/patch-configure.in.diff
+++ b/gnome/dia/files/patch-configure.in.diff
@@ -1,6 +1,6 @@
---- configure.in.orig	2014-09-05 10:05:27.000000000 -0500
-+++ configure.in	2022-05-19 04:16:03.000000000 -0500
-@@ -68,14 +68,14 @@
+--- configure.in.orig	2014-09-05 08:05:27.000000000 -0700
++++ configure.in	2023-06-19 20:59:54.000000000 -0700
+@@ -68,14 +68,14 @@ if test "$have_pangoft2" = "true"; then
    dnl On Solaris with Forte C, at least, need to link app/dia with -lfreetype.
    dnl It's not enough that -lpangoft2 implicitly pulls it in.
    have_freetype=false
@@ -18,7 +18,7 @@
      AC_TRY_CPP([#include <ft2build.h>
  #include FT_FREETYPE_H
  #if (FREETYPE_MAJOR*1000+FREETYPE_MINOR)*1000+FREETYPE_PATCH < 2000009
-@@ -83,9 +83,9 @@
+@@ -83,9 +83,9 @@ if test "$have_pangoft2" = "true"; then
  #endif
  ],
          [AC_MSG_RESULT(yes)
@@ -30,7 +30,7 @@
  	 AC_SUBST(FREETYPE_CFLAGS)
  	 GTK_MODULES="$GTK_MODULES pangoft2"
  	 AC_DEFINE(HAVE_FREETYPE,1,[Define if you have the FreeType2 library])]
-@@ -307,9 +307,6 @@
+@@ -307,9 +307,6 @@ dnl INTLOBJS doesn't seem to always get 
  dnl idempotent
  AC_SUBST(INTLOBJS)
  
@@ -40,7 +40,16 @@
  dnl
  dnl Locate the gnome-xml library
  dnl
-@@ -540,8 +537,8 @@
+@@ -326,7 +323,7 @@ if test $found_libxml = false; then
+     if test "$vers" -ge 2003009; then
+       AC_MSG_RESULT(found)
+       found_libxml=true
+-      XML_LIBS="`$XML2_CONFIG --libs`"
++      XML_LIBS="`$XML2_CONFIG --libs --dynamic`"
+       XML_CFLAGS="`$XML2_CONFIG --cflags`"
+ 
+       if test "$enable_gnome_print" = "yes"; then
+@@ -540,8 +537,8 @@ if test "x$with_hardbooks" = "xno"; then
    AM_CONDITIONAL(WITH_PSDOC, test "xno" != "xno")
  else
    AM_CONDITIONAL(WITH_HTMLDOC, test "x$xsltproc" != "xno")


### PR DESCRIPTION
The build of the dia executable was erroneously including the icu libraries, even though they're not used directly.  This caused breakage when icu was updated without rebuilding dia.  The patchfile for configure.in now corrects this.

Closes: https://trac.macports.org/ticket/67574

TESTED:
Built all variants successfully on 10.9 x86_64.
Built default variants on 10.4-10.5 ppc, 10.5-10.6 i386, 10.5-10.15 x86_64, and 11.x-13.x arm64.  All successful except 10.4 i386 and 10.5 x86_64 (due to broken glib2 build) and 10.5 i386 (due to broken clang-7.0).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.7 20G1345, arm64, Xcode 13.2.1 13C100
macOS 12.6.6 21G646, arm64, Xcode 14.2 14C18
macOS 13.4 22F66, arm64, Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [N/A] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
