### PR TITLE
ruby-build: Update to 20230717

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230710 v
+github.setup        rbenv ruby-build 20230717 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  bb94d165722b1a4451ad72caa99e6ff0f2c62b35 \
-                    sha256  c16d229e32cadd21f77554044554b6e0aafb0813f21356e4bc750b328f477db4 \
-                    size    80359
+checksums           rmd160  bc4e758fe842e404dcdd8825cf0d89c866fbb866 \
+                    sha256  f9a1c5c098d53cfb5573551fb0b332088176ea7ce6e32558c518e03fd38b3e92 \
+                    size    80372
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Upstream changelog:

```
- Follow truffleruby dev standalones rename by @eregon in #2219
```

The upstream GraalVM repository renamed builds from `truffleruby-dev-OS-ARCH.tar.gz` to `truffleruby-community-dev-OS-ARCH.tar.gz`

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?