### PR TITLE
Lisp: avoid depndency cycles

### DIFF
--- a/_resources/port1.0/group/common_lisp-1.0.tcl
+++ b/_resources/port1.0/group/common_lisp-1.0.tcl
@@ -35,11 +35,8 @@ default common_lisp.clisp       yes
 options common_lisp.build_run
 default common_lisp.build_run   yes
 
-options common_lisp.system
-default common_lisp.system      {*.asd}
-
-options common_lisp.test_system
-default common_lisp.test_system {}
+options common_lisp.systems
+default common_lisp.systems     {*.asd}
 
 categories-append               lisp
 
@@ -120,19 +117,11 @@ build {
 
     xinstall -m 0755 -d ${common_lisp.build}/source
     xinstall -m 0755 -d ${common_lisp.build}/system
-    xinstall -m 0755 -d ${common_lisp.build}/test_system
 
     file copy ${worksrcpath} ${common_lisp.build}/source/${subport}
 
-    foreach f [glob -dir ${common_lisp.build}/source/${subport} -tails {*}[option common_lisp.system]] {
+    foreach f [glob -dir ${common_lisp.build}/source/${subport} -tails {*}[option common_lisp.systems]] {
         ln -sf ../source/${subport}/$f ${common_lisp.build}/system
-        ln -sf ../source/${subport}/$f ${common_lisp.build}/test_system
-    }
-
-    if {[llength [option common_lisp.test_system]]} {
-        foreach f [glob -dir ${common_lisp.build}/source/${subport} -tails {*}[option common_lisp.test_system]] {
-            ln -sf ../source/${subport}/$f ${common_lisp.build}/test_system
-        }
     }
 
     if {[option common_lisp.build_run]} {
@@ -155,8 +144,8 @@ test {
         return
     }
 
-    foreach item [glob -dir ${common_lisp.build}/test_system -tails *.asd] {
-        common_lisp::asdf_operate "test-op" [string range ${item} 0 end-4] ${common_lisp.build}/test_system
+    foreach item [glob -dir ${common_lisp.build}/system -tails *.asd] {
+        common_lisp::asdf_operate "test-op" [string range ${item} 0 end-4] ${common_lisp.build}/system
     }
 }
 

--- a/lisp/cl-acclimation/Portfile
+++ b/lisp/cl-acclimation/Portfile
@@ -7,7 +7,7 @@ PortGroup           common_lisp 1.0
 github.setup        robert-strandh Acclimation 4fc59692f2a12d1038fd3978bb6e66f554672049
 name                cl-acclimation
 version             20230226
-revision            0
+revision            1
 
 checksums           rmd160  0afecc870f6e5a0c4ef397867a45c23a71838465 \
                     sha256  413ad271ba3efe4db9eb145521de02c7a81783b4ac78db36293bc86975bfb446 \
@@ -21,5 +21,5 @@ description         Library supporting internationalization
 
 long_description    {*}${description}
 
-common_lisp.system  {*.asd} \
-                    {Temperature/*.asd}
+common_lisp.systems {*.asd} \
+                    {*/*.asd}

--- a/lisp/cl-cffi-gtk/Portfile
+++ b/lisp/cl-cffi-gtk/Portfile
@@ -6,7 +6,7 @@ PortGroup               common_lisp 1.0
 
 github.setup            sharplispers cl-cffi-gtk 1700fe672c65455c1fc33061ec92a3df84287ec7
 version                 20230202
-revision                0
+revision                1
 
 checksums               rmd160  362d3c12fb3350cf9bbe56ebc1832c1997280ffb \
                         sha256  1cac5def70716d78154c2e7591590388ea49383d59abbdb7057f33efd0854254 \
@@ -20,7 +20,8 @@ description             A Lisp binding to GTK 3
 
 long_description        {*}${description}
 
-common_lisp.system      {cairo/*.asd} \
+# test system requires X11, maybe use Xvfb one day?
+common_lisp.systems     {cairo/*.asd} \
                         {gdk-pixbuf/*.asd} \
                         {gdk/*.asd} \
                         {gio/*.asd} \
@@ -28,8 +29,6 @@ common_lisp.system      {cairo/*.asd} \
                         {gobject/*asd} \
                         {gtk/*.asd} \
                         {pango/*.asd}
-
-common_lisp.test_system {test/*.asd}
 
 # I may split it into subports but all that dependency from one cluster
 depends_lib-append      path:lib/libcairo.dylib:cairo \
@@ -48,6 +47,3 @@ depends_lib-append      path:lib/libcairo.dylib:cairo \
                         port:cl-trivial-garbage
 
 common_lisp.threads     yes
-
-# test requires X11, maybe use Xvfb one day?
-test.run                no

--- a/lisp/cl-change-case/Portfile
+++ b/lisp/cl-change-case/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
 github.setup        rudolfochrist cl-change-case 0.2.0
-revision            0
+revision            1
 
 checksums           rmd160  ee991805293fc634a9c2726db93db9026e0fcfd6 \
                     sha256  da5647dd8bf7b77d14538759bb2e3a6dc5eba35d3932f22843f256f46c6eecf1 \
@@ -20,6 +20,5 @@ description         Convert strings between camelCase, param-case, PascalCase an
 long_description    {*}${description}
 
 depends_lib-append  port:cl-ppcre \
-                    port:cl-unicode
-
-depends_test-append port:cl-fiveam
+                    port:cl-ppcre-unicode \
+                    port:cl-fiveam

--- a/lisp/cl-clsql/Portfile
+++ b/lisp/cl-clsql/Portfile
@@ -5,7 +5,7 @@ PortGroup               common_lisp 1.0
 
 name                    cl-clsql
 version                 6.7.0
-revision                0
+revision                1
 
 checksums               rmd160  bee90661e8e3f5685493604755fbe1391d2f7e2c \
                         sha256  0b5fe43da00ebc0333c1a8f9ccbaefe11b03154c8444366aada8b3dc86fafb2f \
@@ -29,7 +29,7 @@ common_lisp.build_run   no
 test.run                no
 
 depends_lib-append      port:cl-uffi \
-                        port:cl-postmodern
+                        port:cl-postgres
 
 livecheck.type          regex
 livecheck.url           ${master_sites}

--- a/lisp/cl-cluffer/Portfile
+++ b/lisp/cl-cluffer/Portfile
@@ -7,7 +7,7 @@ PortGroup               common_lisp 1.0
 github.setup            robert-strandh Cluffer 0c40c544f9e29911fffd0a0afb78b6c1b220ed28
 name                    cl-cluffer
 version                 20230224
-revision                0
+revision                1
 
 checksums               rmd160  e8189b81e0e8211efab67308d206301f5c57aa76 \
                         sha256  4796d58b6f8642b8317f3e0245dbb3e2f38af9c17576fcf45d6faf6540604a20 \
@@ -24,9 +24,5 @@ long_description        {*}${description}
 depends_lib-append      port:cl-acclimation \
                         port:cl-clump
 
-common_lisp.system      {*.asd} \
-                        {Base/*.asd} \
-                        {Simple-*/*.asd} \
-                        {Standard-*/*.asd}
-
-common_lisp.test_system {Test/*.asd}
+common_lisp.systems     {*.asd} \
+                        {*/*.asd}

--- a/lisp/cl-clump/Portfile
+++ b/lisp/cl-clump/Portfile
@@ -7,7 +7,7 @@ PortGroup               common_lisp 1.0
 github.setup            robert-strandh Clump 1ea4dbac1cb86713acff9ae58727dd187d21048a
 name                    cl-clump
 version                 20160408
-revision                0
+revision                1
 
 checksums               rmd160  83f02df7aae96bc1b198d6366abd73fff21b5e53 \
                         sha256  05adc736740d4e74ff0302397a0a32b2abd9bf9825f071f6eded9b3cd2bcd131 \
@@ -21,10 +21,7 @@ description             Library for operations on different kinds of trees
 
 long_description        {*}${description}
 
-common_lisp.system      {*.asd} \
-                        {2-3-tree/*.asd} \
-                        {Binary-tree/*.asd}
-
-common_lisp.test_system {Test/*.asd}
+common_lisp.systems     {*.asd} \
+                        {*/*.asd}
 
 depends_lib-append      port:cl-acclimation

--- a/lisp/cl-containers/Portfile
+++ b/lisp/cl-containers/Portfile
@@ -6,7 +6,7 @@ PortGroup           common_lisp 1.0
 
 github.setup        gwkkwg cl-containers cc491c299ebeb607a875e119a826b3acd4e2b3bf
 version             20230111
-revision            0
+revision            1
 
 checksums           rmd160  67a51fdc41834522f6ef569f31a3307a8ef67b43 \
                     sha256  a109b8539d1a28a6ee8bd69d27623b7d427309abb3a334eb1c7c5e302dcf35ad \
@@ -20,8 +20,7 @@ description         Containers Library for Common Lisp
 
 long_description    {*}${description}
 
-depends_lib-append  port:cl-metatilities \
-                    port:cl-metatilities-base \
+depends_lib-append  port:cl-metatilities-base \
                     port:cl-metacopy \
                     port:cl-lift \
                     port:cl-variates

--- a/lisp/cl-dbi/Portfile
+++ b/lisp/cl-dbi/Portfile
@@ -6,7 +6,7 @@ PortGroup           common_lisp 1.0
 
 github.setup        fukamachi cl-dbi 3d4b48c7b6736a4257043cde60687614775714d6
 version             20230417
-revision            0
+revision            1
 
 checksums           rmd160  ab006654ea419289995bb8c3a4b2e5ef4ab617f3 \
                     sha256  f5eb74204be7db60dc2f30c519a8e1eb540b7e6a9cdb1915e77eb35d5593ad90 \
@@ -23,7 +23,7 @@ long_description    {*}${description}
 depends_lib-append  port:cl-alexandria \
                     port:cl-closer-mop \
                     port:cl-mysql \
-                    port:cl-postmodern \
+                    port:cl-postgres \
                     port:cl-rove \
                     port:cl-sqlite \
                     port:cl-trivial-garbage \

--- a/lisp/cl-local-time/Portfile
+++ b/lisp/cl-local-time/Portfile
@@ -7,7 +7,7 @@ PortGroup               common_lisp 1.0
 github.setup            dlowe-net local-time 40169fe26d9639f3d9560ec0255789bf00b30036
 name                    cl-local-time
 version                 20221106
-revision                0
+revision                1
 
 checksums               rmd160  78410dc3f9f0168bd11a232b98018602ccc74b37 \
                         sha256  515d7e47d68733232cb289b1ed2b46d42128ea68b7b0cb7654b013adc1a58ef7 \
@@ -21,13 +21,18 @@ description             Time manipulation library for Common Lisp
 
 long_description        {*}${description}
 
-# cl-local-time depends on cl-postmodern which depends on cl-local-time
-common_lisp.build_run   no
+if {${name} eq ${subport}} {
+    depends_lib-append  port:cl-hu.dwim.stefil
 
-depends_lib-append      port:cl-fad \
-                        port:cl-hu.dwim.stefil
+    common_lisp.systems local-time.asd
+}
 
-depends_test-append     port:cl-postmodern
+subport cl-postgres-plus-local-time {
+    depends_lib-append  port:cl-local-time \
+                        port:cl-postgres
 
-# cl-postmodern requires threads
-common_lisp.threads     yes
+    # cl-postmodern requires threads
+    common_lisp.threads yes
+
+    common_lisp.systems {cl-postgres+local-time.asd}
+}

--- a/lisp/cl-metacopy/Portfile
+++ b/lisp/cl-metacopy/Portfile
@@ -22,5 +22,5 @@ description         flexibly shallow/deep copying library for Common Lisp
 long_description    {*}${description}
 
 depends_lib-append  port:cl-contextl \
-                    port:cl-metatilities \
+                    port:cl-moptilities \
                     port:cl-lift

--- a/lisp/cl-metatilities/Portfile
+++ b/lisp/cl-metatilities/Portfile
@@ -7,7 +7,7 @@ PortGroup               common_lisp 1.0
 github.setup            gwkkwg metatilities 82e13df0545d0e47ae535ea35c5c99dd3a44e69e
 name                    cl-metatilities
 version                 20170330
-revision                0
+revision                1
 
 checksums               rmd160  338451d9668a04559b682a09fb4c130989c60a41 \
                         sha256  9c0eb7e15e0871f103bd8c2e179d722758dd7933a123f23add3e88a3c4c0fd75 \
@@ -21,14 +21,11 @@ description             These are metabang.com's Common Lisp basic utilities
 
 long_description        {*}${description}
 
-# cl-metatilities depends on cl-metacopy which depends on cl-metatilities
-# cl-metatilities depends on cl-containers which depends on cl-metatilities
-common_lisp.build_run   no
-
-depends_lib-append      port:cl-metatilities-base \
+depends_lib-append      port:cl-containers \
+                        port:cl-metatilities-base \
                         port:cl-metabang-bind \
                         port:cl-moptilities \
                         port:cl-lift
 
-depends_test-append     port:cl-containers \
-                        port:cl-metacopy
+# *** - PROBE-FILE: No file name given:
+common_lisp.clisp   no

--- a/lisp/cl-nodgui/Portfile
+++ b/lisp/cl-nodgui/Portfile
@@ -7,7 +7,7 @@ PortGroup           common_lisp 1.0
 codeberg.setup      cage nodgui a81925a0c052f28867804881fadbe256cfd7676a
 name                cl-nodgui
 version             20230811
-revision            0
+revision            1
 
 checksums           rmd160  b9fa768c404f93b55aa000fc1a1e2d2fef484a25 \
                     sha256  c69659fb18e4d6637670eb217e0cce040f7d9c7cb6d55d4f58f9616bb853aaa0 \
@@ -30,6 +30,7 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-named-readtables \
                     port:cl-parse-number \
                     port:cl-ppcre \
-                    port:cl-unicode \
+                    port:cl-ppcre-unicode \
+                    port:cl-unicode
 
 common_lisp.threads yes

--- a/lisp/cl-parenscript/Portfile
+++ b/lisp/cl-parenscript/Portfile
@@ -8,7 +8,7 @@ gitlab.instance         https://gitlab.common-lisp.net
 gitlab.setup            parenscript parenscript 1fd720bc4e2bc5ed92064391b730b9d4db35462a
 name                    cl-parenscript
 version                 20200618
-revision                0
+revision                1
 
 checksums               rmd160  9b76057e7680c60f517e3790f75473b5e78de240 \
                         sha256  0c110235c2a0cce2ee260a6402ce09001fe5c8e3da7327ce869c45896bc2760e \
@@ -26,11 +26,6 @@ long_description        {*}${description}
 
 depends_lib-append      port:cl-anaphora \
                         port:cl-named-readtables \
-                        port:cl-ppcre
-
-depends_test-append     port:cl-fiveam \
+                        port:cl-ppcre \
+                        port:cl-fiveam \
                         port:cl-js
-
-common_lisp.system      parenscript.asd
-
-common_lisp.test_system parenscript.tests.asd

--- a/lisp/cl-postmodern/Portfile
+++ b/lisp/cl-postmodern/Portfile
@@ -6,7 +6,7 @@ PortGroup           common_lisp 1.0
 
 github.setup        marijnh Postmodern 1.33.8 v
 name                cl-postmodern
-revision            0
+revision            1
 
 checksums           rmd160  27286c1230006b4a09cbee1bce7392e66c2ab12a \
                     sha256  c20e350efb57b61f69520b2e93563e1c4322b946ee0f534c080d9040d801d590 \
@@ -20,20 +20,41 @@ description         A Common Lisp PostgreSQL programming interface
 
 long_description    {*}${description}
 
-depends_lib-append  port:cl-alexandria \
+subport cl-postgres {
+    depends_lib-append \
                     port:cl-base64 \
-                    port:cl-bordeaux-threads \
-                    port:cl-closer-mop \
                     port:cl-fiveam \
-                    port:cl-global-vars \
                     port:cl-ironclad \
-                    port:cl-local-time \
                     port:cl-md5 \
                     port:cl-split-sequence \
                     port:cl-uax-15 \
                     port:cl-usocket
 
-patchfiles-append   ecl-usocket.diff
+    common_lisp.systems \
+                    cl-postgres.asd
+
+    patchfiles-append \
+                    ecl-usocket.diff
+}
+
+if {${name} eq ${subport}} {
+    depends_lib-append \
+                    port:cl-alexandria \
+                    port:cl-postgres \
+                    port:cl-global-vars \
+                    port:cl-split-sequence \
+                    port:cl-bordeaux-threads \
+                    port:cl-closer-mop \
+                    port:cl-fiveam \
+                    port:cl-local-time \
+                    port:cl-postgres-plus-local-time
+
+    common_lisp.systems \
+                    postmodern.asd \
+                    s-sql.asd \
+                    simple-date.asd
+
+}
 
 common_lisp.threads yes
 

--- a/lisp/cl-ppcre/Portfile
+++ b/lisp/cl-ppcre/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
 github.setup        edicl cl-ppcre 2.1.1 v
-revision            2
+revision            3
 
 checksums           rmd160  106346027a81f75e27f11b2719d499ffea606d9e \
                     sha256  89631179b71648d9e6c565a928f6896a9d5742aa2083b9c1b705fe0b45d85def \
@@ -22,8 +22,15 @@ long_description    CL-PPCRE is a fast, portable, thread-safe regular expression
 
 github.tarball_from archive
 
-# cl-ppcre depedns on cl-unicode, and cl-unicode depends on cl-ppcre
-common_lisp.build_run   no
+if {${name} eq ${subport}} {
+    depends_lib-append  port:cl-flexi-streams
 
-depends_test-append port:cl-flexi-streams \
-                    port:cl-unicode
+    common_lisp.systems cl-ppcre.asd
+}
+
+subport cl-ppcre-unicode {
+    depends_lib-append  port:cl-ppcre \
+                        port:cl-unicode
+
+    common_lisp.systems cl-ppcre-unicode.asd
+}

--- a/lisp/cl-str/Portfile
+++ b/lisp/cl-str/Portfile
@@ -8,7 +8,7 @@ github.setup            vindarel cl-str 81e3129c1a6bd96508f4c1a6636a1e1cf3c15b01
 # The next release will be 0.20 -> save to include dayte this way
 # See: https://github.com/vindarel/cl-str/issues/107
 version                 0.19.20230802
-revision                0
+revision                1
 
 checksums               rmd160  c445507c4fe169d3f01475e49e7025c87b4a92e6 \
                         sha256  45b93b383e35bbe910d85f431dc8b2e39fdb4caf8b7393c6907506cc5decf5c8 \
@@ -22,11 +22,6 @@ description             Modern, consistent and terse Common Lisp string manipula
 
 long_description        {*}${description}
 
-common_lisp.system      str.asd
-
 depends_lib-append      port:cl-ppcre \
-                        port:cl-change-case
-
-common_lisp.test_system str.test.asd
-
-depends_test-append     port:cl-fiveam
+                        port:cl-change-case \
+                        port:cl-fiveam

--- a/lisp/cl-str/Portfile
+++ b/lisp/cl-str/Portfile
@@ -8,7 +8,7 @@ github.setup            vindarel cl-str 81e3129c1a6bd96508f4c1a6636a1e1cf3c15b01
 # The next release will be 0.20 -> save to include dayte this way
 # See: https://github.com/vindarel/cl-str/issues/107
 version                 0.19.20230802
-revision                1
+revision                2
 
 checksums               rmd160  c445507c4fe169d3f01475e49e7025c87b4a92e6 \
                         sha256  45b93b383e35bbe910d85f431dc8b2e39fdb4caf8b7393c6907506cc5decf5c8 \
@@ -22,6 +22,6 @@ description             Modern, consistent and terse Common Lisp string manipula
 
 long_description        {*}${description}
 
-depends_lib-append      port:cl-ppcre \
+depends_lib-append      port:cl-ppcre-unicode \
                         port:cl-change-case \
                         port:cl-fiveam

--- a/lisp/cl-trivial-clipboard/Portfile
+++ b/lisp/cl-trivial-clipboard/Portfile
@@ -7,7 +7,7 @@ PortGroup               common_lisp 1.0
 github.setup            snmsts trivial-clipboard 19262e0cd3d493bf641668f09d1995fd0e954100
 name                    cl-trivial-clipboard
 version                 20230405
-revision                0
+revision                1
 
 checksums               rmd160  5c5bb42a9f26007ef96a79cb47a9cf3aa0effbc1 \
                         sha256  e1e7f3b724edb1ee17ae8a307c8453b3db089ed1aa50d26f5d04c5aa92812b6e \
@@ -21,10 +21,5 @@ description             trivial-clipboard let access system clipboard
 
 long_description        {*}${description}
 
-common_lisp.system      trivial-clipboard.asd
-
-depends_lib-append      port:cl-cffi
-
-common_lisp.test_system trivial-clipboard-test.asd
-
-depends_test-append     port:cl-fiveam
+depends_lib-append      port:cl-cffi \
+                        port:cl-fiveam


### PR DESCRIPTION
#### Description

Some ports may depends on test system at its test system. The good example is cl-clack which test system depends on cl-lack's one.

Such dependencies may not always can be statisfied without introducing dependency cycles. As a hack I've used `common_lisp.build_run no` which avoid building such port and simple installs it as is.

Here I've removed a few hacks and make dependencies cleaner to avoid a few covered depndency cycles.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->