### PR TITLE
libzip: update to 1.10.1, unbreak build on < 10.7

### DIFF
--- a/archivers/libzip/Portfile
+++ b/archivers/libzip/Portfile
@@ -2,19 +2,18 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
-PortGroup           legacysupport 1.0
+PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
-name                libzip
-version             1.10.0
+github.setup        nih-at libzip 1.10.1 v
 revision            0
 
-checksums           rmd160  0335ec20dbf1071278ec0ac10b121cab9f24e0e7 \
-                    sha256  cd2a7ac9f1fb5bfa6218272d9929955dc7237515bba6e14b5ad0e1d1e2212b43 \
-                    size    771676
+checksums           rmd160  728507cd4cbd250218b496dfaa010612a4084337 \
+                    sha256  dc3c8d5b4c8bbd09626864f6bcf93de701540f761d76b85d7c7d710f4bd90318 \
+                    size    774144
 
 categories          archivers
 license             BSD
-platforms           darwin
 maintainers         nomaintainer
 description         libzip is a C library for reading, creating, and modifying zip archives
 long_description    {*}${description}. \
@@ -22,7 +21,10 @@ long_description    {*}${description}. \
                     copied directly from other zip archives. Changes made without \
                     closing the archive can be reverted.
 homepage            https://libzip.org/
-master_sites        ${homepage}download/
+# For some reason downloading from the website is unreliable.
+# Use releases from GitHub repo, they are identical to xz sources from the website.
+# master_sites        ${homepage}download/
+github.tarball_from releases
 use_xz              yes
 
 depends_build-append \
@@ -35,6 +37,9 @@ configure.args-append \
                     -DENABLE_GNUTLS:Bool=OFF \
                     -DENABLE_MBEDTLS:Bool=OFF \
                     -DENABLE_OPENSSL:Bool=OFF
+
+# zip.h: error: wrong number of arguments specified for ‘deprecated’ attribute
+compiler.blacklist-append *gcc-4.0 *gcc-4.2
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
#### Description

Update, a trivial fix for old systems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
