### PR TITLE
eza: new port (version 0.11.0)

### DIFF
--- a/sysutils/eza/Portfile
+++ b/sysutils/eza/Portfile
@@ -1,0 +1,178 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github  1.0
+PortGroup           cargo   1.0
+
+github.setup        eza-community eza 0.11.0 v
+github.tarball_from archive
+revision            0
+
+description         A modern, maintained replacement for ls
+
+long_description    \
+    ${name} is a modern, maintained replacement for the venerable \
+    file-listing command-line program ls that ships with Unix and Linux \
+    operating systems, giving it more features and better defaults. It uses \
+    colours to distinguish file types and metadata. It knows about symlinks, \
+    extended attributes, and Git. And it’s small, fast, and just one single \
+    binary. By deliberately making some decisions differently, ${name} \
+    attempts to be a more featureful, more user-friendly version of ls.
+
+categories          sysutils
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  e5a0ee8636b6d13431dc62197f281abececce99b \
+                    sha256  fdaaf450cfaaa41d6ea8ae12fbb8e41e955e255b1169022a7675ca29d7d621c0 \
+                    size    1215969
+
+depends_lib-append  port:libiconv \
+                    path:lib/pkgconfig/libgit2.pc:libgit2 \
+                    port:zlib
+
+variant git description {Build with git functionality} {}
+
+variant doc description {Build man pages} {
+    if {${os.platform} eq "darwin" && ${os.major} < 17 || \
+    ${configure.build_arch} eq "arm64"} {
+        depends_build-append port:go-md2man
+        post-build {
+            system -W ${worksrcpath}/man "${prefix}/bin/go-md2man \
+                -in=${name}.1.md -out=${name}.1"
+            system -W ${worksrcpath}/man "${prefix}/bin/go-md2man \
+                -in=${name}_colors.5.md -out=${name}_colors.5"
+        }
+        notes "
+            The man pages for macOS 10.12 and below or Apple Silicon have\
+            minor formatting errors as they were built with go-md2man instead\
+            of pandoc.
+        "
+    } else {
+        depends_build-append port:pandoc
+        post-build {
+            system -W ${worksrcpath}/man "${prefix}/bin/pandoc --standalone \
+                -f markdown -t man ${name}.1.md > ${name}.1"
+            system -W ${worksrcpath}/man "${prefix}/bin/pandoc --standalone \
+                -f markdown -t man ${name}_colors.5.md > ${name}_colors.5"
+        }
+    }
+}
+
+default_variants +git +doc
+
+if {![variant_isset git]} {
+    build.args      --no-default-features
+}
+
+test.run            yes
+test.cmd            ${cargo.bin} test
+test.args           --target [cargo.rust_platform]
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+
+    if {[variant_isset doc]} {
+        xinstall -m 0444 \
+            ${worksrcpath}/man/${name}.1 ${destroot}${prefix}/share/man/man1/
+
+        xinstall -m 0444 \
+            ${worksrcpath}/man/${name}_colors.5 \
+            ${destroot}${prefix}/share/man/man5/
+    }
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} \
+        README.md LICENCE \
+        ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0644 ${worksrcpath}/completions/bash/${name} \
+        ${destroot}${prefix}/share/bash-completion/completions/${name}
+
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0644 ${worksrcpath}/completions/zsh/_${name} \
+        ${destroot}${prefix}/share/zsh/site-functions/_${name}
+
+    xinstall -d ${destroot}${prefix}/share/fish/completions
+    xinstall -m 0644 ${worksrcpath}/completions/fish/${name}.fish \
+        ${destroot}${prefix}/share/fish/completions/${name}.fish
+}
+
+cargo.crates \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                         2.4.0  b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635 \
+    byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
+    cc                              1.0.79  50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f \
+    datetime                         0.5.2  44c3f7a77f3e57fedf80e09136f2d8777ebf621207306f6d96d610af048354bc \
+    errno                            0.3.3  136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd \
+    errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
+    form_urlencoded                  1.0.1  5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191 \
+    git2                            0.18.0  12ef350ba88a33b4d524b1d1c79096c9ade5ef8c59395df0e60d1e1889414c0e \
+    glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
+    hermit-abi                       0.3.2  443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b \
+    idna                             0.2.3  418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8 \
+    io-lifetimes                    1.0.11  eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2 \
+    jobserver                       0.1.22  972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                           0.2.147  b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3 \
+    libgit2-sys               0.16.1+1.7.1  f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c \
+    libz-sys                         1.1.2  602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655 \
+    linux-raw-sys                    0.3.8  ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519 \
+    locale                           0.2.2  5fdbe492a9c0238da900a1165c42fc5067161ce292678a6fe80921f30fe307fd \
+    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
+    natord                           1.0.9  308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c \
+    num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
+    number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
+    openssl-src            111.26.0+1.1.1u  efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37 \
+    openssl-sys                     0.9.61  313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f \
+    pad                              0.1.6  d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3 \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
+    phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
+    phf_macros                      0.11.2  3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b \
+    phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
+    pkg-config                      0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
+    proc-macro2                     1.0.66  18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9 \
+    quote                           1.0.33  5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    rustix                         0.37.23  4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06 \
+    scoped_threadpool                0.1.9  1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8 \
+    siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
+    syn                             2.0.29  c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a \
+    term_grid                        0.1.7  230d3e804faaed5a39b08319efb797783df2fd9671b39b7596490cb486d702cf \
+    terminal_size                    0.2.6  8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237 \
+    timeago                          0.4.1  5082dc942361cdfb74eab98bf995762d6015e5bb3a20bf7c5c71213778b4fcb4 \
+    tinyvec                          1.2.0  5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342 \
+    tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
+    unicode-bidi                     0.3.5  eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0 \
+    unicode-ident                   1.0.11  301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c \
+    unicode-normalization           0.1.17  07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef \
+    unicode-width                   0.1.10  c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b \
+    url                              2.2.1  9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b \
+    uzers                           0.11.2  49546562f3f91dcad51aab95b9664113f099dd829c5dcd8ba1486fddb7d3bccc \
+    vcpkg                           0.2.12  cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
+    zoneinfo_compiled                0.5.1  64fbebe65e899530f43bd760b23fda8f141118f4db49952b02998cbd0907a5de


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
