### PR TITLE
qt4-mac: drop Rosetta SDK hack, replace with a proper patch

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -11,7 +11,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                qt4-mac
 version             4.8.7
-revision            14
+revision            15
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 categories          aqua
@@ -45,14 +45,6 @@ depends_lib-append  port:zlib \
                     port:libpng \
                     port:libmng \
                     path:include/turbojpeg.h:libjpeg-turbo
-
-platform darwin 10 {
-    # Rosetta build fails with macosx_deployment_target 10.6
-    # https://trac.macports.org/ticket/65596
-    if {${build_arch} eq "ppc"} {
-        macosx_deployment_target 10.5
-    }
-}
 
 # easy solution for deprecated font API; see also
 # https://trac.macports.org/ticket/66114
@@ -422,6 +414,10 @@ patchfiles-append patch-test_compiler_version.diff
 # ASM keyword; removing it should not hurt other compilers; if it does
 # we'll add an "if" to narrow the scope of application
 patchfiles-append patch-src_3rdparty_javascriptcore_JavaScriptCore_jit_JITStubs.cpp_remove_volatile.diff
+
+# Fixes building for ppc on 10.6.x without downgrading deployment target.
+# https://trac.macports.org/ticket/65596
+patchfiles-append patch-fix-malloc-powerpc.diff
 
 # the version header file is part of C++20
 # newer versions of Clang find VERSION instead

