### PR TITLE
loli: ensure right compiler is picked

### DIFF
--- a/lang/loli/Portfile
+++ b/lang/loli/Portfile
@@ -8,7 +8,7 @@ PortGroup           makefile 1.0
 github.setup        LoLi-Lang LoLi 9306a531a42df9e81b75de4bc278aa8dc9c22a3f
 name                loli
 version             2016.07.01
-revision            0
+revision            1
 categories          lang
 license             GPL-3
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -23,8 +23,8 @@ build.dir           ${worksrcpath}/src/LoLi2
 patchfiles          loli-fix.diff
 
 post-patch {
-    reinplace "s,@CC@,${configure.cxx},g" ${build.dir}/Makefile
-    reinplace "s,@ARCHFLAGS@,[get_canonical_archflags cc],g" ${build.dir}/Makefile
+    reinplace "s,@CXX@,${configure.cxx},g" ${build.dir}/Makefile
+    reinplace "s,@ARCHFLAGS@,[get_canonical_archflags cxx],g" ${build.dir}/Makefile
     delete ${build.dir}/currentc ${build.dir}/test
 }
 

--- a/lang/loli/files/loli-fix.diff
+++ b/lang/loli/files/loli-fix.diff
@@ -17,7 +17,7 @@
 -CLANG = clang++
 -CFLAGSG = -std=c++11 -stdlib=libstdc++ -Wall -Og -Wextra -g
 -CFLAGSC = -std=c++11 -stdlib=libstdc++ -Wall -O0 -Wextra -g
-+CC = @CXX@
++CXX = @CXX@
 +CFLAGSG = @ARCHFLAGS@ -std=gnu++11 -Wall -Og -Wextra -g
 +CFLAGSC = @ARCHFLAGS@ -std=c++11 -Wall -O0 -Wextra -g
  
@@ -28,15 +28,15 @@
  
  CURRENTG: 
 -	$(CC) $(CFLAGSG) -o currentg $(MAIN)
-+	$(CC) $(CFLAGSG) -o currentg $(MAIN) -lstdc++
++	$(CXX) $(CFLAGSG) -o currentg $(MAIN) -lstdc++
  
  CURRENTC:
 -	$(CLANG) $(CFLAGSC) -o currentc $(MAIN)
-+	$(CC) $(CFLAGSC) -o currentc $(MAIN) -lc++
++	$(CXX) $(CFLAGSC) -o currentc $(MAIN) -lc++
  
  TEST:	$(HEADERS)
 -	$(CLANG) $(CFLAGSC) $(GCINCLUDE) $(GC) -o test $(TEST)
-+	$(CC) $(CFLAGSC) $(GCINCLUDE) $(GC) -o test $(TEST)
++	$(CXX) $(CFLAGSC) $(GCINCLUDE) $(GC) -o test $(TEST)
  
  .PHONY: clean
  clean:


### PR DESCRIPTION
#### Description

Turned out, having (CC) in the Makefile may result in gcc being picked over g++ which breaks linking. Use (CXX) coherently.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
