### PR TITLE
Lisp new ports 2

### DIFF
--- a/lisp/cl-anaphora/Portfile
+++ b/lisp/cl-anaphora/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        spwhitton anaphora 0.9.8
+name                cl-anaphora
+revision            0
+
+checksums           rmd160  2c128c285d65f8413ac9dbb93ba456ce2cf9fc50 \
+                    sha256  030314d25298169dbc6da657f792b903a8aaab7947233076c36c753b349a11cb \
+                    size    6452
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         The anaphoric macro collection from Hell
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-rt

--- a/lisp/cl-ansi-text/Portfile
+++ b/lisp/cl-ansi-text/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        pnathan cl-ansi-text 2.0.1 v
+revision            0
+
+checksums           rmd160  4f9055021862c6c39fc7dfc251e4484e2e16d0bf \
+                    sha256  564d817011e84c14e9229d53631c87ceb0f897a6fbe491b4ebb97ecee932936f \
+                    size    6905
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Enables ANSI colors for printing.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-colors2 \
+                    port:cl-fiveam

--- a/lisp/cl-checkl/Portfile
+++ b/lisp/cl-checkl/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        rpav CheckL 80328800d047fef9b6e32dfe6bdc98396aee3cc9
+name                cl-checkl
+version             20180316
+revision            0
+
+checksums           rmd160  c45ec42571e0930fc589aa7da0e7edaed7481f7e \
+                    sha256  ff03f8af4ea6ce00543a6d1f717b6dff1678bdb40cc96e2481c35ceecc84dd3c \
+                    size    8372
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Why write programs in Common Lisp but tests like Java? Meet CheckL!
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-fiveam \
+                    port:cl-gendoc \
+                    port:cl-marshal
+
+# See: https://github.com/rpav/CheckL/issues/4
+test.run            no

--- a/lisp/cl-clunit2/Portfile
+++ b/lisp/cl-clunit2/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-clunit2
+set git_commit      200839e8e47e9212ded2d36520d84b9be681037c
+version             20221002
+revision            0
+
+checksums           rmd160  1f3243c6f97894f0662d6cc5662e16389fbc5d5d \
+                    sha256  b6bda85757986882177baaf2200b2eeaf2c69093a84942c6741df59d28ef004f \
+                    size    39670
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+homepage            https://notabug.org/cage/clunit2
+master_sites        ${homepage}/archive
+distname            ${git_commit}
+worksrcdir          clunit2
+
+description         Unit Testing Framework, fork of clunit.
+
+long_description    {*}${description}
+
+# should be enabled when PG for notabug.org is created
+livecheck.type      none

--- a/lisp/cl-colors/Portfile
+++ b/lisp/cl-colors/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        tpapp cl-colors 827410584553f5c717eec6182343b7605f707f75
+version             20180307
+revision            0
+
+checksums           rmd160  b2664aedc781a2000eb07047c8dac59fee0033c5 \
+                    sha256  21925e5bf3924db8cfa4013aa7dec2c15fc826b8c34ebffdd4d66efe397bd761 \
+                    size    14701
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             Boost-1
+
+description         Simple color library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-let-plus

--- a/lisp/cl-colors2/Portfile
+++ b/lisp/cl-colors2/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-colors2
+version             0.5.4
+revision            0
+
+checksums           rmd160  c041ad4d848491d38881e4464c5475a94636e0aa \
+                    sha256  3abb0ed686f87781d8f637482cb947e2ec72ca49f560b4b34ac89ad08d35ea74 \
+                    size    36149
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             Boost-1
+
+homepage            https://notabug.org/cage/cl-colors2
+master_sites        ${homepage}/archive
+distname            v${version}
+worksrcdir          ${name}
+
+description         Simple color library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-clunit2 \
+                    port:cl-ppcre
+
+livecheck.type      regex
+livecheck.url       ${homepage}/releases
+livecheck.regex     v(\[\\d.\]+)${extract.suffix}

