### PR TITLE
Add btop port

### DIFF
--- a/sysutils/btop/Portfile
+++ b/sysutils/btop/Portfile
@@ -2,6 +2,8 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
+PortGroup compiler_blacklist_versions 1.0
 
 github.setup        aristocratos btop 7e50b03e391a346b2b6ce92be332c58d91f75a00
 version             20230615
@@ -20,10 +22,10 @@ categories          sysutils
 license             Apache-2
 maintainers         {samasaur.com:sam @samasaur1} openmaintainer
 
-use_configure       no
-depends_build       port:coreutils port:gmake port:clang-16
-destroot.args       PREFIX=${prefix}
-build.args          CXX=clang++-mp-16
+depends_build       port:coreutils port:gmake
+compiler.cxx_standard   2020
+compiler.blacklist-append {clang < 1600} {*gcc-[4-9]*} {*clang-[3-9]*} \
+    *clang-10 *clang-11 *clang-12 *clang-13 *clang-14 *clang-15
 
 # ---
 # The above Portfile is based off of a Git commit, because the latest tagged

--- a/sysutils/btop/Portfile
+++ b/sysutils/btop/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        aristocratos btop 7e50b03e391a346b2b6ce92be332c58d91f75a00
+version             20230615
+
+fetch.type          git
+
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+description         A monitor of resources
+
+long_description    Resource monitor that shows usage and stats for processor, memory, disks, network and processes.
+
+categories          sysutils
+license             Apache-2
+maintainers         {samasaur.com:sam @samasaur1} openmaintainer
+
+use_configure       no
+depends_build       port:coreutils port:gmake port:clang-16
+destroot.args       PREFIX=${prefix}
+build.args          CXX=clang++-mp-16
+
+# ---
+# The above Portfile is based off of a Git commit, because the latest tagged
+# version could not be built with libc++20, instead needing to be build with
+# libstdc++20. Since MacPorts was complaining, I have switched to using the
+# most recent commit. The next tagged version will work with MacPorts clang 16
+# and libc++20. The commented-out Portfile options below are what is necessary
+# to build the latest tagged version using MacPorts GCC 12 and libstdc++20
+# ---
+
+# github.setup        aristocratos btop 1.2.13 v
+# github.tarball_from archive
+#
+# checksums           rmd160  883dd119e48bc6668535f7a30a8bfe49922e8a85 \
+#                     sha256  2e5919bc5fa99ef33c561e7e0c75bfb6fbdcb953dfa6a50f959c447b61e9168e \
+#                     size    982789
+#
+# use_configure       no
+# depends_build       port:coreutils port:gmake port:gcc12
+# destroot.args       PREFIX=${prefix}


### PR DESCRIPTION
As the comment in the Portfile notes, this port currently uses the latest commit and not the latest tagged version, because there has not been a tagged version that can be built with Clang and libc++20. Upon the release of the next tagged version, I will update this Portfile

#### Description

Add [`btop`](https://github.com/aristocratos/btop) port.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
