### PR TITLE
libfixmath: update to 2023.08.08

### DIFF
--- a/math/libfixmath/Portfile
+++ b/math/libfixmath/Portfile
@@ -4,19 +4,19 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        PetteriAimonen libfixmath 9457f48b5caa955b9675b61c99bd27b9e0093dcb
-version             2023.03.20
+github.setup        PetteriAimonen libfixmath d308e466e1a09118d03f677c52e5fbf402f6fdd0
+version             2023.08.08
 revision            0
 categories          math
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Q16.16 format fixed point operations in C
 long_description    {*}${description}
-checksums           rmd160  b89c9c7a5a32add14878d2997e6b7cd03e9ee6c3 \
-                    sha256  89b77ea98719a21df12f322fe0f8eb29da0430f1f0fb4b22e9f21d1f157d8ab2 \
-                    size    267764
+checksums           rmd160  722e3b497db8ca051fb084ccf5767836ee2eb55c \
+                    sha256  3b073a5b756d1753fc2c3a18c217fd63396b77579b1ca9967c0a9d56f58254f6 \
+                    size    268677
+github.tarball_from archive
 
-patch.pre_args      -p1
 patchfiles          0001-Fix-install-targets.patch
 
 compiler.cxx_standard 2011

--- a/math/libfixmath/files/0001-Fix-install-targets.patch
+++ b/math/libfixmath/files/0001-Fix-install-targets.patch
@@ -6,42 +6,44 @@ Subject: [PATCH 1/1] Fix install targets See:
 
 In addition, duplicate liblib* has been fixed.
 
----
- CMakeLists.txt              | 11 ++++++++---
- libfixmath/libfixmath.cmake |  9 ++++++---
- 2 files changed, 14 insertions(+), 6 deletions(-)
-
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index dbcf5e3..865d096 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -14,14 +14,19 @@ include(libfixmath/libfixmath.cmake)
- include(tests/tests.cmake)
+--- CMakeLists.txt	2023-08-08 14:08:53.000000000 +0800
++++ CMakeLists.txt	2023-08-26 19:09:01.000000000 +0800
+@@ -12,18 +12,25 @@
  
- file(GLOB fixsingen-srcs fixsingen/*.c)
--file(GLOB fixtest-srcs fixtest/*.c fixtest/*.h)
-+file(GLOB fixtest-srcs fixtest/*.c)
+ include(libfixmath/libfixmath.cmake)
  
- add_executable(fixtest ${fixtest-srcs})
--target_link_libraries(fixtest PRIVATE libfixmath m)
-+target_link_libraries(fixtest PRIVATE fixmath m)
- target_include_directories(fixtest PRIVATE ${CMAKE_SOURCE_DIR})
+-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
++# if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+     # We're in the root, define additional targets for developers.
+     include(tests/tests.cmake)
  
- add_executable(fixsingen ${fixsingen-srcs})
--target_link_libraries(fixsingen PRIVATE libfixmath m)
-+target_link_libraries(fixsingen PRIVATE fixmath m)
- target_include_directories(fixsingen PRIVATE ${CMAKE_SOURCE_DIR})
+     file(GLOB fixsingen-srcs fixsingen/*.c)
+-    file(GLOB fixtest-srcs fixtest/*.c fixtest/*.h)
++    file(GLOB fixtest-srcs fixtest/*.c)
  
+     add_executable(fixtest ${fixtest-srcs})
+-    target_link_libraries(fixtest PRIVATE libfixmath m)
++    target_link_libraries(fixtest PRIVATE fixmath m)
+     target_include_directories(fixtest PRIVATE ${CMAKE_SOURCE_DIR})
+ 
+     add_executable(fixsingen ${fixsingen-srcs})
+-    target_link_libraries(fixsingen PRIVATE libfixmath m)
++    target_link_libraries(fixsingen PRIVATE fixmath m)
+     target_include_directories(fixsingen PRIVATE ${CMAKE_SOURCE_DIR})
+-endif()
++# endif()
++
 +install(TARGETS fixmath
 +    ARCHIVE DESTINATION lib
 +    LIBRARY DESTINATION lib
 +)
- 
++
 +install(FILES ${libfixmath-includes} DESTINATION include/libfixmath)
+
 diff --git a/libfixmath/libfixmath.cmake b/libfixmath/libfixmath.cmake
 index 138b1de..b92e677 100644
---- a/libfixmath/libfixmath.cmake
-+++ b/libfixmath/libfixmath.cmake
+--- libfixmath/libfixmath.cmake
++++ libfixmath/libfixmath.cmake
 @@ -1,6 +1,9 @@
  file(GLOB libfixmath-srcs libfixmath/*.c)
 +file(GLOB libfixmath-includes libfixmath/*.h libfixmath/*.hpp)
@@ -56,6 +58,3 @@ index 138b1de..b92e677 100644
 +    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libfixmath>
 +    $<INSTALL_INTERFACE:include>
 +)
--- 
-2.37.3
-


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
