### PR TITLE
sane-backends: add snmp variant

### DIFF
--- a/graphics/sane-backends/Portfile
+++ b/graphics/sane-backends/Portfile
@@ -4,7 +4,7 @@ PortSystem                  1.0
 
 name                        sane-backends
 version                     1.2.1
-revision                    0
+revision                    1
 set upload_tag              110fc43336d0fb5e514f1fdc7360dd87
 categories                  graphics
 platforms                   darwin
@@ -29,7 +29,6 @@ depends_build               port:pkgconfig
 
 depends_lib                 path:include/turbojpeg.h:libjpeg-turbo \
                             path:lib/pkgconfig/libusb-1.0.pc:libusb \
-                            port:net-snmp \
                             port:tiff \
                             port:zlib \
                             port:libxml2
@@ -40,6 +39,7 @@ depends_lib-append          path:lib/libcrypto.dylib:openssl
 patchfiles                  patch-configure.diff \
                             patch-frontend-scanimage.c.diff
 
+compiler.c_standard         1999
 # genesys backend now uses C++11
 compiler.cxx_standard       2011
 
@@ -48,7 +48,8 @@ configure.cppflags-append   -fno-common
 configure.args              --without-avahi \
                             --without-gphoto2 \
                             --without-libcurl \
-                            --without-poppler-glib
+                            --without-poppler-glib \
+                            --without-snmp
 
 post-configure {
     reinplace -E {s|-arch [a-z0-9_]+||g} \
@@ -65,11 +66,13 @@ pre-destroot {
 
 destroot.keepdirs ${destroot}${prefix}/var/lock
 
-default_variants            +avahi
+default_variants            +avahi +snmp
 
 variant no_local conflicts pnm gphoto2 description "turn off compilation of all backends but net" {
     depends_lib-delete      port:libusb-compat
     configure.args-append   --disable-local-backends --without-usb
+
+    compiler.cxx_standard   1998
 }
 
 variant pnm conflicts no_local description "enable the pnm backend for testing frontends (possible security risk, see PROBLEMS file)" {
@@ -97,6 +100,12 @@ variant escl requires avahi description "include the eSCL backend" {
                             --without-poppler-glib
     configure.args-append   --with-libcurl \
                             --with-poppler-glib
+}
+
+variant snmp description "enable automatic network discovery via SNMP" {
+    depends_lib-append      port:net-snmp
+    configure.args-delete   --without-snmp
+    configure.args-append   --with-snmp
 }
 
 # This project uses u_long *everywhere* and doesn't bother including sys/types.h


### PR DESCRIPTION
#### Description

On Mac OS X 10.5.8 the build of sane-backends currently fails because net-snmp does not build on it.

As I don't need SNMP auto-detection of my scanners and I can imagine few people do, I think it makes sense to add a variant to enable SNMP when needed.

While at it I also restore the C++ standard version when the `no_local` variant is used.
As far as I know a C++11 compatible compiler is only required for the genesys backend.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.5.8
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
