### PR TITLE
mrustc: update to 1.54-20230625

### DIFF
--- a/lang/mrustc/Portfile
+++ b/lang/mrustc/Portfile
@@ -5,14 +5,14 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        thepowersgang mrustc b4503ee66847581e0483b6cff0ebc3a3d99fb4ff
+github.setup        thepowersgang mrustc 53967c441b6de394f4f8459237cc6bc77b72ad58
 
 set rust_version    1.54.0
 set rust_version_major [join [lrange [split ${rust_version} .-] 0 1] .]
 set rust_version_major_underscore [join [lrange [split ${rust_version} .-] 0 1] _]
 
 # subport mrustc-rust has its own versioning
-version             ${rust_version_major}-20230414
+version             ${rust_version_major}-20230625
 revision            0
 epoch               1
 
@@ -34,9 +34,9 @@ master_sites-append https://static.rust-lang.org/dist/:rust
 distfiles-append    rustc-${rust_version}-src.tar.gz:rust
 
 checksums           mrustc-${github.version}.tar.gz \
-                    rmd160  d561a9f23493f4b1554260332fb278ae0ca1d91b \
-                    sha256  d299d2bee3c86ba58be2c43a0b0e1ff21e1dd0d5b1694a56a0da00735c38e932 \
-                    size    1191828 \
+                    rmd160  f815ee21f9d12d116151f66e4df83efc1f9b7ccf \
+                    sha256  19ba6875d81055f8c1d9d062e2cd3a1cf507040a8417e52219bb36b3a6d48e3c \
+                    size    1192088 \
                     rustc-${rust_version}-src.tar.gz \
                     rmd160  be2de16e2deaf91aee723e631a36f6de52636ddd \
                     sha256  ac8511633e9b5a65ad030a1a2e5bdaa841fdfe3132f2baaa52cc04e71c6c6976 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.7 21G651 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->