### PR TITLE
abseil: update to 20230802.0

### DIFF
--- a/devel/abseil/Portfile
+++ b/devel/abseil/Portfile
@@ -6,11 +6,11 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
-# MAP_ANONYMOUS
-legacysupport.newest_darwin_requires_legacy 14
+# MAP_ANONYMOUS and clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 # Ports that depend on this port must be revbump after update.
-github.setup        abseil abseil-cpp 20230125.3
+github.setup        abseil abseil-cpp 20230802.0
 name                abseil
 revision            0
 categories          devel
@@ -24,11 +24,15 @@ long_description    Abseil is an open-source collection of C++ library \
                     Google's own C++ code base, has been extensively \
                     tested and used in production.
 
-checksums           rmd160  18ea059168c7f8b5dbaeea433e71c57e9644b157 \
-                    sha256  0195e85f858b38f4563a6f2912e30bfc45dfad4815fbf97d273ed1cae9bbca94 \
-                    size    2119590
+checksums           rmd160  dc95a6a1b741cce460d02c9d40bd332f6acdfdb6 \
+                    sha256  9b19d2f920105e9bee2a4741f63b4d25d987603e1345d2d8c54694f5bdff1a4e \
+                    size    2156696
 
 patchfiles          patch-remove-Xarch-from-pkg-config.diff
+
+# Abseil broken for 10.4-10.5, it's the pthread issue.
+# See https://github.com/macports/macports-ports/pull/19905#issuecomment-1679652939
+patchfiles-append   patch-pthread.diff
 
 platform darwin {
     if {${build_arch} in [list ppc ppc64]} {

--- a/devel/abseil/files/patch-pthread.diff
+++ b/devel/abseil/files/patch-pthread.diff
@@ -1,0 +1,32 @@
+--- absl/base/internal/sysinfo.cc.orig	2023-08-07 21:40:00.000000000 +0300
++++ absl/base/internal/sysinfo.cc	2023-08-16 00:59:00.596362110 +0300
+@@ -58,6 +58,10 @@
+ #include "absl/base/internal/unscaledcycleclock.h"
+ #include "absl/base/thread_annotations.h"
+ 
++#if defined __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ namespace absl {
+ ABSL_NAMESPACE_BEGIN
+ namespace base_internal {
+@@ -428,7 +432,17 @@
+   // `nullptr` here implies this thread.  This only fails if the specified
+   // thread is invalid or the pointer-to-tid is null, so we needn't worry about
+   // it.
++#if (MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || defined(__POWERPC__)
++  tid = pthread_mach_thread_np(pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++  if (&pthread_threadid_np) {
++    pthread_threadid_np(nullptr, &tid);
++  } else {
++    tid = pthread_mach_thread_np(pthread_self());
++  }
++#else
+   pthread_threadid_np(nullptr, &tid);
++#endif
+   return static_cast<pid_t>(tid);
+ }
+ 
+

--- a/devel/apache-arrow/Portfile
+++ b/devel/apache-arrow/Portfile
@@ -10,7 +10,7 @@ PortGroup           active_variants 1.1
 boost.version       1.81
 
 github.setup        apache arrow 13.0.0 apache-arrow-
-revision            0
+revision            1
 name                ${github.author}-${github.project}
 
 categories          devel

--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 # NOTE: Also rev-bump 'apache-arrow' when updating this port
 github.setup        grpc grpc 1.48.4 v
-revision            0
+revision            1
 categories          devel
 maintainers         nomaintainer
 license             Apache-2

--- a/devel/protobuf3-cpp-upstream/Portfile
+++ b/devel/protobuf3-cpp-upstream/Portfile
@@ -15,7 +15,7 @@ set release_version \
 name            protobuf3-cpp-upstream
 github.setup    protocolbuffers protobuf 3.${release_version} v
 git.branch      v${release_version}
-revision        0
+revision        1
 
 categories      devel
 maintainers     {mascguy @mascguy} openmaintainer

--- a/devel/re2/Portfile
+++ b/devel/re2/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        google re2 2023-07-01
 epoch               1
-revision            0
+revision            1
 
 github.tarball_from archive
 checksums           rmd160 aa42a0e985c5d4e8011f12bb43631e25f8779a2d \

--- a/math/s2geometry/Portfile
+++ b/math/s2geometry/Portfile
@@ -4,11 +4,12 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
 github.setup        google s2geometry 7773d518b1f29caa1c2045eb66ec519e025be108
 version             0.10.0
-revision            0
+revision            1
 categories          math science
 license             Apache-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -18,6 +19,10 @@ homepage            https://s2geometry.io
 checksums           rmd160  f4d412b134d0879a7bd2284f571b3f64066b1a1a \
                     sha256  36998cb5fd5309c4d42008591ce7946a53cef8dffb25a04c09673ac616ac9820 \
                     size    1179957
+
+# clock_gettime needed for abseil
+# https://github.com/macports/macports-ports/pull/19905#issuecomment-1680281240
+legacysupport.newest_darwin_requires_legacy 15
 
 depends_lib-append  port:abseil
 


### PR DESCRIPTION
#### Description

Commits:

- abseil: update to 20230802.0
- apache-arrow,grpc,brotobuf3*,re2,s2geometry: Revbump after update abseil

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F770820d x86_64
Xcode 15.0 15A5195m

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
