### PR TITLE
openjdk20-zulu: update to 20.32.11

### DIFF
--- a/java/openjdk20-zulu/Portfile
+++ b/java/openjdk20-zulu/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk20-zulu
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-20-sts&os=macos&package=jdk
-version      20.30.11
+version      20.32.11
 revision     0
 
-set openjdk_version 20.0.1
+set openjdk_version 20.0.2
 
 description  Azul Zulu Community OpenJDK 20 (Short Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,27 +29,17 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  3404ec8d2d3008e6df66baafda7137a469072080 \
-                 sha256  befee9db92345d5146945061b721d3a6c6e182471c1536f87dbadfd5aab0e241 \
-                 size    203031268
+    checksums    rmd160  232cec730f1bfb0d53fc23a3cb866792e46f5f1c \
+                 sha256  12ff4a1ba0efb819ec66b3a0b8bb0ed4a433b9d1c205c24dc0a878e489e99dfa \
+                 size    205278797
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  a9dc3f90a5b1de952488766f7f9bfd7c326943e7 \
-                 sha256  01e59f0160d051524bb16d865652d25d00a85390581737a8f35f89057c80892d \
-                 size    200551830
+    checksums    rmd160  c9978c8d529386e4420402ae6e5511d0fdc673c9 \
+                 sha256  d79b8d67ab8c7d2012577414daada803f8c19363c21ce7d28e7d4663bffba886 \
+                 size    202801603
 }
 
 worksrcdir   ${distname}/zulu-20.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 18} {
-    # See https://www.azul.com/downloads/?version=java-20-sts&os=macos&package=jdk
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.14 Mojave or later."
-        return -code error
-    }
-}
 
 homepage     https://www.azul.com/downloads/
 


### PR DESCRIPTION
#### Description

Update to Azul Zulu 20.32.11 (OpenJDK 20.0.2).

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?