### PR TITLE
urjtag: move pkgconfig from depends_lib to depends_build

### DIFF
--- a/cross/urjtag/Portfile
+++ b/cross/urjtag/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                urjtag
 version             2021.03
+revision            1
 categories          cross devel
 license             GPL MIT
 maintainers         {snc @nerdling} openmaintainer
@@ -20,8 +21,8 @@ checksums           rmd160  5a064ba37ffedcd6f8e57506947ac5d6c4ea5af1 \
                     sha256  b0a2eaa245513af096dc4d770109832335c694c6c12aa5e92fefae8685416f1c \
                     size    1208440
 
-depends_lib         port:pkgconfig \
-                    port:libftdi0
+depends_build       port:pkgconfig
+depends_lib         port:libftdi0
 
 configure.args-append   --without-ftd2xx --with-libftdi --disable-python --disable-apps
 # python is disabled due to linker issues during build


### PR DESCRIPTION
#### Description

This Portfile had `port:pkgconfig` in `depends_lib` but it probably belongs in `depends_build`. This pull request moves `port:pkgconfig` from `depends_lib` to `depends_build`.

Note: I got errors with `sudo port -vst install` but the error message was:

    /opt/local/bin/gmkdir: No such file or directory

which is wierd because I do have /opt/local/bin/gmkdir installed (from coreutils), and a plain `port install urjtag` worked fine. So I don't know if it's important.

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?