### PR TITLE
mysql8 and mysql81: Fix zlib link in mysql_config

### DIFF
--- a/databases/mysql8/Portfile
+++ b/databases/mysql8/Portfile
@@ -15,8 +15,8 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     3
-set revision_server     1
+set revision_client     4
+set revision_server     2
 
 set name_mysql          ${name}
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
@@ -220,6 +220,10 @@ if {$subport eq $name} {
         ln -s -f ../mysql/libprotobuf-lite.3.19.4.dylib \
             ${destroot}${prefix}/lib/${name_mysql}/plugin/libprotobuf-lite.3.19.4.dylib
 
+        # Work around bad zlib linker flags in `mysql_config`.
+        # https://bugs.mysql.com/bug.php?id=111011
+        # https://trac.macports.org/ticket/68002
+        reinplace -q "s|-lzlib|-lz|g" ${destroot}${prefix}/lib/${name_mysql}/bin/mysql_config
     }
 
     post-install {

--- a/databases/mysql81/Portfile
+++ b/databases/mysql81/Portfile
@@ -15,8 +15,8 @@ maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 
 # Set revision_client and revision_server to 0 on version bump.
-set revision_client     3
-set revision_server     1
+set revision_client     4
+set revision_server     2
 
 set name_mysql          ${name}
 set version_branch      [join [lrange [split ${version} .] 0 1] .]
@@ -220,6 +220,10 @@ if {$subport eq $name} {
         ln -s -f ../mysql/libprotobuf-lite.3.19.4.dylib \
             ${destroot}${prefix}/lib/${name_mysql}/plugin/libprotobuf-lite.3.19.4.dylib
 
+        # Work around bad zlib linker flags in `mysql_config`.
+        # https://bugs.mysql.com/bug.php?id=111011
+        # https://trac.macports.org/ticket/68002
+        reinplace -q "s|-lzlib|-lz|g" ${destroot}${prefix}/lib/${name_mysql}/bin/mysql_config
     }
 
     post-install {


### PR DESCRIPTION
  Fixes a bug in mysql8 and mysql8.1 which incorrectly puts
  a link to zlib and not libz or lz in mysql_config

 See: https://bugs.mysql.com/bug.php?id=111011
 Closes: https://trac.macports.org/ticket/68002

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5 22G74 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
