### PR TITLE
procServ: update to 2.8.0

### DIFF
--- a/science/procServ/Portfile
+++ b/science/procServ/Portfile
@@ -3,25 +3,24 @@
 PortSystem          1.0
 
 name                procServ
-version             2.6.0
+version             2.8.0
 categories          science
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-3
 
 description         command wrapper
 
 long_description    procServ is a wrapper that starts an arbitrary \
-                    command(e.g. an EPICS soft IOC) as a child process \
+                    command (e.g. an EPICS soft IOC) as a child process \
                     in the background, connecting its standard input \
                     and output to a TCP port for telnet access. It supports \
-                    logging, child restart (manual or automatic),...
+                    logging, child restart (manual or automatic) etc.
 
-homepage            http://sourceforge.net/projects/procserv/
+homepage            https://sourceforge.net/projects/procserv
 master_sites        sourceforge:project/procserv/${version}
 
-checksums           md5     bbf052e7fcc6fa403d2514219346da04 \
-                    rmd160  795119646dcb1133ffbe05a71c3e5013c6b6ab81 \
-                    sha256  4ac2c3bc16abca2970a9a33935bb739df9910ec90297a60eaffb7bbc74d5645d
+checksums           rmd160  378ef392db0e1915a5c8ede1e6c28b845ac38f79 \
+                    sha256  299cd831cfe03c9ab639aee3c2189081ddef2df4049778caaf2309de1764def6 \
+                    size    398486
 
 livecheck.regex     /${name}-(\[0-9.\]+)${extract.suffix}


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
