### PR TITLE
nyxt: new port (version 3.5.0)

### DIFF
--- a/www/nyxt/Portfile
+++ b/www/nyxt/Portfile
@@ -1,0 +1,120 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               app 1.1
+PortGroup               github 1.0
+PortGroup               makefile 1.0
+
+github.setup            atlas-engineer nyxt 3.5.0
+revision                0
+
+checksums               rmd160  ff4877172e92ded69b5bd30d2cea966c14aebbb9 \
+                        sha256  75776454c9d6ac23b33cf1473d840e769a5dd44da13ccd05cf0455b6f4aaf308 \
+                        size    642479
+
+categories-append       www
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 BSD
+
+description             Extensible web browser in Common Lisp
+
+long_description        {*}${description}
+
+patchfiles-append       macos-compatibility.diff
+
+# it is complied only by SBCL and uses nasdf
+depends_build-append    port:cl-nasdf \
+                        port:sbcl
+
+# we're managing dependencies via MacPorts
+build.env-append        NYXT_SUBMODULES=false
+
+# seems that GTK is the only working option
+# See: https://github.com/atlas-engineer/nyxt/issues/3118
+build.env-append        NYXT_RENDERER=gtk
+
+# majority of dependencies are build time only, and will be included into image
+depends_build-append    port:cl-alexandria \
+                        port:cl-base64 \
+                        port:cl-bordeaux-threads \
+                        port:cl-calispel \
+                        port:cl-closer-mop \
+                        port:cl-clss \
+                        port:cl-cluffer \
+                        port:cl-colors2 \
+                        port:cl-containers \
+                        port:cl-dexador \
+                        port:cl-dissect \
+                        port:cl-enchant \
+                        port:cl-flexi-streams \
+                        port:cl-gopher \
+                        port:cl-history-tree \
+                        port:cl-html-diff \
+                        port:cl-idna \
+                        port:cl-iolib \
+                        port:cl-json \
+                        port:cl-lass \
+                        port:cl-local-time \
+                        port:cl-log4cl \
+                        port:cl-lparallel \
+                        port:cl-montezuma \
+                        port:cl-moptilities \
+                        port:cl-nclasses \
+                        port:cl-ndebug \
+                        port:cl-nfiles \
+                        port:cl-nhooks \
+                        port:cl-njson \
+                        port:cl-nkeymaps \
+                        port:cl-nsymbols \
+                        port:cl-parenscript \
+                        port:cl-phos \
+                        port:cl-plump \
+                        port:cl-ppcre \
+                        port:cl-ppcre-unicode \
+                        port:cl-prevalence \
+                        port:cl-prompter \
+                        port:cl-py-configparser \
+                        port:cl-qrencode \
+                        port:cl-quri \
+                        port:cl-serapeum \
+                        port:cl-slynk \
+                        port:cl-spinneret \
+                        port:cl-str \
+                        port:cl-swank \
+                        port:cl-tld \
+                        port:cl-trivia \
+                        port:cl-trivial-clipboard \
+                        port:cl-trivial-features \
+                        port:cl-trivial-garbage \
+                        port:cl-trivial-package-local-nicknames \
+                        port:cl-trivial-types \
+                        port:cl-unix-opts \
+                        port:cl-cffi-gtk \
+                        port:cl-webkit2
+
+# It builds lisp image as binary executable file which contains links to shared
+# libraries, you may use command below to get actual list
+#   nyxt --eval "(format t \"~{  ~A~%~}\" (mapcar 'sb-alien::shared-object-pathname sb-sys:*shared-objects*))" --quit | xargs port provides
+
+depends_lib-append      path:lib/libcairo.2.dylib:cairo \
+                        path:lib/libcrypto.dylib:openssl \
+                        path:lib/libfixposix.4.dylib:libfixposix \
+                        path:lib/libgdk-3.0.dylib:gtk3 \
+                        path:lib/libgdk_pixbuf-2.0.0.dylib:gdk-pixbuf2 \
+                        path:lib/libgio-2.0.0.dylib:glib2 \
+                        path:lib/libglib-2.0.0.dylib:glib2 \
+                        path:lib/libgobject-2.0.0.dylib:glib2 \
+                        path:lib/libgthread-2.0.0.dylib:glib2 \
+                        path:lib/libgtk-3.0.dylib:gtk3 \
+                        path:lib/libpango-1.0.0.dylib:pango \
+                        path:lib/libpangocairo-1.0.0.dylib:pango \
+                        path:lib/libssl.dylib:openssl \
+                        path:lib/libwebkit2gtk-4.0.dylib:webkit2-gtk
+
+app.icon                assets/nyxt_512x512.png
+app.retina              no
+app.dark_mode           no
+app.use_launch_script   yes
+app.hide_dock_icon      yes
+
+destroot.env            {*}${build.env}

