### PR TITLE
openjdk20-oracle: update to 20.0.2

### DIFF
--- a/java/openjdk20-oracle/Portfile
+++ b/java/openjdk20-oracle/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk20-oracle
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,24 +14,24 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://jdk.java.net/20/
-version      20.0.1
+version      20.0.2
 revision     0
 
 description  Oracle OpenJDK 20
 long_description Open-source Oracle build of OpenJDK 20, the Java Development Kit, an implementation of the Java SE Platform.
 
-master_sites https://download.java.net/java/GA/jdk${version}/b4887098932d415489976708ad6d1a4b/9/GPL/
+master_sites https://download.java.net/java/GA/jdk${version}/6e380f22cbe7469fa75fb448bd903d8e/9/GPL/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  afe22426379c1fb266baa139e41e1251da393cff \
-                 sha256  215a181fda2ac9f33d8262476eba6c9beb0ae20d2b592e03411fe71a7d89bb24 \
-                 size    194341938
+    checksums    rmd160  7a4d111f12cb49c6374a488305f05f6c51ebff19 \
+                 sha256  c65ba92b73d8076e2a10029a0674d40ce45c3e0183a8063dd51281e92c9f43fc \
+                 size    194664908
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  64775d68ff1a17c72b8aceb1fdf9e979b70501fe \
-                 sha256  78ae5bb4c96632df8d3f776919c95653d1afd3e715981c4d33be5b3c81d05420 \
-                 size    191896005
+    checksums    rmd160  b7d50885fc35a311ec851e97a87bd3945bdc009e \
+                 sha256  2e6522bb574f76cd3f81156acd59115a014bf452bbe4107f0d31ff9b41b3da57 \
+                 size    192225913
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle OpenJDK 20.0.2.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?