### PR TITLE
google-cloud-sdk: update to 438.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             437.0.1
+version             438.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  871d9e1defbd4b3c1ab6f09982346d7f9c68d919 \
-                    sha256  9c72e01fdebf686751b224fd7513545787fe032a59c6575841635871c78ce250 \
-                    size    100577590
+    checksums       rmd160  f3a00cb706c939f5f0993b06763ddb9feb99b12d \
+                    sha256  8f49c0f27d37859b69b430e1baf4741e7c3bce4b5c8f2f9b78627fa1d22e6ddf \
+                    size    100796402
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b8b444e34856b1a5c6beaf08222ae21a23af403b \
-                    sha256  abdc930d3eee5cd551e2f243f37b27899bbb89f6e214933bb866c4c9c3c5726e \
-                    size    120855397
+    checksums       rmd160  a324f9b193ba2f057fddc75d62cf5b9713909909 \
+                    sha256  4841c84890f013607ab8de52db76365ad4d037fe4cee86aaf030df1df7ac78cc \
+                    size    121050318
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  40532fba56160bbc5e54606a437036d65f00d045 \
-                    sha256  44282327276fc12535e242b109f719d7fed2a975ad7d8a995ce10320bf10a747 \
-                    size    117974387
+    checksums       rmd160  a99cfa40d85b681cf1074fd15af81fdab15adcd6 \
+                    sha256  927fb8fdc54b674929a863c69a40a50b5324214972de2da70d6a898d56c7f516 \
+                    size    118221168
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 438.0.0.

###### Tested on

macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?