### PR TITLE
Update Portfile qgis3 to 3.32

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -10,7 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 # For stability reasons and to keep in sync with livecheck, update to latest
 # long-term-release (LTR).
-github.setup        qgis QGIS 3_28_7 final-
+github.setup        qgis QGIS 3_32_0 final-
 name                qgis3
 version             [string map {_ .} ${github.version}]
 revision            3
@@ -26,9 +26,9 @@ license             GPL-2+
 
 homepage            https://www.qgis.org/
 
-checksums           rmd160  d26e5914c81eb8641a4a83c0efed452200f81483 \
-                    sha256  bd8dc56b47578c33e9f3c57147312d7a6778bddf375be6980addab9498040e4d \
-                    size    183946344
+checksums           rmd160  108cc4afe476788b80ae65b134e5fc13e4916bc6 \
+                    sha256  d36cb17624f34b484fe3954bc994b4c9498af8ec1467fc2ea953a109be2d7c78 \
+                    size    186482670
 
 # Enable use of 'macports-libcxx' for macOS 10.14 and earlier, as port uses
 # libcxx features normally only available on 10.15 and later.


### PR DESCRIPTION
Update qgis3 to qgis-3.32_0

#### Description

Updates the QGIS port to the current version 3.32.0. Replaces git repo tag to download and build version 3.32.0. Updates checksums to match the repo archive. No other changes required for successful build on my system.

###### Type(s)
- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4 22F66 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x ] tested basic functionality of all binary files?
- [x ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
