### PR TITLE
py-torchvision: update to 0.15.2

### DIFF
--- a/python/py-torchvision/Portfile
+++ b/python/py-torchvision/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        pytorch vision 0.13.0 v
+github.setup        pytorch vision 0.15.2 v
 revision            0
 name                py-torchvision
 
@@ -20,9 +20,9 @@ long_description    The torchvision package consists of popular \
                     datasets, model architectures, and common image \
                     transformations for computer vision.
 
-checksums           rmd160  0e81916b138162f27b7d5b0bb386789ad5024b1c \
-                    sha256  2cfe99212d92972f576e0848c772d2a030f29f7ee731068fba7c63edc6648fcc \
-                    size    9242004
+checksums           rmd160  a52c8e235cfd977d78db5f4666f518dc42565fb6 \
+                    sha256  e7425cb4313919d9b3873c8395d1e7d7abb9e0f32a38ce9dcb3b4160ffd979b8 \
+                    size    13091302
 
 python.versions     38 39 310
 


### PR DESCRIPTION
#### Description

Current version fails to build on several platforms

https://ports.macports.org/port/py-torchvision/details/
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
