### PR TITLE
py-python-dotenv: update to 1.0.0

### DIFF
--- a/python/py-python-dotenv/Portfile
+++ b/python/py-python-dotenv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        theskumar python-dotenv 0.20.0 v
+github.setup        theskumar python-dotenv 1.0.0 v
 github.tarball_from archive
 revision            0
 
@@ -22,11 +22,11 @@ long_description    $description \
                     environment variable. It is great for managing app settings \
                     during development and in production using 12-factor principles.
 
-checksums           rmd160  38a1b93a1769a10eb9fb6b62806609d4519ea0bf \
-                    sha256  f25324ebe83467c58a089b30cda9775b3e4d4aa727e898dd2373142679807263 \
-                    size    22356
+checksums           rmd160  bb5dad62bb6f59198fa04b004d211e053d16bb85 \
+                    sha256  93fc54524656990bc9911ab224c991457cd8f39364c48cded2f1c4cb3846c0ac \
+                    size    24730
 
-python.versions     37 38 39 310
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

- Update drops support for Python 3.7
- Add py311 subport

Closes: https://trac.macports.org/ticket/67692

###### Tested on
macOS 13.4 22F66 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?