### PR TITLE
ntpsec: update to 1.2.2a, fixing crash bug

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -6,8 +6,8 @@ PortGroup           python 1.0
 PortGroup           openssl 1.0
 
 name                ntpsec
-version             1.2.2
-revision            1
+version             1.2.2a
+revision            0
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
 description         A secure, hardened, and improved implementation of NTP
@@ -20,9 +20,9 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  60b8c64a75d27d8e34db51c17050ccecc182f972 \
-                    sha256  2f2848760b915dfe185b9217f777738b36ceeb78a7fc208b7e74e039dec22df5 \
-                    size    2710329
+checksums           rmd160  a00b6cddeb16087bd2c139340142519f68fefd5b \
+                    sha256  e0ce93af222a0a9860e6f5a51aadba9bb5ca601d80b2aea118a62f0a3226950e \
+                    size    2710790
 
 # 10.5 x86_64 builds successfully and passes all build tests, but doesn't
 # actually work.  This has apparently been true forever, but until recently,
@@ -182,3 +182,6 @@ notes-append "Configuration is in ${prefix}/etc/ntp.conf."
 startupitem.create      yes
 startupitem.netchange   yes
 startupitem.executable  ${prefix}/sbin/ntpd -n -g -p ${prefix}/var/run/ntpd.pid -f ${prefix}/var/db/ntp.drift -c ${prefix}/etc/ntp.conf
+
+# Allow an optional letter after the version for patch releases
+livecheck.regex ${name}-(\\d+(?:\\.\\d+)*\\w+)

--- a/sysutils/ntpsec/files/patch-allfixes.diff
+++ b/sysutils/ntpsec/files/patch-allfixes.diff
@@ -1,5 +1,5 @@
 --- attic/backwards.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ attic/backwards.c	2022-12-30 00:59:15.000000000 -0800
++++ attic/backwards.c	2023-08-09 00:16:14.000000000 -0700
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -9,8 +9,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
---- attic/clocks.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ attic/clocks.c	2022-12-30 00:59:15.000000000 -0800
+--- attic/clocks.c.orig	2023-08-02 21:19:11.000000000 -0700
++++ attic/clocks.c	2023-08-09 00:16:14.000000000 -0700
 @@ -9,6 +9,8 @@
  #include <unistd.h>
  
