### PR TITLE
vegeta: update to 12.10.0

### DIFF
--- a/net/vegeta/Portfile
+++ b/net/vegeta/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/tsenart/vegeta 12.9.0 v
+go.setup            github.com/tsenart/vegeta 12.10.0 v
 categories          net
 maintainers         {amake @amake} openmaintainer
 license             MIT
@@ -14,22 +14,27 @@ long_description    A versatile HTTP load testing tool built out of a \
                     need to drill HTTP services with a constant request rate.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  ca1c807635968ed3905a50dfeadf35a11ce43d6c \
-                        sha256  5495a51114930fa725ba40272c555e8fd993400079953d2129cbdc3e404b5510 \
-                        size    503754
+                        rmd160  d694c4f17e9e99a45cc41e3cab2ff43045254edb \
+                        sha256  a5b3c318f09defac39d277cb43dbcf852fd5c14bde2ba900bd85c4098bf00cf5 \
+                        size    503297
 
 go.vendors          pgregory.net/rapid \
                         repo    github.com/flyingmutant/rapid \
-                        lock    v0.3.3 \
-                        rmd160  359b70e8d66b33ad9935e5b8fb2afa3eb9b79801 \
-                        sha256  7fca0b183e0d3722e200e813d32f874fb9a02fc41c2d6cca5341634257ac0367 \
-                        size    72556 \
+                        lock    v1.0.0 \
+                        rmd160  d3d5be5b3bd2d3a9d81eb95052f50ceaa0aa2f28 \
+                        sha256  37042b91a978f769e55cb4d89ec4de5cd942a1e314b38df3078d14290673f14c \
+                        size    81888 \
                     gonum.org/v1/gonum \
                         repo    github.com/gonum/gonum \
                         lock    3f7ecaa7e8ca \
                         rmd160  123cdcea01b610832fd9882c35bb56247ddfe3da \
                         sha256  8725ccb88b4278206da6b63affcde9b6daccef368510c7027d5f8dc21842e04e \
                         size    3883924 \
+                    golang.org/x/tools \
+                        lock    v0.6.0 \
+                        rmd160  4b249b4a0a81358289599e3505f17490396d4d06 \
+                        sha256  e064d0d45d4ca70abd87066b550137f985d487b424f8d58b39b6e6f4129dcea5 \
+                        size    3307706 \
                     golang.org/x/text \
                         lock    v0.11.0 \
                         rmd160  c4603f279575a9642b4444914247fdbb0e9954c4 \
@@ -41,25 +46,25 @@ go.vendors          pgregory.net/rapid \
                         sha256  131890e51d97b703ad20cebc231370408213b554c32231001d204bfac7ac96d5 \
                         size    1441834 \
                     golang.org/x/sync \
-                        lock    112230192c58 \
-                        rmd160  37a8b11def31e2ad355002a8671245962be359f6 \
-                        sha256  951a6df1dadb061510f1c646197dd8f8a7c7842729d02c6a68a86bce66349f79 \
-                        size    16832 \
+                        lock    v0.1.0 \
+                        rmd160  bf68702d961107a225cce561701852f129f16a3d \
+                        sha256  50a67a11e715a61c022f218604adc63e61684de5f5db2330741077439c4ce68f \
+                        size    19355 \
                     golang.org/x/net \
                         lock    v0.12.0 \
                         rmd160  d599e183fa279c044432d748157f06265fe5d787 \
                         sha256  b0f10ee750ae27d7761d93c01c01aceea2f5b25a591acbb9bc91f378cf04920d \
                         size    1371560 \
+                    golang.org/x/mod \
+                        lock    v0.8.0 \
+                        rmd160  7e8a20bec3182f47d0739ba5f6d12ae0141bdbf9 \
+                        sha256  e34ac19715958f315113b06a357c655cfd21b257cf69ae63b3c0f93a3b9f2e9f \
+                        size    120235 \
                     golang.org/x/exp \
                         lock    8460e604b9de \
                         rmd160  ac9510358006c68ea5aed4a108229f287d055b36 \
                         sha256  a271e22ada9fa2a0c44f5c155bf437cb8f63ede920bac36ca9a85049960b2a3b \
                         size    1327643 \
-                    golang.org/x/crypto \
-                        lock    v0.11.0 \
-                        rmd160  c00277dedc81b9ed173fb03d8d8c1293ff659463 \
-                        sha256  bb0cd20fd6f6bc93d8546af593d8763ff89875078758563a1881c0316283f80e \
-                        size    1789100 \
                     github.com/tsenart/go-tsz \
                         lock    0bd30b3df1c3 \
                         rmd160  eae07bb44d7c5049ef8ef6adf849280defb5ecb9 \
@@ -75,16 +80,31 @@ go.vendors          pgregory.net/rapid \
                         rmd160  796d92efbaec1166254908cdba3b53205888c36c \
                         sha256  4218d73850186c214bb8ed579faa8e31ad1ecf2515f00d6942dd71c4001bddb7 \
                         size    4843 \
+                    github.com/shurcooL/vfsgen \
+                        lock    0000e147ea92 \
+                        rmd160  e2564fa61666d1a441daafb88883a3ba6f41c29f \
+                        sha256  a0ba6481bdd00f62d4c4058e8472bf6c4629b577d3ee17125bc93a231111726b \
+                        size    13504 \
+                    github.com/shurcooL/httpfs \
+                        lock    f1e31cf0ba5c \
+                        rmd160  53481cafa0a579fc272355fb283bd32d2686aadc \
+                        sha256  82e76b01153de1309f445d9c584cdd628fcdff9d355e783e636ed8a26ac04210 \
+                        size    8520 \
+                    github.com/rs/dnscache \
+                        lock    e0241e321417 \
+                        rmd160  67728d7da46eae7a9041b7b24e2fd4194479d952 \
+                        sha256  b7a97b52b42731a53be3d425ef870017bebf33b2576f88f534d42a5347cc8b22 \
+                        size    5838 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
                         sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
                         size    11409 \
                     github.com/miekg/dns \
-                        lock    v1.1.25 \
-                        rmd160  fed850fe45142a57c770b56b84b9e595d3558ce5 \
-                        sha256  686fc26de84b3e5420c76c0fb19add70594fd79061850baaa974d86a3eb1e163 \
-                        size    179434 \
+                        lock    v1.1.55 \
+                        rmd160  74fcf61d430158d43deebad5a3ba5469522b444f \
+                        sha256  989d30c90e45d7ddd8290b084ab71ca9542819aeb2f8ad214674c0fd51b81056 \
+                        size    212453 \
                     github.com/mailru/easyjson \
                         lock    v0.7.7 \
                         rmd160  f40deae988781d59d399784445dc89fe84d69e37 \


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
