### PR TITLE
AfterStep: require +x11 variant for gdk-pixbuf2

### DIFF
--- a/x11/AfterStep/Portfile
+++ b/x11/AfterStep/Portfile
@@ -53,6 +53,8 @@ depends_lib-append  \
                 port:xorg-libsm \
                 port:zlib
 
+require_active_variants gdk-pixbuf2 x11
+
 patchfiles      libpng.patch
 
 configure.args  --mandir=${prefix}/share/man \


### PR DESCRIPTION
This is basically another attempt at doing PR #11655, except this time without the merge commit.

Closes: https://trac.macports.org/ticket/62366

#### Description
See linked Trac bug

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 11.4 20F71 x86_64
Xcode 12.5.1 12E507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Note that I have only tested that building fails properly when gdk-pixbuf2 is installed without the `+x11` variant; I haven't actually tested trying to do a successful install, since that would require reinstalling gdk-pixbuf2 and possibly breaking my entire setup.

