### PR TITLE
opam: update to 2.1.5

### DIFF
--- a/ocaml/opam/Portfile
+++ b/ocaml/opam/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ocaml opam 2.1.3
+github.setup        ocaml opam 2.1.5
 
 name                opam
 revision            0
@@ -21,9 +21,9 @@ long_description    OPAM is a source-based package manager for OCaml.\
 github.tarball_from releases
 distname            opam-full-${version}
 
-checksums           rmd160  0040c5f2352266123125e6ad0593e124aefeb9d5 \
-                    sha256  cb2ab00661566178318939918085aa4b5c35c727df83751fd92d114fdd2fa001 \
-                    size    9618995
+checksums           rmd160  82bc333e314439e8cf8a5f83e5b091c3ed275fab \
+                    sha256  09f8d9e410b2f5723c2bfedbf7970e3b305f5017895fcd91759f05e753ddcea5 \
+                    size    10801367
 
 depends_build       port:ocaml
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.1 19B88 x86_64
Command Line Tools 

The Command Line Tools version command reported the following error:

	No receipt for 'com.apple.pkg.CLTools_Executables' found at '/'.

I was able to find a partial version number in `/Library/Receipts/InstallHistory.plist`:

	<key>displayName</key>
	<string>Command Line Tools for Xcode</string>
	<key>displayVersion</key>
	<string>11.0</string>


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
