### PR TITLE
fossil: update to 2.22

### DIFF
--- a/devel/fossil/Portfile
+++ b/devel/fossil/Portfile
@@ -5,13 +5,12 @@ PortSystem          1.0
 PortGroup           openssl 1.0
 
 name                fossil
-version             2.21
+version             2.22
 revision            0
 epoch               20110901182519
 categories          devel
-platforms           darwin
 license             BSD
-maintainers         {ciserlohn @ci42}
+maintainers         {ciserlohn @ci42} openmaintainer
 
 description         Simple, high-reliability, distributed software configuration management
 
@@ -25,19 +24,22 @@ homepage            https://fossil-scm.org/home/
 
 master_sites        ${homepage}tarball/version-${version}/
 
-checksums           rmd160  5671e04453fd7eaec5c9a4be4132cb1b5cb95a44 \
-                    sha256  c1feeca782124cde76992407c70f2cefffcbe1b78b66dc246890d83159ef8084 \
-                    size    6703304
+checksums           rmd160  99e144282ede18d8f2221d0752cdd16935b2d09e \
+                    sha256  81d823ff6f5d175b384dfa84eeba0d052da73a37cd66cd72b786e71671210d6b \
+                    size    6730169
 
 test.run            yes
 
 openssl.branch      3
 
-depends_lib-append  port:tcl \
-                    port:zlib \
-                    port:libiconv
+depends_lib-append  port:libiconv \
+                    port:sqlite3 \
+                    port:tcl \
+                    port:zlib
 
-configure.args-append       --with-tcl=${prefix}/lib \
+configure.args-append       --disable-fusefs \
+                            --with-sqlite=${prefix}/lib \
+                            --with-tcl=${prefix}/lib \
                             --with-openssl=[openssl::install_area] \
                             --with-zlib=${prefix}/lib \
                             --with-th1-docs \
@@ -52,7 +54,7 @@ configure.ldflags-append    -liconv
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${name}
     xinstall -d ${docdir}
-    xinstall -m 644 -W ${worksrcpath} \
+    xinstall -m 0644 -W ${worksrcpath} \
         COPYRIGHT-BSD2.txt \
         ${docdir}
 }


### PR DESCRIPTION
- make port openmaintainer as ci42 has been non-responsive for a long time
- build with sqlite
- disable fusefs

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
