### PR TITLE
cmake-devel: update to 3.27.1

### DIFF
--- a/devel/cmake-devel/Portfile
+++ b/devel/cmake-devel/Portfile
@@ -36,11 +36,11 @@ homepage            https://cmake.org
 platforms           darwin freebsd
 gitlab.instance     https://gitlab.kitware.com
 
-gitlab.setup        cmake   cmake 454bfa77b2951cc53296da86928dce00885d4d5b
-version             20230308-3.26.0-rc6-[string range ${gitlab.version} 0 7]
-checksums           rmd160  14084f8407a6c6a189f443ebcbe5c5b6d9baa4cf \
-                    sha256  ce091ec5972ea67cb79efa63460b9a71623a75b7cb54ad5468ab077c5a54064f \
-                    size    8147049
+gitlab.setup        cmake   cmake b5c54d9c8a1fdfdbf1a133040029a4924b69185e
+version             20230725-3.27.1-[string range ${gitlab.version} 0 7]
+checksums           rmd160  b084716cbd4abb6826f4bc9db5bdfe3b51b307f7 \
+                    sha256  17324d9d7317439790429e963ee2c1870fa6afd6696a082717e22a57ca64c4ed \
+                    size    8423291
 revision            0
 
 epoch               1
@@ -149,7 +149,8 @@ configure.args-append \
     --system-libs \
     --no-qt-gui \
     --no-system-jsoncpp \
-    --no-system-librhash
+    --no-system-librhash \
+    --no-system-cppdap
 
 configure.universal_args
 

--- a/devel/cmake-devel/files/patch-fix-system-prefix-path.diff
+++ b/devel/cmake-devel/files/patch-fix-system-prefix-path.diff
@@ -1,6 +1,6 @@
 --- Modules/Platform/Darwin.cmake.orig
 +++ Modules/Platform/Darwin.cmake
-@@ -262,7 +262,9 @@
+@@ -265,7 +265,9 @@
      endforeach()
    endif()
  endif()
@@ -16,7 +16,7 @@
 +)
 --- Modules/Platform/UnixPaths.cmake.orig
 +++ Modules/Platform/UnixPaths.cmake
-@@ -27,22 +27,39 @@
+@@ -30,22 +30,39 @@
  # synchronized
  list(APPEND CMAKE_SYSTEM_PREFIX_PATH
    # Standard

--- a/devel/cmake-devel/files/patch-qt5gui.diff
+++ b/devel/cmake-devel/files/patch-qt5gui.diff
@@ -1,6 +1,6 @@
 --- Source/QtDialog/CMakeLists.txt.orig
 +++ Source/QtDialog/CMakeLists.txt
-@@ -307,7 +307,8 @@
+@@ -308,7 +308,8 @@
      OUTPUT_NAME CMake
      MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
      MACOSX_BUNDLE_SHORT_VERSION_STRING "${CMAKE_BUNDLE_VERSION}"
@@ -10,7 +10,7 @@
      MACOSX_BUNDLE_COPYRIGHT "${copyright_line}"
      MACOSX_BUNDLE_GUI_IDENTIFIER "org.cmake.cmake"
      )
-@@ -344,8 +345,12 @@
+@@ -345,8 +346,12 @@
  endif()
  
  if(APPLE)
@@ -53,7 +53,7 @@
  	<key>CFBundleSignature</key>
 --- CMakeLists.txt.orig
 +++ CMakeLists.txt
-@@ -419,12 +419,20 @@
+@@ -440,12 +440,20 @@
      if(APPLE)
        set(CMAKE_BUNDLE_VERSION
          "${CMake_VERSION_MAJOR}.${CMake_VERSION_MINOR}.${CMake_VERSION_PATCH}")


### PR DESCRIPTION
#### Description

Update cmake-devel to 3.27.1 (see also https://trac.macports.org/ticket/67540).

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b

macOS 12.6.3 21G419 arm64
Xcode 13.3.1 13E500a


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
