### PR TITLE
skaffold: update to 2.6.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.5.1 v
+github.setup        GoogleContainerTools skaffold 2.6.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  543227cdf8f84378dc520a13d7a43734631f63ec \
-                    sha256  7852273b13eda1068e300fb22f1cce022b47cfefd2429dac6a30a23074655ce3 \
-                    size    59959604
+checksums           rmd160  252e0c0c71f9cd4293989c41b7b87d7db5e652d0 \
+                    sha256  1c730cc4e0f1c5be78082ea70d8e41462b3b87a6577c889e5befb16626c03650 \
+                    size    60017541
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.6.0.

###### Tested on

macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?