### PR TITLE
virt-manager: fix port

### DIFF
--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           app 1.0
 
 github.setup        virt-manager virt-manager 4.1.0 v
-revision            0
+revision            1
 checksums           rmd160  75b773577e04827d808cc85f3a781d1135026215 \
                     sha256  950681d7b32dc61669278ad94ef31da33109bf6fcf0426ed82dfd7379aa590a2 \
                     size    3151412
@@ -42,7 +42,6 @@ python.pep517           no
 # 'gettext-runtime', as this port utilizes Python's built-in 'gettext' support.
 depends_build \
     port:gettext \
-    port:intltool \
     path:bin/glib-compile-schemas:glib2 \
     port:python${python.version} \
     port:py${python.version}-docutils \


### PR DESCRIPTION
#### Description

Revision wasn't bumped when updating to Python 3.11 leading to scripts looking for Python 3.10 libraries.

- Remove unused dependency

###### Type(s)

- [x] bugfix

###### Tested on
macOS 13.4.1 22F82 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?