### PR TITLE
llvm-1[5-6]: backport upstream patch (memrchr unavailable)

### DIFF
--- a/lang/llvm-15/Portfile
+++ b/lang/llvm-15/Portfile
@@ -25,7 +25,7 @@ set clang_exe_version   ${llvm_version}
 version                 ${llvm_version}.0.7
 
 name                    llvm-${llvm_version}
-revision                0
+revision                1
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 2 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
@@ -140,6 +140,7 @@ patchfiles-append \
     0015-Fixup-libstdc-header-search-paths-for-older-versions.patch \
     0019-10.6-and-less-use-emulated-TLS-before-10.7.patch \
     0025-lldb-add-defines-needed-for-older-SDKs.patch \
+    0026-llvm-set-memrchr-unavailable.patch \
     0999-i386-fix.diff
 
 if {${os.platform} eq "darwin" && ${os.major} < 14} {

--- a/lang/llvm-15/files/0026-llvm-set-memrchr-unavailable.patch
+++ b/lang/llvm-15/files/0026-llvm-set-memrchr-unavailable.patch
@@ -1,0 +1,11 @@
+diff --git a/llvm/lib/Analysis/TargetLibraryInfo.cpp b/llvm/lib/Analysis/TargetLibraryInfo.cpp
+--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
++++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
+@@ -203,6 +203,7 @@
+     TLI.setAvailable(LibFunc_getchar_unlocked);
+     TLI.setAvailable(LibFunc_putc_unlocked);
+     TLI.setAvailable(LibFunc_putchar_unlocked);
++    TLI.setUnavailable(LibFunc_memrchr);
+ 
+     if (T.isMacOSXVersionLT(10, 5)) {
+       TLI.setUnavailable(LibFunc_memset_pattern4);

--- a/lang/llvm-16/Portfile
+++ b/lang/llvm-16/Portfile
@@ -25,7 +25,7 @@ set clang_exe_version   ${llvm_version}
 version                 ${llvm_version}.0.6
 
 name                    llvm-${llvm_version}
-revision                0
+revision                1
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 clang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 1 ] }
@@ -140,6 +140,7 @@ patchfiles-append \
     0015-Fixup-libstdc-header-search-paths-for-older-versions.patch \
     0019-10.6-and-less-use-emulated-TLS-before-10.7.patch \
     0025-lldb-add-defines-needed-for-older-SDKs.patch \
+    0026-llvm-set-memrchr-unavailable.patch \
     0999-i386-fix.diff
 
 if {${os.platform} eq "darwin" && ${os.major} < 14} {

--- a/lang/llvm-16/files/0026-llvm-set-memrchr-unavailable.patch
+++ b/lang/llvm-16/files/0026-llvm-set-memrchr-unavailable.patch
@@ -1,0 +1,11 @@
+diff --git a/llvm/lib/Analysis/TargetLibraryInfo.cpp b/llvm/lib/Analysis/TargetLibraryInfo.cpp
+--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
++++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
+@@ -203,6 +203,7 @@
+     TLI.setAvailable(LibFunc_getchar_unlocked);
+     TLI.setAvailable(LibFunc_putc_unlocked);
+     TLI.setAvailable(LibFunc_putchar_unlocked);
++    TLI.setUnavailable(LibFunc_memrchr);
+ 
+     if (T.isMacOSXVersionLT(10, 5)) {
+       TLI.setUnavailable(LibFunc_memset_pattern4);


### PR DESCRIPTION
#### Description

With LLVM 15 and LLVM 16, Clang is allowed in some cases to replace `strrchr` with `memrchr` when compiling with optimisations enabled. The problem is that `memrchr` is unavailable on several OS X versions, resulting in a confusing linker error. As discovered by @mohd-akram (see his comments on PR #19868 and on the linked LLVM.org issue), the bug has been [patched upstream](https://reviews.llvm.org/D155168) by setting `memrchr` as unavailable on Mac systems. What I am doing here is to backport this patch to LLVM 15 and 16.

I wrote a simple test program that I used to trigger the issue and verified that this patch does make it go away when rebuilding ports llvm-15 and llvm-16 with it. This also allows me to build GPAC, the port that made me run into this problem in the first place. See this comment for details: https://github.com/macports/macports-ports/pull/19868#issuecomment-1676414804

Note: I am not familiar with the naming conventions for patch file numbers in LLVM, so I picked the next free number (0026). Let me know if this is wrong.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
