### PR TITLE
libjodycode: new port (version 3.1)

### DIFF
--- a/devel/libjodycode/Portfile
+++ b/devel/libjodycode/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+
+github.setup        jbruchon libjodycode 3.1 v
+revision            0
+checksums           rmd160  521a8c7eada622e8569e5bd3d6add6cf1fb40a99 \
+                    sha256  7e07cad7931602b6de2130d0ad82cc964d2f5dae17853e7e54f50b91fc205960 \
+                    size    27359
+
+categories          devel
+license             MIT
+maintainers         nomaintainer
+description         Library for imagepile, jdupes, winregfs, zeromerge.
+long_description    ${name} is a software code library containing code \
+                    shared among several of the programs written by \
+                    Jody Bruchon such as imagepile, jdupes, winregfs, \
+                    and zeromerge.
+
+# The following patch adds the absolute path to -install_name, along
+# with version numbers to -compatibility_version and -current version.
+# This patch also renames the compiled library and symlinks to .dylib
+# rather than .so.
+patchfiles          Makefile.patch
+
+platform darwin 8 {
+    depends_build-append port:gmake
+    build.cmd ${prefix}/bin/gmake
+}

--- a/devel/libjodycode/files/Makefile.patch
+++ b/devel/libjodycode/files/Makefile.patch
@@ -1,0 +1,93 @@
+--- Makefile.orig	2023-07-02 10:15:42.000000000 -0400
++++ Makefile	2023-08-25 00:00:00.000000000 -0700
+@@ -15,7 +15,6 @@
+ MKDIR   = mkdir -p
+ INSTALL_PROGRAM = $(INSTALL) -m 0755
+ INSTALL_DATA    = $(INSTALL) -m 0644
+-SO_SUFFIX = so
+ API_VERSION = $(shell grep -m 1 '^.define LIBJODYCODE_VER ' libjodycode.h | sed 's/[^"]*"//;s/\..*//')
+ 
+ # Make Configuration
+@@ -30,9 +29,13 @@
+ CROSS_DETECT  = $(shell true | $(CC) -dM -E - | grep -m 1 __x86_64 || echo "cross")
+ 
+ ifeq ($(UNAME_S), Darwin)
+-	LINK_OPTIONS += -Wl,-install_name,$(PROGRAM_NAME).$(SO_SUFFIX).$(API_VERSION)
+-else
+-	LINK_OPTIONS += -Wl,-soname,$(PROGRAM_NAME).$(SO_SUFFIX).$(API_VERSION)
++	SO_SUFFIX =
++	DYLIB_SUFFIX = .dylib
++	LINK_OPTIONS += -Wl,-install_name,$(LIB_DIR)/$(PROGRAM_NAME)$(SO_SUFFIX).$(API_VERSION)$(DYLIB_SUFFIX) -compatibility_version $(API_VERSION) -current_version $(VERSION)
++else
++	SO_SUFFIX = .so
++	DYLIB_SUFFIX =
++	LINK_OPTIONS += -Wl,-soname,$(PROGRAM_NAME)$(SO_SUFFIX).$(API_VERSION)$(DYLIB_SUFFIX)
+ endif
+ 
+ # Don't use unsupported compiler options on gcc 3/4 (Mac OS X 10.5.8 Xcode)
+@@ -49,7 +52,8 @@
+ ifeq ($(OS), Windows_NT)
+ 	ifndef NO_WINDOWS
+ 		ON_WINDOWS=1
+-		SO_SUFFIX=dll
++		SO_SUFFIX=.dll
++		DYLIB_SUFFIX=
+ 	endif
+ endif
+ 
+@@ -124,9 +128,9 @@
+ 	-@test "$(CROSS_DETECT)" = "cross" && echo "NOTICE: SIMD disabled: !x86_64 or a cross-compiler detected (CC = $(CC))" || true
+ 
+ sharedlib: $(OBJS) $(SIMD_OBJS)
+-	$(CC) -shared -o $(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION) $(OBJS) $(SIMD_OBJS) $(LDFLAGS) $(CFLAGS) $(CFLAGS_EXTRA)
+-	$(LN)            $(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION) $(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION_MAJOR)
+-	$(LN)            $(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION_MAJOR) $(PROGRAM_NAME).$(SO_SUFFIX)
++	$(CC) -shared -o $(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION)$(DYLIB_SUFFIX) $(OBJS) $(SIMD_OBJS) $(LDFLAGS) $(CFLAGS) $(CFLAGS_EXTRA)
++	$(LN)            $(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION)$(DYLIB_SUFFIX) $(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION_MAJOR)$(DYLIB_SUFFIX)
++	$(LN)            $(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION_MAJOR)$(DYLIB_SUFFIX) $(PROGRAM_NAME)$(SO_SUFFIX)$(DYLIB_SUFFIX)
+ 
+ staticlib: $(OBJS) $(SIMD_OBJS)
+ 	$(AR) rcs libjodycode.a $(OBJS) $(SIMD_OBJS)
+@@ -170,9 +174,9 @@
+ 	test -e $(DESTDIR)$(MAN7_DIR) || $(MKDIR) $(DESTDIR)$(MAN7_DIR)
+ 
+ installfiles:
+-	$(INSTALL_PROGRAM) $(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION)            $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION)
+-	$(LN)           $(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION) $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION_MAJOR)
+-	$(LN)           $(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION_MAJOR) $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME).$(SO_SUFFIX)
++	$(INSTALL_PROGRAM) $(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION)$(DYLIB_SUFFIX)            $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION)$(DYLIB_SUFFIX)
++	$(LN)           $(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION)$(DYLIB_SUFFIX) $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION_MAJOR)$(DYLIB_SUFFIX)
++	$(LN)           $(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION_MAJOR)$(DYLIB_SUFFIX) $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME)$(SO_SUFFIX)$(DYLIB_SUFFIX)
+ 	$(INSTALL_DATA) $(PROGRAM_NAME).a  $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME).a
+ 	$(INSTALL_DATA) $(PROGRAM_NAME).h  $(DESTDIR)$(INC_DIR)/$(PROGRAM_NAME).h
+ 	$(INSTALL_DATA) $(PROGRAM_NAME).7  $(DESTDIR)$(MAN7_DIR)/$(PROGRAM_NAME).7
+@@ -185,9 +189,9 @@
+ 	-test -e $(DESTDIR)$(MAN7_DIR) && $(RMDIR) $(DESTDIR)$(MAN7_DIR)
+ 
+ uninstallfiles:
+-	$(RM)  $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION)
+-	$(RM)  $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION_MAJOR)
+-	$(RM)  $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME).$(SO_SUFFIX)
++	$(RM)  $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION)$(DYLIB_SUFFIX)
++	$(RM)  $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION_MAJOR)$(DYLIB_SUFFIX)
++	$(RM)  $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME)$(SO_SUFFIX)$(DYLIB_SUFFIX)
+ 	$(RM)  $(DESTDIR)$(LIB_DIR)/$(PROGRAM_NAME).a
+ 	$(RM)  $(DESTDIR)$(INC_DIR)/$(PROGRAM_NAME).h
+ 	$(RM)  $(DESTDIR)$(MAN7_DIR)/$(PROGRAM_NAME).7
+@@ -198,14 +202,14 @@
+ 	./test.sh
+ 
+ stripped: sharedlib staticlib
+-	strip --strip-unneeded libjodycode.$(SO_SUFFIX)
++	strip --strip-unneeded libjodycode$(SO_SUFFIX)$(DYLIB_SUFFIX)
+ 	strip --strip-debug libjodycode.a
+ 
+ objsclean:
+ 	$(RM) $(OBJS) $(SIMD_OBJS) vercheck.o
+ 
+ clean: objsclean
+-	$(RM) $(PROGRAM_NAME).$(SO_SUFFIX) $(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION_MAJOR) $(PROGRAM_NAME).$(SO_SUFFIX).$(VERSION)
++	$(RM) $(PROGRAM_NAME)$(SO_SUFFIX)$(DYLIB_SUFFIX) $(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION_MAJOR)$(DYLIB_SUFFIX) $(PROGRAM_NAME)$(SO_SUFFIX).$(VERSION)$(DYLIB_SUFFIX)
+ 	$(RM) apiver vercheck *.a *~ helper_code/*~ libjodycode.so.* libjodycode.dll.* .*.un~ *.gcno *.gcda *.gcov
+ 
+ distclean: objsclean clean


### PR DESCRIPTION
#### Description
libjodycode: new port (version 3.1)

###### Tested on
macOS 12.6.6 21G646 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?