### PR TITLE
asl: fix build on arm64

### DIFF
--- a/math/asl/Portfile
+++ b/math/asl/Portfile
@@ -22,6 +22,8 @@ checksums                       rmd160  911acfa42bd5e57d037141400327da8152e7afed
                                 sha256  d789ade0be2595516ff10fd84c7724a10a89bb8c7dceefcbc2ba48426ec05909 \
                                 size    1575275
 
+patchfiles-append               patch-darwin-arm.diff
+
 configure.args-append           -DBUILD_SHARED_LIBS=ON \
                                 -DBUILD_CPP=ON
 

--- a/math/asl/files/patch-darwin-arm.diff
+++ b/math/asl/files/patch-darwin-arm.diff
@@ -1,0 +1,26 @@
+https://github.com/ampl/asl/pull/15
+
+diff --git support/cmake/setArchitecture.cmake support/cmake/setArchitecture.cmake
+index c8f9819..dd2904a 100644
+--- support/cmake/setArchitecture.cmake
++++ support/cmake/setArchitecture.cmake
+@@ -74,6 +74,8 @@ function(targetArchitecture output_var)
+         set(osx_arch_i386 TRUE)
+       elseif("${osx_arch}" STREQUAL "x86_64")
+         set(osx_arch_x86_64 TRUE)
++      elseif("${osx_arch}" STREQUAL "arm64")
++        set(osx_arch_arm64 TRUE)
+       elseif("${osx_arch}" STREQUAL "ppc64" AND ppc_support)
+         set(osx_arch_ppc64 TRUE)
+       else()
+@@ -94,6 +96,10 @@ function(targetArchitecture output_var)
+       list(APPEND ARCH x86_64)
+     endif()
+ 
++    if(osx_arch_arm64)
++      list(APPEND ARCH arm64)
++    endif()
++
+     if(osx_arch_ppc64)
+       list(APPEND ARCH ppc64)
+     endif()


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1 22F82 arm64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->