### PR TITLE
py-*: remove old subports without dependencies

### DIFF
--- a/python/py-about-time/Portfile
+++ b/python/py-about-time/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  c7e8941d0d92ee11976753dba045dd4df6abf065 \
                     sha256  6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
                     size    15380
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-acoustid/Portfile
+++ b/python/py-acoustid/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  eab4ff70a8681b538625e4de65f845b26664e270 \
                     sha256  c279d9c30a7f481f1420fc37db65833b5f9816cd364dc2acaa93a11c482d4141 \
                     size    15869
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-alive-progress/Portfile
+++ b/python/py-alive-progress/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  512cb394ec62f1c892b64422edcfbcf8be7d3ee9 \
                     sha256  74a95d8d0d42bc99d3a3725dbd06ebb852245f1b64e301a7c375b92b22663f7b \
                     size    110126
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-anytree/Portfile
+++ b/python/py-anytree/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  7c606b5c4fa6c6903ef85f9b017c597c0d65569f \
                     sha256  06f7bc294293da2755f4699cc5da5c92d9182a5cfae2842c83fb56f02bd427c8 \
                     size    29226
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 python.pep517           yes
 python.pep517_backend   poetry

--- a/python/py-aubio/Portfile
+++ b/python/py-aubio/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  27d2b00ff798c284e7b071edd560e520bbf525bc \
                     sha256  df1244f6c4cf5bea382c8c2d35aa43bc31f4cf631fe325ae3992c219546a4202 \
                     size    479008
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-audioread/Portfile
+++ b/python/py-audioread/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  8ff9c35549428512e3574d678e7aef33a2c66047 \
                     sha256  df38a52b2f06d2b2fb3f250bd2578a953240ff47238f849568bc2ba91f37eb91 \
                     size    111995
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-bottlenose/Portfile
+++ b/python/py-bottlenose/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  a63666b30af5051546576052616836e4a0b9e9ee \
                     sha256  a4e356eac8c7998091f82f70c30239a99de83729b199e4e053ce3c9acb592df3 \
                     size    116538
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-confuse/Portfile
+++ b/python/py-confuse/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  8e84892813d70dc267984afbf72547d1718a59b2 \
                     sha256  7379a2ad49aaa862b79600cc070260c1b7974d349f4fa5e01f9afa6c4dd0611f \
                     size    50872
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 python.pep517       yes
 python.pep517_backend \

--- a/python/py-discogs-client/Portfile
+++ b/python/py-discogs-client/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  d8c0697bb283dcd48a0cb010b067e967e4ab2d0f \
                     sha256  25949b9dc6130985d8e0199e4c950351e364e273f9476546bd9e171802e007a1 \
                     size    36551
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-grapheme/Portfile
+++ b/python/py-grapheme/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  1997cabe5c3b15bd1b3699c521e158528d1fad7b \
                     sha256  44c2b9f21bbe77cfb05835fec230bd435954275267fea1858013b102f8603cca \
                     size    207306
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ibroadcast/Portfile
+++ b/python/py-ibroadcast/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  f05caa256b32d8b6e9e597a908392654ce86145b \
                     sha256  70670e113ffcdf439e9b0dc961c0d1c5b01875b52128d4e836826a78265f3b87 \
                     size    11759
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ifaddr/Portfile
+++ b/python/py-ifaddr/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  a7d6fa7f48edb1ef317503a5cfa3e1c0ec65857e \
                     sha256  cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4 \
                     size    10485
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-imaplib2/Portfile
+++ b/python/py-imaplib2/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  2e8e893f8145f9a613c1d36c07007edec470132b \
                     sha256  96cb485b31868a242cb98d5c5dc67b39b22a6359f30316de536060488e581e5b \
                     size    26252
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ipdb/Portfile
+++ b/python/py-ipdb/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  ea110bf740e026b06fe58e814b6d77268dd28d77 \
                     sha256  9d21dd5d0ccc7c4538f71f704e8b5ae136c2da79913332eb323c5997e00fd48d \
                     size    13456
 
-python.versions     27 37 38 39 310 311
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-itsdangerous/Portfile
+++ b/python/py-itsdangerous/Portfile
@@ -12,7 +12,7 @@ checksums           rmd160  9cb8e57e022a081bd7fb4d43848bcc99b89818b1 \
                     sha256  5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a \
                     size    56143
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 37 38 39 310 311
 license             BSD
 platforms           {darwin any}
 supported_archs     noarch

--- a/python/py-jfricas/Portfile
+++ b/python/py-jfricas/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  3377e595c0dc865026e93075937422df16ba74a0 \
                     sha256  da8abc50728faf57ce78fcae34a1fb9765719a497a5a7f3deab3c1307d24fbe5 \
                     size    12451
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     PortGroup       active_variants 1.1

--- a/python/py-jsonpath-rw/Portfile
+++ b/python/py-jsonpath-rw/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  a7071db0a51a94e97868c03d50098ae022022a41 \
                     sha256  05c471281c45ae113f6103d1268ec7a4831a2e96aa80de45edc89b11fac4fbec \
                     size    13814
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-mechanicalsoup/Portfile
+++ b/python/py-mechanicalsoup/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  cae4b2ca21b72318b9bf28ae43f7d660e801ae4d \
                     sha256  38e8748f62fd9455a0818701a9e2dbfa549639d09f829f3fdd03665c825e7ce1 \
                     size    50826
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-mediafile/Portfile
+++ b/python/py-mediafile/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  1f2d76c352617697876c9f854e9c521dea295a6a \
 python.pep517           yes
 python.pep517_backend   flit
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-mpd2/Portfile
+++ b/python/py-mpd2/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  68c5f82df8dc02ec11a221ec0f0259b2dd60e361 \
                     sha256  f33c2cdb0d6baa74a36724f38c1c4a099a7ce2c8ec4a2bb7192150a5855df476 \
                     size    58269
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 python.test_framework   unittest
 

