### PR TITLE
smartmontools: update to 7.4

### DIFF
--- a/sysutils/smartmontools/Portfile
+++ b/sysutils/smartmontools/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                smartmontools
-version             7.3
+version             7.4
 categories          sysutils
 license             GPL-2+
 platforms           darwin
@@ -22,9 +22,9 @@ long_description \
 homepage            http://smartmontools.sourceforge.net/
 master_sites        sourceforge:project/smartmontools/smartmontools/${version}/
 
-checksums           rmd160  2b07b544d418396a529039c589408ab172e69ac3 \
-                    sha256  a544f8808d0c58cfb0e7424ca1841cb858a974922b035d505d4e4c248be3a22b \
-                    size    1043932
+checksums           rmd160  83e872ed4c1fef4dbd648158b1f84fd5ebc08c90 \
+                    sha256  e9a61f641ff96ca95319edfb17948cd297d0cd3342736b2c49c99d4716fb993d \
+                    size    1094955
 
 configure.args      --without-savestates \
                     --without-attributelog \


### PR DESCRIPTION
#### Description

Tested out locally by running smart tests / dumping smart status.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5 22G74 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
