### PR TITLE
jitsi-meet-electron: new port

### DIFF
--- a/net/jitsi-meet-electron/Portfile
+++ b/net/jitsi-meet-electron/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        jitsi jitsi-meet-electron 2023.10.0 v
+github.tarball_from archive
+revision            0
+
+categories          net
+installs_libs       no
+license             Apache-2
+maintainers         {@takikawa simplyrobot.org:agile.ice1123} openmaintainer
+description         Jitsi Meet Electron
+long_description    Jistsi Meet Electron is a client for the open-source Jitsi Meet teleconferencing system
+
+checksums           rmd160  e228a568fd78c6679594e765e2948db1fd16dab3 \
+                    sha256  1d7f996d4119f1ef6fb70530c60ea0240fcf046f1631ee43a5ce9d883b73b180 \
+                    size    827902
+
+depends_build       port:yarn
+
+build.env-append    CSC_IDENTITY_AUTO_DISCOVERY=false
+
+use_configure       no
+
+build {
+    # Fetch and build JS dependencies
+    # First line needed to work around https://github.com/jitsi/jitsi-meet-electron/issues/812
+    system -W ${worksrcpath} "${build.env} yarn add jsonfile"
+    system -W ${worksrcpath} "${build.env} yarn --frozen-lockfile"
+
+    # Build electron app
+    system -W ${worksrcpath} "${build.env} yarn run build"
+    system -W ${worksrcpath} "${build.env} yarn run electron-builder --mac --dir"
+}
+
+destroot {
+    copy {*}[glob ${worksrcpath}/dist/mac*/Jitsi\ Meet.app] ${destroot}${applications_dir}
+}


### PR DESCRIPTION
#### Description

New port for jitsi-meet-electron GUI application for teleconference meetings.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5.1
Xcode 14.3.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. --> (no existing tickets)
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`? (no tests, new port)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? (no variants)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
