### PR TITLE
cl-mgl-pax, cl-named-readtables, cl-trivial-utf-8: update to 20230822

### DIFF
--- a/lisp/cl-mgl-pax/Portfile
+++ b/lisp/cl-mgl-pax/Portfile
@@ -4,14 +4,14 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 PortGroup                   common_lisp 1.0
 
-github.setup                melisgl mgl-pax 8e7dc0ce2eec26a17543e53d3527eb7315711f16
+github.setup                melisgl mgl-pax 7a07993b2a96a7679e1638f8bb0342bdf0ce42d7
 name                        cl-mgl-pax
-version                     20230810
+version                     20230823
 revision                    0
 
-checksums                   rmd160  52867424bbda4828739abfa92cbf66356c42a594 \
-                            sha256  1ec3abded0b021de81f60890df3b1583b76f2896f20e6388e37c34b31f7e19fd \
-                            size    979681
+checksums                   rmd160  d69ec58de6196504ff4b5aad044a3adc368a2595 \
+                            sha256  60b2a7f90f472ee368fa031e3d5cb81875cf80f169957155e7a84bf3d897a32a \
+                            size    980322
 
 categories-append           devel textproc
 maintainers                 {@catap korins.ky:kirill} openmaintainer
@@ -21,33 +21,50 @@ description                 Reify definitions, provide portable access to docstr
 
 long_description            {*}${description}
 
-if {${name} eq ${subport}} {
-    depends_lib-append      port:cl-3bmd \
-                            port:cl-alexandria \
-                            port:cl-dref \
-                            port:cl-named-readtables \
-                            port:cl-md5 \
-                            port:cl-pythonic-string-reader
-
-    depends_test-append     port:cl-trivial-utf-8 \
-                            port:cl-try
+subport cl-mgl-pax-bootstrap {
+    common_lisp.systems     mgl-pax-bootstrap.asd
 }
 
 subport cl-dref {
-    # NOTE: cl-dref depends on cl-mgl-pax which depends on cl-dref :)
-    # MacPorts can't handle such dependency => switch off building
-    # and avoid dependency from cl-dref to cl-mgl-pax
-    common_lisp.build_run   no
+    depends_lib-append      port:cl-mgl-pax-bootstrap \
+                            port:cl-named-readtables \
+                            port:cl-pythonic-string-reader
 
-    worksrcdir              ${worksrcdir}/dref
+    common_lisp.systems     dref/dref.asd
 
-    depends_lib-append      port:cl-alexandria \
+    # to prevent dependency loop tests at dedicated subport
+    test.run                no
+}
+
+if {${name} eq ${subport}} {
+    depends_lib-append      port:cl-3bmd \
+                            port:cl-alexandria \
+                            port:cl-md5 \
+                            port:cl-mgl-pax-bootstrap \
                             port:cl-named-readtables \
                             port:cl-pythonic-string-reader \
-                            port:cl-swank
+                            port:cl-swank \
+                            port:cl-trivial-utf-8
 
-    depends_test-append     port:cl-mgl-pax \
+    common_lisp.systems     mgl-pax.asd \
+                            mgl-pax.asdf.asd
+
+    # to prevent dependency loop tests at dedicated subport
+    test.run                no
+}
+
+subport cl-dref-test {
+    depends_lib-append      port:cl-dref \
+                            port:cl-mgl-pax \
                             port:cl-try
 
-    livecheck.type          none
+    common_lisp.systems     dref/dref-test.asd
+}
+
+subport cl-mgl-pax-test {
+    depends_lib-append      port:cl-dref-test \
+                            port:cl-mgl-pax \
+                            port:cl-try
+
+    common_lisp.systems     mgl-pax-test.asd
 }

--- a/lisp/cl-named-readtables/Portfile
+++ b/lisp/cl-named-readtables/Portfile
@@ -1,26 +1,38 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           common_lisp 1.0
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
 
-github.setup        melisgl named-readtables 2c05652f8b6f5b2de8feefda069274c0478ab0f3
-name                cl-named-readtables
-version             20230721
-revision            0
+github.setup            melisgl named-readtables 40f979602bba168109534121bb24cb6daf980f76
+name                    cl-named-readtables
+version                 20230823
+revision                0
 
-checksums           rmd160  5b9664fb6f10f2aba13d23d36a8a24a5c354c93f \
-                    sha256  d8e6ab5f853173383298e6a2a48a8a8914e01b0a623cbf71105ce5565d7b4a86 \
-                    size    28391
+checksums               rmd160  a01da096fa34bdb902fb412b6670560176d834ec \
+                        sha256  f40bcfa531a97751a29986751c84371df3f06de676432a23f4c67205cd0bd345 \
+                        size    28445
 
-categories-append   devel
-maintainers         {@catap korins.ky:kirill} openmaintainer
-license             BSD
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 BSD
 
-description         Named-Readtables is a library that provides a namespace for readtables akin to the already-existing namespace of packages.
+description             Named-Readtables is a library that provides a namespace for readtables akin to the already-existing namespace of packages.
 
-long_description    {*}${description}
+long_description        {*}${description}
 
-# TODO: requires cl-try which depends on cl-named-readtables via cl-mgl-pax
-# should be enabled as soon as all ports are ready.
-test.run            no
+if {${name} eq ${subport}} {
+    depends_lib-append  port:cl-mgl-pax-bootstrap
+
+    common_lisp.systems named-readtables.asd
+
+    # to prevent dependency loop tests at dedicated subport
+    test.run            no
+}
+
+subport cl-named-readtables-test {
+    depends_lib-append  port:cl-named-readtables \
+                        port:cl-try
+
+    common_lisp.systems named-readtables-test.asd
+}

--- a/lisp/cl-trivial-utf-8/Portfile
+++ b/lisp/cl-trivial-utf-8/Portfile
@@ -5,14 +5,14 @@ PortGroup           gitlab 1.0
 PortGroup           common_lisp 1.0
 
 gitlab.instance     https://gitlab.common-lisp.net
-gitlab.setup        trivial-utf-8 trivial-utf-8 6ca9943588cbc61ad22a3c1ff81beb371e122394
+gitlab.setup        trivial-utf-8 trivial-utf-8 41421c98507bfa7dc5623aa997c4245e44dfcd4d
 name                cl-trivial-utf-8
-version             20220214
+version             20220223
 revision            0
 
-checksums           rmd160  86582b0dbf24bf4ae3e44fd55a21f4742b559506 \
-                    sha256  e1204a804d935422420ca0c7df48f83f6529a805ce7809d42f5b9f143ce74196 \
-                    size    7242
+checksums           rmd160  3f396cf4fd442912e9ec42dbdaf25dc09ff1c446 \
+                    sha256  97b6531325384eab599d515588e7bb867b8c2443a8f6e1a48f0d499710c18ceb \
+                    size    6975
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -22,4 +22,4 @@ description         Trivial UTF-8 provides more efficient ways of reading and wr
 
 long_description    {*}${description}
 
-depends_lib-append  port:cl-mgl-pax
+depends_lib-append  port:cl-mgl-pax-bootstrap


### PR DESCRIPTION
#### Description

This update removes cyclic dependencies between all these ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->