### PR TITLE
kerberos5: Update Portfile to better handle Python version

### DIFF
--- a/net/kerberos5/Portfile
+++ b/net/kerberos5/Portfile
@@ -30,9 +30,12 @@ homepage                    http://web.mit.edu/kerberos/
 master_sites                ${homepage}dist/krb5/${branch}/
 distname                    krb5-${version}
 
+set python_branch           3.11
+set python_version          [strsed ${python_branch} {s|\.||}]
+
 depends_build               port:gettext \
                             port:pkgconfig \
-                            port:python311
+                            port:python${python_version}
 
 depends_lib                 port:gettext-runtime \
                             port:libcomerr \
@@ -55,7 +58,7 @@ configure.checks.implicit_function_declaration.whitelist-append strchr
 # remove ${prefix}/lib from configure.ldflags to allow linking against its own libs first
 # adding ${worksrcpath}/lib is not necessary and pollutes krb5-config --libs and pkg-config files
 configure.ldflags-delete    -L${prefix}/lib
-configure.python            ${prefix}/bin/python3.10
+configure.python            ${prefix}/bin/python${python_branch}
 configure.args              --with-system-et \
                             --without-system-db \
                             --without-hesiod \


### PR DESCRIPTION
ref https://trac.macports.org/ticket/67889#comment:2

#### Description

Avoid python branch deviates from version in Portfile.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.9 20G1426 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
