### PR TITLE
qt6: Patches for building on macOS 10.14, Xcode 11.3

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -933,6 +933,8 @@ subport ${name}-qtdeclarative {
 
     # Xcode 10.3 compiler segfaults
     compiler.blacklist-append       {clang < 1100}
+
+    patchfiles-append               patch-qtdeclarative-xcode11.3.diff
 }
 
 subport ${name}-qttools {
@@ -949,6 +951,13 @@ subport ${name}-qttools {
 }
 
 subport ${name}-qtwebengine {
+    patchfiles-append               patch-qtwebengine-xcode11.3.diff
+    patchfiles-append               patch-qtwebengine-xcode11-backport.diff
+    patchfiles-append               patch-qtwebengine-is_cpp17_contiguous_iterator.diff
+    if { ${os.platform} eq "darwin" && ${os.major} < 19 } {
+        patchfiles-append           patch-qtwebengine-mojave.diff
+    }
+
     configure.env-append            PYTHON3_PATH=${prefix}/Library/Frameworks/Python.framework/Versions/${python_branch}/bin
     # in ${worksrcpath}, `${qt6.dir}/bin/qt-configure-module . -help` and `${qt6.dir}/bin/qt-configure-module . -list-features`
     # it is not clear why, but icu and ffmpeg support must be added manually
@@ -966,6 +975,8 @@ subport ${name}-qtwebengine {
 }
 
 subport ${name}-qtmultimedia {
+    patchfiles-append               patch-qtmultimedia-macos_10.14_sdk.diff
+
     # GStreamer will be found if gstreamer1 and gstreamer1-gst-plugins-base are installed
     # however, an error will ensue since the GStreamer support requires "Linux DMA buffer support"
     # see
@@ -979,16 +990,27 @@ subport ${name}-qt5compat {
 }
 
 subport ${name}-qtspeech {
+    patchfiles-append               patch-qtspeech-macos_10.14_sdk.diff
+
     # ALSA is Linux only (https://www.alsa-project.org/wiki/Main_Page)
     # Speech Dispatcher *might* be made to work on macOS (https://freebsoft.org/speechd)
     configure.args-append           -no-flite-alsa \
                                     -no-speechd
 }
 
+subport ${name}-qtpositioning {
+    patchfiles-append               patch-qtpositioning-macos_10.14_sdk.diff
+}
+
 if { ${subport} eq "${name}-qtbase" || ${subport} eq "${name}-qtbase-docs" } {
     # allow building with macOS 10.14 SDK
     # see https://trac.macports.org/ticket/64345
     patchfiles-append               patch-qtbase-macos_10.14_sdk.diff
+
+    # Disarm ac7f73e507be238a9c573c1e082713c4f3449e36 incompatible with Apple Clang < 12
+    if { ${use_xcode} ? ([vercmp ${xcodeversion} 12.0] < 0) : ([vercmp ${xcodecltversion} 12.0] < 0) } {
+        patchfiles-append           patch-qtbase-xcode11-avx512.diff
+    }
 
     configure.pre_args-replace      --prefix=${prefix} \
                                     "-prefix ${qt6.dir}"

--- a/aqua/qt6/files/patch-qtbase-macos_10.14_sdk.diff
+++ b/aqua/qt6/files/patch-qtbase-macos_10.14_sdk.diff
@@ -17,7 +17,7 @@ Upstream-Status: Inappropriate [violates DRY]
                  if (charactersWithModifiers.length > 0)
 --- src/gui/rhi/qrhimetal.mm.orig
 +++ src/gui/rhi/qrhimetal.mm
-@@ -382,15 +382,15 @@
+@@ -369,15 +369,15 @@
      driverInfoStruct.deviceType = QRhiDriverInfo::IntegratedDevice;
  #else
      if (@available(macOS 10.15, *)) {
@@ -37,3 +37,191 @@ Upstream-Status: Inappropriate [violates DRY]
              driverInfoStruct.deviceType = QRhiDriverInfo::ExternalDevice;
              break;
          default:
+@@ -403,7 +403,7 @@
+     caps.maxTextureSize = 16384;
+     caps.baseVertexAndInstance = true;
+     if (@available(macOS 10.15, *))
+-        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamilyApple7];
++        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamily(1007)]; // MTLGPUFamilyApple7
+     caps.maxThreadGroupSize = 1024;
+ #elif defined(Q_OS_TVOS)
+     if ([d->dev supportsFeatureSet: MTLFeatureSet(30003)]) // MTLFeatureSet_tvOS_GPUFamily2_v1
+@@ -2545,122 +2545,156 @@
+         return srgb ? MTLPixelFormatASTC_12x12_sRGB : MTLPixelFormatASTC_12x12_LDR;
+ #else
+     case QRhiTexture::ETC2_RGB8:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatETC2_RGB8_sRGB : MTLPixelFormatETC2_RGB8;
+         }
++#endif
+         qWarning("QRhiMetal: ETC2 compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ETC2_RGB8A1:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatETC2_RGB8A1_sRGB : MTLPixelFormatETC2_RGB8A1;
+         }
++#endif
+         qWarning("QRhiMetal: ETC2 compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ETC2_RGBA8:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatEAC_RGBA8_sRGB : MTLPixelFormatEAC_RGBA8;
+         }
++#endif
+         qWarning("QRhiMetal: ETC2 compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_4x4:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_4x4_sRGB : MTLPixelFormatASTC_4x4_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_5x4:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_5x4_sRGB : MTLPixelFormatASTC_5x4_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_5x5:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_5x5_sRGB : MTLPixelFormatASTC_5x5_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_6x5:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_6x5_sRGB : MTLPixelFormatASTC_6x5_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_6x6:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_6x6_sRGB : MTLPixelFormatASTC_6x6_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_8x5:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_8x5_sRGB : MTLPixelFormatASTC_8x5_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_8x6:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_8x6_sRGB : MTLPixelFormatASTC_8x6_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_8x8:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_8x8_sRGB : MTLPixelFormatASTC_8x8_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_10x5:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_10x5_sRGB : MTLPixelFormatASTC_10x5_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_10x6:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_10x6_sRGB : MTLPixelFormatASTC_10x6_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_10x8:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_10x8_sRGB : MTLPixelFormatASTC_10x8_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_10x10:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_10x10_sRGB : MTLPixelFormatASTC_10x10_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_12x10:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_12x10_sRGB : MTLPixelFormatASTC_12x10_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+     case QRhiTexture::ASTC_12x12:
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (d->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *))
+                 return srgb ? MTLPixelFormatASTC_12x12_sRGB : MTLPixelFormatASTC_12x12_LDR;
+         }
++#endif
+         qWarning("QRhiMetal: ASTC compression not supported on this platform");
+         return MTLPixelFormatInvalid;
+ #endif
+@@ -2761,6 +2761,7 @@
+     switch (m_type) {
+     case DepthStencil:
+ #ifdef Q_OS_MACOS
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (rhiD->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *)) {
+                 desc.storageMode = MTLStorageModeMemoryless;
+@@ -2769,10 +2770,13 @@
+                 Q_UNREACHABLE();
+             }
+         } else {
++#endif
+             desc.storageMode = MTLStorageModePrivate;
+             d->format = rhiD->d->dev.depth24Stencil8PixelFormatSupported
+                     ? MTLPixelFormatDepth24Unorm_Stencil8 : MTLPixelFormatDepth32Float_Stencil8;
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         }
++#endif
+ #else
+         desc.storageMode = MTLStorageModeMemoryless;
+         d->format = MTLPixelFormatDepth32Float_Stencil8;

