### PR TITLE
manif: new port in devel

### DIFF
--- a/devel/manif/Portfile
+++ b/devel/manif/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        artivis manif bb3f6758ae467b7f24def71861798d131f157032
+version             2023.07.18
+revision            0
+categories          devel
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Small C++11 header-only library for Lie theory
+long_description    manif is a Lie theory library for state-estimation targeted at robotics applications. \
+                    It is developed as a header-only C++11 library with Python 3 wrappers.
+homepage            https://artivis.github.io/manif
+checksums           rmd160  35258b7f2b38c05b41e97d0a219a96a08429ba86 \
+                    sha256  259d47a31c543c82e0d708dfc679366f74b97cd85f69fa304f67501926eb1915 \
+                    size    728258
+installs_libs       no
+supported_archs     noarch
+
+depends_lib-append  path:share/pkgconfig/eigen3.pc:eigen3
+
+# https://github.com/artivis/manif/pull/277
+patchfiles-append   0001-Add-missing-cassert-in-eigen.h.patch \
+                    0002-Set-correct-C-standard-in-tests.patch \
+                    0003-Fix-gtest_rn-for-32-bit-platforms.patch
+
+# Required for tests, see: https://github.com/artivis/manif/issues/269
+compiler.cxx_standard 2014
+cmake.set_cxx_standard yes
+
+configure.args-append \
+                    -DBUILD_BENCHMARKING=OFF \
+                    -DBUILD_EXAMPLES=OFF \
+                    -DBUILD_PYTHON_BINDINGS=OFF \
+                    -DBUILD_TESTING=ON \
+                    -DBUILD_TESTING_PYTHON=OFF \
+                    -DENABLE_CPPCHECK=OFF \
+                    -DUSE_SYSTEM_WIDE_TL_OPTIONAL=OFF
+
+test.run            yes

--- a/devel/manif/files/0001-Add-missing-cassert-in-eigen.h.patch
+++ b/devel/manif/files/0001-Add-missing-cassert-in-eigen.h.patch
@@ -1,0 +1,22 @@
+From bd2d162fcb7524bf9b67ff9116bfe12918f2002f Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 24 Jul 2023 23:15:35 +0800
+Subject: [PATCH 1/3] Add missing cassert in eigen.h
+
+---
+ include/manif/impl/eigen.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git include/manif/impl/eigen.h include/manif/impl/eigen.h
+index faf67c9..ab07526 100644
+--- include/manif/impl/eigen.h
++++ include/manif/impl/eigen.h
+@@ -1,6 +1,8 @@
+ #ifndef _MANIF_MANIF_EIGEN_H_
+ #define _MANIF_MANIF_EIGEN_H_
+ 
++#include <cassert>
++
+ #include <Eigen/Core>
+ #include <Eigen/LU> // for mat.inverse()
+ #include <Eigen/Geometry>

