### PR TITLE
symfony-cli: update to 5.5.8

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.5.7
+version             5.5.8
 revision            0
 
 if {${os.major} >= 17} {
@@ -32,7 +32,7 @@ long_description    The Symfony CLI tool is a must-have tool when developing \
 
 categories          devel
 installs_libs       no
-license             AGPL-3.0
+license             AGPL-3+
 maintainers         {@antalaron antalaron.hu:antalaron} \
                     openmaintainer
 
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  16700dbd2b6ca67569663125e444ed61a34b5a3c \
-                        sha256  881fe138f5ffc67db7a36f9fe66a730a23fa6013a2169f1a797e18a034540022 \
-                        size    252755
+    checksums           rmd160  d446acee11dbeacb72551459cf1a59a8d7f525e0 \
+                        sha256  803f2a3824a2e1c8e71f6e4596b9e050206d83cd53236986dbfbd39b7d73c99c \
+                        size    252762
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  fb3f36ae4463fdd0337e599861e6fc22d168e00c \
-                        sha256  a82ba6fdc8649930464147db9a46fa8ded5a07a91690435e84eec9335f3b91d1 \
-                        size    11014539
+    checksums           rmd160  ab4662a23623b96a776cd9d64be56955bb98ceba \
+                        sha256  d04f195a0698a1cbfbcff721801cc4d3b00dcd10befe3d437bcaa4df4350fb74 \
+                        size    11018873
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.5.8

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
