### PR TITLE
monkeys-audio: new port

### DIFF
--- a/audio/monkeys-audio/Portfile
+++ b/audio/monkeys-audio/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cmake 1.1
+PortGroup               github 1.0
+
+github.setup            fernandotcl monkeys-audio 3.99.6 release-
+revision                0
+categories              audio
+maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
+license                 Restrictive NoMirror
+# Re license see: https://lists.debian.org/debian-legal/2007/09/msg00079.html
+description             Lossless audio compressor
+long_description        Monkeyʼs Audio Codec is a lossless compressor for audio files. \
+                        Files in this format can typically be recognized by the .ape extension.
+
+checksums               rmd160  f4bcebe08ade43065f783c880a82e1a9f42e2980 \
+                        sha256  0d279bf2042ac5a8fc57674de0f20a4c78f8f33926346d98949bc312c76860f1 \
+                        size    78937
+github.tarball_from     archive
+
+# https://github.com/fernandotcl/monkeys-audio/pull/8
+patchfiles              0001-CMakeLists-use-MATCHES-for-Clang.patch

--- a/audio/monkeys-audio/files/0001-CMakeLists-use-MATCHES-for-Clang.patch
+++ b/audio/monkeys-audio/files/0001-CMakeLists-use-MATCHES-for-Clang.patch
@@ -1,0 +1,28 @@
+# https://github.com/fernandotcl/monkeys-audio/pull/8
+
+From a1a9edbb59f3bb68bacdeda248a9ce1e6054af7e Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Tue, 25 Jul 2023 12:39:12 +0800
+Subject: [PATCH] CMakeLists: use MATCHES for Clang
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git CMakeLists.txt CMakeLists.txt
+index bc4d06f..c6ecfad 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -1,10 +1,10 @@
+ cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+ project(monkeys-audio)
+ 
+-if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
++if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -pedantic -Wno-long-long")
+     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_RELEASE} -O0")
+-endif(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
++endif(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+ 
+ include(CheckFunctionExists)
+ include(CheckIncludeFiles)


### PR DESCRIPTION
#### Description

New port in audio.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
