### PR TITLE
libident: Update config.guess/config.sub for arm64; indicate permissive license

### DIFF
--- a/security/libident/Portfile
+++ b/security/libident/Portfile
@@ -4,6 +4,7 @@ version         0.32
 revision        1
 categories      security
 maintainers     {toby @tobypeterson}
+license         Permissive
 description     Ident protocol library
 long_description \
 	This is a library which provides a simple \

--- a/security/libident/Portfile
+++ b/security/libident/Portfile
@@ -23,6 +23,7 @@ checksums       rmd160 45c01b3c54a441b085ea3b8dc451eb8c33b7bd2e \
 patchfiles      patch-id_parse.c patch-ident.c
 
 use_autoreconf  yes
+autoreconf.args -fvi
 
 configure.cflags-append -Wall -W
 configure.args  --mandir=${prefix}/share/man


### PR DESCRIPTION
#### Description

Added `-f` to autoreconf args to update the bundled ancient config.guess and config.sub which should fix this configure failure on arm64:

```
checking build system type... configure: error: /bin/sh ./admin/config.sub -apple-darwin22.6.0 failed
```

Also indicated that the license is permissive. Looks like this version of the software is under a modified version of FSFULLR ([FSF Unlimited License (with License Retention)](https://spdx.org/licenses/FSFULLR.html)) and based on an earlier version which was in the public domain.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.7 21G651 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
