### PR TITLE
ancient: update to 2.1.1

### DIFF
--- a/archivers/ancient/Portfile
+++ b/archivers/ancient/Portfile
@@ -4,20 +4,21 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 
-github.setup            temisu ancient 2.0.0 v
+github.setup            temisu ancient 2.1.1 v
 revision                0
 
-checksums               rmd160  f8d30777332232b770e9c03cd4c3b32325c7f44f \
-                        sha256  54885c6b943dc2bb335cd07e09a6625645b7bd0d92a6d45a8232af016bae0629 \
-                        size    98737
+checksums               rmd160  d2562af8bd2375d4ba06f74acf7349cb754f7cec \
+                        sha256  6f63e2765866925f1b188baee958d4518720bd0009ab4f50b390ea5028649ec2 \
+                        size    117915
 
 license                 BSD
 categories              archivers
 maintainers             nomaintainer
 
 description             Decompression routines for ancient formats
-
 long_description        {*}${description}
+
+github.tarball_from     archive
 
 depends_build-append    port:autoconf-archive \
                         port:pkgconfig


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
