### PR TITLE
cl-lift: backport patch to fix support of modern lisps

### DIFF
--- a/lisp/cl-containers/Portfile
+++ b/lisp/cl-containers/Portfile
@@ -30,6 +30,3 @@ depends_lib-append  port:cl-metatilities-base \
 post-extract {
     file delete -force ${worksrcpath}/cl-containers-documentation.asd
 }
-
-# *** - PROBE-FILE: No file name given:
-common_lisp.clisp   no

--- a/lisp/cl-docudown/Portfile
+++ b/lisp/cl-docudown/Portfile
@@ -27,8 +27,7 @@ depends_lib-append  port:cl-markdown \
                     port:cl-moptilities \
                     port:cl-lift
 
-# See: https://github.com/gwkkwg/dynamic-classes/issues/2
-test.run            no
+patchfiles-append   modern-lift.diff
 
 # No repository, just one archive in wiki
 livecheck.type      none

--- a/lisp/cl-docudown/files/modern-lift.diff
+++ b/lisp/cl-docudown/files/modern-lift.diff
@@ -1,0 +1,23 @@
+--- lift-standard.config.orig	2023-08-21 23:41:28.000000000 +0200
++++ lift-standard.config	2023-08-21 23:42:25.000000000 +0200
+@@ -17,17 +17,17 @@
+ (:report-property :style-sheet "test-style.css")
+ (:report-property :if-exists :supersede)
+ (:report-property :format :html)
+-(:report-property :name "test-results/test-report.html")
++(:report-property :full-pathname "test-results/test-report.html")
+ (:report-property :unique-name t)
+ (:build-report)
+ 
+ (:report-property :unique-name t)
+ (:report-property :format :describe)
+-(:report-property :name "test-results/test-report.txt")
++(:report-property :full-pathname "test-results/test-report.txt")
+ (:build-report)
+ 
+ (:report-property :format :save)
+-(:report-property :name "test-results/test-report.sav")
++(:report-property :full-pathname "test-results/test-report.sav")
+ (:build-report)
+ 
+ (:report-property :format :describe)

--- a/lisp/cl-dynamic-classes/Portfile
+++ b/lisp/cl-dynamic-classes/Portfile
@@ -30,5 +30,4 @@ long_description    {*}${description}
 depends_lib-append  port:cl-metatilities-base \
                     port:cl-lift
 
-# See: https://github.com/gwkkwg/dynamic-classes/issues/2
-test.run            no
+patchfiles-append   modern-lift.diff

--- a/lisp/cl-dynamic-classes/Portfile
+++ b/lisp/cl-dynamic-classes/Portfile
@@ -4,7 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg dynamic-classes ebd7405603f67b16e8f2bc08ce8e2bcfcf439501
+github.setup        hraban dynamic-classes ebd7405603f67b16e8f2bc08ce8e2bcfcf439501
+
+# NOTE: repository was moved from github user gwkkwg to hraban,
+# and github produces archive which contains user name inside
+# => checksums are miss match with distfiles, until any commit is made
+master_sites        macports_distfiles
+
 name                cl-dynamic-classes
 version             20230809
 revision            0

--- a/lisp/cl-dynamic-classes/files/modern-lift.diff
+++ b/lisp/cl-dynamic-classes/files/modern-lift.diff
@@ -1,0 +1,27 @@
+https://github.com/hraban/dynamic-classes/pull/3
+
+diff --git lift-standard.config lift-standard.config
+index 3ffda9e..bbe3911 100644
+--- lift-standard.config
++++ lift-standard.config
+@@ -17,17 +17,17 @@
+ (:report-property :style-sheet "test-style.css")
+ (:report-property :if-exists :supersede)
+ (:report-property :format :html)
+-(:report-property :name "test-results/test-report.html")
++(:report-property :full-pathname "test-results/test-report.html")
+ (:report-property :unique-name t)
+ (:build-report)
+ 
+ (:report-property :unique-name t)
+ (:report-property :format :describe)
+-(:report-property :name "test-results/test-report.txt")
++(:report-property :full-pathname "test-results/test-report.txt")
+ (:build-report)
+ 
+ (:report-property :format :save)
+-(:report-property :name "test-results/test-report.sav")
++(:report-property :full-pathname "test-results/test-report.sav")
+ (:build-report)
+ 
+ (:report-property :format :describe)

