### PR TITLE
eigen3-devel: update to 20230802

### DIFF
--- a/math/eigen3/Portfile
+++ b/math/eigen3/Portfile
@@ -30,9 +30,9 @@ if {${subport} eq ${name}} {
 }
 
 subport eigen3-devel {
-    gitlab.setup        libeigen eigen 3791ac8a
+    gitlab.setup        libeigen eigen 0ae7d7a3
     # For when there is no current development version (other than rolling snapshot)
-    version             3.4-tracking-20230628
+    version             3.4-tracking-20230802
     revision            0
     epoch               3
     gitlab.livecheck.branch 3.4
@@ -42,9 +42,9 @@ subport eigen3-devel {
     long_description    {*}${description} This (-devel) version tracks \
                         development of the current (3.4) branch.
 
-    checksums           rmd160  1ac19999b373612d7fb3e8657cb7452aa0ff3cde \
-                        sha256  e1bac2e4e1c44d15ee5fc262dabce31618620e0af52ccb93da186115da163cfc \
-                        size    2232745
+    checksums           rmd160  7ecfda0712e8e8890f0c5cee6ad5d72b80dca5d9 \
+                        sha256  993c422768b12496ed853c267ac765af33840fef84d79a9f0eb95fa4f98d0e68 \
+                        size    2248972
 
     compilers.setup     require_fortran
 }


### PR DESCRIPTION
#### Description

Only -devel port is updated.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
