### PR TITLE
clang-{11..16}: fix build on macOS 10.5

### DIFF
--- a/devel/ld64/Portfile
+++ b/devel/ld64/Portfile
@@ -212,6 +212,8 @@ subport ld64-274 {
 }
 
 subport ld64-latest {
+    PortGroup legacysupport 1.1
+
     # Xcode 10.2
     version 450.3
     set makefile        "Makefile-450"
@@ -244,6 +246,15 @@ subport ld64-latest {
     # silence some warnings
     configure.cxxflags-append -Wno-deprecated-declarations
     configure.cxxflags-append -Wno-parentheses-equality
+
+    # Avoid `error: unknown type name 'uuid_string_t'`
+    legacysupport.newest_darwin_requires_legacy 9
+
+    if { ${os.platform} eq "darwin" && ${os.major} <= 9 } {
+        depends_lib-append          port:libblocksruntime
+        configure.cxxflags-append   -fblocks
+        configure.ldflags-append    -lBlocksRuntime
+    }
 
     supported_archs i386 x86_64
 }

--- a/lang/llvm-11/Portfile
+++ b/lang/llvm-11/Portfile
@@ -375,6 +375,14 @@ platform darwin {
             # TO DO: the blocks functionality can be replaced by libblocksruntime
             # this might be integrated into clang on < 10.6
             patchfiles-append leopard-no-blocks.patch
+
+            # Building Xray forces build of sanitizer_common, even if
+            # COMPILER_RT_BUILD_SANITIZERS=OFF, and this fails on 10.5
+            # due to lack of pthread_getname_np
+            configure.args-append    -DCOMPILER_RT_BUILD_XRAY=OFF
+
+            # on Leopard part of symbols like __udivdi3 in -lgcc_s.1 instead of -lSystem
+            patchfiles-append leopard-link-against-gcc_s.diff
         }
     }
 }

