### PR TITLE
tkimg: fix build

### DIFF
--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -17,7 +17,6 @@ platforms               darwin
 
 master_sites            sourceforge:tkimg/tkimg/[join [lrange [split ${version} .] 0 1] .]/tkimg%20${version}
 distname                Img-${version}-Source
-worksrcdir              Img-${version}
 
 checksums               rmd160  f02804981502adaa4ffcd0cd6fc2129a88264efb \
                         sha256  7510b1b819464f228d228a862e53d9e1d3b41c23013b73790a29f7e9165abb21 \


### PR DESCRIPTION
#### Description
Patch phase failing on macOS 13 ARM: https://build.macports.org/builders/ports-13_arm64-builder/builds/30553/steps/install-port/logs/stdio

```
--->  Applying patches to tkimg
--->  Applying patch-quartz.diff
Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_graphics_tkimg/tkimg/work/Img-1.4.14" && /usr/bin/patch -p0 < '/opt/local/var/macports/sources/github.com/macports/macports-ports/graphics/tkimg/files/patch-quartz.diff'
can't find file to patch at input line 3
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|--- pixmap/pixmapUnix.c.orig	2020-04-30 07:19:44.000000000 -0700
|+++ pixmap/pixmapUnix.c	2020-04-30 07:18:58.000000000 -0700
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
1 out of 1 hunk ignored
can't find file to patch at input line 22
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|--- window/window.c.orig	2020-04-30 07:21:45.000000000 -0700
|+++ window/window.c	2020-04-30 07:21:04.000000000 -0700
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
1 out of 1 hunk ignored
Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_github.com_macports_macports-ports_graphics_tkimg/tkimg/work/Img-1.4.14" && /usr/bin/patch -p0 < '/opt/local/var/macports/sources/github.com/macports/macports-ports/graphics/tkimg/files/patch-quartz.diff'
Exit code: 1
Warning: The following existing file was hidden from the build system by trace mode:
  /private/var/select/sh
Error: Failed to patch tkimg: command execution failed
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 Intel
Xcode 14.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
