### PR TITLE
madness: update to 2023.07.03

### DIFF
--- a/science/madness/Portfile
+++ b/science/madness/Portfile
@@ -7,8 +7,8 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        m-a-d-n-e-s-s madness 441936ae637eacf84f34c55b510344b696150064
-version             2023.06.07
+github.setup        m-a-d-n-e-s-s madness 22b860d2aac3dc4560ecf31b071ca336cf87130f
+version             2023.07.03
 revision            0
 categories          science math
 license             GPL-2
@@ -18,9 +18,9 @@ long_description    MADNESS provides a high-level environment for the solution \
                     of integral and differential equations in many dimensions \
                     using adaptive, fast methods with guaranteed precision \
                     based on multi-resolution analysis and novel separated representations.
-checksums           rmd160  747d7d9d6b1fe76f18ff759a58529c7ee32394a0 \
-                    sha256  7c22463534f8837bdef3dc06fe601b098c638e7a91aaa8997cd1d034ea683583 \
-                    size    29146694
+checksums           rmd160  8af773f07a45e269291164911d5be83dc7ddd389 \
+                    sha256  cad07548de16931867c872aefea42991c056e5820293b25a1438b4937784cda9 \
+                    size    29147233
 
 set py_ver          3.11
 set py_ver_nodot    [string map {. {}} ${py_ver}]


### PR DESCRIPTION
#### Description

Simple update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
