### PR TITLE
tk +quartz: backport fix for crash

### DIFF
--- a/x11/tk/Portfile
+++ b/x11/tk/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.1
 
 name                tk
 version             8.6.13
-revision            1
+revision            2
 categories          x11
 license             Tcl/Tk
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -43,6 +43,9 @@ patchfiles-append   patch-dyld_fallback_library_path.diff
 
 # Fix for https://core.tcl-lang.org/tk/info/310c74ecf4
 patchfiles-append   fix-themechanged-error.patch
+
+# Fix for https://core.tcl-lang.org/tk/info/ef5d3e29a429
+patchfiles-append   fix-kvo-crash.diff
 
 # https://github.com/tcltk/tk/commit/b0cb1a48cb0c4a0118d45e8804476a6b4ab502c8
 # this is the only code that fails on OSX 10.6, so enable it for 10.7 or newer only; see also

--- a/x11/tk/files/fix-kvo-crash.diff
+++ b/x11/tk/files/fix-kvo-crash.diff
@@ -1,0 +1,83 @@
+diff --git macosx/tkMacOSXWindowEvent.c macosx/tkMacOSXWindowEvent.c
+index c0f8afc94..e261bee71 100644
+--- macosx/tkMacOSXWindowEvent.c
++++ macosx/tkMacOSXWindowEvent.c
+@@ -239,8 +239,8 @@ extern NSString *NSWindowDidOrderOffScreenNotification;
+     if (winPtr) {
+ 	TKContentView *view = [window contentView];
+ 
+-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+-	if (@available(macOS 10.15, *)) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++	if (@available(macOS 10.14, *)) {
+ 	    [view viewDidChangeEffectiveAppearance];
+ 	}
+ #endif
+@@ -1237,29 +1237,8 @@ static const char *const accentNames[] = {
+     } else if (effectiveAppearanceName == NSAppearanceNameDarkAqua) {
+ 	TkSendVirtualEvent(tkwin, "DarkAqua", NULL);
+     }
+-    if ([NSApp macOSVersion] < 101500) {
+-
+-	/*
+-	 * Mojave cannot handle the KVO shenanigans that we need for the
+-	 * highlight and accent color notifications.
+-	 */
+-
+-	return;
+-    }
+     if (!defaultColor) {
+ 	defaultColor = [NSApp macOSVersion] < 110000 ? "Blue" : "Multicolor";
+-	preferences = [[NSUserDefaults standardUserDefaults] retain];
+-
+-	/*
+-	 * AppKit calls this method when the user changes the Accent Color
+-	 * but not when the user changes the Highlight Color.  So we register
+-	 * to receive KVO notifications for Highlight Color as well.
+-	 */
+-
+-	[preferences addObserver:self
+-		      forKeyPath:@"AppleHighlightColor"
+-			 options:NSKeyValueObservingOptionNew
+-			 context:NULL];
+     }
+     NSString *accent = [preferences stringForKey:@"AppleAccentColor"];
+     NSArray *words = [[preferences stringForKey:@"AppleHighlightColor"]
+diff --git macosx/tkMacOSXWm.c macosx/tkMacOSXWm.c
+index 8b72faf16..75ebdbc1c 100644
+--- macosx/tkMacOSXWm.c
++++ macosx/tkMacOSXWm.c
+@@ -1289,6 +1289,11 @@ TkWmDeadWindow(
+ 	    [NSApp _setMainWindow:nil];
+ 	}
+ 	[deadNSWindow close];
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++	NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
++	[preferences removeObserver:deadNSWindow.contentView
++		      forKeyPath:@"AppleHighlightColor"];
++#endif
+ 	[deadNSWindow release];
+ 
+ #if DEBUG_ZOMBIES > 1
+@@ -6763,6 +6768,21 @@ TkMacOSXMakeRealWindowExist(
+     }
+     TKContentView *contentView = [[TKContentView alloc]
+ 				     initWithFrame:NSZeroRect];
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
++    NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
++
++    /*
++     * AppKit calls the viewDidChangeEffectiveAppearance method when the
++     * user changes the Accent Color but not when the user changes the
++     * Highlight Color.  So we register to receive KVO notifications for
++     * Highlight Color as well.
++     */
++
++    [preferences addObserver:contentView
++		  forKeyPath:@"AppleHighlightColor"
++		     options:NSKeyValueObservingOptionNew
++		     context:NULL];
++#endif
+     [window setContentView:contentView];
+     [contentView release];
+     [window setDelegate:NSApp];


### PR DESCRIPTION
#### Description
Fix an issue which has been reported several times mainly by Tkinter users: https://core.tcl-lang.org/tk/info/ef5d3e29a4

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8
Xcode 14.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