--- a/aqua/qt6/files/patch-qtbase-xcode11-avx512.diff
+++ b/aqua/qt6/files/patch-qtbase-xcode11-avx512.diff
@@ -1,0 +1,38 @@
+Mask some AVX512 optimizations incompatible with XCode 11.x CLang
+
+--- src/corelib/global/qfloat16.cpp.orig	2023-02-14 09:26:04.000000000 +0100
++++ src/corelib/global/qfloat16.cpp	2023-07-08 17:02:40.000000000 +0200
+@@ -172,6 +172,7 @@
+     return qCpuHasFeature(ArchSkylakeAvx512);
+ }
+ 
++#if 0
+ static QT_FUNCTION_TARGET(ARCH_SKYLAKE_AVX512)
+ void qFloatToFloat16_tail_avx256(quint16 *out, const float *in, qsizetype len) noexcept
+ {
+@@ -190,6 +191,7 @@
+     _mm256_mask_storeu_ps(out, mask, f32);
+ };
+ #endif
++#endif
+ 
+ QT_FUNCTION_TARGET(F16C)
+ static void qFloatToFloat16_fast(quint16 *out, const float *in, qsizetype len) noexcept
+@@ -214,7 +216,7 @@
+         return convertOneChunk(len - Step);
+     }
+ 
+-#if QT_COMPILER_SUPPORTS_HERE(AVX512VL) && QT_COMPILER_SUPPORTS_HERE(AVX512BW)
++#if 0
+     if (hasFastF16Avx256())
+         return qFloatToFloat16_tail_avx256(out, in, len);
+ #endif
+@@ -259,7 +261,7 @@
+         return convertOneChunk(len - Step);
+     }
+ 
+-#if QT_COMPILER_SUPPORTS_HERE(AVX512VL) && QT_COMPILER_SUPPORTS_HERE(AVX512BW)
++#if 0
+     if (hasFastF16Avx256())
+         return qFloatFromFloat16_tail_avx256(out, in, len);
+ #endif

--- a/aqua/qt6/files/patch-qtbase-xcode11.3.diff
+++ b/aqua/qt6/files/patch-qtbase-xcode11.3.diff
@@ -1,0 +1,11 @@
+--- src/corelib/global/qcompilerdetection.h.orig        2023-02-14 09:26:04.000000000 +0100
++++ src/corelib/global/qcompilerdetection.h     2023-06-01 17:09:55.000000000 +0200
+@@ -125,7 +125,7 @@
+ #      elif __apple_build_version__ >= 11000033 // Xcode 11.0
+ #        define Q_CC_CLANG 800
+ #      else
+-#        error "Unsupported Apple Clang version"
++         static_assert(false, "Unsupported Apple Clang version" #__apple_build_version__);
+ #      endif
+ #    else
+        // Non-Apple Clang, so we trust the versions reported

--- a/aqua/qt6/files/patch-qtdeclarative-xcode11.3.diff
+++ b/aqua/qt6/files/patch-qtdeclarative-xcode11.3.diff
@@ -1,0 +1,22 @@
+--- src/qml/jsruntime/qv4engine_p.h.orig	2023-03-11 23:23:17.000000000 +0100
++++ src/qml/jsruntime/qv4engine_p.h	2023-07-08 21:48:13.000000000 +0200
+@@ -774,7 +774,7 @@
+ };
+ 
+ #define CHECK_STACK_LIMITS(v4) if ((v4)->checkStackLimits()) return Encode::undefined(); \
+-    ExecutionEngineCallDepthRecorder _executionEngineCallDepthRecorder(v4);
++    ExecutionEngineCallDepthRecorder<1> _executionEngineCallDepthRecorder(v4);
+ 
+ template<int Frames = 1>
+ struct ExecutionEngineCallDepthRecorder
+--- src/qml/jsruntime/qv4vme_moth.cpp.orig	2023-03-11 23:23:17.000000000 +0100
++++ src/qml/jsruntime/qv4vme_moth.cpp	2023-07-08 21:59:27.000000000 +0200
+@@ -400,7 +400,7 @@
+         frame->setReturnValueUndefined();
+         return;
+     }
+-    ExecutionEngineCallDepthRecorder executionEngineCallDepthRecorder(engine);
++    ExecutionEngineCallDepthRecorder<1> executionEngineCallDepthRecorder(engine);
+ 
+     Function *function = frame->v4Function;
+     Q_ASSERT(function->aotFunction);

--- a/aqua/qt6/files/patch-qtmultimedia-macos_10.14_sdk.diff
+++ b/aqua/qt6/files/patch-qtmultimedia-macos_10.14_sdk.diff
@@ -1,0 +1,51 @@
+--- src/multimedia/darwin/qcoreaudioutils.mm.orig	2023-03-12 04:46:05.000000000 +0100
++++ src/multimedia/darwin/qcoreaudioutils.mm	2023-07-08 23:42:48.000000000 +0200
+@@ -119,11 +119,13 @@
+         { QAudioFormat::TopFrontLeft, kAudioChannelLabel_VerticalHeightLeft },
+         { QAudioFormat::TopFrontRight, kAudioChannelLabel_VerticalHeightRight },
+         { QAudioFormat::TopFrontCenter, kAudioChannelLabel_VerticalHeightCenter },
+-        { QAudioFormat::TopCenter, kAudioChannelLabel_CenterTopMiddle },
++        { QAudioFormat::TopCenter, kAudioChannelLabel_TopCenterSurround },
+         { QAudioFormat::TopBackLeft, kAudioChannelLabel_TopBackLeft },
+         { QAudioFormat::TopBackRight, kAudioChannelLabel_TopBackRight },
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+         { QAudioFormat::TopSideLeft, kAudioChannelLabel_LeftTopMiddle },
+         { QAudioFormat::TopSideRight, kAudioChannelLabel_RightTopMiddle },
++#endif
+         { QAudioFormat::TopBackCenter, kAudioChannelLabel_TopBackCenter },
+ };
+ 
+--- src/plugins/multimedia/darwin/camera/qavfcamerabase.mm.orig	2023-03-12 04:46:05.000000000 +0100
++++ src/plugins/multimedia/darwin/camera/qavfcamerabase.mm	2023-07-09 00:18:24.000000000 +0200
+@@ -93,18 +93,20 @@
+ #endif // defined(Q_OS_IOS)
+ 
+ bool isFlashAvailable(AVCaptureDevice* captureDevice) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+     if (@available(macOS 10.15, *)) {
+         return [captureDevice isFlashAvailable];
+     }
+-
++#endif
+     return true;
+ }
+ 
+ bool isTorchAvailable(AVCaptureDevice* captureDevice) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+     if (@available(macOS 10.15, *)) {
+         return [captureDevice isTorchAvailable];
+     }
+-
++#endif
+     return true;
+ }
+ 
+@@ -723,7 +725,7 @@
+ 
+     if (@available(macOS 10.15, *)) {
+         AVCaptureDevice *captureDevice = device();
+-        return captureDevice && [captureDevice isExposureModeSupported:AVCaptureExposureModeCustom];
++        return captureDevice && [captureDevice isExposureModeSupported:AVCaptureExposureMode(3)]; // AVCaptureExposureModeCustom
+     }
+ 
+     return false;

