### PR TITLE
Lisp new ports 4

### DIFF
--- a/lisp/cl-assoc-utils/Portfile
+++ b/lisp/cl-assoc-utils/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi assoc-utils 483a22ef42995f84fac00d11fb27ace671480153
+name                cl-assoc-utils
+version             20220921
+revision            0
+
+checksums           rmd160  61d8adc6a0645cb615356c6f2b56e60bb9cb463b \
+                    sha256  aecbf31603a1633931c6dcd329e9851be209db46506d38ce2ba9d6e9d6d80bac \
+                    size    3515
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         Utilities for manipulating association lists
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-prove

--- a/lisp/cl-circular-streams/Portfile
+++ b/lisp/cl-circular-streams/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi circular-streams e770bade1919c5e8533dd2078c93c3d3bbeb38df
+name                cl-circular-streams
+version             20161202
+revision            0
+
+checksums           rmd160  78d36f7cfba4722092fb1b98a5ab8803c18ee0c1 \
+                    sha256  b0d19362c3f0d3155d47c16b0248e4132b10bbae764b51df2fe65f1f59c21387 \
+                    size    3374
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Circularly readable streams for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-fast-io \
+                    port:cl-flexi-streams \
+                    port:cl-test-more \
+                    port:cl-trivial-gray-streams
+
+# *** - DEFMETHOD: OUTPUT-STREAM-P does not name a generic function
+common_lisp.clisp   no

--- a/lisp/cl-containers/Portfile
+++ b/lisp/cl-containers/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gwkkwg cl-containers cc491c299ebeb607a875e119a826b3acd4e2b3bf
+version             20230111
+revision            0
+
+checksums           rmd160  67a51fdc41834522f6ef569f31a3307a8ef67b43 \
+                    sha256  a109b8539d1a28a6ee8bd69d27623b7d427309abb3a334eb1c7c5e302dcf35ad \
+                    size    232507
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Containers Library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-metatilities \
+                    port:cl-metatilities-base \
+                    port:cl-metacopy \
+                    port:cl-lift \
+                    port:cl-variates
+
+# cl-containers-documentation.asd: don't recognize component type :DOCUDOWN-SOURCE
+post-extract {
+    file delete -force ${worksrcpath}/cl-containers-documentation.asd
+}
+
+# *** - PROBE-FILE: No file name given:
+common_lisp.clisp   no

--- a/lisp/cl-contextl/Portfile
+++ b/lisp/cl-contextl/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        pcostanza contextl f4fb3f59b0844788613fc4d1cc0d2b08df9488bb
+name                cl-contextl
+version             20211216
+revision            0
+
+checksums           rmd160  61e16eb89fc86706a8576336749f6f555955dc60 \
+                    sha256  b91bed29f6179be2b128adca1d9ae87c0b5d696d6b49e79a7350b905698f13cf \
+                    size    26767
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         ContextL is a CLOS extension for Context-oriented Programming (COP)
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-closer-mop \
+                    port:cl-lw-compat
+
+# See: https://github.com/pcostanza/contextl/issues/2
+common_lisp.ecl     no
+common_lisp.clisp   no

--- a/lisp/cl-cookie/Portfile
+++ b/lisp/cl-cookie/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi cl-cookie e6babbf57c9c6e0b6998a5b5ecaea8fa59f88296
+version             20220620
+revision            0
+
+checksums           rmd160  48a4a1fd0a83f2546989927fc12004180b9866c3 \
+                    sha256  29367a5e1e5c3512efa9a99574730035a7b2295b9dc77321b6090d3f939a0c56 \
+                    size    5404
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         HTTP cookie manager for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-local-time \
+                    port:cl-ppcre \
+                    port:cl-proc-parse \
+                    port:cl-prove \
+                    port:cl-quri

