### PR TITLE
py-memprof: add 3.11 variant

### DIFF
--- a/python/py-memprof/Portfile
+++ b/python/py-memprof/Portfile
@@ -18,7 +18,7 @@ long_description    ${description} It logs and plots the memory usage of all\
                     the variables during the execution of the decorated methods.
 
 homepage            https://jmdana.github.io/memprof/
-python.versions     39 310
+python.versions     39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-memprof/files/py311-memprof
+++ b/python/py-memprof/files/py311-memprof
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.11/bin/mp_plot


### PR DESCRIPTION
#### Description

Add 3.11 variant to py-memprof.
Question, what's the advantage of a separate `select.file` rather than coding it in the portfile directly?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.3 22E252 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
