### PR TITLE
libuninameslist: update to 20230523

### DIFF
--- a/devel/libuninameslist/Portfile
+++ b/devel/libuninameslist/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 epoch               1
-github.setup        fontforge libuninameslist 20221022
+github.setup        fontforge libuninameslist 20230523
 categories          devel textproc
 maintainers         nomaintainer
 license             Permissive
@@ -16,9 +16,9 @@ long_description    The Unicode consortium provides a file containing \
                     contains a compiled version of this file so that programs \
                     can access these data easily.
 
-checksums           rmd160  c70b52d85e19595e0a05a8e1f546a36e833e3345 \
-                    sha256  bffc86f6e5090721f8520dbbdc14138afd801a9f3b9eb9b233e672602513b9b9 \
-                    size    940390
+checksums           rmd160  983ac8c876a918301fd76c224f4848e73701fa06 \
+                    sha256  5273cb2dfec3c79839d8b17f59071288dc01e3c17e2c5a1ada66410a378b9ab2 \
+                    size    952143
 
 use_autoreconf      yes
 


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
