### PR TITLE
srt: new port

### DIFF
--- a/net/srt/Portfile
+++ b/net/srt/Portfile
@@ -1,0 +1,89 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        Haivision srt 1.5.2 v
+github.tarball_from archive
+revision            0
+
+categories          net multimedia comms
+license             MPL-2
+maintainers         @jasonliu-- openmaintainer
+
+description         transport protocol for ultra-low latency live \
+                    video and audio streaming
+long_description    Secure Reliable Transport (SRT) is a \
+                    ${description}, as well as for generic bulk data \
+                    transfer. SRT provides reliable transmission \
+                    similar to TCP\; however, it does so at the \
+                    application layer, and uses UDP as the underlying \
+                    transport layer. This package contains the \
+                    open-source reference implementation of the SRT \
+                    library, and was written by Haivision, the \
+                    original developers of the SRT protocol.
+
+checksums           rmd160  89f3ee7d48f9b22c6e6aa5a582959e1f6e03b22e \
+                    sha256  463970a3f575446b3f55abb6f323d5476c963c77b3c975cd902e9c87cdd9a92c \
+                    size    1699747
+
+compiler.cxx_standard   2011
+
+configure.args-append   -DENABLE_APPS=OFF \
+                        -DENABLE_LOGGING=OFF \
+                        -DENABLE_ENCRYPTION=OFF \
+                        -DENABLE_SHOW_PROJECT_CONFIG=ON
+
+pre-test {
+    if {![variant_isset tests]} {
+        ui_error "'tests' variant must be activated to enable test support"
+        error "Please enable the 'tests' variant and try again"
+    }
+}
+
+variant utils description {Build command-line tools} {
+    configure.args-delete   -DENABLE_APPS=OFF
+}
+
+variant logging description {Enable logging} {
+    configure.args-delete   -DENABLE_LOGGING=OFF
+}
+
+variant heavy_logging requires logging \
+    description {Enable heavy logging} \
+{
+    configure.args-append   -DENABLE_HEAVY_LOGGING=ON
+}
+
+variant tests description {Build unit tests} {
+    # Googletest requires C++14 or newer
+    compiler.cxx_standard   2014
+    depends_lib-append      port:gtest
+    post-patch {
+        reinplace "/target_include_directories.test-srt/a\\
+\\        set_property(TARGET test-srt PROPERTY CXX_STANDARD 14)\\
+" \
+            ${worksrcpath}/CMakeLists.txt
+    }
+    configure.args-append   -DENABLE_UNITTESTS=ON
+    test.run yes
+}
+
+variant openssl conflicts mbedtls \
+    description {Enable encryption in SRT using OpenSSL} \
+{
+    depends_lib-append      port:openssl
+    configure.args-delete   -DENABLE_ENCRYPTION=OFF
+    configure.args-append   -DUSE_ENCLIB=openssl
+}
+
+variant mbedtls conflicts openssl \
+    description {Enable encryption in SRT using Mbed TLS} \
+{
+    depends_lib-append      port:mbedtls
+    configure.args-delete   -DENABLE_ENCRYPTION=OFF
+    configure.args-append   -DUSE_ENCLIB=mbedtls
+}
+
+default_variants    +utils +logging +openssl


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Secure Reliable Transport (SRT) is a transport protocol for ultra-low latency live video and audio streaming, as well as for generic bulk data transfer. SRT provides reliable transmission similar to TCP; however, it does so at the application layer, and uses UDP as the underlying transport layer. This package contains the open-source reference implementation of the SRT library, and was written by Haivision, the original developers of the SRT protocol.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
