### PR TITLE
openjdk11-microsoft: update to 11.0.20

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      11.0.19
-set build    7
+version      11.0.20
+set build    8
 revision     0
 
 description  Microsoft Build of OpenJDK 11 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  b6d503d1a9bcccfb58e3777478b284c6bcfc7657 \
-                 sha256  61c3b5e5770154788505670085df8345173f2881e456c396659e4ba5e54552cc \
-                 size    187478168
+    checksums    rmd160  cc737933af49e6474296615d03cc27707e923c66 \
+                 sha256  70f52a819119f97c54e825f56f75d813e60088816f684bc59e06608783eb0a78 \
+                 size    187730360
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  f9f07d546fb632762f030c9f0c103876746f424f \
-                 sha256  ea35aa9cdadd6bde65fc470b60e88a1ed015ef445ae3958f968317d7d643657c \
-                 size    185045288
+    checksums    rmd160  fbf166d6a7b5571b36ecef54ae83aba28b93b561 \
+                 sha256  7ec3a5a77a73fb076adbb369a967e53716b250da611bd0c45b5760111e6ee902 \
+                 size    185287208
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.20.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?