### PR TITLE
google-cloud-sdk: update to 443.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             442.0.0
+version             443.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  88cfd53fe485084635de891e2d4b54ea2c53b0d3 \
-                    sha256  b5e047a389a2cb83efd9e8569eda2a1676c0010e5026995a0def37a5130924db \
-                    size    101190514
+    checksums       rmd160  d52cc989bc674f3560538d6774616a45333d72de \
+                    sha256  6e51d65ae98c033fbb1bbd5d03f5757bc1a5db69b72af0fcff8d2190f21dcb73 \
+                    size    101286148
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  7d9f436a3cefa4ebaecdba2d6c053c521128d945 \
-                    sha256  60a0ec0ce7d7b57d83debbaad585d8da23d08e35885de0c75f789c7ee7b65276 \
-                    size    121438423
+    checksums       rmd160  60c78d25fb98141aa25c0a6238e834c9b5d76b3f \
+                    sha256  55038341395bfde339bb29cb9c42e0ffea1fa8061aac9bfac00ab3b74c1b33f3 \
+                    size    121549882
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  2767008d22afc0d632654ed28d283df3d5250551 \
-                    sha256  5bc8916871ed1f9d596353fa44995eeda314c6e98560c8990e62e866309edb4f \
-                    size    118604251
+    checksums       rmd160  02eaf8c11a5f2be5b830cb5332b7d52505d34b16 \
+                    sha256  5211340b4a330e3dd72476bcbe1c326d8b089829df5e878623273c5c270834b1 \
+                    size    118714709
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 443.0.0.

###### Tested on

macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?