### PR TITLE
ecl: blacklist clang only on i386

### DIFF
--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -70,8 +70,10 @@ compiler.blacklist-append *gcc-3.* *gcc-4.*
 # See:
 #  - https://gitlab.com/embeddable-common-lisp/ecl/-/issues/705
 #  - https://github.com/ivmai/bdwgc/issues/569
-platform darwin i386 {
-    compiler.blacklist-append *clang*
+if {${build_arch} eq "i386"} {
+    compiler.blacklist-append   *clang*
+    # I must ban libc++ because it will dismiss gcc
+    configure.cxx_stdlib        libstdc++
 }
 
 patchfiles          patch-macports-xdg-data-dir.diff


### PR DESCRIPTION
This is a fix of issue which was discussed here: https://github.com/macports/macports-ports/commit/516dc218a673906a8c9452f515f9c794ec7ae34a#commitcomment-126531860

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->