### PR TITLE
eigenmath: update to 2023.06.16

### DIFF
--- a/math/eigenmath/Portfile
+++ b/math/eigenmath/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 
-github.setup        georgeweigt eigenmath bf47d3fec262a00dd909d79c3ee18b76097e14b6
-version             2023.04.07
+github.setup        georgeweigt eigenmath 800adc5c0bd654eb9ad28497e1b78c4061b3a4cb
+version             2023.06.16
 revision            0
 categories          math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -13,9 +13,9 @@ license             BSD
 description         Symbolic math app
 long_description    {*}${description}
 homepage            https://georgeweigt.github.io
-checksums           rmd160  266e5c028b7e1bc269848bfb7e777e630244d88e \
-                    sha256  23620c5e601fe165a2a88d809329f7f495840ddac40e2b3aab61c5b36ccf6a2d \
-                    size    828262
+checksums           rmd160  6c3146845a73da86de624a811ac4be131047dc2d \
+                    sha256  c424aa0182f252ac25928c5722d4f5dbf6d8737915c0b084933d04a1ec057859 \
+                    size    834089
 
 patchfiles-append   patch-Makefile.diff
 


### PR DESCRIPTION
#### Description

Simple update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
