### PR TITLE
libtapi: default to cmake-bootstrap

### DIFF
--- a/devel/libtapi/Portfile
+++ b/devel/libtapi/Portfile
@@ -23,6 +23,11 @@ checksums               rmd160  a99aa279e626d4d638281ef9555d9b5db5f15145 \
                         sha256  66c715baaea6f28e8c079f36189027a52744138c38e83e97aeb399232365138f \
                         size    32205809
 
+# use cmake-bootstrap to minimize dependencies.
+depends_build-replace   path:bin/cmake:cmake port:cmake-bootstrap
+configure.cmd           ${prefix}/libexec/cmake-bootstrap/bin/cmake
+depends_skip_archcheck-append cmake-bootstrap
+
 platform darwin {
     # pick a suitable python to build with
     if {${os.major} < 11} {
@@ -87,12 +92,6 @@ if {[string match macports-clang-* ${configure.compiler}]} {
 # on macOS before 10.13 use clang-11-bootstrap
 if {${os.platform} eq "darwin" && ${os.major} < 17 && ${build_arch} ni [list ppc ppc64]} {
 
-    # use cmake-bootstrap to minimize dependencies.
-    depends_build-replace  path:bin/cmake:cmake port:cmake-bootstrap
-    configure.cmd          ${prefix}/libexec/cmake-bootstrap/bin/cmake
-    depends_skip_archcheck-append \
-                           cmake-bootstrap
-
     configure.compiler.add_deps no
 
     depends_build-append   port:clang-11-bootstrap
@@ -114,9 +113,6 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # https://llvm.org/bugs/show_bug.cgi?id=25680
     configure.cxxflags-append -U__STRICT_ANSI__
 }
-
-# Rosetta build may not match cmake arch
-depends_skip_archcheck-append cmake
 
 # add a missing strnlen definition if needed
 patchfiles-append       patch-0006-strnlen.diff


### PR DESCRIPTION
#### Description

Simply want to make it easier to bootstrap `libtapi`

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A5301h x86_64
Xcode 15.0 15A5209g

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
