### PR TITLE
py-dockerpty: add py310 and py311 subports

### DIFF
--- a/python/py-dockerpty/Portfile
+++ b/python/py-dockerpty/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  6d0604c549d301b92b98c2b25825ff04881e48cd \
                     sha256  9603174148835398767ee75ac763333321bf84f764de93891a5decd07aa58d08 \
                     size    19608
 
-python.versions     37 38 39
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \


### PR DESCRIPTION
###### Type(s)

- [x] enhancement

###### Tested on
macOS 13.4.1 22F770820d x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?