### PR TITLE
libxslt: update to 1.1.38

### DIFF
--- a/textproc/libxslt/Portfile
+++ b/textproc/libxslt/Portfile
@@ -3,10 +3,10 @@
 PortSystem      1.0
 
 name            libxslt
-version         1.1.37
-checksums       rmd160  24d4fef82d38e667cd6d5b207976df17c44ccca1 \
-                sha256  3a4b27dc8027ccd6146725950336f1ec520928f320f144eb5fa7990ae6123ab4 \
-                size    1588572
+version         1.1.38
+checksums       rmd160  477c8cb70f77dbcf10c40a989d2a2c08ab5215a3 \
+                sha256  1f32450425819a09acaff2ab7a5a7f8a2ec7956e505d7beeb45e843d0e1ecab1 \
+                size    1576676
 
 set branch      [join [lrange [split ${version} .] 0 1] .]
 categories      textproc
@@ -36,7 +36,7 @@ configure.args  --without-python \
                 --disable-silent-rules
 
 if {${name} eq ${subport}} {
-    revision            2
+    revision            0
 
     depends_lib-append  path:lib/pkgconfig/icu-uc.pc:icu \
                         port:libiconv \
@@ -61,7 +61,7 @@ post-destroot {
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}
     xinstall -m 0644 -W ${worksrcpath} AUTHORS COPYING Copyright FEATURES \
-        NEWS README TODO ${destroot}${docdir}
+        NEWS README.md TODO ${destroot}${docdir}
 }
 
 variant doc description {Install extra documentation} {
@@ -77,16 +77,17 @@ variant debug description {Enable debug support} {
     livecheck.type  none
 }
 
-foreach v {27} {
-    subport py${v}-${name} "
-        set python.version $v
-        set python.branch [join [split $v ""] .]
+foreach v {2.7 3.8 3.9 3.10 3.11} {
+    set v_nodot [string map {. {}} $v]
+    subport py${v_nodot}-${name} "
+        set python.version $v_nodot
+        set python.branch $v
     "
 }
 
 if {${name} ne ${subport}} {
     epoch                   1
-    revision                1
+    revision                0
     categories-append       python
 
     description             Python bindings for libxslt
@@ -96,9 +97,12 @@ if {${name} ne ${subport}} {
                             port:python${python.version} \
                             port:py${python.version}-libxml2
 
+    set python_prefix       ${frameworks_dir}/Python.framework/Versions/${python.branch}
     configure.args-replace  --without-python --with-python
     configure.args-append   --with-python-sys-prefix
     configure.python        ${prefix}/bin/python${python.branch}
+    configure.ldflags-append \
+                            -L${python_prefix}/lib -lpython${python.branch}
 
     destroot.dir            ${worksrcpath}/python
 

--- a/textproc/libxslt/files/dynamic_lookup-11.patch
+++ b/textproc/libxslt/files/dynamic_lookup-11.patch
@@ -1,8 +1,8 @@
-Recognize macOS 11 and later, remove inaccurate comment, and simplify.
+Recognize macOS 12 and later, remove inaccurate comment, and simplify.
 https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44605
---- configure.orig	2022-08-29 09:47:40.000000000 -0500
-+++ configure	2022-09-20 02:20:18.000000000 -0500
-@@ -9571,16 +9571,11 @@
+--- configure.orig	2023-05-08 05:30:52.000000000 -0500
++++ configure	2023-09-17 01:31:54.000000000 -0500
+@@ -9573,16 +9573,11 @@
        _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
      darwin1.*)
        _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
@@ -11,14 +11,14 @@ https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44605
 -      # to the OS version, if on x86, and 10.4, the deployment
 -      # target defaults to 10.4. Don't you love it?
 -      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
--	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+-	10.0,*86*-darwin8*|10.0,*-darwin[912]*)
 -	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
 -	10.[012][,.]*)
 +    darwin*)
 +      case ${MACOSX_DEPLOYMENT_TARGET},$host in
-+	10.[012],*|,*powerpc*)
++	10.[012],*|,*powerpc*-darwin[5-8]*)
  	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
--	10.*)
+-	10.*|11.*)
 +	*)
  	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
        esac


### PR DESCRIPTION
#### Description

I got the Python library building under both python 2.7 and python 3.x.  Although I didn't have a way to test the Python functionality I was able to import the libraries fine which is promising.

I am closing the ticket about compile-time flags as the last comment says `-flto=thin` is not needed, but I did test the build out with it and it works fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.1 22G90 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
