### PR TITLE
go: fix errors caused by GOPROXY not being set

### DIFF
--- a/_resources/port1.0/group/golang-1.0.tcl
+++ b/_resources/port1.0/group/golang-1.0.tcl
@@ -231,14 +231,9 @@ proc go.append_env {} {
         ui_debug "Disabling offline building for Go"
 
         configure.env-delete \
-                            GO111MODULE=off
-        build.env-delete    GO111MODULE=off
-        test.env-delete     GO111MODULE=off
-
-        configure.env-replace \
-                            GOPROXY=off GOPROXY=https://proxy.golang.org
-        build.env-replace   GOPROXY=off GOPROXY=https://proxy.golang.org
-        test.env-replace    GOPROXY=off GOPROXY=https://proxy.golang.org
+                            GO111MODULE=off GOPROXY=off
+        build.env-delete    GO111MODULE=off GOPROXY=off
+        test.env-delete     GO111MODULE=off GOPROXY=off
     }
 }
 port::register_callback go.append_env

--- a/lang/go/Portfile
+++ b/lang/go/Portfile
@@ -19,12 +19,12 @@ epoch               3
 if {${os.platform} eq "darwin" && ${os.major} < 17} {
     version         1.17.13
     set unsupported_macos true
+    revision        0
 } else {
     version         1.21.0
     set unsupported_macos false
+    revision        1
 }
-
-revision            0
 
 set legacy_build    false
 
@@ -305,6 +305,10 @@ destroot {
         ${docdir}
 
     copy {*}[glob -directory ${worksrcpath}/doc *] ${docdir}
+
+    if { [ file exists ${worksrcpath}/go.env ] } {
+        copy ${worksrcpath}/go.env ${grfdir}/
+    }
 }
 
 if {${os.platform} eq "darwin" && ${os.major} < 10} {


### PR DESCRIPTION
https://trac.macports.org/ticket/67961

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
