### PR TITLE
grpc: update to 1.48.4, unbreak build

### DIFF
--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -7,8 +7,8 @@ PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 # NOTE: Also rev-bump 'apache-arrow' when updating this port
-github.setup        grpc grpc 1.48.0 v
-revision            8
+github.setup        grpc grpc 1.48.4 v
+revision            0
 categories          devel
 maintainers         nomaintainer
 license             Apache-2
@@ -27,6 +27,9 @@ homepage            https://grpc.io/
 github.livecheck.regex  {([0-9.]+)}
 
 set name_io         ${name}io
+
+# https://trac.macports.org/ticket/65525#comment:1
+patchfiles-append   patch-unbreak-port_platform.diff
 
 # error: constexpr function never produces a constant expression
 # Requires c++17 support
@@ -78,6 +81,15 @@ configure.args-append \
                     -DgRPC_RE2_PROVIDER=package \
                     -DgRPC_SSL_PROVIDER=package \
                     -DgRPC_ZLIB_PROVIDER=package
+
+# https://github.com/grpc/grpc/pull/32159
+configure.cppflags-append \
+                    -D__STDC_FORMAT_MACROS
+
+if {${build_arch} in [list i386 ppc] && [string match *gcc* ${configure.compiler}]} {
+    # ___atomic_fetch_sub_8 etc.
+    configure.ldflags-append -latomic
+}
 
 # the build must link against its own libraries
 cmake.install_rpath

--- a/devel/grpc/files/patch-unbreak-port_platform.diff
+++ b/devel/grpc/files/patch-unbreak-port_platform.diff
@@ -1,0 +1,15 @@
+--- include/grpc/impl/codegen/port_platform.h.orig	2023-08-12 14:29:01.000000000 +0800
++++ include/grpc/impl/codegen/port_platform.h	2023-08-12 14:44:01.000000000 +0800
+@@ -242,9 +242,11 @@
+ #define GPR_CPU_POSIX 1
+ #define GPR_POSIX_CRASH_HANDLER 1
+ #endif
+-#if !(defined(__has_feature) && __has_feature(cxx_thread_local))
++#if defined(__has_feature)
++#if __has_feature(cxx_thread_local)
+ #define GPR_PTHREAD_TLS 1
+ #endif
++#endif
+ #define GPR_APPLE 1
+ #define GPR_GCC_ATOMIC 1
+ #define GPR_POSIX_LOG 1


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/65525

#### Description

@mascguy Maybe we just update to a latest minor version of 1.48.x branch? At least to fix the build (one issue is a wrong code in `port_platform`; then atomics, again).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
