### PR TITLE
openjdk17-graalvm: use existing ${jdk} variable

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -79,7 +79,7 @@ set jdk ${jvms}/${name}
 pre-install {
     # Clean up previous installations, because some old subport files may have been left behind (https://trac.macports.org/ticket/67935)
     # Don't remove before 2024-08-20
-    delete ${jvms}/${name}
+    delete ${jdk}
 }
 
 destroot {


### PR DESCRIPTION
#### Description

Minor deduplication update, reusing the `${jdk}` variable.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?