### PR TITLE
opendx: fix implicitly declared function errors in compilation

### DIFF
--- a/science/opendx/Portfile
+++ b/science/opendx/Portfile
@@ -84,6 +84,10 @@ configure.pre_args-replace \
 
 configure.args-append   --without-javadx
 
+# ignore implicitly declared functions to allow compilation with modern
+# compilers
+configure.cflags-append -Wno-error=implicit-function-declaration
+
 post-destroot {
     foreach bin [glob -tails -directory ${destroot}${prefix}/libexec/${name}/bin *] {
         ln -s ${prefix}/libexec/${name}/bin/${bin} ${destroot}${prefix}/bin/${bin}


### PR DESCRIPTION
#### Description
Make it possible to compile opendx with modern compilers by ignoring implicitly declared functions (bison/flex-related).

Fixes trac ticket 61842 https://trac.macports.org/ticket/61842

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
macOS 11.7.8 20G1351 arm64
Xcode 13.2.1 13C100
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
