### PR TITLE
openjdk20-corretto: update to 20.0.2.9.1

### DIFF
--- a/java/openjdk20-corretto/Portfile
+++ b/java/openjdk20-corretto/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk20-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-20/releases
-version      20.0.1.9.1
+version      20.0.2.9.1
 revision     0
 
 description  Amazon Corretto OpenJDK 20 (Short Term Support)
@@ -24,21 +24,21 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  ff6833d1e0ec7103e2b831af8f1ece24e2d5d263 \
-                 sha256  93c0d7f4f632d276e0f90889238db3d41f61aa369be5b10bbeec4fbf7e7c3d80 \
-                 size    197522142
+    checksums    rmd160  91f88417f6dfc53208a49c836dcc0b7205aa45f6 \
+                 sha256  0c651e2c75d26a3112871d0f13d952b97637c0fc8f4779ad4adb2bb678f25b7a \
+                 size    197828666
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  3cb8f9ec3123e1016be7a4ea0e2f9f6fa1f52def \
-                 sha256  7ffaf0ac579ed58053d5ab7a5de0e5cd0e0193953f5d235f5739d85c1a448b14 \
-                 size    195367408
+    checksums    rmd160  0697115cd04cdd61ab863e2f53b52058feb6c18d \
+                 sha256  d6c0dd12a89961d40fcf3d277765692fa437a5c2da39a1eb7c1429ab10b5a9f9 \
+                 size    195700215
 }
 
 worksrcdir   amazon-corretto-20.jdk
 
 # https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 if {${os.platform} eq "darwin" && ${os.major} < 20} {
-    # See https://github.com/corretto/corretto-20/blob/release-20.0.1.9.1/CHANGELOG.md
+    # See https://github.com/corretto/corretto-20/blob/release-20.0.2.9.1/CHANGELOG.md
     known_fail yes
     pre-fetch {
         ui_error "${name} ${version} is only supported on macOS 11.0 Big Sur or later."


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 20.0.2.9.1.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?