### PR TITLE
tatami-devel: update to 2023.08.06

### DIFF
--- a/devel/tatami/Portfile
+++ b/devel/tatami/Portfile
@@ -20,13 +20,13 @@ supported_archs     noarch
 installs_libs       no
 
 subport tatami-devel {
-    github.setup    tatami-inc tatami 7b356d097d9f796d867476a2760efa04e2c9d859
-    version         2023.07.10
+    github.setup    tatami-inc tatami fb4105a2b2cf3d799c126a25156f87c6577ba157
+    version         2023.08.06
     revision        0
     conflicts       tatami
-    checksums       rmd160  93f1aeda5b990f873fbc6fd95ed5ff7ad101ea02 \
-                    sha256  552fef1b0b2ff58ff6b60af4df88e639d944436592cc77ddf962e04aafd0d90c \
-                    size    169981
+    checksums       rmd160  d2d0ac8f33dc916df2a57aa3c64bb5f13bc9fd0b \
+                    sha256  88837f8db8b0a087815b0ae2162dea5042b7ba520c3160ebdf52a948714e6ca5 \
+                    size    164525
 }
 
 if {${subport} ne "tatami-devel"} {


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
