### PR TITLE
fsearch: move pkgconfig from depends_lib to depends_build

### DIFF
--- a/sysutils/fsearch/Portfile
+++ b/sysutils/fsearch/Portfile
@@ -7,7 +7,7 @@ PortGroup           meson 1.0
 
 github.setup        cboxdoerfer fsearch 0.2.2
 epoch               1
-revision            3
+revision            4
 categories          sysutils
 license             GPL-2+
 maintainers         {mps @Schamschula} openmaintainer
@@ -24,6 +24,7 @@ compiler.c_standard 2011
 # AT_SYMLINK_NOFOLLOW
 legacysupport.newest_darwin_requires_legacy 13
 
+depends_build       port:pkgconfig
 depends_lib         port:adwaita-icon-theme \
                     port:dbus-glib \
                     port:gettext \
@@ -32,8 +33,7 @@ depends_lib         port:adwaita-icon-theme \
                     port:hicolor-icon-theme \
                     path:lib/pkgconfig/icu-uc.pc:icu \
                     port:intltool \
-                    port:pcre2 \
-                    port:pkgconfig
+                    port:pcre2
 
 pre-configure {
        copy ${filespath}/strverscmp.c ${worksrcpath}/src/


### PR DESCRIPTION
#### Description

This Portfile had `port:pkgconfig` in `depends_lib` but it probably belongs in `depends_build`. This pull request moves it.

Note: `port install -vst install fsearch` didn't work because an indirect dependency (py-poetry-core) failed to install with -vst. I have submitted a separate pull request for that port. With that fixed, `port install -vst fsearch` works as well.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
