### PR TITLE
cl-mgl-pax: add missed test dependency

### DIFF
--- a/lisp/cl-mgl-pax/Portfile
+++ b/lisp/cl-mgl-pax/Portfile
@@ -29,7 +29,8 @@ if {${name} eq ${subport}} {
                             port:cl-md5 \
                             port:cl-pythonic-string-reader
 
-    depends_test-append     port:cl-trivial-utf-8
+    depends_test-append     port:cl-trivial-utf-8 \
+                            port:cl-try
 }
 
 subport cl-dref {


### PR DESCRIPTION
#### Description

And I've found and fixed one more missed dependency. This time is test one.

Technically it should be all `depends_lib` but it introduces a cycle which I'm working with upstream to sort of.

So, for now it test.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->