### PR TITLE
Lisp new ports 7

### DIFF
--- a/_resources/port1.0/group/common_lisp-1.0.tcl
+++ b/_resources/port1.0/group/common_lisp-1.0.tcl
@@ -41,7 +41,7 @@ default common_lisp.system      {*.asd}
 options common_lisp.test_system
 default common_lisp.test_system {}
 
-categories                      lisp
+categories-append               lisp
 
 use_configure                   no
 

--- a/lisp/cl-change-case/Portfile
+++ b/lisp/cl-change-case/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        rudolfochrist cl-change-case 0.2.0
+revision            0
+
+checksums           rmd160  ee991805293fc634a9c2726db93db9026e0fcfd6 \
+                    sha256  da5647dd8bf7b77d14538759bb2e3a6dc5eba35d3932f22843f256f46c6eecf1 \
+                    size    4900
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Convert strings between camelCase, param-case, PascalCase and more
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-ppcre \
+                    port:cl-unicode
+
+depends_test-append port:cl-fiveam

--- a/lisp/cl-jpeg/Portfile
+++ b/lisp/cl-jpeg/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        sharplispers cl-jpeg bef2c3bb64dd19cb31c26338dcbecbf2542a2619
+name                cl-jpeg
+version             20230102
+revision            0
+
+checksums           rmd160  ff96fe1a81b3babad95792e95fa5f333acfa136d \
+                    sha256  a64deac403437154cd6b67ffd22b3d108fd8404b1a94214bd615002880a51c89 \
+                    size    25368
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         A Common Lisp library for reading and writing JPEG image files
+
+long_description    {*}${description}

--- a/lisp/cl-js/Portfile
+++ b/lisp/cl-js/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        akapav js 3a9a1a887bef6b571922f2820f871935121052a5
+name                cl-js
+version             20221206
+revision            0
+
+checksums           rmd160  7e4dba6b3d96e8d39f1f100cf8a688aa5f02adb6 \
+                    sha256  657f617d5ac9cccac5e435152843e9a0992d70a4e735acc2aed70940a2cf9877 \
+                    size    65242
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         JavaScript compiler for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-local-time \
+                    port:cl-parse-js \
+                    port:cl-ppcre

--- a/lisp/cl-nodgui/Portfile
+++ b/lisp/cl-nodgui/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           codeberg 1.0
+PortGroup           common_lisp 1.0
+
+codeberg.setup      cage nodgui a81925a0c052f28867804881fadbe256cfd7676a
+name                cl-nodgui
+version             20230811
+revision            0
+
+checksums           rmd160  b9fa768c404f93b55aa000fc1a1e2d2fef484a25 \
+                    sha256  c69659fb18e4d6637670eb217e0cce040f7d9c7cb6d55d4f58f9616bb853aaa0 \
+                    size    172591
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Lisp bindings for the Tk toolkit
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-bordeaux-threads \
+                    port:cl-clunit2 \
+                    port:cl-colors2 \
+                    port:cl-esrap \
+                    port:cl-jpeg \
+                    port:cl-named-readtables \
+                    port:cl-parse-number \
+                    port:cl-ppcre \
+                    port:cl-unicode \
+
+common_lisp.threads yes

--- a/lisp/cl-parenscript/Portfile
+++ b/lisp/cl-parenscript/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               gitlab 1.0
+PortGroup               common_lisp 1.0
+
+gitlab.instance         https://gitlab.common-lisp.net
+gitlab.setup            parenscript parenscript 1fd720bc4e2bc5ed92064391b730b9d4db35462a
+name                    cl-parenscript
+version                 20200618
+revision                0
+
+checksums               rmd160  9b76057e7680c60f517e3790f75473b5e78de240 \
+                        sha256  0c110235c2a0cce2ee260a6402ce09001fe5c8e3da7327ce869c45896bc2760e \
+                        size    120593
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 BSD
+
+homepage                https:/parenscript.common-lisp.dev
+
+description             Lisp to JavaScript transpiler
+
+long_description        {*}${description}
+
+depends_lib-append      port:cl-anaphora \
+                        port:cl-named-readtables \
+                        port:cl-ppcre
+
+depends_test-append     port:cl-fiveam \
+                        port:cl-js
+
+common_lisp.system      parenscript.asd
+
+common_lisp.test_system parenscript.tests.asd

--- a/lisp/cl-parse-js/Portfile
+++ b/lisp/cl-parse-js/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        marijnh parse-js fbadc6029bec7039602abfc06c73bb52970998f6
+name                cl-parse-js
+version             20160322
+revision            0
+
+checksums           rmd160  d6f3692afd1f849af91eff928862191da8794304 \
+                    sha256  db284af8670d2693eaedf8cb239a4d1e1390152362cc5754ae9201dd7f243bb0 \
+                    size    10748
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         JavaScript parser
+
+long_description    {*}${description}

