### PR TITLE
cl-cffi: fix support on arm64 on ECL

### DIFF
--- a/lisp/cl-cffi/Portfile
+++ b/lisp/cl-cffi/Portfile
@@ -6,7 +6,7 @@ PortGroup           common_lisp 1.0
 
 github.setup        cffi cffi 0.24.1 v
 name                cl-cffi
-revision            1
+revision            2
 
 checksums           rmd160  efbe4f1c7577943db8bdd6fc5a7c9672737d5551 \
                     sha256  4025586fc921b2a1ebbe3c8ebec90ae5afc5aba142d97ea22f3951e155449993 \

--- a/lisp/cl-cffi/files/0002-fix-tests-on-SBCL-Darwin-arm64.patch
+++ b/lisp/cl-cffi/files/0002-fix-tests-on-SBCL-Darwin-arm64.patch
@@ -3,6 +3,8 @@ From: "Kirill A. Korinsky" <kirill@korins.ky>
 Date: Wed, 31 May 2023 16:15:41 +0200
 Subject: [PATCH] fix tests on SBCL-Darwin-arm64
 
+Also overstep https://gitlab.com/embeddable-common-lisp/ecl/-/issues/713
+
 ---
  libffi/libffi-types.lisp | 1 +
  1 file changed, 1 insertion(+)
@@ -15,7 +17,7 @@ index b2ec1dd..b8374fe 100644
   ((:default-abi "FFI_DEFAULT_ABI"))
   #-x86-64
   ((:sysv "FFI_SYSV"))
-+ #-arm64
++ #-(or arm64 arm)
   ((:unix64 "FFI_UNIX64")))
  
  (ctype ffi-abi "ffi_abi")


### PR DESCRIPTION
A dirty hack to overstep https://gitlab.com/embeddable-common-lisp/ecl/-/issues/713 which fixes near of all ports which uses cffi.


#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F82 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->