### PR TITLE
git: update to 2.42.0

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 10
 name                git
 # NOTE: Update the DEVEL version first before updating this RELEASE version,
 #       to verify that the intended version builds on all platforms.
-version             2.41.0
+version             2.42.0
 revision            0
 
 description         A fast version control system
@@ -58,13 +58,13 @@ if {${name} eq ${subport}} {
                     git-manpages-${version}${extract.suffix}
 
     checksums       git-${version}${extract.suffix} \
-                    rmd160  e984285a4c9d4b883095f57f4aa18f1eb9eb6aaa \
-                    sha256  e748bafd424cfe80b212cbc6f1bbccc3a47d4862fb1eb7988877750478568040 \
-                    size    7273624 \
+                    rmd160  4a3c0c51498a4dee0a9a1edb8e6810a47bb9ccd5 \
+                    sha256  3278210e9fd2994b8484dd7e3ddd9ea8b940ef52170cdb606daa94d887c93b0d \
+                    size    7346760 \
                     git-manpages-${version}${extract.suffix} \
-                    rmd160  14c8dd2a0de9eaaf83288f84cd794b4f19568e26 \
-                    sha256  bc7a4c944492c76fc3cd766ce22e826d0241e43792c611d4fdc068e0df545877 \
-                    size    565060
+                    rmd160  b025932a4c5822ab523dcaa27f1a496f74e3fbca \
+                    sha256  03e0dc60a077ad31b10119e6619af8b50e652bd5c8a95c891523d73af1e573b9 \
+                    size    567824
 
     extract.only    git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
@@ -256,9 +256,9 @@ variant doc description {Install HTML and plaintext documentation} {
         # RELEASE
         distfiles-append    git-htmldocs-${version}${extract.suffix}
         checksums-append    git-htmldocs-${version}${extract.suffix} \
-                            rmd160  d0fd291528d2b4973247876fe76cb4bdb2f2ebf1 \
-                            sha256  0cb2d4a09270eede7c1b686e2dfeac9bffef9e42c117a7e120f3cbb3e665d286 \
-                            size    1525692
+                            rmd160  0af3932003e51923a40b93e4afa0e47e7269a91c \
+                            sha256  c027ad23614d19685677899527360985ec9186e97528084dc4f8d611f6c3483f \
+                            size    1536088
 
         patchfiles-append   patch-git-subtree.html.diff
 


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
