### PR TITLE
manif: add build dep on gtest, blacklist clang < 800

### DIFF
--- a/devel/manif/Portfile
+++ b/devel/manif/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 github.setup        artivis manif bb3f6758ae467b7f24def71861798d131f157032
@@ -21,6 +22,8 @@ installs_libs       no
 supported_archs     noarch
 
 depends_lib-append  path:share/pkgconfig/eigen3.pc:eigen3
+depends_build-append \
+                    port:gtest
 
 # https://github.com/artivis/manif/pull/277
 patchfiles-append   0001-Add-missing-cassert-in-eigen.h.patch \
@@ -29,6 +32,7 @@ patchfiles-append   0001-Add-missing-cassert-in-eigen.h.patch \
 
 # Required for tests, see: https://github.com/artivis/manif/issues/269
 compiler.cxx_standard 2014
+compiler.blacklist-append {clang < 800}
 cmake.set_cxx_standard yes
 
 configure.args-append \


### PR DESCRIPTION
#### Description

Depend on `gtest` to avoid a need to fetch it during the build.
Fix, hopefully, a failure on Yosemite.
Should fix systems currently failing: https://ports.macports.org/port/manif/details

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
