### PR TITLE
stack: update to 2.11.1 & enable arm64 build

### DIFF
--- a/_resources/port1.0/group/haskell_stack-1.0.tcl
+++ b/_resources/port1.0/group/haskell_stack-1.0.tcl
@@ -70,8 +70,8 @@ post-extract {
     xinstall -m 0755 -d "[option haskell_stack.stack_root]"
 }
 
-# stack builds x86_64 binaries
-supported_archs     x86_64
+# stack builds arm64 and x86_64 binaries
+supported_archs     arm64 x86_64
 
 # libHSbase shipped with GHC links against system libiconv, which provides the
 # 'iconv' symbol, but not the 'libiconv' symbol. Because the compilation

--- a/lang/stack/Portfile
+++ b/lang/stack/Portfile
@@ -6,7 +6,7 @@ PortGroup           gpg_verify 1.0
 PortGroup           haskell_stack 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        commercialhaskell stack 2.9.1 v
+github.setup        commercialhaskell stack 2.11.1 v
 revision            0
 
 name                stack
@@ -28,50 +28,56 @@ homepage            https://haskellstack.org
 variant prebuilt \
 	    description {Do not bootstrap stack; install the pre-built binary.} {}
 
-distname            ${name}-${github.version}-osx-x86_64
+if {${build_arch} eq "x86_64"} {
+    distname        ${name}-${github.version}-osx-x86_64
+} elseif {${build_arch} eq "arm64"} {
+    distname        ${name}-${github.version}-osx-aarch64
+}
 
 worksrcdir          ${name}-${github.version}
 
 master_sites        ${github.homepage}/releases/download/${github.tag_prefix}${github.version}/:release \
+                    https://downloads.haskell.org/ghcup/unofficial-bindists/stack/${github.version}/:release_arm \
                     ${github.homepage}/archive/refs/tags/:archive
 
-distfiles           ${distname}-bin:release \
-                    ${github.tag_prefix}${github.version}${extract.suffix}:archive
+distfiles           ${github.tag_prefix}${github.version}${extract.suffix}:archive
+if {${build_arch} eq "x86_64"} {
+    distfiles-append    ${distname}-bin:release
+} elseif {${build_arch} eq "arm64"} {
+    distfiles-append    ${distname}${extract.suffix}:release_arm
+}
 
 extract.only        ${github.tag_prefix}${github.version}${extract.suffix}
+if {${build_arch} eq "arm64"} {
+    extract.only-append \
+                    ${distname}${extract.suffix}
+}
 
-checksums           ${distname}-bin \
-                    rmd160  1bef40f79e2ce2981fed55cd360adbb367f66c4d \
-                    sha256  5b338fba3c679d9e4d3b3a8cd1ac6a9e55916755da22165554005f79fc7be3e2 \
-                    size    32626208 \
-                    ${github.tag_prefix}${github.version}${extract.suffix} \
-                    rmd160  ca4cd87ce2e03a65840747efc56286b8e662ce17 \
-                    sha256  512d0188c195073d7c452f4b54ca005005ce7b865052a4856dc9975140051d9c \
-                    size    767680 \
-                    ${distname}-bin.asc \
-                    size    488
-
-gpg_verify.use_gpg_verification \
-                    yes
-
-if {[option gpg_verify.use_gpg_verification]} {
-    distfiles-append \
-                    ${distname}-bin.asc:release
-
-    post-checksum {
-        # check GPG signature: https://docs.haskellstack.org/en/stable/SIGNING_KEY/
-        set gpg_keyid 575159689befb442
-
-        gpg_verify.verify_gpg_signature \
-            ${filespath}/keyid-${gpg_keyid}.txt \
-            ${distpath}/${distname}-bin.asc \
-            ${distpath}/${distname}-bin
-    }
+checksums           ${github.tag_prefix}${github.version}${extract.suffix} \
+                    rmd160  bc09152bfc711cd2839b2395976ebfaaaff0b6bd \
+                    sha256  7a3a7e4aca8aef9ab6c081ea553a681844e6dad901c6b36b5e4cacae2fef6d23 \
+                    size    839729
+if {${build_arch} eq "x86_64"} {
+    checksums-append \
+                    ${distname}-bin \
+                    rmd160  cc7b03e0312c6bb0a2994a674962c0200bbf86e3 \
+                    sha256  5b76cf79c84ba3718730afedd86f85a1170046bb8768e20fb119dcfe25f2a5f2 \
+                    size    32657688 \
+} elseif {${build_arch} eq "arm64"} {
+    checksums-append \
+                    ${distname}${extract.suffix} \
+                    rmd160  208c1e26e3c51d07b830dbf052a16d353bd245b1 \
+                    sha256  3ea56c5885c9c6d7e2dce927e44f48f6024a4a5a039f7acad79b19654a6f95b5 \
+                    size    24192614
 }
 
 post-extract {
     xinstall -W ${workpath} -d ./bin
-    xinstall -m 0755 -W ${distpath} ./${distname}-bin ${workpath}/bin
+    if {${build_arch} eq "x86_64"} {
+        xinstall -m 0755 ${distpath}/${distname}-bin ${workpath}/bin
+    } elseif {${build_arch} eq "arm64"} {
+        xinstall -m 0755 ${workpath}/${distname}/${name} ${workpath}/bin
+    }
 }
 
 # bootstrap binaries seg fault on 10.7 and older
@@ -113,8 +119,10 @@ if { [variant_isset "prebuilt"] } {
         # standard stack install with 'curl | sh'; don't use
         # system -W ${worksrcpath} "/bin/mkdir ./bin && /usr/bin/curl -sSL https://get.haskellstack.org/ | /bin/sh -s - -d ./bin"
         # bootstrap using the pre-built ./stack binary
-        ln -s       ${workpath}/bin/${distname}-bin \
+        if {${build_arch} eq "x86_64"} {
+            ln -s   ${workpath}/bin/${distname}-bin \
                     ${workpath}/bin/${name}
+        }
     }
 
     set haskell_stack.bin ${workpath}/bin/stack


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A5276g arm64
Xcode 15.0 15A5161b
macOS 13.4.1 22F82 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
