### PR TITLE
py-Pillow: remove py35 subport

### DIFF
--- a/python/py-Pillow/Portfile
+++ b/python/py-Pillow/Portfile
@@ -9,7 +9,7 @@ revision            0
 categories-append   devel
 license             BSD
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 36 37 38 39 310 311
 python.pep517       no
 
 maintainers         {stromnov @stromnov} openmaintainer
@@ -26,9 +26,6 @@ checksums           rmd160  15a9b4178db7e5995d94650021cdc58631a15226 \
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {
         conflicts   py${python.version}-pil
-    }
-
-    if {${python.version} < 36} {
         version             6.2.2
         revision            0
         checksums           md5 46cad14f0044a5ac4b2d801271528893 \


### PR DESCRIPTION
Appears to have no remaining dependents.
