### PR TITLE
Update py-openstackclient to 6.2.0 + dependencies

### DIFF
--- a/python/py-cinderclient/Portfile
+++ b/python/py-cinderclient/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-cinderclient
 python.rootname     python-cinderclient
-version             7.1.0
+version             9.3.0
 revision            0
 
 categories-append   net
@@ -22,11 +22,7 @@ long_description    Client for the OpenStack Volume API. There’s a \
 
 homepage            https://docs.openstack.org/python-cinderclient/latest/
 
-checksums           rmd160  9706fd47624c8490cfbbcc8620a4fe986ecb79b0 \
-                    sha256  625d34dd6a3626f9a02e83af554441d96ff91ab20aa081412c7530c1e87ec642 \
-                    size    243949
-
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-cliff/Portfile
+++ b/python/py-cliff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cliff
-version             3.3.0
+version             4.3.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -16,11 +16,8 @@ long_description    cliff is a framework for building command line \
                     provide subcommands, output formatters, and other \
                     extensions.
 homepage            https://docs.openstack.org/cliff/latest/
-checksums           rmd160  131952d0886ea27d1b4225c3065c2ee5467cc63d \
-                    sha256  611595ad7b4bdf57aa252027796dac3273ab0f4bc1511e839cce230a351cb710 \
-                    size    79680
 
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-cmd2/Portfile
+++ b/python/py-cmd2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cmd2
-version             2.3.3
+version             2.4.3
 revision            0
 
 maintainers         nomaintainer
@@ -16,11 +16,7 @@ description         Tool for building interactive command line applications in P
 long_description    {*}${description}
 homepage            https://github.com/python-cmd2/cmd2
 
-checksums           rmd160  8f15ccfc87a3b094b68682da668e1562ce819cf5 \
-                    sha256  750d7eb04d55c3bc2a413e191bc177856f388102de47d11f2210a35266543640 \
-                    size    675880
-
-python.versions     37 38 39 310
+python.versions     36 37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-debtcollector/Portfile
+++ b/python/py-debtcollector/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-debtcollector
-version             2.1.0
+version             2.5.0
 revision            0
 
 maintainers         nomaintainer
@@ -27,11 +27,8 @@ long_description    A collection of Python deprecation patterns and \
                     developers using libraries (or potentially \
                     applications) about future deprecations.
 homepage            https://docs.openstack.org/debtcollector/latest/
-checksums           rmd160  0525388be16b904a74450901facf99539b307201 \
-                    sha256  a25fc6215560d81cb9f2a0b58d6c834f2a24010987027bde169599e138a205af \
-                    size    28706
 
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-dogpile-cache/Portfile
+++ b/python/py-dogpile-cache/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-dogpile-cache
 python.rootname     dogpile.cache
-version             1.0.1
+version             1.2.2
 revision            0
 
 maintainers         nomaintainer
@@ -21,7 +21,7 @@ checksums           rmd160  e2543c06ee36c130b689911fcf0021a72ae958df \
                     sha256  695dd61f32d97233d5c5e1d7ac1238f5116391ea990b4b24a239229e280bf36e \
                     size    339926
 
-python.versions     37 38
+python.versions     36 37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-keystoneauth1/Portfile
+++ b/python/py-keystoneauth1/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-keystoneauth1
-version             4.2.0
+version             5.2.1
 categories-append   net
 maintainers         nomaintainer
 license             Apache-2
@@ -14,11 +14,8 @@ platforms           {darwin any}
 description         Tools for authenticating to an OpenStack-based cloud
 long_description    {*}${description}
 homepage            https://docs.openstack.org/keystoneauth/latest/
-checksums           rmd160  4aadc7a93a4a1b87764b0c11ba908431644352bd \
-                    sha256  000ffd0d752f13eb235dae06f5f5dea16a2ca1f737fe3339632bd696b12489f7 \
-                    size    256375
 
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-keystoneclient/Portfile
+++ b/python/py-keystoneclient/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-keystoneclient
-version             4.1.0
+version             5.1.0
 categories-append   net
 platforms           {darwin any}
 maintainers         nomaintainer
@@ -15,12 +15,8 @@ description         Client for the OpenStack Identity API
 long_description    {*}${description}
 homepage            https://docs.openstack.org/python-keystoneclient/latest/
 python.rootname     python-keystoneclient
