### PR TITLE
openjdk20: update to 20.0.2

### DIFF
--- a/java/openjdk20/Portfile
+++ b/java/openjdk20/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                openjdk20
-# https://github.com/openjdk/jdk20u/tags
-version             20.0.1
+# See https://github.com/openjdk/jdk20u/tags for the version and build number that matches the latest tag that ends with '-ga'
+version             20.0.2
 set build 9
 revision            0
 categories          java devel
@@ -17,11 +17,11 @@ long_description    JDK 20 builds of OpenJDK, the Open-Source implementation \
 homepage            https://openjdk.java.net/
 master_sites        https://git.openjdk.java.net/jdk20u/archive/refs/tags
 distname            jdk-${version}-ga
-worksrcdir          jdk20u-[string map {+ -} ${distname}]
+worksrcdir          jdk20u-${distname}
 
-checksums           rmd160  dc2fb313f073b95429356eea469ef27ec47d99f2 \
-                    sha256  ced1915490f6831cd53bbf84281e8bd6b0c5e3fe6ab7c04e3428df1f32343a1e \
-                    size    109446355
+checksums           rmd160  49c8b1dca909b4debda7d16cd15251407a2c61ad \
+                    sha256  359fbcdb5bb2645f9dcc65072b62cb646498e95643774ebca2fcbf599f73f79e \
+                    size    109625812
 
 depends_lib         port:freetype
 depends_build       port:openjdk20-bootstrap \


### PR DESCRIPTION
#### Description

Update to OpenJDK 20.0.2.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?