### PR TITLE
fpc: bugfix extract

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 
 name                fpc
 version             3.2.2
-categories          lang
+categories          lang pascal
 platforms           darwin
-license             GPL-2 LGPL-2
+license             {GPL-2 LGPL-2}
 maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
 description         Free Pascal, an open source Pascal and Object Pascal compiler.
 long_description    Free Pascal is a 32, 64 and 16 bit professional Pascal compiler. \
@@ -14,7 +14,7 @@ long_description    Free Pascal is a 32, 64 and 16 bit professional Pascal compi
                     AMD64/x86-64, PowerPC, PowerPC64, SPARC, ARM, AArch64, MIPS and the JVM. \
                     Supported operating systems include Linux, FreeBSD, Mac OS X/iOS/iPhoneSimulator/Darwin, \
                     Win32, Win64, WinCE and Android.
-homepage            http://www.freepascal.org
+homepage            https://www.freepascal.org
 master_sites        sourceforge:freepascal:main \
                     ftp://ftp.freepascal.org/pub/fpc/dist/3.0.4/bootstrap/:bootstrap
 
@@ -221,13 +221,11 @@ subport "${name}-cross-x86-64-win64" {
 }
 
 if {${subport} eq "${name}"} {
-    revision            0
+    revision            1
 
     installs_libs       yes
 
-    post-extract {
-        system -W ${workpath} "bzip2 -dc ${distpath}/${pp} | tar xf -"
-    }
+    extract.only-append ${pp}
 
     post-patch {
         # adjust the path "codfilepath" for plex from /usr/local to MacPort's prefix.


### PR DESCRIPTION
#### Description

fpc: bugfix for the extract bug as seen on some CI queues and listed in trac:
https://trac.macports.org/ticket/62002
In addition, some smaller updates.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
  https://trac.macports.org/ticket/62002
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
