### PR TITLE
openjdk17-corretto: update to 17.0.8.8.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -5,17 +5,22 @@ PortSystem       1.0
 name             openjdk17-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
+
+# See https://github.com/corretto/corretto-17/blob/release-17.0.8.8.1/CHANGELOG.md
+# and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any} {darwin >= 20}
+
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
+
 # This port uses prebuilt binaries for a particular architecture; they are not universal binaries
 universal_variant no
 
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.8.7.1
-revision     1
+version      17.0.8.8.1
+revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
 long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
@@ -24,27 +29,17 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  e50662e272d4f429839e3a19409bd871397531df \
-                 sha256  10dafc711e1ea18246f942cd067a007f3756495c117b1ea1ff40acdf2c944952 \
-                 size    188397854
+    checksums    rmd160  e51445248da6b5b78a55c486c0dc14d71ce2d2a3 \
+                 sha256  edb6d0406a8c16b44b7bd81b3d23d2a3de054c06ec8d86a25872093eee501ba0 \
+                 size    188403389
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  fcdd2689734392e327bfb35ca42ac52489dcf09c \
-                 sha256  053c0bac27f5847bb2a2e7c6dbc223b880b3873b671ff8793a529d28cc37519d \
-                 size    186442711
+    checksums    rmd160  6db542f6f8c7f3af83912e0fbe0377f0d0725c66 \
+                 sha256  08833433222ddb241a448eab92e0926d96287986f85dd5a6a065ae724e1bce43 \
+                 size    186434619
 }
 
 worksrcdir   amazon-corretto-17.jdk
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 20} {
-    # See https://github.com/corretto/corretto-17/blob/release-17.0.8.7.1/CHANGELOG.md
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 11 Big Sur or later."
-        return -code error
-    }
-}
 
 homepage     https://aws.amazon.com/corretto/
 


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.8.8.1.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?