### PR TITLE
sbcl: add devel subport

### DIFF
--- a/_resources/port1.0/group/common_lisp-1.0.tcl
+++ b/_resources/port1.0/group/common_lisp-1.0.tcl
@@ -70,8 +70,12 @@ proc common_lisp::add_dependencies {} {
     global common_lisp.ccl
 
     if {[option common_lisp.sbcl]} {
-        depends_build-delete    port:sbcl
-        depends_build-append    port:sbcl
+        depends_build-delete    port:sbcl \
+                                port:sbcl-devel \
+                                path:bin/sbcl:sbcl \
+                                path:bin/sbcl:sbcl-devel
+
+        depends_build-append    path:bin/sbcl:sbcl
     }
 
     if {[option common_lisp.ecl]} {

--- a/lang/QiII/Portfile
+++ b/lang/QiII/Portfile
@@ -34,7 +34,7 @@ supported_archs   noarch
 
 checksums         md5 3a0b5c56d0f107f80f5bca11b82a4d59
 
-depends_build     port:sbcl
+depends_build     path:bin/sbcl:sbcl
 
 set qiii_dir        ${prefix}/share/${name}
 

--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -30,9 +30,6 @@ long_description \
 
 
 homepage        http://www.sbcl.org
-master_sites    sourceforge
-
-use_bzip2       yes
 
 # https://bugs.launchpad.net/sbcl/+bug/2033284
 patchfiles      0001-fix-building-when-root-directory-contain-non-ASCII-c.patch \
@@ -47,7 +44,7 @@ checksums       rmd160  03daa7508f3e99af0515b748ee644ef47000a0af \
 # such platforms, we have a different epoch and versioning.
 #
 # Please do not update it without testing.
-if {${os.platform} eq "darwin" && ${configure.build_arch} in [list ppc i386]} {
+if {${os.platform} eq "darwin" && ${configure.build_arch} in [list ppc i386] && ${name} eq ${subport}} {
     version     2.3.8
     revision    0
     epoch       [ expr ${epoch} + 1 ]
@@ -80,16 +77,46 @@ if {${os.platform} eq "darwin" && ${configure.build_arch} in [list ppc i386]} {
                 1020-ppc-Darwin-fix-build-on-32-bit-systems.patch
 }
 
-distfiles       ${name}-${version}-source${extract.suffix}
-worksrcdir      ${name}-${version}
+if {${name} eq ${subport}} {
+    master_sites \
+                sourceforge
+
+    use_bzip2   yes
+
+    distfiles   ${name}-${version}-source${extract.suffix}
+    worksrcdir  ${name}-${version}
+}
+
+conflicts       sbcl-devel
+
+subport sbcl-devel {
+    PortGroup   github  1.0
+
+    github.setup \
+                sbcl sbcl 30d8e41b80e0d7be41c46c42ae036ae8ac814461
+    version     20230831
+    revision    0
+
+    conflicts   sbcl
+
+    checksums   rmd160  6d6bb85f304c9b817b5b77512bbc7c2aedc6f25f \
+                sha256  2d3d32a92a8644498fb766ab31a36e256aba614c58f1469dbe700a3ea8d0aef4 \
+                size    9648041
+
+    pre-build {
+        system -W ${worksrcpath} "echo '\"${version}\"' > version.lisp-expr"
+    }
+}
 
 depends_build-append \
                 port:sbcl-bootstrap
 depends_skip_archcheck-append \
                 sbcl-bootstrap
 
-# clock_gettime
-legacysupport.newest_darwin_requires_legacy 15
+if {${name} eq ${subport}} {
+    # clock_gettime
+    legacysupport.newest_darwin_requires_legacy 15
+}
 
 # Uses: __attribute__((aligned(8)))
 # See: https://bugs.launchpad.net/sbcl/+bug/1991485

--- a/lang/slime/Portfile
+++ b/lang/slime/Portfile
@@ -51,7 +51,7 @@ variant app description "Build SLIME against editors/emacs-app" {
 }
 
 variant sbcl description "Require lang/sbcl for SLIME" {
-    depends_run-append port:sbcl
+    depends_run-append path:bin/sbcl:sbcl
 }
 
 variant clisp description "Require lang/clisp for SLIME" {

--- a/math/acl2/Portfile
+++ b/math/acl2/Portfile
@@ -51,7 +51,7 @@ distname            ${name}-${version}
 
 use_configure           no
 
-depends_lib             port:sbcl
+depends_lib             path:bin/sbcl:sbcl
 
 set heap_image          "saved_acl2.core"
 set heap_image_nonstd   "saved_acl2r.core"
@@ -108,7 +108,7 @@ platform darwin powerpc {
 variant emacs description {Include support for using acl2 under emacs} { }
 
 variant ccl description {Use ccl as the underlying lisp} {
-    depends_lib-delete    port:sbcl
+    depends_lib-delete    path:bin/sbcl:sbcl
     depends_lib-append    port:ccl
 
     global heap_image

--- a/math/fricas/Portfile
+++ b/math/fricas/Portfile
@@ -80,7 +80,7 @@ variant hunchentoot description {Include Hunchentoot into fricas} {
 
 variant sbcl conflicts ccl ecl \
     description {Use SBCL as lisp implementation} {
-    depends_lib-append      port:sbcl
+    depends_lib-append      path:bin/sbcl:sbcl
     configure.args-append   --with-lisp='${sbcl_script}'
 }
 

--- a/math/maxima/Portfile
+++ b/math/maxima/Portfile
@@ -123,7 +123,7 @@ variant gcl conflicts abcl ccl clisp ecl sbcl \
 
 variant sbcl conflicts abcl ccl clisp ecl gcl \
     description {Use SBCL as lisp implementation} {
-    depends_lib-append      port:sbcl
+    depends_lib-append      path:bin/sbcl:sbcl
     configure.args-append   --enable-sbcl \
                             --enable-sbcl-exec \
                             --with-sbcl=${prefix}/bin/sbcl

--- a/www/nyxt/Portfile
+++ b/www/nyxt/Portfile
@@ -23,8 +23,8 @@ long_description        {*}${description}
 patchfiles-append       macos-compatibility.diff
 
 # it is complied only by SBCL and uses nasdf
-depends_build-append    port:cl-nasdf \
-                        port:sbcl
+depends_build-append    path:bin/sbcl:sbcl \
+                        port:cl-nasdf
 
 # we're managing dependencies via MacPorts
 build.env-append        NYXT_SUBMODULES=false


### PR DESCRIPTION
#### Description

Recover support of x86 and PPC were merged into sbcl mainstream and I introduced `sbcl-devel` subport which can be updated more often than normal `sbcl` which allows us to catch broken support at some point.

Thus, as some nice bonus as one the merged patches was remove requirement of legacy support.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->