### PR TITLE
mat2: update to 0.13.4

### DIFF
--- a/multimedia/mat2/Portfile
+++ b/multimedia/mat2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                mat2
-version             0.13.3
+version             0.13.4
 revision            0
 categories-prepend  multimedia
 license             LGPL-3
@@ -18,11 +18,11 @@ long_description    mat2 is a metadata removal tool, supporting a wide range \
                     of commonly used file formats, written in python3.
 homepage            https://0xacab.org/jvoisin/mat2
 
-checksums           rmd160  90d001f866a48fde781a092a0b88db1c2f623997 \
-                    sha256  6446e0141987cc7356b00e5e5ae7a0a13d7d64bfdd2f2439568c766e2f07f0c0 \
-                    size    46331
+checksums           rmd160  2b44330ae69d37ecb916fc35614365dfbc4fe67f \
+                    sha256  744aeee924c9898a397fe930593b803c540389bf39cd24553b99a89acc2f5901 \
+                    size    47947
 
-python.default_version 310
+python.default_version 311
 
 depends_lib-append  port:py${python.version}-cairo \
                     port:py${python.version}-mutagen \
@@ -31,3 +31,7 @@ depends_lib-append  port:py${python.version}-cairo \
                     port:librsvg \
                     port:ffmpeg \
                     port:exiftool
+
+post-destroot {
+    ln -s ${python.prefix}/man/man1/mat2.1 ${destroot}${prefix}/share/man/man1/mat2.1
+}


### PR DESCRIPTION
#### Description

mat2: update to 0.13.4

- made python 3.11 default
- added in man page

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement


###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