--- a/lisp/cl-documentation-utils/Portfile
+++ b/lisp/cl-documentation-utils/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            Shinmera documentation-utils 0196f6ce6828a745121374c238972491074f5eb1
+name                    cl-documentation-utils
+version                 20230703
+revision                0
+
+checksums               rmd160  843f83ff4eb59de9c3c027464841f7af708a6049 \
+                        sha256  424f539acd9540c05ce99a82aa2da3a97ca11a4f3a464833e52c02a98c41b710 \
+                        size    8912
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 zlib
+
+description             A tiny logging library for Common Lisp
+
+long_description        {*}${description}
+
+# NOTE: multilang-documentation-utils.asd depends on cl-multilang-documentation which depends on this port
+common_lisp.build_run   no
+
+depends_lib-append      port:cl-trivial-indent
+
+test.run                no

--- a/lisp/cl-eos/Portfile
+++ b/lisp/cl-eos/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        adlai Eos b4413bccc4d142cbe1bf49516c3a0a22c9d99243
+name                cl-eos
+version             20200631
+revision            0
+
+checksums           rmd160  af3ece1ab5329ccdf282a4e8cd84c4518ed20098 \
+                    sha256  4c51a05971b48f45ce0c65963da22c2022e2ddf28c06dfc26dbc2f5a31b93554 \
+                    size    13226
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         obsolete fork of FiveAM
+
+long_description    {*}${description}

--- a/lisp/cl-fare-quasiquote/Portfile
+++ b/lisp/cl-fare-quasiquote/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fare fare-quasiquote ccb0285b456c4d6bb09b9f931cf0ac5e72353ae5
+name                cl-fare-quasiquote
+version             20200801
+revision            0
+
+checksums           rmd160  d8f29bdbd95d93e2782ecf819a2edb8283516c34 \
+                    sha256  8fabe0e49474e40a559cfbc44177223c7395da25c1bd89d29b48558c45acebd1 \
+                    size    15789
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Portable implementation of quasiquote for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-fare-utils \
+                    port:cl-named-readtables \
+                    port:cl-optima \
+                    port:cl-trivia
+
+# by unknown reason it can't locate cl-optima
+common_lisp.build_run   no
+test.run                no

--- a/lisp/cl-fast-io/Portfile
+++ b/lisp/cl-fast-io/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        rpav fast-io a4c5ad600425842e8b6233b1fa22610ffcd874c3
+name                cl-fast-io
+version             20220807
+revision            0
+
+checksums           rmd160  3ab598b68fcf2934b3d77cc66e1fca5583223893 \
+                    sha256  12f0b0e76999dac0dae8aad04aac12e1a137ba8bb62c7cc106c293df200f118e \
+                    size    9724
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Fast octet-vector/stream I/O for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-checkl \
+                    port:cl-fiveam \
+                    port:cl-static-vectors \
+                    port:cl-trivial-gray-streams
+
+# *** - DEFMETHOD: OUTPUT-STREAM-P does not name a generic function
+common_lisp.clisp   no

--- a/lisp/cl-fset/Portfile
+++ b/lisp/cl-fset/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        slburson fset 69c209e6eb15187da04f70ece3f800a6e3cc8639
+name                cl-fset
+version             20200622
+revision            0
+
+checksums           rmd160  b2c24731f526688870802953c920758ad000d0dd \
+                    sha256  3bd74f77bd1109cdd66887a8fec89a7613b55791cc43ab32ca269873ad197619 \
+                    size    125023
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         FSet, the functional collections library for Common Lisp.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-misc-extensions \
+                    port:cl-mt19937 \
+                    port:cl-named-readtables
+
+# See: https://github.com/slburson/fset/issues/42
+common_lisp.ecl     no
+common_lisp.clisp   no

--- a/lisp/cl-gendoc/Portfile
+++ b/lisp/cl-gendoc/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        rpav cl-gendoc c8fed7dd008a0cc34138521e45116e063aea33bd
+version             20180630
+revision            0
+
+checksums           rmd160  b2695d60bf99eecea0774b703f2bc13448743300 \
+                    sha256  0b2c9d0ab2242404114d56e5dfd232cfcf242eee364577fa47e960123b5ad321 \
+                    size    6239
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Simple modular documentation builder for with package reference generator
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-3bmd \
+                    port:cl-who

