### PR TITLE
gcl: fix build on old macOS and without emacs

### DIFF
--- a/lang/gcl/Portfile
+++ b/lang/gcl/Portfile
@@ -35,7 +35,8 @@ checksums           rmd160  d64bb58a38ce45d6c4cf67cec4dff1dc52197a55 \
                     size    11725385
 
 patchfiles          dont-override-CC-or-MACOSX_DEPLOYMENT_TARGET.patch \
-                    fix-memory-corruption-on-macOS.patch
+                    fix-memory-corruption-on-macOS.patch \
+                    old-macOS.patch
 
 # checking for required object alignment... configure: error: Cannot find object alignent
 universal_variant   no
@@ -49,6 +50,25 @@ configure.args      --disable-notify \
                     --enable-readline \
                     --without-x \
                     --disable-xgcl
+
+# prevent it from picking system emacs
+configure.args-append EMACS=
+# anyway, we need to provide the right path to default.el
+post-configure {
+    reinplace "s|EMACS_DEFAULT_EL=|EMACS_DEFAULT_EL=${prefix}/etc/default.el|g" makedefs makedefc
+}
+
+# /usr/bin/libtool: object: ... malformed object (unknown load command 1)
+if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+    depends_build-append \
+                    port:cctools
+
+    post-patch {
+        reinplace   "s|/usr/bin/libtool|${prefix}/bin/libtool|g" \
+                    h/386-macosx.defs \
+                    h/powerpc-macosx.defs
+    }
+}
 
 use_parallel_build no
 

--- a/lang/gcl/files/old-macOS.patch
+++ b/lang/gcl/files/old-macOS.patch
@@ -1,0 +1,74 @@
+From 5d0926f03527ed236dd045f3ca77f44628fc73a6 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Tue, 1 Aug 2023 22:14:06 +0200
+Subject: [PATCH] Detect by configure availability of readlinkat
+
+---
+ configure      | 8 ++++++++
+ configure.in   | 2 ++
+ h/gclincl.h.in | 3 +++
+ o/unixfsys.c   | 2 +-
+ 4 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git configure configure
+index 8d086abaa..e10fa1af1 100755
+--- configure
++++ configure
+@@ -7865,6 +7865,14 @@ else $as_nop
+ fi
+ 
+ 
++# Not each system has readlinkat
++ac_fn_c_check_func "$LINENO" "readlinkat" "ac_cv_func_readlinkat"
++if test "x$ac_cv_func_readlinkat" = xyes
++then :
++  printf "%s\n" "#define HAVE_READLINKAT 1" >>confdefs.h
++
++fi
++
+ 
+ ac_fn_c_check_header_compile "$LINENO" "sys/ioctl.h" "ac_cv_header_sys_ioctl_h" "$ac_includes_default"
+ if test "x$ac_cv_header_sys_ioctl_h" = xyes
+diff --git configure.in configure.in
+index 4628ea2a0..e4f0a7a92 100644
+--- configure.in
++++ configure.in
+@@ -1601,6 +1601,8 @@ AC_CHECK_FUNCS(getwd)
+ AC_CHECK_FUNC(uname, , AC_DEFINE(NO_UNAME,1,[no uname call]))
+ AC_CHECK_FUNC(gettimeofday, , AC_DEFINE(NO_GETTOD))
+ 
++# Not each system has readlinkat
++AC_CHECK_FUNCS(readlinkat)
+ 
+ AC_CHECK_HEADERS(sys/ioctl.h)
+ 
+diff --git h/gclincl.h.in h/gclincl.h.in
+index 343e7ddda..bd16cd438 100644
+--- h/gclincl.h.in
++++ h/gclincl.h.in
+@@ -183,6 +183,9 @@
+ /* Define to 1 if you have the <readline/readline.h> header file. */
+ #undef HAVE_READLINE_READLINE_H
+ 
++/* Define to 1 if you have the `readlinkat' function. */
++#undef HAVE_READLINKAT
++
+ /* have readline completion matches */
+ #undef HAVE_RL_COMPENTRY_FUNC_T
+ 
+diff --git o/unixfsys.c o/unixfsys.c
+index 6e1ea8b8f..ad56e7a7a 100755
+--- o/unixfsys.c
++++ o/unixfsys.c
+@@ -268,7 +268,7 @@ DEFUN_NEW("READLINKAT",object,fSreadlinkat,SI,2,2,NONE,OI,OO,OO,OO,(fixnum d,obj
+   massert(z1<sizeof(FN1));
+   memcpy(FN1,s->st.st_self,z1);
+   FN1[z1]=0;
+-#ifndef __MINGW32__
++#ifdef HAVE_READLINKAT
+   massert((l=readlinkat(d ? dirfd((DIR *)d) : AT_FDCWD,FN1,FN2,sizeof(FN2)))>=0 && l<sizeof(FN2));
+ #else
+   l=0;
+-- 
+2.41.0
+


### PR DESCRIPTION
#### Description

A hotfix for last update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->