--- a/python/py-munkres/Portfile
+++ b/python/py-munkres/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  d91c3ef91bb5e023b0cdd4716cbf9fe75821b2f2 \
                     sha256  fc44bf3c3979dada4b6b633ddeeb8ffbe8388ee9409e4d4e8310c2da1792db03 \
                     size    14047
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-musicbrainzngs/Portfile
+++ b/python/py-musicbrainzngs/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  81735f581536f9b6ffaa5606b53732d29c7cc24e \
                     sha256  ab1c0100fd0b305852e65f2ed4113c6de12e68afd55186987b8ed97e0f98e627 \
                     size    117469
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ordered-set/Portfile
+++ b/python/py-ordered-set/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  a896f25617cd237391e0987b0bccf2f155e2b072 \
                     sha256  694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8 \
                     size    12826
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pathvalidate/Portfile
+++ b/python/py-pathvalidate/Portfile
@@ -23,4 +23,4 @@ checksums           rmd160  7e1ea60b524ae074e0719942fbffba8a0e9afa16 \
                     size    28762
 
 python.pep517       yes
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311

--- a/python/py-pycryptodome/Portfile
+++ b/python/py-pycryptodome/Portfile
@@ -21,7 +21,7 @@ long_description    PyCryptodome is a self-contained Python package of \
                     low-level cryptographic primitives. \
                     PyCryptodome is a fork of PyCrypto.
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 37 38 39 310 311
 
 checksums           rmd160  71faf56f508a7191259fe6b7683955882b70bb19 \
                     sha256  c9adee653fc882d98956e33ca2c1fb582e23a8af7ac82fee75bd6113c55a0413 \

--- a/python/py-pytest-fixture-config/Portfile
+++ b/python/py-pytest-fixture-config/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  e64e907c7751d57e624d8d4f98dd35884f9a8b43 \
                     sha256  41a17417721f6862ce6b40e3280fddd8e1659b2c306ec46b237d7021fec5218e \
                     size    9884
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pytest-random-order/Portfile
+++ b/python/py-pytest-random-order/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  e172ba5e19b31f3f3fbcec7880b1437d335e1fbf \
                     sha256  dbe6debb9353a7af984cc9eddbeb3577dd4dbbcc1529a79e3d21f68ed9b45605 \
                     size    14576
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pytest-shutil/Portfile
+++ b/python/py-pytest-shutil/Portfile
@@ -27,7 +27,7 @@ checksums           rmd160  869b11f66cfd12c0ee18afee4b825a8a35361a4f \
                     sha256  d8165261de76e7508505c341d94c02b113dc963f274543abca74dbfabd021261 \
                     size    23497
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pytest-virtualenv/Portfile
+++ b/python/py-pytest-virtualenv/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  cb64069d33b247d2a7c67abc5a14dc1f6e4f1b71 \
                     sha256  2270ee8822111ec25db48e9d9f2efec32e68483a015b14cd0d92aeccc6ff820f \
                     size    15767
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-rarfile/Portfile
+++ b/python/py-rarfile/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  2be283cfabc9c6dc57735f773c858dbe2fd01e32 \
                     sha256  67548769229c5bda0827c1663dce3f54644f9dbfba4ae86d4da2b2afd3e602a1 \
                     size    148026
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-reflink/Portfile
+++ b/python/py-reflink/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  34d89acceac5cd1f6fbae6a4dd0ecb5f0b661d50 \
                     sha256  882375ee7319275ae5f6a6a1287406365dac1e9643b91ad10e5187d3f84253bd \
                     size    21956
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-soco/Portfile
+++ b/python/py-soco/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  bddc1487e2983c5c4b420eea757627bec5eabd45 \
                     sha256  6f164ab8c282d5d2e4cc382d55b7e7c1bb45f400d7e784f64b50f97a6c9f7363 \
                     size    729825
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-termplotlib/Portfile
+++ b/python/py-termplotlib/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  003e6303c82d8e68dfa7363c1bc99b4717c1d0e3 \
                     sha256  c04cbd67ac61753eac9162a99cbe87c379d4c5daf720af1df55f4423c094203e \
                     size    24517
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 python.pep517       yes
 

--- a/python/py-termtables/Portfile
+++ b/python/py-termtables/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  231b9706fe44b08d097e4bdb69cf3c534dc266c1 \
                     sha256  797c6afeb78abdab97cd5bfbbd2fc1bfbd9630052699dc881b27b334bcc6a73f \
                     size    17745
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 python.pep517       yes
 

--- a/python/py-validictory/Portfile
+++ b/python/py-validictory/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  c6146e11d2230f61a91fb42bab2a387cac621085 \
                     sha256  3a87b84658592f75f37d6bab77ac223774c9989dc7349c8aad19a424770835ba \
                     size    18162
 
-python.versions     37 38 39
+python.versions     38 39
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-zbar/Portfile
+++ b/python/py-zbar/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  abc63b3ca7899b011e12d69d2a7d46e3623ea827 \
                     sha256  439a5a1eb0ad5f12b96aeb275d7594a68915857a8690d124e190499a451b24b3 \
                     size    45784
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Goal is cleaning up unused py27...py37 ports.

How? I've run the script:
```
port echo maintainer:catap | grep '^py[23][0-7]-' | while read port
do
    if [[ -z $(port echo depends:$port) ]]; then
        echo $port
    fi
done
```
and removes all subport which it find. And repeat it a few times, until it returned an empty string.

Here I've touched only ports where I'm a (co)maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->