### PR TITLE
openjdk8-zulu: update to 8.72.0.17

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk8-zulu
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      8.70.0.23
+version      8.72.0.17
 revision     0
 
-set openjdk_version 8.0.372
+set openjdk_version 8.0.382
 
 description  Azul Zulu Community OpenJDK 8 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  af0d52375aa27dcf9400ca03a668b7a1eed2a730 \
-                 sha256  d35a7bedfb3dde69701d27b7df6100143c5617d5fee746acb3d845311a9573af \
-                 size    106571859
+    checksums    rmd160  e10d8b7851454ae2978967e1ffbfca2ed35c495b \
+                 sha256  ddd4cf20f194793ea76f782770dbc46b8553472408049a69f2865a76b4f64e81 \
+                 size    106562785
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  aab341da1f3dfe79742aea393a6dcabe97db9a4f \
-                 sha256  ae68ae6a93d1d9952e5ff096f6612eea486846a8506e30dec3dd3b3e52b9d005 \
-                 size    104474376
+    checksums    rmd160  1afc4ef5be5f321abf0c94eaf79c28ec79f6c689 \
+                 sha256  acde40238c405a9a44e24265ccca1dd09986c877478d35d8b71f3fc0e5ba0859 \
+                 size    104479863
 }
 
 worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.72.0.17 (OpenJDK 8u382).

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?