### PR TITLE
erlang: update to 26.0

### DIFF
--- a/lang/erlang/Portfile
+++ b/lang/erlang/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 10
 
 name                erlang
-version             25.3
+version             26.0
 revision            0
 
 categories          lang erlang
@@ -47,17 +47,17 @@ distfiles           otp_src_${version}${extract.suffix}                    \
                     otp_doc_html_${version}${extract.suffix}
 
 checksums           otp_src_${version}.tar.gz \
-                    rmd160  5e6fb5e0f158327c86c12a48cc930c63c3d3a0be \
-                    sha256  aeaa546e0c38e338010d16348d8c67f7fc8c02df728a88d8499838d8c9131e1c \
-                    size    103797057 \
+                    rmd160  1db24b24d32c112c7aced2b67983d48383613416 \
+                    sha256  4e411587bd7d18ee2d5a0e7207f638e14036152633db57d2cf49c84a9c92d945 \
+                    size    104745211 \
                     otp_doc_man_${version}.tar.gz \
-                    rmd160  0b4e2aabe13d2fba591d18f898e4b5a2469f8257 \
-                    sha256  675658e5cac834ffe726e180d3f7839e23d32fa57ae921a524ac9f808b6ed76e \
-                    size    1715883 \
+                    rmd160  d61664b1cc544dbe4b3dd365318a723214629ef5 \
+                    sha256  b635836c39671af74cf44098242c62e4515cc0892e0a590c97eab19326dcea8e \
+                    size    1739379 \
                     otp_doc_html_${version}.tar.gz \
-                    rmd160  fe6497919abcd708f5e8a6f60d94120258f5ac48 \
-                    sha256  35cd476ae1a013256d9c51c23216669840512031b8733e5391b6742c3477e140 \
-                    size    41054645
+                    rmd160  20c843e9c65f8401167c37c9cd09d17b34f6fb5e \
+                    sha256  63429515cba922ba7936321a01a4cda6159f2bc82fc7dbce89b051242b0a3b90 \
+                    size    41404488
 
 worksrcdir          otp_src_${version}
 


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
