### PR TITLE
go-devel: update to 1.21rc4

### DIFF
--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -30,7 +30,7 @@ set legacy_build    false
 
 # Subport for Go Unstable Version
 subport ${name}-devel {
-    version         1.21rc3
+    version         1.21rc4
     revision        0
     epoch           1
 
@@ -66,17 +66,17 @@ livecheck.url       ${homepage}/dl/
 if {$subport eq "${name}-devel"} {
     # Go (DEVEL / UNSTABLE)
     checksums       ${go_src_dist} \
-                    rmd160  ab71ceb89bbbd205a3a4159f1eb4798cdb6d9649 \
-                    sha256  9de96a2f15196a9c69cb9ab122c9c2aaecca30ec9448caa71543eaeb19ca91ab \
-                    size    26941603 \
+                    rmd160  d09d5a3a1bc728daa219d04a248a1681766b550c \
+                    sha256  2324f20f11112aec3e5d5e428d046861a34e4f99de0ab82a8d914d26b8fb01fd \
+                    size    26942312 \
                     ${go_armbin_dist} \
-                    rmd160  eb052dbc73e4bf4e7b48998bb2f90049441ac021 \
-                    sha256  cc16e0029edef1f1bd37b678be8c35cfc42aff9ebc3dce7fc4b6f695320bf2a2 \
-                    size    65350962 \
+                    rmd160  1a9c46fc45eb1cf9368e7418750b182d193ef16a \
+                    sha256  b8df7caa45d48c9a872326aacf6d55d38cf3f2de0d0f70c01d4362bf1ae17464 \
+                    size    64956836 \
                     ${go_amdbin_dist} \
-                    rmd160  6208c6f88673c77462a82f5fa9aff79a87c0adf6 \
-                    sha256  cbd24987882706e94289492df4d24c5e5e1a224bf83def3576cf7015c5c54587 \
-                    size    67560306
+                    rmd160  bcb3c8ac6cc108411cb4b6e17aa66f29faf15e6f \
+                    sha256  5fd710d80b0d69eba01e9e4c86a913055df9ddf1485ba0b926fa7f623f093ed3 \
+                    size    67142646
 
     livecheck.regex {go([0-9.A-z]+)\.src\.tar\.gz}
 } else {


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