--- a/devel/manif/files/0002-Set-correct-C-standard-in-tests.patch
+++ b/devel/manif/files/0002-Set-correct-C-standard-in-tests.patch
@@ -1,0 +1,189 @@
+From 3d237706414eda97341c814cdcac03e911c4d67a Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 24 Jul 2023 23:07:35 +0800
+Subject: [PATCH 2/3] Set correct C++ standard in tests
+
+---
+ test/CMakeLists.txt        | 12 ++++++------
+ test/bundle/CMakeLists.txt |  4 ++--
+ test/ceres/CMakeLists.txt  | 10 +++++-----
+ test/rn/CMakeLists.txt     |  4 ++--
+ test/se2/CMakeLists.txt    |  4 ++--
+ test/se3/CMakeLists.txt    |  4 ++--
+ test/se_2_3/CMakeLists.txt |  4 ++--
+ test/so2/CMakeLists.txt    |  4 ++--
+ test/so3/CMakeLists.txt    |  4 ++--
+ 9 files changed, 25 insertions(+), 25 deletions(-)
+
+diff --git test/CMakeLists.txt test/CMakeLists.txt
+index 9b0bae1..53acb2b 100644
+--- test/CMakeLists.txt
++++ test/CMakeLists.txt
+@@ -52,9 +52,9 @@ include_directories(${GTEST_INCLUDE_DIRS})
+ 
+ manif_add_gtest(gtest_misc gtest_misc.cpp)
+ 
+-set(CXX_11_TEST_TARGETS
++set(CXX_14_TEST_TARGETS
+ 
+-  ${CXX_11_TEST_TARGETS}
++  ${CXX_14_TEST_TARGETS}
+ 
+   gtest_misc
+ )
+@@ -104,7 +104,7 @@ else()
+   message(STATUS "Could not find autodiff, autodiff tests will not be built.")
+ endif()
+ 
+-# Set required C++11 flag
+-set_property(TARGET ${CXX_11_TEST_TARGETS} PROPERTY CXX_STANDARD 11)
+-set_property(TARGET ${CXX_11_TEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON)
+-set_property(TARGET ${CXX_11_TEST_TARGETS} PROPERTY CXX_EXTENSIONS OFF)
++# Set required C++14 flag
++set_property(TARGET ${CXX_14_TEST_TARGETS} PROPERTY CXX_STANDARD 14)
++set_property(TARGET ${CXX_14_TEST_TARGETS} PROPERTY CXX_STANDARD_REQUIRED ON)
++set_property(TARGET ${CXX_14_TEST_TARGETS} PROPERTY CXX_EXTENSIONS OFF)
+diff --git test/bundle/CMakeLists.txt test/bundle/CMakeLists.txt
+index c5746ec..a34e65d 100644
+--- test/bundle/CMakeLists.txt
++++ test/bundle/CMakeLists.txt
+@@ -4,9 +4,9 @@ manif_add_gtest(gtest_bundle gtest_bundle.cpp)
+ manif_add_gtest(gtest_bundle_single_group gtest_bundle_single_group.cpp)
+ manif_add_gtest(gtest_bundle_large gtest_bundle_large.cpp)
+ 
+-set(CXX_11_TEST_TARGETS
++set(CXX_14_TEST_TARGETS
+ 
+-  ${CXX_11_TEST_TARGETS}
++  ${CXX_14_TEST_TARGETS}
+ 
+   gtest_bundle
+   gtest_bundle_single_group
+diff --git test/ceres/CMakeLists.txt test/ceres/CMakeLists.txt
+index d63bcc8..f999885 100644
+--- test/ceres/CMakeLists.txt
++++ test/ceres/CMakeLists.txt
+@@ -15,7 +15,7 @@ manif_add_gtest(gtest_se23_ceres gtest_se23_ceres.cpp)
+ 
+ manif_add_gtest(gtest_bundle_ceres gtest_bundle_ceres.cpp)
+ 
+-set(CXX_11_TEST_TARGETS_CERES
++set(CXX_14_TEST_TARGETS_CERES
+   # Rn
+   gtest_rn_ceres
+ 
+@@ -39,14 +39,14 @@ set(CXX_11_TEST_TARGETS_CERES
+   gtest_bundle_ceres
+ )
+ 
+-foreach(target ${CXX_11_TEST_TARGETS_CERES})
++foreach(target ${CXX_14_TEST_TARGETS_CERES})
+   target_link_libraries(${target} ${CERES_LIBRARIES})
+   target_include_directories(${target} SYSTEM PRIVATE ${CERES_INCLUDE_DIRS})
+ endforeach()
+ 
+-set(CXX_11_TEST_TARGETS
+-  ${CXX_11_TEST_TARGETS}
+-  ${CXX_11_TEST_TARGETS_CERES}
++set(CXX_14_TEST_TARGETS
++  ${CXX_14_TEST_TARGETS}
++  ${CXX_14_TEST_TARGETS_CERES}
+ 
+   PARENT_SCOPE
+ )
+diff --git test/rn/CMakeLists.txt test/rn/CMakeLists.txt
+index 44f722d..11c7592 100644
+--- test/rn/CMakeLists.txt
++++ test/rn/CMakeLists.txt
+@@ -2,9 +2,9 @@
+ 
+ manif_add_gtest(gtest_rn gtest_rn.cpp)
+ 
+-set(CXX_11_TEST_TARGETS
++set(CXX_14_TEST_TARGETS
+ 
+-  ${CXX_11_TEST_TARGETS}
++  ${CXX_14_TEST_TARGETS}
+ 
+   # R^n
+   gtest_rn
+diff --git test/se2/CMakeLists.txt test/se2/CMakeLists.txt
+index e49c50f..e259d3c 100644
+--- test/se2/CMakeLists.txt
++++ test/se2/CMakeLists.txt
+@@ -5,9 +5,9 @@ manif_add_gtest(gtest_se2_map gtest_se2_map.cpp)
+ manif_add_gtest(gtest_se2_tangent gtest_se2_tangent.cpp)
+ manif_add_gtest(gtest_se2_tangent_map gtest_se2_tangent_map.cpp)
+ 
+-set(CXX_11_TEST_TARGETS
++set(CXX_14_TEST_TARGETS
+ 
+-  ${CXX_11_TEST_TARGETS}
++  ${CXX_14_TEST_TARGETS}
+ 
+   # SE2
+   gtest_se2
+diff --git test/se3/CMakeLists.txt test/se3/CMakeLists.txt
+index 4c7c514..945a317 100644
+--- test/se3/CMakeLists.txt
++++ test/se3/CMakeLists.txt
+@@ -2,9 +2,9 @@
+ 
+ manif_add_gtest(gtest_se3 gtest_se3.cpp)
+ 
+-set(CXX_11_TEST_TARGETS
++set(CXX_14_TEST_TARGETS
+ 
+-  ${CXX_11_TEST_TARGETS}
++  ${CXX_14_TEST_TARGETS}
+ 
+   # SE3
+   gtest_se3
+diff --git test/se_2_3/CMakeLists.txt test/se_2_3/CMakeLists.txt
+index b2f4d4a..f215378 100644
+--- test/se_2_3/CMakeLists.txt
++++ test/se_2_3/CMakeLists.txt
+@@ -2,9 +2,9 @@
+ 
+ manif_add_gtest(gtest_se_2_3 gtest_se_2_3.cpp)
+ 
+-set(CXX_11_TEST_TARGETS
++set(CXX_14_TEST_TARGETS
+ 
+-  ${CXX_11_TEST_TARGETS}
++  ${CXX_14_TEST_TARGETS}
+ 
+   # SE_2_3
+   gtest_se_2_3
+diff --git test/so2/CMakeLists.txt test/so2/CMakeLists.txt
+index c026f24..114dc2d 100644
+--- test/so2/CMakeLists.txt
++++ test/so2/CMakeLists.txt
+@@ -12,9 +12,9 @@ manif_add_gtest(gtest_so2_tangent gtest_so2_tangent.cpp)
+ # so2 tangent Eigen::Map tests
+ manif_add_gtest(gtest_so2_tangent_map gtest_so2_tangent_map.cpp)
+ 
+-set(CXX_11_TEST_TARGETS
++set(CXX_14_TEST_TARGETS
+ 
+-  ${CXX_11_TEST_TARGETS}
++  ${CXX_14_TEST_TARGETS}
+ 
+   # SO2
+   gtest_so2
+diff --git test/so3/CMakeLists.txt test/so3/CMakeLists.txt
+index 9a8a1e3..3a12098 100644
+--- test/so3/CMakeLists.txt
++++ test/so3/CMakeLists.txt
+@@ -2,9 +2,9 @@
+ 
+ manif_add_gtest(gtest_so3 gtest_so3.cpp)
+ 
+-set(CXX_11_TEST_TARGETS
++set(CXX_14_TEST_TARGETS
+ 
+-  ${CXX_11_TEST_TARGETS}
++  ${CXX_14_TEST_TARGETS}
+ 
+   # SO3
+   gtest_so3

--- a/devel/manif/files/0003-Fix-gtest_rn-for-32-bit-platforms.patch
+++ b/devel/manif/files/0003-Fix-gtest_rn-for-32-bit-platforms.patch
@@ -1,0 +1,45 @@
+From 3ff24821df766aa3f9a24cc57168dbf4b7516183 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 25 Jul 2023 00:59:05 +0800
+Subject: [PATCH 3/3] Fix gtest_rn for 32-bit platforms
+
+---
+ test/rn/CMakeLists.txt | 4 ++++
+ test/rn/gtest_rn.cpp   | 3 ++-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git test/rn/CMakeLists.txt test/rn/CMakeLists.txt
+index 11c7592..bbeeb65 100644
+--- test/rn/CMakeLists.txt
++++ test/rn/CMakeLists.txt
+@@ -1,5 +1,9 @@
+ # SO3 tests
+ 
++if(CMAKE_SIZEOF_VOID_P EQUAL 4)
++  add_definitions(-DMANIF_ARCH_32)
++endif()
++
+ manif_add_gtest(gtest_rn gtest_rn.cpp)
+ 
+ set(CXX_14_TEST_TARGETS
+diff --git test/rn/gtest_rn.cpp test/rn/gtest_rn.cpp
+index 4618130..61c4abc 100644
+--- test/rn/gtest_rn.cpp
++++ test/rn/gtest_rn.cpp
+@@ -14,7 +14,7 @@ using namespace manif;
+ // especially, SO3 wasn't an issue despite being Eigen::Vector4d too...
+ EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(R4d)
+ 
+-#ifdef MANIF_COVERAGE_ENABLED
++#if defined(MANIF_COVERAGE_ENABLED) || defined(MANIF_ARCH_32)
+ 
+ MANIF_TEST(R4d);
+ MANIF_TEST_JACOBIANS(R4d);
+@@ -109,6 +109,7 @@ TEST(TEST_RN, TEST_RN_VEC_ASSIGN_OP)
+ }
+ 
+ // This is a little too heavy for coverage and not relevant...
++// The same applies to 32-bit platforms.
+ 
+ MANIF_TEST(R1f);
+ MANIF_TEST(R2f);


### PR DESCRIPTION
#### Description

New port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

```
--->  Testing manif
Executing:  cd "/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/build" && /usr/bin/make test 
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_devel_manif/manif/work/build
      Start  1: gtest_misc
 1/16 Test  #1: gtest_misc .......................   Passed    0.08 sec
      Start  2: gtest_rn
 2/16 Test  #2: gtest_rn .........................   Passed    0.28 sec
      Start  3: gtest_so2
 3/16 Test  #3: gtest_so2 ........................   Passed    0.24 sec
      Start  4: gtest_so2_map
 4/16 Test  #4: gtest_so2_map ....................   Passed    0.13 sec
      Start  5: gtest_so2_tangent
 5/16 Test  #5: gtest_so2_tangent ................   Passed    0.12 sec
      Start  6: gtest_so2_tangent_map
 6/16 Test  #6: gtest_so2_tangent_map ............   Passed    0.09 sec
      Start  7: gtest_so3
 7/16 Test  #7: gtest_so3 ........................   Passed    0.41 sec
      Start  8: gtest_se2
 8/16 Test  #8: gtest_se2 ........................   Passed    0.40 sec
      Start  9: gtest_se2_map
 9/16 Test  #9: gtest_se2_map ....................   Passed    0.08 sec
      Start 10: gtest_se2_tangent
10/16 Test #10: gtest_se2_tangent ................   Passed    0.07 sec
      Start 11: gtest_se2_tangent_map
11/16 Test #11: gtest_se2_tangent_map ............   Passed    0.08 sec
      Start 12: gtest_se3
12/16 Test #12: gtest_se3 ........................   Passed    0.41 sec
      Start 13: gtest_se_2_3
13/16 Test #13: gtest_se_2_3 .....................   Passed    0.43 sec
      Start 14: gtest_bundle
14/16 Test #14: gtest_bundle .....................   Passed    0.37 sec
      Start 15: gtest_bundle_single_group
15/16 Test #15: gtest_bundle_single_group ........   Passed    0.92 sec
      Start 16: gtest_bundle_large
16/16 Test #16: gtest_bundle_large ...............   Passed    0.85 sec

100% tests passed, 0 tests failed out of 16

Total Test time (real) =   5.09 sec
```