### PR TITLE
cyclonedds: update to 0.10.3

### DIFF
--- a/devel/cyclonedds/Portfile
+++ b/devel/cyclonedds/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        eclipse-cyclonedds cyclonedds 0.10.2
+github.setup        eclipse-cyclonedds cyclonedds 0.10.3
 revision            0
 categories          devel
 license             EPL-2
@@ -13,6 +13,6 @@ description         Eclipse Cyclone DDS project
 long_description    {*}${description}
 homepage            https://cyclonedds.io/
 
-checksums           rmd160  77e7c0261abe246e18a624fc36d60e59706c3596 \
-                    sha256  ac59ee08975cd25a1fb414ddeb0183fb8636b12d49cea80373013bea59465b43 \
-                    size    6978904
+checksums           rmd160  ec29b5aba5dbf7e755666da16031f9f9af04fae0 \
+                    sha256  9e75ef0818fae0f6ad9fa951f388fd8d7e046e5dfa7e8c345dfa51d0ebfbfc7b \
+                    size    6979625


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/eclipse-cyclonedds/cyclonedds/releases/tag/0.10.3)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
