### PR TITLE
fortran-stdlib: update to 2023.06.26

### DIFF
--- a/lang/fortran-stdlib/Portfile
+++ b/lang/fortran-stdlib/Portfile
@@ -7,17 +7,17 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 
 name                fortran-stdlib
-github.setup        fortran-lang stdlib 04d8459f9beafd10303895c64f7cd31fb2c9fc60
-version             2023.06.16
+github.setup        fortran-lang stdlib 2b7280b7176f90b07a4ce420aaa794a472eaef7c
+version             2023.06.26
 revision            0
 categories-append   lang fortran devel
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Fortran Standard Library
 long_description    {*}${description}
-checksums           rmd160  b5a83d78d79b35945f699b938f3d4bff3fa6e26d \
-                    sha256  b03455d93061ca68dc9355adc0506c385660708b61fe2b2a8114523192f7d4cf \
-                    size    385068
+checksums           rmd160  1c6cb18b706a1587998f03b6edf87c2c4654c009 \
+                    sha256  82dfb13d9884c047631a618055a3d42ba9854d8126de1e4ec557fea3573450b7 \
+                    size    385104
 cmake.generator     Ninja
 
 set py_ver          3.11
@@ -33,7 +33,7 @@ platform darwin {
     }
 }
 
-compilers.setup require_fortran -g95
+compilers.setup     require_fortran -g95
 compiler.blacklist-append \
                     {*gcc-[34].*} {macports-gcc-[58]} {clang < 500}
 


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
