### PR TITLE
py-websocket-client: update to 1.6.1

### DIFF
--- a/python/py-websocket-client/Portfile
+++ b/python/py-websocket-client/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-websocket-client
-version             1.1.0
+version             1.6.1
 revision            0
 
 categories-append   devel
@@ -21,11 +21,11 @@ long_description    websocket-client is a WebSocket client for Python. It provid
 
 homepage            https://websocket-client.readthedocs.io/
 
-checksums           rmd160  71adf207cb874be18ae3f001266f1f644eba6b0b \
-                    sha256  b68e4959d704768fa20e35c9d508c8dc2bbc041fd8d267c0d7345cffe2824568 \
-                    size    58890
+checksums           rmd160  878ab60ea2c400755a244a96dbe5271fdd6f8dea \
+                    sha256  c951af98631d24f8df89ab1019fc365f2227c0892f12fd150e935607c79dd0dd \
+                    size    51324
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

- Add py311 subport

###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?