--- a/lisp/cl-lift/Portfile
+++ b/lisp/cl-lift/Portfile
@@ -4,7 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg lift 979e1e7270bc2facc783a28f85dffe8dadb6ebfc
+github.setup        hraban lift 979e1e7270bc2facc783a28f85dffe8dadb6ebfc
+
+# NOTE: repository was moved from github user gwkkwg to hraban,
+# and github produces archive which contains user name inside
+# => checksums are miss match with distfiles, until any commit is made
+master_sites        macports_distfiles
+
 name                cl-lift
 version             20230111
 revision            0

--- a/lisp/cl-lift/Portfile
+++ b/lisp/cl-lift/Portfile
@@ -13,7 +13,7 @@ master_sites        macports_distfiles
 
 name                cl-lift
 version             20230111
-revision            0
+revision            1
 
 checksums           rmd160  57d9bf59e34d1d8fb0c6d951e75f8f6283de15f7 \
                     sha256  0a91477784c14c82a74d7fe13e0e4b15e7bb988021fd2556909b5e5b3fdb553d \
@@ -27,8 +27,4 @@ description         LIsp Framework for Testing
 
 long_description    {*}${description}
 
-# Fails as:
-#   :info:test Unhandled LIFT:ENSURE-NULL-FAILED-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
-#   :info:test                                                      {10047A81B3}>:
-#   :info:test   Ensure null failed: "this fails" evaluates to "this fails" ()
-test.run            no
+patchfiles-append   patch-followup.diff

