### PR TITLE
py-igraph: update to 0.10.5

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -30,6 +30,8 @@ checksums           rmd160  2557fb8d9b1e7a629f99235cf48409586c7bcdb4 \
 
 variant external_igraph description {Use external igraph library} { }
 
+default_variants +external_igraph
+
 if {${name} ne ${subport}} {
     compiler.c_standard     1999
     compiler.cxx_standard   2011

--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-igraph
 python.rootname     igraph
 python.pep517       yes
-version             0.10.4
+version             0.10.5
 revision            0
 categories-append   math science
 platforms           darwin
@@ -24,9 +24,9 @@ long_description    Python interface to the igraph library for network analysis 
 
 homepage            https://igraph.org/python/
 
-checksums           rmd160  db645765a74cda532e097b68137093b18d35c65f \
-                    sha256  4786e05919ee93f6479fe8ca697d68537edfe47549ed09dfb33bda4daced1fb9 \
-                    size    4209850
+checksums           rmd160  2557fb8d9b1e7a629f99235cf48409586c7bcdb4 \
+                    sha256  d9c5f8972c544dfd8c315e1b4b9093f1994fa4f72745ae14c8850834d47557f9 \
+                    size    4232326
 
 variant external_igraph description {Use external igraph library} { }
 
@@ -70,7 +70,6 @@ if {${name} ne ${subport}} {
             -DIGRAPH_USE_INTERNAL_PLFIT=ON
             -DIGRAPH_OPENMP_SUPPORT=OFF
             -DBLA_VENDOR=Apple
-            -DIGRAPH_WARNINGS_AS_ERRORS=OFF
         }
 
         build.env-append        IGRAPH_CMAKE_EXTRA_ARGS=[join $extra_cmake_args]


### PR DESCRIPTION
#### Description

 - update to 0.10.5
 - link to external igraph by default

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4.1 22F82 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
