### PR TITLE
xxhash: Fix 10.7 Lion clang segfault

### DIFF
--- a/devel/xxhash/Portfile
+++ b/devel/xxhash/Portfile
@@ -22,6 +22,12 @@ if {[string match "*gcc-4.*" ${configure.compiler}]} {
                     patch-Makefile-gcc.diff
 }
 
+if {${os.platform} eq "darwin" && ${os.major} == 11} {
+    # see https://trac.macports.org/ticket/67963
+    # clang: error: unable to execute command: Segmentation fault: 11
+    patchfiles-append lion-clang-segfault-fix.diff
+}
+
 subport ${name} {
     revision        2
 

--- a/devel/xxhash/files/lion-clang-segfault-fix.diff
+++ b/devel/xxhash/files/lion-clang-segfault-fix.diff
@@ -1,0 +1,11 @@
+--- xxhash.h.orig	2023-08-15 15:58:56.000000000 +0200
++++ xxhash.h	2023-08-15 16:06:18.000000000 +0200
+@@ -3416,7 +3416,7 @@
+
+ #ifndef XXH_HAS_INCLUDE
+ #  ifdef __has_include
+-#    define XXH_HAS_INCLUDE(x) __has_include(x)
++#    define XXH_HAS_INCLUDE __has_include
+ #  else
+ #    define XXH_HAS_INCLUDE(x) 0
+ #  endif


### PR DESCRIPTION
#### Description

Fixes: https://trac.macports.org/ticket/67963
May supersede https://github.com/macports/macports-ports/pull/19897

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? (There are none)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
