### PR TITLE
uvw: add -static and -headers subports

### DIFF
--- a/devel/uvw/Portfile
+++ b/devel/uvw/Portfile
@@ -20,8 +20,30 @@ checksums               sha256  b93d7cc841ace369f5930953f1b00a008597682a8690950f
                         rmd160  4e1ce2497a5c4eb30c46697a65595004b7d21c55 \
                         size    106022
 
+# uvw upstream may not match the libuv version used by Macports, and some ports may require to be up-to-date with upstream.
+# Having a single uvw port leads into trouble due to potential, and likely, incompatibilities: https://github.com/oxen-io/lokinet/issues/2197
+# So we offer header-only and static lib variants which are intended to be up-to-date, while letting the main variant to lag behind,
+# tracking Macports libuv. Notice, while subports mutually conflict, the main port can co-exist with either of the former.
+set upstream_vvw        3.2.0
+set upstream_luv        1.46
+
+subport uvw-static {
+    github.setup        skypjack uvw ${upstream_vvw} v _libuv_v${upstream_luv}
+    revision            0
+    conflicts           uvw-headers
+    fetch.type          git
+}
+
+subport uvw-headers {
+    github.setup        skypjack uvw ${upstream_vvw} v _libuv_v${upstream_luv}
+    revision            0
+    conflicts           uvw-static
+    checksums           rmd160  d6579c2b1fc6bdf43aadd20ee2ce9f999225c16e \
+                        sha256  67b1c002f51750264db7686ee99e3330e188d9337dc7ebc0e2e2d41210973c31 \
+                        size    106942
+}
+
 depends_build-append    port:pkgconfig
-depends_lib-append      port:libuv
 
 compiler.cxx_standard   2017
 
@@ -29,15 +51,45 @@ configure.pre_args-replace \
                         -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
                         -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
-configure.args-append   -DBUILD_DOCS:BOOL=OFF \
+configure.args-append   -DBUILD_DOCS:BOOL=OFF
+
+if {${subport} eq ${name}} {
+    depends_lib-append  port:libuv
+    configure.args-append \
                         -DBUILD_TESTING:BOOL=ON \
                         -DBUILD_UVW_SHARED_LIB:BOOL=ON \
                         -DFIND_LIBUV:BOOL=ON
+
+    # FIXME: two tests fail on ppc: https://github.com/skypjack/uvw/issues/286
+    test.run            yes
+} elseif {${subport} eq "uvw-static"} {
+    configure.args-append \
+                        -DBUILD_UVW_LIBS:BOOL=ON \
+                        -DFETCH_LIBUV:BOOL=ON
+    post-configure {
+        # Sources of libuv are fetched during configure, so magic is needed.
+        system -W ${cmake.build_dir}/_deps/libuv-src "patch -p0 < [shellescape ${filespath}/patch-libuv-${upstream_luv}.diff]"
+    }
+} elseif {${subport} eq "uvw-headers"} {
+    configure.args-append \
+                        -DBUILD_UVW_LIBS:BOOL=OFF \
+                        -DFETCH_LIBUV:BOOL=OFF
+}
+
+if {${subport} eq "uvw-static" || ${subport} eq "uvw-headers"} {
+    set uvw_libexec     ${prefix}/libexec/uvw/
+    configure.pre_args-append \
+                        -DBUILD_TESTING:BOOL=OFF \
+                        -DBUILD_UVW_SHARED_LIB:BOOL=OFF \
+                        -DCMAKE_INSTALL_INCLUDEDIR:STRING=${uvw_libexec}include \
+                        -DCMAKE_INSTALL_LIBDIR:STRING=${uvw_libexec}lib \
+                        -DFIND_LIBUV:BOOL=OFF
+    pre-destroot {
+        xinstall -d ${destroot}${uvw_libexec}
+    }
+}
 
 platform powerpc {
     configure.args-append \
                         -DUSE_LIBCPP:BOOL=OFF
 }
-
-# FIXME: two tests fail on ppc: https://github.com/skypjack/uvw/issues/286
-test.run                yes