--- a/lisp/cl-dbi/Portfile
+++ b/lisp/cl-dbi/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi cl-dbi 3d4b48c7b6736a4257043cde60687614775714d6
+version             20230417
+revision            0
+
+checksums           rmd160  ab006654ea419289995bb8c3a4b2e5ef4ab617f3 \
+                    sha256  f5eb74204be7db60dc2f30c519a8e1eb540b7e6a9cdb1915e77eb35d5593ad90 \
+                    size    19522
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Database independent interface for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-closer-mop \
+                    port:cl-mysql \
+                    port:cl-postmodern \
+                    port:cl-rove \
+                    port:cl-sqlite \
+                    port:cl-trivial-garbage \
+                    port:cl-trivial-types
+
+# Build and tests requires real MySQL and PostgreSQL
+common_lisp.build_run   no
+test.run                no
+
+common_lisp.threads yes

--- a/lisp/cl-dissect/Portfile
+++ b/lisp/cl-dissect/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera dissect b7bf9b933589ff848497adcffe703013c99aa8de
+name                cl-dissect
+version             20230804
+revision            0
+
+checksums           rmd160  1f80af8bedc6034284731f80c8a5f03a27af9c06 \
+                    sha256  55f9318fb1f2e21bb59fc121f94d4ac20094f11b9559a0b3065f0bd91af156d4 \
+                    size    28395
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         A lib for introspecting the call stack and active restarts.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-ppcre

--- a/lisp/cl-docudown/Portfile
+++ b/lisp/cl-docudown/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-docudown
+version             0.1.1
+revision            0
+
+checksums           rmd160  775cc1857856de12f5278df323159c8f97c84edb \
+                    sha256  aaa888344871132d87fcfe16ae8345547877208061f6ea911883f4de6f2a4c51 \
+                    size    21490
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+homepage            https://cliki.net/docudown
+master_sites        https://common-lisp.net/project/docudown
+distname            docudown
+
+description         Docudown is a Lisp documentation tool built on top of CL-Markdown
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-markdown \
+                    port:cl-moptilities \
+                    port:cl-lift
+
+# See: https://github.com/gwkkwg/dynamic-classes/issues/2
+test.run            no
+
+# No repository, just one archive in wiki
+livecheck.type      none

--- a/lisp/cl-dynamic-classes/Portfile
+++ b/lisp/cl-dynamic-classes/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gwkkwg dynamic-classes 844b077e5ac5ef2127603e692af983e9952ebae9
+name                cl-dynamic-classes
+version             20101221
+revision            0
+
+checksums           rmd160  789d4da92777f03270fbbf82064377c64df54062 \
+                    sha256  15826c31df74a072dbb63a89e7cde37e40a4e9959fa635dff3535e3a22ede583 \
+                    size    7239
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Classes how you want them, when you want them
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-metatilities-base \
+                    port:cl-lift
+
+# See: https://github.com/gwkkwg/dynamic-classes/issues/2
+test.run            no

--- a/lisp/cl-find-port/Portfile
+++ b/lisp/cl-find-port/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        eudoxia0 find-port 666040f72abda155a87576652f0e0fae98b27c13
+name                cl-find-port
+version             20230102
+revision            0
+
+checksums           rmd160  51c4fec6e5ce42bb25e96e02c8702c0e01601e68 \
+                    sha256  fe41b41c7f73b8003c8d804a3ea705bdf028e7b17c1788e1a1a154337c027340 \
+                    size    2664
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Programmatically find open ports
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-fiveam \
+                    port:cl-usocket

--- a/lisp/cl-lisp-unit/Portfile
+++ b/lisp/cl-lisp-unit/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        OdonataResearchLLC lisp-unit 89653a232626b67400bf9a941f9b367da38d3815
+name                cl-lisp-unit
+version             20161227
+revision            0
+
+checksums           rmd160  19c274cb98986a1fed382693932be4e637a327c5 \
+                    sha256  22922cf6101c7b1101017b1bf0d75493f0606a3c5832e6769fcdfdcc6f60641d \
+                    size    18302
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A Test Framework for Common Lisp in the style of JUnit, designed and implemented with simplicity of use in mind.
+
+long_description    {*}${description}

