### PR TITLE
xmlsec-1.2: fix library lookup

### DIFF
--- a/security/xmlsec-1.2/Portfile
+++ b/security/xmlsec-1.2/Portfile
@@ -5,7 +5,7 @@ PortSystem                  1.0
 # Note: this version is for backward compatibility, remove after dependents are updated
 name                        xmlsec-1.2
 version                     1.2.37
-revision                    2
+revision                    3
 checksums                   rmd160  9ef8c08f762a5aba2d6ce7ead53efdcea8fad9cb \
                             sha256  5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c \
                             size    2009175
@@ -38,7 +38,7 @@ depends_lib                 port:libxml2 \
 patchfiles                  patch-src-dl.c.diff \
                             dynamic_lookup-11.patch
 post-patch {
-    reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/src/dl.c
+    reinplace "s|@PREFIX@|${prefix}/lib/${name}|g" ${worksrcpath}/src/dl.c
 }
 
 configure.args              --disable-silent-rules \


### PR DESCRIPTION
#### Description

It seems this was missed when it was moved to a separate port.

###### Type(s)

- [x] bugfix

###### Tested on
macOS 13.5.1 22G90 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?