### PR TITLE
uacme: fix build on OS X < 10.13

### DIFF
--- a/security/uacme/Portfile
+++ b/security/uacme/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
 github.setup        ndilieto uacme 1.7.4 v
-revision            0
+revision            1
 categories          security
 license             GPL-3+
 platforms           any
@@ -47,6 +48,8 @@ platform darwin {
                     --without-ualpn
     depends_lib-delete \
                     port:libev
+
+    legacysupport.newest_darwin_requires_legacy 16
 }
 
 use_autoreconf      yes

--- a/security/uacme/files/autoconf.patch
+++ b/security/uacme/files/autoconf.patch
@@ -1,3 +1,5 @@
+https://github.com/ndilieto/uacme/pull/70
+
 --- configure.ac.orig
 +++ configure.ac
 @@ -340,28 +340,31 @@ if test "x$OPT_UALPN" != "xno"; then


### PR DESCRIPTION
#### Description

To fix the build on OS X < 10.13 legacy-support is needed.

This PR depends on https://github.com/macports/macports-legacy-support/pull/59.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
