### PR TITLE
edid-decode: update to 20230831

### DIFF
--- a/sysutils/edid-decode/Portfile
+++ b/sysutils/edid-decode/Portfile
@@ -1,19 +1,21 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-PortSystem              1.0
-PortGroup               makefile 1.0
 
-name                    edid-decode
-version                 20230804
-categories              sysutils
-maintainers             @wwalexander openmaintainer
-license                 MIT
-description             Decode EDID data in human-readable format
-long_description        edid-decode decodes EDID monitor description data in human-readable format
-set domain              linuxtv.org
-homepage                https://git.${domain}/${name}.git
-fetch.type              git
-git.url                 git://${domain}/${name}.git
-git.branch              5f72326
+PortSystem          1.0
+PortGroup           makefile 1.0
 
-destroot.args-append    bindir=${prefix}/bin \
-                        mandir=${prefix}/share/man
+name                edid-decode
+version             20230804
+categories          sysutils
+maintainers         @wwalexander openmaintainer
+license             MIT
+description         Decode EDID data in human-readable format
+long_description    edid-decode decodes EDID monitor description data in human-readable format
+set domain          linuxtv.org
+homepage            https://git.${domain}/${name}.git
+fetch.type          git
+git.url             git://${domain}/${name}.git
+git.branch          5f72326
+
+destroot.args-append \
+                    bindir=${prefix}/bin \
+                    mandir=${prefix}/share/man

--- a/sysutils/edid-decode/Portfile
+++ b/sysutils/edid-decode/Portfile
@@ -16,6 +16,14 @@ fetch.type          git
 git.url             git://${domain}/${name}.git
 git.branch          5f72326
 
+patchfiles          cxxflags-fix.diff
+
 destroot.args-append \
                     bindir=${prefix}/bin \
                     mandir=${prefix}/share/man
+
+compiler.cxx_standard \
+                    2011
+
+configure.cxxflags-append \
+                    -std=c++11

--- a/sysutils/edid-decode/Portfile
+++ b/sysutils/edid-decode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                edid-decode
-version             20230804
+version             20230831
 categories          sysutils
 maintainers         @wwalexander openmaintainer
 license             MIT
@@ -14,7 +14,7 @@ set domain          linuxtv.org
 homepage            https://git.${domain}/${name}.git
 fetch.type          git
 git.url             git://${domain}/${name}.git
-git.branch          5f72326
+git.branch          e59b8a2
 
 patchfiles          cxxflags-fix.diff
 

--- a/sysutils/edid-decode/files/cxxflags-fix.diff
+++ b/sysutils/edid-decode/files/cxxflags-fix.diff
@@ -1,0 +1,15 @@
+--- Makefile.orig	2023-09-08 16:00:46
++++ Makefile	2023-09-08 16:01:01
+@@ -34,10 +34,10 @@
+ 	$(EMXX) $(LDFLAGS) -s EXPORTED_FUNCTIONS='["_parse_edid"]' -s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -o $@ $(EMOBJECTS) -lm
+ 
+ %.o: %.cpp edid-decode.h oui.h Makefile
+-	$(CXX) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(WARN_FLAGS) -g $(sha) $(date) -o $@ -c $<
++	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(WARN_FLAGS) -g $(sha) $(date) -o $@ -c $<
+ 
+ emscripten/%.o: %.cpp edid-decode.h oui.h Makefile
+-	$(EMXX) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(WARN_FLAGS) $(sha) $(date) -o $@ -c $<
++	$(EMXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(WARN_FLAGS) $(sha) $(date) -o $@ -c $<
+ 
+ clean:
+ 	rm -f *.o emscripten/*.o


### PR DESCRIPTION
Also, add configure and compiler options to specify C++11 on older systems as detailed in https://trac.macports.org/ticket/67934

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?