@@ -20,8 +20,8 @@
  struct table {
    const int type;
    const char* name;
---- attic/cmac-timing.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ attic/cmac-timing.c	2022-12-30 00:59:15.000000000 -0800
+--- attic/cmac-timing.c.orig	2023-08-02 21:19:11.000000000 -0700
++++ attic/cmac-timing.c	2023-08-09 00:16:14.000000000 -0700
 @@ -35,6 +35,8 @@
  #include <openssl/params.h> 
  #endif
@@ -31,8 +31,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  
---- attic/digest-timing.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ attic/digest-timing.c	2022-12-30 00:59:15.000000000 -0800
+--- attic/digest-timing.c.orig	2023-08-02 21:19:11.000000000 -0700
++++ attic/digest-timing.c	2023-08-09 00:16:14.000000000 -0700
 @@ -33,6 +33,8 @@
  #include <openssl/ssl.h>
  #endif
@@ -42,8 +42,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  #ifndef EVP_MD_CTX_reset
---- attic/random.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ attic/random.c	2022-12-30 00:59:15.000000000 -0800
+--- attic/random.c.orig	2023-08-02 21:19:11.000000000 -0700
++++ attic/random.c	2023-08-09 00:16:14.000000000 -0700
 @@ -10,6 +10,8 @@
  #include <openssl/opensslv.h>    /* for OPENSSL_VERSION_NUMBER */
  #include <openssl/rand.h>
@@ -54,7 +54,7 @@
  #define BILLION 1000000000
  #define HISTSIZE 2500
 --- include/ntp_machine.h.orig	2022-12-22 22:08:52.000000000 -0800
-+++ include/ntp_machine.h	2022-12-30 00:59:15.000000000 -0800
++++ include/ntp_machine.h	2023-08-09 00:16:14.000000000 -0700
 @@ -13,14 +13,145 @@
  
  #ifndef CLOCK_REALTIME
@@ -208,7 +208,7 @@
  int ntp_set_tod (struct timespec *tvs);
  
 --- include/ntp_stdlib.h.orig	2022-12-22 22:08:52.000000000 -0800
-+++ include/ntp_stdlib.h	2022-12-30 00:59:15.000000000 -0800
++++ include/ntp_stdlib.h	2023-08-09 00:16:14.000000000 -0700
 @@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
@@ -220,7 +220,7 @@
  extern	const char * socktoa	(const sockaddr_u *);
  extern	const char * socktoa_r	(const sockaddr_u *sock, char *buf, size_t buflen);
 --- include/ntp_syscall.h.orig	2022-12-22 22:08:52.000000000 -0800
-+++ include/ntp_syscall.h	2022-12-30 00:59:15.000000000 -0800
++++ include/ntp_syscall.h	2023-08-09 00:16:14.000000000 -0700
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -234,7 +234,7 @@
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
 --- libntp/clockwork.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ libntp/clockwork.c	2022-12-30 00:59:15.000000000 -0800
++++ libntp/clockwork.c	2023-08-09 00:16:14.000000000 -0700
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -249,7 +249,7 @@
  #include "ntp.h"
  #include "ntp_machine.h"
 --- libntp/statestr.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ libntp/statestr.c	2022-12-30 00:59:15.000000000 -0800
++++ libntp/statestr.c	2023-08-09 00:16:14.000000000 -0700
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -350,8 +350,8 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ntpd/ntp_control.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpd/ntp_control.c	2022-12-30 00:59:15.000000000 -0800
+--- ntpd/ntp_control.c.orig	2023-08-02 21:19:11.000000000 -0700
++++ ntpd/ntp_control.c	2023-08-09 00:16:14.000000000 -0700
 @@ -1388,6 +1388,7 @@ ctl_putsys(
  	char str[256];
  	double dtemp;
@@ -476,7 +476,7 @@
  	case CS_K_PPS_FREQ:
  		CTL_IF_KERNPPS(
 --- ntpd/ntp_loopfilter.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpd/ntp_loopfilter.c	2022-12-30 00:59:15.000000000 -0800
++++ ntpd/ntp_loopfilter.c	2023-08-09 00:16:14.000000000 -0700
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -699,7 +699,7 @@
  }
 -
 --- ntpd/ntp_timer.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpd/ntp_timer.c	2022-12-30 00:59:15.000000000 -0800
++++ ntpd/ntp_timer.c	2023-08-09 00:16:14.000000000 -0700
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -723,7 +723,7 @@
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
 --- ntpd/refclock_local.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpd/refclock_local.c	2022-12-30 00:59:15.000000000 -0800
++++ ntpd/refclock_local.c	2023-08-09 00:16:14.000000000 -0700
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -747,7 +747,7 @@
  	refclock_receive(peer);
  }
 --- ntpfrob/precision.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpfrob/precision.c	2022-12-30 00:59:15.000000000 -0800
++++ ntpfrob/precision.c	2023-08-09 00:16:14.000000000 -0700
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -757,7 +757,7 @@
  #define	DEFAULT_SYS_PRECISION	-99
  
 --- tests/libntp/statestr.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ tests/libntp/statestr.c	2022-12-30 00:59:15.000000000 -0800
++++ tests/libntp/statestr.c	2023-08-09 00:16:14.000000000 -0700
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -779,7 +779,7 @@
  
  // statustoa
 --- wafhelpers/bin_test.py.orig	2022-12-22 22:08:52.000000000 -0800
-+++ wafhelpers/bin_test.py	2022-12-30 00:59:15.000000000 -0800
++++ wafhelpers/bin_test.py	2023-08-09 00:16:14.000000000 -0700
 @@ -103,6 +103,12 @@ def cmd_bin_test(ctx):
      if ctx.env['PYTHON_CURSES']:
          cmd_map_python.update(cmd_map_python_curses)
@@ -793,8 +793,8 @@
      for cmd in sorted(cmd_map):
          if not run(cmd, cmd_map[cmd] % version):
              fails += 1
---- wafhelpers/options.py.orig	2022-12-22 22:08:52.000000000 -0800
-+++ wafhelpers/options.py	2022-12-30 00:59:15.000000000 -0800
+--- wafhelpers/options.py.orig	2023-08-02 21:19:11.000000000 -0700
++++ wafhelpers/options.py	2023-08-09 00:16:14.000000000 -0700
 @@ -23,6 +23,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -804,8 +804,8 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- wscript.orig	2022-12-22 22:08:52.000000000 -0800
-+++ wscript	2022-12-30 00:59:15.000000000 -0800
+--- wscript.orig	2023-08-02 21:19:11.000000000 -0700
++++ wscript	2023-08-09 00:16:14.000000000 -0700
 @@ -585,7 +585,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),


### PR DESCRIPTION
This release is a focused update to 1.2.2, addressing an issue related to (but not quite the same as):

     https://gitlab.com/NTPsec/ntpsec/-/issues/794

Also fixes the livecheck for patch updates (like this one), by allowing an optional single letter after the version number.

As usual, this includes the patches for compatibility with macOS<10.13, which can also be seen (more readably) at:

    https://gitlab.com/fhgwright/ntpsec/tree/macports-1_2_2a

The patchfile is renormalized for the current mtimes, but not substantively changed.

Note that 10.5 x86_64 remains broken and is disabled, as is the untested 10.4 x86_64.

TESTED:
Built and ran tests with all variants on 10.4-10.5 ppc, 10.4-10.6 i386, 10.6-10.15 x86_64, and 11.x-13.x arm64.  Successful except where pythonXY was unavailable or broken on the OS/CPU combination.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.8 20G1351, arm64, Xcode 13.2.1 13C100
macOS 12.6.7 21G651, arm64, Xcode 14.2 14C18
macOS 13.4.1 22F82, arm64, Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
