### PR TITLE
fpc: bugfix bzip2, codesign, linker

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -45,6 +45,10 @@ universal_variant   no
 
 set fpcbasepath     ${prefix}/libexec/${name}
 
+if {${os.major} >= 13} { # Ventura, fix obsolete linker options
+    patchfiles-append   t_darwin.pas.patch
+}
+
 subport "chmcmd-${name}" {
     revision        0
 
@@ -73,6 +77,9 @@ subport "chmcmd-${name}" {
     configure.pre_args
     configure.args  -r -v Makefile.fpc.fpcmake
     configure.post_args
+
+    patchfiles-delete   t_darwin.pas.patch
+
     build.env       PREFIX=${prefix}
     build.target
     build.post_args-append \
@@ -95,6 +102,7 @@ subport "${name}-cross" {
 
     worksrcdir      ${name}build-${version}/fpcsrc/compiler
     use_configure   no
+    patch.pre_args  -p1
     build.args      OPT="-ap -v0"
     build.target    aarch64 arm avr i386 i8086 jvm m68k mips mipsel powerpc powerpc64 sparc x86_64
     switch ${build_arch} {
@@ -253,28 +261,35 @@ if {${subport} eq "${name}"} {
         }
     }
 
-    # os.major = 20 is macOS = 11 (BigSur)
-    if {${os.major} >= 20} {
-        set linkerOptions -XR${configure.sdkroot}
-    } else {
-        set linkerOptions ""
+    if       {${os.major} >= 11}   { # Big Sur
+        set otherOptions "-WM11.0 -XR${configure.sdkroot}"
+    } elseif {[vercmp ${os.version} 10.9] >= 0} { # Mavericks
+        set otherOptions "-WM10.9"
+    } else   {
+        set otherOptions ""
     }
 
     worksrcdir          ${name}build-${version}/fpcsrc
     build.env           PP=${workpath}/${bootstrapCompiler} \
                         PREFIX=${destroot}${fpcbasepath}
-    build.args          OPT="-ap -v0 ${linkerOptions}" CPU_TARGET=${cpuTarget} UTILS=1
+    build.args          OPT="-v0 -ap ${otherOptions}" CPU_TARGET=${cpuTarget} UTILS=1
 
     destroot.args       {*}${build.args}
     destroot.env        {*}${build.env}
+
+    # codesign for older systems does not have a --remove-signature option
+    # work around: replace codesign by a dummy.
+    if {[vercmp ${os.version} 10.11] <= 0} { # El Capitan
+        build.args-append   CODESIGN=/usr/bin/true
+    }
 
     # build the compiler utilities msgdif and msg2inc
     post-build {
         system -W ${worksrcpath}/compiler/utils \
                "../${compiler} -ap -v0 -Fu../../rtl/units/${cpuTarget}-darwin \
-                  -WM${macosx_deployment_target} ${linkerOptions} msgdif.pp && \
+                  ${otherOptions} msgdif.pp && \
                 ../${compiler} -ap -v0 -Fu../../rtl/units/${cpuTarget}-darwin \
-                  -WM${macosx_deployment_target} ${linkerOptions} msg2inc.pp"
+                  ${otherOptions} msg2inc.pp"
     }
 
     post-destroot {
@@ -285,7 +300,7 @@ if {${subport} eq "${name}"} {
             system -W ${worksrcpath} \
                    "make utils_install FPC=${worksrcpath}/compiler/${compiler} \
                        PREFIX=${destroot}${fpcbasepath} \
-                       OPT=\"-Furtl/units/${cpuTarget}-darwin -ap -v0 ${linkerOptions}\""
+                       OPT=\"-Furtl/units/${cpuTarget}-darwin -ap -v0 ${otherOptions}\""
         }
         # generate a configuration file
         xinstall -d ${destroot}${fpcbasepath}/etc
@@ -293,6 +308,16 @@ if {${subport} eq "${name}"} {
                "bin/fpcmkcfg -d basepath=${fpcbasepath}/lib/${name}/${version} -o etc/fpc.cfg"
         ln -s ${fpcbasepath}/etc/fpc.cfg ${destroot}${prefix}/etc
         system "patch ${destroot}${fpcbasepath}/etc/fpc.cfg ${filespath}/fpc.cfg.patch"
+
+        # remove the -WM option for older systems or update it as needed
+        if {[vercmp ${os.version} 10.7] < 0} { # Lion
+            reinplace "s|-WM10.9||g" ${destroot}${fpcbasepath}/etc/fpc.cfg
+        } elseif {${os.major} >=  11} { # Big Sur
+            reinplace "s|-WM10.9|-WM11.0|g" ${destroot}${fpcbasepath}/etc/fpc.cfg
+        }
+
+        # set prefix of search path for qt4pas
+        reinplace "s|PREFIX|${prefix}|g" ${destroot}${fpcbasepath}/etc/fpc.cfg
 
         # install man
         xinstall -d ${destroot}${fpcbasepath}/man

--- a/lang/fpc/files/fpc.cfg.patch
+++ b/lang/fpc/files/fpc.cfg.patch
@@ -1,12 +1,24 @@
 --- etc/fpc.cfg	2019-06-14 15:54:16.000000000 +0200
 +++ fpc.cfg-new	2019-08-17 10:54:57.000000000 +0200
+@@ -175,6 +175,11 @@
+ # searchpath for tools
+ -FD/opt/local/libexec/fpc/lib/fpc/3.2.2/bin/$FPCTARGET
+ 
++# searchpath for qt4pas framework
++#IFDEF Darwin
++-FfPREFIX/libexec/qt4/lib
++#ENDIF
++
+ # path to the gcclib
+ #ifdef cpui386
+ -Fl/Library/Developer/CommandLineTools/usr/lib/clang/14.0.3/lib/darwin
 @@ -267,6 +267,12 @@
  -XX
  #endif
  
 +# Explicitly set minimum version of OS X
 +# Avoids harmless but annoying ld warning
-+# Keep in sync with fpc
++# Patch in sync with fpc and macOS
 +#ifdef darwin
 +-WM10.9
 +#endif

--- a/lang/fpc/files/t_darwin.pas.patch
+++ b/lang/fpc/files/t_darwin.pas.patch
@@ -1,0 +1,32 @@
+--- compiler/systems/t_darwin.pas.orig	2021-04-10 13:02:51
++++ compiler/systems/t_darwin.pas	2023-10-10 11:43:18
+@@ -123,16 +123,16 @@
+              programs with problems that require Valgrind will have more
+              than 60KB of data (first 4KB of address space is always invalid)
+            }
+-           ExeCmd[1]:='ld $PRTOBJ $TARGET $EMUL $OPT $DYNLINK $STATIC $GCSECTIONS $STRIP $MAP $ORDERSYMS -multiply_defined suppress -L. -o $EXE $CATRES $FILELIST';
++           ExeCmd[1]:='ld $PRTOBJ $TARGET $EMUL $OPT $DYNLINK $STATIC $GCSECTIONS $STRIP $MAP $ORDERSYMS -L. -o $EXE $CATRES $FILELIST';
+            if not(cs_gdb_valgrind in current_settings.globalswitches) then
+              ExeCmd[1]:=ExeCmd[1]+' -pagezero_size 0x10000';
+   {$else ndef cpu64bitaddr}
+-           ExeCmd[1]:='ld $PRTOBJ $TARGET $EMUL $OPT $DYNLINK $STATIC $GCSECTIONS $STRIP $MAP $ORDERSYMS -multiply_defined suppress -L. -o $EXE $CATRES $FILELIST';
++           ExeCmd[1]:='ld $PRTOBJ $TARGET $EMUL $OPT $DYNLINK $STATIC $GCSECTIONS $STRIP $MAP $ORDERSYMS -L. -o $EXE $CATRES $FILELIST';
+   {$endif ndef cpu64bitaddr}
+            if (apptype<>app_bundle) then
+-             DllCmd[1]:='ld $PRTOBJ $TARGET $EMUL $OPT $GCSECTIONS $MAP $ORDERSYMS -dynamic -dylib -multiply_defined suppress -L. -o $EXE $CATRES $FILELIST'
++             DllCmd[1]:='ld $PRTOBJ $TARGET $EMUL $OPT $GCSECTIONS $MAP $ORDERSYMS -dynamic -dylib -L. -o $EXE $CATRES $FILELIST'
+            else
+-             DllCmd[1]:='ld $PRTOBJ $TARGET $EMUL $OPT $GCSECTIONS $MAP $ORDERSYMS -dynamic -bundle -multiply_defined suppress -L. -o $EXE $CATRES $FILELIST';
++             DllCmd[1]:='ld $PRTOBJ $TARGET $EMUL $OPT $GCSECTIONS $MAP $ORDERSYMS -dynamic -bundle -L. -o $EXE $CATRES $FILELIST';
+            DllCmd[2]:='strip -x $EXE';
+            DynamicLinker:='';
+          end;
+@@ -360,7 +360,7 @@
+       end;
+       if MacOSXVersionMin<>'' then
+         begin
+-          LinkRes.Add('-macosx_version_min');
++          LinkRes.Add('-macos_version_min');
+           LinkRes.Add(MacOSXVersionMin);
+         end
+       else if iPhoneOSVersionMin<>'' then


### PR DESCRIPTION
#### Description

fpc: bugfix
- extract bzip2 for systems <=10.8 (https://trac.macports.org/ticket/62002)
- prevent linker warnings for systems > 13 and x86_64 (https://trac.macports.org/ticket/64035)
- work around for codesign for systems <= 10.11

###### Type(s)

- [x] bugfix

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
