### PR TITLE
clang compilers: never use clang on Darwin/PowerPC

### DIFF
--- a/_resources/port1.0/compilers/clang_compilers.tcl
+++ b/_resources/port1.0/compilers/clang_compilers.tcl
@@ -7,6 +7,11 @@
 
 global os.major os.platform
 
+# clang is useless on Darwin / PowerPC, let disable it globally
+if {${os.platform} eq "darwin" && [option configure.build_arch] in [list ppc ppc64]} {
+    return
+}
+
 if {${os.major} >= 11 || ${os.platform} ne "darwin"} {
     if {[option compiler.cxx_standard] >= 2014} {
         # For now limit exposure of clang-16 to ports needing c++14 or newer


### PR DESCRIPTION
#### Description

This trivial changes should decrease number of `if` when it blacklists clang on PowerPC. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->