### PR TITLE
mbtileserver: update to 0.9.0

### DIFF
--- a/gis/mbtileserver/Portfile
+++ b/gis/mbtileserver/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/consbio/mbtileserver 0.8.2 v
+go.setup            github.com/consbio/mbtileserver 0.9.0 v
 revision            0
 categories          gis
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -13,45 +13,45 @@ description         A simple Go-based server for map tiles stored in mbtiles for
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  5ad2b4a5e239b99f58447c51a066827148bd56d9 \
-                        sha256  e5f3be51fa1cdbfea2ab9eb88298f5d08e61e1d225a19350ea7150d17cf8282e \
-                        size    1637797
+                        rmd160  835497ccbfcaefe4597d689618cc8eaa817d4392 \
+                        sha256  3a094a792225b174e9b507b30f3fa4ce4f970a8f8361e4ddefe1b5a235263dee \
+                        size    1617064
 
 go.vendors          gopkg.in/yaml.v3 \
-                        lock    496545a6307b \
-                        rmd160  16a43936d8ae6243895e23465132977d3a1193c2 \
-                        sha256  333e78b3b9cb73b3572d62f692d32426a8554b86c93025ea032f779395869e84 \
-                        size    90145 \
+                        lock    v3.0.1 \
+                        rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
+                        sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
+                        size    91208 \
                     golang.org/x/time \
-                        lock    f0f3c7e86c11 \
-                        rmd160  12c83458da614277c6fb69ccda7b68e0302c82d8 \
-                        sha256  05cf5c1700d05a7e4732ba7f4ca0b238babad5c8d0bdbe57e5e224f8fbe8f697 \
-                        size    9629 \
+                        lock    v0.1.0 \
+                        rmd160  5489d3c10b91016ebfe7ff73e6abb181664ebfb1 \
+                        sha256  69763dfe9bac5299bc5209254e6e8f7ffc492abb36e13633e1239ec680ea8893 \
+                        size    11114 \
                     golang.org/x/text \
-                        lock    v0.3.7 \
-                        rmd160  52777fe8a68660aab6e4588322a5949b0ba42e58 \
-                        sha256  48971ba6a3123c4fd81b2bdec9fda3cef5815fad76f2407c8a888032462c542d \
-                        size    8356115 \
+                        lock    v0.4.0 \
+                        rmd160  a3215f5c266b2d6cc0ae945858b543031fcb5a54 \
+                        sha256  c4e794a9e732f422df4e005f87ddba1e640b5bb7d6ce10ad56e40fa8c7d56ee2 \
+                        size    8359157 \
                     golang.org/x/sys \
-                        lock    3b038e5940ed \
-                        rmd160  4f3add590457b00d70a590f8bbef1d617dbf5d56 \
-                        sha256  82f37d083589f99d7566a6dc8f32edd3812f92afc77d7f89c4565d7380b8ef78 \
-                        size    1254461 \
+                        lock    v0.1.0 \
+                        rmd160  91bc7e86c3eb8a828451af8e3fcddd77fb906209 \
+                        sha256  07c0119c0c16e4b5441b93138d1c83aa1103eef441fb1f36eab332207b868a19 \
+                        size    1410248 \
                     golang.org/x/net \
-                        lock    491a49abca63 \
-                        rmd160  7671d08ec00027d57f4b9084dd0919b94bb88bb1 \
-                        sha256  347578522032cd741e84d0dfea82616dedae730416182c2ddb2351d5a6d500be \
-                        size    1226710 \
+                        lock    f25eb7ecb193 \
+                        rmd160  98d5de83aed4b3c2dfc7734e62fe64fb0c1bfb4b \
+                        sha256  ff7dfb7e8e56e1c513d2eaf39c4109371fad4a55ca2c6d1cb6cc7e75f95ea3e5 \
+                        size    1239696 \
                     golang.org/x/crypto \
