### PR TITLE
zabbix4: move pkgconfig from depends_lib to depends_build

### DIFF
--- a/net/zabbix4/Portfile
+++ b/net/zabbix4/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 
 name                zabbix4
-revision            0
+revision            1
 categories          net
 maintainers         {eborisch @eborisch} openmaintainer
 platforms           darwin
@@ -165,13 +165,13 @@ if {[isFlavor agent ${subport}]} {
     long_description-append "This port provides the central server component."
     conflicts-append        zabbix3
 
+    depends_build-append    port:pkgconfig
     depends_lib-append      port:curl \
                             port:OpenIPMI \
                             path:lib/libssl.dylib:openssl \
                             port:libssh2 \
                             port:libxml2 \
                             port:net-snmp \
-                            port:pkgconfig \
                             port:zlib
 
     depends_run-append      port:fping


### PR DESCRIPTION
#### Description

This Portfile had `port:pkgconfig` in `depends_lib` but it probably belongs in `depends_build`. This pull request moves it.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?