### PR TITLE
update for version 1.2 of sysutils/tzdiff from 1.1.1

### DIFF
--- a/sysutils/tzdiff/Portfile
+++ b/sysutils/tzdiff/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        belgianbeer tzdiff 1.1.1
+github.setup        belgianbeer tzdiff 1.2
 revision            0
-checksums           rmd160  20247a433252566bc9d5b5698a6fbea0945eab60 \
-                    sha256  0e98645a96987a7364a42e68f9efb036dbd4a37e1342af5f790260c48fc4ea4c \
-                    size    4968
+checksums           rmd160  66b3cab8884b0127535f5af975530945d9cb8172 \
+                    sha256  edbdb6bf36ee74ed6ee97a93535a5026b67c94f037fb4b825800a7ef12e0a91f \
+                    size    5867
 
 categories          sysutils
 platforms           any


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
sysutils/tzdiff was changed.
- support UTC for start time.
- timezone name changed to only city in default
- -l option added for compatibility.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 / FreeBSD 13.2 / Debian 10

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
