### PR TITLE
libcerf: fix build on powerpc

### DIFF
--- a/math/libcerf/Portfile
+++ b/math/libcerf/Portfile
@@ -21,6 +21,13 @@ checksums           rmd160  f60b6fb827d41e03a83d006e8aac73e4c2ae8eb3 \
                     sha256  02fea3714894fd9577ed5eb48221f470dc3eda3713e16b49b7df3eb3ecc7978b \
                     size    81061
 
+# Build system sets wrong optflags.
+patchfiles-append   patch-powerpc.diff
+
+# Upstream recommends at least 4.3 or preferably later version.
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2 {clang < 400}
+
 test.run            yes
 test.cmd            ctest
 test.target

--- a/math/libcerf/files/patch-powerpc.diff
+++ b/math/libcerf/files/patch-powerpc.diff
@@ -1,0 +1,15 @@
+--- CMakeLists.txt.orig	2023-01-10 16:10:08.000000000 +0800
++++ CMakeLists.txt	2023-06-26 02:28:37.000000000 +0800
+@@ -76,7 +76,11 @@
+     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "GNU" )
+         option(PORTABLE "Build a portable binary without host-specific optimization" OFF)
+         if(NOT PORTABLE)
+-            add_compile_options(-march=native)
++            if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc|ppc64" OR (APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64"))
++                add_compile_options(-mtune=native)
++            else()
++                add_compile_options(-march=native)
++            endif()
+         endif()
+     endif()
+     if (CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
#### Description

Upstream recommends at least gcc-4.3, and since Intel now uses Macports clang on 10.6, this only affects PPC. Also, old Apple compilers do not support `native`.
Then, CMakeLists set wrong optflags which break the build. Fix it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
