### PR TITLE
jet: new submission (version 0.6.26)

### DIFF
--- a/textproc/jet/Portfile
+++ b/textproc/jet/Portfile
@@ -1,0 +1,70 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        borkdude jet 0.6.26 v
+github.tarball_from releases
+revision            0
+
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             EPL-1
+categories          textproc devel
+
+description         CLI to transform between JSON, EDN, YAML and Transit using Clojure
+long_description    {*}${description}
+
+distfiles           ${name}-${version}-standalone.jar
+
+checksums           rmd160  7730a89dbb9117d066a633aad51cfbad6a6d5a43 \
+                    sha256  ce5488219d1857abacb20032973f101a62818bc3302083339a5a087f86c7bc75 \
+                    size    13531702
+
+extract.only
+
+variant jdk17 conflicts jdk11 description {Build using JDK 17} {
+    depends_build-append port:openjdk17-graalvm
+}
+
+variant jdk11 conflicts jdk17 description {Build using the older JDK 11} {
+    depends_build-append port:openjdk11-graalvm-native-image
+}
+
+if {![variant_isset jdk11] && ![variant_isset jdk17]} {
+    default_variants    +jdk17
+}
+
+use_configure       no
+
+pre-fetch {
+    if {![variant_isset jdk11] && ![variant_isset jdk17]} {
+        error "Either +jdk11 or +jdk17 is required"
+    }
+}
+
+build {
+    # Leaving this stub since we cannot declare global variables in the scope of pre-fetch
+    set graalvm_home /Library/Java/JavaVirtualMachines
+
+    if {[variant_isset jdk17]} {
+        set graalvm_home ${graalvm_home}/openjdk17-graalvm
+    } elseif {[variant_isset jdk11]} {
+        set graalvm_home ${graalvm_home}/openjdk11-graalvm
+    }
+
+    set graalvm_home ${graalvm_home}/Contents/Home
+
+    # See: https://github.com/borkdude/jet/blob/master/script/compile
+    set args "-H:+ReportExceptionStackTraces"
+    append args " --verbose"
+    append args " --no-fallback"
+    append args " --no-server"
+    append args " -J-Djet.native=true"
+
+    system -W ${workpath} \
+        "${graalvm_home}/bin/native-image -jar [shellescape ${distpath}/${distfiles}] ${args}"
+}
+
+destroot {
+    xinstall -m 755 ${workpath}/jet ${destroot}${prefix}/bin
+}


### PR DESCRIPTION
#### Description

Jet is a simple CLI utilite to transform between JSON, EDN, YAML and Transit
which is created on Clojure.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->