### PR TITLE
openjdk11-graalvm: clean up old files before installation, install files under ${prefix}

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -21,7 +21,7 @@ if {${configure.build_arch} eq "arm64"} {
     version 22.3.3
 }
 
-revision     0
+revision     1
 
 description  GraalVM Community Edition based on OpenJDK 11
 long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
@@ -78,19 +78,29 @@ test.args   -version
 # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
 destroot.violate_mtree yes
 
-set target /Library/Java/JavaVirtualMachines/${name}
-set destroot_target ${destroot}${target}
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/${name}
+
+pre-install {
+    # Clean up previous installation, because some old subport files may have been left behind (https://trac.macports.org/ticket/67935)
+    # Don't remove before 2024-08-20
+    delete ${jdk}
+}
 
 destroot {
-    xinstall -m 755 -d ${destroot_target}
-    copy ${worksrcpath}/Contents ${destroot_target}
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
 }
 
 notes "
 If you have more than one JDK installed you can make ${name} the default\
 by adding the following line to your shell profile:
 
-    export JAVA_HOME=${target}/Contents/Home
+    export JAVA_HOME=${jdk}/Contents/Home
 "
 
 subport ${name}-native-image {
@@ -112,7 +122,7 @@ subport ${name}-native-image {
                      size    28504616
     }
 
-    set java_home ${target}/Contents/Home
+    set java_home ${prefix}${jdk}/Contents/Home
 
     extract {}
 


### PR DESCRIPTION
#### Description

* Clean up old files before installation. This should fix https://trac.macports.org/ticket/67935.
* Install all actual files under `${prefix}`, only create a symlink under `/Library/Java/JavaVirtualMachines`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?