### PR TITLE
cl-webkit2: new port (version 3.5.9)

### DIFF
--- a/lisp/cl-webkit2/Portfile
+++ b/lisp/cl-webkit2/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        joachifm cl-webkit 3.5.9
+github.tarball_from archive
+name                cl-webkit2
+revision            0
+
+checksums           rmd160  d8d3938d54493a5f21a55dadb8c770248536ae42 \
+                    sha256  29c7ee69a7c05897bac63879c8a5b3bcdcc90ba9ba5daa2fddb50225ad97e1fa \
+                    size    39940
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         A binding to WebKitGTK+ for Common Lisp
+
+long_description    {*}${description}
+
+worksrcdir          ${worksrcdir}/webkit2
+
+depends_lib-append  path:lib/libwebkit2gtk-4.0.dylib:webkit2-gtk \
+                    port:cl-alexandria \
+                    port:cl-cffi \
+                    port:cl-cffi-gtk
+
+depends_test-append port:cl-calispel \
+                    port:cl-fiveam \
+                    port:cl-float-features
+
+common_lisp.threads yes
+
+# test requires X11, maybe use Xvfb one day?
+test.run                no


### PR DESCRIPTION
#### Description

This is extracted commit from https://github.com/macports/macports-ports/pull/19858

As single commit it passes CI => probably it is too heavy by used disc size.

Anyway, I've fixed it locally on macOS 12 and macOS 13 and it also works as expected.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->