### PR TITLE
rawhide: add missing depends_build

### DIFF
--- a/sysutils/rawhide/Portfile
+++ b/sysutils/rawhide/Portfile
@@ -19,9 +19,10 @@ long_description    {*}${description} \
 homepage            https://raf.org/rawhide/
 license             GPL-3+
 categories          sysutils
+depends_build       port:pkgconfig
 depends_lib         port:pcre2 port:libmagic
 maintainers         {raf.org:raf @macportsraf} openmaintainer
-revision            1
+revision            2
 
 github.setup        raforg ${name} ${version} v
 github.tarball_from releases
@@ -34,9 +35,8 @@ patchfiles          patch-Makefile.diff
 use_configure       yes
 configure.args      --macports
 build.target        rh
-# Need openat, fdopendir, fstatat, faccessat, unlinkat, readlinkat.
-# POSIX 2008, but they didn't make it into macOS until later.
-# But note: This compiles, but doesn't work, on macos-10.6.8. :-(
+# Need openat, fdopendir, fstatat, faccessat, unlinkat, and readlinkat.
+# POSIX 2008, but they didn't make it into macOS until 2014 (macOS-10.10).
 legacysupport.newest_darwin_requires_legacy 13
 
 test.run            yes


### PR DESCRIPTION
#### Description

Add missing `depends_build port:pkgconfig` which is needed to find one of the `depends_lib` dependencies, otherwise some features are not included.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
