### PR TITLE
qtwebkit ports: fix patch phase

### DIFF
--- a/aqua/phantomjs-qt/files/patch-qtwebkit_fix_page_shift.diff
+++ b/aqua/phantomjs-qt/files/patch-qtwebkit_fix_page_shift.diff
@@ -374,8 +374,8 @@ Index: trunk/Source/WTF/wtf/FastMalloc.cpp
      {
 +        ASSERT(kPageShift && kNumClasses && kPageSize);
 +
-         bool recordRegionsContainingPointers = m_typeMask & MALLOC_PTR_REGION_RANGE_TYPE;
-         bool recordAllocations = m_typeMask & MALLOC_PTR_IN_USE_RANGE_TYPE;
+         if (!(m_typeMask & (MALLOC_PTR_IN_USE_RANGE_TYPE | MALLOC_PTR_REGION_RANGE_TYPE))) {
+             m_coalescedSpans.clear();
 @@ -4887,4 +4937,5 @@
      int visit(void* ptr)
      {

--- a/aqua/qt511/files/patch-qtwebkit_fix_page_shift.diff
+++ b/aqua/qt511/files/patch-qtwebkit_fix_page_shift.diff
@@ -374,8 +374,8 @@ Index: trunk/Source/WTF/wtf/FastMalloc.cpp
      {
 +        ASSERT(kPageShift && kNumClasses && kPageSize);
 +
-         bool recordRegionsContainingPointers = m_typeMask & MALLOC_PTR_REGION_RANGE_TYPE;
-         bool recordAllocations = m_typeMask & MALLOC_PTR_IN_USE_RANGE_TYPE;
+         if (!(m_typeMask & (MALLOC_PTR_IN_USE_RANGE_TYPE | MALLOC_PTR_REGION_RANGE_TYPE))) {
+             m_coalescedSpans.clear();
 @@ -4887,4 +4937,5 @@
      int visit(void* ptr)
      {

--- a/aqua/qt513/files/patch-qtwebkit_fix_page_shift.diff
+++ b/aqua/qt513/files/patch-qtwebkit_fix_page_shift.diff
@@ -374,8 +374,8 @@ Index: trunk/Source/WTF/wtf/FastMalloc.cpp
      {
 +        ASSERT(kPageShift && kNumClasses && kPageSize);
 +
-         bool recordRegionsContainingPointers = m_typeMask & MALLOC_PTR_REGION_RANGE_TYPE;
-         bool recordAllocations = m_typeMask & MALLOC_PTR_IN_USE_RANGE_TYPE;
+         if (!(m_typeMask & (MALLOC_PTR_IN_USE_RANGE_TYPE | MALLOC_PTR_REGION_RANGE_TYPE))) {
+             m_coalescedSpans.clear();
 @@ -4887,4 +4937,5 @@
      int visit(void* ptr)
      {

--- a/aqua/qt55/files/patch-qtwebkit_fix_page_shift.diff
+++ b/aqua/qt55/files/patch-qtwebkit_fix_page_shift.diff
@@ -374,8 +374,8 @@ Index: trunk/Source/WTF/wtf/FastMalloc.cpp
      {
 +        ASSERT(kPageShift && kNumClasses && kPageSize);
 +
-         bool recordRegionsContainingPointers = m_typeMask & MALLOC_PTR_REGION_RANGE_TYPE;
-         bool recordAllocations = m_typeMask & MALLOC_PTR_IN_USE_RANGE_TYPE;
+         if (!(m_typeMask & (MALLOC_PTR_IN_USE_RANGE_TYPE | MALLOC_PTR_REGION_RANGE_TYPE))) {
+             m_coalescedSpans.clear();
 @@ -4887,4 +4937,5 @@
      int visit(void* ptr)
      {

--- a/aqua/qt56/files/patch-qtwebkit_fix_page_shift.diff
+++ b/aqua/qt56/files/patch-qtwebkit_fix_page_shift.diff
@@ -374,8 +374,8 @@ Index: trunk/Source/WTF/wtf/FastMalloc.cpp
      {
 +        ASSERT(kPageShift && kNumClasses && kPageSize);
 +
-         bool recordRegionsContainingPointers = m_typeMask & MALLOC_PTR_REGION_RANGE_TYPE;
-         bool recordAllocations = m_typeMask & MALLOC_PTR_IN_USE_RANGE_TYPE;
+         if (!(m_typeMask & (MALLOC_PTR_IN_USE_RANGE_TYPE | MALLOC_PTR_REGION_RANGE_TYPE))) {
+             m_coalescedSpans.clear();
 @@ -4887,4 +4937,5 @@
      int visit(void* ptr)
      {

--- a/aqua/qt57/files/patch-qtwebkit_fix_page_shift.diff
+++ b/aqua/qt57/files/patch-qtwebkit_fix_page_shift.diff
@@ -374,8 +374,8 @@ Index: trunk/Source/WTF/wtf/FastMalloc.cpp
      {
 +        ASSERT(kPageShift && kNumClasses && kPageSize);
 +
-         bool recordRegionsContainingPointers = m_typeMask & MALLOC_PTR_REGION_RANGE_TYPE;
-         bool recordAllocations = m_typeMask & MALLOC_PTR_IN_USE_RANGE_TYPE;
+         if (!(m_typeMask & (MALLOC_PTR_IN_USE_RANGE_TYPE | MALLOC_PTR_REGION_RANGE_TYPE))) {
+             m_coalescedSpans.clear();
 @@ -4887,4 +4937,5 @@
      int visit(void* ptr)
      {

--- a/aqua/qt58/files/patch-qtwebkit_fix_page_shift.diff
+++ b/aqua/qt58/files/patch-qtwebkit_fix_page_shift.diff
@@ -374,8 +374,8 @@ Index: trunk/Source/WTF/wtf/FastMalloc.cpp
      {
 +        ASSERT(kPageShift && kNumClasses && kPageSize);
 +
-         bool recordRegionsContainingPointers = m_typeMask & MALLOC_PTR_REGION_RANGE_TYPE;
-         bool recordAllocations = m_typeMask & MALLOC_PTR_IN_USE_RANGE_TYPE;
+         if (!(m_typeMask & (MALLOC_PTR_IN_USE_RANGE_TYPE | MALLOC_PTR_REGION_RANGE_TYPE))) {
+             m_coalescedSpans.clear();
 @@ -4887,4 +4937,5 @@
      int visit(void* ptr)
      {

--- a/aqua/qt59/files/patch-qtwebkit_fix_page_shift.diff
+++ b/aqua/qt59/files/patch-qtwebkit_fix_page_shift.diff
@@ -374,8 +374,8 @@ Index: trunk/Source/WTF/wtf/FastMalloc.cpp
      {
 +        ASSERT(kPageShift && kNumClasses && kPageSize);
 +
-         bool recordRegionsContainingPointers = m_typeMask & MALLOC_PTR_REGION_RANGE_TYPE;
-         bool recordAllocations = m_typeMask & MALLOC_PTR_IN_USE_RANGE_TYPE;
+         if (!(m_typeMask & (MALLOC_PTR_IN_USE_RANGE_TYPE | MALLOC_PTR_REGION_RANGE_TYPE))) {
+             m_coalescedSpans.clear();
 @@ -4887,4 +4937,5 @@
      int visit(void* ptr)
      {


### PR DESCRIPTION
[skip ci]

#### Description

There is an intermediate change to fastmalloc.cpp between qtwebkit 5.9.1 and the change in patch-qtwebkit_fix_page_shift.diff: https://github.com/WebKit/WebKit/commit/2e4db5f8633cffc9ce6124e42a81d4766acbb526. I am personally not interested in attempting to backport that change. Instead, adjust the context in the patch for `PageMapMemoryUsageRecorder::recordPendingRegions()` so that it is successfully applied on more recent macOS (whose `patch` is less willing to fuzz). Error observed by e.g. https://build.macports.org/builders/ports-13_x86_64-builder/builds/46316/steps/install-port/logs/stdio
```
--->  Applying patch-qtwebkit_fix_page_shift.diff
Executing:  cd "/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_aqua_qt513/qt513-qtwebkit/work/qtwebkit-opensource-src-5.9.1" && /usr/bin/patch -p0 < '/opt/bblocal/var/buildworker/ports/build/ports/aqua/qt513/files/patch-qtwebkit_fix_page_shift.diff'
patching file 'Source/WTF/wtf/FastMalloc.cpp'
1 out of 49 hunks failed--saving rejects to 'Source/WTF/wtf/FastMalloc.cpp.rej'
```
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Only patch phase is tested.
macOS 13.5.1
Command Line Tools 15 beta 7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
