### PR TITLE
sysutils/ndcctools: update maintainer

### DIFF
--- a/sysutils/ndcctools/Portfile
+++ b/sysutils/ndcctools/Portfile
@@ -13,7 +13,7 @@ categories              sysutils
 platforms               darwin
 license                 MIT
 
-maintainers             nd.edu:pivie \
+maintainers             {nd.edu:dthain @dthain} \
                         openmaintainer
 
 set description_common  {Notre Dame Cooperative Computing Software}


### PR DESCRIPTION
#### Description

Requesting update of port maintainer to dthain@nd.edu.
I'm the lab director and primary owner of the software as noted here:

http://github.com/cooperative-computing-lab
http://ccl.cse.nd.edu

Will bring the port up to the latest version once we get that sorted out.

###### Type(s)

- [ ] bugfix
- [ x ] enhancement
- [ ] security fix

###### Tested on

macOS 13.4.1 22F82 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->

Have not yet made any changes, I'm sure several things are broken at this point.

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
