### PR TITLE
openjdk20-temurin: update to 20.0.2

### DIFF
--- a/java/openjdk20-temurin/Portfile
+++ b/java/openjdk20-temurin/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 # https://adoptium.net/temurin/releases/?version=20
 supported_archs  x86_64 arm64
 
-version      20.0.1
+version      20.0.2
 set build    9
 revision     0
 
@@ -26,14 +26,14 @@ master_sites https://github.com/adoptium/temurin20-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK20U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  f271f4a672bf6f86a3f01bd5c9d9db7d64186351 \
-                 sha256  7cccfc4fb9f63410b7fdc315fd1c7739cf61888930d7f88f3eee6589d14e861f \
-                 size    197180058
+    checksums    rmd160  a5defd42d992ae97a136edebdf3495df859ef873 \
+                 sha256  bdeb37322a7c9292434e417d4db9f5debd7477cf413335d3a653a4e5e50a2473 \
+                 size    197502362
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK20U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  cdce5c4d9f1579c59d7332aa8e3b04a520413baa \
-                 sha256  e743f7a4aebb46bfb02e164c7aa009a29bcce1d7dd0c4926541893ea6ed21d82 \
-                 size    186409240
+    checksums    rmd160  382a90eb6a9580d316f10e843f51341a0b91de17 \
+                 sha256  6ef42b63581c0265c5a6b734e203bb922ee720571a8de46532ecca50a804c596 \
+                 size    186697641
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 20.0.2.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?