### PR TITLE
zig: update to 0.11.0

### DIFF
--- a/lang/zig/Portfile
+++ b/lang/zig/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 
 legacysupport.use_static  yes
 
-github.setup        ziglang zig 0.10.1
+github.setup        ziglang zig 0.11.0
 github.tarball_from archive
 revision            0
 
@@ -23,7 +23,7 @@ long_description    Zig is a general-purpose programming language designed for \
 
 homepage            https://ziglang.org/
 
-set llvm_version    15
+set llvm_version    16
 
 depends_lib-append  port:clang-${llvm_version} \
                     port:ncurses \
@@ -33,12 +33,13 @@ depends_lib-append  port:clang-${llvm_version} \
 depends_build-append \
                     port:llvm-${llvm_version}
 
-checksums           rmd160  207833bdb9fa9cfaf96894b360973c9b141e270e \
-                    sha256  b511709d5276eca9bd706924d7928c7477fe799ad62d5d37f5f90d7dceadfa2a \
-                    size    23135590
+checksums           rmd160  484834dc8cb38332eeaab2345f605c711198654f \
+                    sha256  71de3e958293dffaa17f7ad1438c775389f5406991c96b533bb1501178092b02 \
+                    size    24606916
 
 set llvm_config     LLVM_CONFIG=llvm-config-mp-${llvm_version}
 
 compiler.whitelist  macports-clang-${llvm_version}
 cmake.module_path   ${prefix}/libexec/llvm-${llvm_version} \
                     ${prefix}
+cmake_share_module_dir ${prefix}/libexec/llvm-${llvm_version}


### PR DESCRIPTION
See https://trac.macports.org/ticket/65333.

#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6.7 21G651 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?