### PR TITLE
singular: update to 4.3.2p3

### DIFF
--- a/math/singular/Portfile
+++ b/math/singular/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        Singular Singular 4-3-2p2 Release-
+github.setup        Singular Singular 4-3-2p3 Release-
 name                singular
 revision            0
 version             [string map {- .} ${github.version}]
@@ -23,9 +23,9 @@ long_description \
     geometry, and singularity theory.
 homepage            https://www.singular.uni-kl.de/
 
-checksums           rmd160  6e418df33304486101b4b10198a7aead615d4a64 \
-                    sha256  04d88ed4a33dc0a2ceddff4bad13d04a8014cfef0a95d0d5bfd84db7802b2e79 \
-                    size    13756650
+checksums           rmd160  69b64977a0631bd9fb1bc8b0e330d95db84f438d \
+                    sha256  e81ac00161d9ea1b4666dc4373ae2165f3fff68bb6e6b519151971896bae0063 \
+                    size    13757103
 
 # clang: error: unknown argument: '-fno-delete-null-pointer-checks'
 # https://trac.macports.org/ticket/65804


### PR DESCRIPTION
#### Description

Clean update singular without any revbump because ABI/API doesn't changed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6.7 21G651 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->