### PR TITLE
obs-build-helpers: remove useless python27 dependency

### DIFF
--- a/devel/obs-build-helpers/Portfile
+++ b/devel/obs-build-helpers/Portfile
@@ -2,9 +2,9 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           python 1.0
 
 github.setup        openSUSE obs-build 2.5.0 obs_
+revision            1
 name                obs-build-helpers
 categories          devel python
 platforms           darwin
@@ -17,11 +17,11 @@ description         Helper tools distributed with obs-build
 
 long_description    obs-build is the tool running builds for the openSUSE build \
                     service. Since these tools are only useful on Linux, this \
-                    port only provides some of the contained helper tools, vc \
-                    and unrpm.
+                    port only provides some of the contained helper tools like vc.
 
 checksums           rmd160  6515dee5fbb207b389c163fcbb0c6a0e5658123d \
-                    sha256  d176b19ccddc11208e6288bdcf758a81d5a194bea994468400a16823135c18d0
+                    sha256  d176b19ccddc11208e6288bdcf758a81d5a194bea994468400a16823135c18d0 \
+                    size    147830
 
 # the tarball contains file names differing in case only,
 # making it impossible to extract on a case-sensitive filesystem
@@ -35,5 +35,3 @@ destroot {
     xinstall -d -m 755 ${destroot}${prefix}/libexec/obs-build
     xinstall -m 755 ${worksrcpath}/vc ${destroot}${prefix}/libexec/obs-build/vc
 }
-
-python.default_version 27


### PR DESCRIPTION
#### Description

This port provides only one bash script which hasn't use python.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->