-                        lock    4570a0811e8b \
-                        rmd160  603e958324fa5cbb605116b2e880297145f33efb \
-                        sha256  183fef0e64ee865da967f48f41bfecdd70ef1402a623539cbd53af7342a72713 \
-                        size    1734498 \
+                        lock    56aed061732a \
+                        rmd160  bc24a671816c7839d9115d98fad7c1beb917ce2d \
+                        sha256  7efc63941baeaf8c5ccec13f41a6a5056d95e76a5893263a825e1633059ab14c \
+                        size    1631972 \
                     github.com/valyala/fasttemplate \
-                        lock    v1.2.1 \
-                        rmd160  f825fd5196461afd7ac55c99ed2d55260b5c40d4 \
-                        sha256  ba85d4a0984ed43285a9cf853be7a3f2760426933bd5afdc0ae32d6d226538af \
-                        size    11551 \
+                        lock    v1.2.2 \
+                        rmd160  c341ee599972d95a7f9235fc4886ac9d7466d600 \
+                        sha256  9725402d25c6a6e0468ac03b67613368a29b742686c34e0b7e5cb2a271f0b40d \
+                        size    11558 \
                     github.com/valyala/bytebufferpool \
                         lock    v1.0.0 \
                         rmd160  32bddf2031e54e583df580e989cfd9be2f51bda8 \
@@ -68,15 +68,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
                         size    50815 \
                     github.com/spf13/cobra \
-                        lock    v1.3.0 \
-                        rmd160  b396e2179691a23f82eae5bb5af09fef218dadf9 \
-                        sha256  173024e7070e355d6c597b648b7096120a36aad4edba2c4b4d54fbc4d074feba \
-                        size    169548 \
+                        lock    v1.6.0 \
+                        rmd160  f44b255ef7a061fe502bc6734331d4c9c648cccd \
+                        sha256  21984b349f556a1441b7ed87504ac38ef76623ea3e237609c9369431be98f37d \
+                        size    110708 \
                     github.com/sirupsen/logrus \
-                        lock    v1.8.1 \
-                        rmd160  aeb4e5f2ea8112e787a72fba611605c4c87f42b5 \
-                        sha256  931c31f624d05136760b41a63f6bc146b79ac91776b4642cbd2026c2792e3aca \
-                        size    47184 \
+                        lock    v1.9.0 \
+                        rmd160  7298932f511bd852fe27d6227e945256ac512479 \
+                        sha256  559f22c05df7f356b90074d4b19035d9a5a8119fe504882fe413105a4f3b4675 \
+                        size    49102 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -88,30 +88,30 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
                         size    13422 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.14 \
-                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
-                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
-                        size    4705 \
+                        lock    v0.0.16 \
+                        rmd160  dcdf01553caa079315f2293c109de17fc72f0c6b \
+                        sha256  391d25a98e2cc92a2ed5c6abd07cde1053411706bb24e5843562931e6085ab46 \
+                        size    4693 \
                     github.com/mattn/go-colorable \
-                        lock    v0.1.12 \
-                        rmd160  e2cc8dfa32f377718b887dd9493e277657206885 \
-                        sha256  2eb2e98a9db73a52b684535450dbc1fda80780eada39612509550fbcb8c71cb1 \
-                        size    9805 \
+                        lock    v0.1.13 \
+                        rmd160  c9e8ab9d0773c0984f36235e3c9f8c033552ac1a \
+                        sha256  0cd9a951799c1a9f999df56e4b020170fa887456049c274aae6262d9ae3f7424 \
+                        size    9778 \
                     github.com/labstack/gommon \
-                        lock    v0.3.1 \
-                        rmd160  a4b2b3ca840130825eb90ba5160219e09044ad28 \
-                        sha256  4452d88fcb76c2bd8394cf412c12b9a4200db8390bde005198503aeb7e36db3a \
-                        size    12430 \
+                        lock    v0.4.0 \
+                        rmd160  82475913c42536c4bc63fbe34115179c473e1dfc \
+                        sha256  18193f7f4461c6e5c182785fc7975f75822aac8612f6efa68183f875ba1d3be0 \
+                        size    13205 \
                     github.com/labstack/echo \
