### PR TITLE
qt6-qtbase: attempt to fix build on 10.14

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -990,6 +990,11 @@ if { ${subport} eq "${name}-qtbase" || ${subport} eq "${name}-qtbase-docs" } {
     # see https://trac.macports.org/ticket/64345
     patchfiles-append               patch-qtbase-macos_10.14_sdk.diff
 
+    # error: no matching function for call to '_mm256_maskz_cvtps_ph'
+    # note: candidate function not viable: requires 2 arguments, but 3 were provided
+    # see https://trac.macports.org/ticket/67802
+    patchfiles-append               patch-qtbase-intel_intrinsics.diff
+
     configure.pre_args-replace      --prefix=${prefix} \
                                     "-prefix ${qt6.dir}"
 

--- a/aqua/qt6/files/patch-qtbase-intel_intrinsics.diff
+++ b/aqua/qt6/files/patch-qtbase-intel_intrinsics.diff
@@ -1,0 +1,20 @@
+LLVM clang [3.9.0,9.0.0) (and so likely also Xcode clang <11.4)
+defined the _mm256_maskz_cvtps_ph intrinsic as 2-argument.
+Use the equivalent intrinsic _mm256_maskz_cvt_roundps_ph instead
+since clang has always defined it as 3-argument.
+https://trac.macports.org/ticket/67802
+
+diff --git a/src/corelib/global/qfloat16.cpp b/src/corelib/global/qfloat16.cpp
+--- src/corelib/global/qfloat16.cpp
++++ src/corelib/global/qfloat16.cpp
+@@ -176,9 +176,9 @@
+ void qFloatToFloat16_tail_avx256(quint16 *out, const float *in, qsizetype len) noexcept
+ {
+     __mmask16 mask = _bzhi_u32(-1, len);
+     __m256 f32 = _mm256_maskz_loadu_ps(mask, in );
+-    __m128i f16 = _mm256_maskz_cvtps_ph(mask, f32, _MM_FROUND_TO_NEAREST_INT);
++    __m128i f16 = _mm256_maskz_cvt_roundps_ph(mask, f32, _MM_FROUND_TO_NEAREST_INT);
+     _mm_mask_storeu_epi16(out, mask, f16);
+ };
+ 
+ static QT_FUNCTION_TARGET(ARCH_SKYLAKE_AVX512)


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/67802

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 Intel
Xcode 14.2
Not tested with an affected compiler/macOS version.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
This is meant as an alternative to disabling the code as done by patch-qtbase-xcode11-avx512.diff in #19407.
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
Only tried build phase; qfloat16.cpp compiles and links fine.
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
