### PR TITLE
meson ports: migrate to meson.wrap_mode, rather than configure arg '--wrap-mode'

### DIFF
--- a/editors/lite-xl/Portfile
+++ b/editors/lite-xl/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 
 github.setup        lite-xl lite-xl 2.1.1 v
 github.tarball_from archive
-revision            0
+revision            1
 maintainers         {harens @harens} openmaintainer
 categories          editors lua
 description         A lightweight text editor written in Lua
@@ -30,9 +30,11 @@ app.retina          yes
 # clock_gettime required by reproc dependency
 legacysupport.newest_darwin_requires_legacy 15
 
-# Do not download any subprojects (https://mesonbuild.com/Subprojects.html#commandline-options)
+# Do not download any subprojects
+meson.wrap_mode     nodownload
+
 configure.args-append \
-                    --wrap-mode=nodownload --buildtype=release
+                    --buildtype=release
 
 # See https://github.com/macports/macports-ports/commit/5f87a7089d78f08e0674db5de0a27c1b4ea528e4
 compiler.cxx_standard 2003

--- a/emulators/dosbox-staging/Portfile
+++ b/emulators/dosbox-staging/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 github.setup          dosbox-staging dosbox-staging 0.80.1 v
 github.tarball_from   archive
-revision              0
+revision              1
 
 categories            emulators
 license               GPL-3+
@@ -56,8 +56,8 @@ if {![variant_isset debug]} {
     configure.args-append -Dbuildtype=release
 }
 
-# Discourage Meson from downloading stuff during the configure process
-configure.args-append --wrap-mode=nofallback --wrap-mode=nodownload
+# Do not download any subprojects
+meson.wrap_mode       nodownload
 
 # Disable OpenGL, as it causes assertion failures
 configure.args-append -Duse_opengl=false


### PR DESCRIPTION
### Description

Meson subproject downloads can now be controlled via a new option, `meson.wrap_mode`.

That eliminates the need to specify `--wrap-mode` as a configure argument. And it provides a formal method for ports to declare how they want subproject downloads to be handled.

Related tracking ticket: [67990 - meson ports: subproject handling: update all, to explicitly declare whether subproject download allowed](https://trac.macports.org/ticket/67990)

CC: @Gcenx