### PR TITLE
miniflux: update to 2.0.46

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.45
+go.setup            github.com/miniflux/v2 2.0.46
 go.package          miniflux.app
 name                miniflux
 revision            0
@@ -16,9 +16,9 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  dcf7756cd48f51b74319c9f6b90568bad62fb40f \
-                        sha256  9196a05bfb0c6630f4b5b6ecba84e520ad321786debabb5c767684d75d4277ad \
-                        size    580612
+                        rmd160  1b9ef683a91720b68b3a7fae64eaf417419f7f44 \
+                        sha256  591f585ba5cd323f473022e88a0badaf3a44fe1047b53ad53a8b3886bb3d1ab9 \
+                        size    586323
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
@@ -31,17 +31,12 @@ go.vendors          mvdan.cc/xurls \
                         rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
                         sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
                         size    91208 \
-                    gopkg.in/square/go-jose.v2 \
-                        lock    v2.6.0 \
-                        rmd160  56e581a46f0364551657e2b7698bd022973e9d7c \
-                        sha256  565d45760f1ee44d3c076b9f5ee46e14e046c00304ddfab345fc48443fd6031c \
-                        size    310376 \
                     google.golang.org/protobuf \
                         repo    github.com/protocolbuffers/protobuf-go \
-                        lock    v1.30.0 \
-                        rmd160  80cc9e6edacb19c225de4f8c07f3c5f79ac9e84a \
-                        sha256  d4ac2c8ff456abc74679f4f37cc8d7aac195684f7698d2030fc5bfe14243b5fa \
-                        size    1299719 \
+                        lock    v1.31.0 \
+                        rmd160  2a79f7c0fd76cecaf9c25e53ad925b9e8fb5f8dc \
+                        sha256  57f5c0096053ab69a9a74f2d815d23a25d6a1efcfc2f21ed92d7d8acf38bbfb1 \
+                        size    1312091 \
                     google.golang.org/appengine \
                         repo    github.com/golang/appengine \
                         lock    v1.6.7 \
@@ -49,35 +44,35 @@ go.vendors          mvdan.cc/xurls \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
                     golang.org/x/text \
-                        lock    v0.10.0 \
-                        rmd160  5a436563b2063896e98976f9d30e74051a024888 \
-                        sha256  73558470c5d1e4c49244b4519c77f4b0dc5988ec8138f89963cbc9fc2aa91a15 \
-                        size    8358210 \
-                    golang.org/x/term \
-                        lock    v0.9.0 \
-                        rmd160  7d57f52bf0195a21d9628f7d04b202b6426bfa21 \
-                        sha256  7628c777f684cd13619c91b2b007c27e6d678fcfee3c6e1a6741a418a5c907d6 \
-                        size    14799 \
-                    golang.org/x/sys \
-                        lock    v0.9.0 \
-                        rmd160  2cc3f76a07816bf45247088a57f093ee1dfebd00 \
-                        sha256  138197a232bf1882aeb8865e8263afc6e7dc3b34e632361098ea3506c13f6791 \
-                        size    1440217 \
-                    golang.org/x/oauth2 \
-                        lock    v0.9.0 \
-                        rmd160  adb437da22c0f7ffd377d9c743f25c45456f935f \
-                        sha256  1920ba51b2dbed56e8e12708939e85c205b56fed329754f5e2f0ab9dbad05f98 \
-                        size    88643 \
-                    golang.org/x/net \
                         lock    v0.11.0 \
-                        rmd160  3a7e9ec93e351ad5dd322e0668c5249bb72dbd1d \
-                        sha256  d8f2473a61f0c3d55f7a1ef159ed6b16479323a5e4e35ec1e81fe790aa918042 \
-                        size    1284069 \
-                    golang.org/x/crypto \
+                        rmd160  c4603f279575a9642b4444914247fdbb0e9954c4 \
+                        sha256  43460e0115cf4129f1de68b767e0f87f9988456e83873d89877c6af5d99e790f \
+                        size    8971482 \
+                    golang.org/x/term \
                         lock    v0.10.0 \
