### PR TITLE
openjdk11-graalvm: update to 22.3.3

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -5,7 +5,7 @@ PortSystem       1.0
 name             openjdk11-graalvm
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
+platforms        {darwin any}
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
@@ -15,10 +15,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 if {${configure.build_arch} eq "arm64"} {
-    # There is no macOS aarch64 build for 22.3.2
+    # There is no macOS aarch64 build for 22.3.2+
     version 22.3.1
 } else {
-    version 22.3.2
+    version 22.3.3
 }
 
 revision     0
@@ -31,9 +31,9 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-ce-java11-darwin-amd64-${version}
-    checksums    rmd160  31d6a6c00d2241775b1a54d9cc9ad6d0735a18e4 \
-                 sha256  da3c52cc68ce0fb4dcc27dba3c59beadafb7588fec9e9d2812f5bc7c7d00ab63 \
-                 size    254235978
+    checksums    rmd160  e596dc7f73ca0f602ae60ca5c1bc4247373ec158 \
+                 sha256  cab6a1436626adc28ec0f72791772315678e7c758e2fbae2cb6758a38f27c56a \
+                 size    254523003
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-ce-java11-darwin-aarch64-${version}
     checksums    rmd160  3421d1754a491b0cfa44d09df798ff5053fcefc8 \
@@ -101,9 +101,9 @@ subport ${name}-native-image {
     if {${configure.build_arch} eq "x86_64"} {
         set jar_file native-image-installable-svm-java11-darwin-amd64-${version}.jar
         distfiles    ${jar_file}
-        checksums    rmd160  f6ef5181f146264d198705ad88f0e2f9f7debf34 \
-                     sha256  ae542383b033576e26d0431b0b62b4f7c048fee3b209dad2a257c4ae6345f1fb \
-                     size    28458434
+        checksums    rmd160  373bfe27fe1acd74596411b52d4506cdbd5260d0 \
+                     sha256  56ddaf1f1d7e69efb88d8e391a4071f3a237723bdcee67794be1c56a03f56536 \
+                     size    28688654
     } elseif {${configure.build_arch} eq "arm64"} {
         set jar_file native-image-installable-svm-java11-darwin-aarch64-${version}.jar
         distfiles    ${jar_file}


### PR DESCRIPTION
#### Description

Update to GraalVM 22.3.3.

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?