### PR TITLE
clojure-lsp: use openjdk17-graalvm instead of deprecated openjdk17-graalvm-native-image

### DIFF
--- a/devel/clojure-lsp/Portfile
+++ b/devel/clojure-lsp/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  5d952615dba87724c96891677baf55d8b2e13a7d \
 depends_lib         port:clojure
 
 variant jdk17 conflicts jdk11 description {Build using JDK 17} {
-    depends_build-append port:openjdk17-graalvm-native-image
+    depends_build-append port:openjdk17-graalvm
 }
 
 variant jdk11 conflicts jdk17 description {Build using the older JDK 11} {


### PR DESCRIPTION
#### Description

The Native Image feature is included in `openjdk17-graalvm` these days and the `openjdk17-graalvm-native-image` port has been deprecated.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?