### PR TITLE
py-photomosaic: fix platforms

### DIFF
--- a/python/py-photomosaic/Portfile
+++ b/python/py-photomosaic/Portfile
@@ -12,7 +12,7 @@ categories-append   graphics
 
 license             public-domain
 maintainers         nomaintainer
-platforms           any
+platforms           {darwin any}
 supported_archs     noarch
 
 description         Creating fun photomosaics, GIFs, and murals from \


### PR DESCRIPTION
#### Description

This Portfile had `platforms any` but python modules should have `platforms {darwin any}`, so this pull request changes it.

The `port install -vst` failed because it failed for py-numpy but it's not failing after py-photomosaic (and py-numpy) has been installed without -vst.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
