### PR TITLE
tippecanoe: update to 2.30.1

### DIFF
--- a/gis/tippecanoe/Portfile
+++ b/gis/tippecanoe/Portfile
@@ -6,7 +6,7 @@ PortGroup               makefile 1.0
 PortGroup               legacysupport 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            felt tippecanoe 2.28.0
+github.setup            felt tippecanoe 2.30.1
 revision                0
 categories              gis
 license                 BSD
@@ -14,9 +14,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             Build vector tilesets from large collections of GeoJSON features
 long_description        {*}${description}
 
-checksums               rmd160  d252c7a7298da0e8d68998cdbd093726c2822543 \
-                        sha256  881549d3eccf15620e15f106c96559212f1d7a2831981ef14fe9dd41ea469646 \
-                        size    20284353
+checksums               rmd160  d770b1a10067d4035a231274aebcea0afdf4075e \
+                        sha256  921650b0e77b35106f5da7938b4beadd1fad180b580fe40ccd5a4c785b7993a5 \
+                        size    21052061
 
 depends_lib-append      port:sqlite3 \
                         port:zlib


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/felt/tippecanoe/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2
Xcode 13.4.1

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
