### PR TITLE
google-cloud-sdk: update to 440.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             439.0.0
+version             440.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  1dca36df4c717ae7ef561c137edc908414268d2e \
-                    sha256  991bd0c69ccfad49de81c68ee3e630826ca733966793c7606f63af5b7d3cc911 \
-                    size    100995658
+    checksums       rmd160  ebeba5c7c1f8c393549e53a71b029d3a45c13146 \
+                    sha256  2eac519baa776aaa4935f474921f0620013c846860b26a1398c9efdc90c1f272 \
+                    size    101057970
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b7c5b77e450094ae42dca5666cb4f61c17f188d6 \
-                    sha256  564c39e3782498a138c1f5d4990e3af0063d5e9bc6eff440802279dd49d11b88 \
-                    size    121250606
+    checksums       rmd160  fdb2594892119070e161b088195cb3416bdbe25c \
+                    sha256  31fbe3f2527734275f51e85349132b4a688bd2078903ca44e375a6ed38baa401 \
+                    size    121315954
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  ed0ae8c6fb52e5370f6bfff76582cb9ee8f26cd6 \
-                    sha256  29ea27050cb84a0dd53a688c3c55057827f61881047658a839a475d15d66b0ac \
-                    size    118421397
+    checksums       rmd160  951614fd4b43b78ee9ccb7754df76d6d666600ed \
+                    sha256  43dd0d753adfe0680d358d0f04ab7f971bcb5590616c87677e77b03b4c69086a \
+                    size    118482227
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 440.0.0.

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?