### PR TITLE
openjdk17-temurin: update to 17.0.8.1

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -14,9 +14,9 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.8
-set build    7
-revision     1
+version      17.0.8.1
+set build    1
+revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
@@ -25,27 +25,17 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  e7cfa2f945690941d5793bf82734a57bbcb77641 \
-                 sha256  6fea89cea64a0f56ecb9e5d746b4921d2b0a80aa65c92b265ee9db52b44f4d93 \
-                 size    187621534
+    checksums    rmd160  157a217fa0c676f7f0feab64f29027b9f4305499 \
+                 sha256  18be56732c1692ef131625d814dcb02ee091a43fdd6f214a33d87cc14842fc3f \
+                 size    187618128
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  1306c8a15d284bdc4df4109d0b0c5b7db9c98ceb \
-                 sha256  105d1ada42927fccde215e8c80b43221cd5aad42e6183819c367234ac062fc10 \
-                 size    177734031
+    checksums    rmd160  5c46b4f219da55ab60e8f7fb91b7d7bf67c47d24 \
+                 sha256  2e95eed48650f00650e963c8213b6c6ecda54458edf8d254ebc99d6a6966ffad \
+                 size    177735753
 }
 
 worksrcdir   jdk-${version}+${build}
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 16} {
-    # See https://adoptium.net/supported_platforms.html
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
-        return -code error
-    }
-}
 
 homepage     https://adoptium.net
 


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.8.1.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?