### PR TITLE
cctools: avoid +llvm10 on PPC

### DIFF
--- a/devel/cctools/Portfile
+++ b/devel/cctools/Portfile
@@ -133,7 +133,7 @@ if { ![some_llvm_variant_set] && ![variant_isset xcode] && ![variant_isset xtool
 
     # If a default llvm is still not set, use +llvm10
     # this fail-safe ensures some cctools variant can build
-    if {![some_llvm_variant_set] && ![variant_isset xcode] && ${os.major} >= 10} {
+    if {![some_llvm_variant_set] && ![variant_isset xcode] && ${os.major} >= 10 && ${build_arch} ni [list ppc ppc64]} {
         default_variants +llvm10
     }
 }


### PR DESCRIPTION
#### Description

Yesterday PR https://github.com/macports/macports-ports/pull/19725 enforces using of `+llvm10` on PowerPC on macOS 10.6; technically it is still posible for so call rosetta setup.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
