### PR TITLE
fatsort: update to 1.6.5.640

### DIFF
--- a/sysutils/fatsort/Portfile
+++ b/sysutils/fatsort/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                fatsort
-version             1.6.4.625
+version             1.6.5.640
 revision            0
 categories          sysutils
 platforms           darwin freebsd linux
@@ -24,9 +24,9 @@ depends_lib         port:libiconv
 
 master_sites        sourceforge:${name}
 use_xz              yes
-checksums           rmd160  e229cfdc4079fdcc007980c2edad7699f7ca569f \
-                    sha256  9a6f89a0640bb782d82ff23a780c9f0aec3dfbe4682c0a8eda157e0810642ead \
-                    size    123964
+checksums           rmd160  4c41df05db01d73958598dfb0b0e6b88647152fe \
+                    sha256  630ece56d9eb3a55524af0aec3aade7854360eba949172a6cfb4768cb8fbe42e \
+                    size    131792
 
 use_configure       no
 variant universal   {}


### PR DESCRIPTION
#### Description

Nothing really changed, just a few misc bugfixes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.4.1 22F82 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