--- a/lisp/cl-phos/Portfile
+++ b/lisp/cl-phos/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        omar-polo phos 6620b82b091cdfed655e1093ef045dbe518d5474
+name                cl-phos
+version             20220119
+revision            0
+
+checksums           rmd160  300b856e6e355f316becdac469145bf9418fb2af \
+                    sha256  1b1ba7e90f2e0d64b5639d10fdf871d99d229a7430b8b75d47e0ad47837c2ecf \
+                    size    6194
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             ISC
+
+description         An experimental Gemini client library
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-nodgui \
+                    port:cl-plus-ssl \
+                    port:cl-ppcre \
+                    port:cl-quri \
+                    port:cl-trivia \
+                    port:cl-usocket
+
+depends_test-append port:cl-clunit2
+
+common_lisp.threads yes

--- a/lisp/cl-prompter/Portfile
+++ b/lisp/cl-prompter/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        atlas-engineer prompter 0.1.0
+name                cl-prompter
+revision            0
+
+checksums           rmd160  0f5fbd79c8c9f5efd1e6aaad79607de06ec6e3de \
+                    sha256  25c3732a99143c197c12de1a72864f2795cf7ccc1b6e34125d21c39b1626d0d3 \
+                    size    69788
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Live-narrowing, fuzzy-matching, extensible prompt framework
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-calispel \
+                    port:cl-closer-mop \
+                    port:cl-containers \
+                    port:cl-lparallel \
+                    port:cl-moptilities \
+                    port:cl-nclasses \
+                    port:cl-serapeum \
+                    port:cl-str \
+                    port:cl-trivial-package-local-nicknames
+
+depends_test-append port:cl-lisp-unit2
+
+common_lisp.threads yes
+
+# ;;; Cannot find the external symbol PARSE-BODY in #<"UIOP/DRIVER" package>.
+common_lisp.ecl     no

--- a/lisp/cl-py-configparser/Portfile
+++ b/lisp/cl-py-configparser/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           common_lisp 1.0
+
+name                cl-py-configparser
+version             1.0.3
+revision            0
+
+checksums           rmd160  f63ba2bdefb704d3fada712f32bc6d344a2aa7e0 \
+                    sha256  b237be141b7dae11ef2c93b819ff88cb195d80e7b4f480b860a79dcdcac79944 \
+                    size    8411
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+homepage            https://py-configparser.common-lisp.dev
+master_sites        ${homepage}/releases
+distname            py-configparser-${version}
+
+description         Common Lisp implementation of the Python ConfigParser module
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-parse-number
+
+livecheck.type      regex
+livecheck.url       ${master_sites}
+livecheck.regex     py-configparser-(\[\\d.\]+)${extract.suffix}

--- a/lisp/cl-simple-tasks/Portfile
+++ b/lisp/cl-simple-tasks/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera simple-tasks 918553cb89ba8d4ef085c976a58167fd7ae04629
+name                cl-simple-tasks
+version             20230603
+revision            0
+
+checksums           rmd160  2f30ae693df635bb595158a90d70f9c968449423 \
+                    sha256  a43977dc1f017f6ae6afefc801b5849d3ecae94472c1ebcfbabdbffcf6360bb6 \
+                    size    12592
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         A very simple task scheduling framework.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-array-utils \
+                    port:cl-bordeaux-threads \
+                    port:cl-dissect
+
+common_lisp.threads yes

--- a/lisp/cl-spinneret/Portfile
+++ b/lisp/cl-spinneret/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        ruricolist spinneret fb843ea8b4aed2d85f17b19abe7ceda29839ffd9
+name                cl-spinneret
+version             20230728
+revision            0
+
+checksums           rmd160  10382c36654c34a5ec21fc31909324e7132e0208 \
+                    sha256  872c6c4253334aa6a25347f1ee5b2a90540ab43d69ef174b32e447a67d192e76 \
+                    size    31203
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Common Lisp HTML5 generator.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-global-vars \
+                    port:cl-markdown \
+                    port:cl-parenscript \
+                    port:cl-ppcre \
+                    port:cl-serapeum \
+                    port:cl-trivia \
+                    port:cl-trivial-gray-streams
+
+depends_test-append port:cl-fiveam
+
+common_lisp.threads yes

