### PR TITLE
AlphaSparse: update to 2023.06.19, fix build again

### DIFF
--- a/math/AlphaSparse/Portfile
+++ b/math/AlphaSparse/Portfile
@@ -5,8 +5,8 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           mpi 1.0
 
-github.setup        AlphaSparse AlphaSparse 06bf06a57f9112c2f940741841485243d8073c7c
-version             2022.03.30
+github.setup        AlphaSparse AlphaSparse 57eefee000734f40d9e972cbd110fbc4c51a71d3
+version             2023.06.19
 revision            0
 categories          math
 license             BSD
@@ -17,9 +17,9 @@ long_description    AlphaSparse aims to build a common interface that provides B
                     and expects to be extended on distributed and heterogeneous platforms. \
                     AlphaSparse is created using the basic C/C++ and can be deployed \
                     on both CPU and DCU (HIP-based many-core platform).
-checksums           rmd160  42732b3b193a3c54c3b8a89a8cb83a8719330bd2 \
-                    sha256  24b5fb8d36a4b80605c6402701d8620e07cb2bb386ea857b0d07259768713812 \
-                    size    9094750
+checksums           rmd160  ad56116e0c4e9672bfb82415540ea459c8a7777a \
+                    sha256  d61b35bf14ab7e6edf12e54a8a5e1a158fa8b453409159462f21dfba3aa45c3e \
+                    size    9093990
 
 patch.pre_args      -p1
 patchfiles-append   0001-Support-PPC-in-Makefile.patch \
@@ -43,6 +43,7 @@ post-extract {
     xinstall -d ${worksrcpath}/src/plain/kernel_1
     xinstall -d ${worksrcpath}/src/plain/kernel_2
     xinstall -d ${worksrcpath}/src/plain/kernel_3
+    xinstall -d ${worksrcpath}/src/plain/kernel_4
     set l1 ${worksrcpath}/src/plain/kernel/level1
     set l2 ${worksrcpath}/src/plain/kernel/level2
     set l3a ${worksrcpath}/src/plain/kernel/level3/add
@@ -57,26 +58,32 @@ post-extract {
             move ${f} ${worksrcpath}/src/plain/kernel_1/
         }
     }
-    fs-traverse f [list ${l3a} ${l3b}] {
+    fs-traverse f ${l3a} {
         if {[file isfile ${f}] && [file extension ${f}] == ".c"} {
             move ${f} ${worksrcpath}/src/plain/kernel_2/
         }
     }
-    fs-traverse f [list ${l3c} ${l3d} ${l3e} ${l3f} ${l3g}] {
+    fs-traverse f ${l3b} {
         if {[file isfile ${f}] && [file extension ${f}] == ".c"} {
             move ${f} ${worksrcpath}/src/plain/kernel_3/
+        }
+    }
+    fs-traverse f [list ${l3c} ${l3d} ${l3e} ${l3f} ${l3g}] {
+        if {[file isfile ${f}] && [file extension ${f}] == ".c"} {
+            move ${f} ${worksrcpath}/src/plain/kernel_4/
         }
     }
     file copy ${worksrcpath}/src/plain/kernel/Makefile ${worksrcpath}/src/plain/kernel_1
     file copy ${worksrcpath}/src/plain/kernel/Makefile ${worksrcpath}/src/plain/kernel_2
     file copy ${worksrcpath}/src/plain/kernel/Makefile ${worksrcpath}/src/plain/kernel_3
+    file copy ${worksrcpath}/src/plain/kernel/Makefile ${worksrcpath}/src/plain/kernel_4
     file delete -force ${worksrcpath}/src/plain/kernel
 }
 
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/Makefile
     reinplace "s|@CC@|${configure.cc}|g" ${worksrcpath}/Makefile
-    reinplace "s|kernel op op_|kernel_1 kernel_2 kernel_3 op op_|" ${worksrcpath}/src/plain/Makefile
+    reinplace "s|kernel op op_|kernel_1 kernel_2 kernel_3 kernel_4 op op_|" ${worksrcpath}/src/plain/Makefile
 }
 
 compiler.c_standard     2011
@@ -116,6 +123,11 @@ if {${build_arch} eq "arm64"} {
 platform darwin 10 powerpc {
     patchfiles-append \
                     0011-Hack-for-Rosetta.patch
+}
+
+if {[string match *clang* ${configure.compiler}]} {
+    patchfiles-append \
+                    0012-patch-clang.diff
 }
 
 destroot {

--- a/math/AlphaSparse/files/0012-patch-clang.diff
+++ b/math/AlphaSparse/files/0012-patch-clang.diff
@@ -1,0 +1,10 @@
+--- a/Makefile	2023-07-08 18:49:07.000000000 +0800
++++ b/Makefile	2023-07-08 18:51:41.000000000 +0800
+@@ -71,6 +71,7 @@
+ CFLAGS += -Wno-unused-parameter
+ CFLAGS += -Wno-unused-function
+ CFLAGS += -Wno-unused-variable
++CFLAGS += -Wno-int-conversion
+ CFLAGS += -fstack-protector-all
+ CFLAGS += -fPIC
+ # CFLAGS += -Wl,-z,relro -Wl,-z,noexecstack -Wl,-z,now


### PR DESCRIPTION
#### Description

While update merely updates readme, we need a fix anyway due to https://github.com/ALSparse/ALSparse/issues/19

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
