### PR TITLE
py-nameutils: new port (version 1.0.0)

### DIFF
--- a/python/py-nameutils/Portfile
+++ b/python/py-nameutils/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-nameutils
+version             1.0.0
+revision            0
+
+license             GPL-3+
+platforms           {darwin any}
+supported_archs     noarch
+maintainers         {raf.org:raf @macportsraf} openmaintainer
+description         Identify given/family names and capitalize correctly
+long_description    {*}${description}. \
+                    \n\nnameutils is a python module containing functions that can split a \
+                    person's full name into their given and family names, and capitalize the \
+                    letters appropriately. It understands complex names in Latin scripts from \
+                    many different languages, and it understands Chinese, Japanese, and Korean \
+                    names, in both their own characters, and romanized.
+
+homepage            https://raf.org/nameutils
+
+checksums           rmd160  0a0fac27a7519b119a616ff6045665bc8fd935b4 \
+                    sha256  1e30bf7420cc74264ecc17a92d12fd2253f9f62ca1949cbbf7c0ffc3e6036bb6 \
+                    size    77846
+
+python.versions     38 39 310 311
+
+if {${name} ne ${subport}} {
+    python.pep517         yes
+    python.pep517_backend hatch
+    python.test_framework unittest
+
+    depends_lib-append    port:py${python.version}-regex
+
+    test.run              yes
+}


### PR DESCRIPTION
#### Description

py-nameutils - Identify given/family names and capitalize correctly

###### Type(s)


- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
