### PR TITLE
cdo: update to 2.2.2

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,7 +5,7 @@ PortGroup                   mpi 1.0
 PortGroup                   legacysupport 1.0
 
 name                        cdo
-version                     2.2.1
+version                     2.2.2
 revision                    0
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} openmaintainer
@@ -13,11 +13,11 @@ license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/28653
+master_sites                https://code.mpimet.mpg.de/attachments/download/28882
 
-checksums           rmd160  1dd5ab388741f20f933f3fd4b62f6de3be455dfa \
-                    sha256  136801db175daeffb39065f8becbb1831944949bfc1872ead6bc5bfd5aa839e5 \
-                    size    13355925
+checksums           rmd160  a7dd552a2375c735480d72541da44e30903a3d19 \
+                    sha256  419c77315244019af41a296c05066f474cccbf94debfaae9e2106da51bc7c937 \
+                    size    13482347
 
 long_description \
     CDO is a collection of command line Operators               \


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.2.2

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.5 22G74 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
