### PR TITLE
pdfjam-extras: new submission

### DIFF
--- a/textproc/pdfjam-extras/Portfile
+++ b/textproc/pdfjam-extras/Portfile
@@ -1,0 +1,53 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+# There are no tags or releases for this repository
+github.setup            rrthomas pdfjam-extras 622e03add59db004144c0b41722a09b3b29d6d3e
+
+# Reverse date of the commit
+version                 20191118
+
+categories              textproc pdf
+maintainers             {breun.nl:nils @breun} openmaintainer
+license                 GPL-2
+platforms               any
+supported_archs         noarch
+use_configure           no
+
+description             Various wrapper scripts that previously were distributed as part of the pdfjam package (prior to pdfjam 3.02)
+
+long_description \
+    These scripts are explicitly not supported. \
+    They are made available just in case someone might find them useful. \
+    These scripts are provided with absolutely no warranty of fitness for any purpose whatsoever. \
+    The wrapper scripts are:\
+    \n\
+    \n* pdfnup, pdfpun\
+    \n* pdfjoin\
+    \n* pdf90, pdf180, pdf270\
+    \n* pdfflip\
+    \n* pdfbook\
+    \n* pdfjam-pocketmod\
+    \n* pdfjam-slides3up, pdfjam-slides6up\
+    \n\
+    \nThey all are intended as example templates of scripts that end-users can make, in order to apply pdfjam conveniently on their specific tasks.
+
+checksums               rmd160  a63612bb76a9853dd747ff7b81f522a38df508eb \
+                        sha256  19b2277580735ff6ce5b9d72781cb4882f1582ce307550dde1e79b4a0e3bcfc1 \
+                        size    15463
+
+depends_run             port:pdfjam
+
+build {}
+
+destroot {
+    foreach f { pdf180 pdf270 pdf90 pdfbook pdfflip pdfjam-pocketmod pdfjam-slides3up pdfjam-slides6up pdfjoin pdfnup pdfpun } {
+        xinstall -m 755 ${worksrcpath}/bin/${f} ${destroot}${prefix}/bin/${f}
+        xinstall -m 644 ${worksrcpath}/man1/${f}.1 ${destroot}${prefix}/share/man/man1/${f}.1
+    }
+
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} COPYING README.md ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
#### Description

New port for [pdfjam-extras](https://github.com/rrthomas/pdfjam-extras), which is a collection of example scripts that was split off from the main [pdfjam](https://github.com/rrthomas/pdfjam) in version 3.02 (since https://github.com/macports/macports-ports/pull/18707).

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?