### PR TITLE
ruby-devel: update to 2023.08.01

### DIFF
--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -11,13 +11,13 @@ PortGroup           legacysupport 1.1
 # MAP_ANONYMOUS
 legacysupport.newest_darwin_requires_legacy 14
 
-github.setup        ruby ruby 4fbfc116ca375ba8ae3747fcf32fdb85c48683c9
+github.setup        ruby ruby 16b91a346f734efea0933495804b53e3ae15f1da
 
 set ruby_ver        3.3
 set ruby_patch      0
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby-devel
-version             2023.07.12
+version             2023.08.01
 revision            0
 
 categories          lang ruby
@@ -33,9 +33,9 @@ long_description    Ruby is the interpreted scripting language \
 homepage            https://www.ruby-lang.org/
 license             {Ruby BSD}
 
-checksums           rmd160  334287e2c827832ed4d7b842c003445ae2c219d5 \
-                    sha256  719240ec8ed3658753b90acf522d8462ebea611f414fb093816dba01e36727db \
-                    size    15905316
+checksums           rmd160  ba3c475e6c3c3b1a080329b971574dab38208e97 \
+                    sha256  98df5b34b1a7d098dffa041d54cb47cfecc1f5e3083de751cc5d251583ee56fa \
+                    size    15915747
 
 universal_variant   no
 


### PR DESCRIPTION
#### Description

Simple update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
