### PR TITLE
R: revbump dependents of GEOS after update; updates to packages

### DIFF
--- a/R/R-SVDNF/Portfile
+++ b/R/R-SVDNF/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran cran SVDNF 0.1.5
+R.setup             cran cran SVDNF 0.1.6
 revision            0
 categories-append   finance math
 maintainers         nomaintainer
 license             GPL-3
-description         Discrete Non-linear filtering for stochastic volatility models
+description         Discrete non-linear filtering for stochastic volatility models
 long_description    {*}${description}
-checksums           rmd160  1353ac33086aabf081e741c4fcbc880c0d3ad2df \
-                    sha256  51affab3f42da0a956feb85bc0918b60148e5bee1b7b9706154e7eacb4d11323 \
-                    size    23243
+checksums           rmd160  20c2ec551d1da2522e616bfc87d0e632ebe88c76 \
+                    sha256  1a1aa51523389991d7d66124468cd03563e3740341d7e37352de04d68bfa3d7c \
+                    size    23250
 
 depends_lib-append  port:R-Rcpp
 

--- a/R/R-bgw/Portfile
+++ b/R/R-bgw/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran cran bgw 0.1.1
-revision            1
+R.setup             cran cran bgw 0.1.2
+revision            0
 categories-append   math
 maintainers         nomaintainer
 license             GPL-3
-description         Bunch–Gay–Welsch Statistical Estimation
+description         Bunch–Gay–Welsch statistical estimation
 long_description    {*}${description}
-checksums           rmd160  3c74b7749e9fd7b60e0ec848999a2a2ed73f17ee \
-                    sha256  584f9c9b40ffb5e3be881bc3ab24e505fdb751907e55b0f4258d5f38f7e391f3 \
-                    size    111295
+checksums           rmd160  bf89f037dc1fd78f4fc9805f22094b14bb352aff \
+                    sha256  7621b8ab6471c27b9766d8acdbdc30337b81d1bbf594ee7ed5e00a00e5b0e42b \
+                    size    112948
 
 compilers.setup     require_fortran
 

--- a/R/R-clinfun/Portfile
+++ b/R/R-clinfun/Portfile
@@ -3,15 +3,15 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran cran clinfun 1.1.2
+R.setup             cran cran clinfun 1.1.3
 revision            0
 maintainers         nomaintainer
 license             GPL-2+
 description         Clinical trial design and data analysis functions
 long_description    {*}${description}
-checksums           rmd160  ff9fe97ed70910954e7c1aa699cc17ecdcb76867 \
-                    sha256  d7e69bfc801bab4fb1700ed828f567d08f899d34acdd7cb0c2ed6cdac2666085 \
-                    size    56586
+checksums           rmd160  0e2e43a565aa74c83acbfa73797a86f2adf990ab \
+                    sha256  b58162e0eb64187f8218b8468c99dfb4316c9a5f0da96763189d45a8b1df5bfb \
+                    size    57248
 
 depends_lib-append  port:R-mvtnorm
 

--- a/R/R-cyclotomic/Portfile
+++ b/R/R-cyclotomic/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-# Revert to GitHub once updated there.
-R.setup             cran stla cyclotomic 1.1.0
+# GitHub version is outdated.
+R.setup             cran stla cyclotomic 1.2.0
 revision            0
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3
 description         The field of cyclotomic numbers
 long_description    {*}${description}
-checksums           rmd160  502a943c2f2e19cd0056ef99f151e43bafcb5599 \
-                    sha256  9712b491990f3e3a5171ff3a920599ec1aecf4bd7c0055f8cb731475fd7fff9a \
-                    size    13335
+checksums           rmd160  50c84e844c62356372390f97d0ad284e22a4392a \
+                    sha256  60bea72ec9c7c14c0bd8c476ca3d9d213c372ae24f74c489bfb8db25bd7b9d58 \
+                    size    13826
 supported_archs     noarch
 
 depends_lib-append  port:R-gmp \

--- a/R/R-exactextractr/Portfile
+++ b/R/R-exactextractr/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             github isciences exactextractr 0.9.1 v
-revision            0
+revision            1
 categories-append   gis
 maintainers         nomaintainer
 license             Apache-2

--- a/R/R-fude/Portfile
+++ b/R/R-fude/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github takeshinishimura fude 0.2.0 v
+R.setup             github takeshinishimura fude 0.3.1 v
 revision            0
 categories-append   math
 maintainers         nomaintainer
