### PR TITLE
openjdk17-corretto: update to 17.0.8.7.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk17-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.7.7.1
+version      17.0.8.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  bd162fbf90d70063bee180b86dc3bc0975398e75 \
-                 sha256  68e169404a1021d24f7c39b2fa2366d40075311377f9cbddd328f0aac6c2ea6c \
-                 size    188082617
+    checksums    rmd160  e50662e272d4f429839e3a19409bd871397531df \
+                 sha256  10dafc711e1ea18246f942cd067a007f3756495c117b1ea1ff40acdf2c944952 \
+                 size    188397854
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  ae628b5840f339e3d71d3c2527f8c61b056b6622 \
-                 sha256  d2410941ee1a8910412511c18a5ff954bc4bd1e4412cb4260a7f138be3a791dd \
-                 size    186100418
+    checksums    rmd160  fcdd2689734392e327bfb35ca42ac52489dcf09c \
+                 sha256  053c0bac27f5847bb2a2e7c6dbc223b880b3873b671ff8793a529d28cc37519d \
+                 size    186442711
 }
 
 worksrcdir   amazon-corretto-17.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 20} {
-    # See https://github.com/corretto/corretto-17/blob/release-17.0.7.7.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-17/blob/release-17.0.8.7.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 11 Big Sur or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.8.7.1.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?