### PR TITLE
openjdk11: update to 11.0.20.1, install files under ${prefix}

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk11
 # See https://github.com/openjdk/jdk11u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             11.0.20
-set build 8
+version             11.0.20.1
+set build 1
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,9 +19,9 @@ master_sites        https://git.openjdk.java.net/jdk11u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk11u-${distname}
 
-checksums           rmd160  94c405bcaf41bf83935bbb16a2baf76695704719 \
-                    sha256  a277b89ff5ade85d3b5885ad7bffb3f2d9c80df47363fedb9110b62c45dbec37 \
-                    size    116150371
+checksums           rmd160  28af98dd0a68ce252016e713cd147d5cb63d88de \
+                    sha256  fe8012c253573536990ad0f987e0ffeae75a12f1dbd7c02caed8ea899006c313 \
+                    size    116165519
 
 depends_lib         port:freetype
 depends_build       port:autoconf \
@@ -35,7 +35,7 @@ pre-patch {
     reinplace "s|assert|vmassert|g" ${worksrcpath}/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
 }
 
-set tpath /Library/Java
+set tpath ${prefix}/Library/Java
 use_configure    yes
 configure.cmd       ${prefix}/bin/bash configure
 configure.pre_args  --prefix=${tpath}
@@ -142,10 +142,17 @@ test.cmd            ${bundle_dir}/Home/bin/java
 test.target         --version
 
 set pathb ${tpath}/JavaVirtualMachines/${name}
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/${name}
 destroot {
     xinstall -m 755 -d ${destroot}${pathb}
     copy ${worksrcpath}/${bundle_dir} ${destroot}${pathb}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${pathb} ${destroot}${jdk}
 }
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
 destroot.violate_mtree      yes
 
 post-destroot {
@@ -154,7 +161,7 @@ post-destroot {
 
 notes "
 If you want to make ${name} the default JDK, add this to shell profile:
-export JAVA_HOME=${pathb}/Contents/Home
+export JAVA_HOME=${jdk}/Contents/Home
 "
 
 livecheck.type      regex


### PR DESCRIPTION
#### Description

* Update to OpenJDK 11.0.20.1.
* Backport of https://github.com/macports/macports-ports/pull/20047 to install all actual files under `${prefix}`, and only create a symlink under `/Library/Java/JavaVirtualMachines`, as suggested on https://trac.macports.org/ticket/67935.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bug fix
- [x] enhancement

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?