### PR TITLE
py-docker: add py311 subport

### DIFF
--- a/python/py-docker/Portfile
+++ b/python/py-docker/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  96de2c178103e03a8ffa43156df5083972053c77 \
                     sha256  bb01ff312c81ea89d7a9f558375455dc0a8227f5411f26235bfa4e73f833c5c4 \
                     size    247141
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \


### PR DESCRIPTION
###### Type(s)

- [x] enhancement

###### Tested on
macOS 13.4.1 22F770820d x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?