### PR TITLE
ecl: unpin i386

### DIFF
--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -30,22 +30,6 @@ checksums           rmd160  631b9427edef67ea3cac91da2031ac4629a6dd33 \
                     sha256  b15a75dcf84b8f62e68720ccab1393f9611c078fcd3afdd639a1086cad010900 \
                     size    7875088
 
-# i386 (and presumable PowerPC) has an issue with long double when its compiled
-# by modern compilers. To avoid blacklisting tons of compilers I've pin the last
-# version of ECL which has `disable-longdouble` on such platforms.
-# See: https://gitlab.com/embeddable-common-lisp/ecl/-/issues/705
-if {${os.platform} eq "darwin" && ${configure.build_arch} in [list ppc i386]} {
-    version         16.1.3
-    revision        0
-
-    checksums       rmd160  320e93e4abe62fa1fe9e36688ba040eef8ae8923 \
-                    sha256  76a585c616e8fa83a6b7209325a309da5bc0ca68e0658f396f49955638111254 \
-                    size    7459212
-
-    configure.args-append \
-                    --disable-longdouble
-}
-
 conflicts           ecl-devel
 
 subport ecl-devel {
@@ -81,6 +65,14 @@ configure.args-append \
 
 # match libatomic_ops restrictions
 compiler.blacklist-append *gcc-3.* *gcc-4.*
+
+# Clang on i386 can't bootstrap ECL after 16.1.3; blacklist it
+# See:
+#  - https://gitlab.com/embeddable-common-lisp/ecl/-/issues/705
+#  - https://github.com/ivmai/bdwgc/issues/569
+platform darwin i386 {
+    compiler.blacklist-append *clang*
+}
 
 patchfiles          patch-macports-xdg-data-dir.diff
 


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->