### PR TITLE
gtk-vnc: add x11 variant

### DIFF
--- a/gnome/gtk-vnc/Portfile
+++ b/gnome/gtk-vnc/Portfile
@@ -6,6 +6,7 @@ PortGroup           meson 1.0
 
 name                gtk-vnc
 version             1.3.1
+revision            1
 maintainers         {danchr @danchr} openmaintainer
 categories          gnome devel
 license             {LGPL GPL-3}
@@ -58,15 +59,26 @@ configure.cppflags-append \
 livecheck.type      gnome
 livecheck.regex     LATEST-IS-(\\d+\\.\\d*\\d(?:\\.\\d+)*)
 
-variant quartz {
+variant quartz conflicts x11 {
+    require_active_variants gtk3 quartz
     # src/vncdisplaykeymap.c includes <gdk/gdkquartz.h>, which in turn
     # includes AppKit -- and that one fails hard in a regular C compiler...
     configure.cflags-append \
         -ObjC
 }
 
-if {[variant_isset quartz]} {
-    require_active_variants gtk3 quartz
-} else {
-    require_active_variants gtk3 "" quartz
+variant x11 conflicts quartz {
+    require_active_variants gtk3 x11
+}
+
+if {![variant_isset quartz]} {
+    default_variants +x11
+}
+if {![variant_isset x11]} {
+    default_variants +quartz
+}
+if {![variant_isset quartz] && ![variant_isset x11]} {
+    pre-configure {
+        return -code error "Either +x11 or +quartz is required"
+    }
 }


### PR DESCRIPTION
#### Description

This makes clear the X11 dependency and ensures the correct version of gtk3 is used. I got this error when running `virt-viewer`:

```
dyld[33883]: Symbol not found: _gdk_x11_display_get_type
  Referenced from: <4CF3FE24-024F-36BE-8651-0D17C1AEE89A> /opt/local/lib/libgtk-vnc-2.0.0.dylib
  Expected in:     <3108FC3A-DD29-3A37-A7AC-4E69C8E97083> /opt/local/lib/libgdk-3.0.dylib
Abort trap: 6
```

###### Type(s)

- [x] enhancement

###### Tested on
macOS 13.4.1 22F770820d x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?