### PR TITLE
emacs{,-app}: fix nativecomp variant

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -103,7 +103,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         29.1
-    revision        0
+    revision        1
 
     checksums       rmd160  c306a0554d77ee472600ed28af4751211dc1ec70 \
                     sha256  5b80e0475b0e619d2ad395ef5bc481b7cb9f13894ed23c301210572040e4b5b1 \
@@ -271,17 +271,10 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
 variant nativecomp description {Builds emacs with native compilation support} {
     set gcc_v                      12
     depends_lib-append             port:gcc${gcc_v}
-    configure.args-append          --with-native-compilation
+    configure.args-append          --with-native-compilation=aot
     compiler.cpath-prepend         ${prefix}/include/gcc${gcc_v}
     compiler.library_path-prepend  ${prefix}/lib/gcc${gcc_v}
     configure.ldflags-append       "-Wl,-rpath ${prefix}/lib/gcc${gcc_v}"
-
-    if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
-        configure.args-replace     --with-native-compilation \
-                                   --with-native-compilation=aot
-    } else {
-        build.args-append          NATIVE_FULL_AOT=1
-    }
 }
 
 variant treesitter description {Builds emacs with tree-sitter support} {


### PR DESCRIPTION
#### Description

In Emacs 29 the flags for enabling full AOT native compilation changed, but I forgot to apply this to the non-devel subports.

Native compilation was still enabled, but the bundled lisp files were (mostly) not compiled ahead of time.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.5 22G74 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
