### PR TITLE
wxMaxima: Update to 23.05.1 and use wxWidgets 3.2

### DIFF
--- a/math/wxMaxima/Portfile
+++ b/math/wxMaxima/Portfile
@@ -4,36 +4,48 @@ PortSystem          1.0
 
 PortGroup           active_variants 1.1
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           wxWidgets 1.0
 PortGroup           github 1.0
 
-github.setup        wxMaxima-developers wxmaxima 21.02.0 Version-
-revision            1
+github.setup        wxMaxima-developers wxmaxima 23.05.1 Version-
+revision            0
+checksums           rmd160  195fbba20e3cd1b83e19b3e3b76f1ea8f60e267c \
+                    sha256  0c26d1439f5aba30cae94d5718d9c35bf83490953cc8696c371658ed13fd57c1 \
+                    size    16220058
+
 name                wxMaxima
 maintainers         @MSoegtropIMC
 license             GPL-2
 # openssl is a dependency of curl in cmake, so build only
 license_noconflict  openssl
-platforms           darwin
 categories          math aqua
 description         Graphical user interface for Maxima based on wxWidgets
 long_description    Maxima is a Computer Algebra System (CAS) and wxMaxima is a work book style \
                     graphical front end for it based on wxWidgets
 
-checksums           rmd160  1160cba3db29ab059afcd2dafbbe02425b2f83f0 \
-                    sha256  a8fd7228beeaa93ae8017d24d3bb652815ed159bd943a6e7c939643a705e3500 \
-                    size    16251280
+github.tarball_from archive
 
 universal_variant   no
 
+compiler.cxx_standard \
+                    2014
+
+# https://github.com/wxMaxima-developers/wxmaxima/issues/1784
+compiler.blacklist-append \
+                    {clang < 1316} \
+                    macports-clang-3.* \
+                    {macports-clang-[4-9].0} \
+                    {macports-clang-1[0-2]}
+
 # Note: as of Match 2020 (1b00466)the build with wxWidgets-3.2 has serious issues with scrolling
-wxWidgets.use       wxWidgets-3.0
+wxWidgets.use       wxWidgets-3.2
 
 depends_lib-append  port:${wxWidgets.port} \
-                    lib:lib/libomp/libomp.dylib:libomp
-
-depends_run-append  port:gnuplot \
+                    lib:lib/libomp/libomp.dylib:libomp \
                     port:maxima
+
+depends_run-append  port:gnuplot
 
 post-patch {
     reinplace -W ${worksrcpath} "s|OSX_MACPORTS_PREFIX \"/opt/local\"|OSX_MACPORTS_PREFIX \"${prefix}\" // patched by MacPorts|" src/Dirstructure.h
@@ -72,9 +84,9 @@ wxMaxima and Maxima startup files can typically be found in:
 ATTENTION: On macOS BigSur there is an issue with wxWidgets, which has the\
 effect that wxMaxima does not start. In order to fix this, run these\
 commands:
-  sudo port -f uninstall wxwidgets-3.0
-  sudo port -v -s install wxwidgets-3.0
-If this does not help, you need to update XCode.
+  sudo port -f uninstall wxWidgets-3.2
+  sudo port -v -s install wxWidgets-3.2
+If this does not help, you need to update Xcode.
 "
 
 github.livecheck.regex  {([a-z0-9.]+)}


### PR DESCRIPTION
#### Description

This is a conversion of a patch from [ticket 66914](https://trac.macports.org/ticket/66914) into a PR with additional fixes. The ticket patch merely updated to 23.05.1 and switched from wxWidgets 3.0 to 3.2. I've added these changes to that:

* Move maxima to be a library dependency because CMake checks for it.
* Indicate C++14 requirement as indicated in CMakeLists.txt and enforce even newer compiler than that due to build failure on earlier compilers.
* Specify `github.tarball_from archive` (adjusting the checksums to match) since all ports that use the github portgroup without specifying `github.tarball_from` should do so.
* Remove `platforms darwin` since that's the default.

Closes: https://trac.macports.org/ticket/66914

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.7 21G651 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
