### PR TITLE
cctools: +llvm34 on macOS 10.5

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -121,7 +121,7 @@ if { ![some_llvm_variant_set] && ![variant_isset xcode] && ![variant_isset xtool
     } elseif {${os.major} >= 12} {
         # llvm-3.7 is the newest llvm the system toolchain can build on these systems
         default_variants +llvm37
-    } elseif {${os.major} >= 10} {
+    } elseif {${os.major} >= 9 && ${build_arch} ni [list ppc ppc64]} {
         # llvm-3.4 is the newest llvm the system toolchain can build on these systems
         default_variants +llvm34
     }


### PR DESCRIPTION
#### Description

Right now cctools hasn't got any LTO support from the box at macOS 10.5 i386 and it's toolschain is enough to build llvm-3.4... Well, let's enable by default its variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
