### PR TITLE
py-poetry-core: add missing dep py-idna

### DIFF
--- a/python/py-poetry-core/Portfile
+++ b/python/py-poetry-core/Portfile
@@ -9,7 +9,7 @@ PortGroup           select 1.0
 # both in terms of APIs but also the version pinning.
 name                py-poetry-core
 version             1.6.1
-revision            0
+revision            1
 
 distname            poetry_core-${version}
 
@@ -38,6 +38,8 @@ if {${name} ne ${subport}} {
     if {${python.version} < 38} {
         depends_lib-append  port:py${python.version}-importlib-metadata
     }
+
+    depends_lib-append  port:py${python.version}-idna
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description

`sudo port install -vst py-poetry-core` failed because the py-idna package was hidden by the -t option. This pull request adds `port:py${python.version}-idna` to `depends_lib`.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
