### PR TITLE
libproxy: use python311 variant by default

### DIFF
--- a/net/libproxy/Portfile
+++ b/net/libproxy/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        libproxy libproxy 0.4.18
-revision            0
+revision            1
 epoch               1
 categories          net
 maintainers         {devans @dbevans} openmaintainer
@@ -91,8 +91,8 @@ variant python311 conflicts python39 python310 description {Build Bindings for P
                     -DPYTHON3_SITEPKG_DIR=${python_prefix}/lib/python3.11/site-packages
 }
 
-if {![variant_isset python311] && ![variant_isset python39]} {
-    default_variants    +python310
+if {![variant_isset python310] && ![variant_isset python39]} {
+    default_variants    +python311
 }
 
 post-patch {


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/67735

###### Type(s)

- [x] enhancement

###### Tested on
macOS 13.5.1 22G90 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?