### PR TITLE
man-db: update to 2.11.2

### DIFF
--- a/textproc/man-db/Portfile
+++ b/textproc/man-db/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                man-db
-version             2.11.1
+version             2.11.2
 categories          textproc
 platforms           darwin linux
 license             GPL-3+
@@ -19,9 +19,9 @@ long_description    man-db is an implementation of the standard Unix documentati
     Linux distributions, including: Arch, Debian, Dragora, Fedora, Gentoo, openSUSE, \
     and Ubuntu.
 
-checksums           rmd160   6aada489203d21155e8254c0298f2db6ee497271 \
-                    sha256   2eabaa5251349847de9c9e43c634d986cbcc6f87642d1d9cb8608ec18487b6cc \
-                    size     1948788
+checksums           rmd160   bc7ffdd1e5cf71a3561d94dc7bbfd68894662860 \
+                    sha256   cffa1ee4e974be78646c46508e6dd2f37e7c589aaab2938cc1064f058fef9f8d \
+                    size     1953276
 
 depends_lib         port:libpipeline
 depends_build       port:pkgconfig \


### PR DESCRIPTION
#### Description

Update `man-db` port to 2.11.2.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
