### PR TITLE
Lisp new ports 5

### DIFF
--- a/lisp/cl-async/Portfile
+++ b/lisp/cl-async/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        orthecreedence cl-async 2d9a976f4d011b9ad45b642013caa9ef93cd1582
+version             20230731
+revision            0
+
+checksums           rmd160  15e283a2ae724d7b7adfa20ddf35e1318aeee104 \
+                    sha256  78d0a4aaec07a1a538e6e9048307525e02b68c17472ad78f1b1a2820dc8a0c04 \
+                    size    58670
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Asynchronous IO library for Common Lisp.
+
+long_description    {*}${description}
+
+post-extract {
+    reinplace "s|/opt/local/lib/libssl.dylib|[openssl::lib_dir]/libssl.dylib|" \
+        ${worksrcpath}/src/ssl/package.lisp
+}
+
+depends_lib-append  port:cl-babel \
+                    port:cl-bordeaux-threads \
+                    port:cl-cffi \
+                    port:cl-fast-io \
+                    port:cl-fiveam \
+                    port:cl-flexi-streams \
+                    port:cl-ironclad \
+                    port:cl-libuv \
+                    port:cl-ppcre \
+                    port:cl-quri \
+                    port:cl-static-vectors \
+                    port:cl-trivial-features \
+                    port:cl-trivial-gray-streams \
+                    port:cl-usocket \
+                    port:cl-vom
+
+common_lisp.threads yes

--- a/lisp/cl-blackbird/Portfile
+++ b/lisp/cl-blackbird/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        orthecreedence blackbird abe3696e1a128bd082fb5d3e211f33d8feb25bc8
+name                cl-blackbird
+version             20220907
+revision            0
+
+checksums           rmd160  ab42c9b9d6e5ac594fd16835cdc67a8cd49131e3 \
+                    sha256  5f636d5932e62a3f32772f5682f1e6995ff514473d52e276097aa833c06e8841 \
+                    size    13020
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A promise implementation for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-async \
+                    port:cl-fiveam \
+                    port:cl-vom
+
+common_lisp.threads yes

--- a/lisp/cl-clack/Portfile
+++ b/lisp/cl-clack/Portfile
@@ -36,4 +36,4 @@ common_lisp.threads     yes
 # cl-clack depends on cl-dexador which depends on cl-clack
 common_lisp.build_run   no
 
-test.run                no
+depends_test-append     port:cl-dexador

--- a/lisp/cl-clack/Portfile
+++ b/lisp/cl-clack/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            fukamachi clack 488cfb36381a4f4c56ad7f1184ea64b6ebcc2cee
+name                    cl-clack
+version                 20230331
+revision                0
+
+checksums               rmd160  c909c54499751fbf89962b07671ce4bd7da4c059 \
+                        sha256  2c100b0e13b4d962cdd01406ed280748ee26273ad6c9488aa0f8406ac193b1ff \
+                        size    171991
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+description             Web server abstraction layer for Common Lisp
+
+long_description        {*}${description}
+
+depends_lib-append      port:cl-alexandria \
+                        port:cl-bordeaux-threads \
+                        port:cl-lack \
+                        port:cl-swank \
+                        port:cl-usocket
+
+depends_test-append     port:cl-fastcgi \
+                        port:cl-toot \
+                        port:cl-wookie
+
+common_lisp.threads     yes
+
+# cl-clack depends on cl-dexador which depends on cl-clack
+common_lisp.build_run   no
+
+test.run                no

--- a/lisp/cl-custom-hash-table/Portfile
+++ b/lisp/cl-custom-hash-table/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        metawilm cl-custom-hash-table 7bd02a529d39065ca8190966403b984552e0212a
+version             20201119
+revision            0
+
+checksums           rmd160  17b69615aeef31cff368436cabd02d174e3e1a27 \
+                    sha256  de3d78eb4fe31e3a1d4bc1d2b7ac6cec6817be8f9d9fb9cfb29edde7252bbdbd \
+                    size    7772
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Custom hash tables for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-hu.dwim.stefil

