### PR TITLE
universal-ctags: update to 6.0.20230702.0, add link

### DIFF
--- a/devel/universal-ctags/Portfile
+++ b/devel/universal-ctags/Portfile
@@ -4,16 +4,18 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        universal-ctags ctags 6.0.20230430.0 p
+github.setup        universal-ctags ctags 6.0.20230702.0 p
 name                universal-ctags
 epoch               1
 revision            0
+conflicts           ctags
 
 categories          devel
 platforms           darwin
 license             GPL-2+
 maintainers         {@kaimingguo gmail.com:augustin.guo} \
                     {@catap korins.ky:kirill} \
+                    {@judaew judaew} \
                     openmaintainer
 
 description         A maintained ctags implementation
@@ -24,9 +26,9 @@ long_description \
 
 homepage            https://ctags.io
 
-checksums           rmd160  27de317531332295f520f32019950b516e17598f \
-                    sha256  5aa23897da5472acf89a441a0ab5dd008049480a405136722643fd0766f4f75d \
-                    size    3038318
+checksums           rmd160  6680af8806a19c6981e7d606e6a1e461053b2c7f \
+                    sha256  11c2c20f9087bd77e5d6e3930e4778ee3b317ac24cf682427cd372fede6c91af \
+                    size    3048211
 
 # LegacySupport is needed for strnlen before 10.7
 legacysupport.newest_darwin_requires_legacy 10
@@ -75,4 +77,8 @@ variant manpages description {Enable documentation} {
 
     configure.args-append   --with-rst2man=${prefix}/bin/rst2man-${python_branch}.py \
                             --with-rst2html=${prefix}/bin/rst2html-${python_branch}.py
+}
+
+post-destroot {
+    ln -s ${prefix}/bin/uctags ${destroot}${prefix}/bin/ctags
 }


### PR DESCRIPTION
#### Description

Some apps expect the `ctags` name binary file if it's Universal Ctags. Often this is due to the fact that they are compatible with both Exuberant Ctags and Universal Ctags. Because of this, I added a soft link from `uctags` to `ctags`.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F82 x86_64
Xcode 15.0 15A5160n

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