-                        rmd160  f3e7f723fa805570142bcb6fc2a7c168f32b1a50 \
-                        sha256  c43ab957e80b3d449442d11ecd9e06d64d9962cf8a632652e6d408f55d844c9d \
-                        size    1785065 \
+                        rmd160  3fe74cc1e896e699905f977770d03fb18d57446e \
+                        sha256  9aecdd02affdb29761beced82234ea873f6452500e7338482be692816c29d6e1 \
+                        size    14801 \
+                    golang.org/x/sys \
+                        lock    v0.10.0 \
+                        rmd160  83368c420a37696a8f102d9409b238b89a9c9d82 \
+                        sha256  131890e51d97b703ad20cebc231370408213b554c32231001d204bfac7ac96d5 \
+                        size    1441834 \
+                    golang.org/x/oauth2 \
+                        lock    v0.10.0 \
+                        rmd160  4f169fe6bfb54e5e56a8ed08d69d552ce5b323ec \
+                        sha256  095faa5b40de1e5f3e1f6982af50d2fc30a1eaa278055f340ed31d38eb8ea24d \
+                        size    140845 \
+                    golang.org/x/net \
+                        lock    v0.12.0 \
+                        rmd160  d599e183fa279c044432d748157f06265fe5d787 \
+                        sha256  b0f10ee750ae27d7761d93c01c01aceea2f5b25a591acbb9bc91f378cf04920d \
+                        size    1371560 \
+                    golang.org/x/crypto \
+                        lock    v0.11.0 \
+                        rmd160  c00277dedc81b9ed173fb03d8d8c1293ff659463 \
+                        sha256  bb0cd20fd6f6bc93d8546af593d8763ff89875078758563a1881c0316283f80e \
+                        size    1789100 \
                     github.com/yuin/goldmark \
                         lock    v1.5.4 \
                         rmd160  7e428750043e781507d94e54431c488a2e07110a \
@@ -133,16 +128,16 @@ go.vendors          mvdan.cc/xurls \
                         rmd160  ad0170daf3d6fd4e32623bdb80c6230fdd511c58 \
                         sha256  884d73dd250c539bc3a784b4d8abce9381d63820737734371c858c4a87da12c7 \
                         size    1102658 \
-                    github.com/pquerna/cachecontrol \
-                        lock    v0.1.0 \
-                        rmd160  e819f8dcacadd42bbe783a3c1810f17f3e43fa95 \
-                        sha256  0b40f48dd0734d739f3e360fea8f43fedd86cee3abfbdf85813573f8eab97fb3 \
-                        size    19877 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
                         sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
                         size    11409 \
+                    github.com/mccutchen/go-httpbin \
+                        lock    v2.10.0 \
+                        rmd160  df8404586a47ad0d47b0e1888c84d3f8e2321c6f \
+                        sha256  22896a125762309ba98c42eefb20c2b5cc1b009fb201873e5b8485a894a72bc8 \
+                        size    124367 \
                     github.com/matttproud/golang_protobuf_extensions \
                         lock    v1.0.4 \
                         rmd160  5cd0af4220838331f336b1dca99297e11441be69 \
@@ -178,16 +173,21 @@ go.vendors          mvdan.cc/xurls \
                         rmd160  80821ad149f661570509a35adcf2d1d73fcf0c10 \
                         sha256  98e078b4f8909436790f12c39fcc589ac7b4e9b39e342966d60470aa2f14fad8 \
                         size    2076483 \
+                    github.com/go-jose/go-jose \
+                        lock    v3.0.0 \
+                        rmd160  adc3ad2bfe484fe710cb86640cb797b3d3182e5e \
+                        sha256  9924c98a6cd4d4d762ba1052bed640798fb3af14d56fdc6603452a80053fcaec \
+                        size    315140 \
                     github.com/davecgh/go-spew \
                         lock    v1.1.1 \
                         rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
                         sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
                         size    42171 \
                     github.com/coreos/go-oidc \
-                        lock    v2.2.1 \
-                        rmd160  d91319f3d8e0a3c82d9a2ee16e0fc101208c253f \
-                        sha256  cb7f8f625e511034f24505efeee92be610f2cbd957114d9c591aea9f29afa22c \
-                        size    24141 \
+                        lock    v3.6.0 \
+                        rmd160  5e15391fd2035dac54fb44a0cb9f9143da2fa877 \
+                        sha256  fa7509bfad868689ddbefda3c726b0f203f2ad95f9f4f130d34bf90014f2a1b4 \
+                        size    31306 \
                     github.com/cespare/xxhash \
                         lock    v2.2.0 \
                         rmd160  17d6143308fd7f2ccf9b885b19a2445a612ce013 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/miniflux/v2/releases/tag/2.0.46)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
