### PR TITLE
openjdk17: update to 17.0.8.1

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 
 name                openjdk17
 # See https://github.com/openjdk/jdk17u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             17.0.8
-set build 7
-revision            2
+version             17.0.8.1
+set build 1
+revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -19,9 +19,9 @@ master_sites        https://git.openjdk.java.net/jdk17u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk17u-${distname}
 
-checksums           rmd160  cc84be8b3828d244fa6b5fcf6a0bd7f1de3b3bf9 \
-                    sha256  8d631dac790ec3eab008639db5b449e8a36310171b3cd68cb7f0b1260ca2467f \
-                    size    105879427
+checksums           rmd160  0bf9602e51e4ecfbd84754d611bcceb623a50d1c \
+                    sha256  484d0cfc164ce4c8aa10987bde7c8abb41e8a51c0459a8740b30d7886248a3b1 \
+                    size    105878760
 
 depends_lib         port:freetype
 depends_build       port:openjdk17-bootstrap \


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.8.1, which contains a fix for [JDK-8313765](https://bugs.openjdk.org/browse/JDK-8313765).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bug fix

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?