--- a/lisp/cl-dexador/Portfile
+++ b/lisp/cl-dexador/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi dexador 843d2622941fcb29ff0baf263435787e0196b4ec
+name                cl-dexador
+version             20230613
+revision            0
+
+checksums           rmd160  46be3b3f0efe0ddba3049d6a741fe47380fab6ee \
+                    sha256  c0a7e1d1ceaa0ce6a9cfa0c54c496c9aa5ebb015b4ebc13e25890117883a0ded \
+                    size    212639
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A fast HTTP client for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-babel \
+                    port:cl-base64 \
+                    port:cl-bordeaux-threads \
+                    port:cl-chipz \
+                    port:cl-chunga \
+                    port:cl-clack \
+                    port:cl-cookie \
+                    port:cl-fast-http \
+                    port:cl-fast-io \
+                    port:cl-lack \
+                    port:cl-plus-ssl \
+                    port:cl-ppcre \
+                    port:cl-quri \
+                    port:cl-rove \
+                    port:cl-trivial-garbage \
+                    port:cl-trivial-gray-streams \
+                    port:cl-trivial-mime \
+                    port:cl-usocket
+
+common_lisp.threads yes

--- a/lisp/cl-do-urlencode/Portfile
+++ b/lisp/cl-do-urlencode/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        drdo do-urlencode 199846441dad5dfac5478b8dee4b4e20d107af6a
+name                cl-do-urlencode
+version             20181007
+revision            0
+
+checksums           rmd160  8736e7ab9327cc2fef5462c39f20caafe61d7e29 \
+                    sha256  221fdcc0e485efaaff5f1d776b164732202915a2e8a3d33848fbe6c4981bf307 \
+                    size    2348
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             ISC
+
+description         Percent Encoding (aka URL Encoding) library
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-babel

--- a/lisp/cl-enchant/Portfile
+++ b/lisp/cl-enchant/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        tlikonen cl-enchant 2021.11
+revision            0
+
+checksums           rmd160  85e5c4707402be404afb2227e3ed07803471fa66 \
+                    sha256  0e0ad3b366224cde1b2f19f24a46d6fdab00afa33409ca330d5a25fd9b65acf0 \
+                    size    8217
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+# license CC0-1.0 (http://creativecommons.org/publicdomain/zero/1.0/)
+license             public-domain
+
+description         Programming interface for Enchant spell-checker library for Common Lisp.
+
+long_description    {*}${description}
+
+patchfiles-append   macports-integration.diff
+
+post-patch {
+    reinplace "s|@@MACPORTS_PREFIX@@|${prefix}|" \
+        ${worksrcpath}/load-enchant.lisp
+}
+
+depends_lib-append  port:cl-cffi \
+                    port:enchant2

--- a/lisp/cl-enchant/files/macports-integration.diff
+++ b/lisp/cl-enchant/files/macports-integration.diff
@@ -1,0 +1,9 @@
+diff --git load-enchant.lisp load-enchant.lisp
+index 35098df..9c12122 100644
+--- load-enchant.lisp
++++ load-enchant.lisp
+@@ -1,3 +1,4 @@
+ (cl:eval-when (:load-toplevel :execute)
+   (cffi:load-foreign-library '(:or (:default "libenchant-2")
++                                   "@@MACPORTS_PREFIX@@/lib/libenchant-2.dylib"
+                                    (:default "libenchant"))))

--- a/lisp/cl-fast-http/Portfile
+++ b/lisp/cl-fast-http/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi fast-http 3d1535b397ba69e3b8f79c7aac8fbdc5a3c7c8f5
+name                cl-fast-http
+version             20230708
+revision            0
+
+checksums           rmd160  9bd5ce34472f232a6c01d41156be82d93b0da7dd \
+                    sha256  6c5038a7166ff895494687a1d51e1105f0b14e3898465f47ece9e9120d0d3d2a \
+                    size    34143
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A fast HTTP request/response parser for Common Lisp.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-babel \
+                    port:cl-interpol \
+                    port:cl-log4cl \
+                    port:cl-proc-parse \
+                    port:cl-prove \
+                    port:cl-smart-buffer \
+                    port:cl-syntax \
+                    port:cl-utilities \
+                    port:cl-xsubseq

--- a/lisp/cl-fastcgi/Portfile
+++ b/lisp/cl-fastcgi/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        KDr2 cl-fastcgi de8b49b26de9863996ec18db28af8ab7e8ac4e20
+version             20210101
+revision            0
+
+checksums           rmd160  1af3cdb78c08352266d3ecf038ce81fcbe28d658 \
+                    sha256  e7e2d97ce97397910c94d262052755614ae5d13fc483aa7d1e4b031e1ee5bd54 \
+                    size    4654
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         A Generic Version of SB-FastCGI, runs on mostly Common Lisp implementations.
+
+long_description    {*}${description}
+
+
+post-extract {
+    reinplace "s|/usr/lib/libfcgi.s|${prefix}/lib/libfcgi.dylib|" \
+        ${worksrcpath}/cl-fastcgi.lisp
+}
+
+depends_lib-append  port:cl-cffi \
+                    port:cl-usocket \
+                    port:fcgi
+
+# <PACKAGE SOCKET> has no external symbol with name "STREAM-HANDLES"
+common_lisp.clisp   no

