### PR TITLE
openjdk20-corretto: update to 20.0.2.10.1

### DIFF
--- a/java/openjdk20-corretto/Portfile
+++ b/java/openjdk20-corretto/Portfile
@@ -5,17 +5,22 @@ PortSystem       1.0
 name             openjdk20-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# See https://github.com/corretto/corretto-20/blob/release-20.0.2.10.1/CHANGELOG.md
+# and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any} {darwin >= 20}
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
+
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
 universal_variant no
 
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-20/releases
-version      20.0.2.9.1
-revision     1
+version      20.0.2.10.1
+revision     0
 
 description  Amazon Corretto OpenJDK 20 (Short Term Support)
 long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
@@ -24,27 +29,17 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  91f88417f6dfc53208a49c836dcc0b7205aa45f6 \
-                 sha256  0c651e2c75d26a3112871d0f13d952b97637c0fc8f4779ad4adb2bb678f25b7a \
-                 size    197828666
+    checksums    rmd160  3e1269f2439de09d1ecba8b3d40811f031151941 \
+                 sha256  d394f4364488501bf63444e9e31c55d7b4890409cf00e3d6b0fe0fcfb0ea9a4e \
+                 size    197821869
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  0697115cd04cdd61ab863e2f53b52058feb6c18d \
-                 sha256  d6c0dd12a89961d40fcf3d277765692fa437a5c2da39a1eb7c1429ab10b5a9f9 \
-                 size    195700215
+    checksums    rmd160  588e4935de0981382fb5c9a196833c7094b69128 \
+                 sha256  30e6d956f3d674e09e7d211e47d2880a17e70ad62460aaa0b6628ed091611c3c \
+                 size    195686408
 }
 
 worksrcdir   amazon-corretto-20.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 20} {
-    # See https://github.com/corretto/corretto-20/blob/release-20.0.2.9.1/CHANGELOG.md
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 11.0 Big Sur or later."
-        return -code error
-    }
-}
 
 homepage     https://aws.amazon.com/corretto/
 


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 20.0.2.10.1.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?