### PR TITLE
openjdk18-openj9: obsolete

### DIFF
--- a/java/openjdk18-openj9/Portfile
+++ b/java/openjdk18-openj9/Portfile
@@ -1,93 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2024-01-02
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk18-openj9
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-# https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
-supported_archs  x86_64 arm64
-
-version      18.0.2
-revision     1
-
-set build    9
-set openj9_version 0.33.1
-
-description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 18
-long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
-                 built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
-
-master_sites https://github.com/ibmruntimes/semeru18-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  1ab42085fd2bef56416b5177e9e75ebff11a69cc \
-                 sha256  a7ecbcfc57304d28637ab490330da33f55255200d7310ba217e255cbacd321e6 \
-                 size    210549227
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  60972530b6f9ccaf963bdf6115462b9ef06deb42 \
-                 sha256  0330df7979f28e17d193b97c190d7be524888247671206eff467144133d8e115 \
-                 size    203764949
-}
-
-worksrcdir   jdk-${version}+${build}
-
-homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
-
-livecheck.type      regex
-livecheck.url       https://github.com/ibmruntimes/semeru18-binaries/releases/
-livecheck.regex     ibm-semeru-open-jdk_.*_mac_(18\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk18-openj9
+categories  java devel
+version     18.0.2
+revision    2
+replaced_by openjdk20-openj9


### PR DESCRIPTION
#### Description

Mark `openjdk18-openj9` as obsolete and replaced by `openjdk20-openj9`.
