### PR TITLE
jdk20: update to 20.0.2

### DIFF
--- a/java/jdk20/Portfile
+++ b/java/jdk20/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk20-mac
-version      20.0.1
+version      20.0.2
 revision     0
 
 description  Oracle Java SE Development Kit 20
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/20/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  07b19469bf70705ab47855d62f589785d8fc0eca \
-                 sha256  3f8b53c63d1f821d5ff8875140428cbb679159ce0d91294ac349b1634fe994df \
-                 size    187934697
+    checksums    rmd160  0a41878ec9fb8553d0576437cd4231f197cb3c69 \
+                 sha256  8a0484e95b40a95f65c0a498a5b299e80757343f0ff1cc1ec43fc5249468bedb \
+                 size    188263345
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  ae7141bee462cfd6bfdf7d54aa18d16a4851fbc8 \
-                 sha256  c264fd7452dd0aa86022b371b8abea3fa2a0b62b45ff7d189e7c519fe837bdb8 \
-                 size    185476515
+    checksums    rmd160  8589c25243754e8117a47f39153f19d0202717f5 \
+                 sha256  e8718838c2011bab3ab00eb8097ddb20aa3b8fe0a8bb0b9e3c9d801c973477bc \
+                 size    185819340
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 20.0.2.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?