### PR TITLE
py-openstackclient: update to 6.2.0; bump dependencies

### DIFF
--- a/python/py-cinderclient/Portfile
+++ b/python/py-cinderclient/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-cinderclient
 python.rootname     python-cinderclient
-version             7.1.0
+version             9.3.0
 revision            0
 
 categories-append   net
@@ -22,9 +22,9 @@ long_description    Client for the OpenStack Volume API. There’s a \
 
 homepage            https://docs.openstack.org/python-cinderclient/latest/
 
-checksums           rmd160  9706fd47624c8490cfbbcc8620a4fe986ecb79b0 \
-                    sha256  625d34dd6a3626f9a02e83af554441d96ff91ab20aa081412c7530c1e87ec642 \
-                    size    243949
+checksums           rmd160  51e3ca99a9aa7bde5f20adbd74413f0897b31705 \
+                    sha256  9a6aa30feff48c0c0fd188e6d5150dbdd91e3fd5b10d2db9d78b9812ab14af88 \
+                    size    236158
 
 python.versions     37 38 39 310 311
 

--- a/python/py-cinderclient/Portfile
+++ b/python/py-cinderclient/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  9706fd47624c8490cfbbcc8620a4fe986ecb79b0 \
                     sha256  625d34dd6a3626f9a02e83af554441d96ff91ab20aa081412c7530c1e87ec642 \
                     size    243949
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-cliff/Portfile
+++ b/python/py-cliff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cliff
-version             3.3.0
+version             4.3.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -16,9 +16,9 @@ long_description    cliff is a framework for building command line \
                     provide subcommands, output formatters, and other \
                     extensions.
 homepage            https://docs.openstack.org/cliff/latest/
-checksums           rmd160  131952d0886ea27d1b4225c3065c2ee5467cc63d \
-                    sha256  611595ad7b4bdf57aa252027796dac3273ab0f4bc1511e839cce230a351cb710 \
-                    size    79680
+checksums           rmd160  4306b032cb675c41291afd8f44eaa1d2b590666a \
+                    sha256  fc5b6ebc8fb815332770b2485ee36c09753937c37cce4f3227cdd4e10b33eacc \
+                    size    82652
 
 python.versions     37 38 39 310 311
 

--- a/python/py-cliff/Portfile
+++ b/python/py-cliff/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  131952d0886ea27d1b4225c3065c2ee5467cc63d \
                     sha256  611595ad7b4bdf57aa252027796dac3273ab0f4bc1511e839cce230a351cb710 \
                     size    79680
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-cmd2/Portfile
+++ b/python/py-cmd2/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  8f15ccfc87a3b094b68682da668e1562ce819cf5 \
                     sha256  750d7eb04d55c3bc2a413e191bc177856f388102de47d11f2210a35266543640 \
                     size    675880
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-debtcollector/Portfile
+++ b/python/py-debtcollector/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-debtcollector
-version             2.1.0
+version             2.5.0
 revision            0
 
 maintainers         nomaintainer
@@ -27,9 +27,9 @@ long_description    A collection of Python deprecation patterns and \
                     developers using libraries (or potentially \
                     applications) about future deprecations.
 homepage            https://docs.openstack.org/debtcollector/latest/
-checksums           rmd160  0525388be16b904a74450901facf99539b307201 \
-                    sha256  a25fc6215560d81cb9f2a0b58d6c834f2a24010987027bde169599e138a205af \
-                    size    28706
+checksums           rmd160  46f841d202dbb52713d31ada0562b4a2ffa52485 \
+                    sha256  dc9d1ad3f745c43f4bbedbca30f9ffe8905a8c028c9926e61077847d5ea257ab \
+                    size    31334
 
 python.versions     37 38 39 310 311
 

--- a/python/py-debtcollector/Portfile
+++ b/python/py-debtcollector/Portfile
@@ -31,7 +31,7 @@ checksums           rmd160  0525388be16b904a74450901facf99539b307201 \
                     sha256  a25fc6215560d81cb9f2a0b58d6c834f2a24010987027bde169599e138a205af \
                     size    28706
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-dogpile-cache/Portfile
+++ b/python/py-dogpile-cache/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  e2543c06ee36c130b689911fcf0021a72ae958df \
                     sha256  695dd61f32d97233d5c5e1d7ac1238f5116391ea990b4b24a239229e280bf36e \
                     size    339926
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-keystoneauth1/Portfile
+++ b/python/py-keystoneauth1/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-keystoneauth1
-version             4.2.0
+version             5.2.1
 categories-append   net
 maintainers         nomaintainer
 license             Apache-2
