### PR TITLE
Lisp new ports 3

### DIFF
--- a/_resources/port1.0/group/common_lisp-1.0.tcl
+++ b/_resources/port1.0/group/common_lisp-1.0.tcl
@@ -105,6 +105,10 @@ pre-build {
     common_lisp::respect_threads_support
 }
 
+pre-test {
+    common_lisp::respect_threads_support
+}
+
 build {
     file delete -force ${common_lisp.build}/source
     file delete -force ${common_lisp.build}/system

--- a/_resources/port1.0/group/common_lisp-1.0.tcl
+++ b/_resources/port1.0/group/common_lisp-1.0.tcl
@@ -124,7 +124,7 @@ build {
 
     if {[option common_lisp.build_run]} {
         foreach item [glob -dir ${common_lisp.build}/system -tails *.asd] {
-            common_lisp::asdf_operate "load-op" [string range ${item} 0 end-4]
+            common_lisp::asdf_operate "build-op" [string range ${item} 0 end-4]
         }
     }
  }

--- a/lisp/cl-calispel/Portfile
+++ b/lisp/cl-calispel/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-calispel
+version             0.1
+revision            0
+
+checksums           rmd160  c2fcacd195ffa7946a0d91e5324ee62a65e058c8 \
+                    sha256  0e37263b766f7583854939af0b34a734743d0d22f63b1927eedf94dfdad98efc \
+                    size    26302
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             ISC
+
+homepage            https://www.thoughtcrime.us/software/calispel
+master_sites        ${homepage}
+distname            calispel-${version}
+
+description         Calispel is a Common Lisp library for thread-safe message-passing channels, in the style of the occam programming language.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-eager-future \
+                    port:cl-jpl-queues \
+                    port:cl-jpl-util
+
+common_lisp.threads yes
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     calispel-(\[\\d.\]+)${extract.suffix}

--- a/lisp/cl-clsql/Portfile
+++ b/lisp/cl-clsql/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               common_lisp 1.0
+
+name                    cl-clsql
+version                 6.7.0
+revision                0
+
+checksums               rmd160  bee90661e8e3f5685493604755fbe1391d2f7e2c \
+                        sha256  0b5fe43da00ebc0333c1a8f9ccbaefe11b03154c8444366aada8b3dc86fafb2f \
+                        size    967249
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+homepage                https://clsql.kpe.io
+master_sites            http://files.kpe.io/clsql/
+distname                clsql-${version}
+
+description             A multi-platform SQL interface for Common Lisp
+
+long_description        {*}${description}
+
+# To build and test it we must guess and add all supported DB into library.
+# That seems useless => disable tests and build and install only lisp files.
+common_lisp.build_run   no
+test.run                no
+
+depends_lib-append      port:cl-uffi \
+                        port:cl-postmodern
+
+livecheck.type          regex
+livecheck.url           ${master_sites}
+livecheck.regex         clsql-(\[\\d.\]+)${extract.suffix}

--- a/lisp/cl-difflib/Portfile
+++ b/lisp/cl-difflib/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        wiseman cl-difflib 98eb335c693f1881584b83ca7be4a0fe05355c4e
+version             20090602
+revision            0
+
+checksums           rmd160  74adcfe1abb710601d4c96c9bc2566b5d47fe949 \
+                    sha256  107d72f7cd35fed674b06450dc1ce02c89332049cdfc0d9502d80a5c559628bf \
+                    size    11977
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A Common Lisp library for computing differences between sequences based on the Python difflib module.
+
+long_description    {*}${description}
+
+patchfiles-append   ASDFv3-test-syntax.diff

--- a/lisp/cl-difflib/files/ASDFv3-test-syntax.diff
+++ b/lisp/cl-difflib/files/ASDFv3-test-syntax.diff
@@ -1,0 +1,53 @@
+https://github.com/wiseman/cl-difflib/pull/1
+
+diff --git cl-difflib-tests.asd cl-difflib-tests.asd
+index 03ed39d..7cc9c91 100644
+--- cl-difflib-tests.asd
++++ cl-difflib-tests.asd
+@@ -18,9 +18,7 @@
+ 
+ (asdf:defsystem :cl-difflib-tests
+     :depends-on (:cl-difflib)
+-    :components ((:file "unit-tests")))
+-
+-(defmethod asdf:perform ((o asdf:test-op) (c (eql (find-system :cl-difflib-tests))))
+-  (or (funcall (intern (symbol-name '#:run-tests)
+-                       (find-package '#:difflib-test)))
+-      (error "test-op failed")))
++    :components ((:file "unit-tests"))
++    :perform (test-op (o s)
++                      (unless (uiop:symbol-call :difflib-test '#:run-tests)
++                        (error "test-op failed"))))
+diff --git cl-difflib.asd cl-difflib.asd
+index 88ab74c..9389a56 100644
+--- cl-difflib.asd
++++ cl-difflib.asd
+@@ -22,12 +22,8 @@
+     :description "A Lisp library for computing differences between sequences."
+     :long-description "A Lisp library for computing differences between sequences.  Based on Python's difflib module."
+     
++    :in-order-to ((test-op (test-op "cl-difflib-tests")))
+     :components ((:file "package")
+ 		 (:file "difflib" :depends-on ("package"))
+ 		 (:static-file "LICENSE.txt")
+ 		 (:static-file "NEWS.txt")))
+-
+-
+-(defmethod perform ((o test-op) (c (eql (find-system 'cl-difflib))))
+-  (oos 'load-op 'cl-difflib-tests)
+-  (oos 'test-op 'cl-difflib-tests :force t))
+\ No newline at end of file
+diff --git unit-tests.lisp unit-tests.lisp
+index 6a9ee41..23fbb04 100644
+--- unit-tests.lisp
++++ unit-tests.lisp
+@@ -99,7 +99,8 @@
+ 	(test-similarity-ratio)
+ 	(test-close-matches)
+ 	(test-unified-diff)
+-	(test-context-diff))
++	(test-context-diff)
++        (null *failed-tests*))
+     (end-tests)))
+ 
+ 

--- a/lisp/cl-documentation-utils/Portfile
+++ b/lisp/cl-documentation-utils/Portfile
@@ -25,5 +25,7 @@ long_description        {*}${description}
 common_lisp.build_run   no
 
 depends_lib-append      port:cl-trivial-indent
+depends_test-append     port:cl-multilang-documentation
 
-test.run                no
+# See: https://github.com/Shinmera/language-codes/issues/3
+common_lisp.clisp   no

--- a/lisp/cl-eager-future/Portfile
+++ b/lisp/cl-eager-future/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-eager-future
+version             0.4
+revision            0
+
+checksums           rmd160  3837407f973411bec04695fc742e4bd6895a0901 \
+                    sha256  86293331f58b2b9f5ddabdfa72bf7d68d2619fa40c61e9575bf4d4338b9273fe \
+                    size    5474
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             ISC
+
+homepage            https://eager-future.common-lisp.dev
+master_sites        ${homepage}/release
+distname            eager-future-${version}
+extract.suffix      .tgz
+
+description         Eager Future is a Common Lisp library that provides composable concurrency primitives
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads
+
+common_lisp.threads yes
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     eager-future-(\[\\d.\]+)${extract.suffix}

--- a/lisp/cl-eager-future2/Portfile
+++ b/lisp/cl-eager-future2/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-eager-future2
+version             0.2
+revision            0
+
+checksums           rmd160  db0fb46b435b8c2e413723ecf1739d0f7238adde \
+                    sha256  cb8b90dfa0642153d83892d7edc3fd1be6c63e64c96e85a0fd399da481691a2a \
+                    size    17758
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             ISC
+
+homepage            https://eager-future.common-lisp.dev
+master_sites        ${homepage}/release
+distname            eager-future2-${version}
+extract.suffix      .tgz
+
+description         Eager Future2 is a Common Lisp library that provides composable concurrency primitives
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-eos \
+                    port:cl-trivial-garbage
+
+common_lisp.threads yes
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     eager-future2-(\[\\d.\]+)${extract.suffix}

--- a/lisp/cl-form-fiddle/Portfile
+++ b/lisp/cl-form-fiddle/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera form-fiddle 3bd0dfdae8f83918fce6cb4a05826bd325da401d
+name                cl-form-fiddle
+version             20230703
+revision            0
+
+checksums           rmd160  122042add92557870fde99901f064953bae3227a \
+                    sha256  8079465f2e746d722d873a10fbd20b97fbcd66521047016bc90f16d9f5df5e11 \
+                    size    5701
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         A collection of utilities to destructure lambda forms.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-documentation-utils

--- a/lisp/cl-gopher/Portfile
+++ b/lisp/cl-gopher/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        knusbaum cl-gopher 15b7528b28a2b9f113a2bd944ba1761ec5055794
+version             20230804
+revision            0
+
+checksums           rmd160  5db50ece6419d7010d09d867355922a741c2fd8c \
+                    sha256  618122780a6180e228094f61d3b0d57f9122bbcbf92a89b0b1a0df58a580f9ae \
+                    size    10575
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Yet another URI library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-drakma \
+                    port:cl-flexi-streams \
+                    port:cl-quri \
+                    port:cl-usocket
+
+common_lisp.threads yes

--- a/lisp/cl-html-diff/Portfile
+++ b/lisp/cl-html-diff/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        wiseman cl-html-diff 5a0b39d1c524278d6f60851d7786bb2585614310
+version             20090528
+revision            0
+
+checksums           rmd160  1726d6393c1aafc12c27d38bacac4088a9e47c27 \
+                    sha256  bd2e27fb79457e1f64fd0c40776be345ed8be8a06848b67d8a417e703501ab9e \
+                    size    4162
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A Common Lisp library for generating a human-readable diff of two HTML documents.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-difflib

--- a/lisp/cl-jonathan/Portfile
+++ b/lisp/cl-jonathan/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        rudolph-miller jonathan fb83ff094d330b2208b0febc8b25983c6050e378
+name                cl-jonathan
+version             20200902
+revision            0
+
+checksums           rmd160  0e6880cb7afacc3e5dd131342fde766c47211b6c \
+                    sha256  4d001d2cf9244c53884ad46066581861e96683c374c1e0fcc8d15a26acf394b1 \
+                    size    160689
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         JSON encoder and decoder.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-annot \
+                    port:cl-babel \
+                    port:cl-fast-io \
+                    port:cl-legion \
+                    port:cl-ppcre \
+                    port:cl-proc-parse \
+                    port:cl-syntax \
+                    port:cl-trivial-types
+
+common_lisp.threads yes

--- a/lisp/cl-jpl-queues/Portfile
+++ b/lisp/cl-jpl-queues/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-jpl-queues
+version             0.1
+revision            0
+
+checksums           rmd160  963739bad227edb1fb9241fbb3340a7b5732ad81 \
+                    sha256  264173a84cf385d08ccdc0e8a3714722ca4aa0232f48850551099e10e4d97bf3 \
+                    size    15113
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             ISC
+
+homepage            https://www.thoughtcrime.us/software/jpl-queues
+master_sites        ${homepage}
+distname            jpl-queues-${version}
+
+description         Common Lisp library implementing a few different kinds of queues
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-jpl-util
+
+common_lisp.threads yes
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     jpl-queues-(\[\\d.\]+)${extract.suffix}

--- a/lisp/cl-jpl-util/Portfile
+++ b/lisp/cl-jpl-util/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-jpl-util
+version             0.4
+revision            0
+
+checksums           rmd160  3d4e0ffdbe7e5f7c11b2a01cd75e7046ba539d22 \
+                    sha256  90e741b78b59c16bb00370bbd232360dfdb32e6f594649e2863dcdaf83b157a6 \
+                    size    36051
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             ISC
+
+homepage            https://www.thoughtcrime.us/software/cl-jpl-util
+master_sites        ${homepage}
+
+description         cl-jpl-util is a collection of Common Lisp utility functions and macros, primarily for software projects by J.P. Larocque
+
+long_description    {*}${description}
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     ${name}-(\[\\d.\]+)${extract.suffix}

--- a/lisp/cl-json/Portfile
+++ b/lisp/cl-json/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        hankhero cl-json 6dfebb9540bfc3cc33582d0c03c9ec27cb913e79
+version             20141108
+revision            0
+
+checksums           rmd160  2021c1361cccad3d4c32ed6bcf8f68d52128e76d \
+                    sha256  7144b2b5101ea0c4396e352024c8789e5f8509410d860bb79170cbca0926f3c8 \
+                    size    62050
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Json encoder and decoder for Common-Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-fiveam

--- a/lisp/cl-legion/Portfile
+++ b/lisp/cl-legion/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi legion 599cca19f0e34246814621f7fe90322221c2e263
+name                cl-legion
+version             20171116
+revision            0
+
+checksums           rmd160  41bc58205cf31cde951ad0ece7e3a049e949cf0d \
+                    sha256  cb45a18ca39b03753218e6906eabdbfc243abb716fde3483f697a495f6005755 \
+                    size    6323
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Simple multithreading worker mechanism.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-local-time \
+                    port:cl-prove \
+                    port:cl-speedy-queue \
+                    port:cl-vom
+
+common_lisp.threads yes
+
+# Test depends on machine => switch it off
+# See: https://github.com/fukamachi/legion/issues/4
+test.run            no

--- a/lisp/cl-local-time/Portfile
+++ b/lisp/cl-local-time/Portfile
@@ -27,7 +27,7 @@ common_lisp.build_run   no
 depends_lib-append      port:cl-fad \
                         port:cl-hu.dwim.stefil
 
+depends_test-append     port:cl-postmodern
+
 # cl-postmodern requires threads
 common_lisp.threads     yes
-
-test.run                no

--- a/lisp/cl-local-time/Portfile
+++ b/lisp/cl-local-time/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            dlowe-net local-time 40169fe26d9639f3d9560ec0255789bf00b30036
+name                    cl-local-time
+version                 20221106
+revision                0
+
+checksums               rmd160  78410dc3f9f0168bd11a232b98018602ccc74b37 \
+                        sha256  515d7e47d68733232cb289b1ed2b46d42128ea68b7b0cb7654b013adc1a58ef7 \
+                        size    680782
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 BSD
+
+description             Time manipulation library for Common Lisp
+
+long_description        {*}${description}
+
+# cl-local-time depends on cl-postmodern which depends on cl-local-time
+common_lisp.build_run   no
+
+depends_lib-append      port:cl-fad \
+                        port:cl-hu.dwim.stefil
+
+# cl-postmodern requires threads
+common_lisp.threads     yes
+
+test.run                no

--- a/lisp/cl-metabang-bind/Portfile
+++ b/lisp/cl-metabang-bind/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gwkkwg metabang-bind 08196426cb099db0623e6cae2aeca566e0b788b2
+version             20230508
+name                cl-metabang-bind
+revision            0
+
+checksums           rmd160  6ec569ef5dc8930c79a90955047e2d32bccdc69b \
+                    sha256  8805c55dcfe612552aff382709d0c0d88f978263dbdc1a8de0dbca36781e7ec1 \
+                    size    22966
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         bind is let and much much more
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-lift
+
+#  *** - PROBE-FILE: No file name given:
+common_lisp.clisp   no

--- a/lisp/cl-moptilities/Portfile
+++ b/lisp/cl-moptilities/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gwkkwg moptilities a436f16b357c96b82397ec018ea469574c10dd41
+name                cl-moptilities
+version             20170330
+revision            0
+
+checksums           rmd160  f04d204d35968279de1a3682fc11eeda67c50d3b \
+                    sha256  8f7d8b0806157810e87dc696c03f2aea04a2fc4fee08f7c810f8aaf48cd86406 \
+                    size    15816
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         compatibility layer for minor MOP implementation differences
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-closer-mop \
+                    port:cl-lift
+
+# :info:test Error while running (BUILD-REPORT) from /opt/local/var/macports/build/_Users_catap_src_macports-ports_lisp_cl-moptilities/cl-moptilities/work/build/source/cl-moptilities/
+# lift-standard.config: Can't create directory /opt/local/share/common-lisp/source/cl-lift/test-results
+test.run            no

--- a/lisp/cl-multilang-documentation/Portfile
+++ b/lisp/cl-multilang-documentation/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera multilang-documentation aa0c7d14f59cbddcfcb6c6bedc3904fe95d654cf
+name                cl-multilang-documentation
+version             20230703
+revision            0
+
+checksums           rmd160  c552d2d2edad5639af211d316fd7d012c24b8214 \
+                    sha256  a16ea4e1570419a8809c333f9f9caf5b96bb052eff432b8b05af8bcac25ed51d \
+                    size    7461
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         A drop-in replacement for cl:documentation with support for multiple languages.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-documentation-utils \
+                    port:cl-language-codes \
+                    port:cl-system-locale
+
+# See: https://github.com/Shinmera/language-codes/issues/3
+common_lisp.clisp   no

--- a/lisp/cl-parachute/Portfile
+++ b/lisp/cl-parachute/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera parachute 6c47ea46f234d62234dbb5fbf92df81de4d06a43
+name                cl-parachute
+version             20230703
+revision            0
+
+checksums           rmd160  1c4cba07d3ec5a6cc3eb9465602c1f3316529808 \
+                    sha256  759e689a7e8eeb95fa47d580cffd388fb1113e39247f05c57f2fd9cb69e8fa60 \
+                    size    60621
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         Common lisp implementation of unicode normalization functions
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-documentation-utils \
+                    port:cl-form-fiddle \
+                    port:cl-trivial-custom-debugger

--- a/lisp/cl-postmodern/Portfile
+++ b/lisp/cl-postmodern/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        marijnh Postmodern 1.33.8 v
+name                cl-postmodern
+revision            0
+
+checksums           rmd160  27286c1230006b4a09cbee1bce7392e66c2ab12a \
+                    sha256  c20e350efb57b61f69520b2e93563e1c4322b946ee0f534c080d9040d801d590 \
+                    size    581561
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT BSD
+
+description         A Common Lisp PostgreSQL programming interface
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-base64 \
+                    port:cl-bordeaux-threads \
+                    port:cl-closer-mop \
+                    port:cl-fiveam \
+                    port:cl-global-vars \
+                    port:cl-ironclad \
+                    port:cl-local-time \
+                    port:cl-md5 \
+                    port:cl-split-sequence \
+                    port:cl-uax-15 \
+                    port:cl-usocket
+
+patchfiles-append   ecl-usocket.diff
+
+common_lisp.threads yes
+
+# Tests requires real PostgreSQL
+test.run            no

--- a/lisp/cl-postmodern/files/ecl-usocket.diff
+++ b/lisp/cl-postmodern/files/ecl-usocket.diff
@@ -1,0 +1,15 @@
+https://github.com/marijnh/Postmodern/pull/322
+
+diff --git cl-postgres.asd cl-postgres.asd
+index 68a755b..d55d98f 100644
+--- cl-postgres.asd
++++ cl-postgres.asd
+@@ -19,7 +19,7 @@
+   :version "1.33.8"
+   :depends-on ("md5" "split-sequence" "ironclad" "cl-base64" "uax-15"
+                      (:feature (:or :allegro :ccl :clisp :genera
+-                                :armedbear :cmucl :lispworks)
++                                :armedbear :cmucl :lispworks :ecl)
+                                "usocket")
+                      (:feature :sbcl (:require :sb-bsd-sockets)))
+   :components

--- a/lisp/cl-quri/Portfile
+++ b/lisp/cl-quri/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi quri 0.7.0
+name                cl-quri
+revision            0
+
+checksums           rmd160  c4f71fc49107c1f5c153fb35fb60ffd65628bdc1 \
+                    sha256  ad7b231a5862dfe923a6b128ab21e3a24643d88947a7d0a575e93f12ef6d55c4 \
+                    size    72686
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Yet another URI library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-babel \
+                    port:cl-prove \
+                    port:cl-split-sequence \
+                    port:cl-utilities

--- a/lisp/cl-s-sysdeps/Portfile
+++ b/lisp/cl-s-sysdeps/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        svenvc s-sysdeps 7f8de283b7fbd8b038fdf08493063a736db36ce7
+name                cl-s-sysdeps
+version             20210202
+revision            0
+
+checksums           rmd160  158b1dde3de1609d7ef5a5aee6d96f25bc502b4a \
+                    sha256  e32585984715db6cc8802a08614e40b1cccbe18d14f7f42ce0109806f8280cd4 \
+                    size    4476
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         A Common Lisp abstraction layer over platform dependent functionality.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-usocket
+
+common_lisp.threads yes

--- a/lisp/cl-s-xml/Portfile
+++ b/lisp/cl-s-xml/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           common_lisp 1.0
+
+gitlab.instance     https://gitlab.common-lisp.net
+gitlab.setup        s-xml s-xml 194cceaf90fb1a268d63f25f9b36e570af07cfb1
+name                cl-s-xml
+version             20080215
+revision            0
+
+checksums           rmd160  96f20526fdeb894ae95695a557e2893177dbdee9 \
+                    sha256  6d4b7c1fc4472a9d870dc3b7d0f88b6fa5654cd9de083a8fa7b8cc7a490ab577 \
+                    size    20190
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+homepage            https://s-xml.common-lisp.dev
+
+description         S-XML is a simple XML parser implemented in Common Lisp
+
+long_description    {*}${description}

--- a/lisp/cl-speedy-queue/Portfile
+++ b/lisp/cl-speedy-queue/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        zkat cl-speedy-queue 0425c7c62ad3b898a5ec58cd1b3e74f7d91eec4b
+version             20110928
+revision            0
+
+checksums           rmd160  40846dd5038a679ec4f95f9ce99996c73106f87d \
+                    sha256  e7094be155114c8f3fc1e3af56c048e95ea2af604384068de3c5fb030d1b1e18 \
+                    size    3649
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Lightweight, optimized queue implementation for CL
+
+long_description    {*}${description}

--- a/lisp/cl-stefil/Portfile
+++ b/lisp/cl-stefil/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           common_lisp 1.0
+
+gitlab.instance     https://gitlab.common-lisp.net
+gitlab.setup        stefil stefil 2008-11-27
+name                cl-stefil
+revision            0
+
+checksums           rmd160  836526b318befd74157cc13ccaf16b6c6f37338c \
+                    sha256  e2d4b1e9642311007ece938b1166701d059b13bffa1b0d265f1aa9a1b1fce53f \
+                    size    16330
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         Stefil - Simple Test Framework In Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-iterate \
+                    port:cl-metabang-bind \
+                    port:cl-swank
+
+# SBCL comply for styles
+common_lisp.sbcl    no

--- a/lisp/cl-syntax/Portfile
+++ b/lisp/cl-syntax/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        m2ym cl-syntax 03f0c329bbd55b8622c37161e6278366525e2ccc
+version             20150315
+revision            0
+
+checksums           rmd160  b4634ca96962417bde876bf07b79458a02141d30 \
+                    sha256  5b50d5a1fc0345c741dbac862def99562a8c574814cd5390afe3bb91c6f90082 \
+                    size    3186
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Reader Syntax Coventions for Common Lisp and SLIME
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-annot \
+                    port:cl-anonfun \
+                    port:cl-clsql \
+                    port:cl-fare-quasiquote \
+                    port:cl-interpol \
+                    port:cl-markup \
+                    port:cl-named-readtables \
+                    port:cl-trivial-types
+
+# cl-clsql is SBCL only port
+common_lisp.clisp   no
+common_lisp.ecl     no

--- a/lisp/cl-trivial-custom-debugger/Portfile
+++ b/lisp/cl-trivial-custom-debugger/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            phoe trivial-custom-debugger a560594a673bbcd88136af82086107ee5ff9ca81
+name                    cl-trivial-custom-debugger
+version                 20200805
+revision                0
+
+checksums               rmd160  5e459045e151b63ec12a5981573e1991cdc55c85 \
+                        sha256  e51fcd5f03e7754040d95c4b7ee284f5046fed23bb683d6c25eba1e95ddf61e8 \
+                        size    3720
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+description             Allows arbitrary functions to become the standard Lisp debugger
+
+long_description        {*}${description}
+
+# NOTE: cl-trivial-custom-debugger depends on cl-parachute which depends on this port
+common_lisp.build_run   no
+
+test.run                no

--- a/lisp/cl-trivial-custom-debugger/Portfile
+++ b/lisp/cl-trivial-custom-debugger/Portfile
@@ -24,4 +24,8 @@ long_description        {*}${description}
 # NOTE: cl-trivial-custom-debugger depends on cl-parachute which depends on this port
 common_lisp.build_run   no
 
-test.run                no
+depends_test-append     port:cl-parachute
+
+# See: https://github.com/phoe/trivial-custom-debugger/issues/3
+common_lisp.ecl         no
+common_lisp.clisp       no

--- a/lisp/cl-uax-15/Portfile
+++ b/lisp/cl-uax-15/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        sabracrolleton uax-15 0.1.3 v
+name                cl-uax-15
+revision            0
+
+checksums           rmd160  7f8b0d23d5390a444dd2147ae5c68bd68e574794 \
+                    sha256  fab8157dde9c3bf428edfe2f71288dc56f17f7e79f65fdeb72f9a49bf8c61bec \
+                    size    856637
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Common lisp implementation of unicode normalization functions
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-parachute \
+                    port:cl-ppcre \
+                    port:cl-split-sequence

--- a/lisp/cl-usocket/Portfile
+++ b/lisp/cl-usocket/Portfile
@@ -16,7 +16,7 @@ categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer
 license             MIT
 
-description         A Common Lisp interface to OpenSSL / LibreSSL
+description         Universal socket library for Common Lisp
 
 long_description    {*}${description}
 

--- a/lisp/cl-utilities/Portfile
+++ b/lisp/cl-utilities/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           common_lisp 1.0
+
+gitlab.instance     https://gitlab.common-lisp.net
+gitlab.setup        cl-utilities cl-utilities dce2d2f6387091ea90357a130fa6d13a6776884b
+version             20060303
+revision            0
+
+checksums           rmd160  7d6a2d65e60fd0953ce11ff6237020f56d3fee0d \
+                    sha256  2901007ce8d78a34e53e8dfe575f52830ddd6beefef7b2a04e5040ca4f5a44b2 \
+                    size    22032
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+homepage            https://cl-utilities.common-lisp.dev
+
+description         a collection of semi-standard utilities for Common Lisp
+
+long_description    {*}${description}


### PR DESCRIPTION
#### Description

Here the third portion of new lisp ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->