### PR TITLE
mumps: update to 5.6.1

### DIFF
--- a/math/mumps/Portfile
+++ b/math/mumps/Portfile
@@ -8,8 +8,8 @@ PortGroup                   makefile 1.0
 PortGroup                   conflicts_build 1.0
 
 name                        mumps
-version                     5.6.0
-revision                    1
+version                     5.6.1
+revision                    0
 categories                  math
 license                     CeCILL-C
 platforms                   darwin
@@ -27,9 +27,9 @@ master_sites                ${homepage}
 
 distname                    MUMPS_${version}
 
-checksums                   rmd160  7e3bb4d1a95e257b43401278de630b78ea1fa4a5 \
-                            sha256  3e08c1bdea7aaaba303d3cf03059f3b4336fa49bef93f4260f478f067f518289 \
-                            size    4337674
+checksums                   rmd160  b587a076c11fe4d63b82bd5200a45431abcabdcb \
+                            sha256  1920426d543e34d377604070fde93b8d102aa38ebdf53300cbce9e15f92e2896 \
+                            size    4338885
 
 conflicts_build-append      ${name}
 


### PR DESCRIPTION
#### Description

Clean update mumps without any revbump because ABI/API doesn't changed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6.7 21G651 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->