### PR TITLE
p5-conf-libconfig: update to 1.0.0

### DIFF
--- a/perl/p5-conf-libconfig/Portfile
+++ b/perl/p5-conf-libconfig/Portfile
@@ -4,18 +4,20 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         Conf-Libconfig 0.101 ../../authors/id/C/CN/CNANGEL/
+perl5.setup         Conf-Libconfig 1.0.0 ../../authors/id/C/CN/CNANGEL/
 
 platforms           darwin
 maintainers         nomaintainer
 license             BSD
 
 description         Perl extension for libconfig
-long_description    ${description}
+long_description    {*}${description}
 
-checksums           rmd160  89d63cfc61b3928130c951b51ea71f91fe1d2d17 \
-                    sha256  aa58e07503d9b34c8e7b7c4eff6461452cb24607e5736ba1c2af9009d61cad85 \
-                    size    47919
+patchfiles          macports.patch
+
+checksums           rmd160  c65f8dc4550b49fc4b1650fd1a0c06a0e2f7b5a7 \
+                    sha256  535ac5a28d841e17445bb207e3602dfe5b0c593f223ee2a01762126c6af3e010 \
+                    size    49715
 
 if {${perl5.major} != ""} {
     depends_build-append \

--- a/perl/p5-conf-libconfig/files/macports.patch
+++ b/perl/p5-conf-libconfig/files/macports.patch
@@ -1,0 +1,70 @@
+--- Libconfig.xs.orig	2023-06-26 20:12:06.000000000 +1000
++++ Libconfig.xs	2023-06-26 20:13:51.000000000 +1000
+@@ -389,6 +389,7 @@
+ 					break;
+ 				}
+ 			default:
++				break;
+ 		}
+ 	}
+ 	while (settinglen > avlen)
+@@ -428,6 +429,7 @@
+ 						break;
+ 					}
+ 				default:
++					break;
+ 			}
+ 		}
+ 		else
+@@ -450,6 +452,7 @@
+ 						break;
+ 					}
+ 				default:
++					break;
+ 			}
+ 		}
+ 	}
+@@ -484,6 +487,7 @@
+ 					break;
+ 				}
+ 				default:
++					break;
+ 			}
+ 		}
+ 		else
+@@ -508,6 +512,7 @@
+ 						break;
+ 					}
+ 				default:
++					break;
+ 			}
+ 		}
+ 	}
+@@ -530,6 +535,7 @@
+ 					break;
+ 				}
+ 				default:
++					break;
+ 			}
+ 		}
+ 		else
+@@ -552,6 +558,7 @@
+ 						break;
+ 					}
+ 				default:
++					break;
+ 			}
+ 		}
+ 	}
+@@ -660,9 +667,11 @@
+ 			*svref = newSVnv(config_setting_get_float(elem));
+ 			break;
+ 		case CONFIG_TYPE_STRING:
++			{
+ 			const char *val = config_setting_get_string(elem);
+ 			*svref = newSVpvn(val, strlen(val));
+ 			break;
++			}
+ 		case CONFIG_TYPE_ARRAY:
+ 			{
+ 				return get_general_array(elem, svref);


### PR DESCRIPTION
#### Description

CPAN perl module Conf::Libconfig - Perl bindings to the C library libconfig
Version 1.0.0

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
