### PR TITLE
ghostscript: minor fix to 10.01.2

### DIFF
--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                ghostscript
 version             10.01.2
-revision            0
+revision            1
 categories          print
 license             AGPL-3 BSD
 maintainers         nomaintainer
@@ -24,7 +24,7 @@ master_sites        https://github.com/ArtifexSoftware/ghostpdl-downloads/releas
 
 # Note: this needs to be manually updated for new upstream commits
 set mappingresources_commit \
-                    a709991e67196a87af053e2c16d7a65108613a41
+                    2dd5e53fb74a01718b9dfd448a0d1cce6fff2aa5
 
 distname            ghostpdl-${version}
 distfiles           ${distname}.tar.gz:source \
@@ -34,7 +34,8 @@ distfiles           ${distname}.tar.gz:source \
 
 patchfiles          patch-base_unix-dll.mak.diff \
                     patch-base_unixinst.mak.diff \
-                    patch-base_gspaint.diff
+                    patch-base_gspaint.diff \
+                    patch-psi_imainarg.c.diff
 
 checksums           ${distname}.tar.gz \
                     rmd160  1a21460fb6ec98858a723cd6570a1b98e9f2124a \
@@ -49,9 +50,9 @@ checksums           ${distname}.tar.gz \
                     sha256  0eb6f356119f2e49b2563210852e17f57f9dcc5755f350a69a46a0d641a0c401 \
                     size    3752871 \
                     ${mappingresources_commit}.zip \
-                    rmd160  6f327e09590d517760dafd99cc7a197e68d85c6e \
-                    sha256  03bb11a4db4b01f8509e93db469a24f904934fece3b5b9b8be932267ed7173f4 \
-                    size    1600471
+                    rmd160  a65458ab9955421cf3085cf84a6eac299e8c93cb \
+                    sha256  e3971985977cee4b75f6b49f6e43842d3b699c4255d010adb82796073e98fbfe \
+                    size    1601563
 
 depends_lib         port:fontconfig \
                     port:freetype \

--- a/print/ghostscript/files/patch-psi_imainarg.c.diff
+++ b/print/ghostscript/files/patch-psi_imainarg.c.diff
@@ -1,0 +1,11 @@
+--- psi/imainarg.c.orig	2023-06-21 14:10:21
++++ psi/imainarg.c	2023-07-24 12:51:29
+@@ -1455,7 +1455,7 @@
+ print_help_trailer(const gs_main_instance *minst)
+ {
+     char buffer[gp_file_name_sizeof];
+-    const char *use_htm = "Use.htm", *p = buffer;
++    const char *use_htm = "Ghostscript.pdf", *p = buffer;
+     uint blen = sizeof(buffer);
+ 
+     if (gp_file_name_combine(gs_doc_directory, strlen(gs_doc_directory),


### PR DESCRIPTION
#### Description

This is a minor fix to the previous revision of the package for ghostscript version 10.01.2.
As pointed out by @tomio-arisaka in https://github.com/macports/macports-ports/commit/1aa266aeb8d6aff98ec6764a883fc36531f5246b#comments there were two issues to be fixed:
- The "Mapping Resources for PDF" (https://github.com/adobe-type-tools/mapping-resources-pdf/) were outdated. This revision included the latest version from 2023-01-18.
- The help page `gs --help` referred to `/opt/local/share/doc/ghostscript/10.01.2/Use.htm`, which is not actually provided. I changed it to `/opt/local/share/doc/ghostscript/10.01.2/Ghostscript.pdf`, which is made available.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4.1 22F770820d x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
