### PR TITLE
qsynth-qt4: new port, legacy version for old systems

### DIFF
--- a/audio/qsynth-qt4/Portfile
+++ b/audio/qsynth-qt4/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           qt4 1.0
+
+# Please keep this pegged, unless a newer version is fixed for Qt4 and confirmed to work.
+# This port is meant only for old systems which do not presently support Qt5.
+name                qsynth-qt4
+set real_name       qsynth
+version             0.5.3
+revision            0
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+categories          audio
+platforms           {darwin < 11}
+license             GPL-2+
+conflicts           qsynth
+
+description         A fluidsynth GUI front-end application
+long_description    Qsynth is a fluidsynth GUI front-end application, written in C++ using the Qt framework. \
+                    This is a legacy version primarily aimed at PowerPC systems.
+
+homepage            https://qsynth.sourceforge.io
+master_sites        sourceforge:project/${real_name}/${real_name}/${version} \
+                    https://download.sourceforge.net/${real_name}/
+
+distname            ${real_name}-${version}
+
+checksums           rmd160  35468f7b9fdbbcfcea919cd4749d4876de984276 \
+                    sha256  2ce9791f8a927425d29bacc44fdfff575638b24512e0f0b6f2eca85deb67f0c9 \
+                    size    269252
+
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+autoreconf.args
+
+# The build system is crazy: in fact C++11 is not required, moreover, both configure and environment settings
+# for compiler choice are stubbornly ignored, and the build picks the compiler which was used to build Qt4,
+# which normally would mean gcc-4.2. Yet, just using gcc-4.2 leads to configure failure: Qt4 version
+# is not recognized correctly. Despite this madness, build succeeds and the app works.
+compiler.cxx_standard 2011
+
+depends_lib-append  port:desktop-file-utils \
+                    port:fluidsynth \
+                    port:xorg-libX11 \
+                    port:xorg-libXext
+
+configure.args-append \
+                    --bindir=${applications_dir} \
+                    --enable-qt4
+
+post-activate {
+    system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
+}

--- a/audio/qsynth/Portfile
+++ b/audio/qsynth/Portfile
@@ -9,8 +9,9 @@ version             0.5.7
 revision            2
 maintainers         {gmail.com:rjvbertin @RJVB} {mojca @mojca} openmaintainer
 categories          audio
-platforms           darwin
+platforms           {darwin > 9}
 license             GPL-2+
+conflicts           qsynth-qt4
 
 description         A fluidsynth GUI front-end application
 long_description    Qsynth is a fluidsynth GUI front-end application, written in C++ using the Qt framework. \


### PR DESCRIPTION
#### Description

I skip CI here, there is nothing to build: `qsynth-qt4` is set for `darwin < 11`, `qsynth` gets non-functional change only: conflict declaration and restriction to `darwin > 9`.

@mascguy @ryandesign Could someone please review this?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
