### PR TITLE
macfuse: update to 4.5.0

### DIFF
--- a/fuse/macfuse/Portfile
+++ b/fuse/macfuse/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        osxfuse osxfuse 4.4.3 macfuse-
+github.setup        osxfuse osxfuse 4.5.0 macfuse-
 revision            0
 name                macfuse
 conflicts           osxfuse
@@ -24,9 +24,9 @@ github.tarball_from releases
 distname            ${name}-${version}
 use_dmg             yes
 
-checksums           rmd160  2671d6fea1e15b499215a663f51222b4f8cb4652 \
-                    sha256  df6611e501c1f5ac838f2febaa8a949ccd7744cebd03db9ccdfa46aec04c9d27 \
-                    size    5970833
+checksums           rmd160  ff3fbf4c08e6cbadfc25304e481daa0c90d62ebb \
+                    sha256  9df7257315a9b9a97a9ba3a76011cabed7bc3784515b69fa098f8d81efec726d \
+                    size    5974209
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
     known_fail yes


### PR DESCRIPTION
###### Tested on
macOS 13.4.1 22F82 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?