--- a/lisp/cl-introspect-environment/Portfile
+++ b/lisp/cl-introspect-environment/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Bike introspect-environment 8fb20a1a33d29637a22943243d1482a20c32d6ae
+name                cl-introspect-environment
+version             20220110
+revision            0
+
+checksums           rmd160  bc4c788ad69121426459e971d51ba6da58ef5502 \
+                    sha256  f4c4c1b9b9fbaa820559e4cdbca86193101c69a370b7322119913e172b523dde \
+                    size    9795
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             WTFPL
+
+description         CL environment introspection portability layer
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-fiveam
+
+# See: https://github.com/Bike/introspect-environment/issues/5
+common_lisp.ecl     no
+common_lisp.clisp   no

--- a/lisp/cl-language-codes/Portfile
+++ b/lisp/cl-language-codes/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera language-codes 358c1de9f2e0d6501aed8cb03030311a32849e0e
+name                cl-language-codes
+version             20230703
+revision            0
+
+checksums           rmd160  d09077f102fe75ac190148d9fb236d090aaad562 \
+                    sha256  3991fe74157341b1f4e827a49b9f177643296cc2926f9ba60adac7ee3e480fe5 \
+                    size    69778
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         A simple library mapping ISO language codes to language names.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-documentation-utils
+
+# See: https://github.com/Shinmera/language-codes/issues/3
+common_lisp.clisp   no

--- a/lisp/cl-let-plus/Portfile
+++ b/lisp/cl-let-plus/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        tpapp let-plus 7cf18b29ed0fe9c667a9a6a101b08ab9661a59e9
+name                cl-let-plus
+version             20180307
+revision            0
+
+checksums           rmd160  e27fc8d3bf326a6d92a48a33a675bf02a51fad74 \
+                    sha256  a18ce878308c2c6bb78d4630942b9abc5b3138553da67681f25635e87a074f6c \
+                    size    11152
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             Boost-1
+
+description         destructuring extension of let*
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-anaphora

--- a/lisp/cl-marshal/Portfile
+++ b/lisp/cl-marshal/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        wlbr cl-marshal 0e48cd4ef4ba1896d38ea0a87f376c1ff25eec71
+version             20200916
+revision            0
+
+checksums           rmd160  1e9aece9f45ddd9a615d6321b1ad314b3b4bf21e \
+                    sha256  c10f7511b8964b253d7da8296642834303aa5f724f50c2ef9237a9180cf48abd \
+                    size    12290
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Simple and fast serialization of all kinds of Common Lisp data structures.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-xlunit

--- a/lisp/cl-misc-extensions/Portfile
+++ b/lisp/cl-misc-extensions/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           common_lisp 1.0
+
+gitlab.instance     https://gitlab.common-lisp.net
+gitlab.setup        misc-extensions devel 101c05112bf2f1e1bbf527396822d2f50ca6327a
+name                cl-misc-extensions
+version             20120122
+revision            0
+
+checksums           rmd160  e8319291057781a66c5532797db372ccd973c33b \
+                    sha256  d5d735903669b55052fecf19048ae0314d4e28920d7c5001843e2b957d3e4ea7 \
+                    size    23596
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         Collection of small macros and extensions for Common Lisp
+
+long_description    {*}${description}

--- a/lisp/cl-mt19937/Portfile
+++ b/lisp/cl-mt19937/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           common_lisp 1.0
+
+gitlab.instance     https://gitlab.common-lisp.net
+gitlab.setup        nyxt mt19937 1.1
+name                cl-mt19937
+revision            0
+
+checksums           rmd160  75068f2e8654f7821857ca02fa80efd4d5692d30 \
+                    sha256  ac7f6011eab28657b2c6f58d2b068acee3dd0238a72ad2bada4cf5d4aeb82bd5 \
+                    size    5587
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         portable Mersenne Twister random number generator
+
+long_description    {*}${description}

--- a/lisp/cl-optima/Portfile
+++ b/lisp/cl-optima/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        m2ym optima 373b245b928c1a5cce91a6cb5bfe5dd77eb36195
+name                cl-optima
+version             20150628
+revision            0
+
+checksums           rmd160  1b6de68a4d3748f821d121bedf90409cf5580ba5 \
+                    sha256  3d08ba88a84c81c59ea6ccd006b4732b759f4308cd03b3f41bb271d7c16175e4 \
+                    size    20577
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Optimized Pattern Matching Library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-closer-mop \
+                    port:cl-eos \
+                    port:cl-ppcre

