### PR TITLE
autoconf: Fix AC_FUNC_MMAP to avoid implicit func

### DIFF
--- a/devel/autoconf/Portfile
+++ b/devel/autoconf/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                autoconf
 epoch               1
 version             2.71
-revision            1
+revision            2
 categories          devel
 # the license is GPL-3+ with an exception:
 # https://www.gnu.org/licenses/autoconf-exception.html
@@ -40,6 +40,7 @@ checksums           rmd160 baa56c2b1e9b2c3d6bffaeb936fa8fbf55318caa \
                     sha256 f14c83cfebcc9427f2c3cea7258bd90df972d92eb26752da4ddad81c87a0faa4
 
 patchfiles          use-macports-tools.patch
+patchfiles-append   AC_FUNC_MMAP.patch
 post-patch {
     # Stop build from trying to regenerate this after patching.
     touch ${worksrcpath}/man/autoreconf.1

--- a/devel/autoconf/files/AC_FUNC_MMAP.patch
+++ b/devel/autoconf/files/AC_FUNC_MMAP.patch
@@ -1,0 +1,59 @@
+Fix:
+
+conftest.c:135:14: error: implicit declaration of function 'getpagesize' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
+
+https://bugs.gentoo.org/898816
+https://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=028526149ee804617a302ccef22cc6adbda681b0
+https://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=33c26d2700f927432c756ccf7a4fc89403d35b95
+--- lib/autoconf/functions.m4.orig	2021-01-28 14:46:48.000000000 -0600
++++ lib/autoconf/functions.m4	2023-07-27 01:25:27.000000000 -0500
+@@ -1281,21 +1281,19 @@
+    VM page cache was not coherent with the file system buffer cache
+    like early versions of FreeBSD and possibly contemporary NetBSD.)
+    For shared mappings, we should conversely verify that changes get
+-   propagated back to all the places they're supposed to be.
+-
+-   Grep wants private fixed already mapped.
+-   The main things grep needs to know about mmap are:
+-   * does it exist and is it safe to write into the mmap'd area
+-   * how to use it (BSD variants)  */
++   propagated back to all the places they're supposed to be.  */
+ 
+ #include <fcntl.h>
+ #include <sys/mman.h>
+ 
+-/* This mess was copied from the GNU getpagesize.h.  */
+-#ifndef HAVE_GETPAGESIZE
++#ifndef getpagesize
+ # ifdef _SC_PAGESIZE
+-#  define getpagesize() sysconf(_SC_PAGESIZE)
+-# else /* no _SC_PAGESIZE */
++#  define getpagesize() sysconf (_SC_PAGESIZE)
++# elif defined _SC_PAGE_SIZE
++#  define getpagesize() sysconf (_SC_PAGE_SIZE)
++# elif HAVE_GETPAGESIZE
++int getpagesize ();
++# else
+ #  ifdef HAVE_SYS_PARAM_H
+ #   include <sys/param.h>
+ #   ifdef EXEC_PAGESIZE
+@@ -1319,16 +1317,15 @@
+ #  else /* no HAVE_SYS_PARAM_H */
+ #   define getpagesize() 8192	/* punt totally */
+ #  endif /* no HAVE_SYS_PARAM_H */
+-# endif /* no _SC_PAGESIZE */
+-
+-#endif /* no HAVE_GETPAGESIZE */
++# endif
++#endif
+ 
+ int
+ main (void)
+ {
+   char *data, *data2, *data3;
+   const char *cdata2;
+-  int i, pagesize;
++  long i, pagesize;
+   int fd, fd2;
+ 
+   pagesize = getpagesize ();


### PR DESCRIPTION
#### Description

Projects like htslib that use `AC_FUNC_MMAP` in their configure.ac files to detect the availability of `mmap` [fail to do so when using Xcode 12 or later](https://trac.macports.org/wiki/WimplicitFunctionDeclaration):

```
conftest.c:135:14: error: implicit declaration of function 'getpagesize' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```

This backports the two upstream commits that fixed that. Configure scripts generated with this fixed version of autoconf won't have that problem.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.7 21G651 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

There is one lint failure, unrelated to my changes, which I leave for the maintainer to fix at their leisure.

The test suite is still running. I'll report back when it finishes.
