### PR TITLE
Lisp: new ports

### DIFF
--- a/_resources/port1.0/group/common_lisp-1.0.tcl
+++ b/_resources/port1.0/group/common_lisp-1.0.tcl
@@ -32,6 +32,9 @@ default common_lisp.ecl         [expr { ${os.platform} eq "darwin" && ${os.major
 options common_lisp.clisp
 default common_lisp.clisp       yes
 
+options common_lisp.build_run
+default common_lisp.build_run   yes
+
 categories                      lisp
 
 use_configure                   no
@@ -115,8 +118,10 @@ build {
         ln -sf ../source/${subport}/$f ${common_lisp.build}/system/$f
     }
 
-    foreach item [glob -dir ${common_lisp.build}/system -tails *.asd] {
-        common_lisp::asdf_operate "load-op" [string range ${item} 0 end-4]
+    if {[option common_lisp.build_run]} {
+        foreach item [glob -dir ${common_lisp.build}/system -tails *.asd] {
+            common_lisp::asdf_operate "load-op" [string range ${item} 0 end-4]
+        }
     }
  }
 

--- a/lang/slime/Portfile
+++ b/lang/slime/Portfile
@@ -6,6 +6,7 @@ PortGroup       github 1.0
 epoch           2022121000
 revision        0
 
+# please keep it synchronized with cl-swank
 github.setup    slime slime 2.28 v
 categories      lang
 platforms       any

--- a/lisp/cl-3bmd/Portfile
+++ b/lisp/cl-3bmd/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        3b 3bmd 0cc2f8627098472bbd72ff9e6a31f17db6486239
+name                cl-3bmd
+version             20230726
+revision            0
+
+checksums           rmd160  d4c3220594c6f7072e650e3f3011847dc16d2690 \
+                    sha256  a6a40efe19330f107bfb89161f82005614f241c4507247a753a7dd84fe92e392 \
+                    size    40571
+
+categories-append   textproc
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         markdown processor in CL using esrap parser
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-colorize \
+                    port:cl-fiasco \
+                    port:cl-esrap \
+                    port:cl-split-sequence
+
+# clisp seems to be broken
+# See: https://github.com/3b/3bmd/issues/61
+common_lisp.clisp   no

--- a/lisp/cl-annot/Portfile
+++ b/lisp/cl-annot/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        m2ym cl-annot c99e69c15d935eabc671b483349a406e0da9518d
+version             20150606
+revision            0
+
+checksums           rmd160  13772949bed97b69b3ede515f398f0e1af335a5c \
+                    sha256  17a75bbc8f1d4d88dac0b57d6266f70dc17f0f43af8e16e925a17910b5976a0c \
+                    size    10158
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Python-like Annotation Syntax for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria
+
+
+# Unhandled UIOP/LISP-BUILD:COMPILE-FILE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
+#
+# COMPILE-FILE-ERROR while
+#   compiling #<CL-SOURCE-FILE "cl-annot-test" "t" "annot">
+post-extract {
+    file delete ${worksrcpath}/cl-annot-test.asd
+}
+
+test.run            no

--- a/lisp/cl-anonfun/Portfile
+++ b/lisp/cl-anonfun/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        arielnetworks cl-anonfun ef3c16cefa80eacce9129ff98f751b8f6f19c237
+version             20111202
+revision            0
+
+checksums           rmd160  eaa05efa8993538e72384b710e614f6ab8cce683 \
+                    sha256  209c5dfa07f847397b307c029a59443163ea827b112977ae46104f8274af090b \
+                    size    2197
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Anonymous function helpers for Common Lisp
+
+long_description    {*}${description}

--- a/lisp/cl-closer-mop/Portfile
+++ b/lisp/cl-closer-mop/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        pcostanza closer-mop 04f2d48b741ffd8c2be343e562cc49d46cce2063
+name                cl-closer-mop
+version             20230730
+revision            0
+
+checksums           rmd160  26f41802b9116a67d7151a94271fbb02e9484685 \
+                    sha256  f007de5791538c9a472ac3647bc257f244ec9ebdd457195b5e310c35f7183e03 \
+                    size    23100
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Closer to MOP is a compatibility layer that rectifies many of the absent or incorrect CLOS MOP features
+
+long_description    {*}${description}

--- a/lisp/cl-colorize/Portfile
+++ b/lisp/cl-colorize/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        kingcons colorize f5ed4b342c40257178ebe176108792c01d2e1187
+name                cl-colorize
+version             20230726
+revision            0
+
+checksums           rmd160  22441924e77a50b28ee0efc943ebaf216c3c6e52 \
+                    sha256  04c19e16642ff242a227594d58242497f526a0c848be52e1ed205640ca0016b4 \
+                    size    40016
+
+categories-append   textproc
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A Syntax Highlighting library
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-html-encode \
+                    port:cl-split-sequence

--- a/lisp/cl-esrap/Portfile
+++ b/lisp/cl-esrap/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        scymtym esrap d806138342a6b27327649fd5f36e0fe2e0966867
+name                cl-esrap
+version             20230422
+revision            0
+
+checksums           rmd160  e9b719bd85b54a408ddafae1f7c134bf2f8ffd46 \
+                    sha256  f5aeff7d6d9b2dd243a03fce851fd7322359a3f6296e7759d6c32428c1461ac7 \
+                    size    70562
+
+categories-append   textproc
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Common Lisp packrat parser
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-fiveam \
+                    port:cl-trivial-with-current-source-form

--- a/lisp/cl-fare-utils/Portfile
+++ b/lisp/cl-fare-utils/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fare fare-utils 2f9c48a23a5c0802566d869d73a58471c05e63f1
+name                cl-fare-utils
+version             20221129
+revision            0
+
+checksums           rmd160  0841d3b45f4d2c4ae27daa3a0c381d16f5601389 \
+                    sha256  5c33d1f905dc0ebb68e81c51f8a37d02537be058fb42647db1dcdb198a4ba168 \
+                    size    32873
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         General purposes utilities for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-hu.dwim.stefil

--- a/lisp/cl-fiasco/Portfile
+++ b/lisp/cl-fiasco/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        joaotavora fiasco bb47d2fef4eb24cc16badc1c9a73d73c3a7e18f5
+name                cl-fiasco
+version             20200314
+revision            0
+
+checksums           rmd160  50105d36359c5be8cb08f8bbb26d2934a0a6c3de \
+                    sha256  1cd30edff5e8b74dca214b672e74b6d1cc5c3dcfddc58a8f1c405ba966cf797f \
+                    size    19464
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Common Lisp test framework that treasures your failures, logical continuation of Stefil.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-trivial-gray-streams

--- a/lisp/cl-html-encode/Portfile
+++ b/lisp/cl-html-encode/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-html-encode
+version             1.2
+revision            0
+
+checksums           rmd160  6ec6ffdd29d88000f3fbc0b7d6c43eb24a0f73c8 \
+                    sha256  8e3da4ad3416b5b9969a76bad7c6a08e7a923bb89bcc5f21d7c5f9922c47ae1a \
+                    size    3132
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+homepage            https://www.cliki.net/html-encode
+master_sites        https://cl-pdx.com/static
+distname            html-encode-${version}
+
+description         html-encode is a small library for encoding text in various web-savvy formats
+
+long_description    {*}${description}
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     html-encode-(\[\\d.\]+)${extract.suffix}

--- a/lisp/cl-ieee-floats/Portfile
+++ b/lisp/cl-ieee-floats/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        marijnh ieee-floats 9566ce8adfb299faef803d95736c780413a1373c
+name                cl-ieee-floats
+version             20220126
+revision            0
+
+checksums           rmd160  7c0e45aa6fcfbc3d311b80d3ee3dbf1c41a9bd49 \
+                    sha256  746b99edcc268602523324c2252f6304a794415b368fd98c2ca4251e988208f2 \
+                    size    5363
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         Common Lisp IEEE-754 float en- and decoding
+
+long_description    {*}${description}
+
+# clisp seems to be broken
+# See: https://github.com/marijnh/ieee-floats/issues/15
+common_lisp.clisp   no

--- a/lisp/cl-interpol/Portfile
+++ b/lisp/cl-interpol/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        edicl cl-interpol 0.2.7 v
+revision            0
+
+checksums           rmd160  3149854d90b67f32cd79a3662d91975abf738dbc \
+                    sha256  7f46ff48bfab2f44b4b2f6929d5a12d04cf72a3fcc62d345945b9824c70ed6e5 \
+                    size    46215
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Common Lisp surface syntax niceties
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-named-readtables \
+                    port:cl-unicode

--- a/lisp/cl-ironclad/Portfile
+++ b/lisp/cl-ironclad/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        sharplispers ironclad 6da010fea49a4edf075943e20f8ec7adea0d9d65
+name                cl-ironclad
+version             20230727
+revision            0
+
+checksums           rmd160  6c9eb47f8a12c13eeec3fd003db9bfddff6524a2 \
+                    sha256  15ab1068af4119d8896b4a405f115e0b04e2f8df685c969d7f5fad24a640723d \
+                    size    1494767
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         A cryptographic toolkit written in Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-flexi-streams
+
+depends_test-append port:cl-rt
+
+common_lisp.threads yes
+
+# NOTE: some test are failing on ECL
+# See: https://github.com/sharplispers/ironclad/issues/63

--- a/lisp/cl-lisp-namespace/Portfile
+++ b/lisp/cl-lisp-namespace/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        guicho271828 lisp-namespace 699fccb6727027343bb5fca69162a3113996edfc
+name                cl-lisp-namespace
+version             20230623
+revision            0
+
+checksums           rmd160  8b39dfb6730d0a7b32b6523f48cc93bfbc7e158d \
+                    sha256  666d46a94fef438c935528fe108c5ec26b9a235463a59612b53078fe6861d65c \
+                    size    10000
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         no more discussion on lisp-1 vs lisp-2. THIS IS LISP-N.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-fiveam

--- a/lisp/cl-markup/Portfile
+++ b/lisp/cl-markup/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        arielnetworks cl-markup e0eb7debf4bdff98d1f49d0f811321a6a637b390
+version             20130917
+revision            0
+
+checksums           rmd160  8fb033a5058e96e1a808a34734013fd018460aba \
+                    sha256  097a9d3131a702587405eeff83bf2257244fe7791a74353dfabf7271b8f068e7 \
+                    size    5918
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Modern markup (HTML) generation library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-test-more

--- a/lisp/cl-mgl-pax/Portfile
+++ b/lisp/cl-mgl-pax/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   github 1.0
+PortGroup                   common_lisp 1.0
+
+github.setup                melisgl mgl-pax 96017fbd19b9edd3a30fa1d5dfc070903d435baf
+name                        cl-mgl-pax
+version                     20230803
+revision                    0
+
+checksums                   rmd160  2197f9fc88f4263a80fda8a96d65dae9cc5a74fd \
+                            sha256  d99e43fcb99484a0251b8461f66472bb9c5213027fa286e02f6d353112f814c0 \
+                            size    979759
+
+categories-append           devel textproc
+maintainers                 {@catap korins.ky:kirill} openmaintainer
+license                     MIT
+
+description                 Reify definitions, provide portable access to docstrings and source locations in an extensible framework.
+
+long_description            {*}${description}
+
+if {${name} eq ${subport}} {
+    depends_lib-append      port:cl-3bmd \
+                            port:cl-alexandria \
+                            port:cl-dref \
+                            port:cl-named-readtables \
+                            port:cl-md5 \
+                            port:cl-pythonic-string-reader
+
+    # requires cl-trivial-utf-8 which depends on cl-mgl-pax
+    test.run                no
+}
+
+subport cl-dref {
+    # NOTE: cl-dref depends on cl-mgl-pax which depends on cl-dref :)
+    # MacPorts can't handle such dependency => switch off building
+    # and avoid dependency from cl-dref to cl-mgl-pax
+    common_lisp.build_run   no
+
+    worksrcdir              ${worksrcdir}/dref
+
+    depends_lib-append      port:cl-alexandria \
+                            port:cl-named-readtables \
+                            port:cl-pythonic-string-reader \
+                            port:cl-swank
+
+    # depends_test-append     port:cl-mgl-pax
+    # requires cl-try which depends on cl-mgl-pax
+    test.run                no
+}

--- a/lisp/cl-mgl-pax/Portfile
+++ b/lisp/cl-mgl-pax/Portfile
@@ -46,7 +46,6 @@ subport cl-dref {
                             port:cl-pythonic-string-reader \
                             port:cl-swank
 
-    # depends_test-append     port:cl-mgl-pax
-    # requires cl-try which depends on cl-mgl-pax
-    test.run                no
+    depends_test-append     port:cl-mgl-pax \
+                            port:cl-try
 }

--- a/lisp/cl-mgl-pax/Portfile
+++ b/lisp/cl-mgl-pax/Portfile
@@ -29,8 +29,7 @@ if {${name} eq ${subport}} {
                             port:cl-md5 \
                             port:cl-pythonic-string-reader
 
-    # requires cl-trivial-utf-8 which depends on cl-mgl-pax
-    test.run                no
+    depends_test-append     port:cl-trivial-utf-8
 }
 
 subport cl-dref {

--- a/lisp/cl-named-readtables/Portfile
+++ b/lisp/cl-named-readtables/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        melisgl named-readtables 2c05652f8b6f5b2de8feefda069274c0478ab0f3
+name                cl-named-readtables
+version             20230721
+revision            0
+
+checksums           rmd160  5b9664fb6f10f2aba13d23d36a8a24a5c354c93f \
+                    sha256  d8e6ab5f853173383298e6a2a48a8a8914e01b0a623cbf71105ce5565d7b4a86 \
+                    size    28391
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Named-Readtables is a library that provides a namespace for readtables akin to the already-existing namespace of packages.
+
+long_description    {*}${description}
+
+# TODO: requires cl-try which depends on cl-named-readtables via cl-mgl-pax
+# should be enabled as soon as all ports are ready.
+test.run            no

--- a/lisp/cl-ppcre/Portfile
+++ b/lisp/cl-ppcre/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
 github.setup        edicl cl-ppcre 2.1.1 v
-revision            1
+revision            2
 
 checksums           rmd160  106346027a81f75e27f11b2719d499ffea606d9e \
                     sha256  89631179b71648d9e6c565a928f6896a9d5742aa2083b9c1b705fe0b45d85def \
@@ -22,22 +22,8 @@ long_description    CL-PPCRE is a fast, portable, thread-safe regular expression
 
 github.tarball_from archive
 
-depends_test-append port:cl-flexi-streams
+# cl-ppcre depedns on cl-unicode, and cl-unicode depends on cl-ppcre
+common_lisp.build_run   no
 
-# broke cyclic dependencies:
-#  - cl-unicode depends on cl-ppcre
-#  - cl-ppcre-unicode depends cl-unicode
-if {${name} eq ${subport}} {
-    post-extract {
-        file delete ${worksrcpath}/cl-ppcre-unicode.asd
-    }
-}
-
-subport cl-ppcre-unicode {
-    depends_lib-append  \
+depends_test-append port:cl-flexi-streams \
                     port:cl-unicode
-
-    post-extract {
-        file delete ${worksrcpath}/cl-ppcre.asd
-    }
-}

--- a/lisp/cl-pythonic-string-reade/Portfile
+++ b/lisp/cl-pythonic-string-reade/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        smithzvk pythonic-string-reader 47a70ba1e32362e03dad6ef8e6f36180b560f86a
+name                cl-pythonic-string-reader
+version             20180618
+revision            0
+
+checksums           rmd160  c6535e66fd171b6544095dd4df2c015c79c84d67 \
+                    sha256  28b2c1703d1e58d8216306f6a8a25b951abf34dfaf806fdb49489875cd185be3 \
+                    size    3629
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         A simple and unintrusive read table modification inspired by Python's three quote strings.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-named-readtables

--- a/lisp/cl-swank/Portfile
+++ b/lisp/cl-swank/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+# please keep it synchronized with slime
+github.setup        slime slime 2.28 v
+name                cl-swank
+revision            0
+
+checksums           rmd160  7412a6f86733cdc2c50f015c7bd4c886b1201b78 \
+                    sha256  c3d41bbbfd71533825d1e937edd96e6dbaf9d97c7a822455e703ef6d942e672e \
+                    size    827019
+
+dist_subdir         slime
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             Permissive
+
+description         Swank from SLIME
+
+long_description    {*}${description}

--- a/lisp/cl-test-more/Portfile
+++ b/lisp/cl-test-more/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        jd cl-test-more ead30e3acf89f770bc033551d15b19c1ab947c8a
+version             20130114
+revision            0
+
+checksums           rmd160  3464d67c9e6f589e4ff39b0aa4a4fcb0917cadcd \
+                    sha256  123964328f547b53d75c429d8bf160acfca9fcae3cefcfd81aaa6599dad64547 \
+                    size    3882
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Yet Another Unit Testing Framework for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-ppcre

--- a/lisp/cl-trivial-cltl2/Portfile
+++ b/lisp/cl-trivial-cltl2/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Zulu-Inuoe trivial-cltl2 2ada8722dc1d7bae1f49832a2ca26b25b90055d3
+name                cl-trivial-cltl2
+version             20211212
+revision            0
+
+checksums           rmd160  4db1279e1d33a381b9c5d90cf84f9b568522829b \
+                    sha256  e00bdf26e37692d77a77de57f54dccfe23911f095f13ceefd8c3507f7c4950ed \
+                    size    6491
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Portable CLtL2
+
+long_description    {*}${description}

--- a/lisp/cl-trivial-features/Portfile
+++ b/lisp/cl-trivial-features/Portfile
@@ -7,7 +7,7 @@ PortGroup           common_lisp 1.0
 github.setup        trivial-features trivial-features d249a62aaf022902398a7141ae17217251fc61db
 name                cl-trivial-features
 version             20230607
-revision            0
+revision            1
 
 checksums           rmd160  cd328aa25a5fe306b685664d2e64a509c4d13628 \
                     sha256  e1913a4957b81a7d2b0e0bce4ccbbc1ecd23aa212950b3f7646237940ac2509b \
@@ -21,30 +21,10 @@ description         Portable CL:*FEATURES*
 
 long_description    {*}${description}
 
-# NOTE: Enable tests introduces cyclic dependencies:
-#  - cl-cffi depends on cl-trivial-features
-#  - cl-trivial-features depends cl-trivial-features-tests
-#  - cl-trivial-features-tests depends cl-cffi-grovel
-#  - cl-cffi-grovel depends cl-cffi
-if {${name} eq ${subport}} {
-    test.run        no
+# cl-cffi depedns on cl-trivial-features which depends on cl-cffi
+common_lisp.build_run   no
 
-    post-extract {
-        file delete ${worksrcpath}/trivial-features-tests.asd
-    }
-}
+depends_test-append port:cl-cffi
 
-subport cl-trivial-features-tests {
-    depends_lib-append  \
-                    port:cl-cffi \
-                    port:cl-trivial-features
-
-    post-extract {
-        file delete ${worksrcpath}/trivial-features.asd
-    }
-
-    # See: https://github.com/trivial-features/trivial-features/issues/23
-    common_lisp.clisp   no
-
-    livecheck.type      none
-}
+# See: https://github.com/trivial-features/trivial-features/issues/23
+common_lisp.clisp   no

--- a/lisp/cl-trivial-types/Portfile
+++ b/lisp/cl-trivial-types/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        m2ym trivial-types ee869f2b7504d8aa9a74403641a5b42b16f47d88
+name                cl-trivial-types
+version             20120318
+revision            0
+
+checksums           rmd160  3619f91b9b85306afe8541cd166f0f35115b2d0b \
+                    sha256  99b3717cb04047c1d39d9177079b699612b6e963f59201e22f4c242745c4e4d9 \
+                    size    3290
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Trivial type definitions for Common Lisp
+
+long_description    {*}${description}

--- a/lisp/cl-trivial-utf-8/Portfile
+++ b/lisp/cl-trivial-utf-8/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           common_lisp 1.0
+
+gitlab.instance     https://gitlab.common-lisp.net
+gitlab.setup        trivial-utf-8 trivial-utf-8 6ca9943588cbc61ad22a3c1ff81beb371e122394
+name                cl-trivial-utf-8
+version             20220214
+revision            0
+
+checksums           rmd160  86582b0dbf24bf4ae3e44fd55a21f4742b559506 \
+                    sha256  e1204a804d935422420ca0c7df48f83f6529a805ce7809d42f5b9f143ce74196 \
+                    size    7242
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Trivial UTF-8 provides more efficient ways of reading and writing UTF-8
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-mgl-pax

--- a/lisp/cl-trivial-with-current-source-form/Portfile
+++ b/lisp/cl-trivial-with-current-source-form/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        scymtym trivial-with-current-source-form dc3fff9d4e04f1613227c25a290c8f34e9f8a311
+name                cl-trivial-with-current-source-form
+version             20230605
+revision            0
+
+checksums           rmd160  fb65d51a022b47d522717860197099bf591dd4bf \
+                    sha256  191de792ea917d880bc8512f25b1bbe05b3e7ddb8baa807fe700e5207cd02ce6 \
+                    size    34886
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Helps macro writers produce better errors for macro users
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria

--- a/lisp/cl-try/Portfile
+++ b/lisp/cl-try/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        melisgl try 494dfe6d31a469e473403e2b48307debfbbe4502
+name                cl-try
+version             20230806
+revision            0
+
+checksums           rmd160  070a0ea614de12d67be0eafda2a4eb2fc42e0a13 \
+                    sha256  f93c78ddc91b82502287ff4f72132d058f1f2ce48c15036181ab906c50c1b72b \
+                    size    140578
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Try is an extensible test framework with equal support for interactive and non-interactive workflows.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-ppcre \
+                    port:cl-closer-mop \
+                    port:cl-mgl-pax \
+                    port:cl-ieee-floats
+
+common_lisp.threads yes
+
+# See: https://github.com/melisgl/try/issues/4
+test.run            no
+
+github.livecheck.branch main

--- a/lisp/cl-uffi/Portfile
+++ b/lisp/cl-uffi/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-uffi
+version             2.1.2
+revision            0
+
+homepage            https://tracker.debian.org/cl-uffi
+
+master_sites        debian:c/${name}/
+worksrcdir          ${name}-${version}
+distname            ${name}_${version}
+extract.suffix      .orig.tar.gz
+
+checksums           rmd160  f160e41e4dc3ff5497a6ef322052e01fec355eca \
+                    sha256  6c2d80779c136066649226edfa59d973fa3135a4630bc919f9a8b1b0395e11f7 \
+                    size    206305
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Universal Foreign Function Library for Common Lisp
+
+long_description    {*}${description}
+
+common_lisp.clisp   no
+common_lisp.ecl     no
+
+post-extract {
+    # :FORCE and :FORCE-NOT arguments not allowed in a nested call to ASDF/OPERATE:OPERATE unless identically to toplevel
+    reinplace {s| :force t||} ${worksrcpath}/uffi.asd
+}
+
+# some tests are failed on macOS
+test.run            no
+
+livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
+livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
#### Description

Here the first portion of new lisp ports.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->