### PR TITLE
apcupsd: Prevent overwriting apcupsd.conf file

### DIFF
--- a/sysutils/apcupsd/Portfile
+++ b/sysutils/apcupsd/Portfile
@@ -4,6 +4,7 @@ PortSystem                  1.0
 
 name                        apcupsd
 version                     3.14.14
+revision                    1
 categories                  sysutils
 license                     GPL-2
 maintainers                 {@stephenreay koalephant.com:stephen} openmaintainer
@@ -31,6 +32,18 @@ startupitem.autostart       yes
 startupitem.install         yes
 startupitem.custom_file     ${worksrcpath}/platforms/darwin/org.apcupsd.apcupsd.plist
 startupitem.type            launchd
+
+post-destroot {
+    # Move conf file to sample so it does not get overwritten
+    file rename ${destroot}${prefix}/etc/apcupsd/apcupsd.conf ${destroot}${prefix}/etc/apcupsd/apcupsd.conf.sample
+}
+
+post-activate {
+    # Create initial conf file if needed
+    if {![file exists ${prefix}/etc/apcupsd/apcupsd.conf]} {
+        file copy ${prefix}/etc/apcupsd/apcupsd.conf.sample ${prefix}/etc/apcupsd/apcupsd.conf
+   }
+}
 
 
 variant usb description {Add USB support} {


### PR DESCRIPTION
#### Description

Bumped revision for apcupsd, to prevent overwrite of config file

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4.1 22F770830e arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
