### PR TITLE
google-cloud-sdk: update to 437.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             436.0.0
+version             437.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  212fd353e800c301dc20f1cbc301a0389474be46 \
-                    sha256  ab0e67acdba90ec7a131cbbe9dbea60c1c021c30c2207c57ec8b4d032be32448 \
-                    size    100525873
+    checksums       rmd160  88ffb077ae26bf23e1bbdd0e8f30dacf38d39390 \
+                    sha256  4285ad617d3c43e33199577077048042dcd40d95fa29adcafdefbd1fc3a166ee \
+                    size    100576122
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  37f31932139e32a3d056b8ed6a42405a46f88609 \
-                    sha256  8d90173018876b95e1a582060537972e7b7b0364e2cf4d8e88718baaae55aa6f \
-                    size    120797929
+    checksums       rmd160  69657308516a4ae8dfaaf0505b7011e8a620c04d \
+                    sha256  9bceaa004f466710edd8c1b0f0682fafa6fbb008d01738f30c1803df3c381aea \
+                    size    120855325
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  e01b8704f73d4d4d06300d495e8791502d531e75 \
-                    sha256  d24e2bce8564ded64b8fa792ea7e6e9922c0a5a9364b45761e5bf4cd68f62fc0 \
-                    size    117918508
+    checksums       rmd160  e29b5e555a5c579f9ddd90b372312b4d157c2c73 \
+                    sha256  f28f7632b75440dc39a90faac27e95e17d7682cc57a88c68ffbacf7a215a5c98 \
+                    size    117974023
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 437.0.0.

###### Tested on

macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?