### PR TITLE
openjdk17-graalvm: fix subport pollution

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -101,14 +101,11 @@ if {${subport} eq ${name}} {
 }
 
 subport ${name}-native-image {
+    PortGroup           stub 1.0
+
+    license             Permissive
     description         Former Native Image component for GraalVM
     long_description    Native Image support is now included in ${name}. Please uninstall ${subport}.
-
-    destroot.violate_mtree no
-    destroot {
-        file mkdir ${destroot}${prefix}/share/doc
-        system "echo ${long_description} > ${destroot}${prefix}/share/doc/README.${subport}.txt"
-    }
 
     notes "${long_description}"
 }

--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -15,28 +15,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 version     17.0.8
-revision    2
+revision    3
 epoch       1
 
-description  GraalVM Community Edition based on OpenJDK 17
-long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
-                 JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
-
 master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     graalvm-community-jdk-${version}_macos-x64_bin
-    checksums    rmd160  26e3d0b7238a6c7fbe10afeae0c4b0e8740b268a \
-                 sha256  cf4bb646018da8bf93f67e5cdae0f583b276d278d0b667d779a68d11d3b6873d \
-                 size    283915786
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     graalvm-community-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  858b540bd9d1ecaef6e89d6f4bb6893a21d6881c \
-                 sha256  89209bbf8346d8dd0847d431bd8654db7d4ff634745207f20af2045c4869fb49 \
-                 size    279784572
-}
-
-worksrcdir   graalvm-community-openjdk-${version}+7.1
 
 homepage     https://www.graalvm.org
 
@@ -45,58 +27,78 @@ livecheck.type  none
 use_configure    no
 build {}
 
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
 set jvms /Library/Java/JavaVirtualMachines
 set jdk ${jvms}/${name}
 
-pre-install {
-    # Clean up previous installations, because some old subport files may have been left behind (https://trac.macports.org/ticket/67935)
-    # Don't remove before 2024-08-20
-    delete ${jdk}
+if {${subport} eq ${name}} {
+    description  GraalVM Community Edition based on OpenJDK 17
+    long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
+                     JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
+
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     graalvm-community-jdk-${version}_macos-x64_bin
+        checksums    rmd160  26e3d0b7238a6c7fbe10afeae0c4b0e8740b268a \
+                     sha256  cf4bb646018da8bf93f67e5cdae0f583b276d278d0b667d779a68d11d3b6873d \
+                     size    283915786
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     graalvm-community-jdk-${version}_macos-aarch64_bin
+        checksums    rmd160  858b540bd9d1ecaef6e89d6f4bb6893a21d6881c \
+                     sha256  89209bbf8346d8dd0847d431bd8654db7d4ff634745207f20af2045c4869fb49 \
+                     size    279784572
+    }
+
+    worksrcdir   graalvm-community-openjdk-${version}+7.1
+
+    variant Applets \
+        description { Advertise the JVM capability "Applets".} {}
+
+    variant BundledApp \
+        description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+    variant JNI \
+        description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+    variant WebStart \
+        description { Advertise the JVM capability "WebStart".} {}
+
+    patch {
+        foreach var { Applets BundledApp JNI WebStart } {
+            if {[variant_isset ${var}]} {
+                reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+            }
+        }
+    }
+
+    test.run    yes
+    test.cmd    Contents/Home/bin/java
+    test.target
+    test.args   -version
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+    destroot.violate_mtree yes
+
+    pre-install {
+        # Clean up previous installations, because some old subport files may have been left behind (https://trac.macports.org/ticket/67935)
+        # Don't remove before 2024-08-20
+        delete ${jdk}
+    }
+
+    destroot {
+        xinstall -m 755 -d ${destroot}${prefix}${jdk}
+        copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+        # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+        xinstall -m 755 -d ${destroot}${jvms}
+        ln -s ${prefix}${jdk} ${destroot}${jdk}
+    }
+
+    notes "
+    If you have more than one JDK installed you can make ${name} the default\
+    by adding the following line to your shell profile:
+
+        export JAVA_HOME=${jdk}/Contents/Home
+    "
 }
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}${jdk}
-    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
-    xinstall -m 755 -d ${destroot}${jvms}
-    ln -s ${prefix}${jdk} ${destroot}${jdk}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${jdk}/Contents/Home
-"
 
 subport ${name}-native-image {
     description         Former Native Image component for GraalVM


### PR DESCRIPTION
#### Description

Don't apply `pre-install`, variants, etc. to subports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?