@@ -11,12 +11,15 @@ license             MIT
 description         Utilities for Fude polygon
 long_description    {*}${description}
 homepage            https://takeshinishimura.github.io/fude
-checksums           rmd160  46335ffbc819a4144f22fa84b65bb5e3ca2b177d \
-                    sha256  f3b8c2872dd829e4af2ba3b85e554ead11c0194350c735ff8075e5e709d1c66b \
-                    size    373496
+checksums           rmd160  9eb7351236838205fa6fb8ae585195ffae32b72d \
+                    sha256  bcfc08bcc04569d97c45e601ea2958d94948e3db23d779a72d6bfe91bf2a3604 \
+                    size    635206
 supported_archs     noarch
 
-depends_lib-append  port:R-sf
+depends_lib-append  port:R-dplyr \
+                    port:R-glue \
+                    port:R-magrittr \
+                    port:R-sf
 
 depends_test-append port:R-testthat
 

--- a/R/R-ggh4x/Portfile
+++ b/R/R-ggh4x/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran teunbrand ggh4x 0.2.4
-revision            1
+R.setup             cran teunbrand ggh4x 0.2.5
+revision            0
 categories-append   graphics
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
 description         Hacks for ggplot2
 long_description    {*}${description}
 homepage            https://teunbrand.github.io/ggh4x
-checksums           rmd160  cbd04371bd269e4d9d64ce0c62aefeb15f943ddb \
-                    sha256  7cf09b31d69da2d84fbc4266c567a65bebc91eaeabe0357bb651b732ed536295 \
-                    size    1301059
+checksums           rmd160  e5afff3fec29ef21cd75a262be1f5b37104731ca \
+                    sha256  61f53a04065725609cb25afae31c1926b4773c87760f4c246d9fd79b3bb54476 \
+                    size    1313317
 supported_archs     noarch
 
 depends_lib-append  port:R-cli \

--- a/R/R-lefko3/Portfile
+++ b/R/R-lefko3/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran cran lefko3 6.0.5
+R.setup             cran cran lefko3 6.1.0
 revision            0
 categories-append   math
 maintainers         nomaintainer
-license             {GPL-2 GPL-3}
+license             GPL-2+
 description         Historical and ahistorical population projection matrix analysis
 long_description    {*}${description}
-checksums           rmd160  21a85a480f3c644cc4f381530c703b56cc588a3e \
-                    sha256  7b9a1c0dbebae1c68e5a0bc77a0256bfa4c397a4a3f803ee7afa632398f9f5be \
-                    size    3082708
+checksums           rmd160  fe2287c2a9e55b6454124ba965005ad08fc85e94 \
+                    sha256  4bcaa5e95a6a90a60feb36ae94f06e8a2f25c1c5d5b1a8dfd2369d7e536f6cea \
+                    size    3073443
 
 depends_lib-append  port:R-BH \
                     port:R-glmmTMB \

--- a/R/R-lwgeom/Portfile
+++ b/R/R-lwgeom/Portfile
@@ -5,7 +5,7 @@ PortGroup           R 1.0
 
 # GitHub version is old.
 R.setup             cran r-spatial lwgeom 0.2-13
-revision            0
+revision            1
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-2

--- a/R/R-mongolite/Portfile
+++ b/R/R-mongolite/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           openssl 1.0
+PortGroup           R 1.0
+
+# GitHub version lags behind.
+R.setup             cran jeroen mongolite 2.7.2
+revision            0
+categories-append   databases
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             Apache-2
+description         Fast and simple MongoDB client for R
+long_description    {*}${description}
+homepage            https://jeroen.github.io/mongolite
+checksums           rmd160  fedc635dbaec4bc2070daed0cabd3119460f19a9 \
+                    sha256  5fc1cc7bed9cb398be402b33d8e23a6fd8ad9abcf2251ccc02d1eb6069e005f4 \
+                    size    730961
+
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:cyrus-sasl2 \
+                    port:R-jsonlite \
+                    port:R-mime \
+                    port:R-openssl
+
+# mongolite upstream has broken the target for bson.
+patchfiles-append   patch-fix-bson.diff \
+                    patch-fix-configure.diff \
+                    patch-pthread.diff
+
+depends_test-append port:R-ggplot2 \
+                    port:R-nycflights13 \
+                    port:R-spelling
+
+test.run            yes

