### PR TITLE
garagejam: update to 0.8.0 (Connect, Recording and Playback works)

### DIFF
--- a/gnome/garagejam/Portfile
+++ b/gnome/garagejam/Portfile
@@ -6,7 +6,7 @@ PortGroup           debug 1.0
 PortGroup           app 1.0
 
 name                garagejam
-version             0.4.0
+version             0.8.0
 revision            0
 
 categories          gnome
@@ -22,9 +22,9 @@ set branch          [join [lrange [split $version .] 0 1] .]
 master_sites        https://www.garagejam.org/src/
 use_xz              yes
 
-checksums           rmd160  67c7368b5768d67989ee5e75a12eff83117c5fed \
-                    sha256  b5fb4ffaa9e3db93a4b007ddb4735896267b669d100febcfe3fd07116b6ccdfe \
-                    size    121844
+checksums           rmd160  62bde814c9c2f216f0f4cb52fd1053b597a167fa \
+                    sha256  47500e4e94fa3cb91ae81ab7acd3da02d982a00728eefbf38a9cd58fabc1516b \
+                    size    122944
 
 depends_build-append \
                     port:gettext \


### PR DESCRIPTION
#### Description

GarageJam 0.8.0 from https://www.garagejam.org/src/garagejam-0.8.0.tar.xz

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->