### PR TITLE
spice-gtk: update to 0.42

### DIFF
--- a/gnome/spice-gtk/Portfile
+++ b/gnome/spice-gtk/Portfile
@@ -5,11 +5,11 @@ PortGroup           active_variants 1.1
 PortGroup           meson 1.0
 
 name                spice-gtk
-version             0.41
+version             0.42
 revision            0
-checksums           rmd160  4f66fd847ec37fc51fd9d36ef690d7f8629e0392 \
-                    sha256  d8f8b5cbea9184702eeb8cc276a67d72acdb6e36e7c73349fb8445e5bca0969f \
-                    size    827320
+checksums           rmd160  19bbc933dff9be4db1f1b0a93319305374b4d756 \
+                    sha256  9380117f1811ad1faa1812cb6602479b6290d4a0d8cc442d44427f7f6c0e7a58 \
+                    size    812776
 
 categories          gnome devel
 platforms           darwin
@@ -27,14 +27,15 @@ homepage            https://www.spice-space.org/spice-gtk.html
 master_sites        https://www.spice-space.org/download/gtk/
 use_xz              yes
 
-set python_version  3.9
+set python_version  3.11
 set python_ver_no_dot [string map {. {}} ${python_version}]
 
 patchfiles-append   patch-meson-python.diff
 
 post-patch {
     reinplace "s|@@PYTHON_BIN@@|${prefix}/bin/python${python_version}|g" \
-        ${worksrcpath}/src/meson.build ${worksrcpath}/subprojects/spice-common/meson.build
+        ${worksrcpath}/subprojects/keycodemapdb/tools/keymap-gen \
+        ${worksrcpath}/subprojects/spice-common/meson.build
 }
 
 depends_build-append \

--- a/gnome/spice-gtk/files/patch-meson-python.diff
+++ b/gnome/spice-gtk/files/patch-meson-python.diff
@@ -1,19 +1,11 @@
-diff --git src/meson.build src/meson.build
-index c742fde..4569647 100644
---- src/meson.build
-+++ src/meson.build
-@@ -300,7 +300,7 @@ if spice_gtk_has_gtk
-   endif
- 
-   # keymaps
--  python = import('python').find_installation()
-+  python = import('python').find_installation('@@PYTHON_BIN@@')
-   keymaps = ['xorgevdev',
-              'xorgkbd',
-              'xorgxquartz',
-Submodule subprojects/spice-common contains modified content
-diff --git subprojects/spice-common/meson.build subprojects/spice-common/meson.build
-index eeccecd..dcef6c9 100644
+--- subprojects/keycodemapdb/tools/keymap-gen.orig	2023-01-20 14:40:33
++++ subprojects/keycodemapdb/tools/keymap-gen	2023-07-17 15:04:20
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python3
++#!@@PYTHON_BIN@@
+ # -*- python -*-
+ #
+ # Keycode Map Generator
 --- subprojects/spice-common/meson.build
 +++ subprojects/spice-common/meson.build
 @@ -127,7 +127,7 @@ endforeach


### PR DESCRIPTION
#### Description

- Use Python 3.11 for build

###### Tested on
macOS 13.4.1 22F770820d x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?