### PR TITLE
p5-lingua-ja-name-splitter: new port (version 0.09)

### DIFF
--- a/perl/p5-lingua-ja-name-splitter/Portfile
+++ b/perl/p5-lingua-ja-name-splitter/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Lingua-JA-Name-Splitter 0.09
+revision            0
+
+license             {Artistic-1 GPL}
+maintainers         {raf.org:raf @macportsraf} openmaintainer
+description         Lingua::JA::Name::Splitter - split a Japanese name into given and family
+long_description    {*}${description}
+platforms           {darwin any}
+supported_archs     noarch
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-lingua-ja-moji
+}
+
+checksums           rmd160 358ea43054f5b543348ef7b8763604b0cf8d52ab \
+                    sha256 0fc56a97be9dfd249f4bf434ca4054d565ee71232906695c899f705f58706e7f \
+                    size 17966
+


### PR DESCRIPTION
#### Description

Lingua::JA::Name::Splitter - split a Japanese name into given and family

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