@@ -14,9 +14,9 @@ platforms           {darwin any}
 description         Tools for authenticating to an OpenStack-based cloud
 long_description    {*}${description}
 homepage            https://docs.openstack.org/keystoneauth/latest/
-checksums           rmd160  4aadc7a93a4a1b87764b0c11ba908431644352bd \
-                    sha256  000ffd0d752f13eb235dae06f5f5dea16a2ca1f737fe3339632bd696b12489f7 \
-                    size    256375
+checksums           rmd160  4b86b0db42314591fb9bb6e6219ec2ff193b2f0f \
+                    sha256  f79b1c27ed5a69be4d03a5bc4967df3dfab0c5d76e85226fa2060cffadff74a1 \
+                    size    273214
 
 python.versions     37 38 39 310 311
 

--- a/python/py-keystoneauth1/Portfile
+++ b/python/py-keystoneauth1/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  4aadc7a93a4a1b87764b0c11ba908431644352bd \
                     sha256  000ffd0d752f13eb235dae06f5f5dea16a2ca1f737fe3339632bd696b12489f7 \
                     size    256375
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-keystoneclient/Portfile
+++ b/python/py-keystoneclient/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-keystoneclient
-version             4.1.0
+version             5.1.0
 categories-append   net
 platforms           {darwin any}
 maintainers         nomaintainer
@@ -15,10 +15,10 @@ description         Client for the OpenStack Identity API
 long_description    {*}${description}
 homepage            https://docs.openstack.org/python-keystoneclient/latest/
 python.rootname     python-keystoneclient
-checksums           md5     3504f6d29b60d77da8d2a14dd4b87fb0 \
-                    rmd160  b974b9fa4ced95f37ab0b22f7b30930cbbeeec04 \
-                    sha256  7b9b99021358a4db20673d338ba42bc2bd8e7e969cfd777f68c600ae6a39cb1b \
-                    size    317929
+checksums           md5     11ed4119004ba511e616afd75411a4d4 \
+                    rmd160  927c8c4ae1532c7b60af1fd2b739502ca745ede9 \
+                    sha256  ba09bdfeafa2a2196450a327cd3f46f2a8a9dd9d21b838f8cb9b17a99740c6a1 \
+                    size    325232
 
 python.versions     37 38 39 310 311
 

--- a/python/py-keystoneclient/Portfile
+++ b/python/py-keystoneclient/Portfile
@@ -20,7 +20,7 @@ checksums           md5     3504f6d29b60d77da8d2a14dd4b87fb0 \
                     sha256  7b9b99021358a4db20673d338ba42bc2bd8e7e969cfd777f68c600ae6a39cb1b \
                     size    317929
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-netifaces/Portfile
+++ b/python/py-netifaces/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  40b7990e7ea06f6c03d5626519c4164de60da92e \
 # See https://github.com/al45tair/netifaces/issues/78
 deprecated.upstream_support no
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-novaclient/Portfile
+++ b/python/py-novaclient/Portfile
@@ -24,7 +24,7 @@ checksums           md5     d4326085ebb9f999c45c37c99b315009 \
                     sha256  cda999e2254787b962e14859f6ca71de640963f3b35c1685fb51ce3a7a0a8958 \
                     size    323260
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-novaclient/Portfile
+++ b/python/py-novaclient/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-novaclient
 python.rootname     python-novaclient
-version             17.2.0
+version             18.3.0
 revision            0
 
 categories-append   net
@@ -19,10 +19,10 @@ long_description    This is a client for the OpenStack Nova API. There's a Pytho
                     API (the novaclient module), and a command-line script (nova). \
                     Each implements 100% of the OpenStack Nova API.
 homepage            https://docs.openstack.org/python-novaclient/latest/