--- a/aqua/qt6/files/patch-qtpositioning-macos_10.14_sdk.diff
+++ b/aqua/qt6/files/patch-qtpositioning-macos_10.14_sdk.diff
@@ -1,0 +1,17 @@
+--- src/plugins/position/corelocation/qgeopositioninfosource_cl.mm.orig	2023-03-12 03:16:54.000000000 +0100
++++ src/plugins/position/corelocation/qgeopositioninfosource_cl.mm	2023-07-09 15:29:51.000000000 +0200
+@@ -52,12 +52,14 @@
+ #ifndef Q_OS_TVOS
+     if (newLocation.course >= 0) {
+         location.setAttribute(QGeoPositionInfo::Direction, newLocation.course);
++#if !defined(Q_OS_MACOS) || MAC_OS_X_VERSION_MAX_ALLOWED >= 101504
+         if (__builtin_available(iOS 13.4, watchOS 6.2, macOS 10.15.4, *)) {
+             if (newLocation.courseAccuracy >= 0) {
+                 location.setAttribute(QGeoPositionInfo::DirectionAccuracy,
+                                       newLocation.courseAccuracy);
+             }
+         }
++#endif
+     }
+     if (newLocation.speed >= 0)
+         location.setAttribute(QGeoPositionInfo::GroundSpeed, newLocation.speed);

