### PR TITLE
bpack: add tarball_from to fix checksums

### DIFF
--- a/math/bpack/Portfile
+++ b/math/bpack/Portfile
@@ -9,16 +9,18 @@ PortGroup           mpi 1.0
 
 github.setup        liuyangzhuan ButterflyPACK 2.2.2 v
 name                bpack
-revision            0
+revision            1
 categories          math science
 license             BSD
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         ButterflyPACK is a mathematical software for rapidly solving large-scale dense linear systems that exhibit off-diagonal rank-deficiency
 long_description    {*}${description}
 homepage            https://portal.nersc.gov/project/sparse/butterflypack
-checksums           rmd160  733f37d48a936805eceb09b5a57f174f5c317a51 \
-                    sha256  5fe32d0d6c259c38df278aeae89d4ba81c4d79d56cfa5f36ecdf6dabad896e14 \
-                    size    378372100
+checksums           rmd160  cad3aaf9b860c32b1ae5b5e9c3482c8bfc47f0b1 \
+                    sha256  73f67073e4291877f1eee19483a8a7b3c761eaf79a75805d52105ceedead85ea \
+                    size    378371560
+github.tarball_from archive
+dist_subdir         ${name}/${version}_1
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description

Github has broken checksums. Add `github.tarball_from` in a hope that helps to prevent sabotage by Github.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
