### PR TITLE
pcaudiolib: fix the build

### DIFF
--- a/audio/pcaudiolib/Portfile
+++ b/audio/pcaudiolib/Portfile
@@ -29,6 +29,9 @@ depends_build       port:pkgconfig
 
 patchfiles          dynamic_lookup-11.patch
 
+# https://github.com/espeak-ng/pcaudiolib/pull/25
+patchfiles-append   0001-Fix-headers-for-macOS.patch
+
 # fatal error: 'stdatomic.h' file not found
 compiler.c_standard 2011
 compiler.blacklist-append \

--- a/audio/pcaudiolib/files/0001-Fix-headers-for-macOS.patch
+++ b/audio/pcaudiolib/files/0001-Fix-headers-for-macOS.patch
@@ -1,0 +1,48 @@
+From 94784d98661a43844457ae81e97b7862fece968c Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Sat, 19 Aug 2023 05:18:56 +0800
+Subject: [PATCH] Fix headers for macOS
+
+---
+ src/TPCircularBuffer/TPCircularBuffer+AudioBufferList.c | 2 +-
+ src/TPCircularBuffer/TPCircularBuffer.h                 | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git src/TPCircularBuffer/TPCircularBuffer+AudioBufferList.c src/TPCircularBuffer/TPCircularBuffer+AudioBufferList.c
+index 7b913dc..df689a7 100644
+--- src/TPCircularBuffer/TPCircularBuffer+AudioBufferList.c
++++ src/TPCircularBuffer/TPCircularBuffer+AudioBufferList.c
+@@ -28,7 +28,7 @@
+ //
+ 
+ #include "TPCircularBuffer+AudioBufferList.h"
+-#import <mach/mach_time.h>
++#include <mach/mach_time.h>
+ 
+ static double __secondsToHostTicks = 0.0;
+ 
+diff --git src/TPCircularBuffer/TPCircularBuffer.h src/TPCircularBuffer/TPCircularBuffer.h
+index f354cfd..6791975 100644
+--- src/TPCircularBuffer/TPCircularBuffer.h
++++ src/TPCircularBuffer/TPCircularBuffer.h
+@@ -43,9 +43,17 @@
+ #define TPCircularBuffer_h
+ 
+ #include <stdbool.h>
++#include <stdint.h>
+ #include <string.h>
+ #include <assert.h>
+ 
++#ifdef __APPLE__
++#include <sys/cdefs.h>
++#ifndef __deprecated_msg
++#define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
++#endif
++#endif
++
+ #ifdef __cplusplus
+     extern "C++" {
+         #include <atomic>
+-- 
+2.41.0
+


### PR DESCRIPTION
#### Description

Fix headers.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
