### PR TITLE
gtk3, gtk4: Add broadway variant

### DIFF
--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -256,6 +256,11 @@ variant tests description {Enable tests} {
     test.target             test
 }
 
+variant broadway description {Enable the broadway (HTML5) gdk backend} {
+    configure.args-append \
+                            -Dbroadway_backend=true
+}
+
 variant demos description {Build demos and examples} {
     configure.args-replace \
                             -Ddemos=false \

--- a/gnome/gtk4/Portfile
+++ b/gnome/gtk4/Portfile
@@ -127,6 +127,10 @@ if {${universal_possible} && [variant_isset universal]} {
     destroot.env-append    "CC=${configure.cc} ${configure.cc_archflags}"
 }
 
+variant broadway description {Enable the broadway (HTML5) gdk backend} {
+    configure.args-append   -Dbroadway-backend=true
+}
+
 variant quartz conflicts x11 {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo quartz
     require_active_variants path:lib/pkgconfig/pango.pc:pango quartz


### PR DESCRIPTION
#### Description
gtk3, gtk4: Add broadway variant
No additional dependencies is required.

See https://trac.macports.org/ticket/67923

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing [ticket 67923 on Trac](https://trac.macports.org/ticket/67923#ticket) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