--- a/lisp/cl-history-tree/Portfile
+++ b/lisp/cl-history-tree/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        atlas-engineer history-tree 0.1.1
+name                cl-history-tree
+revision            0
+
+checksums           rmd160  6f9df9f2a003f53a525fe79e32451df4b74eab8d \
+                    sha256  feb2d141422488b6832edf3b085184814d44cd8644d6d5e56febc1a2a2fd6862 \
+                    size    29089
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Store the history of a browser's visited paths.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-custom-hash-table \
+                    port:cl-local-time \
+                    port:cl-nasdf \
+                    port:cl-nclasses \
+                    port:cl-trivial-package-local-nicknames
+
+depends_test-append port:cl-lisp-unit2
+
+# ;;; Cannot find the external symbol PARSE-BODY in #<"UIOP/DRIVER" package>
+common_lisp.ecl     no
+
+# *** - EVAL: undefined function EXT::ADD-PACKAGE-LOCAL-NICKNAME
+common_lisp.clisp   no

--- a/lisp/cl-http-body/Portfile
+++ b/lisp/cl-http-body/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fukamachi http-body 3e4bedd6a9d9bc4e1dc0a45e5b55360ae30fd388
+name                cl-http-body
+version             20190811
+revision            0
+
+checksums           rmd160  585644ffcb8f8348bf9712b302c7ded436e41993 \
+                    sha256  c91ae5238d11d9a0873366e2ad957538aaa3f9f6145b5e1962f267ee9c2f18fb \
+                    size    15723
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         HTTP POST data parser.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-assoc-utils \
+                    port:cl-babel \
+                    port:cl-fast-http \
+                    port:cl-flexi-streams \
+                    port:cl-jonathan \
+                    port:cl-ppcre \
+                    port:cl-prove \
+                    port:cl-quri \
+                    port:cl-trivial-gray-streams \
+                    port:cl-trivial-utf-8 \
+                    port:cl-utilities
+
+# *** - DEFMETHOD: OUTPUT-STREAM-P does not name a generic function
+common_lisp.clisp   no

--- a/lisp/cl-idna/Portfile
+++ b/lisp/cl-idna/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        antifuchs idna 0.2.2
+name                cl-idna
+revision            0
+
+checksums           rmd160  7018bbce3a2eed324c26538f69fa1ba5436db0a0 \
+                    sha256  cb953ebe30798d2005123541a4ccf16bec025cc33863cd1d6a1751c8ec490500 \
+                    size    6304
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         IDNA (international domain names) string encoding and decoding routines
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-split-sequence

--- a/lisp/cl-lack/Portfile
+++ b/lisp/cl-lack/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            fukamachi lack 3745924e4682523b0969a7042bcdb39aa8f73e8f
+name                    cl-lack
+version                 20230527
+revision                0
+
+checksums               rmd160  62105cfa4d5b101d0101c06e3224c9f3539f7517 \
+                        sha256  ab21f3d61c89d26f34e90b761f186bd2b3ed2933be77e77be2c36650de00717c \
+                        size    180585
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+description             Lack, the core of Clack
+
+long_description        {*}${description}
+
+depends_lib-append      port:cl-alexandria \
+                        port:cl-babel \
+                        port:cl-base64 \
+                        port:cl-bordeaux-threads \
+                        port:cl-circular-streams \
+                        port:cl-cookie \
+                        port:cl-dbi \
+                        port:cl-flexi-streams \
+                        port:cl-http-body \
+                        port:cl-hunchentoot \
+                        port:cl-ironclad \
+                        port:cl-local-time \
+                        port:cl-marshal \
+                        port:cl-ppcre \
+                        port:cl-prove \
+                        port:cl-quri \
+                        port:cl-redis \
+                        port:cl-split-sequence \
+                        port:cl-sqlite \
+                        port:cl-trivial-gray-streams \
+                        port:cl-trivial-mime \
+                        port:cl-trivial-rfc-1123 \
+                        port:cl-trivial-utf-8
+
+common_lisp.threads     yes
+
+# cl-lack depends on cl-dexador which depends on cl-lack
+common_lisp.build_run   no
+
+test.run                no

