### PR TITLE
openjdk17-openj9: update to 17.0.8, install files under ${prefix}

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      17.0.7
+version      17.0.8
 revision     0
 
 set build    7
-set openj9_version 0.38.0
+set openj9_version 0.40.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 17
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru17-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  526ca24a7d89b1d5105c802892d245c6c808bc0d \
-                 sha256  47021dbc5f9f1796479bfa350356dbf17082f6baace42543914dbbecce54e9ee \
-                 size    209975983
+    checksums    rmd160  149ef607283b48d6f0828d6397cfa48618c8e8e2 \
+                 sha256  ff39469f3761465d29a58c94af34bc9071747713b77c1bfb3ae1702f1e0310a7 \
+                 size    210301496
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  e057aa4a352e349dd9f3c68f837f4f4bc9014351 \
-                 sha256  da95343f2cc6ec7e4bd6ed720183b6e9e8d6639df15b2e49ff15a2b5a3780cd7 \
-                 size    203142333
+    checksums    rmd160  4a437058297425a78be6a20b00127d2f8c04b344 \
+                 sha256  df87f86cd3941d78bbcf43bfd308b233c6399b3fea9d88bbc4b63a96e89aa840 \
+                 size    203480616
 }
 
 worksrcdir   jdk-${version}+${build}
@@ -77,17 +77,21 @@ test.args   -version
 # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
 destroot.violate_mtree yes
 
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/${name}
 
 destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
 }
 
 notes "
 If you have more than one JDK installed you can make ${name} the default\
 by adding the following line to your shell profile:
 
-    export JAVA_HOME=${target}/Contents/Home
+    export JAVA_HOME=${jdk}/Contents/Home
 "


### PR DESCRIPTION
#### Description

* Update to IBM Semeru 17.0.8.
* Install all actual files under `${prefix}`, only create a symlink under `/Library/Java/JavaVirtualMachines`, as suggested on https://trac.macports.org/ticket/67935.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?