### PR TITLE
R-tzdb, R-Hmisc: fix-ups for 10.7–10.12

### DIFF
--- a/R/R-Hmisc/Portfile
+++ b/R/R-Hmisc/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran cran Hmisc 5.1-0
+R.setup             github harrelfe Hmisc c960b0517e39a55d800a2e4c002c86602cda0985
+version             5.1-1
 revision            0
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             {GPL-2 GPL-3}
@@ -14,9 +15,9 @@ long_description    Contains many functions useful for data analysis, high-level
                     advanced table making, variable clustering, character string manipulation, \
                     conversion of R objects to LaTeX and html code, and recoding variables.
 homepage            https://hbiostat.org/R/Hmisc
-checksums           rmd160  b7e994f0438952b951cc7565168cfa354750e908 \
-                    sha256  18507eb61d2473918161c232aff61491c028611cbed5ab947de8b4489f852078 \
-                    size    863573
+checksums           rmd160  9250bc043d617afa2190c89219c3ca9c453b9a7c \
+                    sha256  31205afa128c3655abc020b1aacbd6e8b7852d6d1ce3eac35dbc4c3465f2b20c \
+                    size    844092
 
 depends_lib-append  port:R-base64enc \
                     port:R-colorspace \

--- a/R/R-tzdb/Portfile
+++ b/R/R-tzdb/Portfile
@@ -5,7 +5,7 @@ PortGroup           R 1.0
 
 # Revert to GitHub once updated there.
 R.setup             cran r-lib tzdb 0.4.0
-revision            0
+revision            1
 categories-append   devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
@@ -17,6 +17,13 @@ checksums           rmd160  ad91d284b08c90f1b223adee9264dbd64842809b \
                     size    586327
 
 depends_lib-append  port:R-cpp11
+
+platform darwin {
+    if {(${os.major} > 10) && (${os.major} < 16)} {
+        patchfiles-append \
+                    patch-cxx_std.diff
+    }
+}
 
 depends_test-append port:R-covr \
                     port:R-testthat

--- a/R/R-tzdb/files/patch-cxx_std.diff
+++ b/R/R-tzdb/files/patch-cxx_std.diff
@@ -1,0 +1,20 @@
+--- src/Makevars.orig	2023-05-12 20:31:07.000000000 +0800
++++ src/Makevars	2023-07-01 21:09:08.000000000 +0800
+@@ -1,6 +1,5 @@
+-# We no longer specify `CXX_STD = CXX11` since modern versions of R require
+-# C++11 as a minimum. This also allows more modern compilers to use C++14, which
+-# has constexpr benefits.
++# CXX11 is required. Using a newer standard breaks build on 10.7–10.11:
++# https://github.com/r-lib/tzdb/issues/34
+ 
+ # -DINSTALL=dummy
+ # To keep some problematic code from running on windows if INSTALL isn't defined.
+@@ -26,6 +25,8 @@
+ # Because of these issues, we instead default to using an uncompressed
+ # text version of the database that we ship with tzdb.
+ 
++CXX_STD = CXX11
++
+ PKG_CXXFLAGS = \
+ 	-I../inst/include \
+ 	-DINSTALL=dummy \


### PR DESCRIPTION
#### Description

`R-tzdb` does not build on 10.7–10.11 due to https://github.com/r-lib/tzdb/issues/34
https://ports.macports.org/port/R-tzdb/details
Conditionally revert the commit that has broken the build: https://github.com/r-lib/tzdb/commit/a1ed5c012bcc5968f95d4f64ab6a7f658de2a4d6

`R-Hmisc` fails on 10.12, for w/e reason: https://ports.macports.org/port/R-Hmisc/details
Since there is a new version, upgrade and see if the issue is fixed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