--- a/lisp/cl-lml2/Portfile
+++ b/lisp/cl-lml2/Portfile
@@ -1,0 +1,31 @@
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-lml2
+version             1.6.6
+revision            0
+
+homepage            https://tracker.debian.org/pkg/cl-kmrcl
+
+master_sites        debian:c/${name}/
+worksrcdir          ${distname}
+distname            ${name}_${version}
+extract.suffix      .orig.tar.gz
+
+checksums           rmd160  2e79c8b651cdf41ac17900ba176f2a5ffaa20778 \
+                    sha256  949f4a5d8a6d04066fdfd11d0849dbc2cbb973070420f365ccefef6076527b44 \
+                    size    27250
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             GPL
+
+description         LML2 provides a markup language for generation XHTML web pages.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-kmrcl \
+                    port:cl-rt
+
+livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
+livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)

--- a/lisp/cl-log4cl/Portfile
+++ b/lisp/cl-log4cl/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        sharplispers log4cl fe3da517147d023029782ced7cd989ba24f1e62d
+name                cl-log4cl
+version             20230526
+revision            0
+
+checksums           rmd160  1905ebd3c3efcb0e449bfbbb2702fe1ac102c830 \
+                    sha256  0abc0fdfcc839e1a1cf06d135d9d04f974c3adc7c9e24218b2c5e484e948038a \
+                    size    918792
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Common Lisp logging framework, modeled after Log4J
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-slynk \
+                    port:cl-stefil \
+                    port:cl-swank
+
+common_lisp.threads yes
+
+# :info:test Unhandled UIOP/LISP-BUILD:COMPILE-FILE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
+# :info:test                                                           {10013C0073}>:
+# :info:test   COMPILE-FILE-ERROR while compiling #<LOCAL-CL-SOURCE-FILE "stefil" "stefil">
+# :info:test Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {10013C0073}>
+common_lisp.sbcl    no

--- a/lisp/cl-lw-compat/Portfile
+++ b/lisp/cl-lw-compat/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        pcostanza lw-compat aabfe28c6c1a4949f9d7b3cb30319367c9fd1c0d
+name                cl-lw-compat
+version             20160228
+revision            0
+
+checksums           rmd160  5faa560a4c35705dfe62b2cdce5faf09dd7c5f59 \
+                    sha256  fbcb3e0462baf866fff1920371c1becf0be47e367a05e5d483293a8fafd27f3f \
+                    size    2196
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A few utility functions from the LispWorks library that I regularly use, ported to other Common Lisp implementations.
+
+long_description    {*}${description}

--- a/lisp/cl-markdown/Portfile
+++ b/lisp/cl-markdown/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gwkkwg cl-markdown 3c7093c4b67af8c5979264004f4628eb9d3adfaa
+version             20230111
+revision            0
+
+checksums           rmd160  09449f0cae100fa14eaca8e48bbfa0445c0291be \
+                    sha256  111ca1680138fd2f39871f1025ba8801caeaf369b5c9f9ed174ecf51e0c20991 \
+                    size    77203
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A Common Lisp rewrite of Markdown
+
+long_description    {*}${description}
+
+# we're handle dependency by our self, no need for that hack
+# See: https://github.com/gwkkwg/cl-markdown/issues/1
+patchfiles-append   remove-container-dynamic-classes.diff
+
+depends_lib-append  port:cl-anaphora \
+                    port:cl-containers \
+                    port:cl-dynamic-classes \
+                    port:cl-html-diff \
+                    port:cl-html-encode \
+                    port:cl-lift \
+                    port:cl-lml2 \
+                    port:cl-metabang-bind \
+                    port:cl-metatilities-base \
+                    port:cl-ppcre \
+                    port:cl-trivial-shell
+
+# See: https://github.com/gwkkwg/dynamic-classes/issues/2
+test.run            no

