### PR TITLE
ffcall: fix build on macOS 10.5

### DIFF
--- a/devel/ffcall/Portfile
+++ b/devel/ffcall/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
 name                ffcall
 version             2.4
@@ -23,6 +24,9 @@ master_sites        gnu:libffcall
 test.run            yes
 test.target         check
 
+compiler.blacklist-append \
+                    *gcc-3.* *gcc-4.*
+
 configure.checks.implicit_function_declaration.whitelist-append strchr
 
 # configure accepts --infodir, although there is no info pages (yet?).
@@ -41,6 +45,12 @@ foreach arch {arm64 x86_64 i386 ppc ppc64} {
 platform darwin 10 powerpc {
     configure.args-append \
                     --build=powerpc-apple-darwin${os.major}
+}
+
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    depends_build-append port:cctools
+    configure.env-append NM=${prefix}/bin/nm
+    configure.args-append lt_cv_path_NM=${prefix}/bin/nm
 }
 
 use_parallel_build  no


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->