### PR TITLE
virtuoso: add virtuoso-5 to support PowerPC

### DIFF
--- a/devel/virtuoso-5/Portfile
+++ b/devel/virtuoso-5/Portfile
@@ -4,46 +4,40 @@ PortSystem          1.0
 PortGroup           conflicts_build 1.0
 PortGroup           openssl 1.0
 
-name                virtuoso-7
+openssl.branch      1.0
+
+name                virtuoso-5
 set myname          virtuoso
-version             7.2.10
+version             5.0.15
 revision            0
 categories          devel
-maintainers         {snc @nerdling} openmaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL
 description         a high-performance object-relational SQL database
 long_description    Virtuoso is an enterprise-grade server that delivers a platform \
                     for Data Access, Integration and Management.
-platforms           darwin
 homepage            http://${myname}.openlinksw.com/dataspace/dav/wiki/Main/
 master_sites        sourceforge:project/${myname}/${myname}/${version}
 distname            ${myname}-opensource-${version}
 
-checksums           rmd160  a7d1d7c7333b3e125543a70c4644b36de8f7da45 \
-                    sha256  c02b0a966ff33f854a86f8f74caa8a5a957e22b510cc2f808e54ed34b4b27f0f \
-                    size    121992638
+checksums           rmd160  f0d849b49cffd1ccee2bfbb197e2f51195ea0663 \
+                    sha256  b5684608e28b78cffaf437044ca9c5917c6bb03db1847a33a6c5f43d96df3174 \
+                    size    65145784
 
-# https://trac.macports.org/ticket/61216
-patchfiles-append   patch-libsrc-Wi-numeric.c.diff
-configure.cflags-append \
-                    -Wno-error=implicit-function-declaration
+supported_archs     ppc ppc64
+conflicts           virtuoso-7 virtuoso-6
 
-supported_archs     x86_64 arm64
-conflicts           virtuoso-6 virtuoso-5
-conflicts_build     chicken geos
+depends_build-append \
+                    port:gawk
 
-depends_build       port:gawk
-
-depends_lib         port:ImageMagick \
+depends_lib-append  port:ImageMagick \
+                    port:kerberos5 \
                     path:lib/libldap.dylib:openldap
 
-openssl.branch      1.0
-openssl.configure   build_flags
+conflicts_build     unixODBC
 
 configure.args-append   --disable-all-vads \
-                        --disable-silent-rules \
-                        --program-transform-name='s/isql/isql-vt/\;s/isqlw/isqlw-vt/'
-
+                        --enable-krb
 post-configure {
     reinplace "s|\"gcc\"|\"${configure.cc}\"|" ${worksrcpath}/bin/libtool.macosx
     foreach note $PortInfo(notes) {
@@ -70,4 +64,4 @@ building virtuoso; it can be re-enabled after virtuoso has been installed.
 
 livecheck.url       http://sourceforge.net/api/file/index/project-id/161622/mtime/desc/rss?path=/virtuoso
 livecheck.type      regex
-livecheck.regex     ${myname}/(\\d+(\\.\\d+)+)/${myname}-opensource-(\\d+(\\.\\d+)+)
+livecheck.regex     ${myname}/(6(\\.\\d+)+)/${myname}-opensource-(6(\\.\\d+)+)

--- a/devel/virtuoso-6/Portfile
+++ b/devel/virtuoso-6/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  76a397dbd4b7689cbfc55f9373c3e2ed83d497bc \
                     sha256  08d05c6165117de0370e81aa89ddab618e645b5110be301f72e6ffea7044ca50
 
 supported_archs     i386 x86_64
-conflicts           virtuoso-7
+conflicts           virtuoso-7 virtuoso-5
 
 depends_build       port:gawk
 

--- a/devel/virtuoso/Portfile
+++ b/devel/virtuoso/Portfile
@@ -12,7 +12,11 @@ long_description    Virtuoso is an enterprise-grade server that delivers a platf
                     for Data Access, Integration and Management.
 homepage            http://${name}.openlinksw.com/dataspace/dav/wiki/Main/
 
-if { ${configure.build_arch} eq "i386" } {
+if { ${configure.build_arch} in [list ppc ppc64] } {
+    depends_build       port:${name}-5
+    version             5.0.15
+    revision            0
+} elseif { ${configure.build_arch} eq "i386" } {
     depends_build       port:${name}-6
     version             6.1.7
     revision            2


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/67840

#### Description

This will finally allow KDE4 stuff to build on PowerPC.

I skip CI, because `virtuoso-5` is set for `ppc ppc64`, and remaining changes are merely adding conflicts with it and its support into `virtuoso` (there is nothing to build there).
In the meanwhile, `virtuoso-6` is broken now across the board, so it will sabotage CI: https://ports.macports.org/port/virtuoso-6/details

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
