### PR TITLE
openjdk11-zulu: update to 11.66.15

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk11-zulu
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      11.64.19
+version      11.66.15
 revision     0
 
-set openjdk_version 11.0.19
+set openjdk_version 11.0.20
 
 description  Azul Zulu Community OpenJDK 11 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,27 +29,17 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  5f0696c379c1dcde166d36258451c9f7a53cd803 \
-                 sha256  222630bd333f901f53cd0d2341975ec9a31fd6846166d4ce86e8a57a3d734ac5 \
-                 size    194038289
+    checksums    rmd160  02ed30d2b62b3fbe8f02a1024a8bb25713e8292b \
+                 sha256  bcaab11cfe586fae7583c6d9d311c64384354fb2638eb9a012eca4c3f1a1d9fd \
+                 size    196471694
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  b6550b7fcd364566038c98ab5560c2ce6974fcdf \
-                 sha256  f0d84d5f1ae9d67bbb28d4e97fe365692fcdf8f5ad49c57b525281ebb5807577 \
-                 size    192155959
+    checksums    rmd160  222e921ed5ab547342430f952d34c68a46116616 \
+                 sha256  7632bc29f8a4b7d492b93f3bc75a7b61630894db85d136456035ab2a24d38885 \
+                 size    194993088
 }
 
 worksrcdir   ${distname}/zulu-11.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 18} {
-    # See https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.14 Mojave or later."
-        return -code error
-    }
-}
 
 homepage     https://www.azul.com/downloads/
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.66.15 (OpenJDK 11.0.20).

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?