### PR TITLE
openjdk20: install files under ${prefix}

### DIFF
--- a/java/openjdk20/Portfile
+++ b/java/openjdk20/Portfile
@@ -6,7 +6,7 @@ name                openjdk20
 # See https://github.com/openjdk/jdk20u/tags for the version and build number that matches the latest tag that ends with '-ga'
 version             20.0.2
 set build 9
-revision            0
+revision            1
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -34,7 +34,7 @@ pre-patch {
     reinplace "s|xmacosx|xwindows|g" ${worksrcpath}/make/autoconf/lib-freetype.m4
 }
 
-set tpath /Library/Java
+set tpath ${prefix}/Library/Java
 use_xcode           yes
 use_configure    yes
 configure.cmd       ${prefix}/bin/bash configure
@@ -132,10 +132,17 @@ test.cmd            ${bundle_dir}/Home/bin/java
 test.target         --version
 
 set pathb ${tpath}/JavaVirtualMachines/${name}
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/${name}
 destroot {
     xinstall -m 755 -d ${destroot}${pathb}
     copy ${worksrcpath}/${bundle_dir} ${destroot}${pathb}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${pathb} ${destroot}${jdk}
 }
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
 destroot.violate_mtree      yes
 
 post-destroot {
@@ -144,7 +151,7 @@ post-destroot {
 
 notes "
 If you want to make ${name} the default JDK, add this to shell profile:
-export JAVA_HOME=${pathb}/Contents/Home
+export JAVA_HOME=${jdk}/Contents/Home
 "
     
 livecheck.type      regex


### PR DESCRIPTION
#### Description

Port of https://github.com/macports/macports-ports/pull/20047 to install all actual files under `${prefix}`, and only create a symlink under `/Library/Java/JavaVirtualMachines`, as suggested on https://trac.macports.org/ticket/67935.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?