### PR TITLE
py-plyvel: update to 1.5.0

### DIFF
--- a/python/py-plyvel/Portfile
+++ b/python/py-plyvel/Portfile
@@ -4,15 +4,15 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-plyvel
-version             1.1.0
-revision            1
+version             1.5.0
+revision            0
 
 categories-append   devel
 license             BSD
 
-python.versions     37
+python.versions     27 38 39 310 311
 
-maintainers         {ipglider.org:miguel @ipglider} openmaintainer
+maintainers         {ipglider.org:miguel @ipglider} {@catap korins.ky:kirill} openmaintainer
 
 description         Plyvel is a fast and feature-rich Python interface to LevelDB.
 long_description    Plyvel is a Python interface to LevelDB that has a rich \
@@ -20,19 +20,12 @@ long_description    Plyvel is a Python interface to LevelDB that has a rich \
 
 homepage            https://github.com/wbolster/plyvel
 
-checksums           rmd160  680d5e9afb65105e7a73fc1f154530a6f451e84a \
-                    sha256  3731310784aaffe4e4e004ca5899d8d187a3ca9143e606142200498931f39ac5 \
-                    size    143970
+checksums           rmd160  ba5d8a12014c09accf7a1e10646bdc30af412e58 \
+                    sha256  cd918e0b31690abcd3d202a8742caf951ab2fe1573de7af71c38456847f9202b \
+                    size    152348
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools
-    depends_lib-append      port:leveldb
 
-    post-extract {
-        # Unreadable PKG-INFO breaks setuptools, and setuptools doesn't
-        # ensure it is installed with read permissions.
-        # https://github.com/pypa/setuptools/issues/1328
-        # https://github.com/pypa/setuptools/issues/617
-        system "chmod -R a+r ${worksrcpath}"
-    }
+    depends_lib-append      port:leveldb
 }


### PR DESCRIPTION
#### Description

I've drop `py37` subport because here isn't any port which uses it and it can be done safley.

Anyway, my update / fix of `john-jumbo` (See: https://github.com/macports/macports-ports/pull/20299) brings dependency to `p27` which I've tested locally to confirm that it's working fine.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->