### PR TITLE
openjdk8-corretto: update to 8.382.05.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -5,16 +5,21 @@ PortSystem       1.0
 name             openjdk8-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+
+# See https://github.com/corretto/corretto-8/blob/release-8.382.05.1/CHANGELOG.md for minimum supported OS version
+# macOS 11 → Darwin 20 (https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version)
+platforms        {darwin any} {darwin >= 20}
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
+
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
 universal_variant no
 
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      8.372.07.1
+version      8.382.05.1
 revision     0
 
 description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -24,27 +29,17 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  f3100eebfd9c51c758cdab504a85171fb06cd4cd \
-                 sha256  2cce42e96fe56e85a3ed9d2d28ce56133054fc4be4e20085e869a05f121dcbf0 \
-                 size    118746691
+    checksums    rmd160  e1e7fd02328844cb1f86c34065e24c0f4cb7b916 \
+                 sha256  12fe21fc3f3a3bdaed6a04c89f43f59baf47ac48c5846f73951d1961e4ec4d91 \
+                 size    118754745
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  d014e0559d5a51abcc6b5fb0e1c1444581507451 \
-                 sha256  5f34b20138b6fe0adbb410fb0fdfa3183cd486770d6045865cf9336850e55b4d \
-                 size    104171446
+    checksums    rmd160  4c885687ba223c04f718a4686a238e08a7f8dd21 \
+                 sha256  d8988d8b15dc276e9664abbb108ef112a43f0627b6dfb8e2250aa97dda39ef3a \
+                 size    103754800
 }
 
 worksrcdir   amazon-corretto-8.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 20} {
-    # See https://github.com/corretto/corretto-8/blob/release-8.372.07.1/CHANGELOG.md
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 11 Big Sur or later."
-        return -code error
-    }
-}
 
 homepage     https://aws.amazon.com/corretto/
 


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.382.05.1.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?