### PR TITLE
libcifpp: use legacysupport/macports-libcxx for 10.14 and earlier

### DIFF
--- a/science/libcifpp/Portfile
+++ b/science/libcifpp/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
 
 github.setup        PDB-REDO libcifpp 5.1.2 v
 github.tarball_from archive
@@ -19,6 +20,10 @@ long_description    {*}${description}
 checksums           rmd160  dbd84b001e70c927e19556aaa46ba53d06b6051b \
                     sha256  7afb7a1e2053c6896363e7ec5a4d86d4568dba288f84bc2868791facb1c2f8bb \
                     size    2244795
+
+# Needed for std::filesystem
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx                 yes
 
 # blacklisting to select C++20 capable compilers
 compiler.blacklist-append {clang < 1300}


### PR DESCRIPTION
### Description

* Needed for `std::filesystem`
* Tested on a swath of older macOS releases, via trace mode - 10.7, 10.9, 10.11, 10.12, 10.13, 10.14 - and all look good.