### PR TITLE
virt-viewer: update to 11.0

### DIFF
--- a/emulators/virt-viewer/Portfile
+++ b/emulators/virt-viewer/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           meson 1.0
 
 name                virt-viewer
-version             7.0
+version             11.0
 categories          emulators
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -20,12 +21,15 @@ long_description \
     to virtual machines. It uses the GTK-VNC or SPICE-GTK widgets to provide \
     the display, and libvirt for looking up VNC/SPICE server details.
 
-checksums           rmd160  4d42589107601ee96e380e89cab4ea2562b5f228 \
-                    sha256  47c2cfaa376f5f20968c0addfd65c62b90cab4e6336febf2bc44499d4cdcc903 \
-                    size    924475
+use_xz              yes
 
-depends_build       port:pkgconfig \
-                    port:intltool
+checksums           rmd160  d16895408be0b3fa29bbf7854d5e83030e845408 \
+                    sha256  a43fa2325c4c1c77a5c8c98065ac30ef0511a21ac98e590f22340869bad9abd0 \
+                    size    259772
+
+patchfiles          patch-data-meson-build.diff
+
+depends_build       port:pkgconfig
 
 depends_lib         port:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libxml2 \
@@ -34,8 +38,3 @@ depends_lib         port:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:gtk-vnc \
                     port:spice-gtk
-
-configure.args      --without-ovirt \
-                    --with-gtk-vnc \
-                    --with-spice-gtk \
-                    --disable-update-mimedb

--- a/emulators/virt-viewer/files/patch-data-meson-build.diff
+++ b/emulators/virt-viewer/files/patch-data-meson-build.diff
@@ -1,0 +1,50 @@
+From 98d9f202ef768f22ae21b5c43a080a1aa64a7107 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20P=2E=20Berrang=C3=A9?= <berrange@redhat.com>
+Date: Tue, 26 Apr 2022 17:36:54 +0100
+Subject: [PATCH] data: remove bogus param for meson i18n.merge_file
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The positional parameter used to be treated as 'input', but since we
+already set 'input' explicitly it is redundant. With latest meson
+versions it now generates an error
+
+data/meson.build:4:7: ERROR: Function does not take positional arguments.
+
+Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>
+---
+ data/meson.build | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git data/meson.build b/data/meson.build
+index d718491f..43251084 100644
+--- data/meson.build
++++ data/meson.build
+@@ -2,7 +2,6 @@ if host_machine.system() != 'windows'
+   desktop = 'remote-viewer.desktop'
+ 
+   i18n.merge_file (
+-    desktop,
+     type: 'desktop',
+     input: desktop + '.in',
+     output: desktop,
+@@ -14,7 +13,6 @@ if host_machine.system() != 'windows'
+   mimetypes = 'virt-viewer-mime.xml'
+ 
+   i18n.merge_file (
+-    mimetypes,
+     type: 'xml',
+     input: mimetypes + '.in',
+     output: mimetypes,
+@@ -27,7 +25,6 @@ if host_machine.system() != 'windows'
+   metainfo = 'remote-viewer.appdata.xml'
+ 
+   i18n.merge_file (
+-    metainfo,
+     type: 'xml',
+     input: metainfo + '.in',
+     output: metainfo,
+-- 
+GitLab
+


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/67748

###### Tested on
macOS 13.4.1 22F770820d x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?