### PR TITLE
libaec: update to 1.0.6

### DIFF
--- a/archivers/libaec/Portfile
+++ b/archivers/libaec/Portfile
@@ -29,4 +29,4 @@ long_description \
     library. Just replace SZIP's shared library libsz.so* with\
     libaec.so* and libsz.so* from libaec.
 
-configure.pre_args  -DCMAKE_INSTALL_PREFIX=${prefix}/lib/${name}
+configure.args-append -DCMAKE_INSTALL_PREFIX=${prefix}/lib/${name}

--- a/archivers/libaec/Portfile
+++ b/archivers/libaec/Portfile
@@ -1,9 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           gitlab 1.0
 
-name                libaec
-version             1.0.4
+gitlab.instance     https://gitlab.dkrz.de
+gitlab.setup        k202009 libaec 1.0.6 v
+revision            0
+checksums           rmd160  7558198aa9de503dbddcde41b8d4beb76c3c3e81 \
+                    sha256  9b89db38ced9d7c9ddb172236f87ba8e8dbb9840a88f43ee9e1def410f1413ac \
+                    size    2307676
+
 platforms           darwin
 maintainers         {takeshi @tenomoto} openmaintainer
 license             BSD
@@ -12,17 +19,14 @@ description         Adaptive Entropy Coding library
 long_description \
     Libaec provides fast lossless compression of 1 up to 32 bit wide\
     signed or unsigned integers (samples). The library achieves best\
-    results for low entropy data as often encountered in space imaging\
+    results for low entropy data, as often encountered in space imaging\
     instrument data or numerical model output from weather or climate\
     simulations. While floating point representations are not directly\
     supported, they can also be efficiently coded by grouping exponents\
-    and mantissa.
+    and mantissa.\
+    \
+    Libaec includes a free drop-in replacement for the SZIP\
+    library. Just replace SZIP's shared library libsz.so* with\
+    libaec.so* and libsz.so* from libaec.
 
-homepage            https://gitlab.dkrz.de/k202009/libaec
-master_sites        ${homepage}/uploads/ea0b7d197a950b0c110da8dfdecbb71f
-
-checksums           rmd160  e41987d68a1bd5325c9016bb161b51a2b845f81a \
-                    sha256  f2b1b232083bd8beaf8a54a024225de3dd72a673a9bcdf8c3ba96c39483f4309 \
-                    size    3120061
-
-configure.args      --prefix=${prefix}/lib/${name}
+configure.pre_args  -DCMAKE_INSTALL_PREFIX=${prefix}/lib/${name}


### PR DESCRIPTION
#### Description

* Update to libaec v1.0.6.
* Switch to cmake build.
* Fix livecheck via portgroup.
* Advertized as binary compatible, no need to recompile any dependent ports.  See README.SZIP.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.7.6 20G1231 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
