### PR TITLE
composer: new port (version 2.5.8)

### DIFF
--- a/php/composer/Portfile
+++ b/php/composer/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        composer composer 2.5.8
+revision            0
+categories          php devel
+platforms           any
+license             MIT
+maintainers         {ego.team:yet @yugaego} openmaintainer
+
+description         a dependency manager for the PHP programming language
+
+long_description    Composer is {*}${description}. It helps you declare, \
+                    manage, and install dependencies of PHP projects.
+
+homepage            https://getcomposer.org
+
+github.tarball_from releases
+distname            ${name}
+extract.suffix      .phar
+
+revision            0
+checksums           rmd160  cbcc680e5206a5f016151ab15824685523538819 \
+                    sha256  f07934fad44f9048c0dc875a506cca31cc2794d6aebfc1867f3b1fbf48dce2c5 \
+                    size    2837394
+
+depends_run         bin:php:php82
+
+extract {
+    file copy ${distpath}/${distfiles} ${workpath}/${distname}
+}
+
+use_configure no
+
+build {}
+
+destroot {
+    xinstall -m 0755 ${workpath}/${distname} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

This PR suggests adding a new port: for [a PHP dependency manager `Composer`](https://getcomposer.org). This was requested in https://trac.macports.org/ticket/42344 and (tangentially)  https://github.com/sjorek/macports-php/issues/2.

It was selected to use the simplest approach creating this `Portfile`. I assume that support of particular versions can be added later (via variants or subports + select group), if it is requested/needed.

Declared dependencies are also kept to a minimum, since `composer` itself handles them nicely on a call, outputting user messages with additional information. `bin:php:php82` was selected as a format to suggest installing port `php82` (the current latest) if `php` is not available.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

New Portfile submission.

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.4.1 22F82 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
