### PR TITLE
openjdk11-corretto: update to 11.0.20.8.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk11-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-11/releases
 supported_archs  x86_64 arm64
 
-version      11.0.19.7.1
+version      11.0.20.8.1
 revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  70ca24d7e818cd5c2efdbe0b419b2d9b1da5ce67 \
-                 sha256  11e6010e96ca2ee48ae26bdc8d0e233d9fbe3f2a80c50f472f48ef564d245445 \
-                 size    187788888
+    checksums    rmd160  68f41bccbf647f4a2ee8ec0c29cf7baf3e209ef8 \
+                 sha256  9e6bf76968737f929511b7c8f4d1456f7d2f53e996e2ce9f352d529ee8e5c028 \
+                 size    188003170
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  7f072417e0e649756af593f84da59648487a237f \
-                 sha256  d8c19e5ab89ed3ccb66a15d9da59c762907e797ae215e0215ee6cc48175cfe4f \
-                 size    186072451
+    checksums    rmd160  e58cf6d0f4f5b85ffffe8be3b6d933e4bc1fe640 \
+                 sha256  39b540600520dae0e664bf9f7bfa8bf931b6e2b320960e276197670bd9e08928 \
+                 size    186298300
 }
 
 worksrcdir   amazon-corretto-11.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 20} {
-    # See https://github.com/corretto/corretto-11/blob/release-11.0.19.7.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-11/blob/release-11.0.20.8.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 11 Big Sur or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.20.8.1.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?