--- a/devel/uvw/files/patch-libuv-1.46.diff
+++ b/devel/uvw/files/patch-libuv-1.46.diff
@@ -1,0 +1,120 @@
+From 97b062503185cbafaf80cb5ec1da1c1c953411e1 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Tue, 8 Aug 2023 19:03:03 +0800
+Subject: [PATCH] Fix libuv
+
+---
+ src/unix/darwin-proctitle.c |  2 ++
+ src/unix/fs.c               |  2 +-
+ src/unix/process.c          | 10 +++++++---
+ src/unix/tty.c              |  2 +-
+ src/unix/udp.c              |  2 ++
+ 5 files changed, 13 insertions(+), 5 deletions(-)
+
+diff --git src/unix/darwin-proctitle.c src/unix/darwin-proctitle.c
+index 5288083e..c1aa0531 100644
+--- src/unix/darwin-proctitle.c
++++ src/unix/darwin-proctitle.c
+@@ -41,9 +41,11 @@ static int uv__pthread_setname_np(const char* name) {
+   strncpy(namebuf, name, sizeof(namebuf) - 1);
+   namebuf[sizeof(namebuf) - 1] = '\0';
+ 
++#if TARGET_OS_IPHONE || (MAC_OS_X_VERSION_MIN_REQUIRED >= 1060)
+   err = pthread_setname_np(namebuf);
+   if (err)
+     return UV__ERR(err);
++#endif
+ 
+   return 0;
+ }
+diff --git src/unix/fs.c src/unix/fs.c
+index 6b051c12..18e274cf 100644
+--- src/unix/fs.c
++++ src/unix/fs.c
+@@ -1410,7 +1410,7 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
+   dst->st_blksize = src->st_blksize;
+   dst->st_blocks = src->st_blocks;
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)
+   dst->st_atim.tv_sec = src->st_atimespec.tv_sec;
+   dst->st_atim.tv_nsec = src->st_atimespec.tv_nsec;
+   dst->st_mtim.tv_sec = src->st_mtimespec.tv_sec;
+diff --git src/unix/process.c src/unix/process.c
+index dd58c18d..35aa9b1b 100644
+--- src/unix/process.c
++++ src/unix/process.c
+@@ -36,7 +36,9 @@
+ #include <poll.h>
+ 
+ #if defined(__APPLE__)
+-# include <spawn.h>
++# if MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
++#  include <spawn.h>
++# endif
+ # include <paths.h>
+ # include <sys/kauth.h>
+ # include <sys/types.h>
+@@ -407,7 +409,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
+ }
+ 
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+ typedef struct uv__posix_spawn_fncs_tag {
+   struct {
+     int (*addchdir_np)(const posix_spawn_file_actions_t *, const char *);
+@@ -608,9 +610,11 @@ static int uv__spawn_set_posix_spawn_file_actions(
+       }
+     }
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+     if (fd == use_fd)
+         err = posix_spawn_file_actions_addinherit_np(actions, fd);
+     else
++#endif
+         err = posix_spawn_file_actions_adddup2(actions, use_fd, fd);
+     assert(err != ENOSYS);
+     if (err != 0)
+@@ -859,7 +863,7 @@ static int uv__spawn_and_init_child(
+   int exec_errorno;
+   ssize_t r;
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
+   uv_once(&posix_spawn_init_once, uv__spawn_init_posix_spawn);
+ 
+   /* Special child process spawn case for macOS Big Sur (11.0) onwards
+diff --git src/unix/tty.c src/unix/tty.c
+index d099bdb3..899e3a66 100644
+--- src/unix/tty.c
++++ src/unix/tty.c
+@@ -85,7 +85,7 @@ static int uv__tty_is_slave(const int fd) {
+   int dummy;
+ 
+   result = ioctl(fd, TIOCGPTN, &dummy) != 0;
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)
+   char dummy[256];
+ 
+   result = ioctl(fd, TIOCPTYGNAME, &dummy) != 0;
+diff --git src/unix/udp.c src/unix/udp.c
+index c2814512..cba9e821 100644
+--- src/unix/udp.c
++++ src/unix/udp.c
+@@ -892,6 +892,7 @@ static int uv__udp_set_membership6(uv_udp_t* handle,
+     !defined(__ANDROID__) &&                                        \
+     !defined(__DragonFly__) &&                                      \
+     !defined(__QNX__) &&                                            \
++    (!defined(__APPLE__) || (MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)) && \
+     !defined(__GNU__)
+ static int uv__udp_set_source_membership4(uv_udp_t* handle,
+                                           const struct sockaddr_in* multicast_addr,
+@@ -1083,6 +1084,7 @@ int uv_udp_set_source_membership(uv_udp_t* handle,
+     !defined(__ANDROID__) &&                                        \
+     !defined(__DragonFly__) &&                                      \
+     !defined(__QNX__) &&                                            \
++    (!defined(__APPLE__) || (MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)) && \
+     !defined(__GNU__)
+   int err;
+   union uv__sockaddr mcast_addr;


### PR DESCRIPTION
#### Description

`uvw` is meant to be in sync with `libuv`, however there is no guarantee that timings of updates in upstream and Macports match. Most likely they will not: fix example, now Macports lags for many months, being stuck at 1.44, when upstream is at 1.46. (Obviously, reverse may also occur, if `uvw` updates happen to be delayed.)
Dependencies of `uvw` may want the current version. I prefer to keep the main `uvw` port in sync with whatever Macports uses for `libuv`, but now we will offer static and header-only versions (tracking upstream), either of which can co-exist with the main one.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
