### PR TITLE
gk: new port (v1.0.6)

### DIFF
--- a/devel/gk/Portfile
+++ b/devel/gk/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            gitkraken gk-cli 1.0.6 v
+name                    gk
+github.tarball_from     releases
+
+categories              devel
+license                 CCBY-3
+installs_libs           no
+maintainers             {@sergiolms} \
+                        {@alejandroSuch} \
+                        {@JBUinfo} \
+                        openmaintainer
+
+
+supported_archs         x86_64 arm64
+
+
+description             Official CLI for GitKraken
+long_description        ${name} is GitKraken on the command line. It makes working across multiple \
+                        repos easier with Workspaces, provides access to pull requests and \
+                        issues from multiple services (GitHub, GitLab, Bitbucket, etc.), \
+                        and seamlessly connects with GitKraken Client and GitLens in VS Code \
+                        to visualize git information when you need it.
+
+checksums               ${name}_${version}_macOS_arm64.zip \
+                            sha256  2c9d8b920b781321cf4d40db502f1b8049a2074e41ba9fa8c2755ee31927e052 \
+                            rmd160  42f45dd008fd05407bed976c5b8c82fb70436aab \
+                            size    8872315 \
+                        ${name}_${version}_macOS_x86_64.zip \
+                            sha256  7ac2488301ce2b294aaba9a1bc128da52dbe18eca06803351a078c0b12fa5f0e \
+                            rmd160  9301e54fc86ef3f9f37b80b960fa4793112568e1 \
+                            size    9378365
+
+extract.mkdir           yes
+
+build                   {}
+use_configure           no
+use_zip                 yes
+
+if { ${build_arch} eq "arm64" } {
+    distfiles           ${name}_${version}_macOS_arm64.zip
+} else {
+    distfiles           ${name}_${version}_macOS_x86_64.zip
+}
+
+destroot {
+   xinstall -m 0755 -W ${worksrcpath} gk ${destroot}${prefix}/bin
+}
+
+github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
#### Description
**gk** is GitKraken on the command line. It makes working across multiple repos easier with Workspaces, provides access to pull requests and  issues from multiple services (GitHub, GitLab, Bitbucket, etc.), and seamlessly connects with GitKraken Client and GitLens in VS Code  to visualize git information when you need it.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.2 22D49 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
