### PR TITLE
p5-lingua-nameutils: new port (version 1.000)

### DIFF
--- a/perl/p5-lingua-nameutils/Portfile
+++ b/perl/p5-lingua-nameutils/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Lingua-NameUtils 1.000
+revision            0
+
+license             {Artistic-1 GPL}
+maintainers         {raf.org:raf @macportsraf} openmaintainer
+description         Lingua::NameUtils - Identify given/family names and capitalize correctly
+long_description    {*}${description}
+platforms           {darwin any}
+supported_archs     noarch
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-lingua-ja-name-splitter
+}
+
+checksums           rmd160  872c42f8166f9f7b2ec12b3bbad982da84a3a0e8 \
+                    sha256  0815ee58780cc8b4e2bc89670dfb684e59fabe60dc651ca8b455388bc452a3ce \
+                    size    55640
+


### PR DESCRIPTION
#### Description

Lingua::NameUtils - Identify given/family names and capitalize correctly

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
