### PR TITLE
micronaut: update to 4.0.5

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.0.4 v
+github.setup    micronaut-projects micronaut-starter 4.0.5 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  d8d17ad7ff5910259d35de36f0fab8cd06b29288 \
-                sha256  e9f4e6c3fb8348ee0461043bf1fef0c6b73310d801fd4176310e4b3ecdb82c62 \
-                size    20221944
+checksums       rmd160  20007876359963ebe56c55ebf8cff7e7e4d75cc0 \
+                sha256  09b53b6e96978f7b09ea035293aa09b9194d27c244abefb6333ad53bf0ac8f6a \
+                size    20221872
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 4.0.5.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?