--- a/lang/llvm-11/files/leopard-link-against-gcc_s.diff
+++ b/lang/llvm-11/files/leopard-link-against-gcc_s.diff
@@ -1,0 +1,25 @@
+--- ./projects/libcxx/CMakeLists.txt
++++ ./projects/libcxx/CMakeLists.txt
+@@ -738,6 +738,10 @@ function(cxx_link_system_libraries target)
+     target_link_libraries(${target} PRIVATE System)
+   endif()
+ 
++  if (APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    target_link_libraries(${target} PRIVATE gcc_s.1)
++  endif()
++
+   if (LIBCXX_HAS_PTHREAD_LIB)
+     target_link_libraries(${target} PRIVATE pthread)
+   endif()
+--- ./projects/libcxxabi/src/CMakeLists.txt
++++ ./projects/libcxxabi/src/CMakeLists.txt
+@@ -65,6 +65,9 @@ endif()
+ 
+ if (APPLE)
+   add_library_flags_if(LIBCXXABI_HAS_SYSTEM_LIB System)
++  if (CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    add_library_flags(gcc_s.1)
++  endif()
+ else()
+   if (LIBCXXABI_ENABLE_THREADS)
+     add_library_flags_if(LIBCXXABI_HAS_PTHREAD_LIB pthread)

--- a/lang/llvm-12/Portfile
+++ b/lang/llvm-12/Portfile
@@ -138,7 +138,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     patchfiles-append \
         0022-10.5-and-less-default-to-fno-blocks.patch \
-        0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch
+        0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch \
+        0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
 }
 
 post-patch {
@@ -196,9 +197,6 @@ if {${subport} eq "clang-${llvm_version}"} {
 
     select.group        clang
     select.file         ${filespath}/mp-${subport}
-
-    # temporarily restrict to newer systems until older systems can be rigorously vetted
-    platforms {darwin >= 10}
 
     # CMAKE_LINKER is used to determine the value for HOST_LINK_VERSION
     configure.args-append \

--- a/lang/llvm-12/files/0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
+++ b/lang/llvm-12/files/0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
@@ -1,0 +1,43 @@
+From af86bd2ceeaebaa2c96e2f608d74df678479ba45 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Mon, 7 Aug 2023 12:05:37 +0200
+Subject: [PATCH] [libcxx] link gcc_s.1 on macOS before 10.6
+
+leopard and before has some symbols at libgcc_s.1 instead of libSystem.
+---
+ libcxx/CMakeLists.txt        | 4 ++++
+ libcxxabi/src/CMakeLists.txt | 3 +++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/libcxx/CMakeLists.txt b/libcxx/CMakeLists.txt
+index 910d04b54b6d..d1408b4a58c5 100644
+--- a/libcxx/CMakeLists.txt
++++ b/libcxx/CMakeLists.txt
+@@ -738,6 +738,10 @@ function(cxx_link_system_libraries target)
+     target_link_libraries(${target} PRIVATE System)
+   endif()
+ 
++  if (APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    target_link_libraries(${target} PRIVATE gcc_s.1)
++  endif()
++
+   if (LIBCXX_HAS_PTHREAD_LIB)
+     target_link_libraries(${target} PRIVATE pthread)
+   endif()
+diff --git a/libcxxabi/src/CMakeLists.txt b/libcxxabi/src/CMakeLists.txt
+index 42bec421d2be..b85bbc8053a4 100644
+--- a/libcxxabi/src/CMakeLists.txt
++++ b/libcxxabi/src/CMakeLists.txt
+@@ -65,6 +65,9 @@ endif()
+ 
+ if (APPLE)
+   add_library_flags_if(LIBCXXABI_HAS_SYSTEM_LIB System)
++  if (CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    add_library_flags(gcc_s.1)
++  endif()
+ else()
+   if (LIBCXXABI_ENABLE_THREADS)
+     add_library_flags_if(LIBCXXABI_HAS_PTHREAD_LIB pthread)
+-- 
+2.41.0
+

--- a/lang/llvm-13/Portfile
+++ b/lang/llvm-13/Portfile
@@ -146,7 +146,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     patchfiles-append \
         0022-10.5-and-less-default-to-fno-blocks.patch \
-        0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch
+        0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch \
+        0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
 }
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
@@ -279,8 +280,7 @@ if { ${subport} eq "flang-${llvm_version}" } {
     }
 }
 
-if { ${subport} eq "clang-${llvm_version}" ||
-     ${subport} eq "mlir-${llvm_version}" ||
+if { ${subport} eq "mlir-${llvm_version}" ||
      ${subport} eq "flang-${llvm_version}" } {
     # temporarily restrict to newer systems until older systems can be rigorously vetted
     platforms {darwin >= 10}

--- a/lang/llvm-13/files/0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
+++ b/lang/llvm-13/files/0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
@@ -1,0 +1,43 @@
+From af86bd2ceeaebaa2c96e2f608d74df678479ba45 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Mon, 7 Aug 2023 12:05:37 +0200
+Subject: [PATCH] [libcxx] link gcc_s.1 on macOS before 10.6
+
+leopard and before has some symbols at libgcc_s.1 instead of libSystem.
+---
+ libcxx/CMakeLists.txt        | 4 ++++
+ libcxxabi/src/CMakeLists.txt | 3 +++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/libcxx/CMakeLists.txt b/libcxx/CMakeLists.txt
+index 910d04b54b6d..d1408b4a58c5 100644
+--- a/libcxx/CMakeLists.txt
++++ b/libcxx/CMakeLists.txt
+@@ -738,6 +738,10 @@ function(cxx_link_system_libraries target)
+     target_link_libraries(${target} PRIVATE System)
+   endif()
+ 
++  if (APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    target_link_libraries(${target} PRIVATE gcc_s.1)
++  endif()
++
+   if (LIBCXX_HAS_PTHREAD_LIB)
+     target_link_libraries(${target} PRIVATE pthread)
+   endif()
+diff --git a/libcxxabi/src/CMakeLists.txt b/libcxxabi/src/CMakeLists.txt
+index 42bec421d2be..b85bbc8053a4 100644
+--- a/libcxxabi/src/CMakeLists.txt
++++ b/libcxxabi/src/CMakeLists.txt
+@@ -65,6 +65,9 @@ endif()
+ 
+ if (APPLE)
+   add_library_flags_if(LIBCXXABI_HAS_SYSTEM_LIB System)
++  if (CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    add_library_flags(gcc_s.1)
++  endif()
+ else()
+   if (LIBCXXABI_ENABLE_THREADS)
+     add_library_flags_if(LIBCXXABI_HAS_PTHREAD_LIB pthread)
+-- 
+2.41.0
+

--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -152,7 +152,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     patchfiles-append \
         0022-10.5-and-less-default-to-fno-blocks.patch \
-        0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch
+        0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch \
+        0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
 }
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
@@ -284,8 +285,7 @@ if { ${subport} eq "flang-${llvm_version}" } {
     }
 }
 
-if { ${subport} eq "clang-${llvm_version}" ||
-     ${subport} eq "mlir-${llvm_version}" ||
+if { ${subport} eq "mlir-${llvm_version}" ||
      ${subport} eq "flang-${llvm_version}" } {
     # temporarily restrict to newer systems until older systems can be rigorously vetted
     platforms {darwin >= 10}
@@ -339,7 +339,6 @@ if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_versio
         configure.args-append    -DCLANG_ENABLE_CLANGD=OFF \
                                  -DLLVM_ENABLE_BACKTRACES=OFF
     }
-
 }
 
 if {${subport} eq "lldb-${llvm_version}"} {

--- a/lang/llvm-14/files/0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
+++ b/lang/llvm-14/files/0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
@@ -1,0 +1,43 @@
+From af86bd2ceeaebaa2c96e2f608d74df678479ba45 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Mon, 7 Aug 2023 12:05:37 +0200
+Subject: [PATCH] [libcxx] link gcc_s.1 on macOS before 10.6
+
+leopard and before has some symbols at libgcc_s.1 instead of libSystem.
+---
+ libcxx/CMakeLists.txt        | 4 ++++
+ libcxxabi/src/CMakeLists.txt | 3 +++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/libcxx/CMakeLists.txt b/libcxx/CMakeLists.txt
+index 910d04b54b6d..d1408b4a58c5 100644
+--- a/libcxx/CMakeLists.txt
++++ b/libcxx/CMakeLists.txt
+@@ -738,6 +738,10 @@ function(cxx_link_system_libraries target)
+     target_link_libraries(${target} PRIVATE System)
+   endif()
+ 
++  if (APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    target_link_libraries(${target} PRIVATE gcc_s.1)
++  endif()
++
+   if (LIBCXX_HAS_PTHREAD_LIB)
+     target_link_libraries(${target} PRIVATE pthread)
+   endif()
+diff --git a/libcxxabi/src/CMakeLists.txt b/libcxxabi/src/CMakeLists.txt
+index 42bec421d2be..b85bbc8053a4 100644
+--- a/libcxxabi/src/CMakeLists.txt
++++ b/libcxxabi/src/CMakeLists.txt
+@@ -65,6 +65,9 @@ endif()
+ 
+ if (APPLE)
+   add_library_flags_if(LIBCXXABI_HAS_SYSTEM_LIB System)
++  if (CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    add_library_flags(gcc_s.1)
++  endif()
+ else()
+   if (LIBCXXABI_ENABLE_THREADS)
+     add_library_flags_if(LIBCXXABI_HAS_PTHREAD_LIB pthread)
+-- 
+2.41.0
+

--- a/lang/llvm-15/Portfile
+++ b/lang/llvm-15/Portfile
@@ -158,7 +158,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     patchfiles-append \
         0022-10.5-and-less-default-to-fno-blocks.patch \
-        0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch
+        0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch \
+        0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
 }
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
@@ -299,9 +300,6 @@ if { ${subport} eq "flang-${llvm_version}" } {
     }
 }
 
-# Restrict to 10.6 and newer
-platforms {darwin >= 10}
-
 if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_version}" } {
 
     depends_lib-append  port:libxml2 port:libomp port:llvm-${llvm_version}
@@ -355,7 +353,6 @@ if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_versio
         configure.args-append    -DCLANG_ENABLE_CLANGD=OFF \
                                  -DLLVM_ENABLE_BACKTRACES=OFF
     }
-
 }
 
 if {${subport} eq "lldb-${llvm_version}"} {

--- a/lang/llvm-15/files/0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
+++ b/lang/llvm-15/files/0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
@@ -1,0 +1,43 @@
+From af86bd2ceeaebaa2c96e2f608d74df678479ba45 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Mon, 7 Aug 2023 12:05:37 +0200
+Subject: [PATCH] [libcxx] link gcc_s.1 on macOS before 10.6
+
+leopard and before has some symbols at libgcc_s.1 instead of libSystem.
+---
+ libcxx/CMakeLists.txt        | 4 ++++
+ libcxxabi/src/CMakeLists.txt | 3 +++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/libcxx/CMakeLists.txt b/libcxx/CMakeLists.txt
+index 910d04b54b6d..d1408b4a58c5 100644
+--- a/libcxx/CMakeLists.txt
++++ b/libcxx/CMakeLists.txt
+@@ -738,6 +738,10 @@ function(cxx_link_system_libraries target)
+     target_link_libraries(${target} PRIVATE System)
+   endif()
+ 
++  if (APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    target_link_libraries(${target} PRIVATE gcc_s.1)
++  endif()
++
+   if (LIBCXX_HAS_PTHREAD_LIB)
+     target_link_libraries(${target} PRIVATE pthread)
+   endif()
+diff --git a/libcxxabi/src/CMakeLists.txt b/libcxxabi/src/CMakeLists.txt
+index 42bec421d2be..b85bbc8053a4 100644
+--- a/libcxxabi/src/CMakeLists.txt
++++ b/libcxxabi/src/CMakeLists.txt
+@@ -65,6 +65,9 @@ endif()
+ 
+ if (APPLE)
+   add_library_flags_if(LIBCXXABI_HAS_SYSTEM_LIB System)
++  if (CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    add_library_flags(gcc_s.1)
++  endif()
+ else()
+   if (LIBCXXABI_ENABLE_THREADS)
+     add_library_flags_if(LIBCXXABI_HAS_PTHREAD_LIB pthread)
+-- 
+2.41.0
+

--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -158,7 +158,14 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     patchfiles-append \
         0022-10.5-and-less-default-to-fno-blocks.patch \
-        0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch
+        0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch \
+        0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch \
+        0028-libcxx-use-malloc-free-only-on-macOS-before-10.6.patch
+
+    # inverse limit of building for macOS 10.7+
+    # See: https://github.com/llvm/llvm-project/commit/49d2071572d484a2b5dc356f59050bb173c8c77c
+    patchfiles-append \
+        49d2071572d484a2b5dc356f59050bb173c8c77c-inverse.patch
 }
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
@@ -311,9 +318,6 @@ if { ${subport} eq "flang-${llvm_version}" } {
         system "cd ${destroot.dir}/tools/flang && ${destroot.cmd} ${destroot.pre_args} ${destroot.target} ${destroot.post_args}"
     }
 }
-
-# Restrict to 10.6 and newer
-platforms {darwin >= 10}
 
 if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_version}" } {
 

--- a/lang/llvm-16/files/0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
+++ b/lang/llvm-16/files/0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
@@ -1,0 +1,43 @@
+From af86bd2ceeaebaa2c96e2f608d74df678479ba45 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Mon, 7 Aug 2023 12:05:37 +0200
+Subject: [PATCH] [libcxx] link gcc_s.1 on macOS before 10.6
+
+leopard and before has some symbols at libgcc_s.1 instead of libSystem.
+---
+ libcxx/CMakeLists.txt        | 4 ++++
+ libcxxabi/src/CMakeLists.txt | 3 +++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/libcxx/CMakeLists.txt b/libcxx/CMakeLists.txt
+index 910d04b54b6d..d1408b4a58c5 100644
+--- a/libcxx/CMakeLists.txt
++++ b/libcxx/CMakeLists.txt
+@@ -738,6 +738,10 @@ function(cxx_link_system_libraries target)
+     target_link_libraries(${target} PRIVATE System)
+   endif()
+ 
++  if (APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    target_link_libraries(${target} PRIVATE gcc_s.1)
++  endif()
++
+   if (LIBCXX_HAS_PTHREAD_LIB)
+     target_link_libraries(${target} PRIVATE pthread)
+   endif()
+diff --git a/libcxxabi/src/CMakeLists.txt b/libcxxabi/src/CMakeLists.txt
+index 42bec421d2be..b85bbc8053a4 100644
+--- a/libcxxabi/src/CMakeLists.txt
++++ b/libcxxabi/src/CMakeLists.txt
+@@ -65,6 +65,9 @@ endif()
+ 
+ if (APPLE)
+   add_library_flags_if(LIBCXXABI_HAS_SYSTEM_LIB System)
++  if (CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.6)
++    add_library_flags(gcc_s.1)
++  endif()
+ else()
+   if (LIBCXXABI_ENABLE_THREADS)
+     add_library_flags_if(LIBCXXABI_HAS_PTHREAD_LIB pthread)
+-- 
+2.41.0
+

--- a/lang/llvm-16/files/0028-libcxx-use-malloc-free-only-on-macOS-before-10.6.patch
+++ b/lang/llvm-16/files/0028-libcxx-use-malloc-free-only-on-macOS-before-10.6.patch
@@ -1,0 +1,31 @@
+From 438ce8c5bcc4f6d579c1a59bfd209e09862c1beb Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Mon, 7 Aug 2023 15:52:29 +0200
+Subject: [PATCH] [libcxx] use malloc/free only on macOS before 10.6
+
+---
+ libcxx/include/new | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libcxx/include/new b/libcxx/include/new
+index 0c826f4a061c..6a3a787e65f5 100644
+--- a/libcxx/include/new
++++ b/libcxx/include/new
+@@ -355,9 +355,14 @@ inline _LIBCPP_INLINE_VISIBILITY void* __libcpp_aligned_alloc(std::size_t __alig
+     return ::aligned_alloc(__alignment, __size > __rounded_size ? __size : __rounded_size);
+ #  else
+     void* __result = nullptr;
++#  if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1060
+     (void)::posix_memalign(&__result, __alignment, __size);
+     // If posix_memalign fails, __result is unmodified so we still return `nullptr`.
+     return __result;
++#  else
++    // macOS before 10.6 hasn't got alligned malloc, fallback to just malloc
++    return ::malloc(__size);
++#  endif
+ #  endif
+ }
+ 
+-- 
+2.41.0
+

--- a/lang/llvm-16/files/49d2071572d484a2b5dc356f59050bb173c8c77c-inverse.patch
+++ b/lang/llvm-16/files/49d2071572d484a2b5dc356f59050bb173c8c77c-inverse.patch
@@ -1,0 +1,11 @@
+--- a/compiler-rt/cmake/builtin-config-ix.cmake
++++ b/compiler-rt/cmake/builtin-config-ix.cmake
+@@ -97,7 +97,7 @@ if(APPLE)
+   endfunction()
+ 
+   set(DARWIN_EMBEDDED_PLATFORMS)
+-  set(DARWIN_osx_BUILTIN_MIN_VER 10.7)
++  set(DARWIN_osx_BUILTIN_MIN_VER 10.5)
+   set(DARWIN_osx_BUILTIN_MIN_VER_FLAG
+       -mmacosx-version-min=${DARWIN_osx_BUILTIN_MIN_VER})
+   set(DARWIN_osx_BUILTIN_ALL_POSSIBLE_ARCHS ${X86} ${X86_64})


### PR DESCRIPTION
#### Description

Here quite time consuming work: build, fix and test all clang up to 16 includes on macOS 10.5

Each clang was build as `port deactivate active` and after that `port install clang-X`.

After I have installed clang I've tested that it compiles two test programs:

``` c
#include <stdio.h>
#include <math.h>

unsigned long long howmany(unsigned long long x, unsigned y) {
	return (x % y == 0) ? (x / y) : ((x / y) + 1);
}

unsigned long long howmany2(unsigned long long x, unsigned r) {
	return howmany(x, (1U << r));
}

int main(void)
{
    printf("llroundl(2.5): %lld \n", llroundl(2.5));
    printf("howmany(2, 3): %lld \n", howmany(2, 3));
    printf("howmany2(2, 3): %lld \n", howmany2(2, 3));

    return 0;
}

```

and

``` c++
#include <iostream>
#include <cmath>
#include <iosfwd>

int main() {

    std::cout << "llroundl(2.5): " << ::llroundl(2.5) << std::endl;

    return 0;
}
```

This trivial program includes explicit and implicit division by `unsigned long long`, using `cmath`/`math.h` and C++14 features (`iosfwd`).

I'd like to claim that now all clang has passed all this tested clean system.

P.S. as nice side effect I've fixed macports-libcxx which depends on clang-11 for now.

P.P.S. I've ignored CI because it requries much more than 6 hours to build it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->