### PR TITLE
vde2: update to 2.3.3;src move to github

### DIFF
--- a/net/vde2/Portfile
+++ b/net/vde2/Portfile
@@ -1,37 +1,34 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
+github.setup        virtualsquare vde-2 2.3.3 v
 name                vde2
-version             2.3.2
 revision            0
 categories          net
 maintainers         nomaintainer
 license             GPL-2 LGPL-2.1 BSD-old
 
-description         ethernet compliant virtual network
+description         Virtual Distributed Ethernet
 
 long_description    VDE is an ethernet compliant virtual network that can be \
                     spawned over a set of physical computer over the Internet.
 
-homepage            http://vde.sourceforge.net/
-master_sites        sourceforge:vde
-use_bzip2           yes
+github.tarball_from archive
 
-checksums           rmd160  1bd887e6994902d740564b52dccd4cad91a414a0 \
-                    sha256  cbea9b7e03097f87a6b5e98b07890d2275848f1fe4b9fcda77b8994148bc9542 \
-                    size    600527
+checksums           rmd160  257d008bd8ce5a56f1ab7086a7f69a01f639294c \
+                    sha256  a7d2cc4c3d0c0ffe6aff7eb0029212f2b098313029126dcd12dc542723972379 \
+                    size    234790
 
 use_autoreconf      yes
 
 default_variants    +pcap
 
-configure.args      --disable-kernel-switch \
-                    --disable-experimental \
+configure.args      --disable-experimental \
                     --disable-tuntap \
                     --disable-pcap \
-                    --disable-cryptcab \
-                    --disable-python
+                    --disable-cryptcab
 
 # See https://github.com/virtualsquare/vde-2/issues/6
 use_parallel_build  no
@@ -42,7 +39,6 @@ post-destroot {
     xinstall -m 644 -W ${worksrcpath} \
                     COPYING \
                     COPYING.libvdeplug \
-                    COPYING.slirpvde \
                     Changelog \
                     README \
                     doc/README.UML \
@@ -59,17 +55,14 @@ post-destroot {
 
 variant tuntap description {Enable support for TAP devices} {
     depends_lib-append      port:tuntaposx
-    configure.args-replace  "s|--disable-tuntap|--enable-tuntap|"
+    configure.args-replace  --disable-tuntap --enable-tuntap
 }
 
 variant pcap description {Enable support for packet capturing} {
     depends_lib-append      port:libpcap
-    configure.args-replace  "s|--disable-pcap|--enable-pcap|"
+    configure.args-replace  --disable-pcap --enable-pcap
 }
 
 variant experimental description {Enable support for experimental features} {
-    configure.args-replace  "s|--disable-experimental|--enable-experimental|"
+    configure.args-replace  --disable-experimental --enable-experimental
 }
-
-livecheck.type      sourceforge
-livecheck.regex     "${name}-(\\d+\\.\\d+(\\.\\d+)?)${extract.suffix}"


### PR DESCRIPTION
#### Description

- Update version to 2.3.3
- Source code has been moved from sourceforge to github
- Remove unrecognized configure args:
`configure: WARNING: unrecognized options: --disable-kernel-switch, --disable-python`
- Remove COPYING.slirpvde: module deprecated
- Known failure: `port -vst install` failed but `port -vs install` worked
-
  - port -vst install gives:
```
:info:extract Executing:  cd "/opt/macports-test/var/macports/build/_opt_macports-test_macports-ports_net_vde2/vde2/work" && /usr/bin/gzip -dc '/opt/macports-test/var/macports/distfiles/vde2/vde-2-2.3.3.tar.gz' | /usr/bin/tar -xf - 
:debug:extract system:  cd "/opt/macports-test/var/macports/build/_opt_macports-test_macports-ports_net_vde2/vde2/work" && /usr/bin/gzip -dc '/opt/macports-test/var/macports/distfiles/vde2/vde-2-2.3.3.tar.gz' | /usr/bin/tar -xf - 
:info:extract Command failed:  cd "/opt/macports-test/var/macports/build/_opt_macports-test_macports-ports_net_vde2/vde2/work" && /usr/bin/gzip -dc '/opt/macports-test/var/macports/distfiles/vde2/vde-2-2.3.3.tar.gz' | /usr/bin/tar -xf - 
:info:extract Killed by signal: 9
:error:extract Failed to extract vde2: command execution failed
```
-
  - further testing the command:
  `$ sudo /usr/bin/gzip -dc '/opt/macports-test/var/macports/distfiles/vde2/vde-2-2.3.3.tar.gz' | /usr/bin/tar -xf - ` gives:
```
vde-2-2.3.3/: Can't create 'vde-2-2.3.3'
...
```
- Tested with +pcap +experimental variant
- Due to source moved to github and using github portgroup, the distfile now called `vde-2-2.3.3.tar.gz` instead of `vde2-2.3.3.tar.gz`. Sorry I'm new to macports, any idea how to change this back?

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5 22G74 arm64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
