### PR TITLE
cl-plus-ssl: update to 20230731

### DIFF
--- a/lisp/cl-plus-ssl/Portfile
+++ b/lisp/cl-plus-ssl/Portfile
@@ -5,13 +5,13 @@ PortGroup           github 1.0
 PortGroup           openssl 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        cl-plus-ssl cl-plus-ssl 13d824e27cf7f6085086458daea1514b605b3980
-version             20230613
+github.setup        cl-plus-ssl cl-plus-ssl 17d5cdd65405f1d26e26f3e875e70027d0c8eedb
+version             20230731
 revision            0
 
-checksums           rmd160  5e29f56d1280e20e3b6b319a2a4f056a72e6d322 \
-                    sha256  70878e90971300576230c55f4d830e511b5b5e4845a6beeb2ba0e98ea4a67bfe \
-                    size    93535
+checksums           rmd160  823df477edf37a8ad1aa64a4b67c203380d70873 \
+                    sha256  d3037a4f4593396d17677c7ce19a6900b80eed45e8f56f5547c2de4da9649970 \
+                    size    93621
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer


### PR DESCRIPTION
#### Description



###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->