### PR TITLE
maven3: update to 3.9.4

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.9.3
+version         3.9.4
 revision        0
 
 categories      java devel
@@ -35,9 +35,9 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  3b70d4d0874883e10b47ac358c9fbeb5bf5215f2 \
-                sha256  e1e13ac0c42f3b64d900c57ffc652ecef682b8255d7d354efbbb4f62519da4f1 \
-                size    9258617
+checksums       rmd160  b679ca535806cbdd73ed1a5469afc1a204f26e7a \
+                sha256  ff66b70c830a38d331d44f6c25a37b582471def9a161c93902bac7bea3098319 \
+                size    9336368
 
 java.version    1.8+
 java.fallback   openjdk17


### PR DESCRIPTION
#### Description

Update to Apache Maven 3.9.4.

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?