### PR TITLE
mod_ca: move pkgconfig from depends_lib to depends_build

### DIFF
--- a/www/mod_ca/Portfile
+++ b/www/mod_ca/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                mod_ca
 version             0.2.2
-revision            1
+revision            2
 categories          www security
 platforms           darwin
 maintainers         {redwax.org:dirkx @dirkx} openmaintainer
@@ -23,7 +23,8 @@ checksums           sha256  1af9e7fdbb9e22e229d3f74ac220d1778a9f8334b6bbf87322e7
                     rmd160  d99c00654a7a84ebb4c101ab468b27615341662d \
                     size    130093
 
-depends_lib         port:apache2 port:pkgconfig path:lib/libssl.dylib:openssl
+depends_build       port:pkgconfig
+depends_lib         port:apache2 path:lib/libssl.dylib:openssl
 
 pre-build {
     system "echo > ${worksrcpath}/mod_ca_ldap.c"


### PR DESCRIPTION
#### Description

This Portfile had `depends_lib port:pkgconfig` but it probably belongs in `depend_build`.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
