### PR TITLE
py-tensorflow_estimator: Update to Vertsion 2.13.0

### DIFF
--- a/python/py-tensorflow_estimator/Portfile
+++ b/python/py-tensorflow_estimator/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-tensorflow_estimator
-version             2.7.0
+version             2.13.0
 revision            0
 platforms           {darwin any}
 supported_archs     noarch
@@ -19,13 +19,12 @@ long_description    TensorFlow Estimator is a high-level TensorFlow API \
 
 homepage            https://github.com/tensorflow/estimator
 
-master_sites        https://files.pythonhosted.org/packages/db/de/3a71ad41b87f9dd424e3aec3b0794a60f169fa7e9a9a1e3dd44290b86dd6/
-
+master_sites        https://files.pythonhosted.org/packages/72/5c/c318268d96791c6222ad7df1651bbd1b2409139afeb6f468c0f327177016/
 distname            tensorflow_estimator-${version}-py2.py3-none-any
 
-checksums           rmd160  9a8aaa89aca7464ef967d4dba28fc779efa277a6 \
-                    sha256  325b5a224864379242b7b76c6987ca544239be82579d33e68ec7c2bda57abc9d \
-                    size    463110
+checksums           rmd160  576c72a1012a1fe9850179a362bf778c44039283 \
+                    sha256  6f868284eaa654ae3aa7cacdbef2175d0909df9fcf11374f5166f8bf475952aa \
+                    size    440805
 
 livecheck.url       https://pypi.org/project/tensorflow-estimator/
 livecheck.type      regex
@@ -34,7 +33,7 @@ livecheck.regex     /project/tensorflow-estimator/(\\d+(\\.\\d+)+)/
 extract.suffix      .whl
 extract.only
 
-python.versions     37 38 39 310
+python.versions     38 39 310 311
 python.pep517       yes
 python.pep517_backend
 


### PR DESCRIPTION
* Update to Vertsion 2.13.0
* Add Python 311

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
