### PR TITLE
ruby-devel: update to 2023.06.30

### DIFF
--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -11,13 +11,13 @@ PortGroup           legacysupport 1.1
 # MAP_ANONYMOUS
 legacysupport.newest_darwin_requires_legacy 14
 
-github.setup        ruby ruby 542c70aab748cf17960cc2a0959ba490983ceae6
+github.setup        ruby ruby 41779fede04d730f94690ddc9f2b36a4ff73ddb0
 
 set ruby_ver        3.3
 set ruby_patch      0
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby-devel
-version             2023.06.05
+version             2023.06.30
 revision            0
 
 categories          lang ruby
@@ -33,9 +33,9 @@ long_description    Ruby is the interpreted scripting language \
 homepage            https://www.ruby-lang.org/
 license             {Ruby BSD}
 
-checksums           rmd160  82ee12ae3276c47e67238fd9ead2837fb2d5f731 \
-                    sha256  ed213a10cd92f3c0b94ae414a73bc4619ea8a6fa03aa6a5fb5a369c6162cfbff \
-                    size    15805317
+checksums           rmd160  e42f305a289c689c367222bddd4a3ad3ecf4b6a5 \
+                    sha256  4b94f2fab8d9ec30797879db8c8cb808e1444ba0a63fd583eb8ce74a0cf9ea6e \
+                    size    15904516
 
 universal_variant   no
 


### PR DESCRIPTION
#### Description

Simple update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
