### PR TITLE
libmetalink: update to 0.1.3

### DIFF
--- a/net/libmetalink/Portfile
+++ b/net/libmetalink/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 
 name                libmetalink
-version             0.1.2
+version             0.1.3
 categories          net devel
-platforms           darwin
 maintainers         nomaintainer
 license             MIT
 
@@ -15,12 +14,12 @@ long_description    ${description} It is intended to help developers of C progra
                     Metalink functionality.
 
 homepage            https://launchpad.net/${name}
-master_sites        ${homepage}/trunk/packagingfix/+download/
+master_sites        ${homepage}/trunk/${name}-${version}/+download/
+use_xz              yes
 
-use_bzip2           yes
-
-checksums           rmd160  0920813d6117e33f932020688f74ed0a0e397421 \
-                    sha256  cbed9121bf550ef14a434d6ed3d8806ded7a339db16b698cfa2f39fdc3d48bf6
+checksums           rmd160  445dbdbd3b649ccba12caa3fc2d1c566d863267e \
+                    sha256  86312620c5b64c694b91f9cc355eabbd358fa92195b3e99517504076bf9fe33a \
+                    size    278592
 
 depends_lib-append  port:expat
 


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

```
Making check in test
/usr/bin/make  metalinktest
/usr/bin/gcc-4.2 -DHAVE_CONFIG_H -I. -I..   -DHAVE_INTTYPES_H -I/opt/local/include -I../lib -I../lib/includes -I../lib/includes -DLIBMETALINK_TEST_DIR=\"../test/\"  -pipe -Os -arch ppc -MT main.o -MD -MP -MF .deps/main.Tpo -c -o main.o main.c
mv -f .deps/main.Tpo .deps/main.Po
/usr/bin/gcc-4.2 -DHAVE_CONFIG_H -I. -I..   -DHAVE_INTTYPES_H -I/opt/local/include -I../lib -I../lib/includes -I../lib/includes -DLIBMETALINK_TEST_DIR=\"../test/\"  -pipe -Os -arch ppc -MT metalink_list_test.o -MD -MP -MF .deps/metalink_list_test.Tpo -c -o metalink_list_test.o metalink_list_test.c
mv -f .deps/metalink_list_test.Tpo .deps/metalink_list_test.Po
/usr/bin/gcc-4.2 -DHAVE_CONFIG_H -I. -I..   -DHAVE_INTTYPES_H -I/opt/local/include -I../lib -I../lib/includes -I../lib/includes -DLIBMETALINK_TEST_DIR=\"../test/\"  -pipe -Os -arch ppc -MT metalink_pctrl_test.o -MD -MP -MF .deps/metalink_pctrl_test.Tpo -c -o metalink_pctrl_test.o metalink_pctrl_test.c
mv -f .deps/metalink_pctrl_test.Tpo .deps/metalink_pctrl_test.Po
/usr/bin/gcc-4.2 -DHAVE_CONFIG_H -I. -I..   -DHAVE_INTTYPES_H -I/opt/local/include -I../lib -I../lib/includes -I../lib/includes -DLIBMETALINK_TEST_DIR=\"../test/\"  -pipe -Os -arch ppc -MT metalink_parser_test.o -MD -MP -MF .deps/metalink_parser_test.Tpo -c -o metalink_parser_test.o metalink_parser_test.c
mv -f .deps/metalink_parser_test.Tpo .deps/metalink_parser_test.Po
/usr/bin/gcc-4.2 -DHAVE_CONFIG_H -I. -I..   -DHAVE_INTTYPES_H -I/opt/local/include -I../lib -I../lib/includes -I../lib/includes -DLIBMETALINK_TEST_DIR=\"../test/\"  -pipe -Os -arch ppc -MT metalink_parser_test_v4.o -MD -MP -MF .deps/metalink_parser_test_v4.Tpo -c -o metalink_parser_test_v4.o metalink_parser_test_v4.c
mv -f .deps/metalink_parser_test_v4.Tpo .deps/metalink_parser_test_v4.Po
/usr/bin/gcc-4.2 -DHAVE_CONFIG_H -I. -I..   -DHAVE_INTTYPES_H -I/opt/local/include -I../lib -I../lib/includes -I../lib/includes -DLIBMETALINK_TEST_DIR=\"../test/\"  -pipe -Os -arch ppc -MT metalink_helper_test.o -MD -MP -MF .deps/metalink_helper_test.Tpo -c -o metalink_helper_test.o metalink_helper_test.c
mv -f .deps/metalink_helper_test.Tpo .deps/metalink_helper_test.Po
/bin/sh ../libtool  --tag=CC   --mode=link /usr/bin/gcc-4.2 -I../lib -I../lib/includes -I../lib/includes -DLIBMETALINK_TEST_DIR=\"../test/\"  -pipe -Os -arch ppc -static  -L/opt/local/lib -lcunit -L/opt/local/lib -Wl,-headerpad_max_install_names -arch ppc -o metalinktest main.o metalink_list_test.o metalink_pctrl_test.o metalink_parser_test.o metalink_parser_test_v4.o metalink_helper_test.o ../lib/libmetalink.la 
libtool: link: /usr/bin/gcc-4.2 -I../lib -I../lib/includes -I../lib/includes -DLIBMETALINK_TEST_DIR=\"../test/\" -pipe -Os -arch ppc -Wl,-headerpad_max_install_names -arch ppc -o metalinktest main.o metalink_list_test.o metalink_pctrl_test.o metalink_parser_test.o metalink_parser_test_v4.o metalink_helper_test.o  -L/opt/local/lib /opt/local/lib/libcunit.dylib ../lib/.libs/libmetalink.a /opt/local/lib/libexpat.dylib
/usr/bin/make  check-TESTS
PASS: metalinktest
make[4]: Nothing to be done for `all'.
============================================================================
Testsuite summary for libmetalink 0.1.3
============================================================================
# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```