### PR TITLE
science/kicad: update to 7.0.6, python 3.11

### DIFF
--- a/science/kicad/Portfile
+++ b/science/kicad/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitlab 1.0
 PortGroup           boost 1.0
 
 name                kicad
-version             6.0.11
+version             7.0.9
 description         KiCad is an electronic design automation software suite
 long_description    KiCad is an EDA software suite for the creation of professional schematics \
                     and printed circuit boards up to 32 copper layers with additional technical layers.
@@ -15,7 +15,7 @@ license             GPL-3
 maintainers         {ra1nb0w @ra1nb0w} openmaintainer
 homepage            https://www.kicad.org/
 
-set python_version  3.10
+set python_version  3.11
 set py_ver_no_dot   [join [split ${python_version} "."] ""]
 set python_framework_dir ${frameworks_dir}/Python.framework/Versions/${python_version}
 
@@ -25,15 +25,15 @@ if {${name} eq ${subport}} {
 
     gitlab.setup        kicad/code kicad ${version}
 
-    checksums           rmd160  b13a0b899f0548ed8ff76c0c78d33f80c1ab7473 \
-                        sha256  f2b7ad72942c7e154bebb06d4e6d9fd7ea765f679edafb25b059b387860fbe5d \
-                        size    34083016
-    revision            2
+    checksums           rmd160  e52fee69a2d158a8be220880c7789560356c8860 \
+                        sha256  45322e7495cbf0b6bba70b8fb8b58fdafa408d4d8473209fd1c5e8bad5a818f7 \
+                        size    43964032
+    revision            0
 
     patchfiles-append \
-        wxwidgets-4.1-deprecated.patch \
         macports_prefix.patch \
-        0001-cmake-adding-KICAD_MACOSX_APP_BUNDLE-option.patch
+        0001-cmake-adding-KICAD_MACOSX_APP_BUNDLE-option.patch \
+        0002-disable-codesigning.patch
 
     depends_build-append \
         path:bin/doxygen:doxygen \
@@ -53,6 +53,8 @@ if {${name} eq ${subport}} {
         path:lib/pkgconfig/cairo.pc:cairo \
         port:py${py_ver_no_dot}-pybind11 \
         path:lib/pkgconfig/pixman-1.pc:libpixman \
+        port:unixODBC \
+        port:harfbuzz \
         port:kicad-docs \
         port:kicad-symbols \
         port:kicad-footprints \
@@ -124,9 +126,9 @@ subport kicad-docs {
     master_sites        https://kicad-downloads.s3.cern.ch/docs
     distname            ${name}-doc-${version}
 
-    checksums           rmd160  206f25bc6d82b55e265625606664e92123226331 \
-                        sha256  141ef958e8cfd8daf489c8e61b245df64e971bd0b30b2a32857b3210c22f3f4a \
-                        size    278043986
+    checksums           rmd160  e8020d677cd9bf1f58bab6d53fe50b19d1b63029 \
+                        sha256  3e276fd4d5ca1a2cc11cb35770c3ef6a33e02ec4a20243b28d110b647abef00b \
+                        size    694923369
 
     use_configure       no
 
@@ -146,9 +148,10 @@ subport kicad-symbols {
 
     gitlab.setup        kicad/libraries kicad-symbols ${version}
 
-    checksums           rmd160  585801627bf07bf9ce514835c6d8208c38470e77 \
-                        sha256  b4b28ef9449ebce2cbab0555173994b2af6c0157e546ba1308d680ad6fa4a0ca \
-                        size    2291352
+    checksums           rmd160  a4e17bdcfda2283a934e667f910d1fcc7ed35e15 \
+                        sha256  c1be547ab435cccf9c98d21c9a816ab3051ae8e306bcbcb4ac46a896c88210ab \
+                        size    3054537
+
 
     patchfiles-append   kicad_libraries_cmakelists.txt.patch
 }
@@ -161,9 +164,9 @@ subport kicad-footprints {
 
     gitlab.setup        kicad/libraries kicad-footprints ${version}
 
-    checksums           rmd160  f063a0ae6b02d0cc95d5fad77cb1e7ddc30c2faa \
-                        sha256  6229296fb1f7fcd64424230128abcee008eb92c2590da6b40718f0a66810b614 \
-                        size    23763091
+    checksums           rmd160  1f8f14d49dc64342a080d78350e4f11fd0859996 \
+                        sha256  1307f37613c1971794940ee78ad49146ae10eb3525a0c9f427adb8900ddbee0e \
+                        size    24450969
 
     patchfiles-append   kicad_libraries_cmakelists.txt.patch
 }
@@ -176,9 +179,9 @@ subport kicad-packages3D {
 
     gitlab.setup        kicad/libraries kicad-packages3D ${version}
 
-    checksums           rmd160  a41b961ff98d9f24488feb21b20f985009adeff0 \
-                        sha256  ca3291bcf54dc79b37bc8c0e15c3eb6d1a9eea0e391d0e34202bd26b451c6fcb \
-                        size    737065465
+    checksums           rmd160  681a3188e25acc46fc86af91cead540e8ed76f4c \
+                        sha256  cf9dd300e4020f25e17835c7f930af1974d5953694d103b65bb0a41eb80bf19a \
+                        size    773284884
 
     patchfiles-append   kicad_libraries_cmakelists.txt.patch
 }
@@ -191,9 +194,9 @@ subport kicad-templates {
 
     gitlab.setup        kicad/libraries kicad-templates ${version}
 
-    checksums           rmd160  a58993f2d9044a8ba8e7079ef75166cf37eb0f37 \
-                        sha256  a8de6c4653ad7ba711a21d4b081797202e4f4e9954dc6d9fdca3ce2f392448d9 \
-                        size    934873
+    checksums           rmd160  0b32a8fd3aab53794190b52c3902f610d6ffa8f5 \
+                        sha256  3f87dfe352cf12e73cf7769202101935fba547da5f04e1029bdd786ad0f9f0a4 \
+                        size    1247499
 
     patchfiles-append   kicad_libraries_cmakelists.txt.patch
 }

--- a/science/kicad/files/0001-cmake-adding-KICAD_MACOSX_APP_BUNDLE-option.patch
+++ b/science/kicad/files/0001-cmake-adding-KICAD_MACOSX_APP_BUNDLE-option.patch
@@ -8,8 +8,8 @@ index 09f4f557a1..5fc0b08566 100644
  
 -#ifndef __WXMAC__
 +#ifndef __MACOSX_APP__
- 
- #ifdef DEBUG
+     if( wxGetEnv( wxT( "KICAD_RUN_FROM_BUILD_DIR" ), nullptr ) )
+     {
      // set up to work from the build directory
 diff --git 3d-viewer/3d_cache/sg/CMakeLists.txt 3d-viewer/3d_cache/sg/CMakeLists.txt
 index 0899a1925b..13d1e6a688 100644
@@ -24,13 +24,6 @@ index 0899a1925b..13d1e6a688 100644
      # puts library into the main kicad.app bundle in build tree
      set_target_properties( kicad_3dsg PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY "${OSX_BUNDLE_BUILD_LIB_DIR}"
-@@ -108,4 +108,4 @@ install( TARGETS
- if( KICAD_WIN32_INSTALL_PDBS )
-     # Get the PDBs to copy over for MSVC
-     install(FILES $<TARGET_PDB_FILE:kicad_3dsg> DESTINATION ${KICAD_BIN})
--endif()
-\ No newline at end of file
-+endif()
 diff --git CMakeLists.txt CMakeLists.txt
 index 1cd76e8db5..fd76b6bb86 100644
 --- CMakeLists.txt
@@ -308,43 +301,17 @@ index 52a11230ba..49e82646c6 100644
          )
  
      # puts binaries into the *.app bundle while linking
-diff --git eeschema/bom_plugins.cpp eeschema/bom_plugins.cpp
-index 84b6762504..efb8436beb 100644
---- eeschema/bom_plugins.cpp
-+++ eeschema/bom_plugins.cpp
-@@ -75,7 +75,7 @@ BOM_GENERATOR_HANDLER::BOM_GENERATOR_HANDLER( const wxString& aFile )
- #else
- // For macOS, we want to use the Python we bundle along, rather than just PYTHON_EXECUTABLE.
- // For non-Windows, non-macOS, we can call out to PYTHON_EXECUTABLE.
--#ifdef __APPLE__
-+#ifdef __MACOSX_APP__
-         // python is at Contents/Frameworks/Python.framework/Versions/Current/bin/python3
- 
-         // Of course, for macOS, it's not quite that simple, since the relative path
-diff --git eeschema/dialogs/dialog_netlist.cpp eeschema/dialogs/dialog_netlist.cpp
-index ee62d2a6ff..b3a42b4356 100644
---- eeschema/dialogs/dialog_netlist.cpp
-+++ eeschema/dialogs/dialog_netlist.cpp
-@@ -682,7 +682,7 @@ void NETLIST_DIALOG_ADD_GENERATOR::OnBrowseGenerators( wxCommandEvent& event )
- {
-     wxString FullFileName, Path;
- 
--#ifndef __WXMAC__
-+#ifndef __MACOSX_APP__
-     Path = Pgm().GetExecutablePath();
- #else
-     Path = PATHS::GetOSXKicadDataDir() + wxT( "/plugins" );
 diff --git eeschema/sim/ngspice.cpp eeschema/sim/ngspice.cpp
 index e31449c98b..d9cdd0bc81 100644
 --- eeschema/sim/ngspice.cpp
 +++ eeschema/sim/ngspice.cpp
-@@ -431,7 +431,7 @@ void NGSPICE::init_dll()
+@@ -443,7 +443,7 @@
    #else
-     const vector<string> dllPaths = { "", "/mingw64/bin", "/mingw32/bin" };
+     const std::vector<std::string> dllPaths = { "", "/mingw64/bin", "/mingw32/bin" };
    #endif
--#elif defined(__WXMAC__)
 +#elif defined(__MACOSX_APP__)
-     const vector<string> dllPaths = {
+-#elif defined(__WXMAC__)
+     const std::vector<std::string> dllPaths = {
          PATHS::GetOSXKicadUserDataDir().ToStdString() + "/PlugIns/ngspice",
          PATHS::GetOSXKicadMachineDataDir().ToStdString() + "/PlugIns/ngspice",
 diff --git gerbview/CMakeLists.txt gerbview/CMakeLists.txt
@@ -385,7 +352,7 @@ diff --git kicad/CMakeLists.txt kicad/CMakeLists.txt
 index 04edf80fb3..16ba177d45 100644
 --- kicad/CMakeLists.txt
 +++ kicad/CMakeLists.txt
-@@ -47,7 +47,7 @@ if( WIN32 )
+@@ -64,7 +64,7 @@ if( WIN32 )
      endif()
  endif()
  
@@ -394,16 +361,16 @@ index 04edf80fb3..16ba177d45 100644
      set( KICAD_RESOURCES kicad.icns kicad_doc.icns )
      set_source_files_properties( "${CMAKE_CURRENT_SOURCE_DIR}/kicad.icns" PROPERTIES
          MACOSX_PACKAGE_LOCATION Resources
-@@ -60,7 +60,7 @@ if( APPLE )
+@@ -77,7 +77,7 @@ if( APPLE )
      set( MACOSX_BUNDLE_NAME kicad )
  endif()
  
 -add_executable( kicad WIN32 MACOSX_BUNDLE
 +add_executable( kicad WIN32
+     kicad.cpp
      ${KICAD_SRCS}
      ${KICAD_EXTRA_SRCS}
-     ${KICAD_RESOURCES}
-@@ -80,9 +80,10 @@ if( UNIX )
+@@ -111,9 +111,10 @@ if( UNIX )
          )
  endif()
  
@@ -415,7 +382,7 @@ index 04edf80fb3..16ba177d45 100644
          )
      target_link_libraries( kicad
          common
-@@ -112,7 +113,7 @@ if( KICAD_WIN32_INSTALL_PDBS )
+@@ -176,7 +176,7 @@ if( KICAD_WIN32_INSTALL_PDBS )
      install(FILES $<TARGET_PDB_FILE:kicad> DESTINATION ${KICAD_BIN})
  endif()
  
@@ -428,10 +395,10 @@ diff --git kicad/tools/kicad_manager_control.cpp kicad/tools/kicad_manager_contr
 index 383c41c701..36e56f66f1 100644
 --- kicad/tools/kicad_manager_control.cpp
 +++ kicad/tools/kicad_manager_control.cpp
-@@ -799,7 +799,7 @@ int KICAD_MANAGER_CONTROL::Execute( const TOOL_EVENT& aEvent )
-         wxString msg = wxString::Format( _( "%s %s opened [pid=%ld]\n" ), execFile, param, pid );
-         m_frame->PrintMsg( msg );
+@@ -866,7 +866,7 @@ int KICAD_MANAGER_CONTROL::Execute( const TOOL_EVENT& aEvent )
  
+     if( pid > 0 )
+     {
 -#ifdef __WXMAC__
 +#ifdef __MACOSX_APP__
          // This non-parameterized use of wxExecute is fine because execFile is not derived
@@ -441,7 +408,7 @@ diff --git pagelayout_editor/CMakeLists.txt pagelayout_editor/CMakeLists.txt
 index fb621b5aa7..bb10e3ea29 100644
 --- pagelayout_editor/CMakeLists.txt
 +++ pagelayout_editor/CMakeLists.txt
-@@ -61,7 +61,7 @@ if( WIN32 )
+@@ -57,7 +57,7 @@ if( WIN32 )
  endif()
  
  
@@ -450,7 +417,7 @@ index fb621b5aa7..bb10e3ea29 100644
      # setup bundle
      set( PL_EDITOR_RESOURCES pagelayout_editor.icns pagelayout_editor_doc.icns )
      set_source_files_properties( "${CMAKE_CURRENT_SOURCE_DIR}/pagelayout_editor.icns" PROPERTIES
-@@ -76,7 +76,7 @@ if( APPLE )
+@@ -72,7 +72,7 @@ if( APPLE )
  endif()
  
  # a very small program launcher for pl_editor_kiface
@@ -471,13 +438,6 @@ index fb621b5aa7..bb10e3ea29 100644
          )
  
      # puts binaries into the *.app bundle while linking
-@@ -176,4 +177,4 @@ if( KICAD_WIN32_INSTALL_PDBS )
-     # Get the PDBs to copy over for MSVC
-     install(FILES $<TARGET_PDB_FILE:pl_editor> DESTINATION ${KICAD_BIN})
-     install(FILES $<TARGET_PDB_FILE:pl_editor_kiface> DESTINATION ${KICAD_BIN})
--endif()
-\ No newline at end of file
-+endif()
 diff --git pcb_calculator/CMakeLists.txt pcb_calculator/CMakeLists.txt
 index 2069c9e835..4ebf9ca75f 100644
 --- pcb_calculator/CMakeLists.txt
@@ -595,13 +555,6 @@ index 7bcc7656dd..a417d38f88 100644
      # puts library into the main kicad.app bundle in build tree
      set_target_properties( s3d_plugin_idf PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY "${OSX_BUNDLE_BUILD_PLUGIN_DIR}/3d"
-@@ -45,4 +45,4 @@ install( TARGETS
- if( KICAD_WIN32_INSTALL_PDBS )
-     # Get the PDBs to copy over for MSVC
-     install(FILES $<TARGET_PDB_FILE:s3d_plugin_idf> DESTINATION ${KICAD_USER_PLUGIN}/3d)
--endif()
-\ No newline at end of file
-+endif()
 diff --git plugins/3d/oce/CMakeLists.txt plugins/3d/oce/CMakeLists.txt
 index 074df30a67..5998fb7c15 100644
 --- plugins/3d/oce/CMakeLists.txt
@@ -615,13 +568,6 @@ index 074df30a67..5998fb7c15 100644
      # puts library into the main kicad.app bundle in build tree
      set_target_properties( s3d_plugin_oce PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY "${OSX_BUNDLE_BUILD_PLUGIN_DIR}/3d"
-@@ -39,4 +39,4 @@ install( TARGETS
- if( KICAD_WIN32_INSTALL_PDBS )
-     # Get the PDBs to copy over for MSVC
-     install(FILES $<TARGET_PDB_FILE:s3d_plugin_oce> DESTINATION ${KICAD_USER_PLUGIN}/3d)
--endif()
-\ No newline at end of file
-+endif()
 diff --git plugins/3d/vrml/CMakeLists.txt plugins/3d/vrml/CMakeLists.txt
 index b651598842..ebe3a7f7c7 100644
 --- plugins/3d/vrml/CMakeLists.txt
@@ -635,13 +581,6 @@ index b651598842..ebe3a7f7c7 100644
      # puts library into the main kicad.app bundle in build tree
      set_target_properties( s3d_plugin_vrml PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY "${OSX_BUNDLE_BUILD_PLUGIN_DIR}/3d"
-@@ -87,4 +87,4 @@ install( TARGETS
- if( KICAD_WIN32_INSTALL_PDBS )
-     # Get the PDBs to copy over for MSVC
-     install(FILES $<TARGET_PDB_FILE:s3d_plugin_vrml> DESTINATION ${KICAD_USER_PLUGIN}/3d)
--endif()
-\ No newline at end of file
-+endif()
 diff --git scripting/CMakeLists.txt scripting/CMakeLists.txt
 index 07e7e33d9a..851afbeaf5 100644
 --- scripting/CMakeLists.txt
@@ -655,13 +594,6 @@ index 07e7e33d9a..851afbeaf5 100644
      set_target_properties( scripting_kiface PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY ${OSX_BUNDLE_BUILD_KIFACE_DIR}
          )
-@@ -86,4 +86,4 @@ endif()
- install( DIRECTORY ${PROJECT_SOURCE_DIR}/scripting/kicad_pyshell/
-     DESTINATION ${KICAD_DATA}/scripting/kicad_pyshell
-     FILE_PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
--)
-\ No newline at end of file
-+)
 diff --git scripting/python_scripting.cpp scripting/python_scripting.cpp
 index e292887ff0..b2531e8891 100644
 --- scripting/python_scripting.cpp
@@ -701,16 +633,3 @@ index c6dbff6dfa..2cfc6bed06 100644
      # puts binaries into the *.app bundle while linking
      set_target_properties( idfcyl idfrect dxf2idf idf2vrml PROPERTIES
          RUNTIME_OUTPUT_DIRECTORY ${OSX_BUNDLE_BUILD_BIN_DIR}
-diff --git utils/kicad2step/CMakeLists.txt utils/kicad2step/CMakeLists.txt
-index 2bc9c94e29..5eb4bb177b 100644
---- utils/kicad2step/CMakeLists.txt
-+++ utils/kicad2step/CMakeLists.txt
-@@ -59,7 +59,7 @@ target_include_directories( kicad2step_lib PRIVATE
- set_target_properties( kicad2step_bin
-         PROPERTIES OUTPUT_NAME kicad2step)
- 
--if( APPLE )
-+if( KICAD_MACOSX_APP_BUNDLE )
-     # puts binaries into the *.app bundle while linking
-     set_target_properties( kicad2step_bin PROPERTIES
-             RUNTIME_OUTPUT_DIRECTORY ${OSX_BUNDLE_BUILD_BIN_DIR}

--- a/science/kicad/files/0002-disable-codesigning.patch
+++ b/science/kicad/files/0002-disable-codesigning.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt	2023-07-24 17:41:09.037114375 +0200
++++ CMakeLists.txt	2023-07-25 08:53:09.659283252 +0200
+@@ -1071,7 +1071,7 @@
+     add_subdirectory( translation )
+ endif()
+ 
+-if( APPLE )
++if( FALSE )
+     set( KICAD_OSX_CODESIGN ON
+             CACHE BOOL "Sign KiCad.app on macOS" FORCE )
+     set( KICAD_OSX_SIGNING_ID "-"

--- a/science/kicad/files/macports_prefix.patch
+++ b/science/kicad/files/macports_prefix.patch
@@ -14,12 +14,12 @@ diff --git eeschema/sim/ngspice.cpp eeschema/sim/ngspice.cpp
 index 0a3a07ed4b..fe566c9e81 100644
 --- eeschema/sim/ngspice.cpp
 +++ eeschema/sim/ngspice.cpp
-@@ -444,7 +444,7 @@ void NGSPICE::init_dll()
+@@ -456,7 +456,7 @@
                  "/../../../../../Contents/PlugIns/sim"
      };
  #else   // Unix systems
--    const vector<string> dllPaths = { "/usr/local/lib" };
-+    const vector<string> dllPaths = { "@PREFIX_DIR@/lib" };
+-    const std::vector<std::string> dllPaths = { "/usr/local/lib" };
++    const std::vector<std::string> dllPaths = { "@PREFIX_DIR@/lib" };
  #endif
- 
+
  #if defined(__WINDOWS__) || (__WXMAC__)


### PR DESCRIPTION
#### Description

Update kicad to 7.0.6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5 22G74 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
