### PR TITLE
beets-beetcamp: update to 0.17.2; beets-summarize: update to 20230801; beets-devel: update to 20230823

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -530,8 +530,8 @@ subport ${name}-originquery {
 }
 
 subport ${name}-summarize {
-    github.setup    steven-murray beet-summarize e9b9cac3d0afc8bafce3cdc80c2d39bab16cd569
-    version         20230713
+    github.setup    steven-murray beet-summarize 0aa0a8fe37786f82707ee9c965ac5bc0443820c3
+    version         20230801
     revision        0
 
     license         LGPL-3
@@ -540,9 +540,9 @@ subport ${name}-summarize {
     long_description \
                     {*}${description}
 
-    checksums       rmd160  91c926952a7df8d19a0c993c58dd7ea7c8f25ffb \
-                    sha256  363c2717f5c302615d65f1b817aab3a1113bc188c961795908881434ee88aa19 \
-                    size    13331
+    checksums       rmd160  0b1b7acbb4fe498bedb419d4bc50f7769248740b \
+                    sha256  408eab04eb4a299f80460698c1b9ad25bd42794365a63ed802116f4a349fbb46 \
+                    size    13328
 
     python.pep517   yes
 

--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -243,8 +243,8 @@ subport ${name}-barcode {
 
 subport ${name}-beetcamp {
     python.rootname beetcamp
-    version         0.17.1
-    revision        1
+    version         0.17.2
+    revision        0
 
     license         GPL-2
 
@@ -254,9 +254,9 @@ subport ${name}-beetcamp {
 
     homepage        https://github.com/snejus/beetcamp
 
-    checksums       rmd160  8f0dd6bc7bca3f146c2699c6a8cf5b3719a8ec74 \
-                    sha256  e0dfe23703e2a029c71e56ca48d22712ab71403f221610355f5a132e67aece44 \
-                    size    43529
+    checksums       rmd160  866ab8fe35e222115bded1c2a2cbcc7d3ab3cb6f \
+                    sha256  0b4f75323c43e4b32a6fa2d1ea4e1d9265e0299abd19eb558793f77fd5556bd1 \
+                    size    43387
 
     python.pep517   yes
     python.pep517_backend \

--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -39,13 +39,13 @@ if {$subport eq $name} {
 subport ${name}-devel {
     conflicts       $name
 
-    github.setup    beetbox beets 87cd387ecc5793e15a98ec6411db3ea544cbce63
-    version         20230723
+    github.setup    beetbox beets 62859f4389715d87af36827b6042d21a82e91fdc
+    version         20230823
     revision        0
 
-    checksums       rmd160  93769fc6f03381841fe07986e29e2d8693af9438 \
-                    sha256  c5c7371464493ca130a69cc65c21954968b2538f428f8f3f758ea2f755b319f5 \
-                    size    2198322
+    checksums       rmd160  607d024f8cc8d111d418f265e18e0cc16dd6e814 \
+                    sha256  367552c32126ab026d73e9dde5ffe9dcec7178a402eb68f3f84c1d7fba751d83 \
+                    size    2200692
 
     depends_build-append \
                     port:py${python.version}-sphinx


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->