### PR TITLE
KeePassXC: update to 2.7.6

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -32,7 +32,7 @@ license_noconflict      openssl openssl10 openssl11 openssl3
 
 if {${subport} eq ${name}} {
     # stable
-    github.setup        keepassxreboot keepassxc 2.7.5
+    github.setup        keepassxreboot keepassxc 2.7.6
     revision            0
     github.tarball_from releases
     distname            keepassxc-${version}-src
@@ -44,12 +44,12 @@ if {${subport} eq ${name}} {
 
     # See keepassxc-${version}-src.tar.xz.DIGEST on upstream GitHub releases page for SHA256 sums
     checksums           ${distname}${extract.suffix} \
-                        rmd160  aa94b41f8052ee7d587f3990a62495c035b03b75 \
-                        sha256  ede24800901816c49569aa4f8bc7180a40cb8b554617fa2a2a2653caac13000c \
-                        size    8706996 \
+                        rmd160  a939976cff7273f9243f9c3aae39269e11047e6d \
+                        sha256  a58074509fa8e90f152c6247f73e75e126303081f55eedb4ea0cbb6fa980d670 \
+                        size    8474624 \
                         ${distname}${extract.suffix}.sig \
-                        rmd160  636e500b23a5eb2411279754dc8fbbe52bcc2ba5 \
-                        sha256  76440a2b0049a71dbb7bc67330cd8e410e3ca0f9dafd7069140e93c30f7184f7 \
+                        rmd160  693cbc4a5648735cd4a53afdb9617bca9702bf45 \
+                        sha256  af439d1954101c1b140f759cf0f42efdfe19d066f90412e325b806f8d3774eb4 \
                         size    488
 
     gpg_verify.use_gpg_verification \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68003

#### Description
I don't really know what I'm doing. I just tried to follow https://trac.macports.org/wiki/howto/Upgrade.
Haven't checked any of the patch files. 
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files? 
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
