### PR TITLE
Update a few lisp ports

### DIFF
--- a/lisp/cl-3bmd/Portfile
+++ b/lisp/cl-3bmd/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        3b 3bmd 0cc2f8627098472bbd72ff9e6a31f17db6486239
+github.setup        3b 3bmd e68b2d442f29b4534c1c8e2f2cdf7583643a2fc5
 name                cl-3bmd
-version             20230726
+version             20230812
 revision            0
 
-checksums           rmd160  d4c3220594c6f7072e650e3f3011847dc16d2690 \
-                    sha256  a6a40efe19330f107bfb89161f82005614f241c4507247a753a7dd84fe92e392 \
-                    size    40571
+checksums           rmd160  0706813ab19e7137c5c814be233c9cc17ee004bd \
+                    sha256  e05db34291e7dade1fea61b2970f826011e22fec4d26a925b26317f01b4e235a \
+                    size    40751
 
 categories-append   textproc
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -25,7 +25,3 @@ depends_lib-append  port:cl-colorize \
                     port:cl-fiasco \
                     port:cl-esrap \
                     port:cl-split-sequence
-
-# clisp seems to be broken
-# See: https://github.com/3b/3bmd/issues/61
-common_lisp.clisp   no

--- a/lisp/cl-dynamic-classes/Portfile
+++ b/lisp/cl-dynamic-classes/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg dynamic-classes 844b077e5ac5ef2127603e692af983e9952ebae9
+github.setup        gwkkwg dynamic-classes ebd7405603f67b16e8f2bc08ce8e2bcfcf439501
 name                cl-dynamic-classes
-version             20101221
+version             20230809
 revision            0
 
-checksums           rmd160  789d4da92777f03270fbbf82064377c64df54062 \
-                    sha256  15826c31df74a072dbb63a89e7cde37e40a4e9959fa635dff3535e3a22ede583 \
-                    size    7239
+checksums           rmd160  ee14b1f24393ca1e8f6ad2c464041c32a3074e82 \
+                    sha256  f5ebfeb88502e6eaa6ba004760aa4591e635c13eb0e7d8cbe5c1bc776c79016c \
+                    size    7368
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-metacopy/Portfile
+++ b/lisp/cl-metacopy/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg metacopy 03a9cd58938b7aa6de7c9f2527614a1403cbb205
+github.setup        hraban metacopy df7856f2a43fa91124fe780ef22f792040bc130c
 name                cl-metacopy
-version             20230120
+version             20230812
 revision            0
 
-checksums           rmd160  963ac6b82d0a0ca5f96fc0584661d8774b70c2aa \
-                    sha256  26739819dfb4aa76a889965a8bc6b8188ff05fb166aa558781af76dc6019feec \
-                    size    9385
+checksums           rmd160  0815b9decf90b153d084aae8c5d13f43fe57e700 \
+                    sha256  4c817315ef2c7ab1e33feb6cf0813c5e373ab34a0e0d037f56c9fc73ca0cbc80 \
+                    size    9666
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -24,7 +24,3 @@ long_description    {*}${description}
 depends_lib-append  port:cl-contextl \
                     port:cl-metatilities \
                     port:cl-lift
-
-# See: https://github.com/gwkkwg/metacopy/issues/2
-common_lisp.ecl     no
-common_lisp.clisp   no

--- a/lisp/cl-mgl-pax/Portfile
+++ b/lisp/cl-mgl-pax/Portfile
@@ -4,14 +4,14 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 PortGroup                   common_lisp 1.0
 
-github.setup                melisgl mgl-pax 96017fbd19b9edd3a30fa1d5dfc070903d435baf
+github.setup                melisgl mgl-pax 8e7dc0ce2eec26a17543e53d3527eb7315711f16
 name                        cl-mgl-pax
-version                     20230803
+version                     20230810
 revision                    0
 
-checksums                   rmd160  2197f9fc88f4263a80fda8a96d65dae9cc5a74fd \
-                            sha256  d99e43fcb99484a0251b8461f66472bb9c5213027fa286e02f6d353112f814c0 \
-                            size    979759
+checksums                   rmd160  52867424bbda4828739abfa92cbf66356c42a594 \
+                            sha256  1ec3abded0b021de81f60890df3b1583b76f2896f20e6388e37c34b31f7e19fd \
+                            size    979681
 
 categories-append           devel textproc
 maintainers                 {@catap korins.ky:kirill} openmaintainer
@@ -47,4 +47,6 @@ subport cl-dref {
 
     depends_test-append     port:cl-mgl-pax \
                             port:cl-try
+
+    livecheck.type          none
 }


### PR DESCRIPTION
#### Description

This is micro update mainly addressed on fixing issues which I've opened at some ports when it was created.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->