### PR TITLE
nss: drop legacysupport PG

### DIFF
--- a/net/nss/Portfile
+++ b/net/nss/Portfile
@@ -1,13 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           legacysupport 1.1
 PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                nss
 version             3.92
-revision            0
+revision            1
 set NSS_VMAJOR      [lindex [split ${version} .] 0]
 set NSS_VMINOR      [lindex [split ${version} .] 1]
 set NSS_VPATCH      [lindex [split ${version} .] 2]


### PR DESCRIPTION
#### Description

This Portfile started using `PortGroup legacysupport 1.1` five months ago as a mysterious way to solve a compilation error where a make target couldn't be found: https://trac.macports.org/ticket/66933 (It was not a satisfying solution).

It doesn't link against `libMacportsLegacySupport.dylib` so it shouldn't need to do this. There are recent changes-in-the-works to legacysupport to fix `fdopendir` and it results in more functions needing to be wrapped, such as `opendir`, `readdir`, `closedir`. These functions are used by nss.

The nss Makefile is seeing legacysupport's header files but not its libraries (i.e. it seems to be inheriting `$CFLAGS` from the environment but not `$LDFLAGS`). Anyway, the result is that it's now looking for legacysupport wrapper functions but not linking against the library where they are to be found. So nss is failing to link when using the next legacysupport.

Rather than trying to fix the nss Makefile to link against a library that it has no need for, I think the best solution is to just remove the legacysupport port group from the Portfile.

It compiles fine for me on 10.6 and 10.14. Whatever the wierd make problem was a few versions back (that adding legacysupport was supposed to fix) might just be gone now.

P.S. I don't know if the revision needs to be incremented. I don't think this change would be any different to an existing installation of nss. I've incremented it anyway just in case. But I can put it back if that's better.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

macOS 10.6.8 10K549 i386
Xcode 3.2.6 10M2518

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? [only about 10 of them, there are 60]
