### PR TITLE
openjdk11-corretto: update to 11.0.20.9.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -5,17 +5,22 @@ PortSystem       1.0
 name             openjdk11-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# See https://github.com/corretto/corretto-11/blob/release-11.0.20.9.1/CHANGELOG.md
+# and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any} {darwin >= 20}
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
+
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
 universal_variant no
 
-# https://github.com/corretto/corretto-11/releases
 supported_archs  x86_64 arm64
 
-version      11.0.20.8.1
-revision     1
+# https://github.com/corretto/corretto-11/releases
+version      11.0.20.9.1
+revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
 long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
@@ -24,27 +29,17 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  68f41bccbf647f4a2ee8ec0c29cf7baf3e209ef8 \
-                 sha256  9e6bf76968737f929511b7c8f4d1456f7d2f53e996e2ce9f352d529ee8e5c028 \
-                 size    188003170
+    checksums    rmd160  a83da1a31bfa0fb10266394a9206ce802fada46a \
+                 sha256  bbb6dbb917b8def5fa2c7e94a52c8b92020d6e38c5f55634296facff3168e4b4 \
+                 size    188004395
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  e58cf6d0f4f5b85ffffe8be3b6d933e4bc1fe640 \
-                 sha256  39b540600520dae0e664bf9f7bfa8bf931b6e2b320960e276197670bd9e08928 \
-                 size    186298300
+    checksums    rmd160  6b3efea37d384ab3e26cb8f522f29a301cac8b7f \
+                 sha256  32c81583c291153662b39e199129ec77303651593f531ca3839f78f7a37121c0 \
+                 size    186292265
 }
 
 worksrcdir   amazon-corretto-11.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 20} {
-    # See https://github.com/corretto/corretto-11/blob/release-11.0.20.8.1/CHANGELOG.md
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 11 Big Sur or later."
-        return -code error
-    }
-}
 
 homepage     https://aws.amazon.com/corretto/
 


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.20.9.1.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?