### PR TITLE
jq: update to new Github project

### DIFF
--- a/sysutils/jq/Portfile
+++ b/sysutils/jq/Portfile
@@ -3,13 +3,14 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        stedolan jq 1.6 jq-
+github.setup        jqlang jq 1.6 jq-
+github.tarball_from releases
 revision            4
+
 categories          sysutils
-platforms           darwin
+license             MIT
 maintainers         {raimue @raimue} \
                     openmaintainer
-license             MIT
 
 description         A lightweight and flexible command-line JSON processor
 long_description\
@@ -17,8 +18,7 @@ long_description\
     map and transform structured data with the same ease that sed, awk, \
     grep and friends let you play with text.
 
-homepage            https://stedolan.github.io/jq/
-github.tarball_from releases
+homepage            https://jqlang.github.io/jq
 
 depends_lib         port:oniguruma6
 


### PR DESCRIPTION
`jq` is now at a new home on Github, though no checksums have changed.
This PR updates the port to reflect that.