### PR TITLE
qt*-qttranslations: move qttools dependency to build

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -627,13 +627,13 @@ array set modules {
             38b942bc7e62794dd072945c8a92bb9dfffed24070aea300327a3bb42f855609
             1635736
         }
-        ""
         "port:qt5-qttools"
+        ""
         ""
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -546,13 +546,13 @@ array set modules {
             fa84b284d8aa34d6076b5e87a33ba6eb2382b69c371089c1c25b88bfd4141149
             1424160
         }
-        ""
         "port:qt511-qttools"
+        ""
         ""
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -546,13 +546,13 @@ array set modules {
             25755941a2525de2d7ae48e0011d04db7cc09e4e73fe83293206ceafa0aa82d9
             1365880
         }
-        ""
         "port:qt513-qttools"
+        ""
         ""
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt53/Portfile
+++ b/aqua/qt53/Portfile
@@ -387,13 +387,13 @@ array set modules {
             29b648f005e9e588714c8e3c2115db65c7a944a6ba84baafb84091d73213c5cd
             1047568
         }
-        ""
         "port:qt53-qttools"
+        ""
         ""
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtwebkit {

--- a/aqua/qt55/Portfile
+++ b/aqua/qt55/Portfile
@@ -414,13 +414,13 @@ array set modules {
             41f800710f0bc6ca263f1e54f1fa22be7043962999304e73ce9887ebefc7a4c6
             1153132
         }
-        ""
         "port:qt55-qttools"
+        ""
         ""
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtwebchannel {

--- a/aqua/qt56/Portfile
+++ b/aqua/qt56/Portfile
@@ -435,13 +435,13 @@ array set modules {
             6ded4e0162c2e4f092f824f98cd35bc46d0b0d4b08e21ca200b3af14ab776cab
             1225908
         }
-        ""
         "port:qt56-qttools"
+        ""
         ""
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtwebchannel {

--- a/aqua/qt57/Portfile
+++ b/aqua/qt57/Portfile
@@ -512,13 +512,13 @@ array set modules {
             16ecdb09532724e80fa6202e5604d80877923b652b771b6020cea36bee0258e7
             1206116
         }
-        ""
         "port:qt57-qttools"
+        ""
         ""
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt58/Portfile
+++ b/aqua/qt58/Portfile
@@ -525,13 +525,13 @@ array set modules {
             3b7cf72ec50bc2a02bf4e4427b184febac909dba0e02e1861321ca1629c3fc2e
             1209556
         }
-        ""
         "port:qt58-qttools"
+        ""
         ""
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -544,13 +544,13 @@ array set modules {
             f7474f260a1382549720081bf2359a3d425ec3bf7d31976c512834303d30d73b
             1329900
         }
-        ""
         "port:qt59-qttools"
+        ""
         ""
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtvirtualkeyboard {

--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -175,13 +175,13 @@ array set modules {
             79e56b7800d49649a8a8010818538c367a829e0b7a09d5f60bd3aecf5abe972c
             1466828
         }
+        "port:qt6-qttools"
         ""
         ""
-        "qttools"
         {"translation files"}
         ""
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtdoc {


### PR DESCRIPTION
#### Description

qttranslations is a port which contains only .qm files; this ports is runtime dependency for near of all Qt-based applications like wireshark. qttools depends on clang because qdoc uses it to parce C++ files. That makes wireshark to depends on clang via qttranslations.

The first attempt to fix it at 43d7a354e89046be136d961c3bdb760788bb4224 simple moved definition of lib dependency from `qttools` to `qtX-qttools`, and here the real fix.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->