### PR TITLE
tcpflow: add -devel subport; remove useless dependency from python27

### DIFF
--- a/net/tcpflow/Portfile
+++ b/net/tcpflow/Portfile
@@ -8,6 +8,16 @@ PortGroup           openssl 1.0
 github.setup        simsong tcpflow 1.6.1 tcpflow-
 revision            2
 
+conflicts           ${name}-devel
+
+subport ${name}-devel {
+    github.setup    simsong tcpflow 5ca444e3b872f10f927d5d3673a4c4caa412a23e
+    version         20230726
+    revision        0
+
+    conflicts       ${name}
+}
+
 categories          net security
 platforms           darwin freebsd
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/net/tcpflow/Portfile
+++ b/net/tcpflow/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           openssl 1.0
 
 github.setup        simsong tcpflow 1.6.1 tcpflow-
-revision            1
+revision            2
 
 categories          net security
 platforms           darwin freebsd
@@ -37,7 +37,6 @@ depends_lib-append  port:bzip2 \
                     port:freetype \
                     port:libpcap \
                     path:lib/pkgconfig/pixman-1.pc:libpixman \
-                    port:python27 \
                     port:zlib
 
 boost.depends_type  build


### PR DESCRIPTION
#### Description

Well, without python27 ./configure complains:
```
  *** Cannot find python library.
  *** Please install python-devel to enable scanner python.
  ...
  configure: *** You have missing libraries. To install them:
  configure: *** Red Hat: sudo yum install  python-devel  python-devel
  configure: *** Fedora:  sudo dnf install  python-devel  python-devel
  configure: *** Ubuntu:  sudo apt-get install  libpython2.7-dev libpython2.7-dev
  configure: *** MacOS:   sudo port install  python27 python27
```
but since version 1.6.1 tcpflow doesn't require nor use python anymore because the only plugin which is used it (`scan_python.cpp`) was excluded from build.

See:
 - https://github.com/simsong/tcpflow/blob/tcpflow-1.6.1/src/scan_python.cpp
 - https://github.com/simsong/tcpflow/issues/254

Anyway, future release may bring that plugin back.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->