### PR TITLE
weechat: update to 4.0.2

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             3.8
+version             4.0.2
 revision            0
-checksums           rmd160  7fc2a475998a1dbcdc25ae2ba939c8b85fd5f3ae \
-                    sha256  f7cb65c200f8c090c56f2cf98c0b184051e516e5f7099a4308cacf86f174bf28 \
-                    size    2777420
+checksums           rmd160  86a96f18563a1558b7d7b5b11f3fa44da37dbe9e \
+                    sha256  0e648ee0d024c8099425ee60d41b272924ec8e19800ee8f1441090708834023c \
+                    size    2573044
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description
weechat: update to 4.0.2

###### Tested on
macOS 12.6.6 21G646 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?