### PR TITLE
kubectx: update to 0.9.5

### DIFF
--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        ahmetb kubectx 0.9.4 v
-revision            1
+github.setup        ahmetb kubectx 0.9.5 v
+revision            0
 categories          sysutils
 platforms           any
 supported_archs     noarch
@@ -15,11 +15,11 @@ description         Power tools for kubectl
 long_description    kubectx helps you switch between clusters back and forth. \
                     kubens helps you switch between Kubernetes namespaces smoothly.
 
-checksums           rmd160  63b2b1f45a352baa6e05bd65baf425d1b13cd0bc \
-                    sha256  85ff8ff3882c4b5eda4d7c90e98d7fca8bdab54cb54a71fb11e7ad0b291439ed \
-                    size    520687
+checksums           rmd160  d83ba4c5db6a0500e258a2dc7ca4c3b30e8c4567 \
+                    sha256  e823287ad55864b1f96d9c79191159bfc489f821ec4996299edbe5829e214583 \
+                    size    523315
 
-depends_run         path:${prefix}/bin/kubectl:kubectl-1.22
+depends_run         path:${prefix}/bin/kubectl:kubectl-1.27
 
 use_configure       no
 build {}
@@ -43,8 +43,8 @@ destroot    {
 
     set zsh_completion_dir ${destroot}${prefix}/share/zsh/site-functions
     xinstall -d ${zsh_completion_dir}
-    xinstall -m 644 ${src_completion_dir}/kubectx.zsh ${zsh_completion_dir}/_kubectx
-    xinstall -m 644 ${src_completion_dir}/kubens.zsh ${zsh_completion_dir}/_kubens
+    xinstall -m 644 ${src_completion_dir}/_kubectx.zsh ${zsh_completion_dir}/_kubectx
+    xinstall -m 644 ${src_completion_dir}/_kubens.zsh ${zsh_completion_dir}/_kubens
 
     set bash_completion_dir ${destroot}${prefix}/etc/bash_completion.d
     xinstall -d ${bash_completion_dir}


### PR DESCRIPTION
#### Description

Update to kubectx 0.9.5.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?