### PR TITLE
common_lisp PG: add support ABCL and CCL; cl-*: disable unsupped lisps

### DIFF
--- a/lisp/cl-3bmd/Portfile
+++ b/lisp/cl-3bmd/Portfile
@@ -25,3 +25,6 @@ depends_lib-append  port:cl-colorize \
                     port:cl-fiasco \
                     port:cl-esrap \
                     port:cl-split-sequence
+
+# See: https://github.com/3b/3bmd/issues/63
+common_lisp.abcl    no

--- a/lisp/cl-async/Portfile
+++ b/lisp/cl-async/Portfile
@@ -42,4 +42,5 @@ depends_lib-append  port:cl-babel \
                     port:cl-usocket \
                     port:cl-vom
 
+common_lisp.ffi     yes
 common_lisp.threads yes

--- a/lisp/cl-atomics/Portfile
+++ b/lisp/cl-atomics/Portfile
@@ -26,3 +26,11 @@ depends_lib-append  port:cl-documentation-utils \
 
 # *** - CLISP is not supported by the Atomics library.
 common_lisp.clisp   no
+
+# Support CCL quite limited, almost none
+# See: https://github.com/Clozure/ccl/pull/52
+common_lisp.ccl     no
+
+# No suport of ABCL
+# See: https://github.com/armedbear/abcl/issues/92
+common_lisp.abcl    no

--- a/lisp/cl-base64/Portfile
+++ b/lisp/cl-base64/Portfile
@@ -29,5 +29,10 @@ long_description    {*}${description}
 depends_test-append port:cl-kmrcl \
                     port:cl-ptester
 
+# Caught READER-ERROR while processing --eval option "(asdf:operate (quote asdf:build-op) (quote kmrcl))":
+#   The symbol "MAKE-THREAD-LOCK" was not found in package EXT.
+# See: https://github.com/armedbear/abcl/issues/616
+common_lisp.abcl    no
+
 livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
 livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)

--- a/lisp/cl-blackbird/Portfile
+++ b/lisp/cl-blackbird/Portfile
@@ -25,4 +25,5 @@ depends_lib-append  port:cl-async \
                     port:cl-fiveam \
                     port:cl-vom
 
+common_lisp.ffi     yes
 common_lisp.threads yes

--- a/lisp/cl-cffi-gtk/Portfile
+++ b/lisp/cl-cffi-gtk/Portfile
@@ -47,6 +47,7 @@ depends_lib-append      path:lib/libcairo.dylib:cairo \
                         port:cl-trivial-features \
                         port:cl-trivial-garbage
 
+common_lisp.ffi         yes
 common_lisp.threads     yes
 
 # ECL detects such machines as arm,  not arm64 that leads to

--- a/lisp/cl-cffi/Portfile
+++ b/lisp/cl-cffi/Portfile
@@ -33,6 +33,7 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-trivial-features \
                     port:libffi
 
