### PR TITLE
openjdk17-microsoft: update to 17.0.8

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      17.0.7
+version      17.0.8
 set build    7
 revision     0
 
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  15310019479998e592e2fdf5ffcf6f7687da0030 \
-                 sha256  1a7ccf0b748c9b3ef441678aebfe85631986f7860f8b1c5eab263cfee41889c0 \
-                 size    187677698
+    checksums    rmd160  ea9ff26770a5b4e01b50c09ec795393c3bb19492 \
+                 sha256  88e74d5011a36bc7120e66d05ef66deb5c439125b80e830f7ae073897a43bd65 \
+                 size    188014149
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  f4427717f247b887fce6a371de4e7d8902f4f52b \
-                 sha256  48e4f97b524ae4aed5c80b4672fa746c72efb648172a99828ffe5ed501029a6e \
-                 size    177836676
+    checksums    rmd160  b74b21917a5e493c44552e8b543d3184de39dffc \
+                 sha256  4bbdb18be7af5f2af8fcb782e6372ac32d854d5672006ebcc623f544298646c0 \
+                 size    178140995
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.8.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?