### PR TITLE
qt5-qtwebkit-examples: fix patch phase

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1001,7 +1001,7 @@ foreach {module module_info} [array get modules] {
 
         if { ${module} ne "qtwebengine" } {
             distname ${module}-${middle_name}-src-${version}
-            if { ${module} ne "qtwebkit" } {
+            if { ${module} ni [list "qtwebkit" "qtwebkit-examples"] } {
                 worksrcdir ${module}-${worksrcdir_middle_name}-src-${version}
             }
         }


### PR DESCRIPTION
[skip ci]

#### Description
As seen during recent macOS 13 CI build (https://github.com/macports/macports-ports/pull/19884#issuecomment-1682498109) and by macOS 13 ARM64 builder: https://build.macports.org/builders/ports-13_arm64-builder/builds/29300/steps/install-port/logs/stdio

```
--->  Applying patches to qt5-qtwebkit-examples
--->  Applying patch-qtwebkit-examples_header_location.diff
DEBUG: Creating patch directory: /opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_aqua_qt5/qt5-qtwebkit-examples/work/qtwebkit-examples-everywhere-src-5.9.1
DEBUG: Environment: 
CC_PRINT_OPTIONS='YES'
CC_PRINT_OPTIONS_FILE='/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_aqua_qt5/qt5-qtwebkit-examples/work/.CC_PRINT_OPTIONS'
CPATH='/opt/local/include'
DEVELOPER_DIR='/Library/Developer/CommandLineTools'
LIBRARY_PATH='/opt/local/lib'
MACOSX_DEPLOYMENT_TARGET='13.0'
SDKROOT='/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk'
Executing:  cd "/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_aqua_qt5/qt5-qtwebkit-examples/work/qtwebkit-examples-everywhere-src-5.9.1" && /usr/bin/patch -p0 < '/opt/bblocal/var/buildworker/ports/build/ports/aqua/qt5/files/patch-qtwebkit-examples_header_location.diff'
DEBUG: system:  cd "/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_aqua_qt5/qt5-qtwebkit-examples/work/qtwebkit-examples-everywhere-src-5.9.1" && /usr/bin/patch -p0 < '/opt/bblocal/var/buildworker/ports/build/ports/aqua/qt5/files/patch-qtwebkit-examples_header_location.diff'
File to patch: 
No file found--skip this patch? [y] 
1 out of 1 hunks ignored--saving rejects to Oops.rej
File to patch: 
No file found--skip this patch? [y] 
1 out of 1 hunks ignored--saving rejects to Oops.rej
File to patch: 
No file found--skip this patch? [y] 
1 out of 1 hunks ignored--saving rejects to Oops.rej
File to patch: 
No file found--skip this patch? [y] 
1 out of 1 hunks ignored--saving rejects to Oops.rej
File to patch: 
No file found--skip this patch? [y] 
1 out of 1 hunks ignored--saving rejects to Oops.rej
Command failed:  cd "/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_aqua_qt5/qt5-qtwebkit-examples/work/qtwebkit-examples-everywhere-src-5.9.1" && /usr/bin/patch -p0 < '/opt/bblocal/var/buildworker/ports/build/ports/aqua/qt5/files/patch-qtwebkit-examples_header_location.diff'
Exit code: 1
```


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Only the patch phase is tested.
macOS 12.6.8
Xcode  14.2
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
