### PR TITLE
common_lisp PG: avoid CLisp issue on case sensetive FS

### DIFF
--- a/_resources/port1.0/group/common_lisp-1.0.tcl
+++ b/_resources/port1.0/group/common_lisp-1.0.tcl
@@ -265,7 +265,10 @@ proc common_lisp::run {lisp eval_arg op name build_system_path} {
 
     set loadcmd ${lisp}
 
-    append loadcmd " ${eval_arg} '(require :asdf)'"
+    # CLisp has a bug which leads to loading upper case system name when it defines via :
+    # to avoid that the system name should be double quoted.
+    # See: https://gitlab.com/gnu-clisp/clisp/-/issues/46
+    append loadcmd " ${eval_arg} '(require \"asdf\")'"
     append loadcmd " ${eval_arg} '(setf asdf:*central-registry* (list* (quote *default-pathname-defaults*) ${lisp-build-system-path} ${lisp-system-path} asdf:*central-registry*))'"
     append loadcmd " ${eval_arg} '(asdf:operate (quote asdf:${op}) (quote ${name}))'"
 


### PR DESCRIPTION
#### Description

Here a trivial fix to overstep CLisp bug which brokes build bot for all lisp port which is supported by clips.

See details here: https://gitlab.com/gnu-clisp/clisp/-/issues/46

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->