### PR TITLE
p5-mime-mini: new port (version 1.001)

### DIFF
--- a/perl/p5-mime-mini/Portfile
+++ b/perl/p5-mime-mini/Portfile
@@ -1,0 +1,20 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         MIME-Mini 1.001
+revision            0
+
+license             {Artistic-1 GPL}
+maintainers         {raf.org:raf @macportsraf} openmaintainer
+description         MIME::Mini - Minimal code to parse/create mbox files and mail messages
+long_description    {*}${description}
+platforms           {darwin any}
+supported_archs     noarch
+
+checksums           rmd160  4d81f752c4d1ea695ee0fe69e875b7e7c72a3512 \
+                    sha256  97c2088a8350e3e7d03dd38253a5746f2ec5b49dd02c8b64a2a8eeb32a877a86 \
+                    size    50219
+


### PR DESCRIPTION
#### Description

MIME::Mini - Minimal code to parse/create mbox files and mail messages

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?