### PR TITLE
cmake-devel-gui: fix CMAKE_ROOT for cmake-gui

### DIFF
--- a/devel/cmake-devel/Portfile
+++ b/devel/cmake-devel/Portfile
@@ -41,7 +41,7 @@ version             20230810-3.27.2-[string range ${gitlab.version} 0 7]
 checksums           rmd160  7a30991369c51f9d0e6875d6ba40d10c31730fb6 \
                     sha256  4ecc149a24251b3d6ba12e00893b5265fff580755c8630e8512cc56692cfff98 \
                     size    8423256
-revision            0
+revision            1
 
 epoch               1
 
@@ -76,7 +76,8 @@ patchfiles-append \
     patch-fix-clock_gettime-test.diff \
     patch-qt5gui.diff \
     patch-cmake-cmInstallRuntime-initializer-fix.diff \
-    patch-uv_spawn.diff
+    patch-uv_spawn.diff \
+    patch-cmakeroot-with-app.diff
 
 depends_lib-append \
     port:curl \
@@ -188,7 +189,8 @@ post-patch {
     # patch PREFIX
     reinplace "s|__PREFIX__|${prefix}|g" \
         ${worksrcpath}/macports.cmake \
-        ${worksrcpath}/Modules/Platform/Darwin.cmake
+        ${worksrcpath}/Modules/Platform/Darwin.cmake \
+        ${worksrcpath}/Source/cmSystemTools.cxx
 
     # patch FRAMEWORKS
     reinplace "s|__FRAMEWORKS_DIR__|${frameworks_dir}|g" \

--- a/devel/cmake-devel/files/patch-cmakeroot-with-app.diff
+++ b/devel/cmake-devel/files/patch-cmakeroot-with-app.diff
@@ -1,0 +1,13 @@
+Addresses https://trac.macports.org/ticket/62855
+
+--- Source/cmSystemTools.cxx.orig	2023-03-08 20:04:09.000000000 +0100
++++ Source/cmSystemTools.cxx	2023-07-25 11:24:23.000000000 +0200
+@@ -2570,6 +2570,8 @@
+     exe_dir = cmSystemTools::GetFilenamePath(exe_dir);
+     if (cmSystemTools::FileExists(exe_dir + CMAKE_BIN_DIR "/cmake")) {
+       exe_dir += CMAKE_BIN_DIR;
++    } else if (cmSystemTools::FileExists("__PREFIX__" CMAKE_BIN_DIR "/cmake")) {
++        exe_dir = cmSystemTools::GetFilenamePath("__PREFIX__" CMAKE_BIN_DIR "/cmake");
+     } else {
+       exe_dir = cmSystemTools::GetFilenamePath(exe_dir);
+       exe_dir = cmSystemTools::GetFilenamePath(exe_dir);


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

CMake code for `cmake-devel-gui` looks inside app bundle for CMAKE_ROOT, this patches it to look in MacPorts $prefix.

To start with, update `cmake-devel` only. Once it's been thoroughly validated in the wild, it can be integrated into `cmake`.

See: https://trac.macports.org/ticket/62855


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.6 21G646 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
