### PR TITLE
py-argcomplete: update to 3.1.1

### DIFF
--- a/python/py-argcomplete/Portfile
+++ b/python/py-argcomplete/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-argcomplete
-version             3.0.5
+version             3.1.1
 license             Apache-2
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 
@@ -13,12 +13,12 @@ long_description    {*}${description}
 
 homepage            https://kislyuk.github.io/argcomplete
 
-checksums           rmd160  836c52fbbbaaa43a9122ef7a6260126ccfde30ed \
-                    sha256  fe3ce77125f434a0dd1bffe5f4643e64126d5731ce8d173d36f62fa43d6eb6f7 \
-                    size    65470
+checksums           rmd160  4c1cd23a8a26c75a8fd7bdadbae6f3a055cc6856 \
+                    sha256  6c4c563f14f01440aaffa3eae13441c5db2357b5eec639abe7c0b15334627dff \
+                    size    79356
 
 python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
-    depends_build   port:py${python.version}-setuptools
+    depends_build   port:py${python.version}-setuptools_scm
 }


### PR DESCRIPTION
###### Tested on
macOS 13.4.1 22F82 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?