### PR TITLE
redis: update to 7.2.0

### DIFF
--- a/databases/redis/Portfile
+++ b/databases/redis/Portfile
@@ -10,7 +10,7 @@ PortGroup           makefile 1.0
 legacysupport.newest_darwin_requires_legacy 15
 
 name                redis
-version             7.0.11
+version             7.2.0
 revision            0
 categories          databases
 platforms           darwin
@@ -25,9 +25,9 @@ set redis_domain    redis.io
 homepage            https://${redis_domain}
 master_sites        https://download.${redis_domain}/releases/
 
-checksums           rmd160  0b72b143c7f2ec7862bf0c04b4aed65f5760e3a1 \
-                    sha256  ce250d1fba042c613de38a15d40889b78f7cb6d5461a27e35017ba39b07221e3 \
-                    size    2988485
+checksums           rmd160  0c839d7224e3f744e02e488353e1989f582a3e17 \
+                    sha256  8b12e242647635b419a0e1833eda02b65bf64e39eb9e509d9db4888fb3124943 \
+                    size    3381269
 
 patchfiles          patch-redis.conf.diff \
                     patch-hiredis.diff


### PR DESCRIPTION
#### Description

Tested with redis cli / redis server locally.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.1 22G90 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
