### PR TITLE
xinit: do not test for dispatch on powerpc

### DIFF
--- a/x11/xinit/Portfile
+++ b/x11/xinit/Portfile
@@ -38,6 +38,10 @@ if {[vercmp ${os.version} 10.3.0] < 0} {
     patchfiles-append disable-launchagent.patch
 }
 
+# libdispatch is unsupported on powerpc, despite possibly present headers (ex. Rosetta).
+# Run the test on non-powerpc systems only.
+patchfiles-append   patch-no-libdispatch-ppc.diff
+
 patch.pre_args -p1
 
 use_autoreconf  yes

--- a/x11/xinit/files/patch-no-libdispatch-ppc.diff
+++ b/x11/xinit/files/patch-no-libdispatch-ppc.diff
@@ -1,0 +1,18 @@
+--- a/configure.ac	2019-03-04 03:58:11.000000000 +0800
++++ b/configure.ac	2023-08-15 04:33:00.000000000 +0800
+@@ -125,9 +125,15 @@
+ 			TIGER_LAUNCHD=yes
+ 		;;
+ 	esac
++	case $host in
++		powerpc*-*-darwin*)
++		;;
++		*)
+         AC_CHECK_FUNC(dispatch_async,
+                               AC_DEFINE([HAVE_LIBDISPATCH], 1, [Define to 1 if you have the libdispatch (GCD) available]),
+                               [])
++        ;;
++    esac
+ fi
+ 
+ AC_DEFINE_UNQUOTED(BUNDLE_ID_PREFIX, "$bundleidprefix", [Prefix to use for launchd identifiers])


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/67921

#### Description

There are no powerpc systems with functional `libdispatch`, even though superficially headers may be present, say, in Rosetta. Run configure test which defines `HAVE_LIBDISPATCH` only on non-powerpc systems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
