### PR TITLE
acpica: do not use old Xcode gcc, they fail to build it

### DIFF
--- a/devel/acpica/Portfile
+++ b/devel/acpica/Portfile
@@ -44,5 +44,10 @@ makefile.override-delete \
 # CFLAGS has MacPorts optimization
 build.args-append   OPT_CFLAGS=""
 
+# dmtbdump2.c:1226: error: ‘for’ loop initial declaration used outside C99 mode
+# aeinstall.c:443: error: ‘ACPI_RESOURCE_EXTENDED_IRQ’ has no member named ‘Interrupts’
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
+
 livecheck.regex     ${name}-unix-(\[0-9.\]+)${extract.suffix}
 livecheck.url       ${homepage}downloads/


### PR DESCRIPTION
#### Description

See comments.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
