### PR TITLE
ecl{,-devel}: fix build on i386

### DIFF
--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -30,12 +30,6 @@ checksums           rmd160  631b9427edef67ea3cac91da2031ac4629a6dd33 \
                     sha256  b15a75dcf84b8f62e68720ccab1393f9611c078fcd3afdd639a1086cad010900 \
                     size    7875088
 
-# ECL-21.2.1 seems that doesn't support i386 and PowerPC
-# See: https://gitlab.com/embeddable-common-lisp/ecl/-/issues/705
-if {${name} eq ${subport}} {
-    supported_archs arm64 x86_64
-}
-
 conflicts           ecl-devel
 
 subport ecl-devel {
@@ -68,12 +62,14 @@ depends_lib-append  port:boehmgc \
 configure.args      --enable-boehm=system \
                     --enable-gmp=system
 
-# ecl-16.1.3 fails in (asdf:test-op :hunchentoot) with an "Illegal
-# Instruction: 4" error This error is an "internal Apple error", so we
-# blacklist the failing versions clang, in favor of gcc.
-compiler.blacklist      { clang < 300 }
-#compiler.whitelist      macports-gcc-4.9
-#compiler.whitelist       cc
+platform darwin i386 {
+    # match libatomic_ops restrictions
+    compiler.blacklist-append *gcc-3.* *gcc-4.*
+
+    # modern clang on i386 leads to memory corruption, blacklist only tested
+    # See: https://gitlab.com/embeddable-common-lisp/ecl/-/issues/705
+    compiler.blacklist-append {macports-clang-[5-7].*}
+}
 
 patchfiles          patch-macports-xdg-data-dir.diff
 


### PR DESCRIPTION
#### Description

It was tested as `port test cl-hunchentoot` with enabled support of ECL inside `common_lisp` PG for `i386`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->