### PR TITLE
openjdk11-graalvm: fix subport pollution

### DIFF
--- a/java/openjdk11-graalvm/Portfile
+++ b/java/openjdk11-graalvm/Portfile
@@ -21,27 +21,9 @@ if {${configure.build_arch} eq "arm64"} {
     version 22.3.3
 }
 
-revision     1
-
-description  GraalVM Community Edition based on OpenJDK 11
-long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
-                 JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
+revision     2
 
 master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     graalvm-ce-java11-darwin-amd64-${version}
-    checksums    rmd160  e596dc7f73ca0f602ae60ca5c1bc4247373ec158 \
-                 sha256  cab6a1436626adc28ec0f72791772315678e7c758e2fbae2cb6758a38f27c56a \
-                 size    254523003
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     graalvm-ce-java11-darwin-aarch64-${version}
-    checksums    rmd160  3421d1754a491b0cfa44d09df798ff5053fcefc8 \
-                 sha256  c59f32289d92671bea46a34f4227fef484a4aa9eeece159e59a486205aaa6c31 \
-                 size    249144742
-}
-
-worksrcdir   graalvm-ce-java11-${version}
 
 homepage     https://www.graalvm.org
 
@@ -50,58 +32,78 @@ livecheck.type  none
 use_configure    no
 build {}
 
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/openjdk11-graalvm
 
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+if {${subport} eq ${name}} {
+    description  GraalVM Community Edition based on OpenJDK 11
+    long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
+                     JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
 
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     graalvm-ce-java11-darwin-amd64-${version}
+        checksums    rmd160  e596dc7f73ca0f602ae60ca5c1bc4247373ec158 \
+                     sha256  cab6a1436626adc28ec0f72791772315678e7c758e2fbae2cb6758a38f27c56a \
+                     size    254523003
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     graalvm-ce-java11-darwin-aarch64-${version}
+        checksums    rmd160  3421d1754a491b0cfa44d09df798ff5053fcefc8 \
+                     sha256  c59f32289d92671bea46a34f4227fef484a4aa9eeece159e59a486205aaa6c31 \
+                     size    249144742
+    }
 
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
+    worksrcdir   graalvm-ce-java11-${version}
 
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+    variant Applets \
+        description { Advertise the JVM capability "Applets".} {}
+
+    variant BundledApp \
+        description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+    variant JNI \
+        description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+    variant WebStart \
+        description { Advertise the JVM capability "WebStart".} {}
+
+    patch {
+        foreach var { Applets BundledApp JNI WebStart } {
+            if {[variant_isset ${var}]} {
+                reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+            }
         }
     }
+
+    test.run    yes
+    test.cmd    Contents/Home/bin/java
+    test.target
+    test.args   -version
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+    destroot.violate_mtree yes
+
+    pre-install {
+        # Clean up previous installation, because some old subport files may have been left behind (https://trac.macports.org/ticket/67935)
+        # Don't remove before 2024-08-20
+        delete ${jdk}
+    }
+
+    destroot {
+        xinstall -m 755 -d ${destroot}${prefix}${jdk}
+        copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+        # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+        xinstall -m 755 -d ${destroot}${jvms}
+        ln -s ${prefix}${jdk} ${destroot}${jdk}
+    }
+
+    notes "
+    If you have more than one JDK installed you can make ${name} the default\
+    by adding the following line to your shell profile:
+
+        export JAVA_HOME=${jdk}/Contents/Home
+    "
 }
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/${name}
-
-pre-install {
-    # Clean up previous installation, because some old subport files may have been left behind (https://trac.macports.org/ticket/67935)
-    # Don't remove before 2024-08-20
-    delete ${jdk}
-}
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}${jdk}
-    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
-    xinstall -m 755 -d ${destroot}${jvms}
-    ln -s ${prefix}${jdk} ${destroot}${jdk}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${jdk}/Contents/Home
-"
 
 subport ${name}-native-image {
     depends_lib        port:${name}


### PR DESCRIPTION
#### Description

Don't apply `pre-install`, variants, etc. to subports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?