### PR TITLE
openttd: update to 13.3

### DIFF
--- a/games/openttd/Portfile
+++ b/games/openttd/Portfile
@@ -13,12 +13,12 @@ maintainers         {cal @neverpanic} openmaintainer
 if {${name} eq ${subport}} {
     PortGroup           cmake 1.1
 
-    version             12.2
+    version             13.3
     revision            0
 
-    checksums           rmd160  33e354a8bfca07e43837425e2559b9794933cc28 \
-                        sha256  81508f0de93a0c264b216ef56a05f8381fff7bffa6d010121a21490b4dace95c \
-                        size    7377496
+    checksums           rmd160  23fe31f99b55bb075b6d34bdd681de89e61ea6f5 \
+                        sha256  aafa16d2fb67165134c73a888f79f7a5ed7da17a04cf6e9ecf672c9cb89e7192 \
+                        size    7417568
 
     license             GPL-2
 
@@ -56,6 +56,16 @@ if {${name} eq ${subport}} {
     configure.args-append \
                         -DOPTION_USE_ASSERTS=Off \
                         -DCMAKE_INSTALL_PREFIX=${applications_dir}/OpenTTD.app/Contents/Resources/
+
+    post-destroot {
+        xinstall -m 0644 ${worksrcpath}/os/macosx/openttd.icns \
+            ${destroot}${applications_dir}/OpenTTD.app/Contents/Resources/OpenTTD.icns
+
+        xinstall -m 0644 ${cmake.build_dir}/Info.plist.in \
+            ${destroot}${applications_dir}/OpenTTD.app/Contents/Info.plist
+        reinplace "s|#CPACK_PACKAGE_VERSION#|${version}|g" \
+            ${destroot}${applications_dir}/OpenTTD.app/Contents/Info.plist
+    }
 
     livecheck.type      regex
     livecheck.url       ${homepage}


### PR DESCRIPTION
#### Description

Thus, I've also added missed `Info.plist` into the right place and fixed an icon.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->