### PR TITLE
cfonts: update to 1.1.1

### DIFF
--- a/textproc/cfonts/Portfile
+++ b/textproc/cfonts/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo  1.0
 
-github.setup        DominikWilkowski cfonts 1.1.0 v rust
+github.setup        DominikWilkowski cfonts 1.1.1 v rust
 revision            0
 
 categories          textproc
@@ -17,9 +17,9 @@ long_description    This is a silly little command line tool for sexy fonts in t
                     Give your cli some love.
 
 checksums           ${distfiles} \
-                    rmd160  cd1099abdbf581dd4bd3a1a0bd156ee3f9a6e953 \
-                    sha256  edd9a1f4ce246eee3f10f084d72e4e650bd68539d8bc8f9e4eca61f2f9c79293 \
-                    size    3315389
+                    rmd160  aa6b31b1815a41d9c39ccd440957f335af36c153 \
+                    sha256  b77bb8aa2868e990dabd43d947b1f7b2cc72113ba1dca35ca9bd237179e0ae01 \
+                    size    3323439
 
 build.dir           ${worksrcpath}/rust
 
@@ -33,50 +33,80 @@ destroot {
 }
 
 cargo.crates \
-    assert_cmd                       2.0.4  93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e \
-    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
-    bstr                            0.2.17  ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223 \
+    anstyle                          1.0.1  3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd \
+    assert_cmd                      2.0.12  88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                         2.4.0  b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635 \
+    bstr                             1.6.0  6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05 \
+    cc                              1.0.82  305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
-    either                           1.6.1  e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457 \
-    enable-ansi-support              0.1.2  28d29d3ca9ba14c336417f8d7bc7f373e8c16d10c30cc0794b09d3cecab631ab \
+    either                           1.9.0  a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07 \
+    enable-ansi-support              0.2.1  aa4ff3ae2a9aa54bf7ee0983e59303224de742818c1822d89f07da9856d9bc60 \
+    errno                            0.3.2  6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f \
+    errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
     exitcode                         1.1.2  de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193 \
-    getrandom                        0.2.6  9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad \
-    heck                             0.4.0  2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9 \
-    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    getrandom                       0.2.10  be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427 \
+    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    hermit-abi                       0.3.2  443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b \
+    io-lifetimes                    1.0.11  eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2 \
+    is-terminal                      0.4.9  cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b \
     is_ci                            1.1.1  616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb \
-    itertools                       0.10.3  a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3 \
-    itoa                             1.0.1  1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35 \
-    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.125  5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b \
+    itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
+    itoa                             1.0.9  af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38 \
+    libc                           0.2.147  b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3 \
+    linux-raw-sys                    0.3.8  ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519 \
+    linux-raw-sys                    0.4.5  57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503 \
+    lock_api                        0.4.10  c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16 \
     memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
-    once_cell                       1.10.0  87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9 \
-    ppv-lite86                      0.2.16  eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872 \
-    predicates                       2.1.1  a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c \
-    predicates-core                  1.0.3  da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb \
-    predicates-tree                  1.0.5  4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032 \
-    proc-macro2                     1.0.37  ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1 \
-    quote                           1.0.18  a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1 \
+    parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
+    parking_lot_core                 0.9.8  93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447 \
+    ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
+    predicates                       3.0.3  09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9 \
+    predicates-core                  1.0.6  b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174 \
+    predicates-tree                  1.0.9  368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf \
+    proc-macro2                     1.0.66  18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9 \
+    quote                           1.0.32  50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
-    rand_core                        0.6.3  d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7 \
-    regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
-    rustversion                      1.0.6  f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f \
-    ryu                              1.0.9  73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f \
-    serde                          1.0.136  ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789 \
-    serde_derive                   1.0.136  08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9 \
-    serde_json                      1.0.79  8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95 \
-    strum                           0.24.0  e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8 \
-    strum_macros                    0.24.0  6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef \
-    supports-color                   1.3.0  4872ced36b91d47bae8a214a683fe54e7078875b399dfa251df346c9b547d1f9 \
-    syn                             1.0.91  b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d \
-    temp-env                         0.2.0  45107136c2ddf8c4b87453c02294fd0adf41751796e81e8ba3f7fd951977ab57 \
-    terminal_size                   0.1.17  633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df \
-    termtree                         0.2.4  507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b \
-    unicode-xid                      0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
+    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+    redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
+    regex-automata                   0.3.6  fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69 \
+    rustix                         0.37.23  4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06 \
+    rustix                          0.38.8  19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f \
+    rustversion                     1.0.14  7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4 \
+    ryu                             1.0.15  1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741 \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    serde                          1.0.183  32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c \
+    serde_derive                   1.0.183  aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816 \
+    serde_json                     1.0.104  076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c \
+    smallvec                        1.11.0  62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9 \
+    strum                           0.25.0  290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125 \
+    strum_macros                    0.25.2  ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059 \
+    supports-color                   2.0.0  4950e7174bffabe99455511c39707310e7e9b440364a2fcb1cc21521be57b354 \
+    syn                             2.0.28  04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567 \
+    temp-env                         0.3.4  9547444bfe52cbd79515c6c8087d8ae6ca8d64d2d31a27746320f5cb81d1a15c \
+    terminal_size                    0.2.6  8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237 \
+    termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
+    unicode-ident                   1.0.11  301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
-    wasi                          0.10.2+wasi-snapshot-preview1  fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6 \
-    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
-    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    windows-sys                     0.42.0  5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7 \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-targets                 0.48.2  d1eeca1c172a285ee6c2c84c341ccea837e7c01b12fbb2d0fe3c9e550ce49ec8 \
+    windows_aarch64_gnullvm         0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
+    windows_aarch64_gnullvm         0.48.2  b10d0c968ba7f6166195e13d593af609ec2e3d24f916f081690695cf5eaffb2f \
+    windows_aarch64_msvc            0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
+    windows_aarch64_msvc            0.48.2  571d8d4e62f26d4932099a9efe89660e8bd5087775a2ab5cdd8b747b811f1058 \
+    windows_i686_gnu                0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
+    windows_i686_gnu                0.48.2  2229ad223e178db5fbbc8bd8d3835e51e566b8474bfca58d2e6150c48bb723cd \
+    windows_i686_msvc               0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
+    windows_i686_msvc               0.48.2  600956e2d840c194eedfc5d18f8242bc2e17c7775b6684488af3a9fff6fe3287 \
+    windows_x86_64_gnu              0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
+    windows_x86_64_gnu              0.48.2  ea99ff3f8b49fb7a8e0d305e5aec485bd068c2ba691b6e277d29eaeac945868a \
+    windows_x86_64_gnullvm          0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
+    windows_x86_64_gnullvm          0.48.2  8f1a05a1ece9a7a0d5a7ccf30ba2c33e3a61a30e042ffd247567d1de1d94120d \
+    windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
+    windows_x86_64_msvc             0.48.2  d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9


### PR DESCRIPTION
#### Description

Update to latest cfonts version

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
