### PR TITLE
openssh: fix for zlib 1.3 from upstream

### DIFF
--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -48,7 +48,7 @@ if {${name} eq ${subport}} {
         depends_build-append port:cctools
     }
 
-    patch.args          -p1
+    patch.pre_args      -p1
     patchfiles          launchd.patch \
                         agent.patch \
                         pam.patch \

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             9.4p1
-revision            1
+revision            0
 categories          net
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 license             BSD
@@ -57,7 +57,6 @@ if {${name} eq ${subport}} {
                         macports-config.patch \
                         patch.zlib1.3_configure.ac9.4pre2.diff
 
-    # the last patch above is a fix for zlib 1.3 from upstream before next release: https://github.com/openssh/openssh-portable/commit/cb4ed12ffc332d1f72d054ed92655b5f1c38f621
     # We need a couple of patches
     # - pam.patch
     #   getpwnam(3) on OS X always returns "*********" in the pw_passwd field even
@@ -80,6 +79,7 @@ if {${name} eq ${subport}} {
         reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/sandbox-darwin.c
     }
 
+    # We are patching configure.ac
     use_autoreconf          yes
 
     # strnvis(3) isn't actually "broken".  OpenBSD decided to be special and flip

--- a/net/openssh/Portfile
+++ b/net/openssh/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                openssh
 version             9.4p1
-revision            0
+revision            1
 categories          net
 maintainers         {@artkiver gmail.com:artkiver} openmaintainer
 license             BSD
@@ -54,8 +54,10 @@ if {${name} eq ${subport}} {
                         pam.patch \
                         patch-sandbox-darwin.c-apple-sandbox-named-external.diff \
                         patch-sshd.c-apple-sandbox-named-external.diff \
-                        macports-config.patch
+                        macports-config.patch \
+                        patch.zlib1.3_configure.ac9.4pre2.diff
 
+    # the last patch above is a fix for zlib 1.3 from upstream before next release: https://github.com/openssh/openssh-portable/commit/cb4ed12ffc332d1f72d054ed92655b5f1c38f621
     # We need a couple of patches
     # - pam.patch
     #   getpwnam(3) on OS X always returns "*********" in the pw_passwd field even

--- a/net/openssh/files/patch.zlib1.3_configure.ac9.4pre2.diff
+++ b/net/openssh/files/patch.zlib1.3_configure.ac9.4pre2.diff
@@ -1,0 +1,11 @@
+--- configure.ac
++++ configure.ac
+@@ -1464,7 +1464,7 @@
+ 	[[
+ 	int a=0, b=0, c=0, d=0, n, v;
+ 	n = sscanf(ZLIB_VERSION, "%d.%d.%d.%d", &a, &b, &c, &d);
+-	if (n != 3 && n != 4)
++	if (n < 1)
+ 		exit(1);
+ 	v = a*1000000 + b*10000 + c*100 + d;
+ 	fprintf(stderr, "found zlib version %s (%d)\n", ZLIB_VERSION, v);

--- a/net/openssh/files/patch.zlib1.3_configure.ac9.4pre2.diff
+++ b/net/openssh/files/patch.zlib1.3_configure.ac9.4pre2.diff
@@ -1,5 +1,11 @@
---- configure.ac
-+++ configure.ac
+Fix:
+
+configure: error: *** zlib too old - check config.log ***
+
+https://bugzilla.mindrot.org/show_bug.cgi?id=3604
+https://github.com/openssh/openssh-portable/commit/cb4ed12ffc332d1f72d054ed92655b5f1c38f621
+--- a/configure.ac
++++ b/configure.ac
 @@ -1464,7 +1464,7 @@
  	[[
  	int a=0, b=0, c=0, d=0, n, v;


### PR DESCRIPTION
 * closes https://trac.macports.org/ticket/67986

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5.1 22G90 arm64
Xcode 15.0 15A5219j

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
