### PR TITLE
avidemux: update to 2.8.1, unbreak PowerPC

### DIFF
--- a/multimedia/avidemux/Portfile
+++ b/multimedia/avidemux/Portfile
@@ -46,6 +46,16 @@ patchfiles-append           0001-ADM_imageSave.cpp-add-missing-header.patch \
                             0002-ADM_coreUtils.h-fix-symbols-export.patch \
                             0003-Fix-missing-ADM_swap64.patch
 
+# remove VERSION file from ffmpeg source, that conflicts with newer compilers
+# that have a <version> header. The VERSION file has been removed in ffmpeg 6.0
+# which will be used in the next release of avidemux
+patchfiles-append           patch-avidemux-remove-VERSION.diff
+
+# fix c++11-narrowing error using upstream patch
+# https://github.com/mean00/avidemux2/commit/65878cb39f3d9a2e51cb248cdab9724824f80558
+patchfiles-append           65878cb39f3d9a2e51cb248cdab9724824f80558.patch
+
+
 depends_build-append        port:bash \
                             port:gmake \
                             port:pkgconfig \

--- a/multimedia/avidemux/Portfile
+++ b/multimedia/avidemux/Portfile
@@ -3,17 +3,26 @@
 PortSystem                  1.0
 PortGroup                   cmake 1.1
 PortGroup                   app 1.0
-PortGroup                   qt5 1.0
+
+if {${os.platform} eq "darwin" && ${os.major} < 14} {
+    PortGroup               qt4 1.0
+
+} else {
+    PortGroup               qt5 1.0
+
+    # qt5.min_version       ??  # Project does not indicate
+    qt5.depends_component   qttools
+}
 
 name                        avidemux
-version                     2.7.6
-revision                    3
+version                     2.8.1
+revision                    0
 
 categories                  multimedia
 platforms                   macosx
 license                     GPL-2
 maintainers                 nomaintainer
-homepage                    http://avidemux.sourceforge.net/
+homepage                    https://avidemux.sourceforge.net
 
 description                 video editor designed for simple cutting, filtering and encoding tasks
 long_description            Avidemux is a free video editor designed for simple cutting, \
@@ -25,14 +34,21 @@ long_description            Avidemux is a free video editor designed for simple 
 master_sites                sourceforge:project/avidemux/avidemux/${version}
 distname                    ${name}_${version}
 
-checksums           rmd160  68f4037e10d0a10a7a1b3e2dea95e48506641908 \
-                    sha256  9a88741f3535443d4bde35d4207ca2ff96d3b136db2e7232cb50dd6b4eb293cf \
-                    size    24372770
+checksums                   rmd160  c4c3591c880eb54f52f3cbcec601363839c8f295 \
+                            sha256  77d9bdca8683ce57c192b69d207cfab7cf92a7759ce0f63fa37b5c8e42ad3da2 \
+                            size    26126065
 
-patchfiles                  patch-admPlugins_VapourSynth.cmake.diff
+patchfiles                  patch-admPlugins_VapourSynth.cmake.diff \
+                            patch-cpuchecks.diff
+
+# https://github.com/mean00/avidemux2/pull/500
+patchfiles-append           0001-ADM_imageSave.cpp-add-missing-header.patch \
+                            0002-ADM_coreUtils.h-fix-symbols-export.patch \
+                            0003-Fix-missing-ADM_swap64.patch
 
 depends_build-append        port:bash \
                             port:gmake \
+                            port:pkgconfig \
                             port:yasm
 
 depends_lib-append          port:fontconfig \
@@ -42,10 +58,7 @@ depends_lib-append          port:fontconfig \
                             port:libmad \
                             port:zlib
 
-# qt5.min_version           ??  # Project does not indicate
-qt5.depends_component       qttools
-
-default_variants            +aac +gettext +lame +opus +sqlite +twolame +vorbis +x264 +x265 +xvid
+default_variants            +aac +gettext +lame +opus +sqlite +twolame +vorbis +vpx +x264 +x265 +xvid
 
 # only build with one job (otherwise it fails in avidemux_core)
 use_parallel_build          no
@@ -53,6 +66,8 @@ use_parallel_build          no
 # ffmpeg requires a C11 compiler, assume avidemux does too
 compiler.c_standard         2011
 compiler.cxx_standard       2011
+
+cmake.set_cxx_standard      yes
 
 configure.cxxflags-append   -D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1
 
@@ -65,10 +80,8 @@ configure.args-append       -DCMAKE_C_COMPILER=${configure.cc} \
 
 # some default settings
 configure.args-append       -DGTK=OFF \
