### PR TITLE
quazip, quazip1: use qt4 on < 10.7

### DIFF
--- a/archivers/quazip/Portfile
+++ b/archivers/quazip/Portfile
@@ -3,7 +3,14 @@
 PortSystem              1.0
 PortGroup               cmake 1.1
 PortGroup               github 1.0
-PortGroup               qt5 1.0
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    PortGroup           qt4 1.0
+
+} else {
+    PortGroup           qt5 1.0
+
+}
 
 github.setup            stachenov quazip 0.9.1 v
 epoch                   1
@@ -14,7 +21,6 @@ checksums               rmd160  12d0089dfd38b19d96030c3a1fc703ce66474eeb \
                         size    155775
 
 categories              archivers devel
-platforms               darwin
 license                 LGPL-2.1
 maintainers             nomaintainer
 

--- a/archivers/quazip1/Portfile
+++ b/archivers/quazip1/Portfile
@@ -4,7 +4,14 @@ PortSystem              1.0
 
 PortGroup               cmake   1.1
 PortGroup               github  1.0
-PortGroup               qt5     1.0
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    PortGroup           qt4 1.0
+
+} else {
+    PortGroup           qt5 1.0
+
+}
 
 github.setup            stachenov quazip 1.4 v
 github.tarball_from     archive


### PR DESCRIPTION
#### Description

qt5 is unsupported on old systems. `quazip` builds with qt4 with no changes to the code.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
