### PR TITLE
google-cloud-sdk: update to 444.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             443.0.0
+version             444.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  d52cc989bc674f3560538d6774616a45333d72de \
-                    sha256  6e51d65ae98c033fbb1bbd5d03f5757bc1a5db69b72af0fcff8d2190f21dcb73 \
-                    size    101286148
+    checksums       rmd160  7c7a1d81d61e018d638c7ca17ff694f7df4c4a00 \
+                    sha256  61a2faeb2b843eec69c82d10055ee8d9eed28e84340379e8ca5da12cce6bf4dd \
+                    size    101375017
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  60c78d25fb98141aa25c0a6238e834c9b5d76b3f \
-                    sha256  55038341395bfde339bb29cb9c42e0ffea1fa8061aac9bfac00ab3b74c1b33f3 \
-                    size    121549882
+    checksums       rmd160  445f7cc94c8e997bb1b01006ba3a788fb876382a \
+                    sha256  e7ae3bb93ea96a56f997eeff63fcafa26d67869f748dcc6b46e0615bb7f03841 \
+                    size    121637787
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  02eaf8c11a5f2be5b830cb5332b7d52505d34b16 \
-                    sha256  5211340b4a330e3dd72476bcbe1c326d8b089829df5e878623273c5c270834b1 \
-                    size    118714709
+    checksums       rmd160  d26eadced3b0798be493d82cab53423745be75a9 \
+                    sha256  7d291386bac17102ca0af66f261eac786d5bf8dde27f8ecf3d4efa32dd6ae807 \
+                    size    118799659
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 444.0.0.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?