### PR TITLE
stern: update to 1.26.0

### DIFF
--- a/sysutils/stern/Portfile
+++ b/sysutils/stern/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/stern/stern 1.25.0 v
+go.setup            github.com/stern/stern 1.26.0 v
 maintainers         {breun.nl:nils @breun} openmaintainer
 platforms           darwin
 categories          sysutils
@@ -15,9 +15,9 @@ long_description    Stern allows you to tail multiple pods on Kubernetes and \
                     multiple containers within the pod. Each result is color \
                     coded for quicker debugging.
 
-checksums           rmd160  4fd0bce930ecbc26d3429a409fb6dd94335a7b4b \
-                    sha256  a58bbae61a9617956fb058390c208ed1a2be4349f9ce2a365b87714ae1f83f66 \
-                    size    58323
+checksums           rmd160  50dd1ce5666741c5096d0af9c194d1a5cfff4f63 \
+                    sha256  0b699e2144478887d4b32ee9a65f10b534ce167c099c6862f3b4d69198f769b6 \
+                    size    57895
 
 set go_ldflags      "-s -w -X ${go.package}/cmd.version=${version}"
 build.args          -ldflags \"${go_ldflags}\" -o bin/${name}


### PR DESCRIPTION
#### Description

Update to Stern 1.26.0.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?