### PR TITLE
grpc: add test variant

### DIFF
--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 # NOTE: Also rev-bump 'apache-arrow' when updating this port
 github.setup        grpc grpc 1.48.4 v
-revision            2
+revision            3
 categories          devel
 maintainers         nomaintainer
 license             Apache-2
@@ -51,7 +51,6 @@ depends_lib-append \
                     path:lib/libssl.dylib:openssl \
                     port:abseil \
                     port:c-ares \
-                    port:gperftools \
                     port:lbzip2 \
                     port:libuv \
                     port:protobuf3-cpp \
@@ -82,6 +81,7 @@ post-fetch {
 
 configure.args-append \
                     -DBUILD_SHARED_LIBS:BOOL=ON \
+                    -DgRPC_BUILD_TESTS=OFF \
                     -DgRPC_ABSL_PROVIDER=package \
                     -DgRPC_CARES_PROVIDER=package \
                     -DgRPC_PROTOBUF_PROVIDER=package \
@@ -140,7 +140,14 @@ if {[info exists cmake.build_dir]
 
 build.target
 
-if {${name} eq ${subport}} {
+variant test description {Build and run unit testing framework} {
+    depends_test-append \
+                    port:gperftools
+
+    configure.args-replace \
+                    -DgRPC_BUILD_TESTS=OFF \
+                    -DgRPC_BUILD_TESTS=ON
+
     test.run         yes
 
     test {


### PR DESCRIPTION
#### Description

The only reason to have gperftools depedency is to run tests,
which can be avoided by introducing test variant.

See: https://trac.macports.org/ticket/68132

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->