### PR TITLE
igraph: fix build on 10.7 and 10.8

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -63,6 +63,16 @@ configure.args-append   -DUSE_CCACHE=OFF \
                         -DIGRAPH_OPENMP_SUPPORT=OFF \
                         -DIGRAPH_WARNINGS_AS_ERRORS=OFF
 
+# This should be removed for igraph 0.10.8 or later.
+platform darwin {
+    if {${os.major} >= 11 && ${os.major} <= 12} {
+        # On OS X 10.7 and 0.18, including <iostream> triggers
+        # an error without this.
+        # https://trac.macports.org/ticket/60885
+        configure.cxxflags-append -D_DARWIN_C_SOURCE
+    }
+}
+
 pre-configure {
     # Link to chosen BLAS/LAPACK
     configure.args-append   ${cmake_linalglib}


### PR DESCRIPTION
 - See https://trac.macports.org/ticket/67988
 - Workaround added upstream, this commit needs to be reverted for igraph 0.10.8

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