--- a/R/R-mongolite/files/patch-fix-bson.diff
+++ b/R/R-mongolite/files/patch-fix-bson.diff
@@ -1,0 +1,56 @@
+--- src/bson/bson-config.h.orig	2023-01-07 06:38:44.000000000 +0800
++++ src/bson/bson-config.h	2023-07-15 07:44:47.000000000 +0800
+@@ -8,31 +8,35 @@
+ #define BSON_HAVE_ATOMIC_64_ADD_AND_FETCH 0
+ /* sparc is big endian */
+ #include <sys/byteorder.h>
+-#ifdef _BIG_ENDIAN
++#define BSON_BYTE_ORDER 4321
++#elif defined(__APPLE__) && defined(__POWERPC__)
++#define BSON_BYTE_ORDER 4321
++#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+ #define BSON_BYTE_ORDER 4321
+ #else
+ #define BSON_BYTE_ORDER 1234
+ #endif
+-#else
+-/* for everyone else */
+-#define BSON_BYTE_ORDER 1234
++
+ #define BSON_HAVE_STRNLEN 1
+ #define BSON_HAVE_ATOMIC_32_ADD_AND_FETCH 1
+ #define BSON_HAVE_ATOMIC_64_ADD_AND_FETCH 1
+ #if !defined (__FreeBSD__) && !defined (__OpenBSD__)
+ #define BSON_HAVE_SYSCALL_TID 1
+ #endif
+-#endif
+ 
+ /* Fix for snow leopard */
+ #ifdef __APPLE__
+ #define BSON_HAVE_REALLOCF 1
+ #define BSON_HAVE_STRLCPY 1
+-#include <Availability.h>
++#include <AvailabilityMacros.h>
+ #ifndef MAC_OS_X_VERSION_10_8
+ #undef BSON_HAVE_STRNLEN
+ #define BSON_HAVE_STRNLEN 0
+ #endif
++#ifdef __ppc__
++#undef BSON_HAVE_ATOMIC_64_ADD_AND_FETCH
++#define BSON_HAVE_ATOMIC_64_ADD_AND_FETCH 0
++#endif
+ #endif
+ 
+ /*
+
+--- src/Makevars.in.orig	2023-01-07 06:38:40.000000000 +0800
++++ src/Makevars.in	2023-07-15 09:44:13.000000000 +0800
+@@ -6,7 +6,7 @@
+ 	bson/bson-error.o bson/bson-iso8601.o bson/bson-iter.o bson/bson-json.o \
+ 	bson/bson-keys.o bson/bson-md5.o bson/bson-memory.o bson/bson-oid.o \
+ 	bson/bson-reader.o bson/bson-string.o bson/bson-timegm.o bson/bson-utf8.o \
+-	bson/bson-value.o bson/bson.o bson/bson-decimal128.o jsonsl/jsonsl.o
++	bson/bson-value.o bson/bson.o bson/bson-decimal128.o bson/bson-atomic.o jsonsl/jsonsl.o
+ 
+ LIBMONGOC=mongoc/mongoc-array.o common/common-b64.o mongoc/mongoc-buffer.o \
+ 	mongoc/mongoc-bulk-operation.o mongoc/mongoc-client-pool.o mongoc/mongoc-client.o \

--- a/R/R-mongolite/files/patch-fix-configure.diff
+++ b/R/R-mongolite/files/patch-fix-configure.diff
@@ -1,0 +1,54 @@
+--- configure.orig	2023-03-30 23:15:39.000000000 +0800
++++ configure	2023-07-15 06:21:28.000000000 +0800
+@@ -4,19 +4,12 @@
+ # INCLUDE_DIR and LIB_DIR manually via e.g:
+ # R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
+ 
+-# Special case: On MacOS we now use the native crypto instead of openssl
+-if [ `uname` = "Darwin" ] && [ -z "$MONGOLITE_USE_OPENSSL" ]; then
+-  echo "Using native crypto for MacOS, don't need OpenSSL"
+-  cat src/osx/Makevars > src/Makevars
+-  exit 0
+-fi
+-
+ # Library settings
+ PKG_CONFIG_NAME="openssl"
+ PKG_DEB_NAME="libssl-dev, libsasl2-dev"
+ PKG_RPM_NAME="openssl-devel, cyrus-sasl-devel"
+ PKG_CSW_NAME="libssl_dev, sasl_dev"
+-PKG_BREW_NAME="openssl@1.1"
++PKG_MP_NAME="openssl3, cyrus-sasl2"
+ PKG_TEST_FILE="src/tests/dependencies.c"
+ SASL_LIBS="-lsasl2"
+ 
+@@ -44,17 +37,6 @@
+   echo "Found pkg-config cflags and libs!"
+   PKG_CFLAGS="${PKGCONFIG_CFLAGS}"
+   PKG_LIBS="${SASL_LIBS} ${PKGCONFIG_LIBS}"
+-elif [ `uname` = "Darwin" ]; then
+-  test ! "$CI" && brew --version 2>/dev/null
+-  if [ $? -eq 0 ]; then
+-    BREWDIR=`brew --prefix`
+-    PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include"
+-    PKG_LIBS="-L$BREWDIR/opt/$PKG_BREW_NAME/lib -lssl -lcrypto"
+-  else
+-    curl -sfL "https://autobrew.github.io/scripts/openssl" > autobrew
+-    . autobrew
+-  fi
+-  PKG_LIBS="$PKG_LIBS $SASL_LIBS"
+ fi
+ 
+ # Apple has deprecated SASL but there is no alternative yet
+@@ -89,9 +71,9 @@
+   echo " * deb: $PKG_DEB_NAME (Debian, Ubuntu, etc)"
+   echo " * rpm: $PKG_RPM_NAME (Fedora, CentOS, RHEL)"
+   echo " * csw: $PKG_CSW_NAME (Solaris)"
+-  echo " * brew: $PKG_BREW_NAME (Mac OSX)"
+-  echo "If $PKG_CONFIG_NAME is already installed, check that 'pkg-config' is in your"
+-  echo "PATH and PKG_CONFIG_PATH contains a $PKG_CONFIG_NAME.pc file. If pkg-config"
++  echo " * port install $PKG_MP_NAME (Mac OSX)"
++  echo "If $PKG_CONFIG_NAME is already installed, check that 'pkgconfig' is in your"
++  echo "PATH and PKG_CONFIG_PATH contains a $PKG_CONFIG_NAME.pc file. If pkgconfig"
+   echo "is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:"
+   echo "R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'"
+   echo "---------------------------[ ERROR MESSAGE ]----------------------------"

--- a/R/R-mongolite/files/patch-pthread.diff
+++ b/R/R-mongolite/files/patch-pthread.diff
@@ -1,0 +1,31 @@
+--- src/mongoc/mongoc-log.c.orig	2022-11-07 14:43:57.000000000 +0800
++++ src/mongoc/mongoc-log.c	2023-07-15 05:54:52.000000000 +0800
+@@ -31,6 +31,10 @@
+ #include <stdarg.h>
+ #include <time.h>
+ 
++#if defined(__APPLE__)
++#include <AvailabilityMacros.h>
++#endif
++
+ #include "mongoc-log.h"
+ #include "mongoc-log-private.h"
+ #include "mongoc-thread-private.h"
+@@ -205,7 +209,17 @@
+    pid = (int) _lwp_self ();
+ #elif defined(__APPLE__)
+    uint64_t tid;
++#if (MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || defined(__POWERPC__)
++   tid = pthread_mach_thread_np (pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++   if (&pthread_threadid_np) {
++      pthread_threadid_np (0, &tid);
++   } else {
++      tid = pthread_mach_thread_np (pthread_self());
++   }
++#else
+    pthread_threadid_np (0, &tid);
++#endif
+    pid = (int) tid;
+ #else
+    pid = (int) getpid ();

--- a/R/R-qspray/Portfile
+++ b/R/R-qspray/Portfile
@@ -4,16 +4,16 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 # GitHub version is archaic.
-R.setup             cran stla qspray 1.1.1
+R.setup             cran stla qspray 2.0.0
 revision            0
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3
 description         Multivariate polynomials with rational coefficients
 long_description    {*}${description}
-checksums           rmd160  5ec407ca12d92fb2b7928d0ebaf2415d63d8c8f2 \
-                    sha256  cb909ce687d7199c159e5c1f92fd6fa63a2cb82b2783f695a5af6f2f2c3ca27c \
-                    size    15784
+checksums           rmd160  f62daa0ceee84cb1f4e0c7051942eded161e90ef \
+                    sha256  352560ac75d5763797b07b4c15fa4b06e13a209806cfb3f45d0868d1cc68e75d \
+                    size    19954
 
 depends_build-append \
                     port:pkgconfig

--- a/R/R-rgeos/Portfile
+++ b/R/R-rgeos/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran cran rgeos 0.6-3
-revision            0
+revision            1
 categories-append   math
 maintainers         nomaintainer
 license             {GPL-2 GPL-3}

--- a/R/R-rtsdata/Portfile
+++ b/R/R-rtsdata/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             cran rtsvizteam rtsdata 0.1.3
+revision            0
+categories-append   databases
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             MIT
+description         R time series intelligent data storage
+long_description    {*}${description}
+homepage            https://bitbucket.org/rtsvizteam/rtsdata
+checksums           rmd160  e77718ed4031c8ee3c5c86f27f9600bd4962ec61 \
+                    sha256  c9f2e04f0fecdcfd6cb0adfc6d25cd9ad3702636dae6f807955b1ac741459c7a \
+                    size    16389
+supported_archs     noarch
+
+depends_lib-append  port:R-anytime \
+                    port:R-brotli \
+                    port:R-curl \
+                    port:R-data.table \
+                    port:R-mongolite \
+                    port:R-Quandl \
+                    port:R-quantmod \
+                    port:R-xts \
+                    port:R-zoo
+
+depends_test-append port:R-RQuantLib
+
+test.run            yes

--- a/R/R-sass/Portfile
+++ b/R/R-sass/Portfile
@@ -3,15 +3,15 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran rstudio sass 0.4.6
+R.setup             cran rstudio sass 0.4.7
 revision            0
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
 description         Syntactically Awesome Style Sheets
 long_description    {*}${description}
-checksums           rmd160  b6af8d93755b872b7fb704bdd13cd55b269d56df \
-                    sha256  2ee82ce709b7fdee78f7e2364d04f369f58fc2cda4bb5a235bd53c49d311c019 \
-                    size    3024838
+checksums           rmd160  222d29d85157b82034562e3eda413b7d5bc14cf4 \
+                    sha256  717a08b63615a4fd9e494f775c33f0f965db83677cf1cc37849afc3da1c5e9ee \
+                    size    3025460
 
 depends_lib-append  port:R-fs \
                     port:R-htmltools \

--- a/R/R-ssh/Portfile
+++ b/R/R-ssh/Portfile
@@ -21,3 +21,12 @@ depends_build-append \
 depends_lib-append  port:libssh \
                     port:R-askpass \
                     port:R-credentials
+
+depends_test-append port:R-knitr \
+                    port:R-mongolite \
+                    port:R-rmarkdown \
+                    port:R-spelling \
+                    port:R-sys \
+                    port:R-testthat
+
+test.run            yes

--- a/R/R-terra/Portfile
+++ b/R/R-terra/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran rspatial terra 1.7-39
-revision            0
+revision            1
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3+

--- a/R/R-tidytree/Portfile
+++ b/R/R-tidytree/Portfile
@@ -3,15 +3,15 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran YuLab-SMU tidytree 0.4.2
-revision            1
+R.setup             cran YuLab-SMU tidytree 0.4.4
+revision            0
 maintainers         nomaintainer
 license             Artistic-2
 description         Tidy tool for phylogenetic tree data manipulation
 long_description    {*}${description}
-checksums           rmd160  206088baa0b89caf271aa90bb8c11bdc91e7e37e \
-                    sha256  cb831a66d8afa5e21f5072e4fbebcbd2228881090d0040f87605f5aeefda155e \
-                    size    64216
+checksums           rmd160  f678bcd7339c84c3734bd40c2e65e9887a39b72a \
+                    sha256  21560aa418af1f2db25e2b4f591ceb44508e0ef81a36892482fcaa77873ccca4 \
+                    size    67657
 supported_archs     noarch
 
 depends_lib-append  port:R-ape \

--- a/R/R-tpn/Portfile
+++ b/R/R-tpn/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             cran cran tpn 1.3
+R.setup             cran cran tpn 1.4
 revision            0
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-2+
 description         Truncated positive normal model and extensions
 long_description    {*}${description}
-checksums           rmd160  bf04e1b22fa19c3ea5b3c3697a5fd737d4002c86 \
-                    sha256  aaf7fe837ea27a182dd88ff3fb9316a58b4f87564fc42d0a502b6292dc07b26f \
-                    size    10739
+checksums           rmd160  ab44c62815447047c1b3b0b9910be42faf832891 \
+                    sha256  c66e8735896177b8c858531bdbd91e274392283aa8d7e447ea8ec0b7728c0869 \
+                    size    12287
 supported_archs     noarch
 
 depends_lib-append  port:R-moments \


### PR DESCRIPTION
#### Description

Recent update to GEOS did not revbump its dependents: https://github.com/macports/macports-ports/commit/38b2617e60f8bbf5e457bbf637fd38c78c6f9466
R packages complain about version mismatch. (I do not revbump `R-sf`, since I have updated it after GEOS update.)

Update a few recently updated packages. (`R-rtsdata` added here due to its dependencies.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
