### PR TITLE
openjdk20-graalvm: update to 20.0.2

### DIFF
--- a/java/openjdk20-graalvm/Portfile
+++ b/java/openjdk20-graalvm/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk20-graalvm
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -14,7 +14,7 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version     20.0.1
+version     20.0.2
 revision    0
 
 description  GraalVM Community Edition based on OpenJDK 20
@@ -25,14 +25,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-community-jdk-${version}_macos-x64_bin
-    checksums    rmd160  564a8de20455600405b42f91e30b8e0c3a3be3d8 \
-                 sha256  0baffa8076049915c93e97f61ea9528959c6d30e9f03943c71a7b995fc73e36d \
-                 size    295385552
+    checksums    rmd160  6684d7bf1a0f724d0042f38e55e15c92e43dd7bd \
+                 sha256  5e57fffa27282f27976a07d27611256ea4219f02756612fe500a5ff80ed5fc2a \
+                 size    294990467
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-community-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  7cf90e8da7a36d66e31f9c7c0675cd190073a07b \
-                 sha256  be18d18f1fb805a0a3185c3eb6f08d6f7c93172025d8c8bd16c2a70b5105e28c \
-                 size    291203447
+    checksums    rmd160  4adc0d1ad0af8318fb18f9578fbfd231f642c800 \
+                 sha256  96e2227c4319ecb5eed755f8abb1411a56f51dd8f30e9770127bcd1cce2cd644 \
+                 size    290805758
 }
 
 worksrcdir   graalvm-community-openjdk-${version}+9.1


### PR DESCRIPTION
#### Description

Update to GraalVM 20.0.2.

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?