### PR TITLE
PothosCore: improve GCC patch

### DIFF
--- a/science/PothosCore/files/patch-unbreak-gcc-build.diff
+++ b/science/PothosCore/files/patch-unbreak-gcc-build.diff
@@ -1,15 +1,16 @@
 --- a/cmake/Modules/PothosStandardFlags.cmake	2021-01-25 11:32:12.000000000 +0800
-+++ b/cmake/Modules/PothosStandardFlags.cmake	2023-07-13 18:47:50.000000000 +0800
-@@ -27,9 +27,9 @@
-         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
++++ b/cmake/Modules/PothosStandardFlags.cmake	2023-07-28 03:07:44.000000000 +0800
+@@ -28,8 +28,13 @@
      endif()
  
--    #force a compile-time error when symbols are missing
--    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
--    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-undefined")
-+    # This flag is unsupported and breaks the build.
-+    # set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
-+    # set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-undefined")
+     #force a compile-time error when symbols are missing
++  if(APPLE)
++    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error")
++    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-undefined,error")
++  else()
+     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--no-undefined")
++  endif()
  
      #these warnings are caused by static warnings used throughout the code
      add_compile_options(-Wno-unused-local-typedefs)


### PR DESCRIPTION
#### Description

Addressing: https://github.com/macports/macports-ports/pull/19424
Flags added for Apple build with GCC according to the suggestion by @kencu 
Also Linux flags are retained so that port builds (presumably) on Linux too.

@mascguy @ra1nb0w Please notice that my fix (including [earlier one](https://github.com/macports/macports-ports/commit/173952e1f8755a6233dc557de7520f3dda6994ca)) has an effect only for builds with GCC, which is not the case on Intel in Macports. So I could not have broken anything with its dependencies, when build is done with Clang. At the very worst, I might have broken Linux builds with GCC, when I removed Linux-only flag from GCC options. That should be fixed with this PR.
Original code: https://github.com/pothosware/PothosCore/blob/bee99d002740e1de6a58ee1812d9a01e79d3d56c/cmake/Modules/PothosStandardFlags.cmake#L23-L45

P. S. Neither the last fix to `poco` should have any consequence for `PothosFlow` or other Pothos* ports: https://github.com/macports/macports-ports/commit/68c15a190fdde88aa50983ddce975ce2cb0ed888
Besides fixing tests and setting MongoDB variant, it only passes `-latomic`, only for GCC. There were no patches to `poco` sources.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
