### PR TITLE
qt5-qtwebkit-examples: remove qtwebengine dependency

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -715,11 +715,11 @@ array set modules {
         }
         ""
         ""
-        "qtwebkit qtdeclarative qtlocation qttools qtwebchannel qtwebengine"
+        "qtwebkit qtdeclarative qtlocation qttools qtwebchannel"
         {"examples for Qt WebKit"}
         "community support only (use Qt WebEngine)"
         "variant overrides: ++examples ~docs "
-        "revision 4"
+        "revision 5"
         "License: "
     }
     qtwebsockets {

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -638,11 +638,11 @@ array set modules {
         }
         ""
         ""
-        "qtwebkit qtdeclarative qtlocation qttools qtwebchannel qtwebengine"
+        "qtwebkit qtdeclarative qtlocation qttools qtwebchannel"
         {"examples for Qt WebKit"}
         "community support only (use Qt WebEngine)"
         "variant overrides: ++examples ~docs "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtwebsockets {

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -638,11 +638,11 @@ array set modules {
         }
         ""
         ""
-        "qtwebkit qtdeclarative qtlocation qttools qtwebchannel qtwebengine"
+        "qtwebkit qtdeclarative qtlocation qttools qtwebchannel"
         {"examples for Qt WebKit"}
         "community support only (use Qt WebEngine)"
         "variant overrides: ++examples ~docs "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtwebsockets {

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -621,11 +621,11 @@ array set modules {
         }
         ""
         ""
-        "qtwebkit qtdeclarative qtlocation qttools qtwebchannel qtwebengine"
+        "qtwebkit qtdeclarative qtlocation qttools qtwebchannel"
         {"examples for Qt WebKit"}
         "community support only (use Qt WebEngine)"
         "variant overrides: ++examples ~docs "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtwebsockets {


### PR DESCRIPTION
#### Description
Was present since https://github.com/macports/macports-ports/commit/ac4c68ed32941102dfdf0bb7936692a497678b1e#diff-bc9f30dc8c9f361f400189b91801321d634f45c504735b63dd156a06e245449fR512 but these ports install fine without qtwebengine and the installed files contain no mention or linkage to qtwebengine.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8
Xcode 14.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
