### PR TITLE
qemu: add spice and vnc to default variants

### DIFF
--- a/emulators/qemu/Portfile
+++ b/emulators/qemu/Portfile
@@ -9,7 +9,7 @@ legacysupport.newest_darwin_requires_legacy 16
 
 name                    qemu
 version                 8.0.2
-revision                0
+revision                1
 categories              emulators
 license                 GPL-2+
 maintainers             {raimue @raimue} \
@@ -190,7 +190,7 @@ pre-configure {
 # disable silent rules
 build.args-append       V=1
 
-default_variants        +usb
+default_variants        +usb +spice +vnc
 
 # https://trac.macports.org/ticket/62164#comment:10
 if {${os.platform} eq "darwin" && ${os.major} < 18} {
@@ -231,7 +231,9 @@ variant sdl2 description {Use the SDL 2 graphical user interface} conflicts coco
 
 variant usb description {Support forwarding of USB devices to the guest} {
     configure.args-replace  --disable-libusb --enable-libusb
-    depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb
+    configure.args-replace  --disable-usb-redir --enable-usb-redir
+    depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb \
+                            port:usbredir
 }
 
 variant curl description {Support network block devices using CURL} {


### PR DESCRIPTION
#### Description

Enable USB redirection for usb variant.

These are required to interact with QEMU virtual machines through other clients such as virt-manager.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 13.4.1 22F770820d x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?