### PR TITLE
openjdk11-microsoft: update to 11.0.20.1

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -14,9 +14,9 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      11.0.20
-set build    8
-revision     1
+version      11.0.20.1
+set build    1
+revision     0
 
 description  Microsoft Build of OpenJDK 11 (Long Term Support)
 long_description The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's open source \
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  cc737933af49e6474296615d03cc27707e923c66 \
-                 sha256  70f52a819119f97c54e825f56f75d813e60088816f684bc59e06608783eb0a78 \
-                 size    187730360
+    checksums    rmd160  1beb37e09fd650036b1e136111c6164d8515a17f \
+                 sha256  023ddec42f85db9c26a80ad1e5b2f8081796f46437fba7e8f6282c3b47c73c28 \
+                 size    187733259
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  fbf166d6a7b5571b36ecef54ae83aba28b93b561 \
-                 sha256  7ec3a5a77a73fb076adbb369a967e53716b250da611bd0c45b5760111e6ee902 \
-                 size    185287208
+    checksums    rmd160  595a6b46a200e5d20eeb3ad4c2956432a7c7e5fa \
+                 sha256  e9773c9dfd72b62924aff4f1dbe8602d5889d02ad0d9aaf4f7e1e2cb0196bd75 \
+                 size    185294857
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.20.1.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?