### PR TITLE
libjwt: move pkgconfig from depend_lib to depends_build

### DIFF
--- a/devel/libjwt/Portfile
+++ b/devel/libjwt/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        benmcollins libjwt 1.9.0 v
-revision            2
+revision            3
 
 platforms           darwin
 categories          devel
@@ -22,4 +22,6 @@ checksums           rmd160  9745d46848cec2a49c251a61d12e5af8cec5047c \
 
 use_autoreconf      yes
 
-depends_lib         port:jansson path:lib/libssl.dylib:openssl port:pkgconfig
+depends_build-append \
+                    port:pkgconfig
+depends_lib         port:jansson path:lib/libssl.dylib:openssl


### PR DESCRIPTION
#### Description

This Portfile had `port:pkgconfig` in `depends_lib` but it probably belongs in `depends_build`. This pull request moves it.

Note: The port -vst install check failed with this error:

    /bin/sh: /opt/local/bin/gmkdir: No such file or directory

But that is installed (coreutils). I don't know if it's important. A plain `sudo port install libjwt` works fine.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
