### PR TITLE
openjdk19-openj9: obsolete

### DIFF
--- a/java/openjdk19-openj9/Portfile
+++ b/java/openjdk19-openj9/Portfile
@@ -1,93 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2024-01-03
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk19-openj9
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-# https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
-supported_archs  x86_64 arm64
-
-version      19.0.2
-revision     0
-
-set build    7
-set openj9_version 0.37.0
-
-description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 19
-long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
-                 built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
-
-master_sites https://github.com/ibmruntimes/semeru19-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  f8f5d6c46fb334411a7954dd011e5dc23e09032f \
-                 sha256  2eb2ae87c797999c794f54bac19e7f9062a17be2eb8ee1d200f3a2dcba654f4b \
-                 size    217109255
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  9a67606d0b32e4e890aed1ade25912e3511653a4 \
-                 sha256  8f3ad4044689a49cc69873b6ce9136ecdb44b81ef2fa6201c8cf85da038053ec \
-                 size    210519089
-}
-
-worksrcdir   jdk-${version}+${build}
-
-homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
-
-livecheck.type      regex
-livecheck.url       https://github.com/ibmruntimes/semeru19-binaries/releases/
-livecheck.regex     ibm-semeru-open-jdk_.*_mac_(19\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set target /Library/Java/JavaVirtualMachines/jdk-19-ibm-semeru.jdk
-set destroot_target ${destroot}${target}
-
-destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${target}/Contents/Home
-"
+name        openjdk19-openj9
+categories  java devel
+version     19.0.2
+revision    1
+replaced_by openjdk20-openj9


### PR DESCRIPTION
#### Description

Mark `openjdk19-openj9` as obsolete and replaced by `openjdk20-openj9`.