### PR TITLE
Thunar: fix build on < 10.7

### DIFF
--- a/xfce/Thunar/Portfile
+++ b/xfce/Thunar/Portfile
@@ -14,7 +14,7 @@ categories          xfce
 license             GPL-2+ LGPL-2+
 maintainers         nomaintainer
 description         Thunar is a modern file manager for the Unix/Linux desktop
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://docs.xfce.org/xfce/thunar/start
 master_sites        https://archive.xfce.org/src/xfce/thunar/${branch}/
@@ -24,15 +24,17 @@ use_bzip2           yes
 patchfiles          INTLTOOL_PERL.patch \
                     no-symlink.patch
 
-configure.args      --enable-dbus \
-                    --enable-startup-notification \
+configure.args-append \
+                    --enable-dbus \
+                    --enable-exif \
                     --enable-pcre \
-                    --enable-exif
+                    --enable-startup-notification
 
-depends_build       port:intltool \
+depends_build-append \
+                    port:intltool \
                     port:pkgconfig
 
-depends_lib         port:desktop-file-utils \
+depends_lib-append  port:desktop-file-utils \
                     port:exo \
                     port:libexif \
                     port:libnotify \
@@ -40,6 +42,9 @@ depends_lib         port:desktop-file-utils \
                     port:shared-mime-info \
                     port:startup-notification \
                     port:xfce4-panel
+
+# thunar-gobject-extensions.c: error: ‘for’ loop initial declaration used outside C99 mode
+configure.cflags-append -std=c99
 
 variant quartz conflicts x11 {
     depends_lib-delete \


### PR DESCRIPTION
#### Description

Same issue as with another xfce port: it needs C99.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
