### PR TITLE
gallery-dl: updated to 1.25.8

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        mikf gallery-dl 1.25.7 v
+github.setup        mikf gallery-dl 1.25.8 v
 github.tarball_from releases
 distname            gallery_dl-${github.version}
 
@@ -12,9 +12,9 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  1a87646b2ae4d0b4d8fefc9e32af4cc01f12606c \
-                    sha256  881bfb661fe4598fe4634d669e269b18d488a773cb8982ba20c20dc39d5f35d9 \
-                    size    554458
+checksums           rmd160  d046a4cd506dfc524c966bfc356da21be4671e16 \
+                    sha256  eaad85f73486669d2266806f39422e204a8db3dee16ec6f3136dd72724d95037 \
+                    size    554759
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites


### PR DESCRIPTION
#### Description

gallery-dl: updated to 1.25.8

###### Type(s)

- [x] bugfix
- [x] enhancement


###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? 
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
