### PR TITLE
pv: Update to 1.7.0

### DIFF
--- a/sysutils/pv/Portfile
+++ b/sysutils/pv/Portfile
@@ -34,6 +34,8 @@ patchfiles          remove_64_suffixed_calls.patch
 configure.args      --mandir=${prefix}/share/man \
                     --infodir=${prefix}/share/info
 
+test.run            yes
+
 depends_lib-append      port:gettext
 depends_build-append    port:autoconf
 

--- a/sysutils/pv/Portfile
+++ b/sysutils/pv/Portfile
@@ -2,10 +2,11 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
+PortGroup           github 1.0
 
-name                pv
-version             1.6.20
-revision            1
+github.setup        a-j-wood pv 1.7.0 v
+
+revision            0
 categories          sysutils
 platforms           darwin
 maintainers         {eborisch @eborisch} openmaintainer
@@ -21,37 +22,35 @@ long_description    pv - Pipe Viewer - is a terminal-based tool for monitoring \
                     is, and an estimate of how long it will be until completion.
 
 homepage            http://www.ivarch.com/programs/pv.shtml
-master_sites        http://www.ivarch.com/programs/sources/
-
-use_bzip2           yes
 
 checksums \
-    size    115310 \
-    rmd160  0368b2bbca567052afaeedab01fe22c41eccce41 \
-    sha256  e831951eff0718fba9b1ef286128773b9d0e723e1fbfae88d5a3188814fdc603
+    size    96081 \
+    rmd160  fb6e1655e9b65d55325686575375b4b87ea20fd3 \
+    sha256  b1f3e39841182999b963c3a11b645efe79b7c006c5da491858088a4ad924fc4c
+
+# We patch the build to drop all the *64 (stat64, etc.) calls now. Just cleaner.
+patchfiles          remove_64_suffixed_calls.patch
 
 configure.args      --mandir=${prefix}/share/man \
                     --infodir=${prefix}/share/info
 
-depends_lib         port:gettext
+depends_lib-append      port:gettext
+depends_build-append    port:autoconf
 
