### PR TITLE
hexedit: update to 1.6

### DIFF
--- a/sysutils/hexedit/Portfile
+++ b/sysutils/hexedit/Portfile
@@ -4,12 +4,11 @@ PortSystem          1.0
 
 PortGroup           github 1.0
 
-github.setup        pixel hexedit 1.5
+github.setup        pixel hexedit 1.6
 
 revision            0
 
 categories          sysutils editors
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-2
 
@@ -23,9 +22,10 @@ long_description \
 
 homepage            http://rigaux.org/hexedit.html
 
-checksums           rmd160  6983ed6ec1a55ef12756b2320a0c03de86c0ab60 \
-                    sha256  4c368cb88d67680676eea42961e25744846b46418f65a22b4ff0a2b7c78bdd50 \
-                    size    30552
+checksums           rmd160  b1d81542acd03b50b00e9e098695a37eaee55efb \
+                    sha256  598906131934f88003a6a937fab10542686ce5f661134bc336053e978c4baae3 \
+                    size    31085
+github.tarball_from archive
 
 configure.cmd       ./autogen.sh && ./configure
 


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
