### PR TITLE
openjdk17: update to 17.0.8 GA

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 
 name                openjdk17
-# https://github.com/openjdk/jdk17u/tags
+# See https://github.com/openjdk/jdk17u/tags for the version and build number that matches the latest tag that ends with '-ga'
 version             17.0.8
-set build 3
-revision            0
+set build 7
+revision            1
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -16,12 +16,12 @@ long_description    JDK 17 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk17u/archive/refs/tags
-distname            jdk-${version}+${build}
-worksrcdir          jdk17u-[string map {+ -} ${distname}]
+distname            jdk-${version}-ga
+worksrcdir          jdk17u-${distname}
 
-checksums           rmd160  a842cc00e74064faf239d0df710b1ef0a0f2a1e2 \
-                    sha256  1547e64f8818de595b228f46454390669aa4bd2850ea53da27f0189ccbdf0e10 \
-                    size    105731315
+checksums           rmd160  cc84be8b3828d244fa6b5fcf6a0bd7f1de3b3bf9 \
+                    sha256  8d631dac790ec3eab008639db5b449e8a36310171b3cd68cb7f0b1260ca2467f \
+                    size    105879427
 
 depends_lib         port:freetype
 depends_build       port:openjdk17-bootstrap \


### PR DESCRIPTION
#### Description

Update to GA release of OpenJDK 17.0.8.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?