### PR TITLE
csound: fix the port

### DIFF
--- a/audio/csound/Portfile
+++ b/audio/csound/Portfile
@@ -5,6 +5,7 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 
 github.setup        csound csound 6.18.1
+revision            1
 categories          audio
 license             LGPL-2.1+
 maintainers         nomaintainer
@@ -19,8 +20,9 @@ long_description    Csound is a computer programming language for dealing with \
 
 homepage            http://www.csounds.com/
 github.tarball_from archive
-checksums           rmd160 3702ec791eb5f98f807aed6ec3de7f4eb9deab77 \
-                    sha256 b84be8237fa9258ef60fdddf36fae27b20c11665811bf5ed12540da9a9a4414e
+checksums           rmd160  3702ec791eb5f98f807aed6ec3de7f4eb9deab77 \
+                    sha256  b84be8237fa9258ef60fdddf36fae27b20c11665811bf5ed12540da9a9a4414e \
+                    size    31925161
 
 depends_build-append \
                     port:gettext \
@@ -34,6 +36,10 @@ depends_lib         port:curl \
 
 patchfiles          MAC_OS_X_VERSION.patch
 
+# https://github.com/csound/csound/pull/1732
+patchfiles-append   0001-Use-correct-clang-options-in-CMakeLists.patch \
+                    0002-Altivec-code-is-broken-for-Darwin-so-disable-it-ther.patch
+
 cmake.out_of_source yes
 compiler.cxx_standard   2011
 
@@ -43,16 +49,25 @@ configure.args-append   -DFAIL_MISSING=ON \
                         -DBUILD_LUA_INTERFACE=OFF \
                         -DBUILD_TESTS=OFF \
                         -DCS_FRAMEWORK_DEST=${frameworks_dir} \
+                        -DCS_DEFAULT_PLUGINDIR=${prefix}/lib/csound/plugins64 \
                         -DUSE_ALSA=OFF \
                         -DUSE_JACK=OFF \
                         -DUSE_PORTAUDIO=OFF \
                         -DUSE_PORTMIDI=OFF \
                         -DUSE_PULSEAUDIO=OFF
 
+# CMake Error at CMakeLists.txt:146 (message): BUILD_TESTS is enabled, but BUILD_STATIC_LIBRARY="OFF"
+# Building static lib does not hurt even without tests enabled, since dylib is still built as well.
+configure.args-append   -DBUILD_STATIC_LIBRARY=ON
+
 variant tests description "Build tests" {
     depends_build-append    port:cunit
     configure.args-replace  -DBUILD_TESTS=OFF \
                             -DBUILD_TESTS=ON
+
+    # Otherwise libraries are looked for in the prefix, which fails, if the port has not been installed earlier.
+    test.env-append         DYLD_LIBRARY_PATH=${cmake.build_dir}:${cmake.build_dir}/CsoundLib64.framework/Versions/6.0
+    test.run                yes
 }
 
 # Note: fltk functionality has moved to a separate 'plugins' repo upstream.

--- a/audio/csound/files/0001-Use-correct-clang-options-in-CMakeLists.patch
+++ b/audio/csound/files/0001-Use-correct-clang-options-in-CMakeLists.patch
@@ -1,0 +1,64 @@
+From 9b33b2ffdedcaf61e453ad41f09342af4e147ae7 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 26 Jul 2023 18:29:26 +0800
+Subject: [PATCH] Use correct clang options in CMakeLists
+
+---
+ CMakeLists.txt | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git CMakeLists.txt CMakeLists.txt
+index c333e83aa..80213d700 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -32,7 +32,7 @@ project(Csound)
+ 
+ ENABLE_TESTING()
+ 
+-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
++if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+   set(CMAKE_COMPILER_IS_CLANG 1)
+ endif()
+ 
+@@ -304,8 +304,10 @@ endif()
+ 
+ # MacOS/IOS c++11 flags
+ if(APPLE)
+-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+-    set_target_properties(${CSOUNDLIB} PROPERTIES CXX_COMPILE_FLAGS  "-std=c++11")
++    if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
++        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
++    endif()
++    set_target_properties(${CSOUNDLIB} PROPERTIES CXX_COMPILE_FLAGS "-std=c++11")
+ endif()
+ 
+ set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+From 97c6fe6315d1ac5ac7d3570a9dd23d5ed2fdad68 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 26 Jul 2023 19:26:35 +0800
+Subject: [PATCH] Opcodes/CMakeLists: also does not hardcode C++ runtime
+
+---
+ Opcodes/CMakeLists.txt | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git Opcodes/CMakeLists.txt Opcodes/CMakeLists.txt
+index 82327ed3d..1e2097676 100644
+--- Opcodes/CMakeLists.txt
++++ Opcodes/CMakeLists.txt
+@@ -61,8 +61,12 @@ endif()
+ if(BUILD_PADSYNTH_OPCODES)
+ if(APPLE)
+   make_plugin(padsynth padsynth_gen.cpp)
+-  set_target_properties(padsynth PROPERTIES COMPILE_FLAGS "-std=gnu++11 -stdlib=libc++"
+-    LINK_FLAGS "-std=gnu++11 -stdlib=libc++")
++  if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
++    set_target_properties(padsynth PROPERTIES COMPILE_FLAGS "-std=gnu++11 -stdlib=libc++"
++      LINK_FLAGS "-std=gnu++11 -stdlib=libc++")
++  else()
++    set_target_properties(padsynth PROPERTIES COMPILE_FLAGS "-std=gnu++11")
++  endif()
+ elseif(LINUX)
+     include(CheckCXXCompilerFlag)
+     CHECK_CXX_COMPILER_FLAG("-std=gnu++11" COMPILER_SUPPORTS_CXX11)

--- a/audio/csound/files/0002-Altivec-code-is-broken-for-Darwin-so-disable-it-ther.patch
+++ b/audio/csound/files/0002-Altivec-code-is-broken-for-Darwin-so-disable-it-ther.patch
@@ -1,0 +1,25 @@
+From e6b1d05d3c8791e83831f8587b4c54bf97a43f08 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 26 Jul 2023 19:01:04 +0800
+Subject: [PATCH] Altivec code is broken for Darwin, so disable it there
+
+---
+ OOps/pffft.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git OOps/pffft.c OOps/pffft.c
+index e9696a77c..87862b531 100644
+--- OOps/pffft.c
++++ OOps/pffft.c
+@@ -100,9 +100,9 @@
+ //#define PFFFT_SIMD_DISABLE
+ 
+ /*
+-   Altivec support macros
++   Altivec support macros. (The code below is broken for Darwin, so disable it explicitly.)
+ */
+-#if !defined(PFFFT_SIMD_DISABLE) && (defined(__ppc__) || defined(__ppc64__))
++#if !defined(PFFFT_SIMD_DISABLE) && (defined(__ppc__) || defined(__ppc64__)) && !defined(__APPLE__)
+ typedef vector float v4sf;
+ #  define SIMD_SZ 4
+ #  define VZERO() ((vector float) vec_splat_u8(0))


### PR DESCRIPTION
#### Description

`csound` has been recently updated in https://github.com/macports/macports-ports/commit/a53352e74756ee902814c6f1cc8c312e1f0d3a63 which fixed the build with Clangs, but left tests broken.
This PR fixes tests and fixes build with GCC.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