-checksums           md5     3504f6d29b60d77da8d2a14dd4b87fb0 \
-                    rmd160  b974b9fa4ced95f37ab0b22f7b30930cbbeeec04 \
-                    sha256  7b9b99021358a4db20673d338ba42bc2bd8e7e969cfd777f68c600ae6a39cb1b \
-                    size    317929
 
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-netifaces/Portfile
+++ b/python/py-netifaces/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  40b7990e7ea06f6c03d5626519c4164de60da92e \
 # See https://github.com/al45tair/netifaces/issues/78
 deprecated.upstream_support no
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-novaclient/Portfile
+++ b/python/py-novaclient/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-novaclient
 python.rootname     python-novaclient
-version             17.2.0
+version             18.3.0
 revision            0
 
 categories-append   net
@@ -19,12 +19,8 @@ long_description    This is a client for the OpenStack Nova API. There's a Pytho
                     API (the novaclient module), and a command-line script (nova). \
                     Each implements 100% of the OpenStack Nova API.
 homepage            https://docs.openstack.org/python-novaclient/latest/
-checksums           md5     d4326085ebb9f999c45c37c99b315009 \
-                    rmd160  8d56940807effd3f96d552de86948cde21b2e1e6 \
-                    sha256  cda999e2254787b962e14859f6ca71de640963f3b35c1685fb51ce3a7a0a8958 \
-                    size    323260
 
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-openstackclient/Portfile
+++ b/python/py-openstackclient/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-openstackclient
-version             5.3.1
+version             6.2.0
 categories-append   net
 platforms           {darwin any}
 maintainers         nomaintainer
@@ -19,12 +19,8 @@ long_description    OpenStackClient (aka OSC) is a command-line \
                     shell with a uniform command structure.
 homepage            https://docs.openstack.org/python-openstackclient/latest/
 python.rootname     python-openstackclient
-checksums           md5     f23af9b5fa44488c031e0a4d065822a8 \
-                    rmd160  e87155ec05bfbcf708688dd3baa479f86f6cc7cb \
-                    sha256  dcbdc95f6f577f621fc2b3862a3e1143dedd7d8a95e6ed08bd953d95aa24a1cf \
-                    size    725685
 
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-openstacksdk/Portfile
+++ b/python/py-openstacksdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-openstacksdk
-version             0.48.0
+version             1.4.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -13,11 +13,8 @@ platforms           {darwin any}
 description         Client library for building applications to work with OpenStack clouds
 long_description    {*}${description}
 homepage            https://docs.openstack.org/openstacksdk/
-checksums           rmd160  e7aed89078ee3d730e82f6be6cfe526a0be10b00 \
-                    sha256  8652664a30041325a980d03a37c92ca546ed923d26c246a2bb3c92fc5f24243c \
-                    size    935288
 
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-os-service-types/Portfile
+++ b/python/py-os-service-types/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  7f8b29835237773138d4902eba57d02422bdca11 \
                     sha256  31800299a82239363995b91f1ebf9106ac7758542a1e4ef6dc737a5932878c6c \
                     size    24474
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-osc-lib/Portfile
+++ b/python/py-osc-lib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-osc-lib
-version             2.2.0
+version             2.8.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -13,11 +13,8 @@ platforms           {darwin any}
 description         Common support modules for writing OpenStackClient plugins
 long_description    {*}${description}
 homepage            https://docs.openstack.org/osc-lib/latest/
-checksums           rmd160  fcaf7f86ad54d9897288c6a90cc51fc6591a641a \
-                    sha256  fcfce4d63a633c3161e2a6666764446e3f32668e814a94ab98da12e3908ee1d6 \
-                    size    94181
 
-python.versions     37 38
+python.versions     36 37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-oslo-config/Portfile
+++ b/python/py-oslo-config/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-oslo-config
-version             8.3.1
+version             9.1.1
 platforms           {darwin any}
 maintainers         nomaintainer
 license             Apache-2
@@ -14,12 +14,8 @@ description         Oslo Configuration Library
 long_description    {*}${description}
 homepage            https://docs.openstack.org/oslo.config/latest/
 python.rootname     oslo.config
-checksums           md5     f28614f3647fdbf6348f377dada38af2 \
-                    rmd160  3bb48fec41ac70f977286b7ec91226b507ca45e8 \
-                    sha256  dfbb83dc5b4c86ddf8b96f3967252f17586a67f2cef65309df2fd510bf9e87fc \
-                    size    149370
 
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     livecheck.type  none