--- a/lisp/cl-markdown/files/remove-container-dynamic-classes.diff
+++ b/lisp/cl-markdown/files/remove-container-dynamic-classes.diff
@@ -1,0 +1,13 @@
+diff --git cl-markdown.asd cl-markdown.asd
+index e9a99cf..81280da 100644
+--- cl-markdown.asd
++++ cl-markdown.asd
+@@ -61,8 +61,6 @@
+ 		      :config :generic))
+   :depends-on ((:version :metatilities-base "0.6.0") 
+ 	       :metabang-bind
+-	       ;; ugh, the order matters here. Add more duct tape
+-	       #-asdf-system-connections :container-dynamic-classes
+ 	       (:version :cl-containers "0.11.5")
+ 	       :dynamic-classes
+ 	       :anaphora

--- a/lisp/cl-metacopy/Portfile
+++ b/lisp/cl-metacopy/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gwkkwg metacopy 03a9cd58938b7aa6de7c9f2527614a1403cbb205
+name                cl-metacopy
+version             20230120
+revision            0
+
+checksums           rmd160  963ac6b82d0a0ca5f96fc0584661d8774b70c2aa \
+                    sha256  26739819dfb4aa76a889965a8bc6b8188ff05fb166aa558781af76dc6019feec \
+                    size    9385
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         flexibly shallow/deep copying library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-contextl \
+                    port:cl-metatilities \
+                    port:cl-lift
+
+# See: https://github.com/gwkkwg/metacopy/issues/2
+common_lisp.ecl     no
+common_lisp.clisp   no

--- a/lisp/cl-metatilities-base/Portfile
+++ b/lisp/cl-metatilities-base/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gwkkwg metatilities-base ef04337759972fd622c9b27b53149f3d594a841f
+name                cl-metatilities-base
+version             20191219
+revision            0
+
+checksums           rmd160  784ea5cbb94ce7885b69d1bc62feb598a364db82 \
+                    sha256  1d434de91e437ce64b90d44e9e7abe2a4a4e1cc344d2d960133491f1ff5c34e3 \
+                    size    72046
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         These are metabang.com's Common Lisp basic utilities
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-lift
+
+#  *** - PROBE-FILE: No file name given:
+common_lisp.clisp   no

--- a/lisp/cl-metatilities/Portfile
+++ b/lisp/cl-metatilities/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            gwkkwg metatilities 82e13df0545d0e47ae535ea35c5c99dd3a44e69e
+name                    cl-metatilities
+version                 20170330
+revision                0
+
+checksums               rmd160  338451d9668a04559b682a09fb4c130989c60a41 \
+                        sha256  9c0eb7e15e0871f103bd8c2e179d722758dd7933a123f23add3e88a3c4c0fd75 \
+                        size    196186
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+description             These are metabang.com's Common Lisp basic utilities
+
+long_description        {*}${description}
+
+# cl-metatilities depends on cl-metacopy which depends on cl-metatilities
+# cl-metatilities depends on cl-containers which depends on cl-metatilities
+common_lisp.build_run   no
+
+depends_lib-append      port:cl-metatilities-base \
+                        port:cl-metabang-bind \
+                        port:cl-moptilities \
+                        port:cl-lift
+
+test.run                no

--- a/lisp/cl-metatilities/Portfile
+++ b/lisp/cl-metatilities/Portfile
@@ -30,4 +30,6 @@ depends_lib-append      port:cl-metatilities-base \
                         port:cl-moptilities \
                         port:cl-lift
 
+depends_test-append     port:cl-metacopy
+
 test.run                no

--- a/lisp/cl-metatilities/Portfile
+++ b/lisp/cl-metatilities/Portfile
@@ -30,6 +30,5 @@ depends_lib-append      port:cl-metatilities-base \
                         port:cl-moptilities \
                         port:cl-lift
 
-depends_test-append     port:cl-metacopy
-
-test.run                no
+depends_test-append     port:cl-containers \
+                        port:cl-metacopy

--- a/lisp/cl-mysql/Portfile
+++ b/lisp/cl-mysql/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            hackinghat cl-mysql 3fbf6e1421484f64c5bcf2ff3c4b96c6f0414f09
+version                 20200501
+revision                0
+
+checksums               rmd160  7585a5d464b9c2477d30a66dffe0f81785277b92 \
+                        sha256  10a551e8e18a41cb35bf53bf8f577452ffae9d2847937e73152dc0d37b9c8d53 \
+                        size    25831
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+description             Common Lisp MySQL library
+
+long_description        {*}${description}
+
+depends_lib-append      port:cl-cffi \
+                        port:cl-stefil
+
+# Build and test requires real MySQL
+common_lisp.build_run   no
+test.run                no

--- a/lisp/cl-prevalence/Portfile
+++ b/lisp/cl-prevalence/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        40ants cl-prevalence e6b27640ce89ae5f8af38beb740e319bb6cd2368
+version             20221122
+revision            0
+
+checksums           rmd160  cbfc5514beb217502ce4aeb364105a83fe565717 \
+                    sha256  0dad9e18b147c0612d78b02ce7f183b7030aac56b9d7253b30e229dbed685f17 \
+                    size    24752
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         In memory database system for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-find-port \
+                    port:cl-fiveam \
+                    port:cl-moptilities \
+                    port:cl-s-sysdeps \
+                    port:cl-s-xml
+
+common_lisp.threads yes
+
+# Test are working only on SBCL
+# See: https://github.com/40ants/cl-prevalence/issues/19
+common_lisp.ecl     no

--- a/lisp/cl-qrencode/Portfile
+++ b/lisp/cl-qrencode/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        jnjcc cl-qrencode 0.1.2 v
+revision            0
+
+checksums           rmd160  5d538e512c9691ee4a3af8aa78c09944aa7df7a8 \
+                    sha256  f5e63803d8c807104e756780268b1463ade30bb4707814312302dde4d8b12afe \
+                    size    31068
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             GPL
+
+description         QR code 2005 encoder in Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-lisp-unit \
+                    port:cl-zpng

--- a/lisp/cl-rove/Portfile
+++ b/lisp/cl-rove/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi rove 6a5dfcdced42879a4eff2a529e7e8ce492fadf41
+name                cl-rove
+version             20230131
+revision            0
+
+checksums           rmd160  9fbf199cc8e75c092f5d115b991ce1e7481e61b6 \
+                    sha256  5d9bcbff36868478713ac0444abbf7d157abea694bbee97b98179969809c0aad \
+                    size    17247
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Yet another testing framework intended to be a successor of Prove
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-dissect \
+                    port:cl-trivial-gray-streams
+
+common_lisp.threads yes

--- a/lisp/cl-salza2/Portfile
+++ b/lisp/cl-salza2/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        xach salza2 2.1 release-
+name                cl-salza2
+revision            0
+
+checksums           rmd160  2daf46315455d2af3efcfaf5dd84981810128622 \
+                    sha256  96369f903ef7050e967dc53e1de5fdeeeb89244c662bd067f9cd6111d5cf86c1 \
+                    size    17075
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         ZLIB compression in Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-chipz \
+                    port:cl-flexi-streams \
+                    port:cl-parachute \
+                    port:cl-trivial-gray-streams

--- a/lisp/cl-slynk/Portfile
+++ b/lisp/cl-slynk/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        joaotavora sly 1.0.43
+name                cl-slynk
+revision            0
+
+checksums           rmd160  7f5ecb13adae94feba08985b356040c9eb298493 \
+                    sha256  5a4b6a08c4c8de71f6eb392ddf1f7d4ba977f3f13ab4d0a05e7f1d090a63b03b \
+                    size    1835781
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         SLYNK - Sylvester the Cat's Common Lisp IDE
+
+long_description    {*}${description}
+
+worksrcdir          ${worksrcdir}/slynk

--- a/lisp/cl-smart-buffer/Portfile
+++ b/lisp/cl-smart-buffer/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi smart-buffer 619759d8a6f821773bbc65c0bda553d30e51e6f3
+name                cl-smart-buffer
+version             20211018
+revision            0
+
+checksums           rmd160  76a28535f98f9832b6adb2fd27995b128c39560b \
+                    sha256  09b484b809738191f2da0e833b15c7e718431bea4cf872d7f668d8245eaaa7b0 \
+                    size    3480
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Smart octets buffer
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-babel \
+                    port:cl-flexi-streams \
+                    port:cl-prove \
+                    port:cl-xsubseq

--- a/lisp/cl-sqlite/Portfile
+++ b/lisp/cl-sqlite/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        TeMPOraL cl-sqlite 0.2.1
+revision            0
+
+checksums           rmd160  cb9dbd607846df0af964e3ba14dd0fd4d78acbf4 \
+                    sha256  608c2f821b556cab325e8fd7529d595389dd1497f43813bd0de5d212aa8bbeb2 \
+                    size    15098
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         Common Lisp binding for SQLite
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-cffi \
+                    port:cl-fiveam \
+                    port:cl-iterate \
+                    port:sqlite3
+
+common_lisp.threads yes

--- a/lisp/cl-tld/Portfile
+++ b/lisp/cl-tld/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        lu4nx cl-tld b6b24d9c63da77052775992463f0bfac63383234
+version             20220217
+revision            0
+
+checksums           rmd160  c943f52847c6c2aef6589cd1d1271c3f5ffbf41e \
+                    sha256  a5951a11aedf91c321333df51d923bd1c45766d05b1cc92241028e7e9d7c11ed \
+                    size    79690
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         Extracts the TLD(Top Level Domain) from domain, for Common Lisp
+
+long_description    {*}${description}

--- a/lisp/cl-trivial-shell/Portfile
+++ b/lisp/cl-trivial-shell/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gwkkwg trivial-shell ad4218b62bea99ef10c1675eeba5cd96c763e46e
+name                cl-trivial-shell
+version             20230111
+revision            0
+
+checksums           rmd160  7376e3c095705dbb1a674e2d1d0f1befd38c2e45 \
+                    sha256  15ff275f3ff1174839b9006c7cd513c183d7d0211db03d130b4a55cf5e78abe8 \
+                    size    14918
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A simple Common-Lisp interface to the underlying Operating System
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-lift

--- a/lisp/cl-variates/Portfile
+++ b/lisp/cl-variates/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           common_lisp 1.0
+
+gitlab.instance     https://gitlab.common-lisp.net
+gitlab.setup        cl-variates cl-variates 4e7548754d8a8731a42487fae31174db4bf36d47
+version             20071019
+revision            0
+
+checksums           rmd160  465bcec1215e2104537531e2a0eaeedda069acfe \
+                    sha256  af8e961598a865d4ebc329adb50cac656e97dc026c0cc3e72a1f87f45a4a3759 \
+                    size    13004
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+homepage            https:/cl-variates.common-lisp.dev
+
+description         Portable Common Lisp Random Number Generation.
+
+long_description    {*}${description}
+
+# See: https://gitlab.common-lisp.net/cl-variates/cl-variates/-/issues/1
+post-extract {
+    file delete -force ${worksrcpath}/cl-variates-test.asd
+}
+
+test.run            no

--- a/lisp/cl-xsubseq/Portfile
+++ b/lisp/cl-xsubseq/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi xsubseq 5ce430b3da5cda3a73b9cf5cee4df2843034422b
+name                cl-xsubseq
+version             20170803
+revision            0
+
+checksums           rmd160  46ad22b7d74360afbbde6ae57eab5f04c62b8462 \
+                    sha256  8a11c0be683a5ccd27efe7ec75fa50ed5e3ab636f767826a91143a4678d2ebcb \
+                    size    4082
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         {Efficient way to use "subseq"s in Common Lisp}
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-prove

--- a/lisp/cl-zpng/Portfile
+++ b/lisp/cl-zpng/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        xach zpng 1.2.2 release-
+name                cl-zpng
+revision            0
+
+checksums           rmd160  4ed0a5a186f1e88800cf62af3de7a8fdd7c644ab \
+                    sha256  9b1259c5beab7b677385ee18e089191825327796d21df2b8694f63dbc0e20f4e \
+                    size    39762
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Common Lisp PNG creation library
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-salza2


### PR DESCRIPTION
#### Description

Here the fourth portion of new lisp ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->