### PR TITLE
svndigest: Fix build on Lion; fix GitHub handle

### DIFF
--- a/devel/svndigest/Portfile
+++ b/devel/svndigest/Portfile
@@ -11,7 +11,7 @@ checksums           rmd160  6b677d9c5f25842f929585780bc83f590d61330d \
 
 categories          devel
 license             GPL-3+
-maintainers         {gmail.com:pj31042 peter31042}
+maintainers         {gmail.com:pj31042 @peter31042}
 
 description         Create statistics of a subversion repository
 
@@ -40,5 +40,11 @@ use_parallel_build  yes
 
 test.run            yes
 test.target         check
+
+platform darwin 11 {
+    PortGroup       legacysupport 1.1
+    legacysupport.newest_darwin_requires_legacy 11
+    legacysupport.use_mp_libcxx yes
+}
 
 livecheck.regex     /${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

svndigest: Fix build on Lion; fix GitHub handle

Closes: https://trac.macports.org/ticket/67658

I tested with

```sh
% svn checkout https://svn.macports.org/repository/macports/users/ryandesign
% cd ryandesign
% svndigest -v
```

and after some time it produced the output web page which did include the graph image.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Mac OS X 10.7.5
Xcode 4.6.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
