### PR TITLE
Avoid overlinking abseil in users of grpc and re2

### DIFF
--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 # NOTE: Also rev-bump 'apache-arrow' when updating this port
 github.setup        grpc grpc 1.48.4 v
-revision            1
+revision            2
 categories          devel
 maintainers         nomaintainer
 license             Apache-2
@@ -35,6 +35,8 @@ patchfiles-append   patch-unbreak-port_platform.diff
 # https://trac.macports.org/ticket/62208
 # https://github.com/grpc/grpc/pull/26480
 patchfiles-append   patch-python-respect-cc-variable.diff
+
+patchfiles-append   patch-avoid-overlinking-abseil.diff
 
 # error: constexpr function never produces a constant expression
 # Requires c++17 support

--- a/devel/grpc/files/patch-avoid-overlinking-abseil.diff
+++ b/devel/grpc/files/patch-avoid-overlinking-abseil.diff
@@ -1,0 +1,26 @@
+Avoid overlinking abseil in libs using grpc
+
+grpc exports a pkg-config file that instructs all users of grpc to link
+against some libraries from libabseil when linking against grpc. Because
+abseil often changes its soversion, this requires many ports that use
+grpc to be revbumped whenever abseil changes, even though they only use
+symbols from grpc.
+
+Avoid this by using the Requires.private field in the grpc pkg-config
+file as documented in [1]. See also [2], which explains the difference
+in linking.
+
+[1]: https://people.freedesktop.org/~dbn/pkg-config-guide.html#concepts
+[2]: https://stackoverflow.com/a/61674208
+
+Upstream-Status: Pending
+--- ./cmake/pkg-config-template.pc.in.orig	2023-08-26 21:55:00.000000000 +0200
++++ ./cmake/pkg-config-template.pc.in	2023-08-26 21:59:26.000000000 +0200
+@@ -7,6 +7,6 @@
+ Description: @PC_DESCRIPTION@
+ Version: @PC_VERSION@
+ Cflags: -I${includedir}
+-Requires: @PC_REQUIRES@
++Requires.private: @PC_REQUIRES@
+ Libs: -L${libdir} @PC_LIB@
+ Libs.private: @PC_LIBS_PRIVATE@

--- a/devel/re2/Portfile
+++ b/devel/re2/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 
 github.setup        google re2 2023-07-01
 epoch               1
-revision            1
+revision            2
 
 github.tarball_from archive
 checksums           rmd160 aa42a0e985c5d4e8011f12bb43631e25f8779a2d \
@@ -25,6 +25,8 @@ long_description    RE2 is a fast, safe, thread-friendly alternative to \
                     used in PCRE, Perl, and Python. It is a C++ library.
 
 license             BSD
+
+patchfiles          patch-re2pc-avoid-overlinking.diff
 
 # clock_gettime needed for abseil
 # https://github.com/macports/macports-ports/pull/19905#issuecomment-1680281240

--- a/devel/re2/files/patch-re2pc-avoid-overlinking.diff
+++ b/devel/re2/files/patch-re2pc-avoid-overlinking.diff
@@ -1,0 +1,27 @@
+Avoid overlinking abseil in libs using re2
+
+re2 exports a pkg-config file that instructs all users of re2 to link
+against some libraries from libabseil when linking against re2. Because
+abseil often changes its soversion, this requires many ports that use
+re2 to be revbumped whenever abseil changes, even though they only use
+symbols from re2.
+
+Avoid this by using the Requires.private field in the re2 pkg-config
+file as documented in [1]. See also [2], which explains the difference
+in linking.
+
+[1]: https://people.freedesktop.org/~dbn/pkg-config-guide.html#concepts
+[2]: https://stackoverflow.com/a/61674208
+
+Upstream-Status: Pending
+--- ./re2.pc.in.orig	2023-06-30 16:48:20.000000000 +0200
++++ ./re2.pc.in	2023-08-26 21:36:05.000000000 +0200
+@@ -3,7 +3,7 @@
+ 
+ Name: re2
+ Description: RE2 is a fast, safe, thread-friendly regular expression engine.
+-Requires: @REQUIRES@
++Requires.private: @REQUIRES@
+ Version: @SONAME@.0.0
+ Cflags: -pthread -I${includedir}
+ Libs: -pthread -L${libdir} -lre2


### PR DESCRIPTION
#### Description

grpc and re2 export a pkg-config file that instructs all users to link against some libraries from libabseil when linking against grpc or re2. Because abseil often changes its soversion, this requires many ports that use grpc or re2 to be revbumped whenever abseil changes, even though they only use symbols from grpc or re2.

Avoid this by using the Requires.private field in the grpc and re2 pkg-config file as documented in [\[1\]][1]. See also [\[2\]][2], which explains the difference in linking.

See also https://github.com/macports/macports-ports/pull/19905#issuecomment-1694478949 for previous discussion.

[1]: https://people.freedesktop.org/~dbn/pkg-config-guide.html#concepts
[2]: https://stackoverflow.com/a/61674208

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 21G725 arm64
Xcode 14.2 14C18

I built the Bear and mtxclient ports, which depend on grpc and re2 to test these changes; both built successfully and no longer overlink the abseil libraries.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
