### PR TITLE
jdk17: update to 17.0.8

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk17-mac
-version      17.0.7
+version      17.0.8
 revision     0
 
 description  Oracle Java SE Development Kit 17
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/17/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  b09b03f7afec866fc63c4008036fa5a6a80434e3 \
-                 sha256  f356a82c121963028c54f311fb5bfd6c70cb8fa1cd9d2c55845360ddd1da34b7 \
-                 size    178475259
+    checksums    rmd160  0d4189810e2b58ba803e0e277acf58ff8dc7819a \
+                 sha256  ddc4928be11642f35b3cb1e6a56463032705fccb74e10ed5a67a73a5fc7b639f \
+                 size    178850278
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  8c1efae287f14a56a047de2975447efe4c078273 \
-                 sha256  b0b1377c75b8047662225eb18ca5172bf0291b041af6230c97eb75da68d87c14 \
-                 size    175929432
+    checksums    rmd160  8e4bc916e34a68f975d7b9f90a25d9ad9409ce70 \
+                 sha256  89f26bda33262d70455e774b55678fc259ae4f29c0a99eb0377d570507be3d04 \
+                 size    176285053
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 17.0.8.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?