### PR TITLE
pkcs11-helper: move pkgconfig from depends_lib to depends_build

### DIFF
--- a/security/pkcs11-helper/Portfile
+++ b/security/pkcs11-helper/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           openssl 1.0
 
 github.setup        OpenSC pkcs11-helper 1.27 pkcs11-helper-
-revision            2
+revision            3
 
 openssl.branch      1.1
 
@@ -22,8 +22,8 @@ checksums           rmd160  59c17287ec3ae4c4256364d45ec80d0621b911c5 \
                     sha256  792d7b1ad6e681145b2b3d22cb88afcc43d597761a53d7475ef36ccbdb64d709 \
                     size    115333
 
-depends_lib         path:lib/pkgconfig/gnutls.pc:gnutls \
-                    port:pkgconfig
+depends_build       port:pkgconfig
+depends_lib         path:lib/pkgconfig/gnutls.pc:gnutls
 
 use_autoreconf      yes
 


### PR DESCRIPTION
#### Description

This Portfile had `port:pkgconfig` in `depends_lib` but it probably belongs in `depends_build`. This pull request moves it.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
