### PR TITLE
checkssl: update to 0.5.0

### DIFF
--- a/sysutils/checkssl/Portfile
+++ b/sysutils/checkssl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/szazeski/checkssl 0.4.4 v
+go.setup            github.com/szazeski/checkssl 0.5.0 v
 revision            0
 
 homepage            https://www.checkssl.org
@@ -13,16 +13,15 @@ description         checkssl - simple command line tool to check or monitor your
 long_description    ${description}
 
 categories          sysutils devel
-platforms           darwin
 license             MIT
 installs_libs       no
 
 maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 
-checksums           rmd160  af2456093bdb4d758633ac7f76cba7966207cd1f \
-                    sha256  5880709808f1e090d27328e7d86c6b9ffc328181de3245ab259998c2bb1d64bd \
-                    size    11150
+checksums           rmd160  1dd2cbecb36c1960536c37d76df42bef92cf6248 \
+                    sha256  91b0fe338f0d6fcc6ce7f6f4f16f2ccf2673a1a4b6496c9540ba3c7ea5100ac5 \
+                    size    12271
 
 destroot {
     set doc_dir ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update to checkssl 0.5.0.

###### Tested on

macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?