### PR TITLE
openjdk17-zulu: update to 17.44.15

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk17-zulu
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.42.19
+version      17.44.15
 revision     0
 
-set openjdk_version 17.0.7
+set openjdk_version 17.0.8
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,27 +29,17 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  41ec8cac543cbf2f199c0b1105a1e11629b596bf \
-                 sha256  fd8c32cbe06b9ecda87acc25ee212d74b7e221de5edc067f38ab5ba0c43445ae \
-                 size    193927373
+    checksums    rmd160  d60f2216d8128ad66bf35c0df2bb4f26b920ed84 \
+                 sha256  0a2d7c801900bff514210c3d2a59df89b710317c10446c7a2bb2ff34107b6fb4 \
+                 size    195814035
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  1ecad80bf8ffd61c41b7d357fc0756a018d29a51 \
-                 sha256  650be4ed94caa22ec4242b007f90f8f3bad32f66c0a60ff9a18044ce2761a049 \
-                 size    191683319
+    checksums    rmd160  6e54738912f5d771259c7c41bdd7aefff6ebb2b0 \
+                 sha256  f1bf35418e8319754eb1328cf100f32676235d5d22a426d859a6b3ea817603a9 \
+                 size    193606336
 }
 
 worksrcdir   ${distname}/zulu-17.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 18} {
-    # See https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.14 Mojave or later."
-        return -code error
-    }
-}
 
 homepage     https://www.azul.com/downloads/
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.44.15 (OpenJDK 17.0.8).

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?