### PR TITLE
jdupes: update to 1.27.1

### DIFF
--- a/sysutils/jdupes/Portfile
+++ b/sysutils/jdupes/Portfile
@@ -2,25 +2,22 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
 
-github.setup        jbruchon jdupes 1.21.3 v
+github.setup        jbruchon jdupes 1.27.1 v
 revision            0
-checksums           rmd160  368fd1b563082f52458caf0979bc7474deb3bf31 \
-                    sha256  5ed8780605d9a46abc4768fc9f886f698997548c4400abe7d7983b76ea8c0bcc \
-                    size    156002
+checksums           rmd160  f4bbac6ad219e83cb70b57a2c08e282c88aff7e0 \
+                    sha256  bb9d3c53a6220fe94d9641eb6951faa693d0d2fa6e2af3ae10735d92192ab8b3 \
+                    size    174508
 
-platforms           darwin
 categories          sysutils
 license             MIT
-maintainers         {isi.edu:calvin @cardi} openmaintainer
+maintainers         nomaintainer
 description         identify and take actions upon duplicate files
 long_description    ${name} is a powerful duplicate file finder and an \
                     enhanced fork of 'fdupes'.
 
-use_configure       no
-
-build.args          PREFIX=${prefix} \
-                    CC="${configure.cc} [get_canonical_archflags cc]"
+depends_lib         port:libjodycode
 
 if {${os.platform} eq "darwin" && ${os.major} > 16} {
     # dedupe feature requires macOS 10.13 or higher
@@ -32,5 +29,3 @@ platform darwin 8 {
     depends_build-append port:gmake
     build.cmd ${prefix}/bin/gmake
 }
-
-destroot.args       PREFIX=${prefix}


### PR DESCRIPTION
#### Description
jdupes: update to 1.27.1
* add PortGroup makefile and use its default options
* add new dependency port:libjodycode
* remove implicit `platforms darwin`
* update maintainers

###### Tested on
macOS 12.6.6 21G646 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?