--- a/python/py-oslo-i18n/Portfile
+++ b/python/py-oslo-i18n/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-oslo-i18n
 python.rootname     oslo.i18n
-version             5.0.0
+version             6.0.0
 
 maintainers         nomaintainer
 license             Apache-2
@@ -18,11 +18,7 @@ long_description    The oslo.utils library provides support for common \
                     handling, string manipulation, and time handling.
 homepage            https://docs.openstack.org/oslo.i18n/latest/
 
-checksums           rmd160  2aa7ec36a8a7626a019a91ed27d7c81d5a769baa \
-                    sha256  2e71ae3ec73a74ac71f8f407e6653243dc267eed404624255a296c34f1fc6887 \
-                    size    44211
-
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-oslo-serialization/Portfile
+++ b/python/py-oslo-serialization/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-oslo-serialization
 python.rootname     oslo.serialization
-version             4.0.0
+version             5.1.1
 revision            0
 
 maintainers         nomaintainer
@@ -18,11 +18,8 @@ long_description    The oslo.utils library provides support for common \
                     utility type functions, such as encoding, exception \
                     handling, string manipulation, and time handling.
 homepage            https://docs.openstack.org/oslo.serialization/latest/
-checksums           rmd160  231190c1d32e54a0442ce8531f1e2dfca512da85 \
-                    sha256  f465df171be564282cb3e86ec895f5b6ae5e5b0760e9af2be96a942a5255a860 \
-                    size    30816
 
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-oslo-utils/Portfile
+++ b/python/py-oslo-utils/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-oslo-utils
 python.rootname     oslo.utils
-version             4.3.0
+version             6.2.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -17,11 +17,7 @@ long_description    The oslo.utils library provides support for common \
                     handling, string manipulation, and time handling.
 homepage            https://docs.openstack.org/oslo.utils/latest/
 
-checksums           rmd160  fcd7f3e6c89374fda8506fd0a7dfe9a9f705af04 \
-                    sha256  c608d9676974ae7e81ce51eeecd122690881c3bdc31b26f51c42327a350bd313 \
-                    size    93589
-
-python.versions     37 38
+python.versions     38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-prettytable/Portfile
+++ b/python/py-prettytable/Portfile
@@ -35,7 +35,7 @@ checksums           rmd160  af187cbcf1139866bc67b1bc8cb5c3187726b41f \
                     sha256  2d5460dc9db74a32bcc8f9f67de68b2c4f4d2f01fa3bd518764c69156d9cacd9 \
                     size    24784
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {$subport ne $name} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-requestsexceptions/Portfile
+++ b/python/py-requestsexceptions/Portfile
@@ -17,7 +17,7 @@ checksums           rmd160  1d0b0a38362767f9b033a90f1ad14769dfad50a1 \
                     sha256  b095cbc77618f066d459a02b137b020c37da9f46d9b057704019c9f77dba3065 \
                     size    6880
 
-python.versions     37 38
+python.versions     35 36 37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \


### PR DESCRIPTION
#### Description
openstackclient was horribly out of date, and the `--tag` flag was bugged. Newer versions fix this issue, so I've updated the portfiles related.
I was unable to get port checksum to generate checksums even after a build, so those will need to be generated and added to these portfiles.
*most* are nomaintainer, but a couple have maintainers, but I'm only enabling newer Python builds on those as far as I can tell.

py-cinderclient: 7.1.0 => 9.3.0
py-cliff: 3.3.0 => 4.3.0
py-cmd2: 2.3.3 => 2.4.3
py-debtcollector: 2.1.0 => 2.5.0
py-dogpile-cache: 1.0.1 => 1.2.2
py-keystoneauth1: 4.2.0 => 5.2.1
py-keystoneclient: 4.1.0 => 5.1.0
py-novaclient: 17.2.0 => 18.3.0
py-openstackclient: 5.3.1 => 6.2.0
py-openstacksdk: 0.48.0 => 1.4.0
py-osc-lib: 2.2.0 => 2.8.0
py-oslo-config: 8.3.1 => 9.1.1
py-oslo-i18n: 5.0.0 => 6.0.0
py-oslo-serialization: 4.0.0 => 5.1.1
py-oslo-utils: 4.3.0 => 6.2.0

Updated minimum Python versions to match PyPi listed for all above, and enabled all to be installed on up to 3.11
py-requestsexceptions add py35 py36 py39 py310 py311 py-os-service-types add py39 py310 py311
py-netifaces, py-prettytable add py311

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?