### PR TITLE
chicken: remove Xcode requirement

### DIFF
--- a/lang/chicken/Portfile
+++ b/lang/chicken/Portfile
@@ -8,6 +8,7 @@ PortGroup               muniversal 1.0
 
 name                    chicken
 version                 5.3.0
+revision                1
 categories              lang scheme
 license                 BSD public-domain
 maintainers             nomaintainer

--- a/lang/chicken/files/patch-Makefile.macosx.diff
+++ b/lang/chicken/files/patch-Makefile.macosx.diff
@@ -1,6 +1,32 @@
---- Makefile.macosx.orig	2016-05-28 04:30:50.000000000 -0700
-+++ Makefile.macosx	2016-12-11 14:07:16.000000000 -0700
-@@ -66,18 +66,12 @@
+--- Makefile.macosx.orig	2023-08-20 15:07:14.000000000 +1000
++++ Makefile.macosx	2023-08-20 15:07:18.000000000 +1000
+@@ -28,14 +28,12 @@
+ 
+ # platform configuration
+ 
+-XCODE_DEVELOPER ?= /Applications/Xcode.app/Contents/Developer
+-XCODE_TOOL_PATH ?= $(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin
+-C_COMPILER ?= $(XCODE_DEVELOPER)/usr/bin/gcc
++C_COMPILER ?= /usr/bin/gcc
+ ARCH ?= $(shell sh $(SRCDIR)/config-arch.sh)
+ 
+ # commands
+ 
+-POSTINSTALL_PROGRAM = $(XCODE_TOOL_PATH)/install_name_tool
++POSTINSTALL_PROGRAM = /usr/bin/install_name_tool
+ 
+ # options
+ 
+@@ -49,7 +47,7 @@
+ C_COMPILER_OPTIMIZATION_OPTIONS ?= -Os -fomit-frame-pointer
+ endif
+ endif
+-LIBRARIAN ?= $(XCODE_TOOL_PATH)/ar
++LIBRARIAN ?= /usr/bin/ar
+ LINKER_LINK_SHARED_LIBRARY_OPTIONS = -dynamiclib -compatibility_version 1 -current_version 1.0 -install_name $@
+ POSTINSTALL_PROGRAM_FLAGS = -change lib$(PROGRAM_PREFIX)chicken$(PROGRAM_SUFFIX)$(SO) $(LIBDIR)/lib$(PROGRAM_PREFIX)chicken$(PROGRAM_SUFFIX)$(SO)
+ LIBRARIAN_OPTIONS = scru
+@@ -66,18 +64,12 @@
  
  # architectures
  


### PR DESCRIPTION
Hello,

This patch should allow the Chicken Scheme compiler, `csc`, to function on systems without the full Xcode suite.

I filed [ticket/67917](https://trac.macports.org/ticket/67917) a couple of weeks ago wondering whether the hard Xcode dependency -- **at `csc` run time** -- was a bug.  Since then, I found [SummerOfCode/2019#remove-xcode-dep](https://trac.macports.org/wiki/SummerOfCode/2019#remove-xcode-dep) and `use_xcode`; both seem to imply that this port should function with only the CLT (or, rather, either a full Xcode installation or the CLT).

> By default, it is assumed on macOS that ports will not need tools from Xcode.app unless (1) Command Line Tools aren't installed, (2) you are on an old version of Mac OS X that does not support the xcode-select mechanism, or (3) the port uses build.type xcode or includes the xcode PortGroup.

This patch works by removing upstream references to `Xcode.app` and replacing them with libxcselect shims.

I figure this approach should work OK on OS X 10.9 and later.  MacPorts still distribute Chicken for OS X 10.7 and 10.8, however, and I don't think these older systems shipped with the shims.  What is the correct way to maintain compatibility with OS X < 10.9?  (FWIW, mpstats does not show any chicken installations on anything older than [10.12](https://ports.macports.org/port/chicken/stats/).)

`csc` now works with only the CLT.

```
% csc -o hello-world hello-world.scm
% ./hello-world
Hello, world.
% otool -L hello-world
hello-world:
        /opt/local/lib/libchicken.dylib (compatibility version 1.0.0, current version 1.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
```

`port test` fails, though I think the failure is a false negative?  I shall paste test output separately, below.

Thank you for MacPorts!

---

#### Description

Indirect via libxcselect shims at runtime.
Allows the chicken compiler, csc, to function with only the CLT.

Closes: https://trac.macports.org/ticket/67917


###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix


###### Tested on

<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6.7 21G651 x86_64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?  FAILS - note below
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
