### PR TITLE
Lisp new ports 6

### DIFF
--- a/lisp/cl-acclimation/Portfile
+++ b/lisp/cl-acclimation/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        robert-strandh Acclimation 4fc59692f2a12d1038fd3978bb6e66f554672049
+name                cl-acclimation
+version             20230226
+revision            0
+
+checksums           rmd160  0afecc870f6e5a0c4ef397867a45c23a71838465 \
+                    sha256  413ad271ba3efe4db9eb145521de02c7a81783b4ac78db36293bc86975bfb446 \
+                    size    6475
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Library supporting internationalization
+
+long_description    {*}${description}
+
+common_lisp.system  {*.asd} \
+                    {Temperature/*.asd}

--- a/lisp/cl-array-utils/Portfile
+++ b/lisp/cl-array-utils/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera array-utils dffb2dc3e2fcc40a5af5e4d746a041b5a4aa88c7
+name                cl-array-utils
+version             20230703
+revision            0
+
+checksums           rmd160  9dce84d34aa57f0bd3230763154ef672f1a6e31a \
+                    sha256  11c6eebaf9ada171baf1bd0305247c4b3f9690f7af3be2acc2433a8b7a80bae1 \
+                    size    6990
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         A few utilities for working with arrays.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-parachute

--- a/lisp/cl-atomics/Portfile
+++ b/lisp/cl-atomics/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera atomics 2c6b90272d09378a40c684c466401a02efa1200b
+name                cl-atomics
+version             20230703
+revision            0
+
+checksums           rmd160  c460b897b5fcf58eb080c95430f64548eee8dbb5 \
+                    sha256  61b576a5599981f0f5924e109fbcc1ad13e0b0ac5ad02b8423c76625ef08962a \
+                    size    8586
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         Portability layer for atomic operations like compare-and-swap (CAS)
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-documentation-utils \
+                    port:cl-parachute
+
+# *** - CLISP is not supported by the Atomics library.
+common_lisp.clisp   no

--- a/lisp/cl-cffi-gtk/Portfile
+++ b/lisp/cl-cffi-gtk/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            sharplispers cl-cffi-gtk 1700fe672c65455c1fc33061ec92a3df84287ec7
+version                 20230202
+revision                0
+
+checksums               rmd160  362d3c12fb3350cf9bbe56ebc1832c1997280ffb \
+                        sha256  1cac5def70716d78154c2e7591590388ea49383d59abbdb7057f33efd0854254 \
+                        size    6309517
+
+categories-append       devel graphics
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 LLGPL
+
+description             A Lisp binding to GTK 3
+
+long_description        {*}${description}
+
+common_lisp.system      {cairo/*.asd} \
+                        {gdk-pixbuf/*.asd} \
+                        {gdk/*.asd} \
+                        {gio/*.asd} \
+                        {glib/*.asd} \
+                        {gobject/*asd} \
+                        {gtk/*.asd} \
+                        {pango/*.asd}
+
+common_lisp.test_system {test/*.asd}
+
+# I may split it into subports but all that dependency from one cluster
+depends_lib-append      path:lib/libcairo.dylib:cairo \
+                        path:lib/libgdk-3.dylib:gtk3 \
+                        path:lib/libgdk_pixbuf-2.0.dylib:gdk-pixbuf2 \
+                        path:lib/libgio-2.0.dylib:glib2 \
+                        path:lib/libgobject-2.0.dylib:glib2 \
+                        path:lib/libgthread-2.0.dylib:glib2 \
+                        path:lib/libglib-2.0.dylib:glib2 \
+                        port:cl-alexandria \
+                        port:cl-bordeaux-threads \
+                        port:cl-cffi \
+                        port:cl-closer-mop \
+                        port:cl-iterate \
+                        port:cl-trivial-features \
+                        port:cl-trivial-garbage
+
+common_lisp.threads     yes
+
+# test requires X11, maybe use Xvfb one day?
+test.run                no

--- a/lisp/cl-clss/Portfile
+++ b/lisp/cl-clss/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera clss c51e25d2ea35618a18fb234f724b13dae5550728
+name                cl-clss
+version             20230703
+revision            0
+
+checksums           rmd160  45bf5debe16ac8a7f488c55657054844cfe99de1 \
+                    sha256  e4120ae422a4f71f666019a3d7d4b8370b1586db665728447431eeff0b03ae48 \
+                    size    21810
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         A DOM tree searching engine based on CSS selectors.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-array-utils \
+                    port:cl-plump

--- a/lisp/cl-cluffer/Portfile
+++ b/lisp/cl-cluffer/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            robert-strandh Cluffer 0c40c544f9e29911fffd0a0afb78b6c1b220ed28
+name                    cl-cluffer
+version                 20230224
+revision                0
+
+checksums               rmd160  e8189b81e0e8211efab67308d206301f5c57aa76 \
+                        sha256  4796d58b6f8642b8317f3e0245dbb3e2f38af9c17576fcf45d6faf6540604a20 \
+                        size    102490
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 FreeBSD
+
+description             Library providing a protocol for text-editor buffers.
+
+long_description        {*}${description}
+
+depends_lib-append      port:cl-acclimation \
+                        port:cl-clump
+
+common_lisp.system      {*.asd} \
+                        {Base/*.asd} \
+                        {Simple-*/*.asd} \
+                        {Standard-*/*.asd}
+
+common_lisp.test_system {Test/*.asd}

--- a/lisp/cl-clump/Portfile
+++ b/lisp/cl-clump/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            robert-strandh Clump 1ea4dbac1cb86713acff9ae58727dd187d21048a
+name                    cl-clump
+version                 20160408
+revision                0
+
+checksums               rmd160  83f02df7aae96bc1b198d6366abd73fff21b5e53 \
+                        sha256  05adc736740d4e74ff0302397a0a32b2abd9bf9825f071f6eded9b3cd2bcd131 \
+                        size    25912
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 FreeBSD
+
+description             Library for operations on different kinds of trees
+
+long_description        {*}${description}
+
+common_lisp.system      {*.asd} \
+                        {2-3-tree/*.asd} \
+                        {Binary-tree/*.asd}
+
+common_lisp.test_system {Test/*.asd}
+
+depends_lib-append      port:cl-acclimation

--- a/lisp/cl-com.inuoe.jzon/Portfile
+++ b/lisp/cl-com.inuoe.jzon/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Zulu-Inuoe jzon 1.1.1 v
+name                cl-com.inuoe.jzon
+revision            0
+
+checksums           rmd160  e0b1311c9bcb1b0a9d24ef59c92c5266c02747c6 \
+                    sha256  e111d5d6e990f2df0606eaed852c011801ae4d9bc8143511ffa0adb45b9609ae \
+                    size    67973
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A correct and safe(er) JSON RFC 8259 parser with sane defaults
+
+long_description    {*}${description}
+
+worksrcdir          ${worksrcdir}/src
+
+depends_lib-append  port:cl-closer-mop \
+                    port:cl-flexi-streams \
+                    port:cl-float-features \
+                    port:cl-trivial-gray-streams
+
+# *** - DEFPACKAGE COM.INUOE.JZON/EISEL-LEMIRE: unknown option :LOCAL-NICKNAMES
+common_lisp.clisp   no

--- a/lisp/cl-float-features/Portfile
+++ b/lisp/cl-float-features/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera float-features a9dd62b8863cff3d1f3d26b6ca4f6c5bb7c2321f
+name                cl-float-features
+version             20230703
+revision            0
+
+checksums           rmd160  fe0b28e1b6d4b9b4d05b781038d002c5087f4f96 \
+                    sha256  48fd3ee367551282a46538690857591b35e3a7e4da1b1760d44957080a469dec \
+                    size    11027
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         A portability library for IEEE float features not covered by the CL standard.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-documentation-utils \
+                    port:cl-parachute
+
+# *** - APPLY: too few arguments given to FIND
+common_lisp.clisp   no

--- a/lisp/cl-iolib/Portfile
+++ b/lisp/cl-iolib/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        sionescu iolib 0.8.4 v
+name                cl-iolib
+revision            0
+
+checksums           rmd160  2c91952e399006e62bf3018c23edf374eb3b3a22 \
+                    sha256  d11b7f1d5872daf5c9d76e3229d4e5222d456ae1f863906c1b1f0b891a4e3074 \
+                    size    238857
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Common Lisp I/O library
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-babel \
+                    port:cl-bordeaux-threads \
+                    port:cl-cffi \
+                    port:cl-idna \
+                    port:cl-swap-bytes \
+                    port:cl-trivial-features \
+                    port:libfixposix
+
+depends_test-append port:cl-fiveam
+
+common_lisp.threads yes

--- a/lisp/cl-lass/Portfile
+++ b/lisp/cl-lass/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera LASS 6e069ffc9ea9659b362e5a16ef9be09addf612dd
+name                cl-lass
+version             20230703
+revision            0
+
+checksums           rmd160  0edccf04140ccd53f8bd420c83be60c525b292b8 \
+                    sha256  1c6bcabb175abe18cf075b2e5ba335ea9a05c7461fd5aa0010b1f59eb31ded2d \
+                    size    22553
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         Lisp Augmented Style Sheets
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-base64 \
+                    port:cl-trivial-indent \
+                    port:cl-trivial-mime

--- a/lisp/cl-lparallel/Portfile
+++ b/lisp/cl-lparallel/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        lmj lparallel 2.8.4 lparallel-
+name                cl-lparallel
+revision            0
+
+checksums           rmd160  936e91405a0922f31a0ba45f0dc08a8897d1034f \
+                    sha256  bcb53fccc53dbc49954ee5a414a8726d527f039fa26ff308dbbafc993f9f22c9 \
+                    size    79465
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+homepage            https://lparallel.org
+
+description         Parallelism for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-bordeaux-threads
+
+common_lisp.threads yes
+
+post-patch {
+    # do not waste time on benchmark
+    file delete ${worksrcpath}/lparallel-bench.asd
+}
+
+# Tests are broken.
+# See:
+#  - https://github.com/lmj/lparallel/issues/47
+#  - https://github.com/lmj/lparallel/issues/48
+test.run            no

--- a/lisp/cl-montezuma/Portfile
+++ b/lisp/cl-montezuma/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        sharplispers montezuma ee2129eece7065760de4ebbaeffaadcb27644738
+name                cl-montezuma
+version             20170216
+revision            0
+
+checksums           rmd160  dfbfaad72c4893cccf0253aad402bd9bcedb0742 \
+                    sha256  dcc5a75f2f2510890f0f5cfe562d679f3628c944f6d9eba495c626e107130152 \
+                    size    1270088
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Montezuma is a port of the Lucene text search engine library.
+
+long_description    {*}${description}
+
+post-extract {
+    # :FORCE and :FORCE-NOT arguments not allowed in a nested call to ASDF/OPERATE:OPERATE unless identically to toplevel
+    reinplace {s| :force t||} ${worksrcpath}/montezuma.asd
+}
+
+depends_lib-append  port:cl-babel \
+                    port:cl-fad \
+                    port:cl-ppcre
+
+depends_test-append port:cl-trivial-timeout
+
+common_lisp.threads yes
+
+# See: https://github.com/sharplispers/montezuma/issues/14
+common_lisp.ecl     no

--- a/lisp/cl-ndebug/Portfile
+++ b/lisp/cl-ndebug/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        atlas-engineer ndebug 0.2.0
+name                cl-ndebug
+revision            0
+
+checksums           rmd160  95ba930a991e7ab4a9a52539e2bca49187efb019 \
+                    sha256  999f2e01fd4cd151c7788ee7b700ec52fb1e7a2ab4e5f564ea3456dd46ad8904 \
+                    size    8560
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A toolkit to construct interface-aware yet standard-compliant debugger hooks.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-dissect \
+                    port:cl-trivial-custom-debugger \
+                    port:cl-trivial-gray-streams
+
+depends_test-append port:cl-lisp-unit2
+
+common_lisp.threads yes

--- a/lisp/cl-nfiles/Portfile
+++ b/lisp/cl-nfiles/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        atlas-engineer nfiles 1.1.3
+name                cl-nfiles
+revision            0
+
+checksums           rmd160  96e88df8d8ead12f7254a30b64536c3c72c52fa9 \
+                    sha256  fdf344e40c1573fb2a44a594347282bf2c6daecb56070040fd17e2a43866af17 \
+                    size    37263
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         A toolkit to construct interface-aware yet standard-compliant debugger hooks.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-iolib \
+                    port:cl-nclasses \
+                    port:cl-quri \
+                    port:cl-serapeum \
+                    port:cl-trivial-garbage \
+                    port:cl-trivial-package-local-nicknames \
+                    port:cl-trivial-types
+
+depends_test-append port:cl-lisp-unit2
+
+common_lisp.threads yes
+
+# Cannot find the external symbol PARSE-BODY in #<"UIOP/DRIVER" package>
+common_lisp.ecl     no

--- a/lisp/cl-nhooks/Portfile
+++ b/lisp/cl-nhooks/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        atlas-engineer nhooks 1.2.1
+name                cl-nhooks
+revision            0
+
+checksums           rmd160  d9bce38aea47a8c681dbc84e6ee770611f41ea2f \
+                    sha256  20d3e7897692cbd32fb87055fc0430485aca90d3cdcbf11ac6fafbd0db94f837 \
+                    size    23156
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Improved hooks facility inspired by Serapeum.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-closer-mop \
+                    port:cl-nasdf \
+                    port:cl-serapeum
+
+depends_test-append port:cl-lisp-unit2
+
+common_lisp.threads yes

--- a/lisp/cl-njson/Portfile
+++ b/lisp/cl-njson/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        atlas-engineer njson 1.1.0
+name                cl-njson
+revision            0
+
+checksums           rmd160  5ebee351b6fc2f9ca42d28d904124f5ddefeea68 \
+                    sha256  f5e01287ef1c2c6a475dbaf94b5899aa48eda08ee83736f891dc249d8b081020 \
+                    size    34902
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         NJSON is a JSON handling framework with the focus on convenience and brevity
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-com.inuoe.jzon \
+                    port:cl-json \
+                    port:cl-nasdf

--- a/lisp/cl-nkeymaps/Portfile
+++ b/lisp/cl-nkeymaps/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        atlas-engineer nkeymaps 1.0.0
+name                cl-nkeymaps
+revision            0
+
+checksums           rmd160  271c0406cb9b2ccf5cb6223bcf7b5d67457c6262 \
+                    sha256  86148f1bcb4f2136d26961c9ad011b62dc361f4cf13604b81e45357ab2203276 \
+                    size    19613
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         General-purpose keymap management à-la Emacs.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-fset \
+                    port:cl-nasdf \
+                    port:cl-trivial-package-local-nicknames
+
+# *** - EVAL: undefined function EXT::ADD-PACKAGE-LOCAL-NICKNAME
+common_lisp.clisp   no

--- a/lisp/cl-nsymbols/Portfile
+++ b/lisp/cl-nsymbols/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        atlas-engineer nsymbols 0.3.1
+name                cl-nsymbols
+revision            0
+
+checksums           rmd160  e77a75e13fb6e356716f891eec7039c05f141ce0 \
+                    sha256  abf16b6884b65387f83047631ad22513b0388f35801d241db2e7b61bd92e4eb8 \
+                    size    10245
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         A set of convenience functions to list class, variable, function, and other symbols.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-closer-mop \
+                    port:cl-nasdf
+
+depends_test-append port:cl-lisp-unit2
+
+# See: https://github.com/atlas-engineer/nsymbols/issues/5
+common_lisp.clisp   no

--- a/lisp/cl-parse-declarations/Portfile
+++ b/lisp/cl-parse-declarations/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           common_lisp 1.0
+
+gitlab.instance     https://gitlab.common-lisp.net
+gitlab.setup        parse-declarations parse-declarations 549aebbfb9403a7fe948654126b9c814f443f4f2
+name                cl-parse-declarations
+version             20090908
+revision            0
+
+checksums           rmd160  0cc6576573899172f3eecc101419fa7f655cc31a \
+                    sha256  1dec354f5cd372f2ae089f8577b06e4ed43c9bf28469719a0190919da38d49d6 \
+                    size    33154
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Library to parse and rebuild declarations
+
+long_description    {*}${description}

--- a/lisp/cl-parse-number/Portfile
+++ b/lisp/cl-parse-number/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        sharplispers parse-number 1.7 v
+name                cl-parse-number
+revision            0
+
+checksums           rmd160  41d2b4a4a77cbee94e977dda63b1f0bacec071b7 \
+                    sha256  c8805933cb2383f9d0acba564858e1d4822d18380fde881f7aed5f7ae93bdf26 \
+                    size    5842
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Number parsing library
+
+long_description    {*}${description}

--- a/lisp/cl-plump/Portfile
+++ b/lisp/cl-plump/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera plump c1170ccf8a5660156933bdbe5c271aa72089bdd2
+name                cl-plump
+version             20230703
+revision            0
+
+checksums           rmd160  43bb0f691cdadf94fd124149fa785d8ee61db0d1 \
+                    sha256  132adc3398a2960eb83a61ba7236679c402919f721eac9a560f4419a5540d321 \
+                    size    51972
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         An XML / XHTML / HTML parser that aims to be as lenient as possible.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-array-utils \
+                    port:cl-documentation-utils

--- a/lisp/cl-serapeum/Portfile
+++ b/lisp/cl-serapeum/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        ruricolist serapeum 36f39a7f6239cd7db11a786f2fc6b46524490bd4
+name                cl-serapeum
+version             20230806
+revision            0
+
+checksums           rmd160  a6a59dcb20db9df748a65497f383bc7238a6ad2c \
+                    sha256  3095c2008cb53edb5123fa11b135112cba041f7112744d1708cf6b0f866c4504 \
+                    size    251986
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Utilities beyond Alexandria.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-bordeaux-threads \
+                    port:cl-global-vars \
+                    port:cl-introspect-environment \
+                    port:cl-parse-declarations \
+                    port:cl-parse-number \
+                    port:cl-split-sequence \
+                    port:cl-string-case \
+                    port:cl-trivia \
+                    port:cl-trivial-cltl2 \
+                    port:cl-trivial-file-size \
+                    port:cl-trivial-garbage \
+                    port:cl-trivial-macroexpand-all
+
+depends_test-append port:cl-atomics \
+                    port:cl-local-time
+
+common_lisp.threads yes

--- a/lisp/cl-string-case/Portfile
+++ b/lisp/cl-string-case/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        pkhuong string-case 718c761e33749e297cd2809c7ba3ade1985c49f7
+name                cl-string-case
+version             20180718
+revision            0
+
+checksums           rmd160  2cd1dec367e736ca6d6c308e050ab631e19c83f4 \
+                    sha256  3e27681a66b0de7b2f592dd5f4d0979880e9540ad1ae327e83645ad55164c7b6 \
+                    size    9167
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         string-case is a macro that generates specialised decision trees to dispatch on string equality
+
+long_description    {*}${description}

--- a/lisp/cl-trivial-file-size/Portfile
+++ b/lisp/cl-trivial-file-size/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        ruricolist trivial-file-size 77e98d99d04e017d227a64157f3f8db4b0e0dfe4
+name                cl-trivial-file-size
+version             20220718
+revision            0
+
+checksums           rmd160  3dcccd6df5daca3fb5510267298c0740b7a8cca3 \
+                    sha256  6f4ec80b455bf1432d0757cb1b1398ced148d4b4c8f7ebc08b5d202c0c0e3f7e \
+                    size    3341
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Stat a file's size
+
+long_description    {*}${description}
+
+depends_test-append port:cl-fiveam

--- a/lisp/cl-trivial-macroexpand-all/Portfile
+++ b/lisp/cl-trivial-macroexpand-all/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        cbaggers trivial-macroexpand-all 933270ac7107477de1bc92c1fd641fe646a7a8a9
+name                cl-trivial-macroexpand-all
+version             20171020
+revision            0
+
+checksums           rmd160  0340b55c6faea706099980f14909b7e90561eac3 \
+                    sha256  dc1eb5736ef8693cc92f2d3b364343faa1778e0fb0b81f58467d71b7e0eaf6de \
+                    size    1998
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+# The Unlicense
+license             public-domain
+
+description         Call each implementation's macroexpand-all equivalent
+
+long_description    {*}${description}

--- a/lisp/cl-trivial-timeout/Portfile
+++ b/lisp/cl-trivial-timeout/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gwkkwg trivial-timeout 512497c5c62dc918f7fa8e6e02a543cc9601a31a
+name                cl-trivial-timeout
+version             20230609
+revision            0
+
+checksums           rmd160  e81a16914e15336fee8da691ff5b1a6aca5faece \
+                    sha256  163deaa315dba3aa2e9f14f9cf04a77513cbe5c7763ee3bd7096a97ebe1a9e42 \
+                    size    9972
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         portable and possibly dangerous timeout library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-lift
+
+# The :name property must be a simple name (not a directory), use :full-pathname if you need more control
+test.run            no


### PR DESCRIPTION
#### Description

Here the sixth out of seven portion of new lisp ports that required to bring nyxt.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->