### PR TITLE
sitecopy: Allow building with neon 0.32.x

### DIFF
--- a/www/sitecopy/Portfile
+++ b/www/sitecopy/Portfile
@@ -1,9 +1,11 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem          1.0
+
 name                sitecopy
 version             0.16.6
 revision            1
 categories          www
-platforms           darwin
 maintainers         hal-9k.de:julian
 description         sitecopy website maintenance utility
 long_description    sitecopy allows you to easily maintain remote Web sites. The program \

--- a/www/sitecopy/files/patch-Makefile.in
+++ b/www/sitecopy/files/patch-Makefile.in
@@ -1,5 +1,6 @@
---- Makefile.in 2005-09-27 23:02:48.000000000 +0200
-+++ Makefile.in 2005-09-27 23:02:45.000000000 +0200
+Use the docdir given to configure with the --docdir flag.
+--- Makefile.in.orig	2008-07-07 15:55:29.000000000 -0500
++++ Makefile.in	2023-09-04 11:47:40.000000000 -0500
 @@ -11,7 +11,7 @@
  bindir = @bindir@
  mandir = @mandir@
@@ -8,4 +9,4 @@
 +docdir = @docdir@
  localedir = $(datadir)/locale
  datadir = @datadir@
- pkgdatadir = $(datadir)/sitecopy
+ datarootdir = @datarootdir@

--- a/www/sitecopy/files/patch-configure
+++ b/www/sitecopy/files/patch-configure
@@ -1,11 +1,12 @@
---- configure.orig	2008-07-17 07:15:52.000000000 +1000
-+++ configure	2011-04-23 00:06:20.000000000 +1000
+Recognize newer versions of neon.
+--- configure.orig	2008-07-16 16:15:52.000000000 -0500
++++ configure	2023-09-04 11:47:40.000000000 -0500
 @@ -8456,7 +8456,7 @@
  echo "${ECHO_T}$ne_cv_lib_neon" >&6; }
      if test "$ne_cv_lib_neon" = "yes"; then
         ne_cv_lib_neonver=no
 -       for v in 24 25 26 27 28; do
-+       for v in 24 25 26 27 28 29 30 31; do
++       for v in 24 25 26 27 28 29 30 31 32; do
            case $ne_libver in
            0.$v.*) ne_cv_lib_neonver=yes ;;
            esac


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/68122

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.7 21G651 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
