### PR TITLE
uvw: add uvw2 subport, install everything into sub-prefices

### DIFF
--- a/devel/uvw/Portfile
+++ b/devel/uvw/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 # libuv version here should match the main port.
 github.setup            skypjack uvw 3.0.0 v _libuv_v1.44
-revision                1
+revision                2
 categories              devel
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
 license                 MIT
@@ -21,26 +21,35 @@ checksums               sha256  b93d7cc841ace369f5930953f1b00a008597682a8690950f
                         size    106022
 
 # uvw upstream may not match the libuv version used by Macports, and some ports may require to be up-to-date with upstream.
-# Having a single uvw port leads into trouble due to potential, and likely, incompatibilities: https://github.com/oxen-io/lokinet/issues/2197
+# Having a single uvw port leads into trouble due to potential, and likely, incompatibilities.
 # So we offer header-only and static lib variants which are intended to be up-to-date, while letting the main variant to lag behind,
 # tracking Macports libuv. Notice, while subports mutually conflict, the main port can co-exist with either of the former.
+# In addition, there is a uvw2 port: its API is incompatible with v. 3.x: : https://github.com/oxen-io/lokinet/issues/2197
 set upstream_vvw        3.2.0
 set upstream_luv        1.46
 
 subport uvw-static {
     github.setup        skypjack uvw ${upstream_vvw} v _libuv_v${upstream_luv}
-    revision            0
+    revision            1
     conflicts           uvw-headers
     fetch.type          git
 }
 
 subport uvw-headers {
     github.setup        skypjack uvw ${upstream_vvw} v _libuv_v${upstream_luv}
-    revision            0
+    revision            1
     conflicts           uvw-static
     checksums           rmd160  d6579c2b1fc6bdf43aadd20ee2ce9f999225c16e \
                         sha256  67b1c002f51750264db7686ee99e3330e188d9337dc7ebc0e2e2d41210973c31 \
                         size    106942
+}
+
+subport uvw2 {
+    github.setup        skypjack uvw 2.12.1 v _libuv_v1.44
+    revision            0
+    checksums           rmd160  ab836964c230520bfb970df5b44a4cba9a6a8654 \
+                        sha256  740cb917673cdcbe579ff9a14b92efda7f0190f02902bc63e6f4a0ac98d31042 \
+                        size    107951
 }
 
 depends_build-append    port:pkgconfig
@@ -53,7 +62,7 @@ configure.pre_args-replace \
 
 configure.args-append   -DBUILD_DOCS:BOOL=OFF
 
-if {${subport} eq ${name}} {
+if {${subport} eq ${name} || ${subport} eq "uvw2"} {
     depends_lib-append  port:libuv
     configure.args-append \
                         -DBUILD_TESTING:BOOL=ON \
@@ -76,20 +85,28 @@ if {${subport} eq ${name}} {
                         -DFETCH_LIBUV:BOOL=OFF
 }
 
-if {${subport} eq "uvw-static" || ${subport} eq "uvw-headers"} {
+# Install everything into sub-prefices:
+if {${subport} eq ${name}} {
     set uvw_libexec     ${prefix}/libexec/uvw/
-    configure.pre_args-append \
+} elseif {${subport} eq "uvw2"} {
+    set uvw_libexec     ${prefix}/libexec/uvw2/
+} elseif {${subport} eq "uvw-static" || ${subport} eq "uvw-headers"} {
+    set uvw_libexec     ${prefix}/libexec/uvw-upstream/
+    configure.args-append \
                         -DBUILD_TESTING:BOOL=OFF \
                         -DBUILD_UVW_SHARED_LIB:BOOL=OFF \
-                        -DCMAKE_INSTALL_INCLUDEDIR:STRING=${uvw_libexec}include \
-                        -DCMAKE_INSTALL_LIBDIR:STRING=${uvw_libexec}lib \
                         -DFIND_LIBUV:BOOL=OFF
-    pre-destroot {
-        xinstall -d ${destroot}${uvw_libexec}
-    }
 }
+
+configure.pre_args-append \
+                        -DCMAKE_INSTALL_INCLUDEDIR:STRING=${uvw_libexec}include \
+                        -DCMAKE_INSTALL_LIBDIR:STRING=${uvw_libexec}lib
 
 platform powerpc {
     configure.args-append \
                         -DUSE_LIBCPP:BOOL=OFF
+}
+
+pre-destroot {
+    xinstall -d ${destroot}${uvw_libexec}
 }


### PR DESCRIPTION
#### Description

As to why a separate `uvw2` port needed: https://github.com/oxen-io/lokinet/issues/2197

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
