### PR TITLE
crystal: move pkgconfig from depends_lib to depends_run

### DIFF
--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -20,6 +20,7 @@ homepage            https://crystal-lang.org
 
 set llvm_version    16
 
+# pkg-config is used when compiling user programs
 depends_lib         port:boehmgc \
                     port:gmp \
                     port:libevent \


### PR DESCRIPTION
#### Description

This Portfile had `port:pkgconfig` in `depends_lib` but it probably belongs in `depends_build`. This pull request moves `port:pkgconfig` from `depends_lib` to `depends_build`.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?