### PR TITLE
micronaut: update to 4.1.0

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.0.6 v
+github.setup    micronaut-projects micronaut-starter 4.1.0 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  c165f7245af64f62641a7c1c62f7da13f405f042 \
-                sha256  220f2496791a8fd40532c0c33b68d2ad16954e8eb9bdb1964f271c76d356e132 \
-                size    20240991
+checksums       rmd160  2b787f3c4a52fcf9221817d21544ce41ea8afcf7 \
+                sha256  8fec7aa98a6d577ddc5de678be0cb660d7baa2c807231028c52cfaae7e1d3da4 \
+                size    20282676
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut 4.1.0.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?