--- a/aqua/qt6/files/patch-qtspeech-macos_10.14_sdk.diff
+++ b/aqua/qt6/files/patch-qtspeech-macos_10.14_sdk.diff
@@ -1,0 +1,26 @@
+--- src/plugins/tts/darwin/qtexttospeech_darwin.mm.orig	2023-03-12 05:16:00.000000000 +0100
++++ src/plugins/tts/darwin/qtexttospeech_darwin.mm	2023-07-09 02:30:51.000000000 +0200
+@@ -2,6 +2,7 @@
+ // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only
+ 
+ #include <AVFoundation/AVFoundation.h>
++#include <../../System/Library/Frameworks/AVFoundation.framework/Frameworks/AVFAudio.framework/Headers/AVSpeechSynthesis.h>
+ 
+ #include "qtexttospeech_darwin.h"
+ 
+@@ -281,6 +282,7 @@
+ {
+     // only from macOS 10.15 and iOS 13 on
+     const QVoice::Gender gender = [avVoice]{
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+         if (@available(macos 10.15, ios 13, *)) {
+             switch (avVoice.gender) {
+             case AVSpeechSynthesisVoiceGenderMale:
+@@ -291,6 +293,7 @@
+                 break;
+             };
+         }
++#endif
+         return QVoice::Unknown;
+     }();
+ 

--- a/aqua/qt6/files/patch-qtwebengine-is_cpp17_contiguous_iterator.diff
+++ b/aqua/qt6/files/patch-qtwebengine-is_cpp17_contiguous_iterator.diff
@@ -1,0 +1,155 @@
+See https://github.com/chromium/chromium/commit/5b5551edd3961481e617e510276b9f015a35b861,
+https://github.com/chromium/chromium/commit/9bfbbffdba73668fdb483e5a850911d2b64c35d7
+
+diff --git a/base/containers/checked_iterators.h b/base/containers/checked_iterators.h
+index 0c98b8fab4d003..5c8292bd68a2a4 100644
+--- src/3rdparty/chromium/base/containers/checked_iterators.h
++++ src/3rdparty/chromium/base/containers/checked_iterators.h
+@@ -31,10 +31,8 @@ class CheckedContiguousIterator {
+ 
+   // Required for certain libc++ algorithm optimizations that are not available
+   // for NaCl.
+-#if defined(_LIBCPP_VERSION) && !BUILDFLAG(IS_NACL)
+   template <typename Ptr>
+   friend struct std::pointer_traits;
+-#endif
+ 
+   constexpr CheckedContiguousIterator() = default;
+ 
+@@ -224,7 +222,6 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
+ 
+ }  // namespace base
+ 
+-#if defined(_LIBCPP_VERSION) && !BUILDFLAG(IS_NACL)
+ // Specialize both std::__is_cpp17_contiguous_iterator and std::pointer_traits
+ // for CCI in case we compile with libc++ outside of NaCl. The former is
+ // required to enable certain algorithm optimizations (e.g. std::copy can be a
+@@ -244,9 +241,11 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
+ // [3] https://wg21.link/pointer.traits.optmem
+ namespace std {
+ 
++#if defined(_LIBCPP_VERSION)
+ template <typename T>
+ struct __is_cpp17_contiguous_iterator<::base::CheckedContiguousIterator<T>>
+     : true_type {};
++#endif
+ 
+ template <typename T>
+ struct pointer_traits<::base::CheckedContiguousIterator<T>> {
+@@ -267,6 +266,5 @@ struct pointer_traits<::base::CheckedContiguousIterator<T>> {
+ };
+ 
+ }  // namespace std
+-#endif
+ 
+ #endif  // BASE_CONTAINERS_CHECKED_ITERATORS_H_
+diff --git a/base/containers/checked_iterators.h b/base/containers/checked_iterators.h
+index 5c8292bd68a2a4..b67a2db4bfa3be 100644
+--- src/3rdparty/chromium/base/containers/checked_iterators.h
++++ src/3rdparty/chromium/base/containers/checked_iterators.h
+@@ -24,6 +24,9 @@ class CheckedContiguousIterator {
+   using pointer = T*;
+   using reference = T&;
+   using iterator_category = std::random_access_iterator_tag;
++#if __cplusplus >= 202002L
++  using iterator_concept = std::contiguous_iterator_tag;
++#endif
+ 
+   // Required for converting constructor below.
+   template <typename U>
+@@ -239,14 +242,34 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
+ // [1] https://wg21.link/iterator.concept.contiguous
+ // [2] https://wg21.link/std.iterator.tags
+ // [3] https://wg21.link/pointer.traits.optmem
+-namespace std {
+ 
+ #if defined(_LIBCPP_VERSION)
++
++// TODO(crbug.com/1284275): Remove when C++20 is on by default, as the use
++// of `iterator_concept` above should suffice.
++_LIBCPP_BEGIN_NAMESPACE_STD
++
++// TODO(crbug.com/1449299): https://reviews.llvm.org/D150801 renamed this from
++// `__is_cpp17_contiguous_iterator` to `__libcpp_is_contiguous_iterator`. Clean
++// up the old spelling after libc++ rolls.
++template <typename T>
++struct __is_cpp17_contiguous_iterator;
+ template <typename T>
+ struct __is_cpp17_contiguous_iterator<::base::CheckedContiguousIterator<T>>
+     : true_type {};
++
++template <typename T>
++struct __libcpp_is_contiguous_iterator;
++template <typename T>
++struct __libcpp_is_contiguous_iterator<::base::CheckedContiguousIterator<T>>
++    : true_type {};
++
++_LIBCPP_END_NAMESPACE_STD
++
+ #endif
+ 
++namespace std {
++
+ template <typename T>
+ struct pointer_traits<::base::CheckedContiguousIterator<T>> {
+   using pointer = ::base::CheckedContiguousIterator<T>;
+diff --git a/base/containers/checked_iterators_unittest.cc b/base/containers/checked_iterators_unittest.cc
+index 4d7cffa1630314..07e628a10bafbd 100644
+--- src/3rdparty/chromium/base/containers/checked_iterators_unittest.cc
++++ src/3rdparty/chromium/base/containers/checked_iterators_unittest.cc
+@@ -85,11 +85,8 @@ TEST(CheckedContiguousIterator, ConvertingComparisonOperators) {
+ 
+ }  // namespace base
+ 
+-// ChromeOS does not use the in-tree libc++, but rather a shared library that
+-// lags a bit behind.
+-// TODO(crbug.com/1166360): Enable this test on ChromeOS once the shared libc++
+-// is sufficiently modern.
+-#if defined(_LIBCPP_VERSION) && !BUILDFLAG(IS_NACL) && !BUILDFLAG(IS_CHROMEOS)
++#if defined(_LIBCPP_VERSION)
++
+ namespace {
+ 
+ // Helper template that wraps an iterator and disables its dereference and
+@@ -101,6 +98,8 @@ namespace {
+ template <typename Iterator>
+ struct DisableDerefAndIncr : Iterator {
+   using Iterator::Iterator;
++
++  // NOLINTNEXTLINE(google-explicit-constructor)
+   constexpr DisableDerefAndIncr(const Iterator& iter) : Iterator(iter) {}
+ 
+   constexpr typename Iterator::reference operator*() {
+@@ -121,16 +120,28 @@ struct DisableDerefAndIncr : Iterator {
+ 
+ }  // namespace
+ 
+-// Inherit `__is_cpp17_contiguous_iterator` and `pointer_traits` specializations
+-// from the base class.
+-namespace std {
++// Inherit `__libcpp_is_contiguous_iterator` and `pointer_traits`
++// specializations from the base class.
++
++// TODO(crbug.com/1284275): Remove when C++20 is on by default, as the use
++// of `iterator_concept` should suffice.
++_LIBCPP_BEGIN_NAMESPACE_STD
++
++// TODO(crbug.com/1449299): https://reviews.llvm.org/D150801 renamed this from
++// `__is_cpp17_contiguous_iterator` to `__libcpp_is_contiguous_iterator`. Clean
++// up the old spelling after libc++ rolls.
+ template <typename Iter>
+ struct __is_cpp17_contiguous_iterator<DisableDerefAndIncr<Iter>>
+     : __is_cpp17_contiguous_iterator<Iter> {};
+ 
++template <typename Iter>
++struct __libcpp_is_contiguous_iterator<DisableDerefAndIncr<Iter>>
++    : __libcpp_is_contiguous_iterator<Iter> {};
++
+ template <typename Iter>
+ struct pointer_traits<DisableDerefAndIncr<Iter>> : pointer_traits<Iter> {};
+-}  // namespace std
++
++_LIBCPP_END_NAMESPACE_STD
+ 
+ namespace base {
+ 

--- a/aqua/qt6/files/patch-qtwebengine-mojave.diff
+++ b/aqua/qt6/files/patch-qtwebengine-mojave.diff
@@ -1,0 +1,86 @@
+--- src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/BackendMTL.mm.orig2	2023-07-10 23:01:40.000000000 +0200
++++ src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/BackendMTL.mm	2023-07-10 23:59:25.000000000 +0200
+@@ -350,7 +350,7 @@
+                 }
+             }
+ 
+-#if !TARGET_OS_OSX || MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
++#if 0
+             if (@available(macOS 10.15, iOS 14.0, *)) {
+                 if (IsGPUCounterSupported(
+                         *mDevice, MTLCommonCounterSetStatistic,
+--- src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/QuerySetMTL.mm.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/QuerySetMTL.mm	2023-07-11 00:16:40.000000000 +0200
+@@ -87,6 +87,7 @@
+                 break;
+             }
+             case wgpu::QueryType::PipelineStatistics:
++#if 0
+                 if (@available(macOS 10.15, iOS 14.0, *)) {
+                     DAWN_TRY_ASSIGN(mCounterSampleBuffer,
+                                     CreateCounterSampleBuffer(device, MTLCommonCounterSetStatistic,
+@@ -95,7 +96,11 @@
+                     UNREACHABLE();
+                 }
+                 break;
++#else
++                return DAWN_INTERNAL_ERROR(std::string("MTLCommonCounterSetStatistic API not supported on macOS 10.14"));
++#endif
+             case wgpu::QueryType::Timestamp:
++#if 0
+                 if (@available(macOS 10.15, iOS 14.0, *)) {
+                     DAWN_TRY_ASSIGN(mCounterSampleBuffer,
+                                     CreateCounterSampleBuffer(device, MTLCommonCounterSetTimestamp,
+@@ -104,6 +109,9 @@
+                     UNREACHABLE();
+                 }
+                 break;
++#else
++                return DAWN_INTERNAL_ERROR(std::string("MTLCommonCounterSetTimestamp API not supported on macOS 10.14"));
++#endif
+             default:
+                 UNREACHABLE();
+                 break;
+--- src/3rdparty/chromium/sandbox/mac/system_services.cc.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/sandbox/mac/system_services.cc	2023-07-11 13:40:38.000000000 +0200
+@@ -39,9 +39,11 @@
+ }
+ 
+ void DisableCoreServicesCheckFix() {
++#if 0
+   if (__builtin_available(macOS 10.15, *)) {
+     _CSCheckFixDisable();
+   }
++#endif
+ }
+ 
+ }  // namespace sandbox
+--- src/3rdparty/chromium/media/base/mac/color_space_util_mac.mm.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/media/base/mac/color_space_util_mac.mm	2023-07-11 13:52:53.000000000 +0200
+@@ -127,12 +127,14 @@
+                kCMFormatDescriptionTransferFunction_Linear,
+                gfx::ColorSpace::TransferID::LINEAR});
+         }
++#if 0
+         if (@available(macos 10.15, *)) {
+           supported_transfer_funcs.push_back(
+               {kCVImageBufferTransferFunction_sRGB,
+                kCMFormatDescriptionTransferFunction_sRGB,
+                gfx::ColorSpace::TransferID::SRGB});
+         }
++#endif
+ 
+         return supported_transfer_funcs;
+       }());
+--- src/3rdparty/chromium/base/process/launch_mac.cc.orig2	2023-07-09 19:48:36.000000000 +0200
++++ src/3rdparty/chromium/base/process/launch_mac.cc	2023-07-11 14:05:53.000000000 +0200
+@@ -87,7 +87,9 @@
+   }
+ 
+   void Chdir(const char* path) API_AVAILABLE(macos(10.15)) {
++#if 0
+     DPSXCHECK(posix_spawn_file_actions_addchdir_np(&file_actions_, path));
++#endif
+   }
+ 
+   const posix_spawn_file_actions_t* get() const { return &file_actions_; }

--- a/aqua/qt6/files/patch-qtwebengine-xcode11-backport.diff
+++ b/aqua/qt6/files/patch-qtwebengine-xcode11-backport.diff
@@ -1,0 +1,46 @@
+See https://github.com/chromium/chromium/commit/65b25840093c14bccf9e4108ef1a4340bf2b31d1,
+https://github.com/v8/v8/commit/2c60d0a0872cd2a8a1ffe20e3d50517afd7c8c02
+
+diff --git a/base/process/launch_mac.cc b/base/process/launch_mac.cc
+index 05ad8648a42cdc..a0dfda42bd4bc3 100644
+--- src/3rdparty/chromium/base/process/launch_mac.cc
++++ src/3rdparty/chromium/base/process/launch_mac.cc
+@@ -4,6 +4,7 @@
+ 
+ #include "base/process/launch.h"
+ 
++#include <Availability.h>
+ #include <crt_externs.h>
+ #include <mach/mach.h>
+ #include <os/availability.h>
+@@ -264,11 +265,13 @@ Process LaunchProcess(const std::vector<std::string>& argv,
+   }
+ #endif  // ARCH_CPU_ARM64
+ 
++#if defined(__MAC_11_0)
+   if (__builtin_available(macOS 11.0, *)) {
+     if (options.enable_cpu_security_mitigations) {
+       DPSXCHECK(posix_spawnattr_set_csm_np(attr.get(), POSIX_SPAWN_NP_CSM_ALL));
+     }
+   }
++#endif  // __MAC_11_0
+ 
+   if (!options.current_directory.empty()) {
+     const char* chdir_str = options.current_directory.value().c_str();
+--- src/3rdparty/chromium/v8/src/regexp/regexp-parser.cc.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/v8/src/regexp/regexp-parser.cc	2023-07-10 21:49:00.000000000 +0200
+@@ -346,13 +346,7 @@
+   bool failed_;
+   const uintptr_t stack_limit_;
+ 
+-  friend bool RegExpParser::ParseRegExpFromHeapString(Isolate*, Zone*,
+-                                                      Handle<String>,
+-                                                      RegExpFlags,
+-                                                      RegExpCompileData*);
+-  friend bool RegExpParser::VerifyRegExpSyntax<CharT>(
+-      Zone*, uintptr_t, const CharT*, int, RegExpFlags, RegExpCompileData*,
+-      const DisallowGarbageCollection&);
++  friend class v8::internal::RegExpParser;
+ };
+ 
+ template <class CharT>

--- a/aqua/qt6/files/patch-qtwebengine-xcode11.3.diff
+++ b/aqua/qt6/files/patch-qtwebengine-xcode11.3.diff
@@ -1,0 +1,605 @@
+--- src/3rdparty/chromium/base/numerics/safe_conversions_impl.h.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/base/numerics/safe_conversions_impl.h	2023-07-09 15:58:18.000000000 +0200
+@@ -10,6 +10,8 @@
+ #include <limits>
+ #include <type_traits>
+ 
++#include "../template_util.h"
++
+ #if defined(__GNUC__) || defined(__clang__)
+ #define BASE_NUMERICS_LIKELY(x) __builtin_expect(!!(x), 1)
+ #define BASE_NUMERICS_UNLIKELY(x) __builtin_expect(!!(x), 0)
+@@ -87,7 +89,7 @@
+ 
+ // TODO(jschuh): Switch to std::is_constant_evaluated() once C++20 is supported.
+ // Alternately, the usage could be restructured for "consteval if" in C++23.
+-#define IsConstantEvaluated() (__builtin_is_constant_evaluated())
++#define IsConstantEvaluated() (is_constant_evaluated())
+ 
+ // TODO(jschuh): Debug builds don't reliably propagate constants, so we restrict
+ // some accelerated runtime paths to release builds until this can be forced
+--- src/3rdparty/chromium/third_party/snappy/src/snappy.cc.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/third_party/snappy/src/snappy.cc	2023-07-09 17:21:28.000000000 +0200
+@@ -1041,7 +1041,7 @@
+   size_t literal_len = *tag >> 2;
+   size_t tag_type = *tag;
+   bool is_literal;
+-#if defined(__GNUC__) && defined(__x86_64__)
++#if defined(__GCC_ASM_FLAG_OUTPUTS__) && defined(__x86_64__)
+   // TODO clang misses the fact that the (c & 3) already correctly
+   // sets the zero flag.
+   asm("and $3, %k[tag_type]\n\t"
+--- src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/DeviceMTL.h.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/DeviceMTL.h	2023-07-09 21:49:33.000000000 +0200
+@@ -142,8 +142,8 @@
+         float mTimestampPeriod = 1.0f;
+         // The base of CPU timestamp and GPU timestamp to measure the linear regression between GPU
+         // and CPU timestamps.
+-        MTLTimestamp mCpuTimestamp API_AVAILABLE(macos(10.15), ios(14.0)) = 0;
+-        MTLTimestamp mGpuTimestamp API_AVAILABLE(macos(10.15), ios(14.0)) = 0;
++        uint64_t mCpuTimestamp API_AVAILABLE(macos(10.15), ios(14.0)) = 0;
++        uint64_t mGpuTimestamp API_AVAILABLE(macos(10.15), ios(14.0)) = 0;
+         // The parameters for kalman filter
+         std::unique_ptr<KalmanInfo> mKalmanInfo;
+     };
+--- src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/BackendMTL.mm.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/BackendMTL.mm	2023-07-09 21:55:42.000000000 +0200
+@@ -176,6 +176,7 @@
+ #endif
+ 
+         DAWN_NOINLINE bool IsCounterSamplingBoundarySupport(id<MTLDevice> device)
++#if !TARGET_OS_OSX || MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+             API_AVAILABLE(macos(11.0), ios(14.0)) {
+             bool isBlitBoundarySupported =
+                 [device supportsCounterSampling:MTLCounterSamplingPointAtBlitBoundary];
+@@ -187,6 +188,11 @@
+             return isBlitBoundarySupported && isDispatchBoundarySupported &&
+                    isDrawBoundarySupported;
+         }
++#else
++        {
++            return false;
++        }
++#endif
+ 
+         // This method has seen hard-to-debug crashes. See crbug.com/dawn/1102.
+         // For now, it is written defensively, with many potentially unnecessary guards until
+@@ -344,6 +350,7 @@
+                 }
+             }
+ 
++#if !TARGET_OS_OSX || MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+             if (@available(macOS 10.15, iOS 14.0, *)) {
+                 if (IsGPUCounterSupported(
+                         *mDevice, MTLCommonCounterSetStatistic,
+@@ -371,6 +378,7 @@
+                     }
+                 }
+             }
++#endif
+ 
+             if (@available(macOS 10.11, iOS 11.0, *)) {
+                 mSupportedFeatures.EnableFeature(Feature::DepthClamping);
+@@ -412,16 +420,16 @@
+             // https://developer.apple.com/documentation/metal/mtldevice/detecting_gpu_features_and_metal_software_versions?language=objc
+ 
+             if (@available(macOS 10.15, iOS 10.13, *)) {
+-                if ([*mDevice supportsFamily:MTLGPUFamilyMac2]) {
++                if ([*mDevice supportsFamily:(::MTLGPUFamily(2002))]) { // MTLGPUFamilyMac2
+                     return MTLGPUFamily::Mac2;
+                 }
+-                if ([*mDevice supportsFamily:MTLGPUFamilyMac1]) {
++                if ([*mDevice supportsFamily:(::MTLGPUFamily(2001))]) { // MTLGPUFamilyMac1
+                     return MTLGPUFamily::Mac1;
+                 }
+-                if ([*mDevice supportsFamily:MTLGPUFamilyApple7]) {
++                if ([*mDevice supportsFamily:(::MTLGPUFamily(1007))]) { // MTLGPUFamilyApple7
+                     return MTLGPUFamily::Apple7;
+                 }
+-                if ([*mDevice supportsFamily:MTLGPUFamilyApple6]) {
++                if ([*mDevice supportsFamily:(::MTLGPUFamily(1006))]) { // MTLGPUFamilyApple6
+                     return MTLGPUFamily::Apple6;
+                 }
+                 if ([*mDevice supportsFamily:MTLGPUFamilyApple5]) {
+--- src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/DeviceMTL.mm.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/DeviceMTL.mm	2023-07-09 21:57:05.000000000 +0200
+@@ -70,8 +70,8 @@
+         void API_AVAILABLE(macos(10.15), ios(14))
+             UpdateTimestampPeriod(id<MTLDevice> device,
+                                   KalmanInfo* info,
+-                                  MTLTimestamp* cpuTimestampStart,
+-                                  MTLTimestamp* gpuTimestampStart,
++                                  uint64_t* cpuTimestampStart,
++                                  uint64_t* gpuTimestampStart,
+                                   float* timestampPeriod) {
+             // The filter value is converged to an optimal value when the kalman gain is less than
+             // 0.01. At this time, the weight of the measured value is too small to change the next
+@@ -80,8 +80,13 @@
+                 return;
+             }
+ 
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+             MTLTimestamp cpuTimestampEnd = 0, gpuTimestampEnd = 0;
+             [device sampleTimestamps:&cpuTimestampEnd gpuTimestamp:&gpuTimestampEnd];
++#else
++            uint64_t cpuTimestampEnd = 0, gpuTimestampEnd = 0;
++            [device sampleTimestamps:(NSUInteger *)&cpuTimestampEnd gpuTimestamp:(NSUInteger *)&gpuTimestampEnd];
++#endif
+ 
+             // Update the timestamp start values when timestamp reset happens
+             if (cpuTimestampEnd < *cpuTimestampStart || gpuTimestampEnd < *gpuTimestampStart) {
+@@ -151,7 +156,11 @@
+ 
+             if (@available(macos 10.15, iOS 14.0, *)) {
+                 // Sample CPU timestamp and GPU timestamp for first time at device creation
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+                 [*mMtlDevice sampleTimestamps:&mCpuTimestamp gpuTimestamp:&mGpuTimestamp];
++#else
++                [*mMtlDevice sampleTimestamps:(NSUInteger *)&mCpuTimestamp gpuTimestamp:(NSUInteger *)&mGpuTimestamp];
++#endif
+             }
+         }
+ 
+--- src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/ShaderModuleMTL.mm.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/ShaderModuleMTL.mm	2023-07-09 23:10:05.000000000 +0200
+@@ -220,9 +220,11 @@
+ 
+         NSRef<MTLCompileOptions> compileOptions = AcquireNSRef([[MTLCompileOptions alloc] init]);
+         if (hasInvariantAttribute) {
++#if !TARGET_OS_OSX || MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+             if (@available(macOS 11.0, iOS 13.0, *)) {
+                 (*compileOptions).preserveInvariance = true;
+             }
++#endif
+         }
+         auto mtlDevice = ToBackend(GetDevice())->GetMTLDevice();
+         NSError* error = nullptr;
+--- src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/TextureMTL.mm.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/third_party/dawn/src/dawn/native/metal/TextureMTL.mm	2023-07-09 23:28:55.000000000 +0200
+@@ -376,230 +376,230 @@
+ 
+             case wgpu::TextureFormat::ETC2RGB8Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatETC2_RGB8;
++                    return MTLPixelFormat(180); // MTLPixelFormatETC2_RGB8
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ETC2RGB8UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatETC2_RGB8_sRGB;
++                    return MTLPixelFormat(181); // MTLPixelFormatETC2_RGB8_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ETC2RGB8A1Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatETC2_RGB8A1;
++                    return MTLPixelFormat(182); // MTLPixelFormatETC2_RGB8A1
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ETC2RGB8A1UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatETC2_RGB8A1_sRGB;
++                    return MTLPixelFormat(183); // MTLPixelFormatETC2_RGB8A1_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ETC2RGBA8Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatEAC_RGBA8;
++                    return MTLPixelFormat(178); // MTLPixelFormatEAC_RGBA8
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ETC2RGBA8UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatEAC_RGBA8_sRGB;
++                    return MTLPixelFormat(179); // MTLPixelFormatEAC_RGBA8_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::EACR11Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatEAC_R11Unorm;
++                    return MTLPixelFormat(170); // MTLPixelFormatEAC_R11Unorm
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::EACR11Snorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatEAC_R11Snorm;
++                    return MTLPixelFormat(172); // MTLPixelFormatEAC_R11Snorm
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::EACRG11Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatEAC_RG11Unorm;
++                    return MTLPixelFormat(174); // MTLPixelFormatEAC_RG11Unorm
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::EACRG11Snorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatEAC_RG11Snorm;
++                    return MTLPixelFormat(176); // MTLPixelFormatEAC_RG11Snorm
+                 } else {
+                     UNREACHABLE();
+                 }
+ 
+             case wgpu::TextureFormat::ASTC4x4Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_4x4_LDR;
++                    return MTLPixelFormat(204); // MTLPixelFormatASTC_4x4_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC4x4UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_4x4_sRGB;
++                    return MTLPixelFormat(186); // MTLPixelFormatASTC_4x4_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC5x4Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_5x4_LDR;
++                    return MTLPixelFormat(205); // MTLPixelFormatASTC_5x4_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC5x4UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_5x4_sRGB;
++                    return MTLPixelFormat(187); // MTLPixelFormatASTC_5x4_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC5x5Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_5x5_LDR;
++                    return MTLPixelFormat(206); // MTLPixelFormatASTC_5x5_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC5x5UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_5x5_sRGB;
++                    return MTLPixelFormat(188); // MTLPixelFormatASTC_5x5_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC6x5Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_6x5_LDR;
++                    return MTLPixelFormat(207); // MTLPixelFormatASTC_6x5_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC6x5UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_6x5_sRGB;
++                    return MTLPixelFormat(189); // MTLPixelFormatASTC_6x5_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC6x6Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_6x6_LDR;
++                    return MTLPixelFormat(208); // MTLPixelFormatASTC_6x6_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC6x6UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_6x6_sRGB;
++                    return MTLPixelFormat(190); // MTLPixelFormatASTC_6x6_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC8x5Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_8x5_LDR;
++                    return MTLPixelFormat(210); // MTLPixelFormatASTC_8x5_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC8x5UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_8x5_sRGB;
++                    return MTLPixelFormat(192); // MTLPixelFormatASTC_8x5_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC8x6Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_8x6_LDR;
++                    return MTLPixelFormat(211); // MTLPixelFormatASTC_8x6_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC8x6UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_8x6_sRGB;
++                    return MTLPixelFormat(193); // MTLPixelFormatASTC_8x6_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC8x8Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_8x8_LDR;
++                    return MTLPixelFormat(212); // MTLPixelFormatASTC_8x8_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC8x8UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_8x8_sRGB;
++                    return MTLPixelFormat(194); // MTLPixelFormatASTC_8x8_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC10x5Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_10x5_LDR;
++                    return MTLPixelFormat(213); // MTLPixelFormatASTC_10x5_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC10x5UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_10x5_sRGB;
++                    return MTLPixelFormat(195); // MTLPixelFormatASTC_10x5_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC10x6Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_10x6_LDR;
++                    return MTLPixelFormat(214); // MTLPixelFormatASTC_10x6_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC10x6UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_10x6_sRGB;
++                    return MTLPixelFormat(196); // MTLPixelFormatASTC_10x6_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC10x8Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_10x8_LDR;
++                    return MTLPixelFormat(215); // MTLPixelFormatASTC_10x8_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC10x8UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_10x8_sRGB;
++                    return MTLPixelFormat(197); // MTLPixelFormatASTC_10x8_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC10x10Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_10x10_LDR;
++                    return MTLPixelFormat(216); // MTLPixelFormatASTC_10x10_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC10x10UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_10x10_sRGB;
++                    return MTLPixelFormat(198); // MTLPixelFormatASTC_10x10_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC12x10Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_12x10_LDR;
++                    return MTLPixelFormat(217); // MTLPixelFormatASTC_12x10_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC12x10UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_12x10_sRGB;
++                    return MTLPixelFormat(199); // MTLPixelFormatASTC_12x10_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC12x12Unorm:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_12x12_LDR;
++                    return MTLPixelFormat(218); // MTLPixelFormatASTC_12x12_LDR
+                 } else {
+                     UNREACHABLE();
+                 }
+             case wgpu::TextureFormat::ASTC12x12UnormSrgb:
+                 if (@available(macOS 11.0, iOS 8.0, *)) {
+-                    return MTLPixelFormatASTC_12x12_sRGB;
++                    return MTLPixelFormat(200); // MTLPixelFormatASTC_12x12_sRGB
+                 } else {
+                     UNREACHABLE();
+                 }
+--- src/3rdparty/chromium/ui/gfx/mac/io_surface.cc.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/ui/gfx/mac/io_surface.cc	2023-07-10 00:09:18.000000000 +0200
+@@ -174,20 +174,28 @@
+                                   ColorSpace::TransferID::PQ,
+                                   ColorSpace::MatrixID::BT2020_NCL,
+                                   ColorSpace::RangeID::LIMITED)) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+       if (__builtin_available(macos 11.0, *)) {
+         color_space_name = kCGColorSpaceITUR_2100_PQ;
+       } else {
++#endif
+         return true;
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+       }
++#endif
+     } else if (color_space == ColorSpace(ColorSpace::PrimaryID::BT2020,
+                                          ColorSpace::TransferID::HLG,
+                                          ColorSpace::MatrixID::BT2020_NCL,
+                                          ColorSpace::RangeID::LIMITED)) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+       if (__builtin_available(macos 11.0, *)) {
+         color_space_name = kCGColorSpaceITUR_2100_HLG;
+       } else {
++#endif
+         return true;
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+       }
++#endif
+     }
+   }
+   if (color_space_name) {
+--- src/3rdparty/chromium/net/socket/udp_socket_posix.cc.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/net/socket/udp_socket_posix.cc	2023-07-10 00:30:50.000000000 +0200
+@@ -585,6 +585,7 @@
+   if (!base::mac::IsAtLeastOS11()) {
+     return ERR_NOT_IMPLEMENTED;
+   }
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+   int val = 1;
+   if (addr_family_ == AF_INET6) {
+     int rv =
+@@ -594,7 +595,7 @@
+   }
+   int rv = setsockopt(socket_, IPPROTO_IP, IP_DONTFRAG, &val, sizeof(val));
+   return rv == 0 ? OK : MapSystemError(errno);
+-
++#endif
+ #else
+   if (addr_family_ == AF_INET6) {
+     int val = IPV6_PMTUDISC_DO;
+--- src/3rdparty/chromium/media/gpu/mac/vt_video_decode_accelerator_mac.cc.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/media/gpu/mac/vt_video_decode_accelerator_mac.cc	2023-07-10 02:22:53.000000000 +0200
+@@ -256,7 +256,7 @@
+     absl::optional<gfx::HDRMetadata> hdr_metadata,
+     const gfx::Size& coded_size) {
+   base::ScopedCFTypeRef<CFMutableDictionaryRef> format_config(
+-      CreateFormatExtensions(kCMVideoCodecType_VP9, profile, color_space,
++      CreateFormatExtensions(CMVideoCodecType('vp09'), profile, color_space,
+                              hdr_metadata));
+ 
+   base::ScopedCFTypeRef<CMFormatDescriptionRef> format;
+@@ -266,7 +266,7 @@
+   }
+ 
+   OSStatus status = CMVideoFormatDescriptionCreate(
+-      kCFAllocatorDefault, kCMVideoCodecType_VP9, coded_size.width(),
++      kCFAllocatorDefault, CMVideoCodecType('vp09'), coded_size.width(),
+       coded_size.height(), format_config, format.InitializeInto());
+   OSSTATUS_DLOG_IF(WARNING, status != noErr, status)
+       << "CMVideoFormatDescriptionCreate()";
+@@ -379,8 +379,9 @@
+ 
+   session.reset();
+ 
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+   if (__builtin_available(macOS 11.0, *)) {
+-    VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9);
++    VTRegisterSupplementalVideoDecoderIfAvailable(CMVideoCodecType('vp09'));
+ 
+     // Create a VP9 decoding session.
+     if (!CreateVideoToolboxSession(
+@@ -393,6 +394,7 @@
+       // We don't return false here since VP9 support is optional.
+     }
+   }
++#endif
+ 
+ #if BUILDFLAG(ENABLE_PLATFORM_HEVC_DECODING)
+   if (base::FeatureList::IsEnabled(media::kVideoToolboxHEVCDecoding)) {
+@@ -2327,7 +2329,7 @@
+       if (__builtin_available(macOS 10.13, *)) {
+         if ((supported_profile == VP9PROFILE_PROFILE0 ||
+              supported_profile == VP9PROFILE_PROFILE2) &&
+-            !VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9)) {
++            !VTIsHardwareDecodeSupported(CMVideoCodecType('vp09'))) {
+           continue;
+         }
+ 
+--- src/3rdparty/chromium/media/gpu/mac/vt_video_encode_accelerator_mac.cc.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/media/gpu/mac/vt_video_encode_accelerator_mac.cc	2023-07-10 02:34:24.000000000 +0200
+@@ -150,8 +150,10 @@
+   profile.max_framerate_numerator = kMaxFrameRateNumerator;
+   profile.max_framerate_denominator = kMaxFrameRateDenominator;
+   profile.max_resolution = gfx::Size(kMaxResolutionWidth, kMaxResolutionHeight);
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110300
+   if (__builtin_available(macOS LOW_LATENCY_FLAG_AVAILABLE_VER, *))
+     profile.scalability_modes.push_back(SVCScalabilityMode::kL1T2);
++#endif
+   for (const auto& supported_profile : kSupportedProfiles) {
+     profile.profile = supported_profile;
+     profiles.push_back(profile);
+@@ -595,6 +597,7 @@
+       kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder};
+   std::vector<CFTypeRef> encoder_values{kCFBooleanTrue};
+ 
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110300
+   if (__builtin_available(macOS LOW_LATENCY_FLAG_AVAILABLE_VER, *)) {
+     if (require_low_delay_) {
+       encoder_keys.push_back(
+@@ -602,6 +605,7 @@
+       encoder_values.push_back(kCFBooleanTrue);
+     }
+   }
++#endif
+   base::ScopedCFTypeRef<CFDictionaryRef> encoder_spec =
+       video_toolbox::DictionaryWithKeysAndValues(
+           encoder_keys.data(), encoder_values.data(), encoder_keys.size());
+@@ -669,6 +673,7 @@
+   }
+ 
+   if (num_temporal_layers_ == 2) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110300
+     if (__builtin_available(macOS LOW_LATENCY_FLAG_AVAILABLE_VER, *)) {
+       if (!session_property_setter.IsSupported(
+               kVTCompressionPropertyKey_BaseLayerFrameRateFraction)) {
+@@ -679,9 +684,12 @@
+           kVTCompressionPropertyKey_BaseLayerFrameRateFraction, 0.5);
+       DLOG_IF(ERROR, !rv) << " Setting BaseLayerFrameRate property failed.";
+     } else {
++#endif
+       DLOG(ERROR) << "SVC encoding is not supported on this OS version.";
+       rv = false;
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110300
+     }
++#endif
+   }
+ 
+   return rv;
+--- src/3rdparty/chromium/ui/base/cocoa/permissions_utils.mm.orig	2023-03-12 04:16:34.000000000 +0100
++++ src/3rdparty/chromium/ui/base/cocoa/permissions_utils.mm	2023-07-10 12:05:26.000000000 +0200
+@@ -19,9 +19,12 @@
+ // heuristic methods on 10.15.
+ 
+ bool IsScreenCaptureAllowed() {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+   if (@available(macOS 11.0, *)) {
+     return CGPreflightScreenCaptureAccess();
+-  } else if (@available(macOS 10.15, *)) {
++  } else
++#endif
++  if (@available(macOS 10.15, *)) {
+     // Screen Capture is considered allowed if the name of at least one normal
+     // or dock window running on another process is visible.
+     // See https://crbug.com/993692.
+@@ -58,9 +61,12 @@
+ }
+ 
+ bool TryPromptUserForScreenCapture() {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+   if (@available(macOS 11.0, *)) {
+     return CGRequestScreenCaptureAccess();
+-  } else if (@available(macOS 10.15, *)) {
++  } else
++#endif
++  if (@available(macOS 10.15, *)) {
+     // On 10.15+, macOS will show the permissions prompt for Screen Recording
+     // if we request to create a display stream and our application is not
+     // in the applications list in System permissions. Stream creation will


### PR DESCRIPTION
#### Description

This adds a set of patches that allow to build qt6 packages on macOS 10.14 with Xcode 11.3, which is the last Xcode version supported on macOS 10.14. Since the switch to Qt 6.4.x, they did not build on Mojave and probably Catalina as well.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
