### PR TITLE
python37: mark as EOL

### DIFF
--- a/lang/python37/Portfile
+++ b/lang/python37/Portfile
@@ -3,11 +3,14 @@
 PortSystem 1.0
 PortGroup select 1.0
 PortGroup openssl 1.0
+PortGroup deprecated 1.0
 
 name                python37
 
 # Remember to keep py37-tkinter and py37-gdbm's versions sync'd with this
 version             3.7.17
+
+deprecated.eol_version yes
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang


### PR DESCRIPTION
#### Description

The same change as done in #13680

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.1 22G90 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