-if {${build_arch} eq "arm64"} {
-    # For further information on why we redefine these symbols, see the trac ticket
-    # https://trac.macports.org/ticket/61784#comment:4
-    configure.cppflags-append -Dfstat64=fstat -Dlstat64=lstat -Dstat64=stat
-} elseif {${os.platform} eq "darwin" && ${os.major} != 9} {
-    # Leopard is the only release where stat64 exists and is not deprecated.
-    # Rather than updating a patch to replace each instance, use the deprecated
-    # interface as long as it exists, just don't complain about it. (configure
-    # script runs a check.)
-    configure.cppflags-append -Wno-deprecated
+if {${os.platform} eq "darwin" && ${os.major} < 10 } {
+    # Attempt to still work on *old* systems by redefining *stat to *stat64
+    configure.cppflags-append -Dfstat=fstat64 -Dlstat=lstat64 -Dstat=stat64
+}
+
+pre-configure {
+    system -W ${worksrcpath} './generate.sh'
 }
 
 post-destroot {
     file mkdir ${destroot}${prefix}/share/doc/${name}
     copy ${worksrcpath}/doc/COPYING \
-        ${worksrcpath}/doc/NEWS \
-        ${worksrcpath}/README \
+        ${worksrcpath}/doc/NEWS.md \
+        ${worksrcpath}/README.md \
         ${destroot}${prefix}/share/doc/${name}
 }
 

--- a/sysutils/pv/Portfile
+++ b/sysutils/pv/Portfile
@@ -55,6 +55,3 @@ post-destroot {
         ${worksrcpath}/README.md \
         ${destroot}${prefix}/share/doc/${name}
 }
-
-livecheck.type      regex
-livecheck.regex     >${name}-(\[0-9.\]+)${extract.suffix}<

--- a/sysutils/pv/files/remove_64_suffixed_calls.patch
+++ b/sysutils/pv/files/remove_64_suffixed_calls.patch
@@ -1,0 +1,373 @@
+diff -ru autoconf/configure.in autoconf/configure.in
+--- autoconf/configure.in	2023-07-16 05:09:51.000000000 -0500
++++ autoconf/configure.in	2023-07-25 10:55:35.000000000 -0500
+@@ -41,13 +41,6 @@
+   	CFLAGS="-pg $CFLAGS"
+   fi
+ )
+-LFS_SUPPORT="no"
+-AC_ARG_ENABLE(lfs, [  --disable-lfs           disable LFS support],
+-  if test "$enable_lfs" = "yes"; then
+-    LFS_SUPPORT="yes"
+-  fi,
+-  LFS_SUPPORT="yes"
+-)
+ STATIC_NLS="no"
+ AC_ARG_ENABLE(static-nls, [  --enable-static-nls     hardcode NLS with no support files],
+   if test "$enable_static_nls" = "yes"; then
+@@ -145,23 +138,12 @@
+ AC_CHECK_FUNCS(getopt_long getopt)
+ AC_CHECK_HEADERS(getopt.h)
+ 
+-dnl LFS checks.
+-dnl
+-if test "$LFS_SUPPORT" = "yes"; then
+-  AC_CHECK_FUNCS(open64, AC_DEFINE(ENABLE_LARGEFILE))
+-fi
+-
+ dnl Check for various header files and set various other macros.
+ dnl
+ AC_DEFINE(HAVE_CONFIG_H)
+ AC_HEADER_STDC
+ AC_HEADER_STDBOOL
+ AC_CHECK_FUNCS(memcpy basename snprintf)
+-dnl OSX 11 (apple silicon) lets you link stat64() but fails to compile
+-dnl so use a compile test for stat64() instead of a link test.
+-AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main() { stat64(); }])],
+-		  [AC_DEFINE([HAVE_STAT64], [1], [Is stat64() available])],
+-		  [])
+ AC_CHECK_HEADERS(limits.h)
+ 
+ if test "$IPC_SUPPORT" = "yes"; then
+diff -ru autoconf/header.in autoconf/header.in
+--- autoconf/header.in	2021-09-04 14:59:47.000000000 -0500
++++ autoconf/header.in	2023-07-25 10:52:02.000000000 -0500
+@@ -18,7 +18,6 @@
+ #undef HAVE_MEMCPY
+ #undef HAVE_BASENAME
+ #undef HAVE_SNPRINTF
+-#undef HAVE_STAT64
+ 
+ #undef HAVE_SPLICE
+ #ifdef HAVE_SPLICE
+@@ -53,33 +52,6 @@
+ #define PROJECT_HOMEPAGE "http://www.ivarch.com/programs/" PROGRAM_NAME ".shtml"
+ #define BUG_REPORTS_TO   _("<pv@ivarch.com>")
+ 
+-/* LFS support. */
+-#undef ENABLE_LARGEFILE
+-#ifdef ENABLE_LARGEFILE
+-# define __USE_LARGEFILE64 1
+-# define _LARGEFILE64_SOURCE 1
+-#else
+-/*
+- * Some Macs have stat64 despite not having open64 while others don't have
+- * either, so here even if we don't have open64 or LFS is disabled, we have
+- * to check whether stat64 exists and only redefine it if it doesn't
+- * otherwise some Macs fail to compile.
+- */
+-# ifdef __APPLE__
+-#  ifndef HAVE_STAT64
+-#   define stat64 stat
+-#   define fstat64 fstat
+-#   define lstat64 lstat
+-#  endif
+-# else
+-#  define stat64 stat
+-#  define fstat64 fstat
+-#  define lstat64 lstat
+-# endif
+-# define open64 open
+-# define lseek64 lseek
+-#endif
+-
+ #undef HAVE_IPC
+ #ifdef HAVE_SYS_IPC_H
+ #define HAVE_IPC 1
+diff -ru src/include/pv-internal.h src/include/pv-internal.h
+--- src/include/pv-internal.h	2023-07-17 15:30:32.000000000 -0500
++++ src/include/pv-internal.h	2023-07-25 10:54:07.000000000 -0500
+@@ -18,16 +18,6 @@
+ #include <sys/time.h>
+ #include <sys/stat.h>
+ 
+-/* 
+- * Since macOS 10.6, stat64 variants are equivalent to plain stat, and the
+- * suffixed versions have been removed in macOS 11.  See stat(2).
+- */
+-#if defined(__APPLE__) || defined(APPLE)
+-#define stat64 stat
+-#define fstat64 fstat
+-#define lstat64 lstat
+-#endif
+-
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+@@ -247,8 +237,8 @@
+ #endif
+ 	char file_fdpath[4096];		 /* path to file that was opened */
+ 	char display_name[512];		 /* name to show on progress bar */
+-	struct stat64 sb_fd;		 /* stat of fd symlink */
+-	struct stat64 sb_fd_link;	 /* lstat of fd symlink */
++	struct stat sb_fd;		 /* stat of fd symlink */
++	struct stat sb_fd_link;	 /* lstat of fd symlink */
+ 	unsigned long long size;	 /* size of whole file, 0 if unknown */
+ 	long long position;		 /* position last seen at */
+ 	struct timeval start_time;	 /* time we started watching the fd */
+diff -ru src/main/options.c src/main/options.c
+--- src/main/options.c	2023-07-17 15:52:18.000000000 -0500
++++ src/main/options.c	2023-07-25 10:57:17.000000000 -0500
+@@ -274,12 +274,12 @@
+ 			/* Permit "@<filename>" as well as just a number. */
+ 			if ('@' == *optarg) {
+ 				const char *size_file = 1 + optarg;
+-				struct stat64 sb;
++				struct stat sb;
+ 				int rc;
+ 
+ 				rc = 0;
+ 				memset(&sb, 0, sizeof(sb));
+-				rc = stat64(size_file, &sb);
++				rc = stat(size_file, &sb);
+ 				if (0 == rc) {
+ 					opts->size = sb.st_size;
+ 				} else {
+diff -ru src/pv/file.c src/pv/file.c
+--- src/pv/file.c	2023-07-17 15:52:18.000000000 -0500
++++ src/pv/file.c	2023-07-25 10:53:34.000000000 -0500
+@@ -31,7 +31,7 @@
+ unsigned long long pv_calc_total_size(pvstate_t state)
+ {
+ 	unsigned long long total;
+-	struct stat64 sb;
++	struct stat sb;
+ 	int rc, i, j, fd;
+ 
+ 	total = 0;
+@@ -42,20 +42,20 @@
+ 	 * No files specified - check stdin.
+ 	 */
+ 	if (state->input_file_count < 1) {
+-		if (0 == fstat64(STDIN_FILENO, &sb))
++		if (0 == fstat(STDIN_FILENO, &sb))
+ 			total = sb.st_size;
+ 		return total;
+ 	}
+ 
+ 	for (i = 0; i < state->input_file_count; i++) {
+ 		if (0 == strcmp(state->input_files[i], "-")) {
+-			rc = fstat64(STDIN_FILENO, &sb);
++			rc = fstat(STDIN_FILENO, &sb);
+ 			if (rc != 0) {
+ 				total = 0;
+ 				return total;
+ 			}
+ 		} else {
+-			rc = stat64(state->input_files[i], &sb);
++			rc = stat(state->input_files[i], &sb);
+ 			if (0 == rc)
+ 				rc = access(state->input_files[i], R_OK);
+ 		}
+@@ -79,13 +79,13 @@
+ 			 * them and seeking to the end.
+ 			 */
+ 			if (0 == strcmp(state->input_files[i], "-")) {
+-				fd = open64("/dev/stdin", O_RDONLY);
++				fd = open("/dev/stdin", O_RDONLY);
+ 			} else {
+-				fd = open64(state->input_files[i],
++				fd = open(state->input_files[i],
+ 					    O_RDONLY);
+ 			}
+ 			if (fd >= 0) {
+-				total += lseek64(fd, 0, SEEK_END);
++				total += lseek(fd, 0, SEEK_END);
+ 				close(fd);
+ 			} else {
+ 				pv_error(state, "%s: %s",
+@@ -109,11 +109,11 @@
+ 	 * and that we can seek back to the start after getting the size.
+ 	 */
+ 	if (total <= 0) {
+-		rc = fstat64(STDOUT_FILENO, &sb);
++		rc = fstat(STDOUT_FILENO, &sb);
+ 		if ((0 == rc) && S_ISBLK(sb.st_mode)
+ 		    && (0 == (fcntl(STDOUT_FILENO, F_GETFL) & O_APPEND))) {
+-			total = lseek64(STDOUT_FILENO, 0, SEEK_END);
+-			if (lseek64(STDOUT_FILENO, 0, SEEK_SET) != 0) {
++			total = lseek(STDOUT_FILENO, 0, SEEK_END);
++			if (lseek(STDOUT_FILENO, 0, SEEK_SET) != 0) {
+ 				pv_error(state, "%s: %s: %s", "(stdout)",
+ 					 _
+ 					 ("failed to seek to start of output"),
+@@ -144,19 +144,19 @@
+ 		fd = -1;
+ 
+ 		if (0 == strcmp(state->input_files[i], "-")) {
+-			rc = fstat64(STDIN_FILENO, &sb);
++			rc = fstat(STDIN_FILENO, &sb);
+ 			if ((rc != 0) || (!S_ISREG(sb.st_mode))) {
+ 				total = 0;
+ 				return total;
+ 			}
+ 			fd = dup(STDIN_FILENO);
+ 		} else {
+-			rc = stat64(state->input_files[i], &sb);
++			rc = stat(state->input_files[i], &sb);
+ 			if ((rc != 0) || (!S_ISREG(sb.st_mode))) {
+ 				total = 0;
+ 				return total;
+ 			}
+-			fd = open64(state->input_files[i], O_RDONLY);
++			fd = open(state->input_files[i], O_RDONLY);
+ 		}
+ 
+ 		if (fd < 0) {
+@@ -187,7 +187,7 @@
+ 			}
+ 		}
+ 
+-		lseek64(fd, 0, SEEK_SET);
++		lseek(fd, 0, SEEK_SET);
+ 		close(fd);
+ 	}
+ 
+@@ -205,8 +205,8 @@
+  */
+ int pv_next_file(pvstate_t state, int filenum, int oldfd)
+ {
+-	struct stat64 isb;
+-	struct stat64 osb;
++	struct stat isb;
++	struct stat osb;
+ 	int fd, input_file_is_stdout;
+ 
+ 	if (oldfd > 0) {
+@@ -232,7 +232,7 @@
+ 	if (0 == strcmp(state->input_files[filenum], "-")) {
+ 		fd = STDIN_FILENO;
+ 	} else {
+-		fd = open64(state->input_files[filenum], O_RDONLY);
++		fd = open(state->input_files[filenum], O_RDONLY);
+ 		if (fd < 0) {
+ 			pv_error(state, "%s: %s: %s",
+ 				 _("failed to read file"),
+@@ -243,7 +243,7 @@
+ 		}
+ 	}
+ 
+-	if (fstat64(fd, &isb)) {
++	if (fstat(fd, &isb)) {
+ 		pv_error(state, "%s: %s: %s",
+ 			 _("failed to stat file"),
+ 			 state->input_files[filenum], strerror(errno));
+@@ -252,7 +252,7 @@
+ 		return -1;
+ 	}
+ 
+-	if (fstat64(STDOUT_FILENO, &osb)) {
++	if (fstat(STDOUT_FILENO, &osb)) {
+ 		pv_error(state, "%s: %s",
+ 			 _("failed to stat output file"), strerror(errno));
+ 		close(fd);
+diff -ru src/pv/loop.c src/pv/loop.c
+--- src/pv/loop.c	2023-07-17 15:52:18.000000000 -0500
++++ src/pv/loop.c	2023-07-25 10:52:28.000000000 -0500
+@@ -53,7 +53,7 @@
+ 	struct timeval start_time, next_update, next_ratecheck, cur_time;
+ 	struct timeval init_time, next_remotecheck;
+ 	long double elapsed;
+-	struct stat64 sb;
++	struct stat sb;
+ 	int fd, n;
+ 
+ 	/*
+@@ -116,7 +116,7 @@
+ 	 * Set target buffer size if the initial file's block size can be
+ 	 * read and we weren't given a target buffer size.
+ 	 */
+-	if ((0 == fstat64(fd, &sb)) && (0 == state->target_buffer_size)) {
++	if ((0 == fstat(fd, &sb)) && (0 == state->target_buffer_size)) {
+ 		unsigned long long sz;
+ 		sz = sb.st_blksize * 32;
+ 		if (sz > BUFFER_SIZE_MAX)
+diff -ru src/pv/transfer.c src/pv/transfer.c
+--- src/pv/transfer.c	2023-07-17 15:52:18.000000000 -0500
++++ src/pv/transfer.c	2023-07-25 10:58:48.000000000 -0500
+@@ -361,7 +361,7 @@
+ 		state->read_error_warning_shown = 1;
+ 	}
+ 
+-	orig_offset = lseek64(fd, 0, SEEK_CUR);
++	orig_offset = lseek(fd, 0, SEEK_CUR);
+ 
+ 	/*
+ 	 * If the file is not seekable, we can't skip past the error, so we
+@@ -406,7 +406,7 @@
+ 	if (amount_to_skip > bytes_can_read)
+ 		amount_to_skip = bytes_can_read;
+ 
+-	skip_offset = lseek64(fd, orig_offset + amount_to_skip, SEEK_SET);
++	skip_offset = lseek(fd, orig_offset + amount_to_skip, SEEK_SET);
+ 
+ 	/*
+ 	 * If the skip we just tried didn't work, try only skipping 1 byte
+@@ -415,7 +415,7 @@
+ 	if (skip_offset < 0) {
+ 		amount_to_skip = 1;
+ 		skip_offset =
+-		    lseek64(fd, orig_offset + amount_to_skip, SEEK_SET);
++		    lseek(fd, orig_offset + amount_to_skip, SEEK_SET);
+ 	}
+ 
+ 	if (skip_offset < 0) {
+diff -ru src/pv/watchpid.c src/pv/watchpid.c
+--- src/pv/watchpid.c	2023-07-17 15:52:18.000000000 -0500
++++ src/pv/watchpid.c	2023-07-25 10:57:00.000000000 -0500
+@@ -34,9 +34,9 @@
+ 		 * Get the size of block devices by opening
+ 		 * them and seeking to the end.
+ 		 */
+-		fd = open64(info->file_fdpath, O_RDONLY);
++		fd = open(info->file_fdpath, O_RDONLY);
+ 		if (fd >= 0) {
+-			info->size = lseek64(fd, 0, SEEK_END);
++			info->size = lseek(fd, 0, SEEK_END);
+ 			close(fd);
+ 		} else {
+ 			info->size = 0;
+@@ -87,7 +87,7 @@
+ 
+ 	info->size = 0;
+ 
+-	if (!(0 == stat64(info->file_fdpath, &(info->sb_fd)))) {
++	if (!(0 == stat(info->file_fdpath, &(info->sb_fd)))) {
+ 		if (!automatic)
+ 			pv_error(state, "%s %u: %s %d: %s: %s",
+ 				 _("pid"),
+@@ -171,8 +171,8 @@
+ 		return 2;
+ 	}
+ 
+-	if (!((0 == stat64(info->file_fd, &(info->sb_fd)))
+-	      && (0 == lstat64(info->file_fd, &(info->sb_fd_link))))) {
++	if (!((0 == stat(info->file_fd, &(info->sb_fd)))
++	      && (0 == lstat(info->file_fd, &(info->sb_fd_link))))) {
+ 		if (!automatic)
+ 			pv_error(state, "%s %u: %s %d: %s: %s",
+ 				 _("pid"),
+@@ -214,10 +214,10 @@
+  */
+ int pv_watchfd_changed(pvwatchfd_t info)
+ {
+-	struct stat64 sb_fd, sb_fd_link;
++	struct stat sb_fd, sb_fd_link;
+ 
+-	if ((0 == stat64(info->file_fd, &sb_fd))
+-	    && (0 == lstat64(info->file_fd, &sb_fd_link))) {
++	if ((0 == stat(info->file_fd, &sb_fd))
++	    && (0 == lstat(info->file_fd, &sb_fd_link))) {
+ 		if ((sb_fd.st_dev != info->sb_fd.st_dev)
+ 		    || (sb_fd.st_ino != info->sb_fd.st_ino)
+ 		    || (sb_fd_link.st_mode != info->sb_fd_link.st_mode)


### PR DESCRIPTION
Maintainer update.

Add patch file to just remove all the suffixed-with-64 detection. For old systems, redefine at configure time. (This redefinition is for Tiger and earlier; untested as I don't have a system for that.)

Adds ability to run tests (pass on my x86_64 Big Sur system).