### PR TITLE
docker-compose: use python311

### DIFF
--- a/python/docker-compose/Portfile
+++ b/python/docker-compose/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                docker-compose
 version             1.29.2
-revision            0
+revision            1
 categories-append   devel
 
 platforms           darwin
@@ -26,7 +26,7 @@ checksums           rmd160  09d73fd7b9a3d3de76a67e8319629d86a4cb3d94 \
                     sha256  4c8cd9d21d237412793d18bd33110049ee9af8dab3fe2c213bbd0733959b09b7 \
                     size    288627
 
-python.default_version 39
+python.default_version 311
 
 depends_build-append \
     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/67693

###### Type(s)

- [x] enhancement

###### Tested on
macOS 13.4.1 22F770820d x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?