--- a/aqua/qt4-mac/files/patch-fix-malloc-powerpc.diff
+++ b/aqua/qt4-mac/files/patch-fix-malloc-powerpc.diff
@@ -1,0 +1,198 @@
+--- src/3rdparty/javascriptcore/JavaScriptCore/wtf/TCSystemAlloc.h.orig	2015-05-07 22:14:48.000000000 +0800
++++ src/3rdparty/javascriptcore/JavaScriptCore/wtf/TCSystemAlloc.h	2023-08-25 16:52:18.000000000 +0800
+@@ -68,7 +68,7 @@
+ inline void TCMalloc_SystemRelease(void*, size_t) { }
+ #endif
+ 
+-#if !HAVE(VIRTUALALLOC) && !HAVE(MADV_FREE_REUSE)
++#if !HAVE(VIRTUALALLOC) && !HAVE(MADV_FREE_REUSE) || defined(__POWERPC__)
+ inline void TCMalloc_SystemCommit(void*, size_t) { }
+ #endif
+ 
+--- src/3rdparty/javascriptcore/JavaScriptCore/wtf/TCSystemAlloc.cpp.orig	2015-05-07 22:14:48.000000000 +0800
++++ src/3rdparty/javascriptcore/JavaScriptCore/wtf/TCSystemAlloc.cpp	2023-08-25 16:50:24.000000000 +0800
+@@ -388,7 +388,7 @@
+   return NULL;
+ }
+ 
+-#if HAVE(MADV_FREE_REUSE)
++#if HAVE(MADV_FREE_REUSE) && !defined(__POWERPC__)
+ 
+ void TCMalloc_SystemRelease(void* start, size_t length)
+ {
+@@ -481,7 +481,7 @@
+ 
+ #endif
+ 
+-#if HAVE(MADV_FREE_REUSE)
++#if HAVE(MADV_FREE_REUSE) && !defined(__POWERPC__)
+ 
+ void TCMalloc_SystemCommit(void* start, size_t length)
+ {
+
+--- src/3rdparty/javascriptcore/JavaScriptCore/wtf/FastMalloc.cpp.orig	2015-05-07 22:14:48.000000000 +0800
++++ src/3rdparty/javascriptcore/JavaScriptCore/wtf/FastMalloc.cpp	2023-08-25 16:49:57.000000000 +0800
+@@ -407,7 +407,7 @@
+ #include <wtf/HashSet.h>
+ #include <wtf/Vector.h>
+ #endif
+-#if HAVE(DISPATCH_H)
++#if HAVE(DISPATCH_H) && !defined(__POWERPC__)
+ #include <dispatch/dispatch.h>
+ #endif
+ 
+@@ -1397,7 +1397,7 @@
+   void scavenge();
+   ALWAYS_INLINE bool shouldContinueScavenging() const;
+ 
+-#if !HAVE(DISPATCH_H)
++#if !HAVE(DISPATCH_H) || defined(__POWERPC__)
+   static NO_RETURN void* runScavengerThread(void*);
+   NO_RETURN void scavengerThread();
+ 
+@@ -1448,7 +1448,7 @@
+ 
+ #if USE_BACKGROUND_THREAD_TO_SCAVENGE_MEMORY
+ 
+-#if !HAVE(DISPATCH_H)
++#if !HAVE(DISPATCH_H) || defined(__POWERPC__)
+ 
+ void TCMalloc_PageHeap::initializeScavenger()
+ {
+@@ -2337,7 +2337,7 @@
+ 
+ #if USE_BACKGROUND_THREAD_TO_SCAVENGE_MEMORY
+ 
+-#if !HAVE(DISPATCH_H)
++#if !HAVE(DISPATCH_H) || defined(__POWERPC__)
+ #if OS(WINDOWS)
+ static void sleep(unsigned seconds)
+ {
+@@ -4374,7 +4374,7 @@
+ malloc_introspection_t jscore_fastmalloc_introspection = { &FastMallocZone::enumerate, &FastMallocZone::goodSize, &FastMallocZone::check, &FastMallocZone::print,
+     &FastMallocZone::log, &FastMallocZone::forceLock, &FastMallocZone::forceUnlock, &FastMallocZone::statistics
+ 
+-#if !defined(BUILDING_ON_TIGER) && !defined(BUILDING_ON_LEOPARD) && !OS(IPHONE_OS)
++#if !defined(BUILDING_ON_TIGER) && !defined(BUILDING_ON_LEOPARD) && !OS(IPHONE_OS) && !defined(__POWERPC__)
+     , 0 // zone_locked will not be called on the zone unless it advertises itself as version five or higher.
+ #endif
+ 
+
+--- src/3rdparty/webkit/Source/JavaScriptCore/wtf/TCSystemAlloc.h.orig	2015-05-07 22:14:45.000000000 +0800
++++ src/3rdparty/webkit/Source/JavaScriptCore/wtf/TCSystemAlloc.h	2023-08-25 18:05:46.000000000 +0800
+@@ -68,7 +68,7 @@
+ inline void TCMalloc_SystemRelease(void*, size_t) { }
+ #endif
+ 
+-#if !HAVE(VIRTUALALLOC) && !HAVE(MADV_FREE_REUSE)
++#if !HAVE(VIRTUALALLOC) && !HAVE(MADV_FREE_REUSE) || defined(__POWERPC__)
+ inline void TCMalloc_SystemCommit(void*, size_t) { }
+ #endif
+ 
+--- src/3rdparty/webkit/Source/JavaScriptCore/wtf/TCSystemAlloc.cpp.orig	2015-05-07 22:14:45.000000000 +0800
++++ src/3rdparty/webkit/Source/JavaScriptCore/wtf/TCSystemAlloc.cpp	2023-08-25 18:03:58.000000000 +0800
+@@ -388,7 +388,7 @@
+   return NULL;
+ }
+ 
+-#if HAVE(MADV_FREE_REUSE)
++#if HAVE(MADV_FREE_REUSE) && !defined(__POWERPC__)
+ 
+ void TCMalloc_SystemRelease(void* start, size_t length)
+ {
+@@ -481,7 +481,7 @@
+ 
+ #endif
+ 
+-#if HAVE(MADV_FREE_REUSE)
++#if HAVE(MADV_FREE_REUSE) && !defined(__POWERPC__)
+ 
+ void TCMalloc_SystemCommit(void* start, size_t length)
+ {
+
+--- src/3rdparty/webkit/Source/JavaScriptCore/wtf/FastMalloc.cpp.orig	2023-08-25 14:57:32.000000000 +0800
++++ src/3rdparty/webkit/Source/JavaScriptCore/wtf/FastMalloc.cpp	2023-08-25 19:00:08.000000000 +0800
+@@ -450,7 +450,7 @@
+ #include "HeaderDetection.h"
+ #endif
+ 
+-#if HAVE(DISPATCH_H)
++#if HAVE(DISPATCH_H) && !defined(__POWERPC__)
+ #include <dispatch/dispatch.h>
+ #endif
+ 
+@@ -1457,7 +1457,7 @@
+   void scavenge();
+   ALWAYS_INLINE bool shouldScavenge() const;
+ 
+-#if HAVE(DISPATCH_H) || OS(WINDOWS)
++#if (HAVE(DISPATCH_H) && !defined(__POWERPC__)) || OS(WINDOWS)
+   void periodicScavenge();
+   ALWAYS_INLINE bool isScavengerSuspended();
+   ALWAYS_INLINE void scheduleScavenger();
+@@ -1465,7 +1465,7 @@
+   ALWAYS_INLINE void suspendScavenger();
+ #endif
+ 
+-#if HAVE(DISPATCH_H)
++#if HAVE(DISPATCH_H) && !defined(__POWERPC__)
+   dispatch_queue_t m_scavengeQueue;
+   dispatch_source_t m_scavengeTimer;
+   bool m_scavengingSuspended;
+@@ -1517,7 +1517,7 @@
+ 
+ #if USE_BACKGROUND_THREAD_TO_SCAVENGE_MEMORY
+ 
+-#if HAVE(DISPATCH_H)
++#if HAVE(DISPATCH_H) && !defined(__POWERPC__)
+ 
+ void TCMalloc_PageHeap::initializeScavenger()
+ {
+@@ -2462,7 +2462,7 @@
+ 
+ #if USE_BACKGROUND_THREAD_TO_SCAVENGE_MEMORY
+ 
+-#if HAVE(DISPATCH_H) || OS(WINDOWS)
++#if (HAVE(DISPATCH_H) && !defined(__POWERPC__)) || OS(WINDOWS)
+ 
+ void TCMalloc_PageHeap::periodicScavenge()
+ {
+@@ -4612,7 +4612,7 @@
+ malloc_introspection_t jscore_fastmalloc_introspection = { &FastMallocZone::enumerate, &FastMallocZone::goodSize, &FastMallocZone::check, &FastMallocZone::print,
+     &FastMallocZone::log, &FastMallocZone::forceLock, &FastMallocZone::forceUnlock, &FastMallocZone::statistics
+ 
+-#if !defined(BUILDING_ON_TIGER) && !defined(BUILDING_ON_LEOPARD)
++#if !defined(BUILDING_ON_TIGER) && !defined(BUILDING_ON_LEOPARD) && !defined(__POWERPC__)
+     , 0 // zone_locked will not be called on the zone unless it advertises itself as version five or higher.
+ #endif
+ #if !defined(BUILDING_ON_TIGER) && !defined(BUILDING_ON_LEOPARD) && !defined(BUILDING_ON_SNOW_LEOPARD)
+
+--- src/3rdparty/webkit/Source/JavaScriptCore/wtf/OSAllocatorPosix.cpp.orig	2023-08-25 14:57:32.000000000 +0800
++++ src/3rdparty/webkit/Source/JavaScriptCore/wtf/OSAllocatorPosix.cpp	2023-08-25 19:05:47.000000000 +0800
+@@ -43,7 +43,7 @@
+ #else // OS(QNX)
+ 
+     void* result = reserveAndCommit(bytes, usage, writable, executable);
+-#if HAVE(MADV_FREE_REUSE)
++#if HAVE(MADV_FREE_REUSE) && !defined(__POWERPC__)
+     // To support the "reserve then commit" model, we have to initially decommit.
+     while (madvise(result, bytes, MADV_FREE_REUSABLE) == -1 && errno == EAGAIN) { }
+ #endif
+@@ -118,7 +118,7 @@
+         protection |= PROT_EXEC;
+     if (MAP_FAILED == mmap(address, bytes, protection, MAP_FIXED | MAP_PRIVATE | MAP_ANON, -1, 0))
+         CRASH();
+-#elif HAVE(MADV_FREE_REUSE)
++#elif HAVE(MADV_FREE_REUSE) && !defined(__POWERPC__)
+     UNUSED_PARAM(writable);
+     UNUSED_PARAM(executable);
+     while (madvise(address, bytes, MADV_FREE_REUSE) == -1 && errno == EAGAIN) { }
+@@ -136,7 +136,7 @@
+ #if OS(QNX)
+     // Use PROT_NONE and MAP_LAZY to decommit the pages.
+     mmap(address, bytes, PROT_NONE, MAP_FIXED | MAP_LAZY | MAP_PRIVATE | MAP_ANON, -1, 0);
+-#elif HAVE(MADV_FREE_REUSE)
++#elif HAVE(MADV_FREE_REUSE) && !defined(__POWERPC__)
+     while (madvise(address, bytes, MADV_FREE_REUSABLE) == -1 && errno == EAGAIN) { }
+ #elif HAVE(MADV_FREE)
+     while (madvise(address, bytes, MADV_FREE) == -1 && errno == EAGAIN) { }


### PR DESCRIPTION
A better fix for: https://trac.macports.org/ticket/65596

#### Description

A better fix than redefining the target, which otherwise gets pulled in to subsequent builds of dependents.

Does not affect anything aside of `ppc` builds on 10.6 (Rosetta or native).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

P. S. Draft for a bit – no hurry here, and I wanna compare building with both versions, to make sure no regressions occur.