### PR TITLE
pari: call purge only when it is possible

### DIFF
--- a/math/pari/Portfile
+++ b/math/pari/Portfile
@@ -28,7 +28,9 @@ checksums           rmd160  7f8bb9badcd43665704fbdabe50a9cf4b383b952 \
 # System's tar on at least macOS Ventura is broken
 # See: https://trac.macports.org/ticket/67336
 pre-install {
-    system "/usr/sbin/purge"
+    if {[getuid] == 0 && [file exists /usr/sbin/purge]} {
+        system "/usr/sbin/purge"
+    }
 }
 
 depends_lib         port:gmp \


### PR DESCRIPTION
#### Description

Fix port on system where call of /usr/bin/purge is impossible

See: https://trac.macports.org/ticket/67336


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->