### PR TITLE
nccmp: Fix livecheck

### DIFF
--- a/science/nccmp/Portfile
+++ b/science/nccmp/Portfile
@@ -1,13 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           gitlab 1.0
 
 # this port can optionally be built with cmake (but then tests are run in a different way)
 #PortGroup          cmake 1.1
 
-name                nccmp
-version             1.9.1.0
+gitlab.setup        remikz nccmp 1.9.1.0
 revision            0
+checksums           rmd160  d3eb0a8d2b55c93f42832e74dedab358f42fa243 \
+                    sha256  44768ebdc5633207fbf1a7e087767782c6811f600c6a6c91b5829fb7787064ae \
+                    size    312482
+
 categories          science
 maintainers         {noaa.gov:dave.allured @Dave-Allured} openmaintainer
 license             GPL-2
@@ -15,14 +19,6 @@ description         Tool for comparing NetCDF files
 long_description    nccmp compares two NetCDF files bitwise, semantically or \
                     with a user defined tolerance. Highly recommended for regression testing \
                     scientific models or datasets in a test-driven development environment.
-
-homepage            https://gitlab.com/remikz/nccmp
-master_sites        https://gitlab.com/remikz/nccmp/-/archive/${version}/
-use_bzip2           yes
-
-checksums           rmd160  d3eb0a8d2b55c93f42832e74dedab358f42fa243 \
-                    sha256  44768ebdc5633207fbf1a7e087767782c6811f600c6a6c91b5829fb7787064ae \
-                    size    312482
 
 depends_lib         port:netcdf
 


### PR DESCRIPTION
#### Description

* Use gitlab portgroup
* Fix livecheck

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

Only tested livecheck locally.  OS 12.6.7, x86_64.
Github/CI:  OS11, 12, 13:  All passed.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
