### PR TITLE
warzone2100: use MacPorts discord-rpc

### DIFF
--- a/games/warzone2100/Portfile
+++ b/games/warzone2100/Portfile
@@ -39,7 +39,7 @@ if {$subport eq ${name}} {
     PortGroup           legacysupport 1.1
 
     github.setup        Warzone2100 ${name} 4.3.0
-    revision            3
+    revision            4
     github.tarball_from releases
     distname            ${name}_src
     use_xz              yes
@@ -64,6 +64,7 @@ if {$subport eq ${name}} {
                             port:sqlitecpp \
                             port:re2 \
                             port:${port_libfmt} \
+                            port:discord-rpc \
                             port:libpng \
                             port:libsdl2 \
                             port:openal-soft \
@@ -102,10 +103,16 @@ if {$subport eq ${name}} {
     legacysupport.use_mp_libcxx yes
 
     post-patch {
+        # The source code resets the CMAKE_MODULE_PATH, instead of
+        # adding to the list. This causes CMake to not be able to
+        # find any packages that are available through MacPorts Cmake.
+        reinplace {s/^set.\(CMAKE_MODULE_PATH.*PROJECT_SOURCE_DIR.*cmake\)/list(PREPEND \1/} \
+            ${worksrcpath}/CMakeLists.txt
+
         # Prevent the upstream source from trying to compile these as
         # internal libraries, since we have made them available as
         # dependencies through MacPorts.
-        foreach dep [list utf8proc fmt SQLiteCpp] {
+        foreach dep [list utf8proc fmt discord-rpc SQLiteCpp] {
             reinplace -E \
                 "/add_subdirectory.$dep/,/set_property.*$dep/d" \
                 ${worksrcpath}/3rdparty/CMakeLists.txt
@@ -125,6 +132,22 @@ if {$subport eq ${name}} {
         reinplace {s/re2::re2/re2/} \
             ${worksrcpath}/src/CMakeLists.txt \
             ${worksrcpath}/lib/netplay/CMakeLists.txt
+
+        reinplace "/if.ENABLE_DISCORD/a\\
+            \\        find_package(DiscordRPC)\\
+        " \
+            ${worksrcpath}/3rdparty/CMakeLists.txt \
+            ${worksrcpath}/src/CMakeLists.txt \
+            ${worksrcpath}/src/integrations/CMakeLists.txt
+        reinplace {s/\(TARGET discord-rpc\)/DiscordRPC_FOUND OR \1/} \
+            ${worksrcpath}/src/CMakeLists.txt \
+            ${worksrcpath}/src/integrations/CMakeLists.txt
+        foreach re [list \
+            {/target_include_directories.*3rdparty/s/".*"/"${DiscordRPC_INCLUDE_DIR}"/} \
+            {/target_link_libraries.*discord-rpc/s/discord-rpc/"${DiscordRPC_LIBRARY}"/} \
+        ] {
+            reinplace $re ${worksrcpath}/src/integrations/CMakeLists.txt
+        }
 
         reinplace {/include_directories.*glm/d} \
             ${worksrcpath}/CMakeLists.txt
@@ -254,6 +277,12 @@ if {$subport eq "${name}-music"} {
 
     default_variants    +high
 
+    pre-fetch {
+        if {![variant_isset high] && ![variant_isset standard]} {
+            ui_error "You must install this port with one of the audio quality variants selected!"
+            return -code error "No audio quality variant selected"
+        }
+    }
     use_configure no
     build {}
     destroot {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
