### PR TITLE
qwinff: new port, Qt4 GUI for FFMPEG

### DIFF
--- a/multimedia/qwinff/Portfile
+++ b/multimedia/qwinff/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+PortGroup           qt4 1.0
+
+github.setup        qwinff qwinff 0.2.1 v
+revision            0
+categories          multimedia
+license             GPL-3
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         QWinFF, FFmpeg GUI front-end based on Qt4
+long_description    {*}${description}
+checksums           rmd160  d841c96038868359f1dc5690d0866a416bfe910d \
+                    sha256  cdf5316b01df42572bda4118de1515bb7bb6f211e7cfa01b2d573db6ecb72958 \
+                    size    639145
+github.tarball_from archive
+
+depends_lib-append  port:desktop-file-utils
+depends_run-append  path:lib/libavcodec.dylib:ffmpeg \
+                    port:sox
+
+# https://github.com/qwinff/qwinff/commit/840bfa14c6c1689094b8aa1d3b286e8ed8c2b046
+patchfiles          patch-mediaplayerwidget.diff
+
+destroot {
+    move ${worksrcpath}/bin/${name}.app ${destroot}${applications_dir}/${name}.app
+    xinstall -d ${destroot}${prefix}/share/${name}
+    xinstall -d ${destroot}${prefix}/share/applications
+    xinstall -m 0644 -W ${worksrcpath}/src constants.xml presets.xml ${destroot}${prefix}/share/${name}
+    copy ${worksrcpath}/${name}.desktop ${destroot}${prefix}/share/applications
+}
+
+post-activate {
+    system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"
+}
+
+notes "
+On the first launch the app will not know where to look for FFMPEG and other executables,\
+this is expected. Click Ok to not found message and type in correct paths in the opened window.\
+If you use Macports binaries, those will look like ${prefix}/bin/ffmpeg etc.\
+Settings files are located in ${prefix}/share/${name}
+"

--- a/multimedia/qwinff/files/patch-mediaplayerwidget.diff
+++ b/multimedia/qwinff/files/patch-mediaplayerwidget.diff
@@ -1,0 +1,11 @@
+--- src/ui/mediaplayerwidget.cpp.orig	2015-08-22 09:09:21.000000000 +0800
++++ src/ui/mediaplayerwidget.cpp	2023-08-27 08:47:18.000000000 +0800
+@@ -59,7 +59,7 @@
+     connect(mplayer, SIGNAL(stateChanged(int)), SLOT(playerStateChanged()));
+     connect(ui->slideSeek, SIGNAL(valueChanged(int)), SLOT(seekSliderChanged()));
+     connect(ui->btnPlayPause, SIGNAL(clicked()), SLOT(togglePlayPause()));
+-    connect(ui->btnBack, SIGNAL(clicked()), SLOT(seekBack()));
++    connect(ui->btnBack, SIGNAL(clicked()), SLOT(seekBackward()));
+     connect(ui->btnForward, SIGNAL(clicked()), SLOT(seekForward()));
+     connect(ui->btnReset, SIGNAL(clicked()), SLOT(resetPosition()));
+ 


### PR DESCRIPTION
#### Description

While perhaps not the most sophisticated GUI, it works :)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

![0](https://github.com/macports/macports-ports/assets/92015510/5a72cde5-1e07-44f8-b0a9-2d860c2cd486)
