### PR TITLE
auctex: update to version 13.2

### DIFF
--- a/editors/auctex/Portfile
+++ b/editors/auctex/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                auctex
-version             12.3
+version             13.2
 categories          editors print
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
 license             GPL-3+
@@ -18,11 +18,11 @@ supported_archs     noarch
 homepage            https://www.gnu.org/software/auctex/
 master_sites        gnu
 
-checksums           rmd160  7caab047d23c936fa1d95b5b66e41305e691a466 \
-                    sha256  2fd4fe30b69457c9277fe204d3e83c8472bcf500c8fe4a810d744406174ca9dd \
-                    size    1534283
+checksums           rmd160  e1733d0e247ebfec2b57278bf0b10cc77fcca98b \
+                    sha256  1e7e402abcf846694eba7719925bf095c23ef33a5e6602201c74b6ca60944035 \
+                    size    1667548
 
-depends_build-append    port:texlive-latex \
+depends_build-append    port:texlive-latex-extra \
                         port:texlive-bin-extra
 
 # We want emacs from MacPorts since this will install stuff in emacs'


### PR DESCRIPTION
* update to version 13.2
* change build dependency to texlive-latex-extra

Closes: https://trac.macports.org/ticket/67924

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
