### PR TITLE
emacs-{app-,}devel: add support for new tree-sitter modes

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -106,7 +106,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     github.setup    emacs-mirror emacs 89558533683a100ca7946c4a35bf4ef50463efef
     epoch           5
     version         20230725
-    revision        0
+    revision        1
 
     master_sites    ${github.master_sites}
 
@@ -152,7 +152,9 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
             port:tree-sitter-yaml \
             port:tree-sitter-rust \
             port:tree-sitter-ruby \
-            port:tree-sitter-html
+            port:tree-sitter-html \
+            port:tree-sitter-heex \
+            port:tree-sitter-elixir
     }
 
     default_variants-append +treesitter


### PR DESCRIPTION
#### Description

Emacs 30 has two new tree-sitter modes we did not yet include in the +treesitter variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5 22G74 x86_64
Xcode 14.3.1 14E300c


###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
