### PR TITLE
ncdu: update to 2.3

### DIFF
--- a/sysutils/ncdu/Portfile
+++ b/sysutils/ncdu/Portfile
@@ -32,13 +32,13 @@ subport ncdu1 {
 }
 
 if {${subport} eq ${name}} {
-    version             2.2.2
+    version             2.3
     revision            0
     conflicts           ncdu1
 
-    checksums           rmd160  d537972c6a31f73ca58d8345b5d7d8c86a4eef0a \
-                        sha256  90d920024e752318b469776ce57e03b3c702d49329ad9825aeeab36c3babf993 \
-                        size    56096
+    checksums           rmd160  f09fce3f38afc24c90c70345f9322c9e3dcee971 \
+                        sha256  bbce1d1c70f1247671be4ea2135d8c52cd29a708af5ed62cecda7dc6a8000a3c \
+                        size    56608
 
     depends_build       port:zig
 


### PR DESCRIPTION
We can now build zig 0.11.0 on arm64 and the update to zig has been merged in #20090. Now we update ncdu to 2.3, which requires zig 0.11.0.

See https://trac.macports.org/ticket/67139. This update sidesteps the issue in this ticket by updating zig and ncdu to their latest versions respectively.

#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.6.7 21G651 arm64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?