### PR TITLE
clang-16: revert change that breaks rpath linkages in clang runtime

### DIFF
--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -28,7 +28,7 @@ version                 ${llvm_version}.0.6
 name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
-subport                 clang-${llvm_version} { revision [ expr ${revision} + 0 ] }
+subport                 clang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
 
@@ -190,6 +190,12 @@ if {${os.platform} eq "darwin" && ${os.major} < 12} {
             ${patch.dir}/compiler-rt/lib/builtins/CMakeLists.txt \
             ${patch.dir}/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
     }
+}
+
+# https://trac.macports.org/ticket/67686
+# revert commit that breaks rpath linkages in clang runtime
+if {${os.platform} eq "darwin"} {
+    patchfiles-append b98da4c71edda3df0a0555b1ab63ec52e92252b4-inverse.patch
 }
 
 post-patch {

--- a/lang/llvm-16/files/b98da4c71edda3df0a0555b1ab63ec52e92252b4-inverse.patch
+++ b/lang/llvm-16/files/b98da4c71edda3df0a0555b1ab63ec52e92252b4-inverse.patch
@@ -1,0 +1,13 @@
+--- b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
++++ a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+@@ -392,8 +392,8 @@
+       target_link_libraries(${libname} PRIVATE ${builtins_${libname}})
+     endif()
+     if(${type} STREQUAL "SHARED")
++      if(COMMAND llvm_setup_rpath)
++        llvm_setup_rpath(${libname})
+-      if(APPLE OR WIN32)
+-        set_property(TARGET ${libname} PROPERTY BUILD_WITH_INSTALL_RPATH ON)
+       endif()
+       if(WIN32 AND NOT CYGWIN AND NOT MINGW)
+         set_target_properties(${libname} PROPERTIES IMPORT_PREFIX "")


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/67686

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

[CI skip]