### PR TITLE
nim: update to 1.6.14

### DIFF
--- a/lang/nim/Portfile
+++ b/lang/nim/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                nim
-version             1.6.12
+version             1.6.14
 revision            0
 license             MIT
 categories          lang
@@ -20,9 +20,9 @@ long_description    Nim is a statically typed compiled systems programming \
 homepage            https://nim-lang.org
 
 master_sites        ${homepage}/download/
-checksums           rmd160  6481711d9d9fcd5d939b797b61a114528ed723d2 \
-                    sha256  acef0b0ab773604d4d7394b68519edb74fb30f46912294b28bc27e0c7b4b4dc2 \
-                    size    5180496
+checksums           rmd160  0e73711bdfbd889495f2030140ff48dc674362dd \
+                    sha256  d070d2f28ae2400df7fe4a49eceb9f45cd539906b107481856a0af7a8fa82dc9 \
+                    size    5266632
 
 use_configure       no
 use_xz              yes


### PR DESCRIPTION
#### Description

Update the nim language installation to the current version, 1.6.14

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
