### PR TITLE
cmake-devel: update to 3.27.2

### DIFF
--- a/devel/cmake-devel/Portfile
+++ b/devel/cmake-devel/Portfile
@@ -36,11 +36,11 @@ homepage            https://cmake.org
 platforms           darwin freebsd
 gitlab.instance     https://gitlab.kitware.com
 
-gitlab.setup        cmake   cmake b5c54d9c8a1fdfdbf1a133040029a4924b69185e
-version             20230725-3.27.1-[string range ${gitlab.version} 0 7]
-checksums           rmd160  b084716cbd4abb6826f4bc9db5bdfe3b51b307f7 \
-                    sha256  17324d9d7317439790429e963ee2c1870fa6afd6696a082717e22a57ca64c4ed \
-                    size    8423291
+gitlab.setup        cmake   cmake f3d9a8211042c3df043d886f2217a705a62168a8
+version             20230810-3.27.2-[string range ${gitlab.version} 0 7]
+checksums           rmd160  7a30991369c51f9d0e6875d6ba40d10c31730fb6 \
+                    sha256  4ecc149a24251b3d6ba12e00893b5265fff580755c8630e8512cc56692cfff98 \
+                    size    8423256
 revision            0
 
 epoch               1


### PR DESCRIPTION
#### Description

As per https://trac.macports.org/ticket/67540#comment:4, updating cmake-devel to 3.27.2.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 21G725 arm64
Xcode 13.3.1 13E500a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
