### PR TITLE
beets-devel: update to 20230723; beets-summarize: update to 20230713; py-discogs-client: update to 2.7

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -530,9 +530,9 @@ subport ${name}-originquery {
 }
 
 subport ${name}-summarize {
-    github.setup    steven-murray beet-summarize b4a07c6c4db51d9a332a54e7a83bfc0ac60040ab
-    version         20210908
-    revision        1
+    github.setup    steven-murray beet-summarize e9b9cac3d0afc8bafce3cdc80c2d39bab16cd569
+    version         20230713
+    revision        0
 
     license         LGPL-3
 
@@ -540,9 +540,19 @@ subport ${name}-summarize {
     long_description \
                     {*}${description}
 
-    checksums       rmd160  9631bc2b10a0c6d09bd5c4f743ae6d91ce610155 \
-                    sha256  029cd7799cab022861599af58b608bacd2087aab01ff7096b25ba6303d76cd24 \
-                    size    11013
+    checksums       rmd160  91c926952a7df8d19a0c993c58dd7ea7c8f25ffb \
+                    sha256  363c2717f5c302615d65f1b817aab3a1113bc188c961795908881434ee88aa19 \
+                    size    13331
+
+    python.pep517   yes
+
+    depends_build-append \
+                    port:py${python.version}-setuptools_scm
+
+    build.env-append \
+                    SETUPTOOLS_SCM_PRETEND_VERSION=${version}
+
+    github.livecheck.branch main
 }
 
 subport ${name}-usertag {

--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -39,13 +39,13 @@ if {$subport eq $name} {
 subport ${name}-devel {
     conflicts       $name
 
-    github.setup    beetbox beets 0c3f428a601cb40c5fd463791df6229d51b0635e
-    version         20230606
+    github.setup    beetbox beets 87cd387ecc5793e15a98ec6411db3ea544cbce63
+    version         20230723
     revision        0
 
-    checksums       rmd160  2abb8bd24e470e7fc789f861118f0185b640d3fd \
-                    sha256  367506f9c269aea252474c770d498fee0ed41b01be39eda3bea5edd3f278bff9 \
-                    size    1869560
+    checksums       rmd160  93769fc6f03381841fe07986e29e2d8693af9438 \
+                    sha256  c5c7371464493ca130a69cc65c21954968b2538f428f8f3f758ea2f755b319f5 \
+                    size    2198322
 
     depends_build-append \
                     port:py${python.version}-sphinx

--- a/python/py-discogs-client/Portfile
+++ b/python/py-discogs-client/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-discogs-client
 python.rootname     python3-discogs-client
-version             2.6
+version             2.7
 revision            0
 
 categories-append   devel audio
@@ -21,9 +21,9 @@ homepage            https://github.com/joalla/discogs_client
 
 maintainers         {@catap korins.ky:kirill} openmaintainer
 
-checksums           rmd160  89ed7b5c0a621e14b87f36e0294001b87204ddb7 \
-                    sha256  819135cf40528a83e48de826fbda9218d3e6cac48b55499a798a6bb844bcda87 \
-                    size    36426
+checksums           rmd160  d8c0697bb283dcd48a0cb010b067e967e4ab2d0f \
+                    sha256  25949b9dc6130985d8e0199e4c950351e364e273f9476546bd9e171802e007a1 \
+                    size    36551
 
 python.versions     37 38 39 310 311
 

--- a/python/py-importlib-metadata/Portfile
+++ b/python/py-importlib-metadata/Portfile
@@ -60,6 +60,13 @@ if {${name} ne ${subport}} {
         checksums           rmd160  f5952a964e77c80896fa03f66de0ace77b5a5935 \
                             sha256  766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668 \
                             size    41979
+    } elseif {${python.version} eq "37"} {
+        version             6.7.0
+        epoch               1
+        revision            0
+        checksums           rmd160  8c61967b759c5b5a97acba81fe6973f389b47f73 \
+                            sha256  1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4 \
+                            size    53569
     }
 
     if {${python.version} in "36 37"} {


### PR DESCRIPTION
#### Description

This update includes an update of dependency of beets with one exception. The last update of `py-importlib-metadata` brokes it for python 37, here I've fixed it.
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.7 21G651 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->