### PR TITLE
openjdk17-temurin: update to 17.0.8

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.7
+version      17.0.8
 set build    7
 revision     0
 
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  211c719fba6b08f28e5056c8da6abaceb699e80d \
-                 sha256  50d0e9840113c93916418068ba6c845f1a72ed0dab80a8a1f7977b0e658b65fb \
-                 size    187285514
+    checksums    rmd160  e7cfa2f945690941d5793bf82734a57bbcb77641 \
+                 sha256  6fea89cea64a0f56ecb9e5d746b4921d2b0a80aa65c92b265ee9db52b44f4d93 \
+                 size    187621534
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  90803dc1a390b4fecb57f86bc12aa374b2b76ff2 \
-                 sha256  1d6aeb55b47341e8ec33cc1644d58b88dfdcce17aa003a858baa7460550e6ff9 \
-                 size    177451420
+    checksums    rmd160  1306c8a15d284bdc4df4109d0b0c5b7db9c98ceb \
+                 sha256  105d1ada42927fccde215e8c80b43221cd5aad42e6183819c367234ac062fc10 \
+                 size    177734031
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.8.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?