### PR TITLE
google-cloud-sdk: update to 441.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             440.0.0
+version             441.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  ebeba5c7c1f8c393549e53a71b029d3a45c13146 \
-                    sha256  2eac519baa776aaa4935f474921f0620013c846860b26a1398c9efdc90c1f272 \
-                    size    101057970
+    checksums       rmd160  4ae0cf01c2278c544cc5b703e29ab2d877dca8a1 \
+                    sha256  de6288baa19f99016f00a9f73de6340aa18894908748637d532399e59276478d \
+                    size    101150673
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  fdb2594892119070e161b088195cb3416bdbe25c \
-                    sha256  31fbe3f2527734275f51e85349132b4a688bd2078903ca44e375a6ed38baa401 \
-                    size    121315954
+    checksums       rmd160  73e432e7362bf0efb22dfc0ba38a48c4bfc6d5b1 \
+                    sha256  94db3d0b93ccc91326d35b7a4c5d94532bacac729c6785c25738804bfbfb4bdc \
+                    size    121391903
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  951614fd4b43b78ee9ccb7754df76d6d666600ed \
-                    sha256  43dd0d753adfe0680d358d0f04ab7f971bcb5590616c87677e77b03b4c69086a \
-                    size    118482227
+    checksums       rmd160  feb76429622121a1e206800f033cf8e0239bc243 \
+                    sha256  6e6f977b0ef10751e089cd9d1ae490d55be648205b7a0b46711d0b1422c893ac \
+                    size    118561017
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 441.0.0.

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?