### PR TITLE
mqttui: update to 0.19.0

### DIFF
--- a/net/mqttui/Portfile
+++ b/net/mqttui/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo  1.0
 
-github.setup        EdJoPaTo mqttui 0.18.0 v
+github.setup        EdJoPaTo mqttui 0.19.0 v
 revision            0
 
 categories          net
@@ -15,9 +15,9 @@ description         Simple lightweight terminal based MQTT monitor and publisher
 long_description    {*}${description}
 
 checksums           ${distfiles} \
-                    rmd160  fb369c3e4259daa134b8398f05c9cc6aec4e0989 \
-                    sha256  8be89a815886135f25bf3770175febe811d2a90d829d18e2c87bbda38d5cfd15 \
-                    size    189654
+                    rmd160  5a274e723ef3f90c6352f0ce87bc5eddaec43e0c \
+                    sha256  74a30d808bbdc59843515255583735c0aa73d55cf496574663cb59e3c3f0ec2a \
+                    size    191952
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/target/[option triplet.${muniversal.build_arch}]/release/${name} ${destroot}${prefix}/bin/
@@ -25,331 +25,169 @@ destroot {
 
 cargo.crates \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anyhow                          1.0.66  216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6 \
+    anstream                         0.3.2  0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163 \
+    anstyle                          1.0.0  41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d \
+    anstyle-parse                    0.2.0  e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee \
+    anstyle-query                    1.0.0  5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b \
+    anstyle-wincon                   1.0.1  180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188 \
+    anyhow                          1.0.71  9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8 \
     async-tungstenite               0.16.1  5682ea0913e5c20780fe5785abacb85a411e7437bf52a1bedb93ddb3972cb8dd \
     async_io_stream                  0.3.3  b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c \
     autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
     base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
+    base64                          0.21.0  a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
-    bumpalo                         3.11.1  572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba \
+    bumpalo                         3.12.2  3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b \
     byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
-    bytes                            1.3.0  dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c \
+    bytes                            1.4.0  89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
-    cc                              1.0.77  e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4 \
+    cc                              1.0.79  50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    chrono                          0.4.23  16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f \
-    clap                            4.0.29  4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d \
-    clap_complete                    4.0.6  b7b3c9eae0de7bf8e3f904a5e40612b21fb2e2e566456d177809a48b892d24da \
-    clap_derive                     4.0.21  0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014 \
-    clap_lex                         0.3.0  0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8 \
-    codespan-reporting              0.11.1  3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e \
+    chrono                          0.4.24  4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b \
+    clap                             4.2.7  34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938 \
+    clap_builder                     4.2.7  914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd \
+    clap_complete                    4.2.3  1594fe2312ec4abf402076e407628f5c313e54c32ade058521df4ee34ecac8a8 \
+    clap_derive                      4.2.0  3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4 \
+    clap_lex                         0.4.1  8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1 \
+    colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
     core-foundation                  0.9.3  194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146 \
-    core-foundation-sys              0.8.3  5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc \
-    cpufeatures                      0.2.5  28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320 \
+    core-foundation-sys              0.8.4  e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa \
+    cpufeatures                      0.2.7  3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58 \
     crossterm                       0.25.0  e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67 \
     crossterm_winapi                 0.9.0  2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c \
-    cxx                             1.0.82  d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453 \
-    cxx-build                       1.0.82  06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0 \
-    cxxbridge-flags                 1.0.82  820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71 \
-    cxxbridge-macro                 1.0.82  a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470 \
     digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
     ego-tree                         0.6.2  3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591 \
-    errno                            0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
+    errno                            0.3.1  4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a \
     errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
     flume                          0.10.14  1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
     form_urlencoded                  1.1.0  a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8 \
-    futures                         0.3.25  38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0 \
-    futures-channel                 0.3.25  52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed \
-    futures-core                    0.3.25  04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac \
-    futures-executor                0.3.25  7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2 \
-    futures-io                      0.3.25  00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb \
-    futures-macro                   0.3.25  bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d \
-    futures-sink                    0.3.25  39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9 \
-    futures-task                    0.3.25  2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea \
-    futures-util                    0.3.25  197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6 \
-    generic-array                   0.14.6  bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9 \
-    getrandom                        0.2.8  c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31 \
-    heck                             0.4.0  2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9 \
-    hermit-abi                       0.2.6  ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7 \
-    http                             0.2.8  75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399 \
+    futures                         0.3.28  23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40 \
+    futures-channel                 0.3.28  955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2 \
+    futures-core                    0.3.28  4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c \
+    futures-executor                0.3.28  ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0 \
+    futures-io                      0.3.28  4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964 \
+    futures-macro                   0.3.28  89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72 \
+    futures-sink                    0.3.28  f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e \
+    futures-task                    0.3.28  76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65 \
+    futures-util                    0.3.28  26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533 \
+    generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
+    getrandom                        0.2.9  c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4 \
+    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    hermit-abi                       0.3.1  fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286 \
+    http                             0.2.9  bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482 \
     httparse                         1.8.0  d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904 \
-    iana-time-zone                  0.1.53  64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765 \
-    iana-time-zone-haiku             0.1.1  0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca \
+    iana-time-zone                  0.1.56  0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c \
+    iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.3.0  e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6 \
-    io-lifetimes                     0.7.5  59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074 \
-    io-lifetimes                     1.0.3  46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c \
-    is-terminal                      0.4.1  927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330 \
-    itoa                             1.0.4  4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc \
-    js-sys                          0.3.60  49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47 \
+    io-lifetimes                    1.0.10  9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220 \
+    is-terminal                      0.4.7  adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f \
+    itoa                             1.0.6  453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6 \
+    js-sys                          0.3.63  2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790 \
     json                            0.12.4  078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd \
-    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.137  fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89 \
-    link-cplusplus                   1.0.7  9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369 \
-    linux-raw-sys                   0.0.46  d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d \
-    linux-raw-sys                    0.1.3  8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f \
+    libc                           0.2.144  2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1 \
+    linux-raw-sys                    0.3.7  ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f \
     lock_api                         0.4.9  435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df \
     log                             0.4.17  abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e \
     memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
-    mio                              0.8.5  e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de \
+    mio                              0.8.6  5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9 \
     nanorand                         0.7.0  6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3 \
     num-integer                     0.1.45  225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9 \
     num-traits                      0.2.15  578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd \
-    once_cell                       1.16.0  86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860 \
+    once_cell                       1.17.1  b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3 \
     opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
-    os_str_bytes                     6.4.1  9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee \
     parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
-    parking_lot_core                 0.9.4  4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0 \
+    parking_lot_core                 0.9.7  9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521 \
     percent-encoding                 2.2.0  478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e \
     pharos                           0.5.3  e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414 \
-    pin-project                     1.0.12  ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc \
-    pin-project-internal            1.0.12  069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55 \
+    pin-project                      1.1.0  c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead \
+    pin-project-internal             1.1.0  39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07 \
     pin-project-lite                 0.2.9  e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116 \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    pollster                         0.2.5  5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7 \
     ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
-    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
-    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
-    proc-macro2                     1.0.47  5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725 \
-    quote                           1.0.21  bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179 \
+    proc-macro2                     1.0.58  fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8 \
+    quote                           1.0.27  8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
     redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
     ring                           0.16.20  3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc \
-    rumqttc                         0.18.0  1514bbc994fc9f36ab7f7ae067b3e4758c717aff7a06c4818c6787cad8b086e1 \
+    rumqttc                         0.21.0  04483567c64bb8a9d64364a0a9437215a056a2b886140fd66e62a12394cf5998 \
     rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
-    rustix                         0.35.13  727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9 \
-    rustix                          0.36.4  cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23 \
-    rustls                          0.20.7  539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c \
+    rustix                         0.37.19  acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d \
+    rustls                          0.20.8  fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f \
     rustls-native-certs              0.6.2  0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50 \
-    rustls-pemfile                   0.3.0  1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360 \
-    rustls-pemfile                   1.0.1  0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55 \
-    schannel                        0.1.20  88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2 \
+    rustls-pemfile                   1.0.2  d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b \
+    schannel                        0.1.21  713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3 \
     scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
-    scratch                          1.0.2  9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898 \
     sct                              0.7.0  d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4 \
-    security-framework               2.7.0  2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c \
-    security-framework-sys           2.6.1  0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556 \
-    semver                          1.0.14  e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4 \
+    security-framework               2.9.0  ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1 \
+    security-framework-sys           2.9.0  f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7 \
+    semver                          1.0.17  bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed \
     sha-1                            0.9.8  99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6 \
-    signal-hook                     0.3.14  a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d \
+    signal-hook                     0.3.15  732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9 \
     signal-hook-mio                  0.2.3  29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af \
-    signal-hook-registry             1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
-    slab                             0.4.7  4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef \
+    signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
+    slab                             0.4.8  6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d \
     smallvec                        1.10.0  a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0 \
-    socket2                          0.4.7  02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd \
+    socket2                          0.4.9  64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662 \
     spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
-    spin                             0.9.4  7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09 \
+    spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
     strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
-    syn                            1.0.103  a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d \
-    termcolor                        1.1.3  bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755 \
-    terminal_size                    0.2.2  40ca90c434fd12083d1a6bdcbe9f92a14f96c8a1ba600ba451734ac334521f7a \
-    thiserror                       1.0.37  10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e \
-    thiserror-impl                  1.0.37  982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb \
-    time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
+    syn                             2.0.16  a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01 \
+    terminal_size                    0.2.6  8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237 \
+    thiserror                       1.0.40  978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac \
+    thiserror-impl                  1.0.40  f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f \
     tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
-    tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
-    tokio                           1.22.0  d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3 \
-    tokio-macros                     1.8.0  9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484 \
+    tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
+    tokio                           1.28.1  0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105 \
+    tokio-macros                     2.1.0  630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e \
     tokio-rustls                    0.23.4  c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59 \
     tui                             0.19.0  ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1 \
     tui-tree-widget                 0.11.0  64cd64e2088f26dd5f7e5239cdd7ee234098d3bda4dc214e4bb58c2049ce5af3 \
     tungstenite                     0.16.0  6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1 \
-    typenum                         1.15.0  dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987 \
-    unicode-bidi                     0.3.8  099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992 \
-    unicode-ident                    1.0.5  6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3 \
+    typenum                         1.16.0  497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba \
+    unicode-bidi                    0.3.13  92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460 \
+    unicode-ident                    1.0.8  e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4 \
     unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
-    unicode-segmentation            1.10.0  0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a \
+    unicode-segmentation            1.10.1  1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36 \
     unicode-width                   0.1.10  c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b \
     untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
     url                              2.3.1  0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643 \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
+    utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
     version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
-    wasi                          0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
     wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.83  eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268 \
-    wasm-bindgen-backend            0.2.83  4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142 \
-    wasm-bindgen-macro              0.2.83  052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810 \
-    wasm-bindgen-macro-support      0.2.83  07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c \
-    wasm-bindgen-shared             0.2.83  1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f \
-    web-sys                         0.3.60  bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f \
+    wasm-bindgen                    0.2.86  5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73 \
+    wasm-bindgen-backend            0.2.86  19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb \
+    wasm-bindgen-macro              0.2.86  14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258 \
+    wasm-bindgen-macro-support      0.2.86  e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8 \
+    wasm-bindgen-shared             0.2.86  ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93 \
+    web-sys                         0.3.63  3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2 \
     webpki                          0.22.0  f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows-sys                     0.36.1  ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2 \
+    windows                         0.48.0  e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f \
     windows-sys                     0.42.0  5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7 \
-    windows_aarch64_gnullvm         0.42.0  41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e \
-    windows_aarch64_msvc            0.36.1  9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47 \
-    windows_aarch64_msvc            0.42.0  dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4 \
-    windows_i686_gnu                0.36.1  180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6 \
-    windows_i686_gnu                0.42.0  fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7 \
-    windows_i686_msvc               0.36.1  e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024 \
-    windows_i686_msvc               0.42.0  84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246 \
-    windows_x86_64_gnu              0.36.1  4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1 \
-    windows_x86_64_gnu              0.42.0  bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed \
-    windows_x86_64_gnullvm          0.42.0  09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028 \
-    windows_x86_64_msvc             0.36.1  c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680 \
-    windows_x86_64_msvc             0.42.0  f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5 \
-    ws_stream_tungstenite            0.7.0  a672ec78525bf189cefa7f1b72c55f928b3edbdb967e680ca49748ab20821045
-cargo.crates \
-    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anyhow                          1.0.65  98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602 \
-    async-tungstenite               0.16.1  5682ea0913e5c20780fe5785abacb85a411e7437bf52a1bedb93ddb3972cb8dd \
-    async_io_stream                  0.3.3  b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c \
-    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
-    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
-    base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
-    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
-    bumpalo                         3.11.0  c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d \
-    byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
-    bytes                            1.2.1  ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db \
-    cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
-    cc                              1.0.73  2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11 \
-    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    chrono                          0.4.22  bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1 \
-    clap                            3.2.22  86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750 \
-    clap_complete                    3.2.5  3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8 \
-    clap_derive                     3.2.18  ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65 \
-    clap_lex                         0.2.4  2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5 \
-    core-foundation                  0.9.3  194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146 \
-    core-foundation-sys              0.8.3  5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc \
-    cpufeatures                      0.2.5  28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320 \
-    crossterm                       0.25.0  e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67 \
-    crossterm_winapi                 0.9.0  2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c \
-    digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
-    ego-tree                         0.6.2  3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591 \
-    errno                            0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
-    errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
-    flume                          0.10.14  1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577 \
-    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    form_urlencoded                  1.1.0  a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8 \
-    futures                         0.3.24  7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c \
-    futures-channel                 0.3.24  30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050 \
-    futures-core                    0.3.24  4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf \
-    futures-executor                0.3.24  9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab \
-    futures-io                      0.3.24  bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68 \
-    futures-macro                   0.3.24  42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17 \
-    futures-sink                    0.3.24  21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56 \
-    futures-task                    0.3.24  a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1 \
-    futures-util                    0.3.24  44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90 \
-    generic-array                   0.14.6  bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9 \
-    getrandom                        0.2.7  4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6 \
-    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
-    heck                             0.4.0  2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9 \
-    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
-    http                             0.2.8  75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399 \
-    httparse                         1.8.0  d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904 \
-    iana-time-zone                  0.1.50  fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0 \
-    idna                             0.3.0  e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6 \
-    indexmap                         1.9.1  10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e \
-    io-lifetimes                     0.7.3  1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06 \
-    itoa                             1.0.3  6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754 \
-    js-sys                          0.3.60  49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47 \
-    json                            0.12.4  078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd \
-    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.134  329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb \
-    linux-raw-sys                   0.0.46  d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d \
-    lock_api                         0.4.9  435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df \
-    log                             0.4.17  abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e \
-    memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
-    mio                              0.8.4  57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf \
-    nanorand                         0.7.0  6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3 \
-    num-integer                     0.1.45  225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9 \
-    num-traits                      0.2.15  578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd \
-    once_cell                       1.15.0  e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1 \
-    opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
-    openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
-    os_str_bytes                     6.3.0  9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff \
-    parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
-    parking_lot_core                 0.9.3  09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929 \
-    percent-encoding                 2.2.0  478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e \
-    pharos                           0.5.3  e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414 \
-    pin-project                     1.0.12  ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc \
-    pin-project-internal            1.0.12  069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55 \
-    pin-project-lite                 0.2.9  e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116 \
-    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    pollster                         0.2.5  5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7 \
-    ppv-lite86                      0.2.16  eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872 \
-    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
-    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
-    proc-macro2                     1.0.46  94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b \
-    quote                           1.0.21  bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179 \
-    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
-    rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
-    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
-    redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
-    ring                           0.16.20  3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc \
-    rumqttc                         0.17.0  499b7ab08ffa5a722958b6ce1b7c0270bea30909f589d12c5ec3a051afe423fc \
-    rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
-    rustix                         0.35.11  fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef \
-    rustls                          0.20.6  5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033 \
-    rustls-native-certs              0.6.2  0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50 \
-    rustls-pemfile                   0.3.0  1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360 \
-    rustls-pemfile                   1.0.1  0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55 \
-    schannel                        0.1.20  88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2 \
-    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
-    sct                              0.7.0  d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4 \
-    security-framework               2.7.0  2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c \
-    security-framework-sys           2.6.1  0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556 \
-    semver                          1.0.14  e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4 \
-    sha-1                            0.9.8  99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6 \
-    signal-hook                     0.3.14  a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d \
-    signal-hook-mio                  0.2.3  29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af \
-    signal-hook-registry             1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
-    slab                             0.4.7  4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef \
-    smallvec                        1.10.0  a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0 \
-    socket2                          0.4.7  02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd \
-    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
-    spin                             0.9.4  7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09 \
-    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
-    syn                            1.0.101  e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2 \
-    termcolor                        1.1.3  bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755 \
-    terminal_size                    0.2.1  8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1 \
-    textwrap                        0.15.1  949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16 \
-    thiserror                       1.0.37  10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e \
-    thiserror-impl                  1.0.37  982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb \
-    time                            0.1.44  6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255 \
-    tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
-    tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
-    tokio                           1.21.2  a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099 \
-    tokio-macros                     1.8.0  9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484 \
-    tokio-rustls                    0.23.4  c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59 \
-    tui                             0.19.0  ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1 \
-    tui-tree-widget                 0.11.0  64cd64e2088f26dd5f7e5239cdd7ee234098d3bda4dc214e4bb58c2049ce5af3 \
-    tungstenite                     0.16.0  6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1 \
-    typenum                         1.15.0  dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987 \
-    unicode-bidi                     0.3.8  099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992 \
-    unicode-ident                    1.0.4  dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd \
-    unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
-    unicode-segmentation            1.10.0  0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a \
-    unicode-width                   0.1.10  c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b \
-    untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
-    url                              2.3.1  0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643 \
-    utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
-    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
-    wasi                          0.10.0+wasi-snapshot-preview1  1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f \
-    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.83  eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268 \
-    wasm-bindgen-backend            0.2.83  4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142 \
-    wasm-bindgen-macro              0.2.83  052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810 \
-    wasm-bindgen-macro-support      0.2.83  07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c \
-    wasm-bindgen-shared             0.2.83  1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f \
-    web-sys                         0.3.60  bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f \
-    webpki                          0.22.0  f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd \
-    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
-    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
-    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows-sys                     0.36.1  ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2 \
-    windows_aarch64_msvc            0.36.1  9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47 \
-    windows_i686_gnu                0.36.1  180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6 \
-    windows_i686_msvc               0.36.1  e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024 \
-    windows_x86_64_gnu              0.36.1  4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1 \
-    windows_x86_64_msvc             0.36.1  c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680 \
+    windows-sys                     0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-targets                 0.42.2  8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
+    windows-targets                 0.48.0  7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5 \
+    windows_aarch64_gnullvm         0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
+    windows_aarch64_gnullvm         0.48.0  91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc \
+    windows_aarch64_msvc            0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
+    windows_aarch64_msvc            0.48.0  b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3 \
+    windows_i686_gnu                0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
+    windows_i686_gnu                0.48.0  622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241 \
+    windows_i686_msvc               0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
+    windows_i686_msvc               0.48.0  4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00 \
+    windows_x86_64_gnu              0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
+    windows_x86_64_gnu              0.48.0  ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1 \
+    windows_x86_64_gnullvm          0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
+    windows_x86_64_gnullvm          0.48.0  7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953 \
+    windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
+    windows_x86_64_msvc             0.48.0  1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a \
     ws_stream_tungstenite            0.7.0  a672ec78525bf189cefa7f1b72c55f928b3edbdb967e680ca49748ab20821045


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/EdJoPaTo/mqttui/releases/tag/v0.19.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

