### PR TITLE
google-cloud-sdk: update to 439.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             438.0.0
+version             439.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  f3a00cb706c939f5f0993b06763ddb9feb99b12d \
-                    sha256  8f49c0f27d37859b69b430e1baf4741e7c3bce4b5c8f2f9b78627fa1d22e6ddf \
-                    size    100796402
+    checksums       rmd160  1dca36df4c717ae7ef561c137edc908414268d2e \
+                    sha256  991bd0c69ccfad49de81c68ee3e630826ca733966793c7606f63af5b7d3cc911 \
+                    size    100995658
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a324f9b193ba2f057fddc75d62cf5b9713909909 \
-                    sha256  4841c84890f013607ab8de52db76365ad4d037fe4cee86aaf030df1df7ac78cc \
-                    size    121050318
+    checksums       rmd160  b7c5b77e450094ae42dca5666cb4f61c17f188d6 \
+                    sha256  564c39e3782498a138c1f5d4990e3af0063d5e9bc6eff440802279dd49d11b88 \
+                    size    121250606
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  a99cfa40d85b681cf1074fd15af81fdab15adcd6 \
-                    sha256  927fb8fdc54b674929a863c69a40a50b5324214972de2da70d6a898d56c7f516 \
-                    size    118221168
+    checksums       rmd160  ed0ae8c6fb52e5370f6bfff76582cb9ee8f26cd6 \
+                    sha256  29ea27050cb84a0dd53a688c3c55057827f61881047658a839a475d15d66b0ac \
+                    size    118421397
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 439.0.0.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?