### PR TITLE
py-graph-tool: Update to version 2.57

### DIFF
--- a/gis/cgal5/Portfile
+++ b/gis/cgal5/Portfile
@@ -18,7 +18,7 @@ long_description        The goal of the ${description} is to provide easy access
 platforms               darwin
 
 github.setup            CGAL cgal 5.5.2 v
-revision                0
+revision                1
 conflicts               cgal4
 github.tarball_from     releases
 name                    cgal5
@@ -34,10 +34,11 @@ checksums               rmd160  b38dd935efc17ac7d74a8006987373f8df83b6e8 \
                         sha256  b2b05d5616ecc69facdc24417cce0b04fb4321491d107db45103add520e3d8c3 \
                         size    24159628
 
+boost.version           1.81
+
 depends_lib-append      port:mpfr \
                         port:zlib \
                         port:gmp \
-                        port:boost \
                         path:share/pkgconfig/eigen3.pc:eigen3
 
 compiler.cxx_standard   2014

--- a/python/py-graph-tool/Portfile
+++ b/python/py-graph-tool/Portfile
@@ -6,9 +6,10 @@ PortGroup           boost 1.0
 PortGroup           python 1.0
 
 name                py-graph-tool
-version             2.46
+version             2.57
 revision            0
 epoch               20190711
+supported_archs     arm64 x86_64
 
 categories          python science
 license             LGPL-3
@@ -25,13 +26,14 @@ homepage            https://graph-tool.skewed.de
 master_sites        https://downloads.skewed.de/graph-tool/
 use_bzip2           yes
 
-checksums           rmd160  316e8cc9c0b15e066e8ac2388a460ba4866505fe \
-                    sha256  305508f0c2989a150aecd5df010424979cd17e83f67852121e4ab29eb07d3275 \
-                    size    15189665
+checksums           rmd160  6fab092de09dcc24ef14324349a9604400755c82 \
+                    sha256  a20a0e73b78e78f233e960c6ba89d1969f457221b03b66947c71d3044affbb72 \
+                    size    15192391
 
-boost.version       1.76
+# please ensure that this boost.version matches that specified in cgal5
+boost.version       1.81
 
-python.versions     37 38 39 310
+python.versions     38 39 310 311
 
 if {${os.major} <= 12 && ${os.platform} eq "darwin"} {
     version         2.2.26
@@ -70,8 +72,24 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-numpy \
                     port:py${python.version}-scipy
 
+    depends_lib-append \
+                    port:py${python.version}-matplotlib
+
     # graph-tool relies on Boost.Python, so make sure it is installed.
     require_active_variants boost[boost::version_nodot] python${python.version}
+
+    # remove after this issue is fixed:
+    # https://git.skewed.de/count0/graph-tool/-/issues/761
+    post-patch {
+        fs-traverse f ${worksrcpath}/src {
+            if { [file isfile ${f}]
+                && [regexp {\.(cc|hh)$} [file extension ${f}]] } {
+                reinplace -q -E \
+                    {s|:[[:space:]]+public[[:space:]]+std::unary_function<.+,.+>||} \
+                    ${f}
+            }
+        }
+    }
 
     use_configure   yes
     # parallel build starts swapping with 8GB of RAM.
@@ -115,6 +133,7 @@ if {${name} ne ${subport}} {
     destroot.cmd    make
     destroot.destdir \
                     DESTDIR=${destroot}
+    destroot.target install
 
     variant gtk3 description "Enable interactive drawing with gtk3" {
         depends_lib-append \
@@ -126,8 +145,6 @@ if {${name} ne ${subport}} {
         file rename ${destroot}${prefix}/share/doc/graph-tool \
             ${destroot}${prefix}/share/doc/py${python.version}-graph-tool
     }
-
-    livecheck.type  none
 } else {
     livecheck.type  regex
     livecheck.url   $homepage

--- a/python/py-graph-tool/Portfile
+++ b/python/py-graph-tool/Portfile
@@ -39,9 +39,9 @@ if {${os.major} <= 12 && ${os.platform} eq "darwin"} {
     version         2.2.26
     revision        1
     master_sites    https://downloads.skewed.de/graph-tool/old/
-    checksums       md5     317b29de0d3ef715fdc9281e078cfb17 \
-                    sha1    108be4cf6212eb6886f172ea03813187f73e4c3c \
-                    rmd160  cd2e8506522821750d70a97b951254f0a133d218
+    checksums       rmd160  cd2e8506522821750d70a97b951254f0a133d218 \
+                    sha256  a8ba1f286704f2f54badcb262e6f56055a81f2d66ee1ccedfe31d5c494ee039d \
+                    size    29644168
 } else {
     if {${name} ne ${subport}} {
         compiler.cxx_standard   2017
@@ -117,6 +117,21 @@ if {${name} ne ${subport}} {
                     --with-expat-inc=${prefix}/include \
                     --with-expat-lib="-L${prefix}/lib -lexpat"
 
+    # Suppress most Clang compilation warnings, which utterly pollute build log.
+    # Note: Likely due to project Makefile, which sets '-Wall' and '-Wextra'.
+    # TODO: Try removing this block, when updating to next release.
+    if {[string match *clang* ${configure.compiler}]} {
+        configure.cxxflags-append \
+                    -Wno-delete-non-abstract-non-virtual-dtor \
+                    -Wno-deprecated-copy \
+                    -Wno-deprecated-copy-with-user-provided-copy \
+                    -Wno-missing-field-initializers \
+                    -Wno-parentheses \
+                    -Wno-unused-parameter \
+                    -Wno-error=unknown-warning-option \
+                    -Wno-unknown-warning-option
+    }
+
     # Clang uses the old libstc++ from gcc 4.2 before OS X 10.9. Boost doesn't
     # include some of the tr1 headers in libstdc++ and defines its own tr1
     # classes. This causes conflicts with sparsehash which insists on using
@@ -142,8 +157,9 @@ if {${name} ne ${subport}} {
     }
 
     post-destroot {
-        file rename ${destroot}${prefix}/share/doc/graph-tool \
-            ${destroot}${prefix}/share/doc/py${python.version}-graph-tool
+        set doc_dir ${destroot}${prefix}/share/doc
+        move ${doc_dir}/graph-tool \
+            ${doc_dir}/py${python.version}-graph-tool
     }
 } else {
     livecheck.type  regex


### PR DESCRIPTION
#### Description

py-graph-tool: Update to version 2.57
    * Add 311, Remove 37
    * Use boost181
    * Bugfix for unary_function C++17 removal

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