-                            -DASAN=True \
-                            -DENABLE_QT5=True \
-                            -DUSE_EXTERNAL_LIBASS=true \
-                            -DUSE_EXTERNAL_LIBMAD=true
+                            -DUSE_EXTERNAL_LIBASS=ON \
+                            -DUSE_EXTERNAL_LIBMAD=ON
 
 # disable most options, enable them in variants
 configure.args-append       -DAFTEN=OFF \
@@ -91,9 +104,23 @@ configure.args-append       -DAFTEN=OFF \
                             -DX265=OFF \
                             -DXVID=OFF
 
+if {${os.platform} eq "darwin" && ${os.major} < 14} {
+    configure.args-append   -DENABLE_QT4=ON
+} else {
+    configure.args-append   -DENABLE_QT5=ON
+
+    configure.env-append    QT5_DIR=${qt_dir} QTDIR=${qt_dir}
+}
+
+if {${configure.build_arch} in [list ppc ppc64]} {
+    configure.args-append   -DASAN=OFF \
+                            -DADM_CPU_ALTIVEC=ON
+} else {
+    configure.args-append   -DASAN=ON
+}
+
 # make bundled copy of ffmpeg build verbosely
 # configure.env-append       V=1
-configure.env-append        QT5_DIR=${qt_dir} QTDIR=${qt_dir}
 
 # build {
 configure {
@@ -118,6 +145,8 @@ configure {
 
     # build avidemux core
     process ${workpath} ${worksrcpath} avidemux_core build_core ""
+    # build avidemux GTK UI
+    #process ${workpath} ${worksrcpath} avidemux/gtk build_gtk "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-framework,Cocoa"
     # build avidemux QT UI
     process ${workpath} ${worksrcpath} avidemux/qt4 build_qt4 ""
     # build avidemux cli UI
@@ -150,6 +179,8 @@ variant gettext description {Support for gettext} {
     configure.args-replace  -DGETTEXT=OFF -DGETTEXT=ON
 }
 variant jack description {Support for Jack audio device} {
+    # Do not make a default until this bug is fixed:
+    # https://github.com/jackaudio/jack2/issues/950
     depends_lib-append  port:jack
     configure.args-replace  -DJACK=OFF -DJACK=ON
 }
@@ -175,8 +206,7 @@ variant vorbis description {Support for Vorbis audio codec} {
     configure.args-replace  -DLIBVORBIS=OFF -DLIBVORBIS=ON
 }
 variant vpx description {Support for VP8 video codec} {
-# libvpx is static only so can be considered a build dependency (#47934)
-    depends_build-append path:lib/pkgconfig/vpx.pc:libvpx
+    depends_lib-append  path:lib/pkgconfig/vpx.pc:libvpx
     configure.args-replace  -DVPXDEC=OFF -DVPXDEC=ON
     configure.args-replace  -DVPXENC=OFF -DVPXENC=ON
 }
@@ -195,7 +225,7 @@ variant xvid description {Support for XviD MPEG-4 video codec} {
 
 # .app stuff
 app.name                    Avidemux
-app.executable              Avidemux2.7
+app.executable              Avidemux2.8
 app.use_launch_script       yes
 app.icon                    cmake/osx/avidemux.icns
 

--- a/multimedia/avidemux/files/0001-ADM_imageSave.cpp-add-missing-header.patch
+++ b/multimedia/avidemux/files/0001-ADM_imageSave.cpp-add-missing-header.patch
@@ -1,0 +1,21 @@
+From 9fbbb99a48fce833e817deae78b49cfb13691e0d Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 2 Aug 2023 16:07:29 +0800
+Subject: [PATCH 1/3] ADM_imageSave.cpp: add missing header
+
+---
+ avidemux_core/ADM_coreImage/src/ADM_imageSave.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git avidemux_core/ADM_coreImage/src/ADM_imageSave.cpp avidemux_core/ADM_coreImage/src/ADM_imageSave.cpp
+index 6078181b1..4fe243cc9 100644
+--- avidemux_core/ADM_coreImage/src/ADM_imageSave.cpp
++++ avidemux_core/ADM_coreImage/src/ADM_imageSave.cpp
+@@ -8,6 +8,7 @@
+ #include "ADM_bitmap.h"
+ #include "DIA_coreToolkit.h"
+ #include "ADM_colorspace.h"
++#include "ADM_coreUtils.h"
+ 
+ extern "C" {
+ #include "libavcodec/avcodec.h"

--- a/multimedia/avidemux/files/0002-ADM_coreUtils.h-fix-symbols-export.patch
+++ b/multimedia/avidemux/files/0002-ADM_coreUtils.h-fix-symbols-export.patch
@@ -1,0 +1,26 @@
+From 70c295ef096b31f49c518dca332272265ea8b4bf Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 2 Aug 2023 16:50:42 +0800
+Subject: [PATCH 2/3] ADM_coreUtils.h: fix symbols export
+
+---
+ avidemux_core/ADM_coreUtils/include/ADM_coreUtils.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git avidemux_core/ADM_coreUtils/include/ADM_coreUtils.h avidemux_core/ADM_coreUtils/include/ADM_coreUtils.h
+index 637c9a329..414431262 100644
+--- avidemux_core/ADM_coreUtils/include/ADM_coreUtils.h
++++ avidemux_core/ADM_coreUtils/include/ADM_coreUtils.h
+@@ -26,9 +26,9 @@ ADM_COREUTILS6_EXPORT uint32_t    ADM_Fps1000FromUs(uint64_t us);
+ ADM_COREUTILS6_EXPORT bool        ADM_computeAverageBitrateFromDuration(uint64_t duration, uint32_t sizeInMB, uint32_t *avgInKbits);
+ ADM_COREUTILS6_EXPORT ADM_ASPECT  getAspectRatioFromAR(uint32_t width, uint32_t height,const char **s);
+ ADM_COREUTILS6_EXPORT int32_t     ADM_getNiceValue(uint32_t priorityLevel);
+-void        Endian_AviMainHeader(MainAVIHeader *m);
+-void        Endian_BitMapInfo( ADM_BITMAPINFOHEADER *b);
+-void        Endian_AviStreamHeader(AVIStreamHeader *s);
++ADM_COREUTILS6_EXPORT void        Endian_AviMainHeader(MainAVIHeader *m);
++ADM_COREUTILS6_EXPORT void        Endian_BitMapInfo(ADM_BITMAPINFOHEADER *b);
++ADM_COREUTILS6_EXPORT void        Endian_AviStreamHeader(AVIStreamHeader *s);
+ ADM_COREUTILS6_EXPORT void        Endian_WavHeader(WAVHeader *w);
+ ADM_COREUTILS6_EXPORT void        printBih(ADM_BITMAPINFOHEADER *bi);
+ ADM_COREUTILS6_EXPORT uint8_t     mk_hex(uint8_t a, uint8_t b);

--- a/multimedia/avidemux/files/0003-Fix-missing-ADM_swap64.patch
+++ b/multimedia/avidemux/files/0003-Fix-missing-ADM_swap64.patch
@@ -1,0 +1,22 @@
+From f10df2804df787707d80a1e1869400946d844eaf Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 2 Aug 2023 19:28:48 +0800
+Subject: [PATCH 3/3] Fix missing ADM_swap64
+
+---
+ avidemux_core/ADM_core/include/ADM_assert.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git avidemux_core/ADM_core/include/ADM_assert.h avidemux_core/ADM_core/include/ADM_assert.h
+index 4bb0e61ee..38d21f092 100644
+--- avidemux_core/ADM_core/include/ADM_assert.h
++++ avidemux_core/ADM_core/include/ADM_assert.h
+@@ -53,7 +53,7 @@ ADM_CORE6_EXPORT void     *ADM_realloc(void *in,size_t size);
+ ADM_CORE6_EXPORT void     ADM_dezalloc(void *ptr);
+ ADM_CORE6_EXPORT char     *ADM_strdup( const char *in);
+ /* Endianness stuff */
+-uint64_t 	ADM_swap64(uint64_t in);
++ADM_CORE6_EXPORT uint64_t 	ADM_swap64(uint64_t in);
+ ADM_CORE6_EXPORT uint32_t 	ADM_swap32(uint32_t in);
+ ADM_CORE6_EXPORT uint16_t 	ADM_swap16(uint16_t in);
+ //static inline uint32_t dontswap(uint32_t in) {return in;};

--- a/multimedia/avidemux/files/65878cb39f3d9a2e51cb248cdab9724824f80558.patch
+++ b/multimedia/avidemux/files/65878cb39f3d9a2e51cb248cdab9724824f80558.patch
@@ -1,0 +1,37 @@
+From 65878cb39f3d9a2e51cb248cdab9724824f80558 Mon Sep 17 00:00:00 2001
+From: listout <listout@protonmail.com>
+Date: Tue, 7 Mar 2023 13:27:46 +0530
+Subject: [PATCH] Fix Fixes non-constant-expression cannot be narrowed from
+ type 'uint32_t' error with clang-16
+
+Clang 16 (to be released appx. March 2023) will make the following default errors:
+-Werror=implicit-function-declaration
+-Werror=implicit-int
+-Werror=int-conversion (this is in Clang 15, actually)
+-Werror=incompatible-function-pointer-types (GCC does not have a specific equivalent error, use -Werror=incompatible-pointer-types instead when testing)
+
+Building with Clang-16 results in build failure with
+non-constant-expression cannot be narrowed from type 'uint32_t' error
+with clang-16. Following what the compiler suggests, adding a
+static_cast<int> helps suppress the error.
+
+Signed-off-by: listout <brahmajit.xyz@gmail.com>
+---
+ avidemux_core/ADM_coreImage/src/ADM_colorspace.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git avidemux_core/ADM_coreImage/src/ADM_colorspace.cpp avidemux_core/ADM_coreImage/src/ADM_colorspace.cpp
+index 41628dd347..a6a4834a3e 100644
+--- avidemux_core/ADM_coreImage/src/ADM_colorspace.cpp
++++ avidemux_core/ADM_coreImage/src/ADM_colorspace.cpp
+@@ -637,8 +637,8 @@ void * ADMRGB32Scaler::planeWorker(void *argptr)
+     }
+     
+     // resize plane
+-    int xs[4]={ADM_IMAGE_ALIGN(arg->srcWidth),0,0,0};
+-    int xd[4]={ADM_IMAGE_ALIGN(arg->dstWidth),0,0,0};
++    int xs[4]={static_cast<int>(ADM_IMAGE_ALIGN(arg->srcWidth)),0,0,0};
++    int xd[4]={static_cast<int>(ADM_IMAGE_ALIGN(arg->dstWidth)),0,0,0};
+     uint8_t *src[4]={NULL,NULL,NULL,NULL};
+     uint8_t *dst[4]={NULL,NULL,NULL,NULL};
+     src[0]=arg->iPlane;

--- a/multimedia/avidemux/files/patch-avidemux-remove-VERSION.diff
+++ b/multimedia/avidemux/files/patch-avidemux-remove-VERSION.diff
@@ -1,0 +1,13 @@
+diff --git avidemux_core/ffmpeg_package/patches/remove-version.patch avidemux_core/ffmpeg_package/patches/remove-version.patch
+new file mode 100644
+index 0000000..9a1f3d1
+--- /dev/null
++++ avidemux_core/ffmpeg_package/patches/remove-version.patch
+@@ -0,0 +1,7 @@
++diff --git VERSION VERSION
++deleted file mode 100755
++index 1d068c6..0000000
++--- VERSION
+++++ /dev/null
++@@ -1 +0,0 @@
++-4.4.2

--- a/multimedia/avidemux/files/patch-cpuchecks.diff
+++ b/multimedia/avidemux/files/patch-cpuchecks.diff
@@ -1,0 +1,31 @@
+--- cmake/admDetermineSystem.cmake.orig	2022-09-17 21:59:17.000000000 +0800
++++ cmake/admDetermineSystem.cmake	2023-08-02 15:34:17.000000000 +0800
+@@ -52,12 +52,12 @@
+ # Check CPU support
+ ########################################
+ IF(NOT MSVC)
+-        PERFORM_SYSTEM_TEST(cpu_x86-64_check.cpp "x86 64-bit" X86_64_SUPPORTED)
+-
+         IF (CMAKE_SIZEOF_VOID_P EQUAL 8)
+ 	        SET(ADM_CPU_64BIT 1)
+         ENDIF (CMAKE_SIZEOF_VOID_P EQUAL 8)
+ 
++        PERFORM_SYSTEM_TEST(cpu_x86-64_check.cpp "x86 64-bit" X86_64_SUPPORTED)
++
+         IF (X86_64_SUPPORTED)
+ 	        SET(ADM_CPU_X86 1)
+ 	        SET(ADM_CPU_X86_64 1)
+@@ -88,7 +88,12 @@
+         ENDIF (X86_64_SUPPORTED)
+ 
+         IF (NOT ADM_CPU_X86_32 AND NOT ADM_CPU_X86_64 AND NOT ADM_CPU_ARMEL AND NOT ADM_CPU_ARM64 AND NOT ADM_CPU_RISCV AND NOT ADM_CPU_RISCV_64)
+-	        MESSAGE(FATAL_ERROR "CPU not supported")
++            # Assume PowerPC:
++            IF (ADM_CPU_64BIT)
++	            SET(ADM_CPU_PPC64 1)
++	        ELSE (ADM_CPU_64BIT)
++	            SET(ADM_CPU_PPC 1)
++	        ENDIF (ADM_CPU_64BIT)
+         ENDIF (NOT ADM_CPU_X86_32 AND NOT ADM_CPU_X86_64 AND NOT ADM_CPU_ARMEL AND NOT ADM_CPU_ARM64 AND NOT ADM_CPU_RISCV AND NOT ADM_CPU_RISCV_64)
+ 
+         TEST_BIG_ENDIAN(CMAKE_WORDS_BIGENDIAN)


### PR DESCRIPTION
#### Description

Let’s see if this builds. I cannot check Qt5 build – but Qt4 works fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