-checksums           md5     d4326085ebb9f999c45c37c99b315009 \
-                    rmd160  8d56940807effd3f96d552de86948cde21b2e1e6 \
-                    sha256  cda999e2254787b962e14859f6ca71de640963f3b35c1685fb51ce3a7a0a8958 \
-                    size    323260
+checksums           md5     7277ceb8253253f19fcb0e327dbb9fc6 \
+                    rmd160  8587db8e8641ddc77009403429a364ce6098c984 \
+                    sha256  50f7587c7a2b2528f73505817f9437ac5c1d04d576e9be264d2deeffdb745a76 \
+                    size    339238
 
 python.versions     37 38 39 310 311
 

--- a/python/py-openstackclient/Portfile
+++ b/python/py-openstackclient/Portfile
@@ -24,7 +24,7 @@ checksums           md5     f23af9b5fa44488c031e0a4d065822a8 \
                     sha256  dcbdc95f6f577f621fc2b3862a3e1143dedd7d8a95e6ed08bd953d95aa24a1cf \
                     size    725685
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-openstackclient/Portfile
+++ b/python/py-openstackclient/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-openstackclient
-version             5.3.1
+version             6.2.0
 categories-append   net
 platforms           {darwin any}
 maintainers         nomaintainer
@@ -19,10 +19,10 @@ long_description    OpenStackClient (aka OSC) is a command-line \
                     shell with a uniform command structure.
 homepage            https://docs.openstack.org/python-openstackclient/latest/
 python.rootname     python-openstackclient
-checksums           md5     f23af9b5fa44488c031e0a4d065822a8 \
-                    rmd160  e87155ec05bfbcf708688dd3baa479f86f6cc7cb \
-                    sha256  dcbdc95f6f577f621fc2b3862a3e1143dedd7d8a95e6ed08bd953d95aa24a1cf \
-                    size    725685
+checksums           md5     9c4db008494d1da9c06e6b97013aa827 \
+                    rmd160  cd6c5587661b10f8c6ecf98fb70b237e13f5520d \
+                    sha256  7c53abe1b73b453f59da7b73679c3b759b48e51b8b054864b5fdea2ea82727d6 \
+                    size    886194
 
 python.versions     37 38 39 310 311
 

--- a/python/py-openstacksdk/Portfile
+++ b/python/py-openstacksdk/Portfile
@@ -17,7 +17,7 @@ checksums           rmd160  e7aed89078ee3d730e82f6be6cfe526a0be10b00 \
                     sha256  8652664a30041325a980d03a37c92ca546ed923d26c246a2bb3c92fc5f24243c \
                     size    935288
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-openstacksdk/Portfile
+++ b/python/py-openstacksdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-openstacksdk
-version             0.48.0
+version             1.4.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -13,9 +13,9 @@ platforms           {darwin any}
 description         Client library for building applications to work with OpenStack clouds
 long_description    {*}${description}
 homepage            https://docs.openstack.org/openstacksdk/
-checksums           rmd160  e7aed89078ee3d730e82f6be6cfe526a0be10b00 \
-                    sha256  8652664a30041325a980d03a37c92ca546ed923d26c246a2bb3c92fc5f24243c \
-                    size    935288
+checksums           rmd160  3b5edf80fe3d2e667dccacf85d0de85020ae43db \
+                    sha256  3615129edb67c82afbd1a1706e915ffa68e0eebfc99c903c343aac6517dd5858 \
+                    size    1173316
 
 python.versions     37 38 39 310 311
 

--- a/python/py-os-service-types/Portfile
+++ b/python/py-os-service-types/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  7f8b29835237773138d4902eba57d02422bdca11 \
                     sha256  31800299a82239363995b91f1ebf9106ac7758542a1e4ef6dc737a5932878c6c \
                     size    24474
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-osc-lib/Portfile
+++ b/python/py-osc-lib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-osc-lib
-version             2.2.0
+version             2.8.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -13,9 +13,9 @@ platforms           {darwin any}
 description         Common support modules for writing OpenStackClient plugins
 long_description    {*}${description}
 homepage            https://docs.openstack.org/osc-lib/latest/
-checksums           rmd160  fcaf7f86ad54d9897288c6a90cc51fc6591a641a \
-                    sha256  fcfce4d63a633c3161e2a6666764446e3f32668e814a94ab98da12e3908ee1d6 \
-                    size    94181
+checksums           rmd160  a253a41441b877be98853f2d3246abb5fcff34b3 \
+                    sha256  67e0d413911e8d49cb9601e80eb28dc4b391b3d7dbd70adc9a69a204516d9452 \
+                    size    98870
 
 python.versions     37 38 39 310 311
 

