### PR TITLE
edid-decode: update to 20230804

### DIFF
--- a/sysutils/edid-decode/Portfile
+++ b/sysutils/edid-decode/Portfile
@@ -3,7 +3,7 @@ PortSystem              1.0
 PortGroup               makefile 1.0
 
 name                    edid-decode
-version                 20230616
+version                 20230804
 categories              sysutils
 maintainers             @wwalexander openmaintainer
 license                 MIT
@@ -13,7 +13,7 @@ set domain              linuxtv.org
 homepage                https://git.${domain}/${name}.git
 fetch.type              git
 git.url                 git://${domain}/${name}.git
-git.branch              a31e680
+git.branch              5f72326
 
 destroot.args-append    bindir=${prefix}/bin \
                         mandir=${prefix}/share/man


### PR DESCRIPTION
#### Description

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?