### PR TITLE
bsd-plotutils: new port

### DIFF
--- a/graphics/bsd-plotutils/Portfile
+++ b/graphics/bsd-plotutils/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        Toranktto bsd-plotutils 1.4.2
+github.tarball_from archive
+revision            0
+conflicts           plotutils
+categories          graphics
+license             BSD
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         Traditional plotting utilities and libraries taken from \
+                    4.3BSD with some improvements.
+
+long_description    {*}${description}
+
+checksums           rmd160  f4c96f21683e708d6c51710160661eeb8028fd07 \
+                    sha256  456394a4b37bfec5b0c745333d91754952b69fad400110fec5c71c72b82dce67 \
+                    size    41306
+
+post-patch {
+    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/plot/plot.1 ${worksrcpath}/plot/plot.sh
+    reinplace -E "s/f77plot|py27plot//g" ${worksrcpath}/libplot/bindings/Makefile
+    system -W "${worksrcpath}" "for f in libplot/*/Makefile; do \
+        echo 'LDADD+= -install_name \${PREFIX}/lib/lib\${LIB}.\${SHLIB_MAJOR}.dylib' >> \$f; \
+        echo 'STRIP=' >> \$f; \
+        done"
+}
+
+build.type          bsd
+
+destroot.args-append    MANDIR=${prefix}/share/man/man

--- a/graphics/plotutils/Portfile
+++ b/graphics/plotutils/Portfile
@@ -6,6 +6,7 @@ name             plotutils
 epoch            1
 version          2.6
 revision         5
+conflicts        bsd-plotutils
 categories       graphics
 platforms        darwin
 maintainers      {snc @nerdling} openmaintainer


### PR DESCRIPTION
#### Description

[Traditional plotting utilities and libraries taken from 4.3BSD with some improvements.](https://github.com/Toranktto/bsd-plotutils/tree/1.4.2)

###### Tested on
macOS 13.5 22G74 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?