### PR TITLE
boost181: Apply upstream patch for c++17-compat.

### DIFF
--- a/devel/boost181/Portfile
+++ b/devel/boost181/Portfile
@@ -115,7 +115,7 @@ patchfiles-append patch-boost-context-asm.diff
 patchfiles-append patch-fix-fiber.diff
 
 # Upstream c++17 fix: https://github.com/boostorg/functional/commit/6a573e4
-patchfiles-append patch-include-boost-functional.diff
+patchfiles-append patch-boost-functional.diff
 
 # Availability.h -> AvailabilityMacros.h on Tiger
 # The attempted fix:

--- a/devel/boost181/Portfile
+++ b/devel/boost181/Portfile
@@ -114,6 +114,9 @@ patchfiles-append patch-boost-context-asm.diff
 # https://github.com/boostorg/fiber/pull/306
 patchfiles-append patch-fix-fiber.diff
 
+# Upstream c++17 fix: https://github.com/boostorg/functional/commit/6a573e4
+patchfiles-append patch-include-boost-functional.diff
+
 # Availability.h -> AvailabilityMacros.h on Tiger
 # The attempted fix:
 # https://github.com/boostorg/core/commit/128d9314d6f814930400c46c9afd34399d19132b
@@ -374,7 +377,7 @@ subport ${name}-numpy {
 
 if {$subport eq $name} {
 
-    revision 6
+    revision 7
 
     patchfiles-append patch-disable-numpy-extension.diff
 

--- a/devel/boost181/files/patch-boost-functional.diff
+++ b/devel/boost181/files/patch-boost-functional.diff
@@ -1,0 +1,34 @@
+From 6a573e4b8333ee63ee62ce95558c3667348db233 Mon Sep 17 00:00:00 2001
+From: Glen Fernandes <glen.fernandes@gmail.com>
+Date: Mon, 17 Apr 2023 06:59:02 -0400
+Subject: [PATCH] Define unary_function and binary_function unconditionally
+
+---
+ include/boost/functional.hpp | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/include/boost/functional.hpp b/include/boost/functional.hpp
+index 644307847..6c63146f6 100644
+--- boost/functional.hpp
++++ boost/functional.hpp
+@@ -21,7 +21,6 @@ namespace boost
+     namespace functional
+     {
+         namespace detail {
+-#if defined(_HAS_AUTO_PTR_ETC) && !_HAS_AUTO_PTR_ETC
+             // std::unary_function and std::binary_function were both removed
+             // in C++17.
+ 
+@@ -39,12 +38,6 @@ namespace boost
+                 typedef Arg2 second_argument_type;
+                 typedef Result result_type;
+             };
+-#else
+-            // Use the standard objects when we have them.
+-
+-            using std::unary_function;
+-            using std::binary_function;
+-#endif
+         }
+     }
+ 


### PR DESCRIPTION
#### Description

Applies [upstream patch](https://github.com/boostorg/functional/commit/6a573e4) for boost181 to compile under c++17 (default on clang-16).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.7.8 20G1351 x86_64
Xcode 13.2.1 13C100
