### PR TITLE
openjdk11-openj9: update to 11.0.20.1

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      11.0.20
+version      11.0.20.1
 revision     0
 
-set build    8
+set build    1
 set openj9_version 0.40.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 11
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  9ad0a428cabce234716d24fcb9026c31ed36e17b \
-                 sha256  5b0259f848e5add371a1e58a8adc2e7259062d5c5a979010a485752c691cbde5 \
-                 size    205307642
+    checksums    rmd160  b23f739dec3b0e361d2ad6af7b845609cf95243e \
+                 sha256  253042ac9f6146006a5deb3742e8d14ad41f44f092ed86248e02dc11a7e2fb2f \
+                 size    205331513
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  2fd258dee57185212571e713017bf77b41e85692 \
-                 sha256  38064a6227492dde10258f71dd081163a0921d87b1bc7ddb7db8f669a6fae82f \
-                 size    199485002
+    checksums    rmd160  cffb86a9216ae8dca2880bfe15507d166687321e \
+                 sha256  249706cfaaa82f07ca57c1e23eedfb38956e2a006bee81dd4d06268d798e6866 \
+                 size    199485594
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.20.1.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?