### PR TITLE
daemon: update to 0.8.3

### DIFF
--- a/sysutils/daemon/Portfile
+++ b/sysutils/daemon/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               makefile 1.0
 
 name                    daemon
-version                 0.8.2
+version                 0.8.3
 revision                0
 categories              sysutils
 platforms               darwin
@@ -18,22 +18,23 @@ long_description        Daemon turns other process into daemons. There are many 
                         daemons in languages other than C, C++ or Perl (e.g. \
                         /bin/sh, Java).
 
-homepage                http://libslack.org/daemon/
+homepage                https://libslack.org/daemon/
 master_sites            ${homepage}download/
 
-checksums               rmd160  906fee38272dbd2018e638fcc8f4ec5e11ae94ea \
-                        sha256  b34b37543bba43bd086e59f4b754c8102380ae5c1728b987c890d5da4b4cf3ca \
-                        size    466417
+checksums               rmd160  907a5d09bc405c0a2a23f63d045bdd254423858d \
+                        sha256  bd6fd870ca4761f43f045d72db0f8a0de81a3eac07264bf449b152d7dd899ac0 \
+                        size    466962
 
 patchfiles              disable-test-pseudo.patch
 
 # Only a script, not a real configure.
 use_configure           yes
+configure.args          --prefix=${prefix} --destdir=${destroot}
 
 test.run                yes
-test.target             check
 
-destroot.destdir        PREFIX=${destroot}${prefix}
+destroot.args           install-daemon-conf
+destroot.keepdirs       ${destroot}${prefix}/etc/daemon.conf.d
 
 livecheck.type      regex
 livecheck.url       ${master_sites}

--- a/sysutils/daemon/files/disable-test-pseudo.patch
+++ b/sysutils/daemon/files/disable-test-pseudo.patch
@@ -1,6 +1,6 @@
---- libslack/macros.mk.orig	2021-02-23 14:17:56.632003539 +1100
-+++ libslack/macros.mk	2021-02-23 14:18:16.784003539 +1100
-@@ -179,7 +179,7 @@
+--- libslack/macros.mk.orig	2023-08-19 22:29:03.798660003 +1000
++++ libslack/macros.mk	2023-08-19 23:03:12.756541981 +1000
+@@ -185,7 +185,7 @@
  SLACK_SWIGFILE := $(SLACK_SRCDIR)/slack.swig
  
  SLACK_TESTDIR := $(SLACK_SRCDIR)/test


### PR DESCRIPTION
#### Description

Update daemon to 0.8.3

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G6032 x86_64
Xcode 11.3 11C29

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
