### PR TITLE
kerberos5: build with python311

### DIFF
--- a/net/kerberos5/Portfile
+++ b/net/kerberos5/Portfile
@@ -5,7 +5,7 @@ PortGroup                   compiler_blacklist_versions 1.0
 
 name                        kerberos5
 version                     1.21.1
-revision                    0
+revision                    1
 checksums                   rmd160  2ef15676ff2053f6e6662dbdd6fa76fbc5ce55d4 \
                             sha256  7881c3aaaa1b329bd27dbc6bf2bf1c85c5d0b6c7358aff2b35d513ec2d50fa1f \
                             size    8623049
@@ -32,7 +32,7 @@ distname                    krb5-${version}
 
 depends_build               port:gettext \
                             port:pkgconfig \
-                            port:python310
+                            port:python311
 
 depends_lib                 port:gettext-runtime \
                             port:libcomerr \


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4.1 22F82 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? https://trac.macports.org/ticket/66358
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
