### PR TITLE
docker-compose-plugin: add port

### DIFF
--- a/devel/docker-compose-plugin/Portfile
+++ b/devel/docker-compose-plugin/Portfile
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/docker/compose 2.20.2 v
+revision            0
+name                docker-compose-plugin
+categories          devel
+platforms           darwin
+license             Apache-2
+maintainers         {danchr @danchr} \
+                    openmaintainer
+description         Define and run multi-container applications with Docker
+long_description    A tool for running multi-container applications on \
+                    Docker defined using the Compose file format. A \
+                    Compose file is used to define how one or more \
+                    containers that make up your application are \
+                    configured. Once you have a Compose file, you can \
+                    create and start your application with a single \
+                    command: docker compose up.
+
+checksums           rmd160  19b25b07027568a39b6034c8d62f73e35886b5a7 \
+                    sha256  f32c01f5f53b716866cc62054d26db7ea3ab0c204cb7dc8b98c5a60de5dcf17f \
+                    size    327989
+
+build.env-delete    GO111MODULE=off GOPROXY=off
+build.target         -o ${name} ./cmd
+
+depends_run         port:docker
+
+pre-build {
+    set distfile_dirname [exec tar tzf ${distpath}/[lindex ${distfiles} 0] | sed -n 1p]
+    set docker_gitcommit [string map "${github.author}-${github.project}- {} / {}" ${distfile_dirname}]
+    if {![regexp -nocase -- {^[0-9a-f]{7}$} ${docker_gitcommit}]} {
+        return -code error "can't determine git commit"
+    }
+
+    set val [clock microseconds]
+    set seconds_precision [expr { $val / 1000000 }]
+    set build_time [clock format $seconds_precision -format "%a %b %d %H:%M:%S %Y"]
+
+    # file rename ${worksrcpath} ${worksrcpath}~
+    # file mkdir ${worksrcpath}
+    # file rename ${worksrcpath}~ ${worksrcpath}/v2
+
+    # worksrcdir ${worksrcdir}/v2
+
+    # build.cmd ${go.bin} build -ldflags \
+    #     "\"-X ${go.package}/internal.GitCommit=${docker_gitcommit} -X ${go.package}/internal.Version=${version} -X \\\"${go.package}/internal.BuildTime=${build_time}\\\"\""
+}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/libexec/docker/cli-plugins
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/libexec/docker/cli-plugins/docker-compose
+}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  19b25b07027568a39b6034c8d62f73e35886b5a7 \
+                        sha256  f32c01f5f53b716866cc62054d26db7ea3ab0c204cb7dc8b98c5a60de5dcf17f \
+                        size    327989
+
+github.livecheck.regex  {([^"r]+)}

--- a/devel/docker/Portfile
+++ b/devel/docker/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/docker/cli 20.10.22 v
+go.setup            github.com/docker/cli 24.0.5 v
 revision            0
 name                docker
 categories          devel
@@ -11,15 +11,24 @@ platforms           darwin
 license             Apache-2
 maintainers         {emcrisostomo @emcrisostomo} \
                     openmaintainer
-description         The open-source application container engine
+description         Utilities for the open-source application container engine
 long_description    Docker is an open source project to pack, ship \
-                    and run any application as a lightweight container.
+                    and run any application as a lightweight container. \
+                    This port contains command line utilities for interacting \
+                    with Docker, but not the core daemon.
 
-checksums           rmd160  ee6e3d6c2be1b0d7813aead3f16910982047470c \
-                    sha256  ee3f35297eace28ba3433b38a33c63a5eea250228e4ab35d1fab5c567ad4f8ab \
-                    size    7590078
+checksums           rmd160  1cd95aee22ef0b061fca92a476c9e1dedc401c3a \
+                    sha256  57df09957cf2246e86c182c3ae57da1879d2864f7439d7f6ce15fd7a4b962965 \
+                    size    6244654
 
 build.target        github.com/docker/cli/cmd/docker
+
+patchfiles          plugin-path.diff
+
+post-patch {
+    reinplace s+__PREFIX__+${prefix}+g \
+        ${worksrcpath}/cli-plugins/manager/manager_unix.go
+}
 
 pre-build {
     set distfile_dirname [exec tar tzf ${distpath}/[lindex ${distfiles} 0] | sed -n 1p]
@@ -41,3 +50,8 @@ destroot {
 }
 
 github.livecheck.regex  {([^"r]+)}
+
+
+notes "\
+    This port only contains a utility for working with Docker; to run\
+    containers locally, install e.g. the colima port."

--- a/devel/docker/files/plugin-path.diff
+++ b/devel/docker/files/plugin-path.diff
@@ -1,0 +1,11 @@
+--- cli-plugins/manager/manager_unix.go
++++ cli-plugins/manager/manager_unix.go
+@@ -5,5 +5,5 @@
+ 
+ var defaultSystemPluginDirs = []string{
+ 	"/usr/local/lib/docker/cli-plugins", "/usr/local/libexec/docker/cli-plugins",
+-	"/usr/lib/docker/cli-plugins", "/usr/libexec/docker/cli-plugins",
++	"__PREFIX__/lib/docker/cli-plugins", "__PREFIX__/libexec/docker/cli-plugins",
+ }
+
+Diff finished.  Fri Aug  4 19:09:34 2023


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This updates the Docker port to the latest version, adjusts it so that it can load plugins from the prefix, and adds a `docker-compose-plugin` port. (To retain compatibility, it still loads plugins from `/usr/local` as well.)

I checked Trac, and someone was confused that the `docker` port didn't, in fact, install Docker. So I adjusted the description and added a clarifying note — `colima` is useful for actually running Docker containers, so I made it point to that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
