### PR TITLE
the_Foundation: define environ correctly

### DIFF
--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 gitea.domain        git.skyjake.fi
 gitea.setup         skyjake the_Foundation 1.6.1 v
-revision            0
+revision            1
 categories          devel
 license             BSD
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -31,5 +31,7 @@ depends_lib-append  port:curl \
                     port:zlib
 
 worksrcdir          the_foundation
+
+patchfiles-append   patch-environ.diff
 
 compiler.c_standard 2011

--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -35,3 +35,7 @@ worksrcdir          the_foundation
 patchfiles-append   patch-environ.diff
 
 compiler.c_standard 2011
+
+# t_test.c: error: variable 'remCount' set but not used [-Werror,-Wunused-but-set-variable]
+configure.args-append \
+                    -DTFDN_ENABLE_WARN_ERROR=OFF

--- a/devel/the_Foundation/files/patch-environ.diff
+++ b/devel/the_Foundation/files/patch-environ.diff
@@ -1,0 +1,17 @@
+--- src/platform/posix/process.c.orig	2023-03-09 14:03:49.000000000 +0800
++++ src/platform/posix/process.c	2023-07-22 02:41:02.000000000 +0800
+@@ -59,7 +59,13 @@
+ iDefineObjectConstruction(Process)
+ iDefineClass(Process)
+ 
+-extern char **environ; /* The environment variables. */
++/* The environment variables. */
++#ifdef __APPLE__
++#include <crt_externs.h>
++#define environ (*_NSGetEnviron())
++#else
++ extern char **environ;
++#endif
+ 
+ void init_Process(iProcess *d) {
+     d->pid     = 0;


### PR DESCRIPTION
#### Description

The port is broken quite on a number of systems: https://ports.macports.org/port/the_Foundation/details/
While logs are dead, likely it is caused by missing `environ` define. Fix that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
