### PR TITLE
lastpass-cli: update to 1.36

### DIFF
--- a/security/lastpass-cli/Portfile
+++ b/security/lastpass-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        lastpass lastpass-cli 1.3.5 v
+github.setup        lastpass lastpass-cli 1.3.6 v
 revision            0
 
 categories          security
@@ -20,9 +20,9 @@ depends_lib-append  port:curl \
                     port:libxml2 \
                     path:lib/libssl.dylib:openssl
 
-checksums           rmd160  c071ee64487fd4f5b1097cd0940174b3ba0064a1 \
-                    sha256  478f7a0e227941a32b49915d7ddc97296fbf54d6da582e226dee0301d6fdaf1d \
-                    size    117274
+checksums           rmd160  f3b87a00569daabb5da478175424c6eeeb9251df \
+                    sha256  4b56a18e9899df89db610252e4c207082a5562bb7de5736873aea4bf37693326 \
+                    size    117301
 
 if {${subport} eq ${name}} {
     default_variants    +pinentry


### PR DESCRIPTION
#### Description

lastpass-cli: update to 1.36

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.5.1 22G90 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
