### PR TITLE
xxhashlib: attempt to fix macOS 10.7 build

### DIFF
--- a/devel/xxhash/Portfile
+++ b/devel/xxhash/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        Cyan4973 xxhash 0.8.2 v
 categories          devel
@@ -39,6 +40,10 @@ subport ${name}lib {
     revision        2
 
     license         BSD
+
+    # see https://trac.macports.org/ticket/67963
+    # clang: error: unable to execute command: Segmentation fault: 11
+    compiler.blacklist-append {clang < 500}
 
     post-destroot {
         file delete -force ${destroot}${prefix}/bin


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/67963

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Not tested on affected macOS version.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
