### PR TITLE
swi-prolog-devel: Updated to version 9.1.13

### DIFF
--- a/lang/swi-prolog-devel/Portfile
+++ b/lang/swi-prolog-devel/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 name                swi-prolog-devel
 conflicts           swi-prolog
 epoch               20051223
-version             9.1.11
+version             9.1.13
 revision            0
 
 categories          lang
@@ -31,9 +31,9 @@ master_sites        https://www.swi-prolog.org/download/devel/src/
 distname            swipl-${version}
 dist_subdir         swi-prolog
 
-checksums           rmd160  a7781bdc96a9c1f31f35b42b59635c208c87d810 \
-                    sha256  2a668333faebc19431989bd08f5d0f9716af29eb914a092a795bf3705925a289 \
-                    size    11948413
+checksums           rmd160  3f718151b5a43e84ce3497b58a27ff4784b25fe0 \
+                    sha256  a3dc5cbed4b903e48f25cedec8ee6b39398418bd4efb7cc02a55c582fce7d3ef \
+                    size    12002595
 
 depends_build-append \
                     port:pkgconfig
@@ -53,7 +53,8 @@ depends_lib-append  port:db62 \
                     port:xorg-libXt \
                     port:xpm \
                     port:libyaml \
-                    port:zlib
+                    port:zlib \
+                    port:python311
 
 configure.cmd       cmake
 cmake.generator     Ninja


### PR DESCRIPTION
#### Description

In addition to the usual version bump, this version includes the new embedded Python interface called
Janus.   This adds `python311` to the dependencies.   I'm a bit unhappy with that as I'd like to say "any Python >= 3.6".   If you know a better way to deal with this, please adjust the dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
