### PR TITLE
josm: update to 18822

### DIFF
--- a/gis/JOSM/Portfile
+++ b/gis/JOSM/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                JOSM
-version             18772
+version             18822
 categories          gis editors java
 license             GPL-2+
 supported_archs     i386 x86_64
@@ -18,9 +18,9 @@ homepage            https://josm.openstreetmap.de
 master_sites        ${homepage}/download/macosx/
 distname            josm-macos-${version}-java17
 
-checksums           rmd160  3d4afa404b02d3b2f49b8f63b99f1b25c0f7d1b7 \
-                    sha256  135db9618c15ccbcdb3e1d1b6f3fc5cc93be272b2306129fa4b2a63113bd9c97 \
-                    size    79470439
+checksums           rmd160  c42c304fedbab20c1a9fff9a8f49885ec9a93304 \
+                    sha256  3058966c453c0ba26fabdc2420a00d41ea89876ff20b7cb8d00367184978205d \
+                    size    79896452
 
 extract.mkdir       yes
 


### PR DESCRIPTION
#### Description
[Changelog](https://josm.openstreetmap.de/wiki/Changelog#a2023-08-30:Stablerelease1882223.08)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
