### PR TITLE
google-cloud-sdk: update to 445.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             444.0.0
+version             445.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  7c7a1d81d61e018d638c7ca17ff694f7df4c4a00 \
-                    sha256  61a2faeb2b843eec69c82d10055ee8d9eed28e84340379e8ca5da12cce6bf4dd \
-                    size    101375017
+    checksums       rmd160  60aebc87593162f71ff3d870bea3eace6683a16c \
+                    sha256  2d201e2100433da1e46d949411118f5f245529aed654cb33322ec2d148c2d100 \
+                    size    101427200
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  445f7cc94c8e997bb1b01006ba3a788fb876382a \
-                    sha256  e7ae3bb93ea96a56f997eeff63fcafa26d67869f748dcc6b46e0615bb7f03841 \
-                    size    121637787
+    checksums       rmd160  a3d9ef35515f8c25493e83597af3e98670c0e2af \
+                    sha256  c11c6b84cecf95455c9ca7889575f7ccc02c9e85213b7b5e3be1d1e88a1709ab \
+                    size    121693069
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  d26eadced3b0798be493d82cab53423745be75a9 \
-                    sha256  7d291386bac17102ca0af66f261eac786d5bf8dde27f8ecf3d4efa32dd6ae807 \
-                    size    118799659
+    checksums       rmd160  aa448eff7927455343973bfa55626fdfc7c54532 \
+                    sha256  2bd8c05a49e47d30cc678f3245b46cf975991bf9305f937f511244f97fcc9cce \
+                    size    118847528
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 445.0.0.

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?