--- a/python/py-osc-lib/Portfile
+++ b/python/py-osc-lib/Portfile
@@ -17,7 +17,7 @@ checksums           rmd160  fcaf7f86ad54d9897288c6a90cc51fc6591a641a \
                     sha256  fcfce4d63a633c3161e2a6666764446e3f32668e814a94ab98da12e3908ee1d6 \
                     size    94181
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-oslo-config/Portfile
+++ b/python/py-oslo-config/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-oslo-config
-version             8.3.1
+version             9.1.1
 platforms           {darwin any}
 maintainers         nomaintainer
 license             Apache-2
@@ -14,10 +14,10 @@ description         Oslo Configuration Library
 long_description    {*}${description}
 homepage            https://docs.openstack.org/oslo.config/latest/
 python.rootname     oslo.config
-checksums           md5     f28614f3647fdbf6348f377dada38af2 \
-                    rmd160  3bb48fec41ac70f977286b7ec91226b507ca45e8 \
-                    sha256  dfbb83dc5b4c86ddf8b96f3967252f17586a67f2cef65309df2fd510bf9e87fc \
-                    size    149370
+checksums           md5     769016a71e3074fb32d9f2171092360b \
+                    rmd160  d59bd8418db05788e59e7b17261c9c7fddf56bfa \
+                    sha256  b07654b53d87792ae8e739962ad729c529c9938a118d891ece9ee31d59716bc9 \
+                    size    160964
 
 python.versions     37 38 39 310 311
 

--- a/python/py-oslo-config/Portfile
+++ b/python/py-oslo-config/Portfile
@@ -19,7 +19,7 @@ checksums           md5     f28614f3647fdbf6348f377dada38af2 \
                     sha256  dfbb83dc5b4c86ddf8b96f3967252f17586a67f2cef65309df2fd510bf9e87fc \
                     size    149370
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     livecheck.type  none

--- a/python/py-oslo-i18n/Portfile
+++ b/python/py-oslo-i18n/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-oslo-i18n
 python.rootname     oslo.i18n
-version             5.0.0
+version             6.0.0
 
 maintainers         nomaintainer
 license             Apache-2
@@ -18,9 +18,9 @@ long_description    The oslo.utils library provides support for common \
                     handling, string manipulation, and time handling.
 homepage            https://docs.openstack.org/oslo.i18n/latest/
 
-checksums           rmd160  2aa7ec36a8a7626a019a91ed27d7c81d5a769baa \
-                    sha256  2e71ae3ec73a74ac71f8f407e6653243dc267eed404624255a296c34f1fc6887 \
-                    size    44211
+checksums           rmd160  8ab90a815bc11184f78599d2f972d7c74242a0a2 \
+                    sha256  ed10686b75f7c607825177a669155f4e259ce39f6143a375f6359bbcaa4a35cd \
+                    size    47479
 
 python.versions     37 38 39 310 311
 

--- a/python/py-oslo-i18n/Portfile
+++ b/python/py-oslo-i18n/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  2aa7ec36a8a7626a019a91ed27d7c81d5a769baa \
                     sha256  2e71ae3ec73a74ac71f8f407e6653243dc267eed404624255a296c34f1fc6887 \
                     size    44211
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-oslo-serialization/Portfile
+++ b/python/py-oslo-serialization/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  231190c1d32e54a0442ce8531f1e2dfca512da85 \
                     sha256  f465df171be564282cb3e86ec895f5b6ae5e5b0760e9af2be96a942a5255a860 \
                     size    30816
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-oslo-serialization/Portfile
+++ b/python/py-oslo-serialization/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-oslo-serialization
 python.rootname     oslo.serialization
-version             4.0.0
+version             5.1.1
 revision            0
 
 maintainers         nomaintainer
@@ -18,9 +18,9 @@ long_description    The oslo.utils library provides support for common \
                     utility type functions, such as encoding, exception \
                     handling, string manipulation, and time handling.
 homepage            https://docs.openstack.org/oslo.serialization/latest/
