### PR TITLE
GPXSee: update to 13.5

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.4
+github.setup        tumic0 GPXSee 13.5
 revision            0
 
-checksums           rmd160  28f59b0cf13ba515d370616050df6b1bea1dea9f \
-                    sha256  9807eb963fa1d0829632fcc3549552468e4fbddeb972f1a9c61417022fd137b8 \
-                    size    5498905
+checksums           rmd160  2ad07a5c52a7531561ea562b4bc0adbcd4e883e1 \
+                    sha256  5a527ac591f6eb64a6f0d98802d6e03495d3efd875ac25d8675aa5b7d63b6c7f \
+                    size    5499668
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
