### PR TITLE
micronaut: update to 4.0.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.0.1 v
+github.setup    micronaut-projects micronaut-starter 4.0.2 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  9982325da52975f0eb5a0d33e7d773b403819114 \
-                sha256  9a8a415f8a132d7ac3d1dd4f5e49aeefaf42aab04fecee6549d84d722d6d944d \
-                size    20212755
+checksums       rmd160  822dae43a5ec789ec1ba0e3b6e8501c911ad52bd \
+                sha256  5a409b020767018d6a0d608cc397219dbc66302ceab9f82a02068a0a387e8196 \
+                size    20217351
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 4.0.2.

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?