### PR TITLE
ncarg: rev bump for dependency update

### DIFF
--- a/science/ncarg/Portfile
+++ b/science/ncarg/Portfile
@@ -11,7 +11,7 @@ compilers.allow_arguments_mismatch \
 
 name                        ncarg
 version                     6.6.2
-revision                    21
+revision                    22
 epoch                       1
 set version_no_dot [join [split ${version} "."] ""]
 categories                  science


### PR DESCRIPTION
#### Description

Dependency hdfeos5 was updated from 1.16 to 2.0.
That update issue was:  https://trac.macports.org/ticket/65818

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

Not tested locally.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