--- a/lisp/cl-proc-parse/Portfile
+++ b/lisp/cl-proc-parse/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi proc-parse 3afe2b76f42f481f44a0a495256f7abeb69cef27
+name                cl-proc-parse
+version             20190809
+revision            0
+
+checksums           rmd160  b7191adaeac32bfe3ae47eba87a20b4bccf0efd3 \
+                    sha256  2646c76b36d3b30178a5c527ee53eb2e22f50912a4dc3c8110b1a1194f14af0c \
+                    size    8700
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Procedural vector parser
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-babel \
+                    port:cl-prove

--- a/lisp/cl-prove/Portfile
+++ b/lisp/cl-prove/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi prove 5d71f02795b89e36f34e8c7d50e69b67ec6ca2de
+name                cl-prove
+version             20191231
+revision            0
+
+checksums           rmd160  e3bf95db362ef33a1dcf01b1173cfa575f228a88 \
+                    sha256  2736255e4dcfb6ecd44894b8663cf0e5eb794d9cf10c231c036c242f2c47acb2 \
+                    size    879574
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Yet another unit testing framework for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-ansi-text \
+                    port:cl-colors \
+                    port:cl-ppcre \
+                    port:cl-split-sequence
+
+post-extract {
+    # conflicts with cl-test-more port
+    file delete ${worksrcpath}/cl-test-more.asd
+}

--- a/lisp/cl-static-vectors/Portfile
+++ b/lisp/cl-static-vectors/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        sionescu static-vectors 87a447a8eaef9cf4fd1c16d407a49f9adaf8adad
+name                cl-static-vectors
+version             20220614
+revision            0
+
+checksums           rmd160  28993dc16bd65a6bd462f8f4c8551b16ff69e660 \
+                    sha256  d63285a395f231187d44a977d1a68c81dfe1f9bcfc34533f23fbd98e10ba5f97 \
+                    size    7100
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Allocate SIMPLE-ARRAYs in static memory
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-cffi \
+                    port:cl-fiveam
+
+# static vectors doesn't support CLisp
+common_lisp.clisp   no

--- a/lisp/cl-system-locale/Portfile
+++ b/lisp/cl-system-locale/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera system-locale 218e3149ee110a87b87a8f0b780141ae5933e7a9
+name                cl-system-locale
+version             20230703
+revision            0
+
+checksums           rmd160  e35f54377e8573d04cb67644796937db8724c487 \
+                    sha256  793c75dbe68e358168b88fd658ebdeebd602c7ae74ee2238c2ca2a64e0fbf6e7 \
+                    size    6291
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         System locale and language discovery
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-cffi \
+                    port:cl-documentation-utils

--- a/lisp/cl-test-more/Portfile
+++ b/lisp/cl-test-more/Portfile
@@ -21,3 +21,8 @@ description         Yet Another Unit Testing Framework for Common Lisp
 long_description    {*}${description}
 
 depends_lib-append  port:cl-ppcre
+
+notes "
+This is legacy version of Yet Another Unit Testing Framework for Common Lisp,\
+if you looking for version 2.0.0 it is available as cl-prove port.
+"

--- a/lisp/cl-trivia/Portfile
+++ b/lisp/cl-trivia/Portfile
@@ -42,6 +42,8 @@ depends_lib-append      port:cl-cffi \
                         port:cl-trivial-cltl2 \
                         port:cl-type-i
 
+depends_test-append     port:cl-fare-quasiquote
+
 # See: https://github.com/Bike/introspect-environment/issues/5
 common_lisp.ecl         no
 common_lisp.clisp       no

