### PR TITLE
kerberos5: build with LibreSSL

### DIFF
--- a/net/kerberos5/Portfile
+++ b/net/kerberos5/Portfile
@@ -67,6 +67,20 @@ configure.args              --with-system-et \
                             --without-system-ss \
                             ac_cv_prog_AWK=/usr/bin/awk
 
+# kerberos5 can be built with LibreSSL again, if we can provide "explicit_bzero", see #66601
+# However, this needs 'libbsd' and we use 'libbsd-devel' until new version from upstream.
+variant libressl description {Build with LibreSSL} {
+
+    depends_lib-delete      path:lib/libssl.dylib:openssl
+    depends_lib-append      port:libressl \
+                            port:libbsd-devel
+
+    patchfiles-append       patch-plugins_preauth_pkinit_pkinit__crypto__openssl.c.diff
+
+    configure.optflags-append   -DLIBBSD_OVERLAY -isystem ${prefix}/include/bsd -L${prefix}/lib -lbsd
+
+}
+
 # Needs LIBRARY_PATH support
 compiler.blacklist-append   {clang <= 318.0.61}
 

--- a/net/kerberos5/files/patch-plugins_preauth_pkinit_pkinit__crypto__openssl.c.diff
+++ b/net/kerberos5/files/patch-plugins_preauth_pkinit_pkinit__crypto__openssl.c.diff
@@ -1,0 +1,48 @@
+# This patch was derived from [1] in verbatim form for the MacPorts port.
+# The patch itself was part of commit [2] of @cschuber at FreeBSD.
+# [1] https://github.com/freebsd/freebsd-ports/blob/main/security/krb5-121/files/patch-plugins_preauth_pkinit_pkinit__crypto__openssl.c
+# [2] https://github.com/freebsd/freebsd-ports/commit/49e70b32f3d1610c7a398e8f82343935362d6466
+#
+--- plugins/preauth/pkinit/pkinit_crypto_openssl.c.orig	2022-10-17 09:52:43 UTC
++++ plugins/preauth/pkinit/pkinit_crypto_openssl.c
+@@ -184,6 +184,17 @@ pkcs11err(int err);
+     (*_x509_pp) = PKCS7_cert_from_signer_info(_p7,_si)
+ #endif
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++
++/*
++ * 1.1 adds DHX support, which uses the RFC 3279 DomainParameters encoding we
++ * need for PKINIT.  For 1.0 we must use the original DH type when creating
++ * EVP_PKEY objects.
++ */
++#define EVP_PKEY_DHX EVP_PKEY_DH
++#define d2i_DHxparams d2i_DHparams
++#endif
++
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 
+ /* 1.1 standardizes constructor and destructor names, renaming
+@@ -193,13 +204,6 @@ pkcs11err(int err);
+ #define EVP_MD_CTX_free EVP_MD_CTX_destroy
+ #define ASN1_STRING_get0_data ASN1_STRING_data
+ 
+-/*
+- * 1.1 adds DHX support, which uses the RFC 3279 DomainParameters encoding we
+- * need for PKINIT.  For 1.0 we must use the original DH type when creating
+- * EVP_PKEY objects.
+- */
+-#define EVP_PKEY_DHX EVP_PKEY_DH
+-
+ /* 1.1 makes many handle types opaque and adds accessors.  Add compatibility
+  * versions of the new accessors we use for pre-1.1. */
+ 
+@@ -588,7 +592,7 @@ set_padded_derivation(EVP_PKEY_CTX *ctx)
+ {
+     EVP_PKEY_CTX_set_dh_pad(ctx, 1);
+ }
+-#elif OPENSSL_VERSION_NUMBER >= 0x10100000L
++#elif OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ static void
+ set_padded_derivation(EVP_PKEY_CTX *ctx)
+ {


### PR DESCRIPTION
#### Description

**kerberos5 @1.21.1** can be built **with LibreSSL** again, if we can provide "explicit_bzero", see [#66601](https://trac.macports.org/ticket/66601) trac ticket. However, this requires the [new port 'libbsd' and we use subport 'libbsd-devel'](https://github.com/macports/macports-ports/pull/19785) until new version from upstream is available.

The new port 'libbsd' with subport 'libbsd-devel' was provided as PR #19785 with the specific purpose of supporting this PR.

Please note there is an older PR #16927 addressing the kerberos5 @1.20 legacy version which seems to be stuck and would be superseeded by this PR.

Please be aware the _testing of all binaries was out of scope_ for my current contribution and should be performed by a long-standing expert person like the official maintainer, I presume.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 11.7.9 20G1426 x86_64
Xcode 13.0 13A233

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change? _(see above)_
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files? _(see above)_
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
