### PR TITLE
qt6-qtwebengine-docs: fix build

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -341,7 +341,7 @@ array set modules {
             440562844
         }
         "port:python${python_version} port:py${python_version}-html5lib"
-        "path:bin/node:nodejs16 port:re2 path:lib/pkgconfig/icu-uc.pc:icu port:webp \
+        "path:bin/node:nodejs20 port:re2 path:lib/pkgconfig/icu-uc.pc:icu port:webp \
             port:libopus path:lib/libavcodec.dylib:ffmpeg path:lib/pkgconfig/vpx.pc:libvpx \
             port:snappy path:lib/pkgconfig/glib-2.0.pc:glib2 port:zlib port:minizip port:libevent \
             port:libxml2 port:libxslt port:lcms2 port:libpng path:include/turbojpeg.h:libjpeg-turbo \
@@ -843,6 +843,12 @@ foreach {module module_info} [array get modules] {
 
         depends_build-append                port:${name}-qttools \
                                             port:${name}-sqlite-plugin
+
+        # have the same build dependencies
+        foreach deps [lindex ${module_info} 1] {
+            depends_build-append [subst ${deps}]
+        }
+
         depends_lib-append                  port:${name}-${module}
 
         description                         Documentation for Qt Tool Kit ${qt_major}
@@ -953,7 +959,7 @@ subport ${name}-qttools {
     }
 }
 
-subport ${name}-qtwebengine {
+if { ${subport} in [list "${name}-qtwebengine" "${name}-qtwebengine-docs"] } {
     configure.env-append            PYTHON3_PATH=${prefix}/Library/Frameworks/Python.framework/Versions/${python_branch}/bin
     # in ${worksrcpath}, `${qt6.dir}/bin/qt-configure-module . -help` and `${qt6.dir}/bin/qt-configure-module . -list-features`
     # it is not clear why, but icu and ffmpeg support must be added manually


### PR DESCRIPTION
Use latest LTS Node.js as fallback

#### Description
https://build.macports.org/builders/ports-13_x86_64-builder/builds/44331/steps/install-port/logs/stdio
Build dependencies python311 and py311-html5lib must be specified correctly; otherwise if they are unavailable (i.e. trace mode or not installed) then the build will fail since it produced no output:

```
WARNING: QtWebEngine won't be built. Python3 html5lib is missing.
WARNING: QtPdf won't be built. Python3 html5lib is missing.
…
Error: No files have been installed in the destroot directory!
```

 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8
Xcode 14.2
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
