### PR TITLE
emacs{,-app}: update to 29.1

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -46,11 +46,14 @@ configure.args  --disable-silent-rules \
                 --without-gconf \
                 --without-libotf \
                 --without-m17n-flt \
+                --without-tree-sitter \
                 --with-libgmp \
                 --with-gnutls \
                 --with-json \
                 --with-xml2 \
                 --with-modules \
+                --with-sqlite3 \
+                --with-webp \
                 --infodir ${prefix}/share/info/${name}
 
 depends_build-append   port:pkgconfig \
@@ -59,15 +62,22 @@ depends_lib-append     port:gmp \
                        path:lib/pkgconfig/gnutls.pc:gnutls \
                        port:jansson \
                        port:libxml2 \
-                       port:ncurses
+                       port:ncurses \
+                       port:sqlite3 \
+                       port:webp
 
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/emacs/${version}/leim
     delete ${destroot}${prefix}/bin/ctags
     delete ${destroot}${prefix}/share/man/man1/ctags.1.gz
 
-    # avoid conflicts with xemacs
     if {$subport eq $name || $subport eq "emacs-devel"} {
+        file copy ${filespath}/site-start.el \
+            ${destroot}${prefix}/share/emacs/site-lisp/
+        reinplace "s|__PREFIX__|${prefix}|g" \
+            ${destroot}${prefix}/share/emacs/site-lisp/site-start.el
+
+        # avoid conflicts with xemacs
         move ${destroot}${prefix}/bin/etags ${destroot}${prefix}/bin/etags-emacs
         move ${destroot}${prefix}/share/man/man1/etags.1.gz ${destroot}${prefix}/share/man/man1/etags-emacs.1.gz
     }
@@ -92,12 +102,12 @@ platform darwin {
 }
 
 if {$subport eq $name || $subport eq "emacs-app"} {
-    version         28.2
-    revision        1
+    version         29.1
+    revision        0
 
-    checksums       rmd160  4690d9ab3e7878cbb25eb19c2931c587f971b3bd \
-                    sha256  a6912b14ef4abb1edab7f88191bfd61c3edd7085e084de960a4f86485cb7cad8 \
-                    size    71332149
+    checksums       rmd160  c306a0554d77ee472600ed28af4751211dc1ec70 \
+                    sha256  5b80e0475b0e619d2ad395ef5bc481b7cb9f13894ed23c301210572040e4b5b1 \
+                    size    78324084
 }
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
@@ -114,50 +124,11 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
                     sha256  815333b399dd6978c28bfd80828a086dcf54ed2266ea3a3ef8d73707b25749e1 \
                     size    48420650
 
-    configure.args-append \
-        --with-sqlite3 \
-        --with-webp \
-        --without-tree-sitter
-
-    depends_lib-append \
-        port:sqlite3 \
-        port:webp
-
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"
     }
 
     livecheck.type none
-
-    variant treesitter description {Builds emacs with tree-sitter support} {
-        configure.args-delete   --without-tree-sitter
-        configure.args-append   --with-tree-sitter
-        depends_lib-append  port:tree-sitter
-        depends_run-append  port:tree-sitter-typescript \
-            port:tree-sitter-javascript \
-            port:tree-sitter-tsx \
-            port:tree-sitter-c \
-            port:tree-sitter-cpp \
-            port:tree-sitter-java \
-            port:tree-sitter-python \
-            port:tree-sitter-css \
-            port:tree-sitter-json \
-            port:tree-sitter-c-sharp \
-            port:tree-sitter-bash \
-            port:tree-sitter-dockerfile \
-            port:tree-sitter-cmake \
-            port:tree-sitter-toml \
-            port:tree-sitter-go \
-            port:tree-sitter-go-mod \
-            port:tree-sitter-yaml \
-            port:tree-sitter-rust \
-            port:tree-sitter-ruby \
-            port:tree-sitter-html \
-            port:tree-sitter-heex \
-            port:tree-sitter-elixir
-    }
-
-    default_variants-append +treesitter
 } else {
     livecheck.type  regex
     livecheck.url   https://ftp.gnu.org/gnu/emacs/?C=M&O=D
@@ -272,8 +243,8 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
             ${destroot}${applications_dir}
         # fix read-permission to resources
         system "chmod a+r ${destroot}${applications_dir}/Emacs.app/Contents/Resources/*"
-        file copy ${filespath}/site-start.el \
-            ${destroot}${applications_dir}/Emacs.app/Contents/Resources/site-lisp
+        file copy ${filespath}/site-start-app.el \
+            ${destroot}${applications_dir}/Emacs.app/Contents/Resources/site-lisp/site-start.el
         reinplace "s|__PREFIX__|${prefix}|g" \
             ${destroot}${applications_dir}/Emacs.app/Contents/Resources/site-lisp/site-start.el
     }
