### PR TITLE
s2n-tls: new port (version 1.3.47)

### DIFF
--- a/security/s2n-tls/Portfile
+++ b/security/s2n-tls/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github      1.0
+PortGroup           makefile    1.0
+
+github.setup        aws s2n-tls 1.3.47 v
+github.tarball_from archive
+revision            0
+
+homepage            https://aws.github.io/s2n-tls/doxygen/s2n_8h.html
+
+description         An implementation of the TLS/SSL protocols
+
+long_description    \
+    ${name} is a C99 implementation of the TLS/SSL protocols that is designed \
+    to be simple, small, fast, and with security as a priority.
+
+checksums           rmd160  7fef7b41b4a41d818a14b3596065a80c6c07618a \
+                    sha256  72b4b2dc9f8d8c1647738fca631c7a75b4d2d5e461e21961a3727ab8e9bc6ce6 \
+                    size    4297068
+
+categories          security
+license             Apache-2
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+depends_lib-append  path:lib/libcrypto.dylib:openssl
+
+patchfiles-append   patch-s2n.mk.diff
+
+compiler.c_standard 1999
+
+build.target        bin
+
+makefile.has_destdir no

--- a/security/s2n-tls/files/patch-s2n.mk.diff
+++ b/security/s2n-tls/files/patch-s2n.mk.diff
@@ -1,0 +1,20 @@
+--- ./s2n.mk	2023-07-15 17:59:11.000000000 -0400
++++ ./s2n.mk	2023-07-15 17:59:34.000000000 -0400
+@@ -55,7 +55,7 @@
+ 
+ COVERAGE_CFLAGS = -fprofile-arcs -ftest-coverage
+ COVERAGE_LDFLAGS = --coverage
+-LDFLAGS = -z relro -z now -z noexecstack
++LDFLAGS ?=
+ 
+ FUZZ_CFLAGS = -fsanitize-coverage=trace-pc-guard -fsanitize=address,undefined,leak
+ 
+@@ -175,7 +175,7 @@
+ endif
+ 
+ # Used for testing.
+-prefix ?= /usr/local
++prefix ?= $(PREFIX)
+ exec_prefix ?= $(prefix)
+ bindir ?= $(exec_prefix)/bin
+ libdir ?= $(exec_prefix)/lib64


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
