### PR TITLE
vcvrack: Fix build-time fetch failures

### DIFF
--- a/audio/vcvrack/Portfile
+++ b/audio/vcvrack/Portfile
@@ -25,6 +25,7 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 fetch.type          git
 
 patchfiles          patch-makefile.diff
+patchfiles-append   fetch.patch
 
 depends_fetch-append \
                     port:wget

--- a/audio/vcvrack/files/fetch.patch
+++ b/audio/vcvrack/files/fetch.patch
@@ -1,0 +1,53 @@
+Fix download URLs.
+
+The zlib URL changed because the version being downloaded is outdated and old
+versions are moved into the "fossils" directory.
+
+The pffft URL changed because it was downloading from a Mercurial repository and
+Bitbucket deleted all Mercurial repositories. The developer recreated it as a
+git repository which changed the commit hashes. The 29e4f76ac53b commit of the
+pffft hg repository was added to Rack in 2018. In the pffft git repository,
+74d7261be17c is the most recent commit that would have been available as of
+2018. For confirmation that this is the correct git commit to correspond to the
+old hg commit:
+
+https://github.com/google/visqol/pull/19#issuecomment-680207988
+
+--- dep/Makefile.orig	2023-08-01 15:54:53.000000000 -0500
++++ dep/Makefile	2023-08-01 15:57:11.000000000 -0500
+@@ -146,7 +146,7 @@
+ 	$(MAKE) -C libzip-1.5.2/build install
+ 
+ zlib-1.2.11:
+-	$(WGET) "https://www.zlib.net/zlib-1.2.11.tar.gz"
++	$(WGET) "https://www.zlib.net/fossils/zlib-1.2.11.tar.gz"
+ 	$(SHA256) zlib-1.2.11.tar.gz c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+ 	$(UNTAR) zlib-1.2.11.tar.gz
+ 	rm zlib-1.2.11.tar.gz
+@@ -235,18 +235,18 @@
+ $(osdialog): $(wildcard osdialog/*.h)
+ 	cp $^ include/
+ 
+-jpommier-pffft-29e4f76ac53b:
+-	$(WGET) "https://bitbucket.org/jpommier/pffft/get/29e4f76ac53b.zip"
+-	$(SHA256) 29e4f76ac53b.zip bb10afba127904a0c6c553fa445082729b7d72373511bda1b12a5be0e03f318a
+-	$(UNZIP) 29e4f76ac53b.zip
+-	rm 29e4f76ac53b.zip
++jpommier-pffft-74d7261be17c:
++	$(WGET) "https://bitbucket.org/jpommier/pffft/get/74d7261be17c.zip"
++	$(SHA256) 74d7261be17c.zip 0521a0ae522c74ed2a26130109b6366110ba43445826d98144ad65ef53186136
++	$(UNZIP) 74d7261be17c.zip
++	rm 74d7261be17c.zip
+ 
+-$(pffft): jpommier-pffft-29e4f76ac53b
+-	cp jpommier-pffft-29e4f76ac53b/*.h include/
++$(pffft): jpommier-pffft-74d7261be17c
++	cp jpommier-pffft-74d7261be17c/*.h include/
+ 
+ # Helpers
+ 
+-src: glew-2.1.0 glfw jansson-2.12 speexdsp-SpeexDSP-1.2rc3 openssl-1.1.1d curl-7.66.0 libzip-1.5.2 zlib-1.2.11 rtmidi-4.0.0 rtaudio nanovg nanosvg oui-blendish osdialog jpommier-pffft-29e4f76ac53b
++src: glew-2.1.0 glfw jansson-2.12 speexdsp-SpeexDSP-1.2rc3 openssl-1.1.1d curl-7.66.0 libzip-1.5.2 zlib-1.2.11 rtmidi-4.0.0 rtaudio nanovg nanosvg oui-blendish osdialog jpommier-pffft-74d7261be17c
+ 
+ clean:
+ 	git clean -fdx


### PR DESCRIPTION
#### Description

See: https://trac.macports.org/ticket/67851

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.7 21G651 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
