### PR TITLE
legacy-support-devel: update to 20230722

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -33,13 +33,13 @@ subport ${name} {
 
 subport ${name}-devel {
     conflicts           ${name}
-    github.setup        macports macports-legacy-support b570b7f97476e5377ee2397a7a3a71638b72bdb5
-    version             20230705
-    revision            1
+    github.setup        macports macports-legacy-support 8889f27039e355c2ccadda0240ddd540302e382f
+    version             20230722
+    revision            0
     livecheck.type      none
-    checksums           rmd160  f7cee33104ed1941c389888ef54b4a05cda6ea8e \
-                        sha256  e65d6cf0eae5ee85b818acd39b5a47af15605c410c98bfab653975ca1a2589ea \
-                        size    61879
+    checksums           rmd160  1d7dd90410e2e792a5e92862e93fe957075a9778 \
+                        sha256  38713068aeeb3f41f569ab9ac9ab42fdcf90527ad955a997c4f42d7df12382ec \
+                        size    64514
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
 }


### PR DESCRIPTION
* fix fdopendir so dirfd stays open until closedir (for fstatat etc)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
