### PR TITLE
libcaption: new port

### DIFF
--- a/multimedia/libcaption/Portfile
+++ b/multimedia/libcaption/Portfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        szatmary libcaption 0.7
+categories          multimedia
+license             MIT
+maintainers         @jasonliu-- openmaintainer
+
+description         free, open-source CEA-608/-708 closed-caption \
+                    encoder/decoder
+long_description    ${name} is a library written in C to aid in the \
+                    creating and parsing of closed caption data. To \
+                    maintain consistency across platforms, ${name} \
+                    aims to implement a subset of EIA-608, CEA-708 as \
+                    supported by the Apple iOS platform.
+
+checksums           rmd160  bf5971f889ec0430bc8330140d6b08c25a790b2f \
+                    sha256  6b0f2d1172ea38facc24d0ca5608bdf1ec1839745c88a0acba93a48106d4f4c1 \
+                    size    140039
+
+configure.args-append       -DBUILD_EXAMPLES=OFF
+
+variant re2c description {Use re2c to generate eia608.c} {
+    depends_build-append    port:re2c
+    configure.args-append   -DENABLE_RE2C=ON
+}
+
+variant examples description {Build examples} {
+    configure.args-replace  -DBUILD_EXAMPLES=OFF \
+                            -DBUILD_EXAMPLES=ON
+}
+
+variant docs description {Build documentation} {
+    depends_build-append    port:graphviz \
+                            port:doxygen
+
+    post-patch {
+        reinplace {s/\(add_custom_target.doc\)/\1 ALL/} \
+            ${worksrcpath}/CMakeLists.txt
+    }
+    post-destroot {
+        set docdir ${prefix}/share/doc/${name}
+        xinstall -d ${destroot}$docdir
+        copy {*}[glob ${worksrcpath}/docs/*] ${destroot}$docdir/
+    }
+}
+
+default_variants    +re2c +examples +docs


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

[libcaption](https://github.com/szatmary/libcaption) is a library written in C to aid in the creating and parsing of closed caption data, open sourced under the MIT license to use within community developed broadcast tools. To maintain consistency across platforms libcaption aims to implement a subset of EIA-608, CEA-708 as supported by the Apple iOS platform.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
