### PR TITLE
tkimg: update to 1.4.15

### DIFF
--- a/graphics/tkimg/Portfile
+++ b/graphics/tkimg/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               active_variants 1.1
 
 name                    tkimg
-version                 1.4.14
+version                 1.4.15
 revision                0
 categories              graphics
 license                 Tcl/Tk
@@ -18,9 +18,9 @@ platforms               darwin
 master_sites            sourceforge:tkimg/tkimg/[join [lrange [split ${version} .] 0 1] .]/tkimg%20${version}
 distname                Img-${version}-Source
 
-checksums               rmd160  f02804981502adaa4ffcd0cd6fc2129a88264efb \
-                        sha256  7510b1b819464f228d228a862e53d9e1d3b41c23013b73790a29f7e9165abb21 \
-                        size    9844859
+checksums               rmd160  47cdda888476a5a0ed6c408cf8a6e6f7bdbbb3ec \
+                        sha256  2bd8615ee87197aca48dc7bfeef0749aac5c8c56ac499def94cc5a4700a59d73 \
+                        size    12108837
 
 # ensure tkimg works when tk is installed +quartz
 patchfiles-append       patch-quartz.diff

--- a/graphics/tkimg/files/patch-quartz.diff
+++ b/graphics/tkimg/files/patch-quartz.diff
@@ -17,14 +17,14 @@
  #endif
  
  typedef struct PixmapData {
---- window/window.c.orig	2020-04-30 07:21:45.000000000 -0700
-+++ window/window.c	2020-04-30 07:21:04.000000000 -0700
+--- window/window.c.orig	2023-04-03 08:24:00.000000000 +0000
++++ window/window.c	2023-08-21 12:42:04.000000000 -0500
 @@ -13,13 +13,14 @@
  
  #include "init.c"
  
 -#include "X11/Xutil.h"
- #if !defined(__WIN32__)
+ #if !defined(_WIN32)
  #  if !defined(MAC_OSX_TK)
 -#   include "X11/Xproto.h"
 +#   include <X11/Xutil.h>


### PR DESCRIPTION
#### Description
https://sourceforge.net/p/tkimg/code/HEAD/tree/trunk/ANNOUNCE
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8
Xcode 14.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
Both the +x11 and +quartz variants build.
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
