### PR TITLE
shtools: update to 4.10.4

### DIFF
--- a/science/shtools/Portfile
+++ b/science/shtools/Portfile
@@ -20,11 +20,11 @@ long_description    SHTOOLS is a library of Fortran 95 software that can be \
                     LAPACK compatible libraries.
 homepage            https://shtools.github.io/SHTOOLS/
 
-github.setup        SHTOOLS SHTOOLS 4.10.2 v
+github.setup        SHTOOLS SHTOOLS 4.10.4 v
 github.tarball_from   releases
-checksums           sha256  0caece67d65ddde19a79ec79bc6244f447f6fa878e5b2dc3f635cae2a3d1ee8c \
-                    rmd160  1b81e093d9a3c122beb63e75404a1dddcf667066 \
-                    size    41295121
+checksums           sha256  f31ab09e960d85ad23d046fa427b692ffb80915a2c96773725bb83ad90bdec20 \
+                    rmd160  5ae2a7dca10ed43362bc3aee7c0b67b89a26a1b4 \
+                    size    41551514
 
 use_configure       no
 


### PR DESCRIPTION
This is a simple bug fix for one of the fortran source files. No other changes have been.

#### Description

This is a simple bug fix for one of the fortran source files. No other changes have been made.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.4.1
Xcode x.y / Command Line Tools 14.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
