### PR TITLE
libvirt: enable qemu driver always

### DIFF
--- a/sysutils/libvirt/Portfile
+++ b/sysutils/libvirt/Portfile
@@ -12,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy 12
 # Remember to update libvirt and py-libvirt at the same time.
 name                libvirt
 version             9.8.0
-revision            0
+revision            1
 checksums           rmd160  f0044cda4ac4aa6a434701de3a2bbb75619f298c \
                     sha256  7aa90d133bb301e94663a45c36176f46f4a9fc1b34d77d2e22b7a2517106f506 \
                     size    9307064
@@ -86,7 +86,7 @@ configure.args      -Dapparmor=disabled \
                     -Ddriver_lxc=disabled \
                     -Ddriver_network=disabled \
                     -Ddriver_openvz=disabled \
-                    -Ddriver_qemu=disabled \
+                    -Ddriver_qemu=enabled \
                     -Ddriver_remote=enabled \
                     -Ddriver_secrets=enabled \
                     -Ddriver_test=enabled \
@@ -133,11 +133,6 @@ variant libssh2 description {Enable the libssh2 transport} {
 variant sasl description {Use Cyrus SASL for authentication} {
     depends_lib-append      port:cyrus-sasl2
     configure.args-replace  -Dsasl=disabled -Dsasl=enabled
-}
-
-variant qemu description {Enable the QEMU virtualization driver} {
-    depends_lib-append      port:qemu
-    configure.args-replace  -Ddriver_qemu=disabled -Ddriver_qemu=enabled
 }
 
 notes "


### PR DESCRIPTION
#### Description

Required to [run a server](https://libvirt.org/macos.html).

###### Type(s)

- [x] enhancement

###### Tested on
macOS 13.4.1 22F770820d x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?