--- a/www/nyxt/files/macos-compatibility.diff
+++ b/www/nyxt/files/macos-compatibility.diff
@@ -1,0 +1,121 @@
+From 8b0d15f1e4445d63ae114609ec40ff54ce744f67 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Fri, 11 Aug 2023 21:09:02 +0200
+Subject: [PATCH 1/4] [macOS] define only one `*open-program*`
+
+SBCL-2.3.7 on macOS defines both `bsd` and `darwin` features that
+expands it into code which leads to
+```
+  Error while parsing arguments to DEFMACRO DEFVAR:
+    too many elements in
+      (*OPEN-PROGRAM* "open" "xdg-open"
+       "The program to open unsupported files with.")
+    to satisfy lambda list
+      (VAR &OPTIONAL (VAL) (DOC)):
+    between 1 and 3 expected, but got 4
+```
+---
+ source/global.lisp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git source/global.lisp source/global.lisp
+index 4104b7e8..7cf1e765 100644
+--- source/global.lisp
++++ source/global.lisp
+@@ -27,7 +27,7 @@ For user-facing controls, see `*run-from-repl-p*' and `*debug-on-error*'.")
+ (declaim (type (or string null) *open-program*))
+ (defvar *open-program*
+   #+darwin "open"
+-  #+(or linux bsd) "xdg-open"
++  #+(and (or linux bsd) (not darwin)) "xdg-open"
+   #-(or linux bsd darwin) nil
+   "The program to open unsupported files with.")
+ 
+-- 
+2.41.0
+
+
+From d3d40749d20de3bb09da39e0f69e9b11a111b032 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Fri, 11 Aug 2023 21:29:12 +0200
+Subject: [PATCH 2/4] [macOS] ignore unused variables
+
+---
+ source/configuration.lisp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git source/configuration.lisp source/configuration.lisp
+index e163dce2..de0ef0e8 100644
+--- source/configuration.lisp
++++ source/configuration.lisp
+@@ -508,6 +508,8 @@ Return the persisted file as second value."
+ 
+     (values config target))
+   #-(and unix (not darwin))
++  (declare (ignore name))
++  (declare (ignore targets))
+   (log:warn "Only supported on GNU / BSD systems running XDG-compatible desktop environments."))
+ 
+ 
+-- 
+2.41.0
+
+
+From dc6e58b0abfa10df4c5909e30b427d05532f8c60 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Fri, 11 Aug 2023 22:45:23 +0200
+Subject: [PATCH 3/4] Allow to overwrite env variables at Makefile
+
+---
+ makefile | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git makefile makefile
+index d0906cf6..738c371f 100644
+--- makefile
++++ makefile
+@@ -19,9 +19,13 @@ FLATPAK_APP_ID = engineer.atlas.Nyxt
+ FLATPAK_MANIFEST := $(FLATPAK_APP_ID).yaml
+ FLATPAK_EXPORT_REPOSITORY = _build/nyxt-flatpak-repository
+ 
+-export NYXT_SUBMODULES=true
+-export NYXT_RENDERER=gi-gtk
+-export NASDF_USE_LOGICAL_PATHS=true
++NYXT_SUBMODULES ?= true
++NYXT_RENDERER ?= gi-gtk
++NASDF_USE_LOGICAL_PATHS ?= true
++
++export NYXT_SUBMODULES
++export NYXT_RENDERER
++export NASDF_USE_LOGICAL_PATHS
+ 
+ .PHONY: help
+ help:
+-- 
+2.41.0
+
+
+From ec34fdd9dee1e5b3b5fb46c7e2a2901f9302a571 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Fri, 11 Aug 2023 23:35:45 +0200
+Subject: [PATCH 4/4] `webkit-web-view-is-muted` may not be available
+
+---
+ source/renderer/gtk.lisp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git source/renderer/gtk.lisp source/renderer/gtk.lisp
+index 2dedc6f8..5eafbccf 100644
+--- source/renderer/gtk.lisp
++++ source/renderer/gtk.lisp
+@@ -2199,6 +2199,7 @@ As a second value, return the current buffer index starting from 0."
+   (gtk:gtk-widget-is-focus (gtk-object buffer)))
+ 
+ (define-ffi-method ffi-muted-p ((buffer gtk-buffer))
++  #+webkit2-mute
+   (webkit:webkit-web-view-is-muted (gtk-object buffer)))
+ 
+ (define-ffi-method ffi-tracking-prevention ((buffer gtk-buffer))
+-- 
+2.41.0
+


### PR DESCRIPTION
#### Description

Here the web browser in Lisp :)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->