+common_lisp.ffi     yes
 common_lisp.threads yes
 
 post-patch {

--- a/lisp/cl-clack/Portfile
+++ b/lisp/cl-clack/Portfile
@@ -31,9 +31,14 @@ depends_test-append     port:cl-fastcgi \
                         port:cl-toot \
                         port:cl-wookie
 
+common_lisp.ffi         yes
 common_lisp.threads     yes
 
 # cl-clack depends on cl-dexador which depends on cl-clack
 common_lisp.build_run   no
 
 depends_test-append     port:cl-dexador
+
+# Tests stuck on CCL
+# See: https://github.com/fukamachi/clack/issues/188
+common_lisp.ccl         no

--- a/lisp/cl-contextl/Portfile
+++ b/lisp/cl-contextl/Portfile
@@ -25,5 +25,6 @@ depends_lib-append  port:cl-closer-mop \
                     port:cl-lw-compat
 
 # See: https://github.com/pcostanza/contextl/issues/2
+common_lisp.ccl     no
 common_lisp.ecl     no
 common_lisp.clisp   no

--- a/lisp/cl-dexador/Portfile
+++ b/lisp/cl-dexador/Portfile
@@ -41,4 +41,5 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-trivial-mime \
                     port:cl-usocket
 
+common_lisp.ffi     yes
 common_lisp.threads yes

--- a/lisp/cl-drakma/Portfile
+++ b/lisp/cl-drakma/Portfile
@@ -28,4 +28,5 @@ depends_lib-append  port:cl-base64 \
                     port:cl-ppcre \
                     port:cl-puri
 
+common_lisp.ffi     yes
 common_lisp.threads yes

--- a/lisp/cl-enchant/Portfile
+++ b/lisp/cl-enchant/Portfile
@@ -29,3 +29,5 @@ post-patch {
 
 depends_lib-append  port:cl-cffi \
                     port:enchant2
+
+common_lisp.ffi     yes

--- a/lisp/cl-fastcgi/Portfile
+++ b/lisp/cl-fastcgi/Portfile
@@ -30,5 +30,7 @@ depends_lib-append  port:cl-cffi \
                     port:cl-usocket \
                     port:fcgi
 
+common_lisp.ffi     yes
+
 # <PACKAGE SOCKET> has no external symbol with name "STREAM-HANDLES"
 common_lisp.clisp   no

--- a/lisp/cl-find-port/Portfile
+++ b/lisp/cl-find-port/Portfile
@@ -23,3 +23,12 @@ long_description    {*}${description}
 
 depends_lib-append  port:cl-fiveam \
                     port:cl-usocket
+
+# :info:build Caught IT.BESE.FIVEAM::CHECK-FAILURE while processing --eval option "(asdf:operate (quote asdf:build-op) (quote find-port-test))":
+# :info:build   #<CHECK-FAILURE {3247A9AA}>
+# :info:build  Running test FIND-PORTS X
+common_lisp.abcl    no
+
+# Tests doesn't work on macOS
+# See: https://github.com/eudoxia0/find-port/issues/4
+test.run            off

--- a/lisp/cl-fset/Portfile
+++ b/lisp/cl-fset/Portfile
@@ -27,4 +27,5 @@ depends_lib-append  port:cl-misc-extensions \
 
 # See: https://github.com/slburson/fset/issues/42
 common_lisp.ecl     no
+common_lisp.abcl    no
 common_lisp.clisp   no

--- a/lisp/cl-gobject-introspection/Portfile
+++ b/lisp/cl-gobject-introspection/Portfile
@@ -11,7 +11,7 @@ revision            0
 
 categories-append   devel
 license             BSD
-maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         Common Lisp bindings to gobject-introspection
 

--- a/lisp/cl-gobject-introspection/Portfile
+++ b/lisp/cl-gobject-introspection/Portfile
@@ -26,3 +26,5 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-iterate \
                     port:cl-trivial-garbage \
                     port:gobject-introspection
+
+common_lisp.ffi     yes

--- a/lisp/cl-gopher/Portfile
+++ b/lisp/cl-gopher/Portfile
@@ -26,4 +26,5 @@ depends_lib-append  port:cl-bordeaux-threads \
                     port:cl-quri \
                     port:cl-usocket
 
+common_lisp.ffi     yes
 common_lisp.threads yes

--- a/lisp/cl-hunchentoot/Portfile
+++ b/lisp/cl-hunchentoot/Portfile
@@ -36,4 +36,13 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-usocket \
                     port:cl-who
 
+common_lisp.ffi     yes
 common_lisp.threads yes
+
+# CCL + ABCL has issues with shutdown the server, similar SBCL one
+# SEE: https://github.com/edicl/hunchentoot/issues/131
+#
+# Thus, ABCL additionally has issue with compatiblity with usocket
+# See: https://github.com/usocket/usocket/issues/113
+common_lisp.abcl    no
+common_lisp.ccl     no

--- a/lisp/cl-iolib/Portfile
+++ b/lisp/cl-iolib/Portfile
@@ -30,4 +30,9 @@ depends_lib-append  port:cl-babel \
 
 depends_test-append port:cl-fiveam
 
+common_lisp.ffi     yes
 common_lisp.threads yes
+
+# Tests on macOS seems to be broken
+# See: https://github.com/sionescu/iolib/issues/80
+test.run            no

--- a/lisp/cl-ironclad/Portfile
+++ b/lisp/cl-ironclad/Portfile
@@ -30,3 +30,4 @@ common_lisp.threads yes
 
 # NOTE: some test are failing on ECL
 # See: https://github.com/sharplispers/ironclad/issues/63
+common_lisp.ecl     no

--- a/lisp/cl-iterate/Portfile
+++ b/lisp/cl-iterate/Portfile
@@ -24,3 +24,6 @@ checksums           rmd160  6da2c2444e7ec8b33bcdef7fa60c0bfe62a09aae \
                     size    297681
 
 depends_lib-append  port:cl-rt
+
+# Tests are failed on CLisp
+common_lisp.clisp   no

--- a/lisp/cl-kmrcl/Portfile
+++ b/lisp/cl-kmrcl/Portfile
@@ -38,3 +38,8 @@ livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)
 # Expected value: "3w1d2h2m50.1s"
 # Actual value: "3w1d2h2m50.2s".
 common_lisp.clisp   no
+
+# Caught READER-ERROR while processing --eval option "(asdf:operate (quote asdf:build-op) (quote kmrcl))":
+#   The symbol "MAKE-THREAD-LOCK" was not found in package EXT.
+# See: https://github.com/armedbear/abcl/issues/616
+common_lisp.abcl    no

--- a/lisp/cl-lack/Portfile
+++ b/lisp/cl-lack/Portfile
@@ -45,6 +45,7 @@ depends_lib-append      port:cl-alexandria \
                         port:cl-trivial-rfc-1123 \
                         port:cl-trivial-utf-8
 
+common_lisp.ffi         yes
 common_lisp.threads     yes
 
 # cl-lack depends on cl-dexador which depends on cl-lack

--- a/lisp/cl-libuv/Portfile
+++ b/lisp/cl-libuv/Portfile
@@ -31,3 +31,5 @@ post-extract {
 depends_lib-append  port:cl-alexandria \
                     port:cl-cffi \
                     port:libuv
+
+common_lisp.ffi     yes

--- a/lisp/cl-lml2/Portfile
+++ b/lisp/cl-lml2/Portfile
@@ -27,5 +27,10 @@ long_description    {*}${description}
 depends_lib-append  port:cl-kmrcl \
                     port:cl-rt
 
+# Caught READER-ERROR while processing --eval option "(asdf:operate (quote asdf:build-op) (quote kmrcl))":
+#   The symbol "MAKE-THREAD-LOCK" was not found in package EXT.
+# See: https://github.com/armedbear/abcl/issues/616
+common_lisp.abcl    no
+
 livecheck.url       http://ftp.debian.org/debian/pool/main/c/${name}/?C=N\;O=D
 livecheck.regex     ${name}_(\\d+(?:\\.\\d+)*)

--- a/lisp/cl-log4cl/Portfile
+++ b/lisp/cl-log4cl/Portfile
@@ -33,3 +33,6 @@ common_lisp.threads yes
 # :info:test   COMPILE-FILE-ERROR while compiling #<LOCAL-CL-SOURCE-FILE "stefil" "stefil">
 # :info:test Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {10013C0073}>
 common_lisp.sbcl    no
+
+# See: https://github.com/joaotavora/sly/issues/425
+common_lisp.abcl    no

--- a/lisp/cl-markdown/Portfile
+++ b/lisp/cl-markdown/Portfile
@@ -36,5 +36,10 @@ depends_lib-append  port:cl-anaphora \
                     port:cl-ppcre \
                     port:cl-trivial-shell
 
+# Caught READER-ERROR while processing --eval option "(asdf:operate (quote asdf:build-op) (quote kmrcl))":
+#   The symbol "MAKE-THREAD-LOCK" was not found in package EXT.
+# See: https://github.com/armedbear/abcl/issues/616
+common_lisp.abcl    no
+
 # See: https://github.com/gwkkwg/dynamic-classes/issues/2
 test.run            no

--- a/lisp/cl-marshal/Portfile
+++ b/lisp/cl-marshal/Portfile
@@ -21,3 +21,6 @@ description         Simple and fast serialization of all kinds of Common Lisp da
 long_description    {*}${description}
 
 depends_lib-append  port:cl-xlunit
+
+# See: https://github.com/wlbr/cl-marshal/issues/17
+common_lisp.abcl    no

--- a/lisp/cl-mgl-pax/Portfile
+++ b/lisp/cl-mgl-pax/Portfile
@@ -51,3 +51,7 @@ subport cl-dref {
 
     livecheck.type          none
 }
+
+# Can't ensure directory #P"/Users/macports/.slime/"
+# See: https://github.com/armedbear/abcl/issues/614
+common_lisp.abcl            no

--- a/lisp/cl-montezuma/Portfile
+++ b/lisp/cl-montezuma/Portfile
@@ -36,3 +36,4 @@ common_lisp.threads yes
 
 # See: https://github.com/sharplispers/montezuma/issues/14
 common_lisp.ecl     no
+common_lisp.abcl    no

--- a/lisp/cl-mysql/Portfile
+++ b/lisp/cl-mysql/Portfile
@@ -23,6 +23,8 @@ long_description        {*}${description}
 depends_lib-append      port:cl-cffi \
                         port:cl-stefil
 
+common_lisp.ffi         yes
+
 # Build and test requires real MySQL
 common_lisp.build_run   no
 test.run                no

--- a/lisp/cl-nfiles/Portfile
+++ b/lisp/cl-nfiles/Portfile
@@ -31,6 +31,7 @@ depends_lib-append  port:cl-alexandria \
 
 depends_test-append port:cl-lisp-unit2
 
+common_lisp.ffi     yes
 common_lisp.threads yes
 
 # Cannot find the external symbol PARSE-BODY in #<"UIOP/DRIVER" package>

--- a/lisp/cl-osicat/Portfile
+++ b/lisp/cl-osicat/Portfile
@@ -25,3 +25,5 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-cffi \
                     port:cl-trivial-features \
                     port:cl-rt
+
+common_lisp.ffi     yes

--- a/lisp/cl-phos/Portfile
+++ b/lisp/cl-phos/Portfile
@@ -30,4 +30,5 @@ depends_lib-append  port:cl-nodgui \
 
 depends_test-append port:cl-clunit2
 
+common_lisp.ffi     yes
 common_lisp.threads yes

--- a/lisp/cl-plus-ssl/Portfile
+++ b/lisp/cl-plus-ssl/Portfile
@@ -36,6 +36,8 @@ post-extract {
     reinplace {s|(:feature (:or :sbcl :ccl) :cl-coveralls)||} ${worksrcpath}/cl+ssl.test.asd
 }
 
+common_lisp.ffi     yes
+
 # See: https://github.com/usocket/trivial-sockets/issues/1
 common_lisp.ecl     no
 # Error while trying to load definition for system trivial-sockets from pathname [...]/trivial-sockets.asd: keyword list is not a proper list.

--- a/lisp/cl-prevalence/Portfile
+++ b/lisp/cl-prevalence/Portfile
@@ -30,4 +30,7 @@ common_lisp.threads yes
 
 # Test are working only on SBCL
 # See: https://github.com/40ants/cl-prevalence/issues/19
+common_lisp.abcl    no
+common_lisp.ccl     no
+common_lisp.clisp   no
 common_lisp.ecl     no

--- a/lisp/cl-prompter/Portfile
+++ b/lisp/cl-prompter/Portfile
@@ -37,3 +37,5 @@ common_lisp.threads yes
 
 # ;;; Cannot find the external symbol PARSE-BODY in #<"UIOP/DRIVER" package>.
 common_lisp.ecl     no
+# The function get-structure is not yet implemented for Armed Bear Common Lisp 1.9.2 on X86_64.
+common_lisp.abcl    no

--- a/lisp/cl-rutils/Portfile
+++ b/lisp/cl-rutils/Portfile
@@ -30,3 +30,7 @@ depends_lib-append      port:cl-closer-mop \
                         port:cl-named-readtables
 
 depends_test-append     port:cl-should-test
+
+# Caught ASDF/FIND-SYSTEM:LOAD-SYSTEM-DEFINITION-ERROR while processing --eval option "(asdf:operate (quote asdf:test-op) (quote rutils))":
+#   #<LOAD-SYSTEM-DEFINITION-ERROR {579F4155}>
+common_lisp.abcl        no

--- a/lisp/cl-salza2/Portfile
+++ b/lisp/cl-salza2/Portfile
@@ -24,3 +24,6 @@ depends_lib-append  port:cl-chipz \
                     port:cl-flexi-streams \
                     port:cl-parachute \
                     port:cl-trivial-gray-streams
+
+# make-decompressing-stream is not supported for this lisp implementation
+common_lisp.abcl    no

--- a/lisp/cl-should-test/Portfile
+++ b/lisp/cl-should-test/Portfile
@@ -25,3 +25,6 @@ depends_lib-append  port:cl-local-time \
                     port:cl-osicat \
                     port:cl-ppcre \
                     port:cl-rutils
+
+# See: https://github.com/vseloved/should-test/issues/4
+common_lisp.abcl    no

--- a/lisp/cl-slynk/Portfile
+++ b/lisp/cl-slynk/Portfile
@@ -21,3 +21,6 @@ description         SLYNK - Sylvester the Cat's Common Lisp IDE
 long_description    {*}${description}
 
 worksrcdir          ${worksrcdir}/slynk
+
+# See: https://github.com/joaotavora/sly/issues/425
+common_lisp.abcl    no

--- a/lisp/cl-spinneret/Portfile
+++ b/lisp/cl-spinneret/Portfile
@@ -33,3 +33,6 @@ depends_lib-append  port:cl-alexandria \
 depends_test-append port:cl-fiveam
 
 common_lisp.threads yes
+
+# See: https://github.com/ruricolist/spinneret/issues/87
+common_lisp.abcl    no

--- a/lisp/cl-sqlite/Portfile
+++ b/lisp/cl-sqlite/Portfile
@@ -25,4 +25,5 @@ depends_lib-append  port:cl-bordeaux-threads \
                     port:cl-iterate \
                     port:sqlite3
 
+common_lisp.ffi     yes
 common_lisp.threads yes

--- a/lisp/cl-static-vectors/Portfile
+++ b/lisp/cl-static-vectors/Portfile
@@ -25,5 +25,7 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-cffi \
                     port:cl-fiveam
 
+common_lisp.ffi     yes
+
 # static vectors doesn't support CLisp
 common_lisp.clisp   no

--- a/lisp/cl-stefil/Portfile
+++ b/lisp/cl-stefil/Portfile
@@ -28,3 +28,7 @@ depends_lib-append  port:cl-alexandria \
 
 # SBCL comply for styles
 common_lisp.sbcl    no
+
+# Can't ensure directory #P"/Users/macports/.slime/"
+# See: https://github.com/armedbear/abcl/issues/614
+common_lisp.abcl    no

--- a/lisp/cl-swank/Portfile
+++ b/lisp/cl-swank/Portfile
@@ -22,3 +22,7 @@ license             Permissive
 description         Swank from SLIME
 
 long_description    {*}${description}
+
+# Can't ensure directory #P"/Users/macports/.slime/"
+# See: https://github.com/armedbear/abcl/issues/614
+common_lisp.abcl    no

--- a/lisp/cl-syntax/Portfile
+++ b/lisp/cl-syntax/Portfile
@@ -30,5 +30,7 @@ depends_lib-append  port:cl-annot \
                     port:cl-trivial-types
 
 # cl-clsql is SBCL only port
+common_lisp.abcl    no
+common_lisp.ccl     no
 common_lisp.clisp   no
 common_lisp.ecl     no

--- a/lisp/cl-system-locale/Portfile
+++ b/lisp/cl-system-locale/Portfile
@@ -23,3 +23,5 @@ long_description    {*}${description}
 
 depends_lib-append  port:cl-cffi \
                     port:cl-documentation-utils
+
+common_lisp.ffi     yes

--- a/lisp/cl-toot/Portfile
+++ b/lisp/cl-toot/Portfile
@@ -35,4 +35,5 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-trivial-backtrace \
                     port:cl-usocket
 
+common_lisp.ffi     yes
 common_lisp.threads yes

--- a/lisp/cl-trivia/Portfile
+++ b/lisp/cl-trivia/Portfile
@@ -44,6 +44,8 @@ depends_lib-append      port:cl-cffi \
 
 depends_test-append     port:cl-fare-quasiquote
 
+common_lisp.ffi         yes
+
 # See: https://github.com/Bike/introspect-environment/issues/5
 common_lisp.ecl         no
 common_lisp.clisp       no

--- a/lisp/cl-trivial-clipboard/Portfile
+++ b/lisp/cl-trivial-clipboard/Portfile
@@ -23,3 +23,5 @@ long_description        {*}${description}
 
 depends_lib-append      port:cl-cffi \
                         port:cl-fiveam
+
+common_lisp.ffi         yes

--- a/lisp/cl-trivial-custom-debugger/Portfile
+++ b/lisp/cl-trivial-custom-debugger/Portfile
@@ -28,4 +28,5 @@ depends_test-append     port:cl-parachute
 
 # See: https://github.com/phoe/trivial-custom-debugger/issues/3
 common_lisp.ecl         no
+common_lisp.ccl         no
 common_lisp.clisp       no

--- a/lisp/cl-trivial-features/Portfile
+++ b/lisp/cl-trivial-features/Portfile
@@ -26,5 +26,7 @@ common_lisp.build_run   no
 
 depends_test-append port:cl-cffi
 
+common_lisp.ffi     yes
+
 # See: https://github.com/trivial-features/trivial-features/issues/23
 common_lisp.clisp   no

--- a/lisp/cl-type-i/Portfile
+++ b/lisp/cl-type-i/Portfile
@@ -29,3 +29,9 @@ depends_lib-append      port:cl-alexandria \
                         port:cl-lisp-namespace \
 
 depends_test-append     port:cl-trivia
+
+# See: https://github.com/guicho271828/type-i/issues/6
+common_lisp.ecl         no
+
+# See: https://github.com/guicho271828/type-i/issues/7
+common_lisp.clisp       no

--- a/lisp/cl-uffi/Portfile
+++ b/lisp/cl-uffi/Portfile
@@ -26,8 +26,10 @@ description         Universal Foreign Function Library for Common Lisp
 
 long_description    {*}${description}
 
+# this is very old code which might not be supported by some lisp
 common_lisp.clisp   no
 common_lisp.ecl     no
+common_lisp.abcl    no
 
 post-extract {
     # :FORCE and :FORCE-NOT arguments not allowed in a nested call to ASDF/OPERATE:OPERATE unless identically to toplevel

--- a/lisp/cl-usocket/Portfile
+++ b/lisp/cl-usocket/Portfile
@@ -25,3 +25,7 @@ depends_lib-append  port:cl-bordeaux-threads \
                     port:cl-split-sequence
 
 common_lisp.threads yes
+
+# See: https://github.com/usocket/usocket/issues/113
+common_lisp.ccl     no
+common_lisp.abcl    no

--- a/lisp/cl-webengine/Portfile
+++ b/lisp/cl-webengine/Portfile
@@ -41,6 +41,8 @@ if {${name} eq ${subport}} {
                             port:cl-webengine-lib
 
     # SBCL only port
+    common_lisp.abcl        no
+    common_lisp.ccl         no
     common_lisp.ecl         no
     common_lisp.clisp       no
 }

--- a/lisp/cl-webkit2/Portfile
+++ b/lisp/cl-webkit2/Portfile
@@ -32,6 +32,7 @@ depends_test-append port:cl-calispel \
                     port:cl-fiveam \
                     port:cl-float-features
 
+common_lisp.ffi     yes
 common_lisp.threads yes
 
 # test requires X11, maybe use Xvfb one day?

--- a/lisp/cl-wookie/Portfile
+++ b/lisp/cl-wookie/Portfile
@@ -35,4 +35,5 @@ depends_lib-append  \
                     port:cl-quri \
                     port:cl-vom
 
+common_lisp.ffi     yes
 common_lisp.threads yes


### PR DESCRIPTION
#### Description

This PR future improves support of lisp in MacPorts.

I've enabled all major lisps (SBCL, CLisp, ABCL, ECL and CCL) as used by its group to compile and test ports.

Thus, some ports need to be blacklisted as unsupported :)

I've disabled CI because it hasn't got any chances to pass tests on it.

Anyway, I've tested it locally as:

``` sh
ls lisp | xargs port info --name --subport | cut -d : -f 2 | tr ',' ' ' | grep -v '\-\-' | tr ' ' '\n' | sort | uniq | grep -v "^$" | while read port
do
    echo Building $port at $(date)
    port deactivate $(port echo active | grep cl- | awk '{print $1}') 1>/dev/null 2>/dev/null || :
    (port -N build $port 1>/dev/null 2>/dev/null) || (echo $port >> ports.build_failed; cp $(port logfile $port) $port.log; echo FAIL)
    echo Testing $port at $(date)
    (port -N test $port 1>/dev/null 2>/dev/null) || (echo $port >> ports.tests_failed; cp $(port logfile $port) $port.log; echo FAIL)
done
```

The last round of testing was about 10 hours BTW

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->