-                        lock    v4.6.1 \
-                        rmd160  a4fcb11f9c65ddd1dd5941e3f7854e043e12f3ae \
-                        sha256  1d15f525c1306822db676f25d8e95f0f0dbbf658c9da5d7ce3840ff1a1a6e213 \
-                        size    357676 \
+                        lock    v4.9.1 \
+                        rmd160  6a3bb892429f90008835564eddcc097c2a9788ba \
+                        sha256  ed2bcc87bfccdd1d430db899cbbb597be604ac41b1f4f74b2300486feaf90efa \
+                        size    381789 \
                     github.com/inconshreveable/mousetrap \
-                        lock    v1.0.0 \
-                        rmd160  5c617a09f1432fc543672a0e0c1e13d3752030c2 \
-                        sha256  0e6bae2849f13d12fe361ecac087728e4e97f3482f4cec44f6e7a2c53bb9cd0c \
-                        size    2291 \
+                        lock    v1.0.1 \
+                        rmd160  d5dd7c9ef19fef8876014ae3b08a3f6a2a813bf7 \
+                        sha256  57bdbba1b25456bc66319f0ad5ba00b92dcfddd8431df9152e046fe079ad85b2 \
+                        size    5944 \
                     github.com/golang-jwt/jwt \
                         lock    v3.2.2 \
                         rmd160  358c4daf19c2fba8917970b6dfa258ba7a834123 \
@@ -123,10 +123,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  690d7813db5510d0dc739335dc950519c6664cc47ce49029e9c817f4a0c896c1 \
                         size    19245 \
                     github.com/fsnotify/fsnotify \
-                        lock    v1.5.1 \
-                        rmd160  c99fbad44a371ce38eb2bd5c6ef70fb4537952e3 \
-                        sha256  699405dfda2fe02a305bee66f58046adb43f426ac905f85d80710e36846b3768 \
-                        size    32714 \
+                        lock    v1.6.0 \
+                        rmd160  2d5150222f41b06715da40ebdceafb183979bd07 \
+                        sha256  af0e2b174dd969ee214e5899eb499fec5a75f5319ab4c810256f6018649b2a2c \
+                        size    46049 \
                     github.com/evalphobia/logrus_sentry \
                         lock    v0.8.2 \
                         rmd160  d51b09200a328f2f66ee9f12c7973b9c9abcfb70 \
@@ -143,16 +143,16 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  a06bb1869b1ef9fa2253eaaffc738deed98535e65c04b5fea6e03cbfb5879ec0 \
                         size    121737 \
                     github.com/brendan-ward/mbtiles-go \
-                        lock    67a7dabdbaab \
-                        rmd160  1029dc292e5100c2731b7c4f6df3a26571b35159 \
-                        sha256  84406da6c3f2adffac0ca999b78155f970974a6ad50ab767bfb036cb3309fda1 \
-                        size    1231724 \
+                        lock    a6cb9b848bab \
+                        rmd160  938711dfe2cfd3ecd9601979963a9629bbf954e9 \
+                        sha256  813c51740196cfe4050b507dc66baf4e4c0e14f20729270b88a46cb3e53ef700 \
+                        size    1235657 \
                     crawshaw.io/sqlite \
                         repo    github.com/crawshaw/sqlite \
-                        lock    v0.3.2 \
-                        rmd160  5f846e34da9e2193a7c52521f7f4e46509cb62bf \
-                        sha256  e92f48bb73aac61970219ec27c1c704f6e2baf0f61d095b08577ad76bbbbb832 \
-                        size    2308450 \
+                        lock    2cdb5c1a86a1 \
+                        rmd160  46706e35093a4ea33a886d7fcc8fa1613db90791 \
+                        sha256  02077208fa27cc36eac945c5142bb238dc82a9b92f08275cca0098301d456c72 \
+                        size    2361692 \
                     crawshaw.io/iox \
                         repo    github.com/crawshaw/iox \
                         lock    c51c3df30797 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/consbio/mbtileserver/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
