### PR TITLE
textmate2: Fix build on Ventura

### DIFF
--- a/editors/textmate2/Portfile
+++ b/editors/textmate2/Portfile
@@ -56,7 +56,8 @@ configure.cxx_stdlib    libc++
 # Patch needed during build for download of bundles; will revert later and
 # rebuild
 patchfiles              patch-Frameworks__io__src__path.cc-use-home-from-env.diff \
-                        patch-Applications__TextMate__src__RMateServer.mm-non-objc-ptr-cast-with-arc.diff
+                        patch-Applications__TextMate__src__RMateServer.mm-non-objc-ptr-cast-with-arc.diff \
+                        0001-Avoid-clang-15-crash-by-using-correct-array-size.patch
 
 pre-configure {
     copy ${filespath}/local.rave ${worksrcpath}

--- a/editors/textmate2/files/0001-Avoid-clang-15-crash-by-using-correct-array-size.patch
+++ b/editors/textmate2/files/0001-Avoid-clang-15-crash-by-using-correct-array-size.patch
@@ -1,0 +1,37 @@
+From 759b921e3b5b2422787c9381140c27d065c6bd48 Mon Sep 17 00:00:00 2001
+From: Clemens Lang <cal@macports.org>
+Date: Wed, 19 Jul 2023 10:41:37 +0200
+Subject: [PATCH] Avoid clang 15 crash by using correct array size
+
+Clang 15 crashes when compiling this code because the size of the array
+does not match the initializer. This is fixed in clang 16, but
+
+  Apple clang version 14.0.3 (clang-1403.0.22.14.1)
+
+which is currently shipped in Ventura is still affected by this.
+
+See https://github.com/llvm/llvm-project/issues/56016 for the upstream
+report of this problem.
+
+Signed-off-by: Clemens Lang <cal@macports.org>
+Upstream-Status: Submitted [https://github.com/textmate/textmate/pull/1463]
+---
+ Frameworks/Find/src/Find.mm | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Frameworks/Find/src/Find.mm b/Frameworks/Find/src/Find.mm
+index 39cbbe43..e2104fe4 100644
+--- ./Frameworks/Find/src/Find.mm
++++ ./Frameworks/Find/src/Find.mm
+@@ -1017,7 +1017,7 @@ static NSButton* OakCreateHistoryButton (NSString* toolTip)
+ 
+ - (void)didFind:(NSUInteger)aNumber occurrencesOf:(NSString*)aFindString atPosition:(text::pos_t const&)aPosition wrapped:(BOOL)didWrap
+ {
+-	static std::string const formatStrings[4][3] = {
++	static std::string const formatStrings[2][3] = {
+ 		{ "No more occurrences of “${found}”.", "Found “${found}”${line:+ at line ${line}, column ${column}}.",               "${count} occurrences of “${found}”." },
+ 		{ "No more matches for “${found}”.",    "Found one match for “${found}”${line:+ at line ${line}, column ${column}}.", "${count} matches for “${found}”."    },
+ 	};
+-- 
+2.41.0
+


### PR DESCRIPTION
#### Description

The current clang shipped with Xcode in Ventura crashes when encountering an initializer list that does not match the declared size of an array.

Avoid this crash by fixing the dimensions of the array.

No revbump because the code either compiled correctly (with non-buggy compilers), or not at all.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4.1 22F770820d x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

