### PR TITLE
cl-cffi-gtk: disable ECL on arm64

### DIFF
--- a/lisp/cl-cffi-gtk/Portfile
+++ b/lisp/cl-cffi-gtk/Portfile
@@ -47,3 +47,10 @@ depends_lib-append      path:lib/libcairo.dylib:cairo \
                         port:cl-trivial-garbage
 
 common_lisp.threads     yes
+
+# ECL detects such machines as arm,  not arm64 that leads to
+#    Can not define 'G-SIZE', unknown CPU architectureAn error occurred during initialization:
+# See: https://gitlab.com/embeddable-common-lisp/ecl/-/issues/713
+if {${configure.build_arch} eq "arm64"} {
+    common_lisp.ecl     no
+}


### PR DESCRIPTION
#### Description


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.4.1 22F82 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->