### PR TITLE
qt6-qtbase: fix build with LLVM clang 16

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -1000,6 +1000,9 @@ if { ${subport} eq "${name}-qtbase" || ${subport} eq "${name}-qtbase-docs" } {
     # see https://trac.macports.org/ticket/67802
     patchfiles-append               patch-qtbase-intel_intrinsics.diff
 
+    # see https://trac.macports.org/ticket/67980
+    patchfiles-append               patch-qtbase-memory_resource.diff
+
     configure.pre_args-replace      --prefix=${prefix} \
                                     "-prefix ${qt6.dir}"
 

--- a/aqua/qt6/files/patch-qtbase-memory_resource.diff
+++ b/aqua/qt6/files/patch-qtbase-memory_resource.diff
@@ -1,0 +1,80 @@
+From c70145c6bf54cda9723cccdc7ca07f8d8fd321cd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tor=20Arne=20Vestb=C3=B8?= <tor.arne.vestbo@qt.io>
+Date: Wed, 7 Jun 2023 02:31:42 +0200
+Subject: [PATCH] Opt out of standard library memory_resource on macOS < 14 and
+ iOS < 17
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Although the header is available, and the compiler reports that the
+standard library supports memory_resource, the feature is only
+available on macOS 14 and iOS 17, as reported by
+
+  https://developer.apple.com/xcode/cpp/
+
+As long as our deployment target is lower we can't unconditionally
+use this feature. It's not clear whether the expectation is that
+consumers of the standard library on these platforms will have to
+runtime check their uses of these APIs.
+
+Includes e84c0df50f51c61aa49b47823582b0f8de406e3d for fixing
+missing line continuations.
+
+Task-number: QTBUG-114316
+Change-Id: I50c1425334b9b9842b253442e2b3aade637783ea
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+(cherry picked from commit f7c8ff511c30dc4310a72b3da4b4a345efe1fba0)
+Reviewed-by: Tor Arne Vestbø <tor.arne.vestbo@qt.io>
+---
+ src/corelib/global/qcompilerdetection.h | 20 +++++++++++++-------
+ src/corelib/tools/qduplicatetracker_p.h |  2 +-
+ 2 files changed, 14 insertions(+), 8 deletions(-)
+
+diff --git a/src/corelib/global/qcompilerdetection.h b/src/corelib/global/qcompilerdetection.h
+index f1218934412..70fa7f6c9f7 100644
+--- src/corelib/global/qcompilerdetection.h
++++ src/corelib/global/qcompilerdetection.h
+@@ -895,16 +895,22 @@
+ #   endif // !_HAS_CONSTEXPR
+ #  endif // !__GLIBCXX__ && !_LIBCPP_VERSION
+ # endif // Q_OS_QNX
+-# if defined(Q_CC_CLANG) && defined(Q_OS_MAC) && defined(__GNUC_LIBSTD__) \
+-    && ((__GNUC_LIBSTD__-0) * 100 + __GNUC_LIBSTD_MINOR__-0 <= 402)
++# if defined(Q_CC_CLANG) && defined(Q_OS_MAC)
++#  if defined(__GNUC_LIBSTD__) && ((__GNUC_LIBSTD__-0) * 100 + __GNUC_LIBSTD_MINOR__-0 <= 402)
+ // Apple has not updated libstdc++ since 2007, which means it does not have
+ // <initializer_list> or std::move. Let's disable these features
+-#  undef Q_COMPILER_INITIALIZER_LISTS
+-#  undef Q_COMPILER_RVALUE_REFS
+-#  undef Q_COMPILER_REF_QUALIFIERS
++#   undef Q_COMPILER_INITIALIZER_LISTS
++#   undef Q_COMPILER_RVALUE_REFS
++#   undef Q_COMPILER_REF_QUALIFIERS
+ // Also disable <atomic>, since it's clearly not there
+-#  undef Q_COMPILER_ATOMICS
+-# endif
++#   undef Q_COMPILER_ATOMICS
++#  endif
++#  if defined(__cpp_lib_memory_resource) \
++    && ((defined(__MAC_OS_X_VERSION_MIN_REQUIRED)  && __MAC_OS_X_VERSION_MIN_REQUIRED  < 140000) \
++     || (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 170000))
++#   undef __cpp_lib_memory_resource // Only supported on macOS 14 and iOS 17
++#  endif
++# endif // defined(Q_CC_CLANG) && defined(Q_OS_DARWIN)
+ #endif
+ 
+ // Don't break code that is already using Q_COMPILER_DEFAULT_DELETE_MEMBERS
+diff --git a/src/corelib/tools/qduplicatetracker_p.h b/src/corelib/tools/qduplicatetracker_p.h
+index 950220184f8..23465ecffed 100644
+--- src/corelib/tools/qduplicatetracker_p.h
++++ src/corelib/tools/qduplicatetracker_p.h
+@@ -16,7 +16,7 @@
+ 
+ #include <private/qglobal_p.h>
+ 
+-#if __has_include(<memory_resource>)
++#ifdef __cpp_lib_memory_resource
+ #  include <unordered_set>
+ #  include <memory_resource>
+ #  include <qhash.h> // for the hashing helpers


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/67980

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Only tested build phase.
macOS 12.6.8
LLVM Clang 16.0.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