--- a/lisp/cl-str/Portfile
+++ b/lisp/cl-str/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            vindarel cl-str 81e3129c1a6bd96508f4c1a6636a1e1cf3c15b01
+# The next release will be 0.20 -> save to include dayte this way
+# See: https://github.com/vindarel/cl-str/issues/107
+version                 0.19.20230802
+revision                0
+
+checksums               rmd160  c445507c4fe169d3f01475e49e7025c87b4a92e6 \
+                        sha256  45b93b383e35bbe910d85f431dc8b2e39fdb4caf8b7393c6907506cc5decf5c8 \
+                        size    25452
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+description             Modern, consistent and terse Common Lisp string manipulation library.
+
+long_description        {*}${description}
+
+common_lisp.system      str.asd
+
+depends_lib-append      port:cl-ppcre \
+                        port:cl-change-case
+
+common_lisp.test_system str.test.asd
+
+depends_test-append     port:cl-fiveam

--- a/lisp/cl-trivial-benchmark/Portfile
+++ b/lisp/cl-trivial-benchmark/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera trivial-benchmark 1fbc8d15f09ed8aa426bc73956b8b7c9b2668802
+name                cl-trivial-benchmark
+version             20230603
+revision            0
+
+checksums           rmd160  cd43f8d6c12fc8c85b07db597fabac3532c66b39 \
+                    sha256  87aac7acddcfb0fef3a4f880a88296a1362def2b0ca958dfd70d0a092a4eefc6 \
+                    size    14017
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         An easy to use benchmarking system.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria

--- a/lisp/cl-trivial-clipboard/Portfile
+++ b/lisp/cl-trivial-clipboard/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            snmsts trivial-clipboard 19262e0cd3d493bf641668f09d1995fd0e954100
+name                    cl-trivial-clipboard
+version                 20230405
+revision                0
+
+checksums               rmd160  5c5bb42a9f26007ef96a79cb47a9cf3aa0effbc1 \
+                        sha256  e1e7f3b724edb1ee17ae8a307c8453b3db089ed1aa50d26f5d04c5aa92812b6e \
+                        size    4779
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+description             trivial-clipboard let access system clipboard
+
+long_description        {*}${description}
+
+common_lisp.system      trivial-clipboard.asd
+
+depends_lib-append      port:cl-cffi
+
+common_lisp.test_system trivial-clipboard-test.asd
+
+depends_test-append     port:cl-fiveam

--- a/lisp/cl-trivial-main-thread/Portfile
+++ b/lisp/cl-trivial-main-thread/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera trivial-main-thread ebcb7b70f69cc93cefa18d6be436aa202d7f8b5e
+name                cl-trivial-main-thread
+version             20230603
+revision            0
+
+checksums           rmd160  5ac30276dd5f14deb4161b41b9904e4b21faa645 \
+                    sha256  6e5d43a762e2d5d536da186e671b1f8b7ebf89ecab114a49b138f9608e9b223b \
+                    size    6214
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         Compatibility library to run things in the main thread.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-bordeaux-threads \
+                    port:cl-simple-tasks \
+                    port:cl-trivial-features
+
+common_lisp.threads yes

--- a/lisp/cl-unix-opts/Portfile
+++ b/lisp/cl-unix-opts/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        libre-man unix-opts 0e61f34b2ecf62288437810d4abb31e572048b04
+name                cl-unix-opts
+version             20210107
+revision            0
+
+checksums           rmd160  eab165e566e68a25dd266a15c3c01069be88593e \
+                    sha256  608e818323cde482ab2bc6725716fac4102e34c7c9e90bffa1a3d4132059f44c \
+                    size    15231
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         minimalistic parser of command line arguments
+
+long_description    {*}${description}

--- a/lisp/cl-webengine/Portfile
+++ b/lisp/cl-webengine/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   github 1.0
+
+github.setup                atlas-engineer cl-webengine 0fd81be936b547e008c8f7809b2df962a79da490
+version                     20210225
+revision                    0
+
+checksums                   rmd160  819aeebe25e83ccb8cb1af0e060bd171098c41fc \
+                            sha256  4c82273e5941c1e20eeceac0822fa94f13f013dc4c59bdb78580eceb106a8193 \
+                            size    9188
+
+categories-append           lisp devel
+maintainers                 {@catap korins.ky:kirill} openmaintainer
+license                     BSD
+
+description                 An FFI binding to WebEngine in Qt
+
+long_description            {*}${description}
+
+subport cl-webengine-lib {
+    PortGroup               qmake5 1.0
+
+    qt5.depends_component   qtwebengine
+
+    worksrcdir              ${worksrcdir}/source
+
+    destroot {
+        xinstall -m 755 {*}[glob ${worksrcpath}/*.dylib] ${destroot}${prefix}/lib/
+    }
+}
+
+if {${name} eq ${subport}} {
+    PortGroup               common_lisp 1.0
+
+    depends_lib-append      port:cl-cffi \
+                            port:cl-webengine-lib
+
+    # SBCL only port
+    common_lisp.ecl         no
+    common_lisp.clisp       no
+}


### PR DESCRIPTION
#### Description

Here the last portion of new lisp ports that required to bring nyxt.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->