### PR TITLE
xterm: enable sixel and regis graphics

### DIFF
--- a/x11/xterm/Portfile
+++ b/x11/xterm/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xterm
 version             383
-revision            0
+revision            1
 checksums           rmd160  a265914e1b36b7584b90a6902a42f9949f2bed0e \
                     sha256  a06613bcda508c2a1bff6d4230895da74a798799a2e39a23bac82089d7b9a998 \
                     size    1538968
@@ -38,6 +38,7 @@ configure.args      --mandir=${prefix}/share/man --enable-luit \
                     --enable-logging --enable-wide-chars \
                     --enable-256-color --enable-load-vt-fonts \
                     --enable-double-buffer \
+                    --enable-sixel-graphics --enable-regis-graphics \
                     --x-include=${prefix}/include --x-lib=${prefix}/lib \
                     --with-app-defaults=${prefix}/share/X11/app-defaults
 


### PR DESCRIPTION
#### Description

Enable Sixel and ReGIS graphics. Useful for eg. gnuplot and plotutils.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 13.5 22G74 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?