### PR TITLE
librime-devel: set needed C++14 standard, support testing

### DIFF
--- a/devel/librime-devel/Portfile
+++ b/devel/librime-devel/Portfile
@@ -29,9 +29,22 @@ depends_lib-append  port:capnproto \
                     port:opencc \
                     port:yaml-cpp
 
+compiler.cxx_standard 2014
+
 configure.args      -DBOOST_USE_CXX11=ON \
                     -DBUILD_TEST=OFF
 
 checksums           rmd160  9a46203b8f11a380d7c17df232310d7381a39985 \
                     sha256  591321c13ef15185f3f07a418cffd96d679affd6363c8257225e4c8e77389540 \
                     size    2623636
+
+variant tests description "Build tests" {
+    configure.pre_args-replace \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+    configure.args-replace \
+                    -DBUILD_TEST=OFF \
+                    -DBUILD_TEST=ON
+
+    test.run        yes
+}


### PR DESCRIPTION
#### Description

(I do not update the port, since it requires to revbump its dependent, and I cannot test that.)
However the fix is needed, and support of testing is desirable.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
