### PR TITLE
pdfjam: update to 3.07, add openmaintainer

### DIFF
--- a/textproc/pdfjam/Portfile
+++ b/textproc/pdfjam/Portfile
@@ -3,9 +3,9 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            rrthomas pdfjam 3.04 v
+github.setup            rrthomas pdfjam 3.07 v
 categories              textproc pdf
-maintainers             {gmail.com:jjstickel @jjstickel}
+maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 license                 GPL-2
 platforms               any
 supported_archs         noarch
@@ -22,9 +22,9 @@ long_description \
 
 github.tarball_from     releases
 
-checksums               rmd160  c21641ccd20efbc8d360c6858c9e9ebeec8a8c5d \
-                        sha256  15f060e63b9d12e628ae1c5662b8a662158e2fc86f24b2ee5ecd2a13bb28955d \
-                        size    123125
+checksums               rmd160  92495ccbc6b74c0d9ac7a73c1ae68821e6ca3214 \
+                        sha256  00dcd37db9a7f6246da225be31724faf3616db4f78a3dba521682d54d1e9eba5 \
+                        size    162640
 
 depends_run \
     bin:pdflatex:texlive-latex \


### PR DESCRIPTION
#### Description

* Update to pdfjam 3.07.
* Add `openmaintainer`, as intended by the maintainer @jjstickel [here](https://github.com/macports/macports-ports/pull/18707#discussion_r1307590181).

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?