### PR TITLE
glslang: use `legacysupport.use_mp_libcxx` on Mojave and older to support `<filesystem>`

### DIFF
--- a/graphics/glslang/Portfile
+++ b/graphics/glslang/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.1
 
 github.setup        KhronosGroup glslang 13.0.0
-revision            0
+revision            1
 
 categories          graphics devel
 license             {BSD Permissive}
@@ -26,8 +26,15 @@ set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 compiler.cxx_standard 2017
 
-# Apple Clang doesn't support C++17 on macOS 10.9 Mavericks and older
-legacysupport.newest_darwin_requires_legacy 13
+# Need to use MacPorts libc++ on macOS 10.14 Mojave and older, because
+# Apple Clang only added support for the C++17 <filesystem> library
+# starting in Xcode 11 (clang-1100) for macOS 10.15+.
+# 
+# References:
+# * https://stackoverflow.com/a/55353263
+# * https://developer.apple.com/documentation/xcode-release-notes/xcode-11-release-notes
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx yes
 
 depends_build-append    port:python${py_ver_nodot}
 configure.python        ${prefix}/bin/python${py_ver}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Implement same fix as done in #19033 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
