### PR TITLE
cgrc: update to version 2.0.1

### DIFF
--- a/textproc/cgrc/Portfile
+++ b/textproc/cgrc/Portfile
@@ -6,8 +6,8 @@ PortGroup           cmake 1.1
 PortGroup           qt6 1.0
 
 fetch.type          git
-github.setup        carlonluca cgrc 0.3.2 v
-revision            0
+github.setup        carlonluca cgrc 0.5.0 v
+revision            1
 license             GPL-3
 categories          textproc
 maintainers         {@carlonluca gmail.com:carlon.luca} openmaintainer

--- a/textproc/cgrc/Portfile
+++ b/textproc/cgrc/Portfile
@@ -2,11 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           cmake 1.1
-PortGroup           qt6 1.0
+PortGroup           cargo 1.0
 
 fetch.type          git
-github.setup        carlonluca cgrc 0.5.0 v
+github.setup        carlonluca cgrc 2.0.1 v
 revision            1
 license             GPL-3
 categories          textproc
@@ -16,11 +15,15 @@ long_description    cgrc formats text from stdin according to custom configurati
                     and outputs the result with ANSI escape codes to stdout. Configuration \
                     files includes a set of regular expressions with the related format \
                     to be used to the match and the captures.
-cmake.install_rpath-append \
-                    ${qt_dir}/lib
-compiler.cxx_standard \
-                    2017
+build.dir           ${worksrcpath}/cgrc-rust
+build.args          ""
 
 post-fetch {
     system -W ${worksrcpath} "git submodule update --init"
+    system -W ${worksrcpath}/cgrc-rust "cargo fetch --locked"
+}
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/cgrc-rust/target/[cargo.rust_platform]/release/cgrc \
+        ${destroot}${prefix}/bin/
 }


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Apparently everything works when installing with `sudo port install`, but not with `sudo port -vst install`. Is this a problem?

```
sh: cargo: command not found
Command failed: cargo fetch --locked
Exit code: 127
Warning: The following existing files were hidden from the build system by trace mode:
  /opt/local/bin/cargo
  /private/var/select/sh
Warning: The following file inside the MacPorts prefix not installed by a port was accessed:
  /opt/local/etc/gitconfig
```