### PR TITLE
openjdk11: update to 11.0.20

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -3,9 +3,9 @@
 PortSystem          1.0
 
 name                openjdk11
-# https://github.com/openjdk/jdk11u/tags
-version             11.0.19
-set build 7
+# See https://github.com/openjdk/jdk11u/tags for the version and build number that matches the latest tag that ends with '-ga'
+version             11.0.20
+set build 8
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,9 +19,9 @@ master_sites        https://git.openjdk.java.net/jdk11u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk11u-${distname}
 
-checksums           rmd160  7bb4029949f8c590d3738900a004588a7a8ab206 \
-                    sha256  5077e9713e59ccf92fbe58b9bb63e18294fb2110df644f476638e1528e5dfd46 \
-                    size    123660996
+checksums           rmd160  94c405bcaf41bf83935bbb16a2baf76695704719 \
+                    sha256  a277b89ff5ade85d3b5885ad7bffb3f2d9c80df47363fedb9110b62c45dbec37 \
+                    size    116150371
 
 depends_lib         port:freetype
 depends_build       port:autoconf \


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.20.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?