### PR TITLE
mysql8, mysql81: fix LLVM Clang 16 build

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -169,6 +169,11 @@ if {$subport eq $name} {
     }
 
     post-patch {
+        # https://trac.macports.org/ticket/67324
+        ui_info "$UI_PREFIX Applying patch-boost-clang16-cpp17-compat.diff"
+        system -W ${workpath}/${boost_distname} \
+            "/usr/bin/patch -p0 < ${filespath}/patch-boost-clang16-cpp17-compat.diff"
+
         reinplace "s|@NAME@|${name_mysql}|g" \
             ${worksrcpath}/cmake/install_layout.cmake
 #       reinplace "s|@NAME@|${name_mysql}|g" \

--- a/databases/mysql8/files/patch-boost-clang16-cpp17-compat.diff
+++ b/databases/mysql8/files/patch-boost-clang16-cpp17-compat.diff
@@ -1,0 +1,85 @@
+--- boost/config/stdlib/libcpp.hpp.orig	2023-05-02 17:53:04.000000000 +1000
++++ boost/config/stdlib/libcpp.hpp	2023-05-02 19:47:26.000000000 +1000
+@@ -166,4 +166,13 @@
+ #  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+ #endif
+ 
++#if _LIBCPP_VERSION >= 15000
++//
++// Unary function is now deprecated in C++11 and later:
++//
++#if __cplusplus >= 201103L
++#define BOOST_NO_CXX98_FUNCTION_BASE
++#endif
++#endif
++
+ //  --- end ---
+--- boost/numeric/conversion/detail/int_float_mixture.hpp.orig	2023-03-02 21:34:55.000000000 +1100
++++ boost/numeric/conversion/detail/int_float_mixture.hpp	2023-05-02 18:34:05.000000000 +1000
+@@ -16,15 +16,15 @@
+ #include "boost/numeric/conversion/int_float_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'IntFloatMixture'
+-  typedef mpl::integral_c<int_float_mixture_enum, integral_to_integral> int2int_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, integral_to_float>    int2float_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, float_to_integral>    float2int_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, float_to_float>       float2float_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, integral_to_integral> int2int_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, integral_to_float>    int2float_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, float_to_integral>    float2int_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, float_to_float>       float2float_c ;
+ 
+   // Metafunction:
+   //
+--- boost/numeric/conversion/detail/sign_mixture.hpp.orig	2023-03-02 21:34:55.000000000 +1100
++++ boost/numeric/conversion/detail/sign_mixture.hpp	2023-05-02 18:35:21.000000000 +1000
+@@ -16,15 +16,15 @@
+ #include "boost/numeric/conversion/sign_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'SignMixture'
+-  typedef mpl::integral_c<sign_mixture_enum, unsigned_to_unsigned> unsig2unsig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, signed_to_signed>     sig2sig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, signed_to_unsigned>   sig2unsig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, unsigned_to_signed>   unsig2sig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, unsigned_to_unsigned> unsig2unsig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, signed_to_signed>     sig2sig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, signed_to_unsigned>   sig2unsig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, unsigned_to_signed>   unsig2sig_c ;
+ 
+   // Metafunction:
+   //
+--- boost/numeric/conversion/detail/udt_builtin_mixture.hpp.orig	2023-03-02 21:34:55.000000000 +1100
++++ boost/numeric/conversion/detail/udt_builtin_mixture.hpp	2023-05-02 18:36:25.000000000 +1000
+@@ -15,15 +15,15 @@
+ #include "boost/numeric/conversion/udt_builtin_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'UdtMixture'
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, builtin_to_builtin> builtin2builtin_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, builtin_to_udt>     builtin2udt_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, udt_to_builtin>     udt2builtin_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, udt_to_udt>         udt2udt_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, builtin_to_builtin> builtin2builtin_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, builtin_to_udt>     builtin2udt_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, udt_to_builtin>     udt2builtin_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, udt_to_udt>         udt2udt_c ;
+ 
+   // Metafunction:
+   //

--- a/databases/mysql81/Portfile
+++ b/databases/mysql81/Portfile
@@ -169,6 +169,11 @@ if {$subport eq $name} {
     }
 
     post-patch {
+        # https://trac.macports.org/ticket/67324
+        ui_info "$UI_PREFIX Applying patch-boost-clang16-cpp17-compat.diff"
+        system -W ${workpath}/${boost_distname} \
+            "/usr/bin/patch -p0 < ${filespath}/patch-boost-clang16-cpp17-compat.diff"
+
         reinplace "s|@NAME@|${name_mysql}|g" \
             ${worksrcpath}/cmake/install_layout.cmake
 #       reinplace "s|@NAME@|${name_mysql}|g" \

--- a/databases/mysql81/files/patch-boost-clang16-cpp17-compat.diff
+++ b/databases/mysql81/files/patch-boost-clang16-cpp17-compat.diff
@@ -1,0 +1,85 @@
+--- boost/config/stdlib/libcpp.hpp.orig	2023-05-02 17:53:04.000000000 +1000
++++ boost/config/stdlib/libcpp.hpp	2023-05-02 19:47:26.000000000 +1000
+@@ -166,4 +166,13 @@
+ #  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+ #endif
+ 
++#if _LIBCPP_VERSION >= 15000
++//
++// Unary function is now deprecated in C++11 and later:
++//
++#if __cplusplus >= 201103L
++#define BOOST_NO_CXX98_FUNCTION_BASE
++#endif
++#endif
++
+ //  --- end ---
+--- boost/numeric/conversion/detail/int_float_mixture.hpp.orig	2023-03-02 21:34:55.000000000 +1100
++++ boost/numeric/conversion/detail/int_float_mixture.hpp	2023-05-02 18:34:05.000000000 +1000
+@@ -16,15 +16,15 @@
+ #include "boost/numeric/conversion/int_float_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'IntFloatMixture'
+-  typedef mpl::integral_c<int_float_mixture_enum, integral_to_integral> int2int_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, integral_to_float>    int2float_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, float_to_integral>    float2int_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, float_to_float>       float2float_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, integral_to_integral> int2int_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, integral_to_float>    int2float_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, float_to_integral>    float2int_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, float_to_float>       float2float_c ;
+ 
+   // Metafunction:
+   //
+--- boost/numeric/conversion/detail/sign_mixture.hpp.orig	2023-03-02 21:34:55.000000000 +1100
++++ boost/numeric/conversion/detail/sign_mixture.hpp	2023-05-02 18:35:21.000000000 +1000
+@@ -16,15 +16,15 @@
+ #include "boost/numeric/conversion/sign_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'SignMixture'
+-  typedef mpl::integral_c<sign_mixture_enum, unsigned_to_unsigned> unsig2unsig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, signed_to_signed>     sig2sig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, signed_to_unsigned>   sig2unsig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, unsigned_to_signed>   unsig2sig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, unsigned_to_unsigned> unsig2unsig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, signed_to_signed>     sig2sig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, signed_to_unsigned>   sig2unsig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, unsigned_to_signed>   unsig2sig_c ;
+ 
+   // Metafunction:
+   //
+--- boost/numeric/conversion/detail/udt_builtin_mixture.hpp.orig	2023-03-02 21:34:55.000000000 +1100
++++ boost/numeric/conversion/detail/udt_builtin_mixture.hpp	2023-05-02 18:36:25.000000000 +1000
+@@ -15,15 +15,15 @@
+ #include "boost/numeric/conversion/udt_builtin_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'UdtMixture'
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, builtin_to_builtin> builtin2builtin_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, builtin_to_udt>     builtin2udt_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, udt_to_builtin>     udt2builtin_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, udt_to_udt>         udt2udt_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, builtin_to_builtin> builtin2builtin_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, builtin_to_udt>     builtin2udt_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, udt_to_builtin>     udt2builtin_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, udt_to_udt>         udt2udt_c ;
+ 
+   // Metafunction:
+   //


### PR DESCRIPTION
See: https://trac.macports.org/ticket/67324

#### Description
```
[ 69%] Building CXX object sql/CMakeFiles/sql_gis.dir/gis/buffer.cc.o
cd /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/build/sql && /opt/local/bin/ccache /opt/local/bin/clang++-mp-16 -DBOOST_ALL_NO_LIB -DBOOST_NO_CXX98_FUNCTION_BASE -DHAVE_CONFIG_H -DHAVE_TLSv13 -DLZ4_DISABLE_DEPRECATE_WARNINGS -DMYSQL_SERVER -DRAPIDJSON_NO_SIZETYPEDEFINE -DRAPIDJSON_SCHEMA_USE_INTERNALREGEX=0 -DRAPIDJSON_SCHEMA_USE_STDREGEX=1 -D_USE_MATH_DEFINES -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/opt/local/libexec/openssl11/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/build -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/build/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/mysql-8.0.34 -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/mysql-8.0.34/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/mysql-8.0.34/include/boost_1_77_0/patches -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0 -isystem /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/mysql-8.0.34/extra/rapidjson/include -isystem /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/mysql-8.0.34/extra/protobuf/protobuf-3.19.4/src -isystem /opt/local/include -isystem /opt/local/include/editline -isystem /usr/local/include -isystem /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/mysql-8.0.34/extra/lz4/lz4-1.9.4/lib -isystem /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/mysql-8.0.34/plugin/x/client -isystem /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/build/plugin/x/generated/protobuf_lite -isystem /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/build/plugin/x/generated -std=c++17 -fno-omit-frame-pointer -ftls-model=initial-exec -pipe -I/opt/local/libexec/openssl11/include -Os -DNDEBUG -I/opt/local/libexec/openssl11/include -isystem/opt/local/include -stdlib=libc++ -Wall -Wextra -Wformat-security -Wvla -Wundef -Wmissing-format-attribute -Woverloaded-virtual -Wcast-qual -Wno-null-conversion -Wno-unused-private-field -Wconditional-uninitialized -Wdeprecated -Wno-deprecated-declarations -Wno-shorten-64-to-32 -Wextra-semi -Wheader-hygiene -Wnon-virtual-dtor -Wundefined-reinterpret-cast -Wrange-loop-analysis -Winconsistent-missing-destructor-override -Winconsistent-missing-override -Wshadow-field -ffunction-sections -fdata-sections -O3 -DNDEBUG -arch x86_64 -mmacosx-version-min=10.13 -fPIC -Wshadow-uncaptured-local -MD -MT sql/CMakeFiles/sql_gis.dir/gis/buffer.cc.o -MF CMakeFiles/sql_gis.dir/gis/buffer.cc.o.d  --language=c++  -o CMakeFiles/sql_gis.dir/gis/buffer.cc.o -c /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/mysql-8.0.34/sql/gis/buffer.cc
⋮
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/mysql-8.0.34/sql/gis/buffer.cc:27:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/geometry/algorithms/buffer.hpp:23:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/numeric/conversion/cast.hpp:33:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/numeric/conversion/converter.hpp:13:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/numeric/conversion/conversion_traits.hpp:13:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/numeric/conversion/detail/conversion_traits.hpp:18:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/numeric/conversion/detail/int_float_mixture.hpp:19:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/mpl/integral_c.hpp:32:
/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/mpl/aux_/integral_wrapper.hpp:73:31: error: integer value -1 is outside the valid range of values [0, 3] for this enumeration type [-Wenum-constexpr-conversion]
    typedef AUX_WRAPPER_INST( BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (value - 1)) ) prior;
                              ^
/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/mpl/aux_/static_cast.hpp:24:47: note: expanded from macro 'BOOST_MPL_AUX_STATIC_CAST'
#   define BOOST_MPL_AUX_STATIC_CAST(T, expr) static_cast<T>(expr)
                                              ^
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/mysql-8.0.34/sql/gis/buffer.cc:27:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/geometry/algorithms/buffer.hpp:23:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/numeric/conversion/cast.hpp:33:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/numeric/conversion/converter.hpp:13:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/numeric/conversion/conversion_traits.hpp:13:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/numeric/conversion/detail/conversion_traits.hpp:18:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/numeric/conversion/detail/int_float_mixture.hpp:19:
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/mpl/integral_c.hpp:32:
/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/mpl/aux_/integral_wrapper.hpp:73:31: error: integer value -1 is outside the valid range of values [0, 3] for this enumeration type [-Wenum-constexpr-conversion]
/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_databases_mysql8/mysql8/work/boost_1_77_0/boost/mpl/aux_/static_cast.hpp:24:47: note: expanded from macro 'BOOST_MPL_AUX_STATIC_CAST'
#   define BOOST_MPL_AUX_STATIC_CAST(T, expr) static_cast<T>(expr)
                                              ^
83 warnings and 2 errors generated.
make[2]: *** [sql/CMakeFiles/sql_gis.dir/gis/buffer.cc.o] Error 1
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Only tried mysql8 build which now progresses past sql/CMakeFiles/sql_gis.dir/gis/buffer.cc.o. mysql81 not tested.
macOS 10.13.6
LLVM clang 16.0.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
