### PR TITLE
github CI: enable use of port tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
           exit "$fail"
         env:
           subportlist: ${{ steps.subportlist.outputs.subportlist }}
-      - name: Build changed subports
+      - name: Build and test changed subports
         run: |
           set -eu
 
@@ -181,6 +181,7 @@ jobs:
               --work-dir "$workdir" \
               install-port \
               --source \
+              --test \
               "$subport"
             install_exit=$?
             set -e


### PR DESCRIPTION
#### Description

A lot of ports supports self testing. Here I add to GitHub CI a way to run tests by ports when it is supported.

Why? To increase quality of PRs :)

Depends on https://github.com/macports/mpbb/pull/16

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->