### PR TITLE
py-spyder: add py311 subport

### DIFF
--- a/python/py-cookiecutter/Portfile
+++ b/python/py-cookiecutter/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-cookiecutter
 version             2.3.0
-revision            0
+revision            1
 
 categories-append   devel
 supported_archs     noarch
@@ -36,5 +36,6 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-requests \
                     port:py${python.version}-yaml \
                     port:py${python.version}-slugify \
-                    port:py${python.version}-arrow
+                    port:py${python.version}-arrow \
+                    port:py${python.version}-rich
 }

--- a/python/py-helpdev/Portfile
+++ b/python/py-helpdev/Portfile
@@ -22,7 +22,7 @@ checksums           sha256  bb62a79acbac141dadf42cadeb92bb7450dd18b9824a62043b6a
                     rmd160  7e59fdd17c3e5b3d502ed7a72992d1354fb10172 \
                     size    51575
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-libsass/Portfile
+++ b/python/py-libsass/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-libsass
-version             0.21.0
+version             0.22.0
 revision            0
 
 categories-append   devel
@@ -16,11 +16,11 @@ long_description    ${description}
 
 homepage            https://sass.github.io/libsass-python/
 
-checksums           sha256  d5ba529d9ce668be9380563279f3ffe988f27bc5b299c5a28453df2e0b0fbaf2 \
-                    rmd160  2a0439419e40c1da61f2414b7a78bee72583a580 \
-                    size    317193
+checksums           sha256  3ab5ad18e47db560f4f0c09e3d28cf3bb1a44711257488ac2adad69f4f7f8425 \
+                    rmd160  6e83ef7d1a409c6ab696aaad08f51d79fd3047f0 \
+                    size    316258
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-numpydoc/Portfile
+++ b/python/py-numpydoc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-numpydoc
-version             1.2
+version             1.5.0
 revision            0
 
 supported_archs     noarch
@@ -19,11 +19,11 @@ long_description    Numpydoc inserts a hook into Sphinx’s autodoc \
 
 homepage            https://github.com/numpy/numpydoc
 
-checksums           rmd160  09d3f9809e47eaa06ad3108b2479c88bb67f9eb1 \
-                    sha256  0cec233740c6b125913005d16e8a9996e060528afcb8b7cad3f2706629dfd6f7 \
-                    size    69659
+checksums           rmd160  37b5d6dfb3252a55c12288c73a6111013937a4f6 \
+                    sha256  b0db7b75a32367a0e25c23b397842c65e344a1206524d16c8069f0a1c91b5f4c \
+                    size    71892
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pyls-spyder/Portfile
+++ b/python/py-pyls-spyder/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  8199e9fa566a8220dff156cee9dbac0327b69880 \
                     sha256  45a321c83f64267d82907492c55199fccabda45bc872dd23bf1efd08edac1b0b \
                     size    7427
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-python-lsp-black/Portfile
+++ b/python/py-python-lsp-black/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  93476be0b8bfc85e2da05516e90ed9bb1fcdae14 \
                     sha256  5aa257e9e7b7e5a2316ef2a9fbcd242e82e0f695bf1622e31c0bf5cd69e6113f \
                     size    6092
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-qdarkstyle/Portfile
+++ b/python/py-qdarkstyle/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-qdarkstyle
 python.rootname     QDarkStyle
-version             3.0.3
+version             3.1
 revision            0
 
 categories-append   devel
@@ -20,11 +20,11 @@ long_description    This package provides a dark style sheet for \
 
 homepage            https://github.com/ColinDuquesnoy/QDarkStyleSheet
 
-checksums           sha256  936d2d35b552f429803a985dbc17fc879a2f966faa9fbf8983896ccfa33e68f6 \
-                    rmd160  cd36885f4dd1bc838591b004c7b5efb1b5323931 \
-                    size    431182
+checksums           sha256  600584d625343e0ddd128de08393d3c35637786a49827f174d29aa7caa8279c1 \
+                    rmd160  fb4c60f4d45b78fac9ac9f68e411d4f92431bf40 \
+                    size    698602
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-qtsass/Portfile
+++ b/python/py-qtsass/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-qtsass
-version             0.3.0
+version             0.4.0
 revision            0
 
 categories-append   devel
@@ -18,11 +18,11 @@ long_description    The goal of QtSASS is to be able to generate a Qt-CSS styles
 
 homepage            https://github.com/spyder-ide/qtsass
 
-checksums           sha256  27c49f63cea9e23a0b9618f71f4a4e992833cd1cfdf78ed832c69ceea1de1fe7 \
-                    rmd160  c79b863fed43bec333a533e8292c2805501c7a42 \
-                    size    19356
+checksums           sha256  8341c6d2690f75d651916dcaf96b4fa8c6dc54ef1d96bbc39958cbaa475fbf41 \
+                    rmd160  7409e79b311098d6fa8d087642d1bd7d670b1407 \
+                    size    25595
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-spyder-kernels/Portfile
+++ b/python/py-spyder-kernels/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  6f6adf36f8118f8016669aeb61f9b7d773f88ff0 \
                     sha256  363bb0a0e1594cb691637464192f4f19969095469252242b43c092bf305a25dd \
                     size    98216
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     conflicts       py${python.version}-spyder-kernels-devel

--- a/python/py-spyder/Portfile
+++ b/python/py-spyder/Portfile
@@ -35,7 +35,7 @@ checksums           rmd160  85023c8f0ab5d809d5f111a3c186eb5ea5bd4c7e \
                     sha256  f4ce44b936f0bb7843f492464d0e86c48b2c4c03d298cafffc50f49b86130429 \
                     size    16214815
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     conflicts       py${python.version}-spyder-devel

--- a/python/py-spyder/files/spyder-311
+++ b/python/py-spyder/files/spyder-311
@@ -1,0 +1,1 @@
+bin/spyder-3.11


### PR DESCRIPTION
#### Description
Add subport for Python 3.11 to `py-spyder` and dependencies (including a few updates)

 Tested on
macOS 13.5 22G74 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