--- a/lisp/cl-lack/Portfile
+++ b/lisp/cl-lack/Portfile
@@ -50,4 +50,7 @@ common_lisp.threads     yes
 # cl-lack depends on cl-dexador which depends on cl-lack
 common_lisp.build_run   no
 
+depends_test-append     port:cl-dexador
+
+# See: https://github.com/fukamachi/lack/issues/75
 test.run                no

--- a/lisp/cl-libuv/Portfile
+++ b/lisp/cl-libuv/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        orthecreedence cl-libuv 2ec76dc8b2ae0e21340a3059bb080e31d87cc043
+version             20230616
+revision            0
+
+checksums           rmd160  c727ddd86a5f402a68192095eb36d08c98142463 \
+                    sha256  6a047528672eed6a73e27fb0f583cbb5b565f85bcedfa5555fd4f79b08013915 \
+                    size    14890
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Low-level libuv bindings for Common Lisp.
+
+long_description    {*}${description}
+
+post-extract {
+    reinplace "s|libuv.dylib|${prefix}/lib/libuv.dylib|" \
+        ${worksrcpath}/lib.lisp
+
+    reinplace "s|/usr/local/include|${prefix}/include|" \
+        ${worksrcpath}/grovel.lisp
+}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-cffi \
+                    port:libuv

--- a/lisp/cl-lisp-unit2/Portfile
+++ b/lisp/cl-lisp-unit2/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        AccelerationNet lisp-unit2 0.9.4
+name                cl-lisp-unit2
+revision            0
+
+checksums           rmd160  362a9e00cfd95baa62196e23ae3c6c4a9f0b7549 \
+                    sha256  bc524ce3f699c6b5089a38091e2692815728bd0aebb94576500fb4b9a775f8b8 \
+                    size    35124
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Common Lisp library that supports unit testing.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-interpol \
+                    port:cl-iterate \
+                    port:cl-symbol-munger

--- a/lisp/cl-nasdf/Portfile
+++ b/lisp/cl-nasdf/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        atlas-engineer ntemplate 73c89680ace25929c2a1ccc0809db99e9edffa07
+name                cl-nasdf
+version             20230607
+revision            0
+
+checksums           rmd160  dccf9a5187f34ec692d1cb9475c3a3e4eddef11d \
+                    sha256  1aa045f1f7dfe900457d11c3e6e78c4e7fd2a423e71d0618ff29b95785568762 \
+                    size    18403
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         ASDF helpers for system setup, testing and installation.
+
+long_description    {*}${description}
+
+worksrcdir          ${worksrcdir}/nasdf

--- a/lisp/cl-nclasses/Portfile
+++ b/lisp/cl-nclasses/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        atlas-engineer nclasses 0.6.0
+name                cl-nclasses
+revision            0
+
+checksums           rmd160  0f3cc577df932fefd059a4fc8229308d3f9bd394 \
+                    sha256  f00e023669a376a1a8634c3c36c1a43f79d5643fe59a47dd99d6b782f056e84f \
+                    size    31932
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         Simplify class like definitions with define-class and friends.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-moptilities \
+                    port:cl-nasdf
+
+# ;;; Cannot find the external symbol PARSE-BODY in #<"UIOP/DRIVER" package>.
+common_lisp.ecl     no

--- a/lisp/cl-osicat/Portfile
+++ b/lisp/cl-osicat/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        osicat osicat 2421f0d9608aac44ac0e18b2b5e1ff23c953f190
+name                cl-osicat
+version             20221219
+revision            0
+
+checksums           rmd160  10363e6be456d48bfdbead5155d84ced480b5e3a \
+                    sha256  6baa404f423a0952c8829a3cb448cc61878c9af471e0833e289b0afc2bc75278 \
+                    size    66892
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Osicat is a lightweight operating system interface for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-cffi \
+                    port:cl-trivial-features \
+                    port:cl-rt