@@ -313,4 +284,37 @@ variant nativecomp description {Builds emacs with native compilation support} {
     }
 }
 
-default_variants-append +nativecomp
+variant treesitter description {Builds emacs with tree-sitter support} {
+    configure.args-delete   --without-tree-sitter
+    configure.args-append   --with-tree-sitter
+    depends_lib-append  port:tree-sitter
+    depends_run-append \
+        port:tree-sitter-typescript \
+        port:tree-sitter-javascript \
+        port:tree-sitter-tsx \
+        port:tree-sitter-c \
+        port:tree-sitter-cpp \
+        port:tree-sitter-java \
+        port:tree-sitter-python \
+        port:tree-sitter-css \
+        port:tree-sitter-json \
+        port:tree-sitter-c-sharp \
+        port:tree-sitter-bash \
+        port:tree-sitter-dockerfile \
+        port:tree-sitter-cmake \
+        port:tree-sitter-toml \
+        port:tree-sitter-go \
+        port:tree-sitter-go-mod \
+        port:tree-sitter-yaml \
+        port:tree-sitter-rust \
+        port:tree-sitter-ruby
+
+    if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
+        depends_run-append \
+            port:tree-sitter-html \
+            port:tree-sitter-heex \
+            port:tree-sitter-elixir
+    }
+}
+
+default_variants-append +nativecomp +treesitter

--- a/editors/emacs/files/site-start-app.el
+++ b/editors/emacs/files/site-start-app.el
@@ -1,0 +1,20 @@
+;; load-path contains ${prefix}/share/emacs/site-lisp and its subdirecotries.
+;; See #12115, #29232, #32146.
+(setq load-path (cons "__PREFIX__/share/emacs/site-lisp" load-path))
+(if (file-readable-p "__PREFIX__/share/emacs/site-lisp")
+    (let ((default-directory "__PREFIX__/share/emacs/site-lisp"))
+      (if (file-readable-p "__PREFIX__/share/emacs/site-lisp/subdirs.el")
+          (load "__PREFIX__/share/emacs/site-lisp/subdirs.el")
+        (if (fboundp 'normal-top-level-add-subdirs-to-load-path)
+            (normal-top-level-add-subdirs-to-load-path)))))
+
+;; Info-directory-list contains ${prefix}/share/info. See #32148.
+(setq Info-default-directory-list (cons "__PREFIX__/share/info" Info-default-directory-list))
+
+;; Use the OS X Emoji font for Emoticons
+(when (fboundp 'set-fontset-font)
+  (set-fontset-font t 'emoji '("Apple Color Emoji" . "iso10646-1") nil 'prepend))
+
+;; Look in MacPorts ${prefix} for tree-sitter parser libraries
+(when (boundp 'treesit-extra-load-path)
+  (setq treesit-extra-load-path (cons "__PREFIX__/lib" treesit-extra-load-path)))

--- a/editors/emacs/files/site-start.el
+++ b/editors/emacs/files/site-start.el
@@ -1,20 +1,3 @@
-;; load-path contains ${prefix}/share/emacs/site-lisp and its subdirecotries.
-;; See #12115, #29232, #32146.
-(setq load-path (cons "__PREFIX__/share/emacs/site-lisp" load-path))
-(if (file-readable-p "__PREFIX__/share/emacs/site-lisp")
-    (let ((default-directory "__PREFIX__/share/emacs/site-lisp"))
-      (if (file-readable-p "__PREFIX__/share/emacs/site-lisp/subdirs.el")
-          (load "__PREFIX__/share/emacs/site-lisp/subdirs.el")
-        (if (fboundp 'normal-top-level-add-subdirs-to-load-path)
-            (normal-top-level-add-subdirs-to-load-path)))))
-
-;; Info-directory-list contains ${prefix}/share/info. See #32148.
-(setq Info-default-directory-list (cons "__PREFIX__/share/info" Info-default-directory-list))
-
-;; Use the OS X Emoji font for Emoticons
-(when (fboundp 'set-fontset-font)
-  (set-fontset-font t 'emoji '("Apple Color Emoji" . "iso10646-1") nil 'prepend))
-
 ;; Look in MacPorts ${prefix} for tree-sitter parser libraries
 (when (boundp 'treesit-extra-load-path)
   (setq treesit-extra-load-path (cons "__PREFIX__/lib" treesit-extra-load-path)))


### PR DESCRIPTION
#### Description

Update to 29.1.

This is an opportunity to remove +treesitter from default_variants, but the libraries are small and I feel like the cost is low compared to the advantage for those who want to use the tree-sitter modes.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.5 22G74 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
