### PR TITLE
gnupg1: end conflict (coexist) with gnupg2

### DIFF
--- a/mail/gnupg1/Portfile
+++ b/mail/gnupg1/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 set my_name         gnupg
 name                ${my_name}1
 version             1.4.23
-revision            2
+revision            3
 categories          mail security
 license             GPL-3+
 installs_libs       no
@@ -19,7 +19,6 @@ homepage            https://www.gnupg.org
 platforms           darwin freebsd sunos
 distname            ${my_name}-${version}
 master_sites        ${my_name}:${my_name}
-conflicts           ${my_name}2
 
 use_bzip2           yes
 
@@ -31,6 +30,7 @@ checksums           rmd160  087c494ff78bd1e85873ac383e0c6e236b6a9869 \
 compiler.cxx_standard
 
 configure.args      --infodir=${prefix}/share/info \
+                    --docdir=${prefix} \
                     --disable-asm \
                     --with-libiconv-prefix=${prefix} \
                     --with-libintl-prefix=${prefix} \
@@ -38,7 +38,8 @@ configure.args      --infodir=${prefix}/share/info \
                     --with-bzip2=${prefix} \
                     --with-libusb=${prefix} \
                     --with-ldap=${prefix} \
-                    --with-libcurl=${prefix}
+                    --with-libcurl=${prefix} \
+                    --program-suffix=1
 
 depends_build       port:gettext
 depends_lib         port:libiconv \
@@ -75,13 +76,14 @@ notes {
     are supported, but users are highly recommended to switch to\
     the modern version of GnuPG, provided by the gnupg2 port.
 
-    This port will be made co-installable with the modern version\
-    in mid-October 2018. All binaries will be postfixed with "1"\
-    and dependents switched over to pull in modern GnuPG,\
-    eventually forcing an upgrade. After this date, this port will\
-    still be provided for users that need to work on old data,\
-    which is not supported by the modern version any longer, but\
-    not used within MacPorts.
+    This port can coexist with the modern version.\
+    All binaries are postfixed with "1", and all dependent\
+    ports have adapted to the new names.
+
+    Note: This means that this revision is NOT BACKWARDS-COMPATIBLE\
+    with gnupg1 @1.4.23_2 or earlier. If you have any local scripts that\
+    require GnuPG 1.4 and reference (e.g.) "gpg" or "gpgv", YOU MUST MODIFY\
+    those references to (e.g.) "gpg1" or "gpgv1" instead.
 }
 
 livecheck.type      regex

--- a/mail/gnupg2/Portfile
+++ b/mail/gnupg2/Portfile
@@ -27,7 +27,6 @@ long_description    GnuPG is a complete and free replacement for PGP. Because   
                     without any restrictions. GnuPG is a RFC4880 (OpenPGP)          \
                     compliant application.
 homepage            https://www.gnupg.org
-conflicts           ${my_name}1
 distname            ${my_name}-${version}
 master_sites        ${my_name}:${my_name}
 

--- a/mail/lbdb/Portfile
+++ b/mail/lbdb/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                lbdb
 version             0.48.1
-revision            1
+revision            2
 categories          mail
 maintainers         nomaintainer
 platforms           darwin freebsd
@@ -53,7 +53,7 @@ post-destroot {
 
 variant gpg conflicts gpg2 description {Add support for GnuPG version 1} {
     depends_lib-append      port:gnupg1
-    configure.args-replace  --without-gpg --with-gpg
+    configure.args-replace  --without-gpg --with-gpg=${prefix}/bin/gpg1
 }
 
 variant gpg2 conflicts gpg description {Add support for GnuPG version 2} {

--- a/perl/p5-module-signature/Portfile
+++ b/perl/p5-module-signature/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         Module-Signature 0.88
-revision            0
+revision            1
 license             Permissive
 maintainers         nomaintainer
 description         Module signature file manipulation
@@ -27,6 +27,9 @@ if {${perl5.major} != ""} {
     if {[variant_isset gnupg1]} {
         depends_lib-append \
                     port:gnupg1
+
+        patchfiles-append \
+                    patch-ignore-gnupg2.diff
     } else {
         depends_lib-append \
                     path:bin/gpg2:gnupg2

--- a/perl/p5-module-signature/files/patch-ignore-gnupg2.diff
+++ b/perl/p5-module-signature/files/patch-ignore-gnupg2.diff
@@ -1,0 +1,11 @@
+--- Makefile.PL.orig	2016-11-02 12:38:17.000000000 -0700
++++ Makefile.PL	2016-11-02 12:40:20.000000000 -0700
+@@ -77,7 +77,7 @@
+ 	print "Looking for GNU Privacy Guard (gpg), a cryptographic signature tool...\n";
+ 
+   	my ($gpg, $gpg_path);
+-  	for my $gpg_bin ('gpg', 'gpg2', 'gnupg', 'gnupg2') {
++  	for my $gpg_bin ('gpg1', 'gnupg1') {
+   		$gpg_path = can_run($gpg_bin);
+   		next unless $gpg_path;
+   		next unless `$gpg_bin --version` =~ /GnuPG/;


### PR DESCRIPTION
#### Description

gnupg1 is currently not co-installable with gnupg2. This is unfortunate. Very few people will require gnupg1, but probably everybody requires gnupg2. Many ports require gnupg2. For those few who do require gnupg1, this port not supporting coexistence with gnupg2 prevents these people from benefitting from gnupg2, or requires them to switch backwards and forwards between the two. That is not a desirable situation. This was brought up in https://trac.macports.org/ticket/61245 and my memory is that the maintainer ended up agreeing with me, but the situation was never fixed. I left a working Portfile (named gnupg14) attached to that bugreport.

There has been a note in the Portfile saying that gnupg1 would become co-installable with the modern version in mid-October 2018, but that hasn't happen yet. This pull request implements that intention.

The executable binaries are renamed with "1" postfixed to their original names, and so it is not backwards-compatible. There is a note to explain to users that if they have any local scripts that reference "gpg" or "gpgv" that they must modify those references to "gpg1" or "gpgv1". Also, the two other ports that have variants that depend on gnupg1 are updated to handle the new name (gpg1 rather than gpg), and the gnupg1 and gnupg2 ports no longer conflict with each other.

I've been using my local gnupg14 port alongside gnupg2 for years with no problem. I don't think anyone that requires gnupg 1.4 will mind having to use the name gpg1 rather than gpg, especially if it means that they can have the modern version installed as well.

Another minor change is that the manual entries are installed where man will automatically find them.

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
