### PR TITLE
java PG: allow port to enforce fallback JVM

### DIFF
--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -17,13 +17,17 @@
 # - "+" and "*" wildcards are supported
 #
 # If the required Java cannot be found, an error will be thrown at pre-fetch.
+#
+# Sometimes a port hard code inside produces scripts and other files used JVM,
+# then its true use java.enforce to enforce dependency.
 
-options java.version java.home java.fallback java.deptypes
+options java.version java.home java.fallback java.deptypes java.enforce
 
 default java.version  {}
 default java.home     {}
 default java.fallback {[java::java_get_default_fallback]}
 default java.deptypes lib
+default java.enforce  no
 
 # allow PortGroup to be used inside a variant (e.g. octave)
 global java_version_not_found
@@ -124,7 +128,7 @@ namespace eval java {
         }
 
         # Add dependency if required
-        if { ${java_version_not_found} && ${java.fallback} ne "" } {
+        if { (${java_version_not_found} || [option java.enforce]) && ${java.fallback} ne "" } {
             ui_debug "Adding dependency on JDK fallback ${java.fallback}"
             foreach deptype [option java.deptypes] {
                 depends_${deptype}-append port:${java.fallback}

--- a/lang/abcl/Portfile
+++ b/lang/abcl/Portfile
@@ -5,7 +5,7 @@ PortGroup           java 1.0
 
 name                abcl
 version             1.9.2
-revision            1
+revision            2
 categories          lang java
 license             GPL-2
 maintainers         {easieste @easye} {@catap korins.ky:kirill} openmaintainer
@@ -38,6 +38,7 @@ depends_build       port:apache-ant
 
 java.version        11
 java.fallback       openjdk11
+java.enforce        yes
 use_configure       no
 
 patchfiles-append   patch-macports-xdg-data-dir.diff


### PR DESCRIPTION
#### Description

Sometimes port hard codedes inside produced artifacts path to used Java, and when build bot installs for example OpenJDK11, and user has OpenJDK 17 it can be a disaster.

To reproduce an issue just try to instal and use `abcl` without `openjdk11`.

If you haven't got any JDK => it will work fine. If you have `openjdk17`, well.. java PG decided that it better than 11 and avoid to add dependency, but build bot builds an artifact which hardcoded paths to `openjdk11` ;)

=> nothing works.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->