### PR TITLE
openjdk17-sap: update to 17.0.8

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk17-sap
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.7
+version      17.0.8
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  a320b141567ab7aba6f521f4002a4945852a415a \
-                 sha256  16b876049d34050d1442fe7971c70b581e70c1dec74c3755e2f53c1d04bd2ad0 \
-                 size    180385214
+    checksums    rmd160  8f46006e183c89192ef128c90b33dd625fbf91f3 \
+                 sha256  c78bddc218c1548cf5d06c9c5c1baeb1ad951b9247bf8be539e73bb2b53af7e5 \
+                 size    180670179
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  ab54760f972b274e9c6ca59076a4aa4cad46629f \
-                 sha256  3db9ccca0b5df89a10f53c566bc78f3fd5742d07c11044957996e13f2459c6f6 \
-                 size    178090814
+    checksums    rmd160  5ef2cee1180fbfcede9a1efc50fae1c465703c44 \
+                 sha256  7650dd4daa01e5a0189180d945d2f8a93b1141c24c1ecc4a8fc78067e512e22b \
+                 size    178386578
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.8.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?