### PR TITLE
sfeed: update to 1.9

### DIFF
--- a/net/sfeed/Portfile
+++ b/net/sfeed/Portfile
@@ -5,7 +5,7 @@ PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 name                sfeed
-version             1.8
+version             1.9
 revision            0
 license             ISC
 
@@ -18,9 +18,9 @@ homepage            https://git.codemadness.org/${name}/
 
 master_sites        https://codemadness.org/releases/${name}/
 
-checksums           rmd160  4335f02db9b2b3adbe9d77e1f1681624b494c8be \
-                    sha256  173cffaee785110a73c7e02822d7a8de10307e8a2351fca17eebfdb9483ac7b3 \
-                    size    67335
+checksums           rmd160  337b9ab719bf4b63fd6867e6912856cccce61246 \
+                    sha256  7261dada0e4010ea09f67d1fd737404d691b9c7e5e7362334228c117d98a5646 \
+                    size    67718
 
 depends_lib-append  port:ncurses
 


### PR DESCRIPTION
#### Description
[Changelog](https://git.codemadness.org/sfeed/)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
