### PR TITLE
grass: fix app bundle start script

### DIFF
--- a/gis/grass/Portfile
+++ b/gis/grass/Portfile
@@ -10,7 +10,7 @@ github.setup        OSGeo grass 8.3.0
 name                grass
 epoch               1
 set main_version    [join [lrange [split ${version} "."] 0 1] ""]
-revision            1
+revision            2
 set realVersion     ${version}
 distname            grass-${realVersion}
 maintainers         {yahoo.com:n_larsson @nilason} openmaintainer
@@ -201,7 +201,7 @@ variant gui description {Build with wxPython GUI and application bundle} {
         set script [open "${worksrcpath}/${app_name}/Contents/MacOS/GRASS" w 0755]
         puts ${script} "#!/usr/bin/osascript"
         puts ${script} ""
-        puts ${script} "tell application \"Terminal\" to do script \"${prefix}/bin/grass${main_version} --gui; exit\""
+        puts ${script} "tell application \"Terminal\" to do script \"${prefix}/bin/grass --gui; exit\""
         close ${script}
 
         copy ${worksrcpath}/macosx/app/AppIcon.icns \


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Amazed how this slipped my attention, the 'grass' executable is with version 8+ version-less. This fixes the bad startup script in the app bundle

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
