### PR TITLE
ruby-build: Update to 20230904

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230717 v
+github.setup        rbenv ruby-build 20230904 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  bc4e758fe842e404dcdd8825cf0d89c866fbb866 \
-                    sha256  f9a1c5c098d53cfb5573551fb0b332088176ea7ce6e32558c518e03fd38b3e92 \
-                    size    80372
+checksums           rmd160  0b7d6fe5de460afc8001cf31984b478f7339f38b \
+                    sha256  08e2a5ab0322004fa3d0e7ac2d15e21528b3fe702f5e02b6b08c1aabc342daa3 \
+                    size    78883
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

```
- Show openssl version used from homebrew by default by @MatasNed in #2226
- Bump up OpenSSL versions by @hsbt in #2227
- Avoid test failure when stubbing FreeBSD environment by @mislav in #2228
- Display the actual error when testing for Ruby's openssl extension by @YellowApple in #2223
- Remove require_gcc implementation by @mislav in #2232
- Remove require_llvm implementation by @mislav in #2231
- Update URLs for truffleruby+graalvm-dev by @eregon in #2244
```

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -st install`?
- [x] tested basic functionality of all binary files?