--- a/lisp/cl-lift/files/patch-followup.diff
+++ b/lisp/cl-lift/files/patch-followup.diff
@@ -1,0 +1,83 @@
+https://github.com/hraban/lift/pull/10
+
+diff --git dev/port.lisp dev/port.lisp
+index 34e5b47..640aa18 100644
+--- dev/port.lisp
++++ dev/port.lisp
+@@ -169,6 +169,18 @@ returns a string with the corresponding backtrace.")
+   (with-output-to-string (stream)
+     (core:btcl :stream stream)))
+ 
++#+(or ecl mkcl)
++(defun get-backtrace-as-string (error)
++  (declare (ignore error))
++  (with-output-to-string (stream)
++    (let* ((top (si:ihs-top))
++           (backtrace (loop :for ihs :from 0 :below top
++                            :collect (list (si::ihs-fun ihs)
++                                           (si::ihs-env ihs)))))
++      (loop :for i :from 0 :below top
++            :for frame :in (nreverse backtrace) :do
++              (format stream "~&~D: ~S~%" i frame)))))
++
+ #+allegro
+ (defun cancel-current-profile (&key force?)
+   (when (prof::current-profile-actual prof::*current-profile*)
+diff --git dev/utilities.lisp dev/utilities.lisp
+index 8b7e0a7..5941905 100644
+--- dev/utilities.lisp
++++ dev/utilities.lisp
+@@ -117,8 +117,15 @@ pathspac points. For example:
+ 			  ,(format nil "~@[~a-~]~a-~d~@[.~a~]" 
+ 				   base-name date-part index base-type)))
+ 	    base-pathname) do
+-	   (unless (probe-file name)
+-	     (return name)))
++	   (unless
++           #-clisp
++           (probe-file name)
++           #+clisp
++           (ignore-errors
++             (let ((directory-form (pathname-as-directory pathname)))
++               (when (ext:probe-directory directory-form)
++                 directory-form)))
++	       (return name)))
+ 	(error "Unable to find unique pathname for ~a" pathname))))
+ 
+ (defun date-stamp (&key (datetime (get-universal-time)) (include-time? nil) 
+diff --git lift-standard.config lift-standard.config
+index 81b03ee..6f8a556 100644
+--- lift-standard.config
++++ lift-standard.config
+@@ -19,7 +19,10 @@
+ (:report-property :style-sheet "test-style.css")
+ (:report-property :if-exists :supersede)
+ (:report-property :format :html)
+-(:report-property :name "test-results/")
++(:report-property :full-pathname "test-results/")
++(:build-report)
++
++(:report-property :unique-name t)
+ (:build-report)
+ 
+ (:report-property :format :describe)
+diff --git test/lift-test.lisp test/lift-test.lisp
+index ca52958..19f8f04 100644
+--- test/lift-test.lisp
++++ test/lift-test.lisp
+@@ -700,9 +700,12 @@ See file COPYING for license
+   ;; :categories (foo bar)
+   )
+ 
+-(addtest (test-break-on-failure-helper)
+-  failing-test
+-  (ensure-null "this fails"))
++;; This test is broken, `failing-test` exists only here, let comment it until
++;; it's fixed one day.
++;;
++;; (addtest (test-break-on-failure-helper)
++;;  failing-test
++;;  (ensure-null "this fails"))
+ 
+ (addtest (test-break-on-failure)
+   donot-break-on-failures

--- a/lisp/cl-markdown/Portfile
+++ b/lisp/cl-markdown/Portfile
@@ -27,8 +27,10 @@ description         A Common Lisp rewrite of Markdown
 long_description    {*}${description}
 
 # we're handle dependency by our self, no need for that hack
-# See: https://github.com/gwkkwg/cl-markdown/issues/1
+# See: https://github.com/hraban/cl-markdown/issues/1
 patchfiles-append   remove-container-dynamic-classes.diff
+
+patchfiles-append   modern-lift.diff
 
 depends_lib-append  port:cl-anaphora \
                     port:cl-containers \
@@ -46,6 +48,3 @@ depends_lib-append  port:cl-anaphora \
 #   The symbol "MAKE-THREAD-LOCK" was not found in package EXT.
 # See: https://github.com/armedbear/abcl/issues/616
 common_lisp.abcl    no
-
-# See: https://github.com/gwkkwg/dynamic-classes/issues/2
-test.run            no

--- a/lisp/cl-markdown/Portfile
+++ b/lisp/cl-markdown/Portfile
@@ -4,7 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg cl-markdown 3c7093c4b67af8c5979264004f4628eb9d3adfaa
+github.setup        hraban cl-markdown 3c7093c4b67af8c5979264004f4628eb9d3adfaa
+
+# NOTE: repository was moved from github user gwkkwg to hraban,
+# and github produces archive which contains user name inside
+# => checksums are miss match with distfiles, until any commit is made
+master_sites        macports_distfiles
+
 version             20230111
 revision            0
 

--- a/lisp/cl-markdown/files/modern-lift.diff
+++ b/lisp/cl-markdown/files/modern-lift.diff
@@ -1,0 +1,21 @@
+https://github.com/hraban/cl-markdown/pull/10
+
+diff --git lift-standard.config lift-standard.config
+index 7fe3657..dc29437 100644
+--- lift-standard.config
++++ lift-standard.config
+@@ -19,12 +19,12 @@
+ (:report-property :style-sheet "test-style.css")
+ (:report-property :if-exists :supersede)
+ (:report-property :format :html)
+-(:report-property :name "test-results/test-report")
++(:report-property :full-pathname "test-results/test-report")
+ (:report-property :unique-name t)
+ (:build-report)
+ 
+ (:report-property :format :save)
+-(:report-property :name "test-results/test-report.sav")
++(:report-property :full-pathname "test-results/test-report.sav")
+ (:build-report)
+ 
+ (:report-property :format :describe)

--- a/lisp/cl-metabang-bind/Portfile
+++ b/lisp/cl-metabang-bind/Portfile
@@ -28,6 +28,3 @@ description         bind is let and much much more
 long_description    {*}${description}
 
 depends_lib-append  port:cl-lift
-
-#  *** - PROBE-FILE: No file name given:
-common_lisp.clisp   no

--- a/lisp/cl-metabang-bind/Portfile
+++ b/lisp/cl-metabang-bind/Portfile
@@ -4,7 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg metabang-bind 08196426cb099db0623e6cae2aeca566e0b788b2
+github.setup        hraban metabang-bind 08196426cb099db0623e6cae2aeca566e0b788b2
+
+# NOTE: repository was moved from github user gwkkwg to hraban,
+# and github produces archive which contains user name inside
+# => checksums are miss match with distfiles, until any commit is made
+master_sites        macports_distfiles
+
 version             20230508
 name                cl-metabang-bind
 revision            0

--- a/lisp/cl-metatilities-base/Portfile
+++ b/lisp/cl-metatilities-base/Portfile
@@ -4,7 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg metatilities-base ef04337759972fd622c9b27b53149f3d594a841f
+github.setup        hraban metatilities-base ef04337759972fd622c9b27b53149f3d594a841f
+
+# NOTE: repository was moved from github user gwkkwg to hraban,
+# and github produces archive which contains user name inside
+# => checksums are miss match with distfiles, until any commit is made
+master_sites        macports_distfiles
+
 name                cl-metatilities-base
 version             20191219
 revision            0

--- a/lisp/cl-metatilities-base/Portfile
+++ b/lisp/cl-metatilities-base/Portfile
@@ -28,6 +28,3 @@ description         These are metabang.com's Common Lisp basic utilities
 long_description    {*}${description}
 
 depends_lib-append  port:cl-lift
-
-#  *** - PROBE-FILE: No file name given:
-common_lisp.clisp   no

--- a/lisp/cl-metatilities/Portfile
+++ b/lisp/cl-metatilities/Portfile
@@ -4,7 +4,13 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               common_lisp 1.0
 
-github.setup            gwkkwg metatilities 82e13df0545d0e47ae535ea35c5c99dd3a44e69e
+github.setup            hraban metatilities 82e13df0545d0e47ae535ea35c5c99dd3a44e69e
+
+# NOTE: repository was moved from github user gwkkwg to hraban,
+# and github produces archive which contains user name inside
+# => checksums are miss match with distfiles, until any commit is made
+master_sites            macports_distfiles
+
 name                    cl-metatilities
 version                 20170330
 revision                1

--- a/lisp/cl-metatilities/Portfile
+++ b/lisp/cl-metatilities/Portfile
@@ -32,6 +32,3 @@ depends_lib-append      port:cl-containers \
                         port:cl-metabang-bind \
                         port:cl-moptilities \
                         port:cl-lift
-
-# *** - PROBE-FILE: No file name given:
-common_lisp.clisp   no

--- a/lisp/cl-moptilities/Portfile
+++ b/lisp/cl-moptilities/Portfile
@@ -4,7 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg moptilities a436f16b357c96b82397ec018ea469574c10dd41
+github.setup        hraban moptilities a436f16b357c96b82397ec018ea469574c10dd41
+
+# NOTE: repository was moved from github user gwkkwg to hraban,
+# and github produces archive which contains user name inside
+# => checksums are miss match with distfiles, until any commit is made
+master_sites        macports_distfiles
+
 name                cl-moptilities
 version             20170330
 revision            0

--- a/lisp/cl-moptilities/Portfile
+++ b/lisp/cl-moptilities/Portfile
@@ -30,6 +30,4 @@ long_description    {*}${description}
 depends_lib-append  port:cl-closer-mop \
                     port:cl-lift
 
-# :info:test Error while running (BUILD-REPORT) from /opt/local/var/macports/build/_Users_catap_src_macports-ports_lisp_cl-moptilities/cl-moptilities/work/build/source/cl-moptilities/
-# lift-standard.config: Can't create directory /opt/local/share/common-lisp/source/cl-lift/test-results
-test.run            no
+patchfiles-append   modern-lift.diff

--- a/lisp/cl-moptilities/files/modern-lift.diff
+++ b/lisp/cl-moptilities/files/modern-lift.diff
@@ -1,0 +1,15 @@
+https://github.com/hraban/moptilities/pull/6
+
+diff --git lift-standard.config lift-standard.config
+index 55cf14a..d473842 100644
+--- lift-standard.config
++++ lift-standard.config
+@@ -19,7 +19,7 @@
+ (:report-property :style-sheet "test-style.css")
+ (:report-property :if-exists :supersede)
+ (:report-property :format :html)
+-(:report-property :name "test-results")
++(:report-property :full-pathname "test-results")
+ (:build-report)
+ 
+ (:report-property :format :describe)

--- a/lisp/cl-trivial-backtrace/Portfile
+++ b/lisp/cl-trivial-backtrace/Portfile
@@ -4,7 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg trivial-backtrace 7f90b4a4144775cca0728791e4b92ac2557b07a1
+github.setup        hraban trivial-backtrace 7f90b4a4144775cca0728791e4b92ac2557b07a1
+
+# NOTE: repository was moved from github user gwkkwg to hraban,
+# and github produces archive which contains user name inside
+# => checksums are miss match with distfiles, until any commit is made
+master_sites        macports_distfiles
+
 name                cl-trivial-backtrace
 version             20230111
 revision            0

--- a/lisp/cl-trivial-backtrace/Portfile
+++ b/lisp/cl-trivial-backtrace/Portfile
@@ -28,7 +28,3 @@ description         Portable simple API to work with backtraces in Common Lisp
 long_description    {*}${description}
 
 depends_lib-append  port:cl-lift
-
-# Error while running (BUILD-REPORT) from [...]/lift-standard.config:
-# PROBE-FILE: No file name given: #P"[..]/test-results-2023-05-31-1/"
-common_lisp.clisp   no

--- a/lisp/cl-trivial-shell/Portfile
+++ b/lisp/cl-trivial-shell/Portfile
@@ -4,7 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg trivial-shell ad4218b62bea99ef10c1675eeba5cd96c763e46e
+github.setup        hraban trivial-shell ad4218b62bea99ef10c1675eeba5cd96c763e46e
+
+# NOTE: repository was moved from github user gwkkwg to hraban,
+# and github produces archive which contains user name inside
+# => checksums are miss match with distfiles, until any commit is made
+master_sites        macports_distfiles
+
 name                cl-trivial-shell
 version             20230111
 revision            0

--- a/lisp/cl-trivial-timeout/Portfile
+++ b/lisp/cl-trivial-timeout/Portfile
@@ -29,5 +29,7 @@ long_description    {*}${description}
 
 depends_lib-append  port:cl-lift
 
-# The :name property must be a simple name (not a directory), use :full-pathname if you need more control
-test.run            no
+patchfiles-append   modern-lift.diff
+
+# See: https://github.com/hraban/trivial-timeout/issues/12
+common_lisp.ccl     no

--- a/lisp/cl-trivial-timeout/Portfile
+++ b/lisp/cl-trivial-timeout/Portfile
@@ -4,7 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        gwkkwg trivial-timeout 512497c5c62dc918f7fa8e6e02a543cc9601a31a
+github.setup        hraban trivial-timeout 512497c5c62dc918f7fa8e6e02a543cc9601a31a
+
+# NOTE: repository was moved from github user gwkkwg to hraban,
+# and github produces archive which contains user name inside
+# => checksums are miss match with distfiles, until any commit is made
+master_sites        macports_distfiles
+
 name                cl-trivial-timeout
 version             20230609
 revision            0

--- a/lisp/cl-trivial-timeout/files/modern-lift.diff
+++ b/lisp/cl-trivial-timeout/files/modern-lift.diff
@@ -1,0 +1,36 @@
+https://github.com/hraban/trivial-timeout/pull/11
+
+diff --git lift-local.config lift-local.config
+index a595894..203f6b7 100644
+--- lift-local.config
++++ lift-local.config
+@@ -23,10 +23,10 @@
+ ;;; leads to an error in lift in report-pathname
+ ;; (:report-property :name "test-results/test-report")
+ 
+-(:report-property :name "test-results/")
++(:report-property :full-pathname "test-results/")
+ (:report-property :unique-name t)
+ (:build-report)
+-(:report-property :name "website/output/")
++(:report-property :full-pathname "website/output/")
+ (:report-property :unique-name nil)
+ (:build-report)
+ 
+diff --git lift-standard.config lift-standard.config
+index 3bde213..c5c4379 100644
+--- lift-standard.config
++++ lift-standard.config
+@@ -17,10 +17,10 @@
+ (:report-property :style-sheet "test-style.css")
+ (:report-property :if-exists :supersede)
+ (:report-property :format :html)
+-(:report-property :name "test-results/test-report")
++(:report-property :full-pathname "test-results/test-report")
+ (:report-property :unique-name t)
+ (:build-report)
+-(:report-property :name "website/output/test-report")
++(:report-property :full-pathame "website/output/test-report")
+ (:report-property :unique-name nil)
+ (:build-report)
+ 


### PR DESCRIPTION
#### Description

This PR backport fix to support by lift test framework modern lisp, special CLisp.

I also enable all lisp implementation in dependand ports.

Thus, Gary King (gwkkwg) transfered almost all his repositories to Hraban Luyat (hraban), unfortunately github produces archive which contains user name inside that makes all checksums are broken.

As easy and temporarry fix I've switched to distfiles, until any commit is made.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->