### PR TITLE
clisp: fix build on old system with installed cctools

### DIFF
--- a/lang/clisp/Portfile
+++ b/lang/clisp/Portfile
@@ -68,6 +68,12 @@ configure.args      --with-libiconv-prefix=${prefix} \
                     --with-dynamic-ffi \
                     --with-module=asdf
 
+# Enforce using system ranlib, cctools' ranlib may lead to
+# ranlib: object: lisp.a(lisp.o) malformed object (LC_SEGMENT command 0 filesize field greater than vmsize field)
+# See: https://trac.macports.org/ticket/26102
+configure.args-append \
+                    RANLIB=/usr/bin/ranlib
+
 platform darwin {
     configure.args-append \
                     --disable-rpath


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/26102

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->