--- a/lisp/cl-trivia/Portfile
+++ b/lisp/cl-trivia/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            guicho271828 trivia 9e38bf25c46f44c31fde689cfee09cc0aaf36176
+name                    cl-trivia
+version                 20230302
+revision                0
+
+checksums               rmd160  5de9789dca927824da81808948e63a2ade6f9245 \
+                        sha256  13b60f0fec8f7f6654bcf548391965c99eb232e41eaefe20e8359ec187264096 \
+                        size    62128
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 LLGPL
+
+description             Pattern Matcher Compatible with Optima
+
+long_description        {*}${description}
+
+
+# :info:test Unhandled UIOP/LISP-BUILD:COMPILE-FILE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
+# :info:test                                                           {1004788113}>:
+# :info:test   COMPILE-FILE-ERROR while
+# :info:test   compiling #<CL-SOURCE-FILE "trivia.benchmark" "definitions">
+post-extract {
+    file delete ${worksrcpath}/trivia.benchmark.asd
+}
+
+# NOTE: trivia.quasiquote.asd depends on cl-fare-quasiquote-readtable which depends on this port
+common_lisp.build_run   no
+
+depends_lib-append      port:cl-cffi \
+                        port:cl-closer-mop \
+                        port:cl-fset \
+                        port:cl-iterate \
+                        port:cl-lisp-namespace \
+                        port:cl-ppcre \
+                        port:cl-trivial-cltl2 \
+                        port:cl-type-i
+
+# See: https://github.com/Bike/introspect-environment/issues/5
+common_lisp.ecl         no
+common_lisp.clisp       no

--- a/lisp/cl-trivial-indent/Portfile
+++ b/lisp/cl-trivial-indent/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera trivial-indent b5d490f9c619a8e9ec9e43fe76892e27d3e0f9a8
+name                cl-trivial-indent
+version             20230703
+revision            0
+
+checksums           rmd160  3e2f77aadd1bff703fddd5eb237414b307ef742f \
+                    sha256  385e9de100fc983803e4075188ebb692c34130748ed0364b4a7b25de7f6c3304 \
+                    size    3630
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         A very simple library to allow indentation hints for SWANK.
+
+long_description    {*}${description}

--- a/lisp/cl-type-i/Portfile
+++ b/lisp/cl-type-i/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            guicho271828 type-i 4407a6852e76e795f697180dfb01749b49cc7b0c
+name                    cl-type-i
+version                 20230127
+revision                0
+
+checksums               rmd160  100ff8c3bf26ee4e3154520b1baa7d7f456682f3 \
+                        sha256  037222cf6899331f7566bbb3129246175c2aceaa58660884aa334026502afd78 \
+                        size    6193
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 LLGPL
+
+description             Type Inference Utility on unary type-checking predicates
+
+long_description        {*}${description}
+
+# NOTE: cl-type-i depends on cl-trivia which depends on cl-type-i
+common_lisp.build_run   no
+depends_lib-append      port:cl-alexandria \
+                        port:cl-fiveam \
+                        port:cl-introspect-environment \
+                        port:cl-lisp-namespace \

--- a/lisp/cl-type-i/Portfile
+++ b/lisp/cl-type-i/Portfile
@@ -27,3 +27,5 @@ depends_lib-append      port:cl-alexandria \
                         port:cl-fiveam \
                         port:cl-introspect-environment \
                         port:cl-lisp-namespace \
+
+depends_test-append     port:cl-trivia

--- a/lisp/cl-vom/Portfile
+++ b/lisp/cl-vom/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        orthecreedence vom 1aeafeb5b74c53741b79497e0ef4acf85c92ff24
+name                cl-vom
+version             20160810
+revision            0
+
+checksums           rmd160  9f70b0a9cd4c54fcbbbd03eeac5c8399283040da \
+                    sha256  496d565f3ef88d2a0ff2265faa66128021900938a0377705e08710dd5e079115 \
+                    size    4312
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A tiny logging library for Common Lisp
+
+long_description    {*}${description}

--- a/lisp/cl-xlunit/Portfile
+++ b/lisp/cl-xlunit/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-xlunit
+version             0.6.3
+revision            0
+
+homepage            https://tracker.debian.org/cl-xlunit
+
+master_sites        debian:c/${name}/
+worksrcdir          ${name}-${version}
+distname            ${name}_${version}
+extract.suffix      .orig.tar.gz
+
+checksums           rmd160  5736563f100057e92480b76aa7ea7410d61c721a \
+                    sha256  7711a5b7a8f328f579884d2bd06d9352ac13b30b0cc36977d44213f7576d582e \
+                    size    7978
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         XLUnit is a Test Framework based on XPTest and JUnit.
+
+long_description    {*}${description}
+
+post-extract {
+    # :FORCE and :FORCE-NOT arguments not allowed in a nested call to ASDF/OPERATE:OPERATE unless identically to toplevel
+    reinplace {s| :force t||} ${worksrcpath}/xlunit.asd
+}
+
+livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
+livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
#### Description

Here the second portion of new lisp ports.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->