--- a/lisp/cl-redis/Portfile
+++ b/lisp/cl-redis/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        vseloved cl-redis 7d592417421cf7cd1cffa96043b457af0490df7d
+version             20200616
+revision            0
+
+checksums           rmd160  bec2d541a7bd9db0336d2a4ac3358654c2cf41cd \
+                    sha256  3f56936ddc32fa739adaaa05af8d0807066cfda77959dabedcdfd477d8677c8d \
+                    size    25535
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Redis client for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-babel \
+                    port:cl-bordeaux-threads \
+                    port:cl-flexi-streams \
+                    port:cl-rutils \
+                    port:cl-ppcre \
+                    port:cl-should-test \
+                    port:cl-usocket
+
+# Tests requires real Redis
+test.run            no

--- a/lisp/cl-rutils/Portfile
+++ b/lisp/cl-rutils/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            vseloved rutils 79cb02922f025e818ef4100957abdc9f8d671e2c
+name                    cl-rutils
+version                 20220915
+revision                0
+
+checksums               rmd160  4b7dd50c65ea944cab4f6e553fc7cc8056af3482 \
+                        sha256  07b87c2cd8eb16f471008f2a9454e7b0e62754445bf1fd6b64807ea555dd6de6 \
+                        size    171817
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+description             Radical Utilities for Common Lisp
+
+long_description        {*}${description}
+
+patchfiles-append       fix-syntax-rutilsx-test.asd.diff
+
+# cl-rutils depends on cl-should-test which depends on cl-rutils
+common_lisp.build_run   no
+
+depends_lib-append      port:cl-closer-mop \
+                        port:cl-named-readtables
+
+test.run                no

--- a/lisp/cl-rutils/Portfile
+++ b/lisp/cl-rutils/Portfile
@@ -29,4 +29,4 @@ common_lisp.build_run   no
 depends_lib-append      port:cl-closer-mop \
                         port:cl-named-readtables
 
-test.run                no
+depends_test-append     port:cl-should-test

--- a/lisp/cl-rutils/files/fix-syntax-rutilsx-test.asd.diff
+++ b/lisp/cl-rutils/files/fix-syntax-rutilsx-test.asd.diff
@@ -1,0 +1,12 @@
+https://github.com/vseloved/rutils/pull/62
+
+diff --git rutilsx-test.asd rutilsx-test.asd
+index d5e4195..01541aa 100644
+--- rutilsx-test.asd
++++ rutilsx-test.asd
+@@ -15,4 +15,4 @@
+   :depends-on (#:rutilsx #:should-test)
+   :components
+   ((:module #:test
+-            :components ((:file "packagex"))))))
++            :components ((:file "packagex")))))

--- a/lisp/cl-should-test/Portfile
+++ b/lisp/cl-should-test/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        vseloved should-test 48facb9f9c07aeceb71fc0c48ce17fd7d54a09d4
+name                cl-should-test
+version             20190829
+revision            0
+
+checksums           rmd160  6d60e05a5c27216bd5e0fa9463f54a02ad88d818 \
+                    sha256  fd5bf1ff53a16bcceb1bb4e825bbd468bee27c242562cde6c3bd9c268c324ff2 \
+                    size    7822
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A minimal yet feature-rich Common Lisp test framework
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-local-time \
+                    port:cl-osicat \
+                    port:cl-ppcre \
+                    port:cl-rutils

--- a/lisp/cl-swap-bytes/Portfile
+++ b/lisp/cl-swap-bytes/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        sionescu swap-bytes 1.2 v
+name                cl-swap-bytes
+revision            0
+
+checksums           rmd160  afa4f97dec0c113e1186f3a90d90fe50c85954f2 \
+                    sha256  9bd5d2bb0240c1c5e63aebc566633997be6bdc705f3ca62cb2a6d0f816198241 \
+                    size    4495
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Optimized byte-swapping primitives.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-trivial-features
+
+depends_test-append port:cl-fiveam

--- a/lisp/cl-symbol-munger/Portfile
+++ b/lisp/cl-symbol-munger/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            AccelerationNet symbol-munger e96558e8315b8eef3822be713354787b2348b25e
+name                    cl-symbol-munger
+version                 20220120
+revision                0
+
+checksums               rmd160  cdb9d0db7635298cb7da5985eba0154b84e795d1 \
+                        sha256  2373995107e9698e150e3af4c621cc273d8924c2527c0bce98048a8f65a9af12 \
+                        size    5274
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+description             Common Lisp library that supports unit testing.
+
+long_description        {*}${description}
+
+depends_lib-append      port:cl-alexandria \
+                        port:cl-iterate
+
+# cl-symbol-munger depends on cl-lisp-unit2 which depends on cl-symbol-munger
+common_lisp.build_run   no
+
+test.run                no

