### PR TITLE
openjdk11-sap: update to 11.0.20

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk11-sap
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/11
 supported_archs  x86_64 arm64
 
-version      11.0.19
+version      11.0.20
 revision     0
 
 description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  0b9db762c251d352a4198b28a65545fc4773970f \
-                 sha256  6e57187b804f6614834db1b1cef5469e7e6c74aa9224b685b3fbf8cd99e0083d \
-                 size    187283662
+    checksums    rmd160  6a2e72fd114ef24c7147cca9fb97d242e9d93727 \
+                 sha256  6c251b1d8fe46350c8bbfc94c88fee91115ba4966e158fa71d46190be81d8629 \
+                 size    187514176
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  a1e2c3ccf989519d8d18e56e20f945783e35e700 \
-                 sha256  be9a2446297f641d4cdbbd4083f08a8839b6881d9a0a9dccff6be5038589c029 \
-                 size    185411755
+    checksums    rmd160  919a2c382f2fd497028a70312f382143ec8c2b0c \
+                 sha256  52bb4d9840cacb05d23986bda75e908e65a552a3dd2ed6df2ab3e9b0e9f9681c \
+                 size    185615130
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 11.0.20.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?