### PR TITLE
retdec-devel: updated to 20230718

### DIFF
--- a/devel/retdec/Portfile
+++ b/devel/retdec/Portfile
@@ -98,8 +98,8 @@ if {${name} eq ${subport}} {
 subport retdec-devel {
     conflicts       $name
 
-    github.setup    avast retdec 6238ecada5a880cf3df6b6ad90d49b0c06fdb84b
-    version         20230525
+    github.setup    avast retdec f7e82bb6b2d18d3d33719ed2399e76bf6ffc994a
+    version         20230718
     revision        0
     epoch           1
 
@@ -114,9 +114,9 @@ subport retdec-devel {
 
     checksums-append \
                     ${distname}${extract.suffix} \
-                    rmd160  d02bbe3b4e0f5859998a3e9a129eb071ac0c107a \
-                    sha256  597cd6c5169b669d2e3dc54f9c67b6393630434e64a5d0ff00104fc417e9beba \
-                    size    27197622 \
+                    rmd160  dd67fddd6f98b71eec9024eaae1539bd0ede77f6 \
+                    sha256  1608cdefd43bf6717d2e8a63d0b624fbe0c91a6386bed4139f6d48dbac486d64 \
+                    size    27198272 \
                     ${yaramod_version}${extract.suffix} \
                     rmd160  eab0a12e77f24be097e8f97f768fa02574a23c31 \
                     sha256  f9c75eb93c379ab4e1a80f28a678d54531b1bbc1de2725438b3f54be11332ee9 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.7 21G651 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->