### PR TITLE
osm2pgsql: update to 1.9.0

### DIFF
--- a/gis/osm2pgsql/Portfile
+++ b/gis/osm2pgsql/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           boost 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        openstreetmap osm2pgsql 1.8.1
+github.setup        openstreetmap osm2pgsql 1.9.0
 
 categories          gis
 maintainers         {vince @Veence} openmaintainer
@@ -20,9 +20,9 @@ license             GPL-2+
 
 homepage            https://osm2pgsql.org
 
-checksums           rmd160  f4e53821cf7fafa5c1799ac92927f61e29797782 \
-                    sha256  cedf75b444f982b6d6c7ce340b50ed68d6cde74dc1bd76da35b4b0aa39de9e41 \
-                    size    2545884
+checksums           rmd160  65ee4aa68e897db6f0def578e1badb31d03fd4b5 \
+                    sha256  eaa8a35b9b16ee2239884d104bfad38958b393fbdc3eb22e1c202bc7beef724d \
+                    size    2598762
 
 # It uses include variant
 compiler.cxx_standard 2017
@@ -39,10 +39,13 @@ configure.args-append \
                     -DFMT_INCLUDE_DIR=${prefix}/include/${port_libfmt}
 
 depends_lib-append  port:bzip2 \
+                    port:CImg \
                     port:expat \
                     port:libosmium \
+                    port:nlohmann-json \
                     port:${port_libfmt} \
                     port:postgis3 \
+                    port:potrace \
                     port:proj8 \
                     port:protozero \
                     port:zlib


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/openstreetmap/osm2pgsql/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
