### PR TITLE
py-mitmproxy: add python3.11 subport

### DIFF
--- a/python/py-asgiref/Portfile
+++ b/python/py-asgiref/Portfile
@@ -19,7 +19,7 @@ long_description    {*}${description}
 
 homepage            https://asgi.readthedocs.io/en/latest
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-kaitaistruct/Portfile
+++ b/python/py-kaitaistruct/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  272981cdc06dd84f9060f59bf0307cbe03b9f48f \
                     sha256  3d5845817ec8a4d5504379cc11bd570b038850ee49c4580bc0998c8fb1d327ad \
                     size    5497
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ldap3/Portfile
+++ b/python/py-ldap3/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  79e01fca419bee34e0befa8c6afa9a3ce7ad6101 \
                     sha256  5211bff2765303d3e23234497ccd836c7a3c6519db85127062de71ca38494adf \
                     size    970755
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-mitmproxy/Portfile
+++ b/python/py-mitmproxy/Portfile
@@ -32,7 +32,7 @@ checksums           rmd160  7668d0fe20ad33e026de91345ceb966d408f4774 \
 
 patchfiles          patch-test_version.py.diff
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-passlib/Portfile
+++ b/python/py-passlib/Portfile
@@ -6,7 +6,7 @@ PortGroup               python 1.0
 name                    py-passlib
 version                 1.7.4
 revision                1
-python.versions         37 38 39 310
+python.versions         37 38 39 310 311
 python.pep517           yes
 categories-append       www security
 maintainers             {snc @nerdling} openmaintainer

--- a/python/py-publicsuffix2/Portfile
+++ b/python/py-publicsuffix2/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  bd24ca642bfb156704e96b43114bfea7d54c3a09 \
                     sha256  00f8cc31aa8d0d5592a5ced19cccba7de428ebca985db26ac852d920ddd6fe7b \
                     size    99592
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-wsproto/Portfile
+++ b/python/py-wsproto/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  75d221dfd371b1a4490b80dde90b778c00e50440 \
                     sha256  868776f8456997ad0d9720f7322b746bbe9193751b5b290b7f924659377c8c38 \
                     size    53423
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Add subport for python3.11 with mitmproxy and dependents.

To note: I tried to install from source (`port install -vst`) but can't get it to work. The log file says:
```
:info:extract Executing:  cd "/opt/local/var/macports/build/_Users_julien_src_thirdparty_macports-ports_python_py-mitmproxy/py311-mitmproxy/work" && /usr/bin/gzip -dc '/opt/local/var/macports/distfiles/py-mitmproxy/mitmproxy-7.0.4.tar.gz' | /usr/bin/tar -xf -.
:debug:extract system:  cd "/opt/local/var/macports/build/_Users_julien_src_thirdparty_macports-ports_python_py-mitmproxy/py311-mitmproxy/work" && /usr/bin/gzip -dc '/opt/local/var/macports/distfiles/py-mitmproxy/mitmproxy-7.0.4.tar.gz' | /usr/bin/tar -xf -.
:info:extract Command failed:  cd "/opt/local/var/macports/build/_Users_julien_src_thirdparty_macports-ports_python_py-mitmproxy/py311-mitmproxy/work" && /usr/bin/gzip -dc '/opt/local/var/macports/distfiles/py-mitmproxy/mitmproxy-7.0.4.tar.gz' | /usr/bin/tar -xf -.
:info:extract Killed by signal: 9
:error:extract Failed to extract py311-mitmproxy: command execution failed
```

This is not the first time this has happened, the extract command seems to be problematic on my system but if I sudo to macports and run the commands myself everything works. If anyone had hints as to why this might be happening or how to fix it, I'm quite interested

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.3 22E252 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
