### PR TITLE
librdkafka: update to 2.2.0

### DIFF
--- a/net/librdkafka/Portfile
+++ b/net/librdkafka/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        edenhill librdkafka 1.9.2 v
+github.setup        confluentinc librdkafka 2.2.0 v
 revision            0
 
 categories          net
@@ -13,9 +13,9 @@ maintainers         {@alexeyt820 gmail.com:alexey.trenikhin+macports} openmainta
 description         The Apache Kafka C/C++ library
 long_description    Full Apache Kafka protocol support, including producer and consumer
 
-checksums           sha256  3fba157a9f80a0889c982acdd44608be8a46142270a389008b22d921be1198ad \
-                    rmd160  50fb067798a9e0780bada4f248b213cb421479ff \
-                    size    4185493
+checksums           sha256  af9a820cbecbc64115629471df7c7cecd40403b6c34bfdbb9223152677a47226 \
+                    rmd160  03f261e9362f04e5bb4a97d7b07fddd74defe184 \
+                    size    4340164
 
 configure.args-append   --disable-zstd \
                         --disable-lz4-ext \


### PR DESCRIPTION
#### Description

Update librdkafka to 2.2.0. Note that librdakfka moved from edenhill to confluentinc on GitHub.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5 22G74 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
