### PR TITLE
parallel-netcdf: update to 1.12.3

### DIFF
--- a/science/parallel-netcdf/Portfile
+++ b/science/parallel-netcdf/Portfile
@@ -3,9 +3,9 @@
 PortSystem              1.0
 PortGroup               mpi 1.0
 
-name                    parallel-netcdf
-version                 1.10.0
-
+name                    pnetcdf
+version                 1.12.3
+revision                0
 maintainers             {@thiagoveloso gmail.com:thiagoveloso} openmaintainer
 platforms               darwin
 categories              science devel
@@ -20,15 +20,15 @@ long_description        PnetCDF is a high-performance parallel I/O library \
                         data types and uses 64-bit integers to allow users to define \
                         large dimensions, attributes, and variables (> 2B array elements).
 
-homepage                http://cucis.ece.northwestern.edu/projects/PnetCDF
+homepage                http://parallel-netcdf.github.io/
 
-master_sites            http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/
+master_sites            https://parallel-netcdf.github.io/Release/
 
-checksums               rmd160  4de992174820518019392150d976d7f7eb81375e \
-                        sha256  ed189228b933cfeac3b7b4f8944eb00e4ff2b72cf143365b1a77890980663a09 \
-                        size    2089202
+checksums               rmd160  68beaa5d32f0da382f832d3bd7db41485a0a2352 \
+                        sha256  439e359d09bb93d0e58a6e3f928f39c2eae965b6c97f64e67cd42220d6034f77 \
+                        size    2312555
 
-mpi.setup               require -gcc7 -gfortran
+mpi.setup               require -gcc12 -gfortran
 
 #compilers.choose       fc f77 f90 cc cxx
 
@@ -38,7 +38,7 @@ depends_build-append    port:perl5 \
                         port:libtool \
                         port:m4
 
-default_variants        +gcc7 +mpich
+default_variants        +gcc12 +mpich
 
 use_parallel_build      yes
 


### PR DESCRIPTION
Also changed the name of the port to reflect changes made by the developer (otherwise the source file could not be downloaded).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS Ventura 13.5 (22G74)
Xcode 14.3.1 / Command Line Tools 14.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
