### PR TITLE
ndcctools: update to 7.7.2

### DIFF
--- a/sysutils/ndcctools/Portfile
+++ b/sysutils/ndcctools/Portfile
@@ -1,41 +1,55 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               openssl 1.0
 
 name                    ndcctools
-version                 6.2.10
+version                 7.7.2
 revision                0
-checksums               rmd160  38c802fa436ea33ace1ce420e83653d862262b1d \
-                        sha256  cd97639ad58b2a72cccd2b16f231d3fef7dfb65d6b63d9141e578f9598a6ba76 \
-                        size    12804180
+checksums               rmd160  6f948c3b6056b939614538b082ee4c35d2c61e75 \
+                        sha256  bb4f653584cb0ba628910f03cd6e8c60d82617ed92bbaf7805c8abc9d11713e7 \
+                        size    10002712
 
 categories              sysutils
-platforms               darwin
-license                 MIT
+platforms               darwin linux
+license                 GPL-2
 
 maintainers             {nd.edu:dthain @dthain} \
+                        {nd.edu:btovar @btovar} \
                         openmaintainer
 
-set description_common  {Notre Dame Cooperative Computing Software}
-description             ${description_common} (cooperative-computing-lab)
-long_description        ${description_common} \
-                        Enables collaborators to easily harness large scale \
-                        distributed systems such as clusters, clouds, and grids.
- 
-homepage                http://ccl.cse.nd.edu/
-master_sites            http://ccl.cse.nd.edu/software/files/
+description             distributed computing tools for scientific workflows
+long_description        ${name} is a toolkit that provides a variety of workflow \
+                        and task execution systems for executing complex scientific \
+                        workflows on clusters, clouds, and grids.
+
+homepage                https://cctools.readthedocs.io
+master_sites            https://ccl.cse.nd.edu/software/files/
 distname                cctools-${version}-source
 
-configure.pre_args      --prefix ${destroot}${prefix}
+depends_build-append    port:swig \
+                        port:swig-python
+
+depends_lib-append      port:python312 \
+                        port:readline \
+                        port:curl \
+                        port:groff
+
+configure.pre_args      --prefix ${destroot}${prefix} \
+                        --with-python3-path ${prefix}/Library/Frameworks/Python.framework/Versions/3.12/bin \
+                        --with-openssl-path ${prefix} \
+                        --with-readline-path ${prefix} \
+                        --with-swig-path ${prefix} \
+                        --with-curl-path ${prefix}
+
+# Universal build on osx expects that configure will pick up CFLAGS/CXXFLAGS from the environment.
+# The configure script doesn't currently do this and would need some work to put it all together.
+universal_variant       no
 
 post-destroot {
     xinstall -d -m 0755 ${destroot}${prefix}/share/doc
     file rename -force ${destroot}${prefix}/doc ${destroot}${prefix}/share/doc/${name}
-
-    xinstall -d -m 0755 ${destroot}${prefix}/etc/${name}
-    file rename -force ${destroot}${prefix}/etc/config.mk ${destroot}${prefix}/etc/${name}/config.mk
 }
 
-test.run                yes
 
 livecheck.regex         cctools-(\[0-9.\]+)-source${extract.suffix}


### PR DESCRIPTION
#### Description

Bring package up to date by several years:
- Update source package to 7.6.1
- Add btovar as addl maintainer.
- Add missing package dependencies.
- Update description to match style.
- Update doc links.
- Remove broken install rule for config.mk

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.4.1 22F82 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

