### PR TITLE
magic-wormhole: update to 0.13

### DIFF
--- a/net/magic-wormhole/Portfile
+++ b/net/magic-wormhole/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                magic-wormhole
-version             0.12.0
-revision            1
+version             0.13.0
+revision            0
 
 homepage            https://magic-wormhole.readthedocs.io
 
@@ -27,11 +27,11 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  bbb9d49f4520e5168f95b35264a4fce7ce4732a7 \
-                    sha256  1b0fd8a334da978f3dd96b620fa9b9348cabedf26a87f74baac7a37052928160 \
-                    size    262269
+checksums           rmd160  0f01edf2ff481fa9f773b7470cd7e9f115952f0f \
+                    sha256  ac3bd68286270e7f149c06149a8e409e5fa34d7feb0e88844a26d29eed2d1516 \
+                    size    274564
 
-python.default_version  310
+python.default_version  311
 
 depends_build-append port:py${python.version}-setuptools
 

--- a/python/py-autobahn/Portfile
+++ b/python/py-autobahn/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  08a87f69aad9be6fc0b216604131838cf4d44ac1 \
                     sha256  e126c1f583e872fb59e79d36977cfa1f2d0a8a79f90ae31f406faae7664b8e03 \
                     size    351296
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-cbor/Portfile
+++ b/python/py-cbor/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  27191bbc42751d6a305f8ce7f70748f7541e2e9e \
                     sha256  13225a262ddf5615cbd9fd55a76a0d53069d18b07d2e9f19c39e6acb8609bbb6 \
                     size    20096
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-cbor2/Portfile
+++ b/python/py-cbor2/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  3085abd98292c515ffb75e5ec246ba56f3f29f40 \
                     sha256  a33aa2e5534fd74401ac95686886e655e3b2ce6383b3f958199b6e70a87c94bf \
                     size    81467
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-humanize/Portfile
+++ b/python/py-humanize/Portfile
@@ -13,7 +13,7 @@ maintainers         {@xeron gmail.com:xeron.oskom} openmaintainer
 description         Python humanize utilities
 long_description    {*}${description}
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 homepage            https://pypi.python.org/pypi/${python.rootname}/
 

--- a/python/py-pyqrcode/Portfile
+++ b/python/py-pyqrcode/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  1d90520ec82a029d5ec74229d1eeed5cf8131241 \
 
 python.rootname     PyQRCode
 
-python.versions     38 39 310
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

magic-wormhole: update to 0.13

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
