### PR TITLE
starpu13: new port, bringing back StarPU 1.3 branch

### DIFF
--- a/devel/starpu13/Portfile
+++ b/devel/starpu13/Portfile
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           compilers 1.0
+PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+PortGroup           linear_algebra 1.0
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
+
+# StarPU maintains both the latest 1.4 branch and 1.3, and some ports want the latter.
+# For the time-being, have both in Macports as well. They do not conflict, see below.
+github.setup        starpu-runtime starpu 1.3.11 starpu-
+name                starpu13
+revision            0
+categories          devel
+license             LGPL-2.1
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Unified runtime system for heterogeneous multicore architectures
+long_description    StarPU is a runtime system that offers support for heterogeneous multicore machines. \
+                    While many efforts are devoted to design efficient computation kernels \
+                    for those architectures (e.g. to implement BLAS kernels on GPUs), StarPU \
+                    not only takes care of offloading such kernels (and implementing data coherency \
+                    across the machine), but it also makes sure the kernels are executed as efficiently as possible.
+homepage            https://starpu.gitlabpages.inria.fr
+checksums           rmd160  b2ea9730cbd2ef0c736558d5f7f96bd52cd14cc4 \
+                    sha256  43b27c48a37722ba0e596684ba2e723d72b0f6b020a12c25843f8306049a5af0 \
+                    size    7300244
+github.tarball_from archive
+
+patchfiles          autogen.sh.patch
+
+compiler.blacklist-append \
+                    *gcc-4.* {clang < 400}
+compilers.choose    fc f90 f77 cc
+compilers.setup     require_fortran
+
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+
+configure.args-append \
+                    --disable-silent-rules \
+                    --prefix=${prefix}/libexec/${name}
+
+# The following option allows for non-conflicting installation of binaries into ${prefix}/bin;
+# However it does not work neatly, and multiple files will need to be patched in that case.
+# Furthermore, given the number of components that get installed, having multiple versions of StarPU
+# directly in ${prefix} quickly becomes a mess, even though headers and dylibs are versioned (but pkgconfig files are not).
+# It appears to make a better sense, and far less painful to maintain, just to set a custom prefix.
+#                   --program-suffix="-1.3"
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool \
+                    port:pkgconfig
+depends_lib-append  port:hdf5 \
+                    port:hwloc
+
+test.run            yes
+test.target         check

--- a/devel/starpu13/files/autogen.sh.patch
+++ b/devel/starpu13/files/autogen.sh.patch
@@ -1,0 +1,21 @@
+Avoid error output when libtool is Apple libtool.
+Print errors to stderr not stdout.
+This patch should be sent to the developers.
+--- autogen.sh.orig	2022-11-15 09:40:57.000000000 -0600
++++ autogen.sh	2023-05-02 20:45:50.000000000 -0500
+@@ -14,12 +14,12 @@
+ #
+ # See the GNU Lesser General Public License in COPYING.LGPL for more details.
+ #
+-if ! libtool --version > /dev/null
++if ! libtool --version >/dev/null 2>&1
+ then
+ 	# Perhaps we are on a Mac
+-	if ! glibtool --version > /dev/null
++	if ! glibtool --version >/dev/null 2>&1
+ 	then
+-		echo "GNU Libtool is missing, please install it and fix the PATH to it."
++		echo "GNU Libtool is missing, please install it and fix the PATH to it." >&2
+ 		exit 1
+ 	else
+ 		export LIBTOOL=glibtool


### PR DESCRIPTION
#### Description

Upstream maintains and updates two branches in parallel, 1.4 and 1.3, and some ports require the latter.
Restore 1.3 branch here in a separate, non-conflicting, port.
(This is not a mechanical restore of the earlier port, of course: it is updated to the latest release for the branch, and everything gets installed into a custom prefix.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
