### PR TITLE
initool: update to current upstream, drop now unneeded dep on coreutils

### DIFF
--- a/sysutils/initool/Portfile
+++ b/sysutils/initool/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 
-github.setup        dbohdan initool 75e6b71307ef65ad0061d761acc11713c2ee16f0
-version             2023.06.21
+github.setup        dbohdan initool 5c260d5c15a46387a2749e1bacc33b52399f7b87
+version             2023.07.26
 revision            0
 categories          sysutils
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -15,21 +15,14 @@ long_description    Initool lets you manipulate the contents of INI files from t
                     It is a rewrite of an earlier program by the same developer called iniparse. \
                     Rather than modify INI files in place like iniparse, however, it prints \
                     the modified contents to standard output.
-checksums           rmd160  17e1509f792ec47b6fbcb5c30986f6397aa2c9e1 \
-                    sha256  6fafdb20508d7be49c29e39aab80690f15f2660398c7416291eb1bf4f2a3001f \
-                    size    10814
+checksums           rmd160  374355c6d4f002d5ddbef8b75fccd4972f604aa2 \
+                    sha256  a245a9eba9159e6bd49f4943be64bc29c58a58c71b70bde58bd7c468870a8549 \
+                    size    11120
 github.tarball_from archive
 
 depends_build-append \
-                    path:libexec/coreutils/libstdbuf.so:coreutils \
                     port:mlton
 depends_lib-append  port:gmp
-
-# https://github.com/dbohdan/initool/issues/7
-post-patch {
-    reinplace "s,readlink,greadlink," ${worksrcpath}/test.sh
-    reinplace "s,mktemp,gmktemp," ${worksrcpath}/test.sh
-}
 
 destroot {
     xinstall -d ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Upstream has fixed gnuisms, and we do not need to depend on `coreutils` here anymore. See: https://github.com/dbohdan/initool/issues/7

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
