### PR TITLE
libgit2: update to 1.7.1; py-pygit2: update to 1.13.0; rev-bump all dependents

### DIFF
--- a/R/R-gert/Portfile
+++ b/R/R-gert/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             github r-lib gert 1.9.3 v
-revision            0
+revision            1
 categories-append   www
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/R/R-git2r/Portfile
+++ b/R/R-git2r/Portfile
@@ -6,7 +6,7 @@ PortGroup           R 1.0
 
 # GitHub version lags behind.
 R.setup             cran ropensci git2r 0.32.0
-revision            1
+revision            2
 categories-append   devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-2

--- a/devel/cargo-c/Portfile
+++ b/devel/cargo-c/Portfile
@@ -6,7 +6,7 @@ PortGroup                   cargo  1.0
 
 github.setup                lu-zero cargo-c 0.9.19 v
 github.tarball_from         archive
-revision                    0
+revision                    1
 
 license                     MIT
 categories                  devel

--- a/devel/cargo/Portfile
+++ b/devel/cargo/Portfile
@@ -9,6 +9,7 @@ name                cargo
 epoch               1
 github.setup        rust-lang ${name} 0.72.2
 revision            0
+revision            1
 
 categories          devel
 license             {MIT Apache-2}

--- a/devel/committed/Portfile
+++ b/devel/committed/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo  1.0
 
 github.setup        crate-ci committed 1.0.20 v
-revision            0
+revision            1
 
 categories          devel
 platforms           darwin

--- a/devel/dura/Portfile
+++ b/devel/dura/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 
 github.setup        tkellogg dura 0.2.0 v
 github.tarball_from archive
-revision            2
+revision            3
 
 description         You shouldn\'t ever lose your work if you\'re using Git
 

--- a/devel/git-absorb/Portfile
+++ b/devel/git-absorb/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        tummychow git-absorb 0.6.10
 github.tarball_from archive
-revision            1
+revision            2
 
 description         git commit --fixup, but automatic
 

--- a/devel/git-branchless/Portfile
+++ b/devel/git-branchless/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 
 github.setup        arxanas git-branchless 0.8.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         A suite of advanced tools for Git, such as `git undo`, \
                     and `git sl` (smartlog)

--- a/devel/gitui/Portfile
+++ b/devel/gitui/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        extrawurst gitui 0.24.2 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Blazing fast terminal-ui for git written in Rust.
 

--- a/devel/gitweb/Portfile
+++ b/devel/gitweb/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo 1.0
 PortGroup           openssl 1.0
 
 github.setup        yoannfleurydev gitweb 0.3.5 v
-revision            2
+revision            3
 
 description         Open the current remote git repository in your browser
 

--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -11,9 +11,9 @@ conflicts           libgit2-devel
 set my_name         libgit2
 
 # don't forget to update py-pygit2 and libgit2-glib as well
-github.setup        libgit2 libgit2 1.6.4 v
+github.setup        libgit2 libgit2 1.7.1 v
 github.tarball_from archive
-revision            1
+revision            0
 epoch               1
 
 categories          devel
@@ -30,9 +30,9 @@ homepage            https://libgit2.org/
 
 dist_subdir         ${my_name}
 
-checksums           rmd160  9ab7621fb2d03494af277192661af9a345e26996 \
-                    sha256  d25866a4ee275a64f65be2d9a663680a5cf1ed87b7ee4c534997562c828e500d \
-                    size    6666964
+checksums           rmd160  5dad52197aaa08f44f5faab10935e566ae51da6b \
+                    sha256  17d2b292f21be3892b704dddff29327b3564f96099a1c53b00edc23160c71327 \
+                    size    7548081
 
 depends_build-append \
                     port:pkgconfig

--- a/devel/onefetch/Portfile
+++ b/devel/onefetch/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo 1.0
 
 github.setup        o2sh onefetch 2.13.2 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Git repository summary on your terminal
 

--- a/devel/stgit/Portfile
+++ b/devel/stgit/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo  1.0
 
 github.setup        stacked-git stgit 2.3.2 v
 github.tarball_from releases
-revision            0
+revision            1
 
 categories          devel
 license             GPL-2

