### PR TITLE
spirv-tools: update comment

### DIFF
--- a/graphics/spirv-tools/Portfile
+++ b/graphics/spirv-tools/Portfile
@@ -53,10 +53,9 @@ checksums           SPIRV-Tools-1.3.261.0.tar.gz \
                     size    456630
 
 compiler.cxx_standard 2017
-# Need to use MacPorts libc++ (and MacPorts Clang) on macOS 10.14 Mojave
-# and older, because Apple Clang only added support for the
-# C++17 <filesystem> library starting in Xcode 11 (clang-1100) for
-# macOS 10.15+.
+# Need to use MacPorts libc++ on macOS 10.14 Mojave and older, because
+# Apple Clang only added support for the C++17 <filesystem> library
+# starting in Xcode 11 (clang-1100) for macOS 10.15+.
 #
 # References:
 # * https://stackoverflow.com/a/55353263


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Revbump not needed because PR only changes a comment.

While it's true that we need to use libc++ from legacysupport in order to get access to `<filesystem>` on Mojave and older, it's not necessarily true that we need to compile using MacPorts Clang. Xcode Clang + `legacysupport.use_mp_libcxx` on Mojave compiles just fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
