### PR TITLE
gopass ports: update to 1.15.7

### DIFF
--- a/security/gopass-hibp/Portfile
+++ b/security/gopass-hibp/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-hibp 1.15.5 v
+go.setup            github.com/gopasspw/gopass-hibp 1.15.7 v
+go.offline_build    no
 github.tarball_from archive
 revision            0
 categories          security
@@ -14,12 +15,9 @@ description         Gopass haveibeenpwnd.com integration
 long_description    {*}${description}
 homepage            https://www.gopass.pw
 
-checksums           rmd160  68d9e5d046c50a51e5fe4ee54a2b68f410f28280 \
-                    sha256  812dd769b3e8d08335e92ca9ae49f76e1fc8aacdd0ef280e3c7c959d87ef8908 \
-                    size    27096
-
-
-go.offline_build no
+checksums           rmd160  002a287f86bdef4f6b041d947fab8c824d09417b \
+                    sha256  450b93d310f25e8e248d2f5218cba94a0b8e3966671e16c37c2c402ae7589580 \
+                    size    27891
 
 build.args          -ldflags '-X main.version=${version}'
 

--- a/security/gopass-jsonapi/Portfile
+++ b/security/gopass-jsonapi/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass-jsonapi 1.15.5 v
+go.setup            github.com/gopasspw/gopass-jsonapi 1.15.7 v
+go.offline_build    no
 github.tarball_from archive
 revision            0
 categories          security
@@ -14,12 +15,9 @@ description         Gopass Browser Bindings
 long_description    ${name} enables communication with gopass via JSON messages
 homepage            https://www.gopass.pw
 
-checksums           rmd160  8d000338569ebbdf07894e2e1edf7d5375a53ca9 \
-                    sha256  6fa3f280e3dcb71edc1fd8b8f10da017c28ded3b48064029c89932f4eaef9158 \
-                    size    34898
-
-
-go.offline_build no
+checksums           rmd160  7f0cef9f694be7f54a06b1ae593fd830f2bce75e \
+                    sha256  08ec445cc6929c7887caa3c631ab1aa73def89ca35f16160e5ff2ce535a0370b \
+                    size    35701
 
 build.args          -ldflags '-X main.version=${version}'
 

--- a/security/gopass/Portfile
+++ b/security/gopass/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/gopass 1.15.6 v
+go.setup            github.com/gopasspw/gopass 1.15.7 v
+go.offline_build    no
 github.tarball_from archive
 revision            0
 categories          security
@@ -16,12 +17,11 @@ homepage            https://www.gopass.pw
 
 depends_lib-append  port:gnupg2
 
-checksums           rmd160  eafb199d8ba906cd122e2eaf4ae46cb9c6517015 \
-                    sha256  1cf885380883d8b5c17bb68a882a3b3034651491d273a4c0d2899a3d9048c664 \
-                    size    2307580
+checksums           rmd160  d4b217f64d7518d2320ff5361ca3b1373a2d645a \
+                    sha256  35d1af333de479e429da31427b70b2043e20ef9a7ab0f8b816867ffc6f44927b \
+                    size    2307669
 
 set go_ldflags      "-s -w -X main.version=${version}"
-go.offline_build no
 build.args          -ldflags \"${go_ldflags}\"
 
 destroot {


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