--- a/fortran/fortran-git/Portfile
+++ b/fortran/fortran-git/Portfile
@@ -5,7 +5,7 @@ PortGroup           fortran 1.0
 
 github.setup        interkosmos fortran-git b87f3d118621cdc39f895f8a850e45dc39f1f69d
 version             2023.04.27
-revision            0
+revision            1
 categories-append   devel
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer

--- a/gnome/libgit2-glib/Portfile
+++ b/gnome/libgit2-glib/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson  1.0
 
 gitlab.instance     https://gitlab.gnome.org
 gitlab.setup        GNOME libgit2-glib 1.1.0 v
-revision            2
+revision            3
 license             LGPL-2+
 description         Glib wrapper library around the libgit2 git access library.
 long_description    ${description}

--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -8,7 +8,7 @@ name                        rust
 
 # keep in mind that you also need to update cargo.crates at the end of this file
 version                     1.71.1
-revision                    0
+revision                    1
 subport rust-src {revision  0}
 
 categories                  lang devel

--- a/python/py-pygit2/Portfile
+++ b/python/py-pygit2/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        libgit2 pygit2 1.13.0 v
 name                py-pygit2
-revision            0
+revision            1
 
 categories-append   devel
 license             {GPL-2 Permissive}

--- a/python/py-pygit2/Portfile
+++ b/python/py-pygit2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        libgit2 pygit2 1.12.2 v
+github.setup        libgit2 pygit2 1.13.0 v
 name                py-pygit2
 revision            0
 
@@ -17,9 +17,9 @@ description         Python bindings for libgit2
 long_description    Pygit2 is a set of Python bindings to the libgit2 shared \
                     library, libgit2 implements the core of Git.
 
-checksums           rmd160  5384961682524e5903a2c77f6830bdb610099ab0 \
-                    sha256  d95c7ad50cbb5315c2d4fa358338bff8df9a63d5d8fbeb523e208d27770b362f \
-                    size    760461
+checksums           rmd160  106a8f25e370ad095509f4e59e9a96c74b3f9f5d \
+                    sha256  de89bc77d2e3c7f221f599f985ea308175ddd8eb1e8e82879b0a19fc62fd6f59 \
+                    size    760437
 
 python.versions     38 39 310 311
 

--- a/science/gnuastro/Portfile
+++ b/science/gnuastro/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 
 name                    gnuastro
 version                 0.20
-revision                1
+revision                2
 categories              science
 license                 GPL-3+
 maintainers             {@sikmir disroot.org:sikmir} openmaintainer

--- a/sysutils/broot/Portfile
+++ b/sysutils/broot/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        Canop broot 1.25.1 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://dystroy.org/broot
 

--- a/sysutils/exa/Portfile
+++ b/sysutils/exa/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cargo 1.0
 
 github.setup        ogham exa 0.10.1 v
-revision            4
+revision            5
 categories          sysutils
 platforms           darwin
 maintainers         {catlett.info:chad @chadcatlett} \

--- a/sysutils/eza/Portfile
+++ b/sysutils/eza/Portfile
@@ -7,7 +7,7 @@ PortGroup           cargo   1.0
 
 github.setup        eza-community eza 0.11.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         A modern, maintained replacement for ls
 

--- a/sysutils/starship/Portfile
+++ b/sysutils/starship/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 
 github.setup        starship starship 1.16.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://starship.rs
 

--- a/textproc/bat/Portfile
+++ b/textproc/bat/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        sharkdp bat 0.23.0 v
 github.tarball_from archive
-revision            2
+revision            3
 
 description         A cat(1) clone with syntax highlighting and Git integration.
 

--- a/textproc/git-delta/Portfile
+++ b/textproc/git-delta/Portfile
@@ -7,7 +7,7 @@ PortGroup           github  1.0
 github.setup        dandavison delta 0.16.5
 github.tarball_from archive
 name                git-delta
-revision            0
+revision            1
 
 homepage            https://dandavison.github.io/delta
 

--- a/www/stagit/Portfile
+++ b/www/stagit/Portfile
@@ -5,7 +5,7 @@ PortGroup           makefile 1.0
 
 name                stagit
 version             1.2
-revision            2
+revision            3
 license             MIT
 
 categories          www


### PR DESCRIPTION
### Description

Pre-testing the update via CI, with the caveat that it may or may not timeout. We shall see.