--- a/lisp/cl-symbol-munger/Portfile
+++ b/lisp/cl-symbol-munger/Portfile
@@ -27,4 +27,4 @@ depends_lib-append      port:cl-alexandria \
 # cl-symbol-munger depends on cl-lisp-unit2 which depends on cl-symbol-munger
 common_lisp.build_run   no
 
-test.run                no
+depends_test-append     port:cl-lisp-unit2

--- a/lisp/cl-toot/Portfile
+++ b/lisp/cl-toot/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gigamonkey toot 90f3854f2e548c9ad102c53caba834255dfabfa2
+name                cl-toot
+version             20121120
+revision            0
+
+checksums           rmd160  7057f494dd3cc6a59c100ce4afde7f406ba0d63b \
+                    sha256  3553e35585719f34a38094ad7788df710e9ab79577175011770be34899114f10 \
+                    size    58195
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         A web server created by stripping down and reorganizing Edi Weitz's Hunchentoot
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-base64 \
+                    port:cl-bordeaux-threads \
+                    port:cl-chipz \
+                    port:cl-chunga \
+                    port:cl-fad \
+                    port:cl-flexi-streams \
+                    port:cl-md5 \
+                    port:cl-plus-ssl \
+                    port:cl-ppcre \
+                    port:cl-puri \
+                    port:cl-trivial-backtrace \
+                    port:cl-usocket
+
+common_lisp.threads yes

--- a/lisp/cl-trivial-mime/Portfile
+++ b/lisp/cl-trivial-mime/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera trivial-mimes 1a801939594f1496fae097352033414590811b91
+name                cl-trivial-mime
+version             20230603
+revision            0
+
+checksums           rmd160  b07d432e546397bc6daef68e7cfad689ea1e7f7e \
+                    sha256  d38e5e2680aab08a9e68ab6c17baaa7a3a218fab7d2523464b5ff654072d0dab \
+                    size    22577
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         Tiny Common Lisp library to detect mime types in files.
+
+long_description    {*}${description}

--- a/lisp/cl-trivial-package-local-nicknames/Portfile
+++ b/lisp/cl-trivial-package-local-nicknames/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        phoe trivial-package-local-nicknames 8a4d09c1c5cb2b5349aecbd796164433df7a6cc5
+name                cl-trivial-package-local-nicknames
+version             20200130
+revision            0
+
+checksums           rmd160  b48d1bc63ee321fd836b729446ee3ed7e3eadce7 \
+                    sha256  c35df7eea3171a1d23ff8595b8dc7aa7bb2730496738fb713dd7b03643277faf \
+                    size    3922
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         Portability library for package-local nicknames
+
+long_description    {*}${description}

--- a/lisp/cl-trivial-rfc-1123/Portfile
+++ b/lisp/cl-trivial-rfc-1123/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        stacksmith trivial-rfc-1123 9ef59c3fdec08b0e3c9ed02d39533887b6d1b8e3
+name                cl-trivial-rfc-1123
+version             20220402
+revision            0
+
+checksums           rmd160  680ef73c31ce9d9ff29b335e77e18ffd15d533ab \
+                    sha256  8a0d11bb86ad7462a369831eadd6615e75fe3609a65588e88a3485bca0c1b185 \
+                    size    5650
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         parse and print RFC-1123 timestamps
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-ppcre

--- a/lisp/cl-wookie/Portfile
+++ b/lisp/cl-wookie/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        orthecreedence wookie 1f74b6c24b463c1e6fff35377e477934f72bac20
+name                cl-wookie
+version             20230131
+revision            0
+
+checksums           rmd160  fe263bc7b892cbd71a0220cc42d18d56d64ecb6a \
+                    sha256  25e5a1a56b2c84272537d0b7efbe072effce301984981c26e649ee0388ce5528 \
+                    size    29904
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Asynchronous HTTP server in common lisp
+
+long_description    {*}${description}
+
+depends_lib-append  \
+                    port:cl-alexandria \
+                    port:cl-async \
+                    port:cl-babel \
+                    port:cl-blackbird \
+                    port:cl-chunga \
+                    port:cl-do-urlencode \
+                    port:cl-fad \
+                    port:cl-fast-http \
+                    port:cl-fast-io \
+                    port:cl-ppcre \
+                    port:cl-quri \
+                    port:cl-vom
+
+common_lisp.threads yes


### PR DESCRIPTION
#### Description

Here the fifth portion of new lisp ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->