### PR TITLE
kakoune: unbreak build on ppc

### DIFF
--- a/editors/kakoune/Portfile
+++ b/editors/kakoune/Portfile
@@ -44,6 +44,10 @@ checksums           rmd160  1b30da34e261db28c0f17d280e927c6748ae5bfb \
                     sha256  f3eab1e663763c62881d553ad6263526940fa3ca357e0183767885415fc80b03 \
                     size    679272
 
+# Until someone comes up with a better one at least.
+# https://github.com/mawww/kakoune/issues/4937
+patchfiles-append   patch-unbreak-ppc.diff
+
 # error: 'uncaught_exceptions' is unavailable: introduced in macOS 10.12
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
     post-patch {

--- a/editors/kakoune/files/patch-unbreak-ppc.diff
+++ b/editors/kakoune/files/patch-unbreak-ppc.diff
@@ -1,0 +1,24 @@
+--- src/regex_impl.hh.orig	2022-10-31 06:05:58.000000000 +0800
++++ src/regex_impl.hh	2023-06-26 09:32:37.000000000 +0800
+@@ -117,7 +117,9 @@
+         mutable uint16_t last_step;
+         Param param;
+     };
++#ifndef __ppc__
+     static_assert(sizeof(Instruction) == 8);
++#endif
+ 
+     explicit operator bool() const { return not instructions.empty(); }
+ 
+--- src/regex_impl.cc.orig	2022-10-31 06:05:58.000000000 +0800
++++ src/regex_impl.cc	2023-06-26 09:32:05.000000000 +0800
+@@ -83,7 +83,9 @@
+         Quantifier quantifier;
+         uint16_t filler = 0;
+     };
++#ifndef __ppc__
+     static_assert(sizeof(Node) == 16, "");
++#endif
+ 
+     Vector<Node, MemoryDomain::Regex> nodes;
+ 


### PR DESCRIPTION
#### Description

See: https://github.com/mawww/kakoune/issues/4937

The app seems to be normally functional. (I did not run any specific tests, but it builds, starts and responds to commands given to it.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
