### PR TITLE
qemu: update to 8.0.2

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -8,8 +8,8 @@ PortGroup legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
-version                 7.1.0
-revision                1
+version                 8.0.2
+revision                0
 categories              emulators
 license                 GPL-2+
 maintainers             {raimue @raimue} \
@@ -25,25 +25,35 @@ homepage                https://www.qemu.org
 master_sites            https://download.qemu.org/
 use_xz                  yes
 
-checksums               rmd160  01c82bed8b0219935c00981e16b573004b3802d0 \
-                        sha256  a0634e536bded57cf38ec8a751adb124b89c776fe0846f21ab6c6728f1cbbbe6 \
-                        size    121833004
+checksums               rmd160  1f371669c211a43f2dc681a632a333e02c823374 \
+                        sha256  f060abd435fbe6794125e2c398568ffc3cfa540042596907a8b18edca34cf6a5 \
+                        size    126707132
 
-depends_build           port:texinfo \
+set py_version          311
+set py_branch           \
+    [string index ${py_version} 0].[string range ${py_version} 1 end]
+
+depends_build-append    port:texinfo \
                         port:libtool \
                         port:meson \
                         port:ninja \
                         port:pkgconfig \
-                        port:py39-sphinx
+                        port:py${py_version}-sphinx
 
 # perl5 is only used for build scripts, no linking
 depends_build-append    port:perl5
 
 license_noconflict      perl5
 
-depends_lib             path:lib/pkgconfig/glib-2.0.pc:glib2 \
+depends_lib-append      path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                        path:lib/pkgconfig/pixman-1.pc:libpixman \
+                        port:bzip2 \
+                        port:libslirp \
+                        port:lzfse \
+                        port:lzo2 \
+                        port:snappy \
                         port:zlib \
-                        path:lib/pkgconfig/pixman-1.pc:libpixman
+                        port:zstd
 
 # This patch sets the python interpreter from meson's shebang line
 patchfiles-append       patch-qemu-configure.diff
@@ -77,7 +87,7 @@ configure.args          --cpu=${host_cpu} \
                         --cc=${configure.cc} \
                         --objcc=${configure.objc} \
                         --host-cc=${configure.cc} \
-                        --sphinx-build=${prefix}/bin/sphinx-build-3.9
+                        --sphinx-build=${prefix}/bin/sphinx-build-${py_branch}
 
 # Use MacPorts meson, which includes platform-specific fixes
 configure.args-append   --meson=${prefix}/bin/meson
@@ -97,6 +107,7 @@ configure.args-append   --disable-cocoa \
                         --disable-curl \
                         --disable-attr \
                         --disable-vde \
+                        --disable-jack \
                         --disable-brlapi \
                         --disable-cap-ng \
                         --disable-spice-protocol \
@@ -107,6 +118,7 @@ configure.args-append   --disable-cocoa \
                         --disable-libusb \
                         --disable-usb-redir \
                         --disable-seccomp \
+                        --enable-slirp \
                         --disable-linux-aio \
                         --disable-glusterfs \
                         --disable-rdma \
@@ -117,13 +129,22 @@ configure.args-append   --disable-cocoa \
                         --disable-nettle \
                         --disable-numa \
                         --disable-xen \
-                        --disable-snappy \
-                        --disable-lzo \
-                        --disable-lzfse \
+                        --enable-snappy \
+                        --enable-lzo \
+                        --enable-lzfse \
                         --disable-png \
-                        --disable-zstd \
+                        --enable-zstd \
                         --disable-dbus-display \
-                        --enable-virtfs
+                        --enable-bochs \
+                        --enable-cloop \
+                        --enable-dmg \
+                        --enable-qcow1 \
+                        --enable-qed \
+                        --enable-tools \
+                        --enable-parallels \
+                        --enable-vdi \
+                        --enable-virtfs \
+                        --enable-vvfat
 
 # Use 'smbd' installed by samba port, rather than macOS; latter does not work with qemu.
 configure.args-append   --smbd=${prefix}/sbin/smbd
@@ -199,12 +220,12 @@ variant curses description {Use the curses text-only user interface} {
 # XXX: gtk/sdl need libepoxy for OpenGL
 
 variant gtk3 description {Use the GTK+3 graphical user interface} conflicts cocoa {
-    configure.args-replace --disable-gtk --enable-gtk
-    depends_lib-append     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 port:vte
+    configure.args-replace  --disable-gtk --enable-gtk
+    depends_lib-append      path:lib/pkgconfig/gtk+-3.0.pc:gtk3 port:vte
 }
 
 variant sdl2 description {Use the SDL 2 graphical user interface} conflicts cocoa {
-    configure.args-replace --disable-sdl --enable-sdl
+    configure.args-replace  --disable-sdl --enable-sdl
     depends_lib-append      port:libsdl2
 }
 
@@ -248,26 +269,6 @@ variant spice requires spice_protocol description {Support Spice server} {
 variant vde description {Support VDE networking} {
     configure.args-replace  --disable-vde --enable-vde
     depends_lib-append      port:vde2
-}
-
-variant lzo description {Support LZO compression} {
-    configure.args-replace  --disable-lzo --enable-lzo
-    depends_lib-append      port:lzo
-}
-
-variant lzfse description {Support lzfse compression} {
-    configure.args-replace  --disable-lzfse --enable-lzfse
-    depends_lib-append      port:lzfse
-}
-
-variant snappy description {Support Snappy compression} {
-    configure.args-replace  --disable-snappy --enable-snappy
-    depends_lib-append      port:snappy
-}
-
-variant zstd description {Support zstd compression} {
-    configure.args-replace  --disable-zstd --enable-zstd
-    depends_lib-append      port:zstd
 }
 
 variant ssh description {Support remote block devices over SSH} {


### PR DESCRIPTION
- support numerous image formats (qcow1, parallels, vdi, etc.) by default
- build with compression formats (lzo, snappy, lzfse & zstd) by default
- build with slirp support
- use Python 3.11 Sphinx to build docs
- disable linking against the jack audio library

Fixes: https://trac.macports.org/ticket/67409
Fixes: https://trac.macports.org/ticket/64246
See: https://trac.macports.org/ticket/67549

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
