### PR TITLE
go: update to 1.20.6

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -20,7 +20,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 17} {
     version         1.17.13
     set unsupported_macos true
 } else {
-    version         1.20.5
+    version         1.20.6
     set unsupported_macos false
 }
 
@@ -103,17 +103,17 @@ if {$subport eq "${name}-devel"} {
     } else {
         # 1.20
         checksums   ${go_src_dist} \
-                    rmd160  8c06453e1cc9aa7391dbc255c3b09947da53bc19 \
-                    sha256  9a15c133ba2cfafe79652f4815b62e7cfc267f68df1b9454c6ab2a3ca8b96a88 \
-                    size    26192951 \
+                    rmd160  6012baf03d72b7b1fa0e552b1b7b58dcab86f753 \
+                    sha256  62ee5bc6fb55b8bae8f705e0cb8df86d6453626b4ecf93279e2867092e0b7f70 \
+                    size    26194491 \
                     ${go_armbin_dist} \
-                    rmd160  a7d3f40e8cb4c14e28cc9ba2c266bd3a447ca80c \
-                    sha256  94ad76b7e1593bb59df7fd35a738194643d6eed26a4181c94e3ee91381e40459 \
-                    size    96936413 \
+                    rmd160  619d5cda8d0f369800af08c7b01419978c963362 \
+                    sha256  1163be1998835a13f00dfc869a8e3cdebf86984ad41ff2fff43e35ac2a0d8344 \
+                    size    96962473 \
                     ${go_amdbin_dist} \
-                    rmd160  a1bb3e46457659c549648004083d83bf1ea7dca4 \
-                    sha256  79715ca5b8becd120703ac9af5d1da749e095d2b9bf830c4f3af4b15b2cb049d \
-                    size    100202970
+                    rmd160  542fb694c8c76fcb0554b8522c625698f9304810 \
+                    sha256  98a09c085b4c385abae7d35b9155195d5e584d14988347ac7f18e4cbe3b5ef3d \
+                    size    100224913
     }
 
     livecheck.regex {go([0-9.]+)\.src\.tar\.gz}


### PR DESCRIPTION


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
