### PR TITLE
git-credential-gopass: update to 1.15.7

### DIFF
--- a/security/git-credential-gopass/Portfile
+++ b/security/git-credential-gopass/Portfile
@@ -3,22 +3,23 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gopasspw/git-credential-gopass 1.15.5 v
+go.setup            github.com/gopasspw/git-credential-gopass 1.15.7 v
+go.offline_build    no
 github.tarball_from archive
 revision            0
+
 categories          security
-maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+installs_libs       no
 license             MIT
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 
 description         Gopass git-credentials helper
 long_description    {*}${description}
 homepage            https://www.gopass.pw
 
-checksums           rmd160  eee1cdb183fef8ddb7833eab58627fa70318fe45 \
-                    sha256  58980709c0323acc1297d0a9c81c120b357c5b93cc86214fac99db417298e722 \
-                    size    23210
-
-go.offline_build no
+checksums           rmd160  cbaa527f5a0b303e6b7849083b03cff2fbc97aca \
+                    sha256  ac561ca0b726adeed6f69a4c2bedf4c9c1b8e9ba389eaa3335c6d7277586bcb1 \
+                    size    23973
 
 build.args          -ldflags '-X main.version=${version}'
 


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
