### PR TITLE
ruby-build: Update to 20230710

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230615 v
+github.setup        rbenv ruby-build 20230710 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  21894bad49a1421fcc4a5790085f0c55d0ccb595 \
-                    sha256  5407ebc6431b4d6708a10bf817e70d84131574309766a5eea7c49fce48d611b7 \
-                    size    80376
+checksums           rmd160  bb94d165722b1a4451ad72caa99e6ff0f2c62b35 \
+                    sha256  c16d229e32cadd21f77554044554b6e0aafb0813f21356e4bc750b328f477db4 \
+                    size    80359
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Upstream changelog:

```
- Bump up the latest versions of OpenSSL by @hsbt in #2216
```

###### Tested on

macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?