### PR TITLE
openjdk17-microsoft: update to 17.0.8.1

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -14,9 +14,9 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      17.0.8
-set build    7
-revision     1
+version      17.0.8.1
+set build    1
+revision     0
 
 description  Microsoft Build of OpenJDK 17 (Long Term Support)
 long_description The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's open source \
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  ea9ff26770a5b4e01b50c09ec795393c3bb19492 \
-                 sha256  88e74d5011a36bc7120e66d05ef66deb5c439125b80e830f7ae073897a43bd65 \
-                 size    188014149
+    checksums    rmd160  eb353efe0e7471734553ee5fa7a650761c681d83 \
+                 sha256  e67ed748b9ef6d4557da24beefe9d9ec193e9d9f843be5ff6559a275e0d230b6 \
+                 size    188011209
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  b74b21917a5e493c44552e8b543d3184de39dffc \
-                 sha256  4bbdb18be7af5f2af8fcb782e6372ac32d854d5672006ebcc623f544298646c0 \
-                 size    178140995
+    checksums    rmd160  9bdfe98e710d86404718d3d330fe2bd42c5040e9 \
+                 sha256  8acda4fa59946902180a9283ee191b3db19b8c1146fb8dfa209d316ec78f9a5f \
+                 size    178140824
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.8.1.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?