### PR TITLE
micronaut: update to 4.0.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.0.0 v
+github.setup    micronaut-projects micronaut-starter 4.0.1 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  d4ddbeb369000fc0b54cd3ee954add53961a69ce \
-                sha256  160e4e1edd34e1156b4300599072b220f8a858c39d4e3a41f167211166d0525d \
-                size    20208236
+checksums       rmd160  9982325da52975f0eb5a0d33e7d773b403819114 \
+                sha256  9a8a415f8a132d7ac3d1dd4f5e49aeefaf42aab04fecee6549d84d722d6d944d \
+                size    20212755
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 4.0.1.

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?