### PR TITLE
openjdk11-temurin: update to 11.0.20.1

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -14,9 +14,9 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      11.0.20
-set build    8
-revision     1
+version      11.0.20.1
+set build    1
+revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
 long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
@@ -25,27 +25,17 @@ master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  a2bff63b08473ac166dcc20123817539c9c25a35 \
-                 sha256  3d9c47a20a8ba7b5aeb2354460adeb018af02f20553c0c3c7b733c1fc9aaf03a \
-                 size    186900244
+    checksums    rmd160  cd84caf900e3c2b39c6eba9d3406ef7a88b2da54 \
+                 sha256  42fd1373ee3f7c24f13551be20c8a5ae7ade778f83c45476ea333b2e3e025267 \
+                 size    186910284
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  186a92cb2eefb414599c66d49d62554a6079b205 \
-                 sha256  46bccb356dba38bf463ea2cc5a8d27ed4e5a51680a7a932f78d5e0c4f8af7c54 \
-                 size    185632863
+    checksums    rmd160  59654c32b5a21481dea81298abc2717eeb23a663 \
+                 sha256  d36abd2f8a8cd2c73a7893306d65a5ae03eaa73565c1fc197a69d1d6fb02405e \
+                 size    185621787
 }
 
 worksrcdir   jdk-${version}+${build}
-
-# https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-if {${os.platform} eq "darwin" && ${os.major} < 16} {
-    # See https://adoptium.net/supported_platforms.html
-    known_fail yes
-    pre-fetch {
-        ui_error "${name} ${version} is only supported on macOS 10.12 Sierra or later."
-        return -code error
-    }
-}
 
 homepage     https://adoptium.net
 


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.20.1.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?