### PR TITLE
py-parsimonious: update to 0.10.0; drop py37; add py310 and py311

### DIFF
--- a/python/py-parsimonious/Portfile
+++ b/python/py-parsimonious/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        erikrose parsimonious 0.8.1
+github.setup        erikrose parsimonious 0.10.0
+github.tarball_from archive
 revision            0
 name                py-parsimonious
 
@@ -12,7 +13,7 @@ categories-append   devel
 license             MIT
 supported_archs     noarch
 platforms           {darwin any}
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         The fastest pure-Python PEG parser I can muster
 long_description    Parsimonious aims to be the fastest arbitrary-lookahead \
@@ -20,25 +21,20 @@ long_description    Parsimonious aims to be the fastest arbitrary-lookahead \
                     based on parsing expression grammars (PEGs), which means \
                     you feed it a simplified sort of EBNF notation.
 
-checksums           rmd160  2402241ec9e8c32ebf2681494caeb2a438b7df81 \
-                    sha256  526acc3fdef0012561addcd75cede7742f4731889c4247c395b15d6afd17539c \
-                    size    36567
+checksums           rmd160  e31c67023c9b76fb1fed7df95ef30b9471ebffc9 \
+                    sha256  5fb1a5084d603e890d4fad10fd78ae10962a7a60810d18b2d723570dfd827055 \
+                    size    41081
 
-python.versions     37 38 39
+python.versions     38 39 310 311
+
+python.pep517       yes
+
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
 
-    depends_lib-append \
-                        port:py${python.version}-six
+    depends_lib-append  port:py${python.version}-regex
 
-    depends_test-append  \
-                        port:py${python.version}-nose
     test.run            yes
-    test.cmd            nosetests-${python.branch}
-    test.target
-    test.env            PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->