### PR TITLE
csound: fix paths to installed library

### DIFF
--- a/audio/csound/Portfile
+++ b/audio/csound/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 PortGroup           github 1.0
 
 github.setup        csound csound 6.18.1
-revision            1
+revision            2
 categories          audio
 license             LGPL-2.1+
 maintainers         nomaintainer
@@ -49,7 +49,6 @@ configure.args-append   -DFAIL_MISSING=ON \
                         -DBUILD_LUA_INTERFACE=OFF \
                         -DBUILD_TESTS=OFF \
                         -DCS_FRAMEWORK_DEST=${frameworks_dir} \
-                        -DCS_DEFAULT_PLUGINDIR=${prefix}/lib/csound/plugins64 \
                         -DUSE_ALSA=OFF \
                         -DUSE_JACK=OFF \
                         -DUSE_PORTAUDIO=OFF \
@@ -59,6 +58,18 @@ configure.args-append   -DFAIL_MISSING=ON \
 # CMake Error at CMakeLists.txt:146 (message): BUILD_TESTS is enabled, but BUILD_STATIC_LIBRARY="OFF"
 # Building static lib does not hurt even without tests enabled, since dylib is still built as well.
 configure.args-append   -DBUILD_STATIC_LIBRARY=ON
+
+post-destroot {
+    # While this is not immediately obvious upon install, dylib and binaries are built with wrong paths:
+    # /opt/local/lib/CsoundLib64.framework/Versions/6.0/CsoundLib64
+    # At the same time this is installed correctly into the framework directory, so the path points to nothing.
+    # CMakeLists are a mess, and it is unclear what in particular breaks this. Fix paths in destroot:
+    set csoundlib CsoundLib64.framework/Versions/6.0/CsoundLib64
+    system -W ${destroot}${prefix}/lib "install_name_tool -change ${prefix}/lib/${csoundlib} ${frameworks_dir}/${csoundlib} ./libcsnd6.6.0.dylib"
+    foreach bin [glob ${destroot}${prefix}/bin/*] {
+        system "install_name_tool -change ${prefix}/lib/${csoundlib} ${frameworks_dir}/${csoundlib} ${bin}"
+    }
+}
 
 variant tests description "Build tests" {
     depends_build-append    port:cunit


### PR DESCRIPTION
#### Description

@herbygillot 
Second go. Turned out, while setting frameworks dir ensures correct install destination, build system ignores it when setting paths to installed library. In results, while build succeeds, binaries are broken.
This fixes the problem.

P. S. I also drop explicit setting for `CS_DEFAULT_PLUGINDIR`, it seems that the following chunk sets it to framework: https://github.com/csound/csound/blob/a1580f9cdf331c35dceb486f4231871ce0b00266/CMakeLists.txt#L376-L396 (nothing gets installed there anyway).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
