### PR TITLE
syncthing-macos: fix building with XCode >= 14.3

### DIFF
--- a/net/syncthing-macos/Portfile
+++ b/net/syncthing-macos/Portfile
@@ -25,6 +25,10 @@ depends_lib-append      port:syncthing
 patchfiles-append       patch-no-bundled-syncthing.diff \
                         patch-disable-autoupdatechecks.diff
 
+if {[vercmp $xcodeversion 14.3] >= 0} {
+    patchfiles-append   patch-fix-ventura-build.diff
+}
+
 post-patch {
     reinplace "s|__PREFIX__|${prefix}|" ${worksrcpath}/syncthing/STApplication.m
 }

--- a/net/syncthing-macos/files/patch-fix-ventura-build.diff
+++ b/net/syncthing-macos/files/patch-fix-ventura-build.diff
@@ -1,0 +1,98 @@
+diff --git Pods/Pods.xcodeproj/project.pbxproj Pods/Pods.xcodeproj/project.pbxproj
+index db3a9b1..9013910 100644
+--- Pods/Pods.xcodeproj/project.pbxproj
++++ Pods/Pods.xcodeproj/project.pbxproj
+@@ -330,7 +330,7 @@
+ 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+ 				GCC_WARN_UNUSED_FUNCTION = YES;
+ 				GCC_WARN_UNUSED_VARIABLE = YES;
+-				MACOSX_DEPLOYMENT_TARGET = 10.10;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				MTL_ENABLE_DEBUG_INFO = NO;
+ 				MTL_FAST_MATH = YES;
+ 				PRODUCT_NAME = "$(TARGET_NAME)";
+@@ -353,7 +353,7 @@
+ 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+ 				EXECUTABLE_PREFIX = lib;
+ 				MACH_O_TYPE = staticlib;
+-				MACOSX_DEPLOYMENT_TARGET = 10.10;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				ONLY_ACTIVE_ARCH = NO;
+ 				OTHER_LDFLAGS = "";
+ 				OTHER_LIBTOOLFLAGS = "";
+@@ -373,7 +373,7 @@
+ 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+ 				COMBINE_HIDPI_IMAGES = YES;
+ 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+-				MACOSX_DEPLOYMENT_TARGET = 10.10;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				ONLY_ACTIVE_ARCH = NO;
+ 				SDKROOT = macosx;
+ 			};
+@@ -432,7 +432,7 @@
+ 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+ 				GCC_WARN_UNUSED_FUNCTION = YES;
+ 				GCC_WARN_UNUSED_VARIABLE = YES;
+-				MACOSX_DEPLOYMENT_TARGET = 10.10;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+ 				MTL_FAST_MATH = YES;
+ 				ONLY_ACTIVE_ARCH = YES;
+@@ -457,7 +457,7 @@
+ 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+ 				EXECUTABLE_PREFIX = lib;
+ 				MACH_O_TYPE = staticlib;
+-				MACOSX_DEPLOYMENT_TARGET = 10.10;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				ONLY_ACTIVE_ARCH = NO;
+ 				OTHER_LDFLAGS = "";
+ 				OTHER_LIBTOOLFLAGS = "";
+@@ -477,7 +477,7 @@
+ 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+ 				COMBINE_HIDPI_IMAGES = YES;
+ 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+-				MACOSX_DEPLOYMENT_TARGET = 10.10;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				ONLY_ACTIVE_ARCH = NO;
+ 				SDKROOT = macosx;
+ 			};
+diff --git syncthing.xcodeproj/project.pbxproj syncthing.xcodeproj/project.pbxproj
+index b01cc9b..578ae51 100644
+--- syncthing.xcodeproj/project.pbxproj
++++ syncthing.xcodeproj/project.pbxproj
+@@ -495,7 +495,7 @@
+ 				GCC_WARN_UNUSED_FUNCTION = YES;
+ 				GCC_WARN_UNUSED_VARIABLE = YES;
+ 				HEADER_SEARCH_PATHS = "$(SRCROOT)/syncthing/Test";
+-				MACOSX_DEPLOYMENT_TARGET = 10.10;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				MTL_ENABLE_DEBUG_INFO = YES;
+ 				ONLY_ACTIVE_ARCH = YES;
+ 				SDKROOT = macosx;
+@@ -548,7 +548,7 @@
+ 				GCC_WARN_UNUSED_FUNCTION = YES;
+ 				GCC_WARN_UNUSED_VARIABLE = YES;
+ 				HEADER_SEARCH_PATHS = "$(SRCROOT)/syncthing/Test";
+-				MACOSX_DEPLOYMENT_TARGET = 10.10;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				MTL_ENABLE_DEBUG_INFO = NO;
+ 				ONLY_ACTIVE_ARCH = NO;
+ 				SDKROOT = macosx;
+@@ -574,7 +574,7 @@
+ 				);
+ 				INFOPLIST_FILE = syncthing/Info.plist;
+ 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+-				MACOSX_DEPLOYMENT_TARGET = 10.10;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.xor-gate.syncthing-macosx";
+ 				PRODUCT_NAME = Syncthing;
+ 				PROVISIONING_PROFILE = "";
+@@ -605,7 +605,7 @@
+ 				);
+ 				INFOPLIST_FILE = syncthing/Info.plist;
+ 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+-				MACOSX_DEPLOYMENT_TARGET = 10.10;
++				MACOSX_DEPLOYMENT_TARGET = 10.13;
+ 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.xor-gate.syncthing-macosx";
+ 				PRODUCT_NAME = Syncthing;
+ 				PROVISIONING_PROFILE = "";


### PR DESCRIPTION
#### Description

syncthing-macos fails to build with Xcode versions >= 14.3

```console
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_net_syncthing-macos/syncthing-macos/work/syncthing-macos-1.23.6-1/Pods/Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.10, but the range of supported deployment target versions is 10.13 to 13.3.99. (in target 'Sparkle' from project 'Pods')
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_net_syncthing-macos/syncthing-macos/work/syncthing-macos-1.23.6-1/Pods/Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.10, but the range of supported deployment target versions is 10.13 to 13.3.99. (in target 'Pods-syncthing' from project 'Pods')
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_net_syncthing-macos/syncthing-macos/work/syncthing-macos-1.23.6-1/syncthing.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.10, but the range of supported deployment target versions is 10.13 to 13.3.99. (in target 'syncthing' from project 'syncthing')
warning: Run script build phase 'Run Script' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'syncthing' from project 'syncthing')
** BUILD FAILED **
```

This is probably related to [this issue](https://stackoverflow.com/questions/75574268/missing-file-libarclite-iphoneos-a-xcode-14-3) and a wrongly set deployment target.

This PR adds a patch that changes the deployment target if Xcode version 14.3 or higher is in use.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
