### PR TITLE
qt6: does not support Apple Clang < 11.0

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -3,6 +3,7 @@
 PortSystem                  1.0
 PortGroup                   active_variants 1.1
 PortGroup                   qt6_info 1.0
+PortGroup                   compiler_blacklist_versions 1.0
 
 name                        qt6
 
@@ -24,6 +25,14 @@ set qt_major                [lindex [split ${version} .] 0]
 
 # see https://www.qt.io/blog/qt-6.0-released
 compiler.cxx_standard       2017
+
+# qcompilerdetection.h emits:
+#     error: "Unsupported Apple Clang version"
+# which also means Q_CC_CLANG will not be set.
+# That causes the check for __has_feature(cxx_unicode_literals) to be skipped, causing
+#     error: "Qt6 requires Unicode string support in both the compiler and the standard library"
+# to be emitted, even when the unsupported Apple Clang version does support Unicode string literals.
+compiler.blacklist-append   {clang < 1100}
 
 master_sites                https://download.qt.io/official_releases/qt/${branch}/${version}/submodules
 # file sizes are significantly smaller using xz
@@ -929,10 +938,6 @@ foreach {driver driver_info} [array get sql_plugins] {
 # Special Cases
 ###############################################################################
 subport ${name}-qtdeclarative {
-    PortGroup                       compiler_blacklist_versions 1.0
-
-    # Xcode 10.3 compiler segfaults
-    compiler.blacklist-append       {clang < 1100}
 }
 
 subport ${name}-qttools {


### PR DESCRIPTION
#### Description

This change is necessary but insufficient for fixing the 10.14 buildbot build; other changes like those in #19407 (which I have not thoroughly reviewed) would also be needed.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Not tested on affected macOS versions.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
This is not already proposed by #19407.
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
