### PR TITLE
gpac: fix compilation on Mavericks and Mountain Lion

### DIFF
--- a/multimedia/gpac/Portfile
+++ b/multimedia/gpac/Portfile
@@ -57,6 +57,12 @@ depends_lib         port:freetype \
 patchfiles          patch-configure.diff \
                     patch-no-hevc-yosemite.diff
 
+if {${os.platform} eq "darwin" && (${os.major} == 12 || ${os.major} == 13) } {
+    # Fix undefined symbol _memrchr by copying in the implementation from sudo
+    # https://opensource.apple.com/source/sudo/sudo-67/src/memrchr.c.auto.html
+    patchfiles-append patch-memrchr-mavericks-mountain-lion.diff
+}
+
 post-patch {
     reinplace "s|@APPLICATIONS_DIR@|${applications_dir}|g" ${worksrcpath}/configure
 }

--- a/multimedia/gpac/files/patch-memrchr-mavericks-mountain-lion.diff
+++ b/multimedia/gpac/files/patch-memrchr-mavericks-mountain-lion.diff
@@ -1,0 +1,27 @@
+--- src/filter_core/filter_props.c.orig
++++ src/filter_core/filter_props.c
+@@ -30,6 +30,24 @@
+ //for base64 decode
+ #include <gpac/base_coding.h>
+ 
++void *
++memrchr(s, c, n)
++    const void *s;
++    int c;
++    size_t n;
++{
++    const unsigned char *cp;
++
++    if (n != 0) {
++	cp = (unsigned char *)s + n;
++	do {
++	    if (*(--cp) == (unsigned char)c)
++		return((void *)cp);
++	} while (--n != 0);
++    }
++    return((void *)0);
++}
++
+ typedef u32(*cst_parse_proto)(const char *val);
+ typedef const char *(*cst_name_proto)(u32 val);
+ 


### PR DESCRIPTION
#### Description

The Mavericks build fails with this error (Mountain Lion fails too, and I assume it is for the same reason):

```
:info:build Undefined symbols for architecture x86_64:
:info:build   "_memrchr", referenced from:
:info:build       _gf_props_parse_value in filter_props.o
:info:build ld: symbol(s) not found for architecture x86_64
```

I am not sure why, as `memrchr` does not appear in the GPAC source code. I tried to grep `/opt/local/include` for `memrchr`, but did not find any obviously helpful results. The problem might lie in the compiler. This port blacklists compilers Clang < 700, so on my system it chooses LLVM/Clang 15. I took a look at `gf_props_parse_value` in filter_props.c and I am still non the wiser (it does reference `strrchr`, but could the compiler for some reason replace that with `memrchr`?). The solution I therefore went with is a patch that pastes in an implementation of `memrchr` (from [sudo](https://opensource.apple.com/source/sudo/sudo-67/src/memrchr.c.auto.html)) on OS X 10.8 and 10.9. I do not view it as optimal, but it is the best I have. Another option might be to add this function to LegacySupport.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

(Basic functionality: I ran the two binary files without any command line option to verify that there were no linker errors. I also ran `MP4Box` with `--version`, `-languages` and `-nodes` and verified that the outputs made sense)
