### PR TITLE
openjdk17-graalvm: update to 17.0.8

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk17-graalvm
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version     17.0.7
+version     17.0.8
 revision    0
 epoch       1
 
@@ -26,14 +26,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-community-jdk-${version}_macos-x64_bin
-    checksums    rmd160  080bee211eb78ee8187a80daa1427ef6979bab4f \
-                 sha256  7b38776fc9259af5b9b02ffa21d8c7bf3991fa29bc689d6d1a10a305cd8f50af \
-                 size    284463055
+    checksums    rmd160  26e3d0b7238a6c7fbe10afeae0c4b0e8740b268a \
+                 sha256  cf4bb646018da8bf93f67e5cdae0f583b276d278d0b667d779a68d11d3b6873d \
+                 size    283915786
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-community-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  f98daabd32205fd8573d5b401e5372475dd76669 \
-                 sha256  05d9a51786c578cea346760b3ec3af3721780afb850b739407a2a123f5d081fd \
-                 size    280334645
+    checksums    rmd160  858b540bd9d1ecaef6e89d6f4bb6893a21d6881c \
+                 sha256  89209bbf8346d8dd0847d431bd8654db7d4ff634745207f20af2045c4869fb49 \
+                 size    279784572
 }
 
 worksrcdir   graalvm-community-openjdk-${version}+7.1


### PR DESCRIPTION
#### Description

Update to GraalVM 17.0.8.

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?