### PR TITLE
rawhide: support non-default prefix

### DIFF
--- a/sysutils/rawhide/Portfile
+++ b/sysutils/rawhide/Portfile
@@ -7,6 +7,7 @@ PortGroup           makefile 1.0
 
 name                rawhide
 version             3.2
+revision            2
 
 description         (rh) find files using pretty C expressions
 long_description    {*}${description} \
@@ -22,7 +23,6 @@ categories          sysutils
 depends_build       port:pkgconfig
 depends_lib         port:pcre2 port:libmagic
 maintainers         {raf.org:raf @macportsraf} openmaintainer
-revision            2
 
 github.setup        raforg ${name} ${version} v
 github.tarball_from releases
@@ -30,17 +30,20 @@ checksums           rmd160 685df5c44c4b6ef7ba27817fc1ea92949f81d388 \
                     sha256 73d0f755ec3edb07c714255a4fb2a47b52b6225815fc39c5719b8330f94530ce \
                     size 283346
 
-patchfiles          patch-Makefile.diff
+# Place env CFLAGS after explicit cflags (so that -Os can override -O3).
+# Fix configure bug so --prefix=/path works when it isn't the first argument.
+patchfiles          patch-Makefile.diff patch-configure.diff
 
+# Note: Not a GNU autoconf configure script
 use_configure       yes
-configure.args      --macports
+configure.args      --macports --prefix=${prefix}
 build.target        rh
 # Need openat, fdopendir, fstatat, faccessat, unlinkat, and readlinkat.
 # POSIX 2008, but they didn't make it into macOS until 2014 (macOS-10.10).
 legacysupport.newest_darwin_requires_legacy 13
 
 test.run            yes
-test.target         test
+test.args           quiet=1
 
 livecheck.type      regex
 livecheck.url       ${homepage}download/

--- a/sysutils/rawhide/files/patch-configure.diff
+++ b/sysutils/rawhide/files/patch-configure.diff
@@ -1,0 +1,11 @@
+--- configure.orig	2023-06-21 15:02:27.544776181 +1000
++++ configure	2023-06-14 23:53:57.580143195 +1000
+@@ -995,7 +995,7 @@
+ 
+ 		--prefix=*)
+ 			echo "Configuring $opt"
+-			prefix="${1#--prefix=}"
++			prefix="${opt#--prefix=}"
+ 			[ "$prefix" = "default" ] && prefix=/usr/local
+ 			editconf Makefile 's,^\(PREFIX = \).*$,\1'"$prefix"','
+ 			;;


### PR DESCRIPTION
#### Description

This adds support for installing into a non-default macports prefix (i.e., not /opt/local). It adds a patch to the configure script so that `--prefix=${prefix}` can appear after `--macports`.

It also changes the test command so that testing produces much less output so as to produce much smaller logfiles.

For anyone who already has this installed (in /opt/local), it makes no difference, so the revision hasn't changed (but it has been moved up to just beneath the version directive.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
