### PR TITLE
ecl-devel: update to 20230826

### DIFF
--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -30,24 +30,30 @@ checksums           rmd160  631b9427edef67ea3cac91da2031ac4629a6dd33 \
                     sha256  b15a75dcf84b8f62e68720ccab1393f9611c078fcd3afdd639a1086cad010900 \
                     size    7875088
 
-# ECL seems doesn't support i386 and PowerPC
+# ECL-21.2.1 seems that doesn't support i386 and PowerPC
 # See: https://gitlab.com/embeddable-common-lisp/ecl/-/issues/705
-supported_archs     arm64 x86_64
+if {${name} eq ${subport}} {
+    supported_archs arm64 x86_64
+}
 
 conflicts           ecl-devel
 
 subport ecl-devel {
     PortGroup       gitlab  1.0
+    PortGroup       legacysupport 1.1
 
-    gitlab.setup    embeddable-common-lisp ecl 0e05a7f360c6ae112ff4109aaaefb2d3bcd017ab
-    version         20230807
+    gitlab.setup    embeddable-common-lisp ecl c646799145538997d84ed6d8755be7e7837eb7ef
+    version         20230826
     revision        0
 
     conflicts       ecl
 
-    checksums       rmd160  7976fc57b4efda4bef2930d098df0dd2358db6be \
-                    sha256  dca71fa9b8683315e367e5c97baaf261d61eb5cb24336f7aa6cebc95acfcecc7 \
-                    size    6746151
+    checksums       rmd160  2a34a31aeba8c90c44841039f53d1f088ed9bdc0 \
+                    sha256  a042e37ccaa383160b96da93c3f9881c4fe45c1f0f0968b021a5fe4fcf03607b \
+                    size    6564563
+
+    # requires clock_gettime()
+    legacysupport.newest_darwin_requires_legacy 15
 }
 
 extract.rename      yes

--- a/math/fricas/Portfile
+++ b/math/fricas/Portfile
@@ -98,7 +98,7 @@ variant ccl conflicts gmp sbcl ecl \
 
 variant ecl conflicts gmp sbcl ccl \
     description {Use ECL instead of SBCL as lisp implementation} {
-    depends_lib-append      port:ecl
+    depends_lib-append      path:bin/ecl:ecl
     configure.args-append   --with-lisp=ecl
 }
 

--- a/math/maxima/Portfile
+++ b/math/maxima/Portfile
@@ -107,7 +107,7 @@ variant clisp conflicts abcl ccl ecl gcl sbcl \
 
 variant ecl conflicts abcl ccl clisp gcl sbcl \
     description {Use ECL as lisp implementation} {
-    depends_lib-append      port:ecl
+    depends_lib-append      path:bin/ecl:ecl
     configure.args-append   --enable-ecl \
                             --with-ecl=${prefix}/bin/ecl
 }


### PR DESCRIPTION
#### Description

Here two changes:
 - fix build before 10.16
 - enable all archs

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
