### PR TITLE
dust: Add shell completions and manpage

### DIFF
--- a/sysutils/dust/Portfile
+++ b/sysutils/dust/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        bootandy dust 0.8.6 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         A more intuitive version of du in rust
 
@@ -23,6 +23,13 @@ checksums           ${distname}${extract.suffix} \
                     sha256  feede818e814011207c5bfeaf06dd9fc95825c59ab70942aa9b9314791c5d6b6 \
                     size    102584
 
+post-build {
+    # Completion files are re-generated as part of build, so we
+    # patch afterwards.
+    system -W ${worksrcpath} \
+        "patch -p1 < ${filespath}/patch-fix-bash-and-zsh-completions.diff"
+}
+
 github.livecheck.regex \
                     {([0-9.]+)}
 
@@ -30,6 +37,22 @@ destroot {
     xinstall -m 0755 \
         ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
         ${destroot}${prefix}/bin/
+
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 ${worksrcpath}/man-page/${name}.1 \
+        ${destroot}${prefix}/share/man/man1
+
+    set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${bash_comp_path}
+    xinstall -m 0644 ${worksrcpath}/completions/${name}.bash ${bash_comp_path}/${name}
+
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_comp_path}
+    xinstall -m 0644 ${worksrcpath}/completions/_${name} ${zsh_comp_path}
+
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${fish_comp_path}
+    xinstall -m 0644 ${worksrcpath}/completions/${name}.fish ${fish_comp_path}
 }
 
 cargo.crates \

--- a/sysutils/dust/files/patch-fix-bash-and-zsh-completions.diff
+++ b/sysutils/dust/files/patch-fix-bash-and-zsh-completions.diff
@@ -1,0 +1,37 @@
+commit 0038cb24b4adbb85321e3c36fb7079fc898de44e
+Author: wickles <4229542+wickles@users.noreply.github.com>
+Date:   Fri Jul 14 10:32:21 2023 -0700
+
+    Fix filename completions for zsh and bash (#331)
+
+diff --git a/completions/_dust b/completions/_dust
+index 9e8be82..5443a41 100644
+--- a/completions/_dust
++++ b/completions/_dust
+@@ -64,7 +64,7 @@ _dust() {
+ '(-F --only-file -t --file_types)--only-dir[Only directories will be displayed.]' \
+ '(-D --only-dir)-F[Only files will be displayed. (Finds your largest files)]' \
+ '(-D --only-dir)--only-file[Only files will be displayed. (Finds your largest files)]' \
+-'*::inputs:' \
++'*:inputs:_files' \
+ && ret=0
+ }
+ 
+diff --git a/completions/dust.bash b/completions/dust.bash
+index 83d7b65..e34777a 100644
+--- a/completions/dust.bash
++++ b/completions/dust.bash
+@@ -20,9 +20,12 @@ _dust() {
+     case "${cmd}" in
+         dust)
+             opts="-h -V -d -n -p -X -L -x -s -r -c -b -z -R -f -i -v -e -t -w -H -P -D -F --help --version --depth --number-of-lines --full-paths --ignore-directory --dereference-links --limit-filesystem --apparent-size --reverse --no-colors --no-percent-bars --min-size --screen-reader --skip-total --filecount --ignore_hidden --invert-filter --filter --file_types --terminal_width --si --no-progress --only-dir --only-file <inputs>..."
+-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
++            if [[ ${cur} == -* ]] ; then
+                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                 return 0
++            elif [[ ${cur} == * ]] ; then
++                _filedir
++                return 0
+             fi
+             case "${prev}" in
+                 --depth)


### PR DESCRIPTION
#### Description

Add shell completions and manpage when installing `dust`. I bumped the revision number to signal a patch update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
