### PR TITLE
google-cloud-sdk: update to 442.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             441.0.0
+version             442.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4ae0cf01c2278c544cc5b703e29ab2d877dca8a1 \
-                    sha256  de6288baa19f99016f00a9f73de6340aa18894908748637d532399e59276478d \
-                    size    101150673
+    checksums       rmd160  88cfd53fe485084635de891e2d4b54ea2c53b0d3 \
+                    sha256  b5e047a389a2cb83efd9e8569eda2a1676c0010e5026995a0def37a5130924db \
+                    size    101190514
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  73e432e7362bf0efb22dfc0ba38a48c4bfc6d5b1 \
-                    sha256  94db3d0b93ccc91326d35b7a4c5d94532bacac729c6785c25738804bfbfb4bdc \
-                    size    121391903
+    checksums       rmd160  7d9f436a3cefa4ebaecdba2d6c053c521128d945 \
+                    sha256  60a0ec0ce7d7b57d83debbaad585d8da23d08e35885de0c75f789c7ee7b65276 \
+                    size    121438423
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  feb76429622121a1e206800f033cf8e0239bc243 \
-                    sha256  6e6f977b0ef10751e089cd9d1ae490d55be648205b7a0b46711d0b1422c893ac \
-                    size    118561017
+    checksums       rmd160  2767008d22afc0d632654ed28d283df3d5250551 \
+                    sha256  5bc8916871ed1f9d596353fa44995eeda314c6e98560c8990e62e866309edb4f \
+                    size    118604251
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 442.0.0.

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?