### PR TITLE
libstdcxx_clang_fix: remove platforms any

### DIFF
--- a/devel/libstdcxx_clang_fix/Portfile
+++ b/devel/libstdcxx_clang_fix/Portfile
@@ -5,13 +5,12 @@ PortGroup           stub 1.0
 
 name                libstdcxx_clang_fix
 version             0.0.1
-revision            1
+revision            2
 categories          devel
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 description         Install alternate math.h header file for use when using Clang and libstdc++.
 long_description    {*}${description}
 
-platforms           any
 supported_archs     noarch
 
 if {${os.major} < 11} {


### PR DESCRIPTION
#### Description

`platforms any` states that this port installs identical files on any platform. When the first buildbot which builds it was 10.7+, it produces an artifact which contains only README about stub port.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->