### PR TITLE
garagejam: update to 1.0.0

### DIFF
--- a/gnome/garagejam/Portfile
+++ b/gnome/garagejam/Portfile
@@ -6,7 +6,7 @@ PortGroup           debug 1.0
 PortGroup           app 1.0
 
 name                garagejam
-version             0.8.0
+version             1.0.0
 revision            0
 
 categories          gnome
@@ -22,9 +22,9 @@ set branch          [join [lrange [split $version .] 0 1] .]
 master_sites        https://www.garagejam.org/src/
 use_xz              yes
 
-checksums           rmd160  62bde814c9c2f216f0f4cb52fd1053b597a167fa \
-                    sha256  47500e4e94fa3cb91ae81ab7acd3da02d982a00728eefbf38a9cd58fabc1516b \
-                    size    122944
+checksums           rmd160  cdef6e30752626e41611a94bfc39e7cb31647de9 \
+                    sha256  b7008972b167df451b6db9b4cf39b0576d70631f14563b70405cf8f113ed98af \
+                    size    124616
 
 depends_build-append \
                     port:gettext \


### PR DESCRIPTION
#### Description

garagejam 1.0.0 from https://www.garagejam.org/src/garagejam-1.0.0.tar.xz

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->