### PR TITLE
spdlog: add variant tests; set cmake build type; reduce warnings; don't build examples

### DIFF
--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -28,10 +28,14 @@ configure.args-append \
                     -DSPDLOG_BUILD_SHARED=ON
 
 variant fmt_external description {Use external fmt library instead of bundled} {
-depends_lib-append  port:libfmt10
-    patchfiles      patch-spdlog-fmt-external.diff
-    cmake.module_path-append ${prefix}/lib/libfmt10/cmake
-    configure.args-append    -DSPDLOG_FMT_EXTERNAL=ON
+    patchfiles-append \
+                    patch-spdlog-fmt-external.diff
+    cmake.module_path-append \
+                    ${prefix}/lib/libfmt10/cmake
+    depends_lib-append \
+                    port:libfmt10
+    configure.args-append \
+                    -DSPDLOG_FMT_EXTERNAL=ON
 }
 
 default_variants +fmt_external

--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 
 github.setup        gabime spdlog 1.12.0 v
 github.tarball_from archive
-revision            1
+revision            2
 conflicts           spdlog0
 categories          devel
 license             MIT
@@ -24,8 +24,28 @@ checksums           rmd160  06bfcd66f06a9eea8544edfa81df85cf1f71ac08 \
 compiler.cxx_standard   2011
 compiler.thread_local_storage yes
 
+# Clear optflags; controlled by project, via cmake build type
+configure.optflags
+
+if {[variant_isset debug]} {
+    cmake.build_type Debug
+} else {
+    cmake.build_type RelWithDebInfo
+}
+
+if { [string match *clang* ${configure.compiler}] } {
+    # Quiet warnings
+    configure.cxxflags-append \
+                    -Wno-macro-redefined \
+                    -Wno-error=unknown-warning-option \
+                    -Wno-unknown-warning-option
+}
+
 configure.args-append \
-                    -DSPDLOG_BUILD_SHARED=ON
+                    -DSPDLOG_BUILD_EXAMPLE=OFF \
+                    -DSPDLOG_FMT_EXTERNAL=OFF \
+                    -DSPDLOG_BUILD_SHARED=ON \
+                    -DSPDLOG_BUILD_TESTS=OFF
 
 variant fmt_external description {Use external fmt library instead of bundled} {
     patchfiles-append \
@@ -34,8 +54,21 @@ variant fmt_external description {Use external fmt library instead of bundled} {
                     ${prefix}/lib/libfmt10/cmake
     depends_lib-append \
                     port:libfmt10
-    configure.args-append \
+    configure.args-replace \
+                    -DSPDLOG_FMT_EXTERNAL=OFF \
                     -DSPDLOG_FMT_EXTERNAL=ON
+}
+
+variant tests description {Enable test support} {
+    test.run        yes
+
+    depends_build-append \
+                    path:bin/git:git \
+                    port:pkgconfig
+
+    configure.args-replace \
+                    -DSPDLOG_BUILD_TESTS=OFF \
+                    -DSPDLOG_BUILD_TESTS=ON
 }
 
 default_variants +fmt_external


### PR DESCRIPTION
### Description

* Add new varint `tests`
* Set CMake build type appropriately, for debug/non-debug
* Reduce compiler warnings
* Don't build examples; they aren't installed, and cause build errors for some macOS releases