### PR TITLE
ldid-procursus: new port

### DIFF
--- a/devel/ldid-procursus/Portfile
+++ b/devel/ldid-procursus/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+PortGroup           makefile 1.0
+
+name                ldid-procursus
+version             2.1.5-procursus7
+categories          devel
+license             AGPL-3
+platforms           darwin
+conflicts           ldid
+maintainers         @therealketo procurs.us:team openmaintainer
+description         Put real or fake signatures in a Mach-O.
+long_description    ${description}
+
+github.setup        ProcursusTeam ldid ${version} v
+github.tarball_from archive
+checksums           rmd160 648697e84ac2b71fff24fdc1241f90d7390124d5 \
+                    sha256 04e461c6f02765e48fc9cc0b68d4dc353a9c46bc1c4d8bac0695509d1af1ff5e \
+                    size 53532
+
+depends_build       port:pkgconfig
+depends_lib-append  path:lib/libplist-2.0.dylib:libplist
+universal_variant   no
+
+post-destroot {
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_comp_path}
+    xinstall -m 0644 ${worksrcpath}/_ldid ${zsh_comp_path}
+}


### PR DESCRIPTION
#### Description

`ldid-procursus` is a fork of the original `ldid` project, with extensions that enhance the original behavior of several options. Maintained by the Procursus Team, this fork is open to contributions, becoming "mainstream" in the jailbreaking community - where the original project shines - while working around the fact that the original creator does not accept contributions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
