### PR TITLE
PothosCore: unbreak build with GCC

### DIFF
--- a/science/PothosCore/Portfile
+++ b/science/PothosCore/Portfile
@@ -41,3 +41,8 @@ configure.args-append \
 
 patchfiles patch-092d9.diff
 patch.pre_args -p1
+
+# however keep this one
+# ld: unknown option: --no-undefined
+# collect2: error: ld returned 1 exit status
+patchfiles-append   patch-unbreak-gcc-build.diff

--- a/science/PothosCore/files/patch-unbreak-gcc-build.diff
+++ b/science/PothosCore/files/patch-unbreak-gcc-build.diff
@@ -1,0 +1,15 @@
+--- a/cmake/Modules/PothosStandardFlags.cmake	2021-01-25 11:32:12.000000000 +0800
++++ b/cmake/Modules/PothosStandardFlags.cmake	2023-07-13 18:47:50.000000000 +0800
+@@ -27,9 +27,9 @@
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+     endif()
+ 
+-    #force a compile-time error when symbols are missing
+-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+-    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-undefined")
++    # This flag is unsupported and breaks the build.
++    # set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
++    # set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-undefined")
+ 
+     #these warnings are caused by static warnings used throughout the code
+     add_compile_options(-Wno-unused-local-typedefs)


### PR DESCRIPTION
#### Description

Fix build with GCC.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
