### PR TITLE
hdf5: Update to 1.14.2

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -9,7 +9,7 @@ github.setup            h5py h5py 3.9.0
 name                    py-h5py
 
 # h5py needs to be re-built after hdf5 upgrades
-revision                0
+revision                1
 
 checksums \
     rmd160  6a64c2d8d34347eea34892257e958ef1737c433c \

--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -7,9 +7,9 @@ PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 name                hdf5
-version             1.14.1-2
+version             1.14.2
 set mainversion     [lrange [split ${version} -] 0 0]
-revision            1
+revision            0
 set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
 categories          science
 maintainers         {eborisch @eborisch} openmaintainer
@@ -31,9 +31,9 @@ distfiles           ${name}-${version}.tar.bz2
 master_sites \
     https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${shortversion}/hdf5-${mainversion}/src
 checksums \
-    rmd160  af9a265095ca8a5adf4c40b8808d26299c87e904 \
-    sha256  06ca141d1a3c312b5d7cc4826a12737293ae131031748861689f6a2ec8219dbd \
-    size    16411401
+    rmd160  32d411636a449ef7b03c1ac3eb61b4787d703dcf \
+    sha256  ea3c5e257ef322af5e77fc1e52ead3ad6bf3bb4ac06480dd17ee3900d7a24cfb \
+    size    16070491
 mpi.setup           -gcc44 -gcc45
 
 use_bzip2           yes
@@ -58,14 +58,19 @@ compiler.blacklist-append \
 compiler.c_standard 1999
 
 # Use lib/hdf5 rather than hdf5/lib plugin directory
-configure.args      --with-zlib=yes \
-                    --with-szlib=${prefix}/lib/libaec \
+configure.args \
+                    --disable-cxx \
+                    --disable-fortran \
+                    --disable-hl \
+                    --disable-parallel \
                     --disable-silent-rules \
-                    --enable-build-mode=production --disable-fortran \
-                    --disable-cxx --disable-hl --enable-shared --enable-static \
-                    --disable-parallel --disable-threadsafe \
+                    --disable-threadsafe \
+                    --enable-build-mode=production \
+                    --enable-shared \
+                    --enable-static \
                     --with-default-plugindir=${prefix}/lib/hdf5 \
-                    --with-default-api-version=v110
+                    --with-szlib=${prefix}/lib/libaec \
+                    --with-zlib=yes
 
 # Actively checks how to get clang to warn on implicit functions with this.
 configure.checks.implicit_function_declaration.whitelist-append strchr
@@ -140,7 +145,7 @@ variant fortran description {
   +fortran is EXPERIMENTAL with +threadsafe
 } {
     configure.args-delete       --disable-fortran
-    configure.args-append       --enable-fortran --enable-fortran2003
+    configure.args-append       --enable-fortran
 }
 
 if {[variant_isset fortran] && ![fortran_variant_isset]} {


### PR DESCRIPTION
Maintainer update.

* HDF5 **doesn't complain within 1.14.x (at this point)**. As dependencies were last bumped for 1.14.1, not bumping dependencies unless known to require (py-h5py does its own separate check and complains, for example.)

   **_If a port is known to do its own checks of HDF5 versions, please let me know so it can get bumped._**

   Ref: https://github.com/HDFGroup/hdf5/commit/b8eac9d0

 * **Moving to latest-API-by-default build. Ports that require an old API  to build successfully can add -DH5_USE_110_API (for example) to use the old APIs.**

   Ref: https://docs.hdfgroup.org/hdf5/v1_12/api-compat-macros.html

Tagging maintainers of ports that have historically been bumped, or may need to check if a compatibility macro is needed:

**_PLEASE SEE THE ABOVE NOTE ABOUT PROPOSED CHANGES._**

@BSeppke: vigra
@MarcusCalhoun-Lopez: deal.ii octave cgnslib gmsh libmed xdmf
@Schamschula: mathgl armadillo
@Veence: kealib rsgislib
@barracuda156: R-HDF5Array R-rhdf5 R-rhdf5filters starpu13 libKriging luma mfem
@dstrubbe: paraview
@eborisch: py-h5py HDF5-External-Filter-Plugins
@egull: ALPSMaxent
@galexv: ALPSCore
@jcupitt: vips
@johndesanto: gmtsar
@jswhit: py-netcdf4
@jswoboda: digital_rf
@lpsinger: lal
@mascguy: opencv4-devel opencv4
@mf2k: ncpp
@mtorrent: abinit
@neurodroid: py-stfio stimfit
@petrrr: py-nio
@ra1nb0w: AppCSXCAD openEMS CSXCAD
@rdbisme: vtk
@remkos: nco
@stromnov: InsightToolkit-devel shogun-devel
@tenomoto: gnudatalanguage cdo grads hdfeos5 magicspp metview ncarg netcdf wgrib2