### PR TITLE
twopnt: new port in Fortran

### DIFF
--- a/fortran/twopnt/Portfile
+++ b/fortran/twopnt/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           fortran 1.0
+
+github.setup        perazz twopnt 4ce477215f84a88d879f0ca3937cab9bedfb7762
+version             0.1.0
+revision            0
+categories-append   math
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Modern Fortran translation of the TWOPNT program for Boundary Value Problems
+long_description    {*}${description}. The functions are modernized and translated \
+                    from the original Fortran77 code TWOPNT, written by Dr Joseph F. Grcar \
+                    at Sandia National Laboratories, Livermore, CA. The baseline version \
+                    used for the translation is Version 3.29 from April 1998. \
+                    An object-oriented interface wrapper was also built.
+checksums           rmd160  6a931a5e51898e691a890efb0604dacbcfa7ebfc \
+                    sha256  768144003705bd5a74939ea9d8db5ec47782ae114e6e5759bf1c1489b94fc02a \
+                    size    40753
+
+# Requires at least FPM 0.8.0: https://github.com/perazz/twopnt/issues/2
+
+post-destroot {
+    set docdir ${prefix}/share/doc/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} README.md ${destroot}${docdir}
+}
+
+test.run            yes


### PR DESCRIPTION
#### Description

New port: https://github.com/perazz/twopnt

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
