### PR TITLE
crystal: update to 1.9.1

### DIFF
--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        crystal-lang crystal 1.9.0
+github.setup        crystal-lang crystal 1.9.1
 github.tarball_from archive
 revision            0
 categories          lang
@@ -40,13 +40,13 @@ master_sites-append https://github.com/crystal-lang/${name}/releases/download/${
 distfiles-append    ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  bc5daf54092a9a2d30fb85ab1b27fa77ed56cafe \
-                    sha256  dd5ec1cb1d665968a3fce2617dd79df5759281037d954dae93aad79b1328fb30 \
-                    size    3246261 \
+                    rmd160  ba73fad3cdab5507b4758a7f39653ecd56d2f37c \
+                    sha256  89853c1f87cc89640636b72fd1095ea9a1d260418baddf8b802a0d65942508dd \
+                    size    3246456 \
                     ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix} \
-                    rmd160  3d9a9d8abe6c85df6842ae9a946a24e60f38f596 \
-                    sha256  ef4d3018825f0ee918566b83c365d48c2ed4e0efc68fbc3a1da0c5d814c46849 \
-                    size    57023663
+                    rmd160  9a52f2f4f1ce9dbd96eb5ff9b04b73e7fb92c8e1 \
+                    sha256  597c7c7f3bfaa26fcfb2fd0de3c5a684d8fd14fbf4e6399bb6025c32dfea7cd5 \
+                    size    57023943
 
 patchfiles          patch-static.diff
 


### PR DESCRIPTION
###### Tested on
macOS 13.4.1 22F770820d x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?