### PR TITLE
qtruby: fix build, add modern ruby support

### DIFF
--- a/kde/qtruby/Portfile
+++ b/kde/qtruby/Portfile
@@ -5,7 +5,7 @@ PortGroup           kde4   1.1
 
 name                qtruby
 version             4.14.3
-revision            2
+revision            3
 categories          kde kde4 devel
 license             GPL-2+ LGPL-2.1+
 maintainers         nomaintainer
@@ -13,7 +13,6 @@ description         Binding to Ruby for KDE.
 long_description    Very complete bindings to both the KDE API and the Qt APIs. The Korundum \
                     package includes both a QtRuby Qt-only binding along with the full combined Qt/KDE one. \
                     The QtRuby package contains just Qt bindings with no dependencies on KDE.
-platforms           darwin
 homepage            https://techbase.kde.org/Development/Languages/Ruby
 master_sites        kde:stable/${version}/src/
 use_xz              yes
@@ -23,18 +22,31 @@ checksums           rmd160  a8a7dcef68b7e20c9d20f46ad0d4293c2c1c2a49 \
 
 depends_lib-append  port:smokeqt
 
-patchfiles          patch-CMakeLists.diff
+patchfiles          patch-CMakeLists.diff \
+                    patch-ptr-comparison.diff
 
-variant ruby18 conflicts ruby19 description {Select Ruby 1.8} {
+variant ruby18 conflicts ruby19 ruby32 description {Select Ruby 1.8} {
     depends_lib-append      port:ruby
-    configure.args-append   -DRUBY_EXECUTABLE=${prefix}/bin/ruby1.8
+    configure.args-append   -DRUBY_EXECUTABLE=${prefix}/bin/ruby1.8 \
+                            -DRUBY_LIBRARY=${prefix}/lib/libruby.dylib
 }
-variant ruby19 conflicts ruby18 description {Select Ruby 1.9} {
+variant ruby19 conflicts ruby18 ruby32 description {Select Ruby 1.9} {
     depends_lib-append      port:ruby19
-    configure.args-append   -DRUBY_EXECUTABLE=${prefix}/bin/ruby1.9
+    configure.args-append   -DRUBY_EXECUTABLE=${prefix}/bin/ruby1.9 \
+                            -DRUBY_INCLUDE_DIRS=${prefix}/include/ruby-1.9.1/ruby \
+                            -DRUBY_LIBRARY=${prefix}/lib/libruby1.9.dylib
+}
+variant ruby32 conflicts ruby18 ruby19 description {Select Ruby 3.2} {
+    depends_lib-append      port:ruby32
+    configure.args-append   -DRUBY_EXECUTABLE=${prefix}/bin/ruby3.2 \
+                            -DRUBY_INCLUDE_DIRS=${prefix}/include/ruby-3.2.2/ruby \
+                            -DRUBY_LIBRARY=${prefix}/lib/libruby3.2.dylib
+    configure.cxxflags-append \
+                            -std=c++11
+    compiler.cxx_standard   2011
 }
 
-if {![variant_isset ruby18] && ![variant_isset ruby19]} {
+if {![variant_isset ruby18] && ![variant_isset ruby19] && ![variant_isset ruby32]} {
     default_variants +ruby18
 }
 

--- a/kde/qtruby/files/patch-ptr-comparison.diff
+++ b/kde/qtruby/files/patch-ptr-comparison.diff
@@ -1,0 +1,11 @@
+--- src/qtruby.cpp.orig	2013-06-02 05:39:23.000000000 +0800
++++ src/qtruby.cpp	2023-07-29 04:56:39.000000000 +0800
+@@ -2094,7 +2094,7 @@
+ {
+     void * ptr = 0;
+     ptr = value_to_ptr(obj);
+-    return (ptr > 0 ? Qtrue : Qfalse);
++    return (ptr != 0 ? Qtrue : Qfalse);
+ }
+ 
+ static VALUE


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/66518
Closes: https://trac.macports.org/ticket/67838

#### Description

Let’s see if this builds.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
