### PR TITLE
raja: update to 2023.06.1

### DIFF
--- a/devel/raja/Portfile
+++ b/devel/raja/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           mpi 1.0
 
-github.setup        LLNL RAJA 2023.06.0 v
+github.setup        LLNL RAJA 2023.06.1 v
 name                raja
 revision            0
 categories          devel
@@ -55,11 +55,14 @@ compiler.openmp_version 4.0
 # Tests also fail to build with similar linking errors.
 # OneTBB not yet supported: https://github.com/LLNL/RAJA/issues/1456
 configure.args-append \
+                    -DBUILD_SHARED_LIBS=OFF \
+                    -DENABLE_FORTRAN=ON \
+                    -DENABLE_FRUIT=ON \
+                    -DENABLE_FRUIT_MPI=ON \
+                    -DENABLE_GIT=ON \
                     -DENABLE_MPI=ON \
                     -DENABLE_OPENMP=ON \
-                    -DRAJA_ENABLE_REPRODUCERS=ON \
                     -DPython_EXECUTABLE=${prefix}/bin/python${py_ver} \
-                    -DBUILD_SHARED_LIBS=OFF \
                     -DRAJA_ENABLE_BENCHMARKS=OFF \
                     -DRAJA_ENABLE_CUDA=OFF \
                     -DRAJA_ENABLE_DESUL_ATOMICS=OFF \
@@ -67,8 +70,10 @@ configure.args-append \
                     -DRAJA_ENABLE_EXAMPLES=OFF \
                     -DRAJA_ENABLE_EXERCISES=OFF \
                     -DRAJA_ENABLE_HIP=OFF \
+                    -DRAJA_ENABLE_REPRODUCERS=ON \
                     -DRAJA_ENABLE_TBB=OFF \
-                    -DRAJA_ENABLE_TESTS=OFF
+                    -DRAJA_ENABLE_TESTS=OFF \
+                    -DRAJA_ENABLE_VECTORIZATION=OFF
 
 if {[string match *clang* ${configure.compiler}]} {
     configure.ldflags-append \


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
