### PR TITLE
kotlin: update to 1.9.10

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.9.0 v
+github.setup        JetBrains kotlin 1.9.10 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,9 +24,9 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  9c9d5ada890eed019700b7661302b4c389dcf90f \
-                    sha256  1fc50d805f9809e92de43e91f089cc8618567c1a350faebdabf8a40c5048bee8 \
-                    size    80024303
+checksums           rmd160  14c1d2cb6a68a92657e55485e85147bf9cf5514f \
+                    sha256  7d74863deecf8e0f28ea54c3735feab003d0eac67e8d3a791254b16889c20342 \
+                    size    79892748
 
 java.version        1.8+
 java.fallback       openjdk17


### PR DESCRIPTION
#### Description

Update to Kotlin 1.9.10.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?