### PR TITLE
esmf: Update to 8.5.0

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -12,11 +12,11 @@ compilers.allow_arguments_mismatch \
 mpi.setup
 mpi.enforce_variant netcdf-fortran
 
-github.setup        esmf-org esmf 8.4.0 v
+github.setup        esmf-org esmf 8.5.0 v
 revision            0
-checksums           rmd160  23fa1d62bd36d51f5e99a7ae487777e2fa99e32f \
-                    sha256  28531810bf1ae78646cda6494a53d455d194400f19dccd13d6361871de42ed0f \
-                    size    13969876
+checksums           rmd160  3d1edb514d5b09b46f1f60047e3f5cd3c0bf7b43 \
+                    sha256  acd0b2641587007cc3ca318427f47b9cae5bfd2da8d2a16ea778f637107c29c4 \
+                    size    14091400
 
 version             [string map {_ .} ${github.version}]
 categories          science devel


### PR DESCRIPTION
#### Description

Update to 8.5.0.
Closes:  https://trac.macports.org/ticket/67965

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.7 21G651 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `port -v test`?
      (reports: "esmf has no tests turned on")
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `port -v install`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
