### PR TITLE
mesa: use py311; disable meson subproject download

### DIFF
--- a/x11/mesa/Portfile
+++ b/x11/mesa/Portfile
@@ -13,7 +13,7 @@ legacysupport.newest_darwin_requires_legacy 17
 name                    mesa
 epoch                   1
 version                 22.1.7
-revision                0
+revision                1
 checksums               rmd160  9c570f7e00527c662509ab6fb264caf2c780a4ea \
                         sha256  da838eb2cf11d0e08d0e9944f6bd4d96987fdc59ea2856f8c70a31a82b355d89 \
                         size    16109944
@@ -29,7 +29,10 @@ homepage                https://www.mesa3d.org
 master_sites            https://archive.mesa3d.org
 use_xz                  yes
 
-set py_ver              3.10
+# Disable unexpected download of subprojects
+meson.wrap_mode         nodownload
+
+set py_ver              3.11
 set py_ver_nodot        [string map {. {}} ${py_ver}]
 
 depends_build-append    port:pkgconfig \


### PR DESCRIPTION
### Description

* Update port to use Python 3.11
* Disable Meson subproject download
* Fixes: https://trac.macports.org/ticket/67036