### PR TITLE
skaffold: update to 2.6.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.6.0 v
+github.setup        GoogleContainerTools skaffold 2.6.1 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  252e0c0c71f9cd4293989c41b7b87d7db5e652d0 \
-                    sha256  1c730cc4e0f1c5be78082ea70d8e41462b3b87a6577c889e5befb16626c03650 \
-                    size    60017541
+checksums           rmd160  5501265d1e52dfb3adfe1a2e57916015bd8952d8 \
+                    sha256  ccf7cd19106dd475b51d36853e603aed39b3f3d407fa14403d58f2d35105e4fe \
+                    size    60018170
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.6.1.

###### Tested on

macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?