### PR TITLE
goldendict: update to 1.5.0

### DIFF
--- a/office/goldendict/Portfile
+++ b/office/goldendict/Portfile
@@ -2,13 +2,17 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           qmake 1.0
+PortGroup           qmake5 1.0
 
-github.setup        goldendict goldendict 1.5.0-RC2
-revision            1
+github.setup        goldendict goldendict 1.5.0
+revision            0
+
+checksums           rmd160  be6a97dfe705a637f0e7bb86514ce5faf4fe960d \
+                    sha256  d9ddaca3abc6fced591ecd6060066891a70e672fd687a7c676135b273bf90a67 \
+                    size    20371056
+
 # FIXME: add proper categories
 categories          office
-platforms           darwin
 maintainers         ryandesign openmaintainer
 license             GPL-3+
 
@@ -25,9 +29,6 @@ long_description    A feature-rich dictionary lookup program, \
 
 homepage            http://goldendict.org/
 
-checksums           rmd160  ae6b9d180492bb5beca70ae5dc23ea0a407fcb1f \
-                    sha256  e735cd74030b34accf20cece78dd2363222067cd5d8e593f70117751199fd36d
-
 depends_lib-append  port:bzip2 \
                     port:eb \
                     path:lib/libavcodec.dylib:ffmpeg \
@@ -38,8 +39,8 @@ depends_lib-append  port:bzip2 \
                     port:libiconv \
                     port:lzo2 \
                     port:opencc \
-                    port:phonon \
-                    port:zlib
+                    port:zlib \
+                    port:zstd
 
 post-extract {
     delete ${worksrcpath}/maclibs ${worksrcpath}/winlibs
@@ -50,17 +51,13 @@ patchfiles          patch-goldendict.pro.diff \
                     patch-epwing_book.hh.diff \
                     patch-tiff.cc.diff
 
+qt5.depends_component        qtwebkit
+qt5.depends_build_component  qttools
+
+configure.args-append        goldendict.pro
+
 post-patch {
     reinplace "s|@VERSION@|${version}|g" ${worksrcpath}/goldendict.pro
-}
-
-post-configure {
-    # For some reason the Makefile qmake generates hardcodes the C++ compiler
-    # that qt4-mac was made with as the one used to build any source files
-    # specified as OBJECTIVE_SOURCES. Replace it with $(CXX) which is set by
-    # the qmake portgroup.
-    copy ${worksrcpath}/Makefile ${worksrcpath}/Makefile.orig
-    reinplace -E {/\$\(QMAKE_COMP_QMAKE_OBJECTIVE_CXXFLAGS\)/s/^([[:space:]]+)[^[:space:]]+/\1\$\(CXX\)/} ${worksrcpath}/Makefile
 }
 
 destroot {

--- a/office/goldendict/files/patch-goldendict.pro.diff
+++ b/office/goldendict/files/patch-goldendict.pro.diff
@@ -1,6 +1,8 @@
---- goldendict.pro.orig	2016-04-26 11:32:50.000000000 -0500
-+++ goldendict.pro	2016-05-16 00:37:56.000000000 -0500
-@@ -7,7 +7,7 @@
+diff --git i/goldendict.pro w/goldendict.pro
+index fe2e4b4f..1c5f0c17 100644
+--- goldendict.pro
++++ goldendict.pro
+@@ -7,7 +7,7 @@ VERSION = 1.5.0+git
  # rebuilt; and doing it here is required too since any other way the RCC
  # compiler would complain if version.txt wouldn't exist (fresh checkouts).
  
@@ -9,18 +11,20 @@
  
  isEmpty( hasGit ) {
    message(Failed to precisely describe the version via Git -- using the default version string)
-@@ -203,25 +203,22 @@
+@@ -220,26 +220,23 @@ mac {
          -lvorbisfile \
          -lvorbis \
          -logg \
--        -lhunspell-1.2 \
-+        -lhunspell-1.3 \
+-        -lhunspell-1.6.1 \
++        -lhunspell-1.7 \
          -llzo2
-     isEmpty(DISABLE_INTERNAL_PLAYER) {
+     !CONFIG( no_ffmpeg_player ) {
          LIBS += -lao \
+-            -lswresample-gd \
 -            -lavutil-gd \
 -            -lavformat-gd \
 -            -lavcodec-gd
++            -lswresample \
 +            -lavutil \
 +            -lavformat \
 +            -lavcodec
@@ -41,7 +45,7 @@
                        cp -R locale/*.qm GoldenDict.app/Contents/MacOS/locale/ & \
                        mkdir -p GoldenDict.app/Contents/MacOS/help & \
                        cp -R $${PWD}/help/*.qch GoldenDict.app/Contents/MacOS/help/
-@@ -529,7 +526,7 @@
+@@ -576,7 +573,7 @@ CONFIG( no_epwing_support ) {
    SOURCES += epwing.cc \
               epwing_book.cc \
               epwing_charmap.cc
@@ -50,7 +54,16 @@
  }
  
  CONFIG( chinese_conversion_support ) {
-@@ -595,7 +592,7 @@
+@@ -591,7 +588,7 @@ CONFIG( chinese_conversion_support ) {
+     Release: LIBS += -lopencc
+   } else {
+     mac {
+-      LIBS += -lopencc.2
++      LIBS += -lopencc
+     } else {
+       LIBS += -lopencc
+     }
+@@ -651,7 +648,7 @@ TRANSLATIONS += locale/ru_RU.ts \
    revtarget.target     = $$PWD/version.txt
  
    !win32 {


### PR DESCRIPTION
#### Description
https://github.com/goldendict/goldendict/releases/tag/1.5.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
