### PR TITLE
google-cloud-sdk: update to 437.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             437.0.0
+version             437.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  88ffb077ae26bf23e1bbdd0e8f30dacf38d39390 \
-                    sha256  4285ad617d3c43e33199577077048042dcd40d95fa29adcafdefbd1fc3a166ee \
-                    size    100576122
+    checksums       rmd160  871d9e1defbd4b3c1ab6f09982346d7f9c68d919 \
+                    sha256  9c72e01fdebf686751b224fd7513545787fe032a59c6575841635871c78ce250 \
+                    size    100577590
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  69657308516a4ae8dfaaf0505b7011e8a620c04d \
-                    sha256  9bceaa004f466710edd8c1b0f0682fafa6fbb008d01738f30c1803df3c381aea \
-                    size    120855325
+    checksums       rmd160  b8b444e34856b1a5c6beaf08222ae21a23af403b \
+                    sha256  abdc930d3eee5cd551e2f243f37b27899bbb89f6e214933bb866c4c9c3c5726e \
+                    size    120855397
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  e29b5e555a5c579f9ddd90b372312b4d157c2c73 \
-                    sha256  f28f7632b75440dc39a90faac27e95e17d7682cc57a88c68ffbacf7a215a5c98 \
-                    size    117974023
+    checksums       rmd160  40532fba56160bbc5e54606a437036d65f00d045 \
+                    sha256  44282327276fc12535e242b109f719d7fed2a975ad7d8a995ce10320bf10a747 \
+                    size    117974387
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 437.0.1.

###### Tested on

macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?