### PR TITLE
openjdk11-temurin: update to 11.0.20

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk11-temurin
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      11.0.19
-set build    7
+version      11.0.20
+set build    8
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  c1ca32c99f7d71b7e644d1d197e1b6974fb60a3a \
-                 sha256  fc34c4f0e590071dcd65a0f93540913466ccac3aa8caa984826713b67afb696d \
-                 size    186680275
+    checksums    rmd160  a2bff63b08473ac166dcc20123817539c9c25a35 \
+                 sha256  3d9c47a20a8ba7b5aeb2354460adeb018af02f20553c0c3c7b733c1fc9aaf03a \
+                 size    186900244
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  c925feba4623cb6f05fe264410a60ae36be908ac \
-                 sha256  f3b416ecccf51f45cc8c986975eb7bd35e7e1ad953656ab0a807125963fcf73b \
-                 size    185411705
+    checksums    rmd160  186a92cb2eefb414599c66d49d62554a6079b205 \
+                 sha256  46bccb356dba38bf463ea2cc5a8d27ed4e5a51680a7a932f78d5e0c4f8af7c54 \
+                 size    185632863
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.20.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?