### PR TITLE
skaffold: update to 2.7.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.6.3 v
+github.setup        GoogleContainerTools skaffold 2.7.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  458172cab65803ff9871dc01938a9edebd0211ad \
-                    sha256  40f5754ce24707714ca181673d56f99b7747840f5144d9c8ecc862c8af2038dd \
-                    size    60017371
+checksums           rmd160  6bfb429d176064c055ab9b5b5ccb6d8ab611b40b \
+                    sha256  e276a51f8d0017100dd178f9327556d5442b0a64ea68f97b4d90526b77a4e963 \
+                    size    60089412
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.7.0.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?