### PR TITLE
groovy: update to 4.0.14

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         4.0.13
+version         4.0.14
 revision        0
 
 categories      lang java
@@ -41,9 +41,9 @@ master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zi
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  3bd4b8fd75d1f8fa8aa4a2ed71a3309906774986 \
-                sha256  a1be23ab49dff7672d0a1d6b4322ac30a827a2021b0819e9a6248ab9293f3c84 \
-                size    29637096
+checksums       rmd160  30dafca79e766aa0917a753da64ca37c03df913e \
+                sha256  7d0bea0e2aa5f27ecbc6c0072595b8830a3aab6908bedd0cc0830c8bc38e1f04 \
+                size    29682482
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 4.0.14.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?