### PR TITLE
mxml: update to 3.3.1

### DIFF
--- a/devel/mxml/Portfile
+++ b/devel/mxml/Portfile
@@ -1,14 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           muniversal 1.0
 PortGroup           github 1.0
+PortGroup           muniversal 1.0
 
-github.setup        michaelrsweet mxml 3.1 v
+github.setup        michaelrsweet mxml 3.3.1 v
 revision            0
 
 categories          devel textproc
-platforms           darwin
 license             Apache-2
 maintainers         nomaintainer
 
@@ -23,8 +22,11 @@ long_description    Mini-XML is a tiny XML library that you can use to read and 
 
 homepage            https://www.msweet.org/mxml/
 
-checksums           rmd160  9dcdb46e427ce5f57fd23fbfec55fc7ad9efe8d3 \
-                    sha256  0ad3cf45a6d4a100be6a743887bba9eca58266849e996b5cd83f2cd525295bb5 \
-                    size    9267294
+checksums           rmd160  677e7dbbd2164250129af70fdc601e65d473c6ac \
+                    sha256  0adaa504f79365d7de71ee77c41f7b47687b03e96f0aab5c3620c0631ffc26fd \
+                    size    1554818
+
+# Remove hardcoded flags:
+patchfiles          patch-configure.diff
 
 destroot.destdir    DSTROOT=${destroot}

--- a/devel/mxml/files/patch-configure.diff
+++ b/devel/mxml/files/patch-configure.diff
@@ -1,0 +1,33 @@
+--- configure	2022-07-25 20:56:27.000000000 +0800
++++ configure	2023-08-26 17:32:28.000000000 +0800
+@@ -2874,30 +2874,6 @@
+ 
+ else $as_nop
+ 
+-    case "$host_os_name" in #(
+-  darwin*) :
+-
+-        if test "$host_os_version" -ge 200 -a x$enable_debug != xyes
+-then :
+-
+-            # macOS 11.0 and higher support the Apple Silicon (arm64) CPUs
+-	    ARCHFLAGS="-mmacosx-version-min=10.14 -arch x86_64 -arch arm64"
+-
+-elif test x$enable_debug != xyes
+-then :
+-
+-	    ARCHFLAGS="-mmacosx-version-min=10.14 -arch x86_64"
+-
+-fi
+-     ;; #(
+-  *) :
+-
+-	ARCHFLAGS=""
+-     ;; #(
+-  *) :
+-     ;;
+-esac
+-
+ fi
+ 
+ 


### PR DESCRIPTION
#### Description

Update, fix building

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
