### PR TITLE
colout: update to 1.1

### DIFF
--- a/textproc/colout/Portfile
+++ b/textproc/colout/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        nojhan colout 0.12.0 v
+github.setup        nojhan colout 1.1 v
 github.tarball_from archive
 revision            0
 
@@ -19,11 +19,11 @@ long_description    ${name} read lines of text stream on the standard input and 
 
 homepage            https://nojhan.github.io/colout/
 
-checksums           rmd160  09e17028c02065efc237ed73dbbc415abde78d4e \
-                    sha256  1dfafc1b62054f08ffdcf813b1207e6a67e2f185fc6df329cea78b7425a18256 \
-                    size    36856
+checksums           rmd160  c39174cfe17941160a90e22f3d4f48f660716703 \
+                    sha256  6d13793207b27a5175592818140a83d748e5604b6d6aa63f8f7865cf1d481eee \
+                    size    52783
 
-python.default_version 310
+python.default_version 311
 
 patchfiles-append   patch-setup.py.diff
 


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
