### PR TITLE
py-pylint: fix typo in platforms (all -> any)

### DIFF
--- a/python/py-pylint/Portfile
+++ b/python/py-pylint/Portfile
@@ -8,7 +8,7 @@ name                py-pylint
 version             2.17.4
 revision            0
 categories-append   devel
-platforms           {darwin all}
+platforms           {darwin any}
 license             GPL-2+
 supported_archs     noarch
 


### PR DESCRIPTION
#### Description

This Portfile had `platforms {darwin all}` which looks like a typo (but `port lint --nitpick` didn't say anything so maybe not). This pull request changes it to `platforms {darwin any}`.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
