### PR TITLE
gopass: update to 1.15.6

### DIFF
--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.15.5 v
+go.setup            github.com/gopasspw/gopass 1.15.6 v
 github.tarball_from archive
 revision            0
 categories          security
@@ -16,9 +16,9 @@ homepage            https://www.gopass.pw
 
 depends_lib-append  port:gnupg2
 
-checksums           rmd160  35f7374462035876e954bb1c70685ba33eae9b15 \
-                    sha256  d37e23081abd53c6441a28f1faecc5bbdc760e921ea26fb092745a695e79f60f \
-                    size    2304217
+checksums           rmd160  eafb199d8ba906cd122e2eaf4ae46cb9c6517015 \
+                    sha256  1cf885380883d8b5c17bb68a882a3b3034651491d273a4c0d2899a3d9048c664 \
+                    size    2307580
 
 set go_ldflags      "-s -w -X main.version=${version}"
 build.env-delete    GO111MODULE=off GOPROXY=off


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/gopasspw/gopass/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
