### PR TITLE
openjdk20-sap: update to 20.0.2

### DIFF
--- a/java/openjdk20-sap/Portfile
+++ b/java/openjdk20-sap/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk20-sap
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/20
-version      20.0.1
+version      20.0.2
 revision     0
 
 description  SAP Machine 20
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  0277c0c118d66cf9ef77b6e0f47cef40d8810541 \
-                 sha256  2140c1c35966c5202e4ded8e3a22b2e2114ad011cd49ea561b529dfd2b4257ab \
-                 size    189058189
+    checksums    rmd160  38f2ac23deaa728a7cfbbdca9dbfc071d4d98221 \
+                 sha256  3565914dffecafbccb31c7768b8efd804ee47144cff8a593685d06f6945ece94 \
+                 size    189349299
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  417c8666b5b768281e81e6dae56397433e72d5c4 \
-                 sha256  7f587844546558174f3ab48d7e1523373bb4b35144cdf87b66ff4c9e88885177 \
-                 size    186789886
+    checksums    rmd160  ce87c75024c6d0ac396374b9e2263825775b6f19 \
+                 sha256  5cedd9a935ed094df5f6ccecbb937f1c65b0db11ede2ca3e1a41de92084c42c6 \
+                 size    187089134
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 20.0.2.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?