### PR TITLE
qgis3[-ltr]: update to 3.32.1 and 3.28.9 (LTR)

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -26,23 +26,23 @@ subport ${name-ltr} {}
 
 if {${subport} eq ${name}} {
     # Latest version
-    github.setup    qgis QGIS 3_32_0 final-
+    github.setup    qgis QGIS 3_32_1 final-
     revision        0
     conflicts       ${name-ltr}
 
-    checksums       rmd160  108cc4afe476788b80ae65b134e5fc13e4916bc6 \
-                    sha256  d36cb17624f34b484fe3954bc994b4c9498af8ec1467fc2ea953a109be2d7c78 \
-                    size    186482670
+    checksums       rmd160  87106397935b7ca77926ab03566ac0051f00cae4 \
+                    sha256  736bb9b93c72709578c1c1c9fc16456a3b6a75b6decac9e52181a95b3331b146 \
+                    size    187226059
 } else {
     # LTR version
-    github.setup    qgis QGIS 3_28_8 final-
+    github.setup    qgis QGIS 3_28_9 final-
     revision        0
     conflicts       ${name}
     description     {*}${description} (LTR)
-    
-    checksums       rmd160  787fec9bec335a13fdbf82c8ae2b38183958af8d \
-                    sha256  4eb8bdab3d1197d4c16a79cb75d0fbb104e0f80e9ad053f533c14369027c5c13 \
-                    size    183943016
+
+    checksums       rmd160  a4d466c14051ffe137a453d8354fe9863c9d23bc \
+                    sha256  bfde8b0e47ffda6fbb37c07b97e83afc029c883194014a4627d304380da83e82 \
+                    size    184615427
 }
 
 version             [string map {_ .} ${github.version}]


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update `qgis3` to version 3.32.1 and `qgis3-ltr` to 3.28.9.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.6 21G646 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