-checksums           rmd160  231190c1d32e54a0442ce8531f1e2dfca512da85 \
-                    sha256  f465df171be564282cb3e86ec895f5b6ae5e5b0760e9af2be96a942a5255a860 \
-                    size    30816
+checksums           rmd160  38b001a483b2c37d9ea2ee249ef28b46d4b12dc3 \
+                    sha256  8abbda8b1763a06071fc28c5d8a9be547ba285f4830e68a70ff88fe11f16bf43 \
+                    size    34306
 
 python.versions     37 38 39 310 311
 

--- a/python/py-oslo-utils/Portfile
+++ b/python/py-oslo-utils/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  fcd7f3e6c89374fda8506fd0a7dfe9a9f705af04 \
                     sha256  c608d9676974ae7e81ce51eeecd122690881c3bdc31b26f51c42327a350bd313 \
                     size    93589
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-oslo-utils/Portfile
+++ b/python/py-oslo-utils/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-oslo-utils
 python.rootname     oslo.utils
-version             4.3.0
+version             6.2.0
 maintainers         nomaintainer
 license             Apache-2
 supported_archs     noarch
@@ -17,9 +17,9 @@ long_description    The oslo.utils library provides support for common \
                     handling, string manipulation, and time handling.
 homepage            https://docs.openstack.org/oslo.utils/latest/
 
-checksums           rmd160  fcd7f3e6c89374fda8506fd0a7dfe9a9f705af04 \
-                    sha256  c608d9676974ae7e81ce51eeecd122690881c3bdc31b26f51c42327a350bd313 \
-                    size    93589
+checksums           rmd160  2a37c08aec67c9866f8b0bf9fed1d9681a7853a7 \
+                    sha256  fe1d166f4cb004fbd6b6bc9adfbc32aedeaf3eb54eeaf70d91a224a87543c6a5 \
+                    size    103944
 
 python.versions     37 38 39 310 311
 

--- a/python/py-prettytable/Portfile
+++ b/python/py-prettytable/Portfile
@@ -35,7 +35,7 @@ checksums           rmd160  af187cbcf1139866bc67b1bc8cb5c3187726b41f \
                     sha256  2d5460dc9db74a32bcc8f9f67de68b2c4f4d2f01fa3bd518764c69156d9cacd9 \
                     size    24784
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {$subport ne $name} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-requestsexceptions/Portfile
+++ b/python/py-requestsexceptions/Portfile
@@ -17,7 +17,7 @@ checksums           rmd160  1d0b0a38362767f9b033a90f1ad14769dfad50a1 \
                     sha256  b095cbc77618f066d459a02b137b020c37da9f46d9b057704019c9f77dba3065 \
                     size    6880
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \


### PR DESCRIPTION
#### Description
py-openstackclient was horribly out of date, and the `--tag` flag was bugged. Newer versions fix this issue, so I've updated the portfiles related.
*most* are nomaintainer, but a couple have maintainers, but I'm only enabling newer Python builds on those as far as I can tell.

OpenStack packages modified:
* py-cinderclient bumped to 9.3.0 and enable <=py3.11
* py-cliff bumped to 4.3.0 and enable <=py3.11
* py-debtcollector bumped to 2.5.0 and enable <=py3.11
* py-keystoneauth1 bumped to 5.2.1 and enable <=py3.11
* py-keystoneclient bumped to 5.1.0 and enable <=py3.11
* py-novaclient bumped to 18.3.0 and enable <=py3.11
* py-openstackclient bumped to 6.2.0 and enable <=py3.11
* py-openstacksdk bumped to 1.4.0 and enable <=py3.11
* py-os-service-types already at 1.7.0; enable <=py3.11
* py-osc-lib bumped to 2.8.0 and enable <=py3.11
* py-oslo-config bumped to 9.1.1 and enable <=py3.11
* py-oslo-i18n bumped to 6.0.0 and enable <=py3.11
* py-oslo-serialization bumped to 5.1.1 and enable <=py3.11
* py-oslo-utils bumped to 6.2.0 and enable <=py3.11

additionally, non-OpenStack packages modified
* py-cmd2 enable <=py3.11
* py-dogpile-cache enable <=py3.11
* py-netifaces enable <=py3.11

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.5 22G74 arm64
Xcode 14.3.1 14E300c

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?