### PR TITLE
opensc: update to 0.23.0

### DIFF
--- a/security/opensc/Portfile
+++ b/security/opensc/Portfile
@@ -6,12 +6,12 @@ PortGroup               openssl 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
 name                    opensc
-github.setup            OpenSC OpenSC 0.22.0
+github.setup            OpenSC OpenSC 0.23.0
 revision                0
 
-checksums               rmd160  7796feadb78c57457eb97d9409be2fac36bf61e9 \
-                        sha256  cbe0f660773458ca09b5167addca1f00c65cad424a906749f68eb34ceb6dcd0d \
-                        size    1790141
+checksums               rmd160  17ca6962955588a7a6c8aec0c20af7f2a93eb25c \
+                        sha256  80b9b1c84bb740b0a69109744dbbe0c1f49ab918bbd9500c7f898167b8847fb9 \
+                        size    1965242
 
 categories              security
 license                 LGPL-2.1
@@ -46,7 +46,7 @@ depends_build           port:docbook-xsl-nons \
 
 default_variants        +readline
 
-patchfiles              patch-winscard.diff
+patchfiles              patch-winscard.diff patch-pgp-and-tools.diff
 patch.pre_args          -p1
 
 # https://trac.macports.org/ticket/65709

--- a/security/opensc/files/patch-pgp-and-tools.diff
+++ b/security/opensc/files/patch-pgp-and-tools.diff
@@ -1,0 +1,133 @@
+#
+# Changes are taken from OpenSC master branch, most probably this patch
+# will not be needed after next release.
+#
+diff --git a/src/libopensc/card-openpgp.c b/src/libopensc/card-openpgp.c
+index fad32f0c..e4e6cc4d 100644
+--- a/src/libopensc/card-openpgp.c
++++ b/src/libopensc/card-openpgp.c
+@@ -129,7 +129,7 @@ static pgp_ec_curves_t	ec_curves_gnuk[] = {
+ 
+ static int		pgp_get_card_features(sc_card_t *card);
+ static int		pgp_finish(sc_card_t *card);
+-static void		pgp_iterate_blobs(pgp_blob_t *, void (*func)());
++static void		pgp_free_blobs(pgp_blob_t *);
+ 
+ static int		pgp_get_blob(sc_card_t *card, pgp_blob_t *blob,
+ 				 unsigned int id, pgp_blob_t **ret);
+@@ -947,7 +947,7 @@ pgp_finish(sc_card_t *card)
+ 
+ 		if (priv != NULL) {
+ 			/* delete fake file hierarchy */
+-			pgp_iterate_blobs(priv->mf, pgp_free_blob);
++			pgp_free_blobs(priv->mf);
+ 
+ 			/* delete private data */
+ 			free(priv);
+@@ -1147,10 +1147,10 @@ pgp_free_blob(pgp_blob_t *blob)
+ 
+ 
+ /**
+- * Internal: iterate through the blob tree, calling a function for each blob.
++ * Internal: iterate through the blob tree, calling pgp_free_blob for each blob.
+  */
+ static void
+-pgp_iterate_blobs(pgp_blob_t *blob, void (*func)())
++pgp_free_blobs(pgp_blob_t *blob)
+ {
+ 	if (blob) {
+ 		pgp_blob_t *child = blob->files;
+@@ -1158,10 +1158,10 @@ pgp_iterate_blobs(pgp_blob_t *blob, void (*func)())
+ 		while (child != NULL) {
+ 			pgp_blob_t *next = child->next;
+ 
+-			pgp_iterate_blobs(child, func);
++			pgp_free_blobs(child);
+ 			child = next;
+ 		}
+-		func(blob);
++		pgp_free_blob(blob);
+ 	}
+ }
+ 
+diff --git a/src/tools/cardos-tool.c b/src/tools/cardos-tool.c
+index 4e6dd554..26959abb 100644
+--- a/src/tools/cardos-tool.c
++++ b/src/tools/cardos-tool.c
+@@ -1183,6 +1183,9 @@ int main(int argc, char *argv[])
+ 		}
+ 	}
+ 
++    if (action_count == 0)
++        util_print_usage_and_die(app_name, options, option_help, NULL);
++
+ 	/* create sc_context_t object */
+ 	memset(&ctx_param, 0, sizeof(ctx_param));
+ 	ctx_param.ver      = 0;
+diff --git a/src/tools/netkey-tool.c b/src/tools/netkey-tool.c
+index f2904ad1..ad82b282 100644
+--- a/src/tools/netkey-tool.c
++++ b/src/tools/netkey-tool.c
+@@ -535,6 +535,7 @@ int main(
+ 		fprintf(stderr,"Establish-Context failed: %s\n", sc_strerror(r));
+ 		exit(1);
+ 	}
++       ctx->debug = debug;
+ 	if(ctx->debug>0)
+ 		printf("Context for application \"%s\" created, Debug=%d\n", ctx->app_name, ctx->debug);
+ 
+diff --git a/src/tools/pkcs11-tool.c b/src/tools/pkcs11-tool.c
+index aae205fe..8402fe39 100644
+--- a/src/tools/pkcs11-tool.c
++++ b/src/tools/pkcs11-tool.c
+@@ -7315,41 +7315,42 @@ static int test_random(CK_SESSION_HANDLE session)
+ 		printf("  seeding (C_SeedRandom) not supported\n");
+ 	else if (rv != CKR_OK) {
+ 		p11_perror("C_SeedRandom", rv);
+-		return 1;
++               errors++;
+ 	}
+ 
+ 	rv = p11->C_GenerateRandom(session, buf1, 10);
+ 	if (rv != CKR_OK) {
+ 		p11_perror("C_GenerateRandom", rv);
+-		return 1;
++               errors++;
+ 	}
+ 
+ 	rv = p11->C_GenerateRandom(session, buf1, 100);
+ 	if (rv != CKR_OK) {
+ 		p11_perror("C_GenerateRandom(buf1,100)", rv);
+-		return 1;
++               errors++;
+ 	}
+ 
+ 	rv = p11->C_GenerateRandom(session, buf1, 0);
+ 	if (rv != CKR_OK) {
+ 		p11_perror("C_GenerateRandom(buf1,0)", rv);
+-		return 1;
++               errors++;
+ 	}
+ 
+ 	rv = p11->C_GenerateRandom(session, buf2, 100);
+ 	if (rv != CKR_OK) {
+ 		p11_perror("C_GenerateRandom(buf2,100)", rv);
+-		return 1;
++               errors++;
+ 	}
+ 
+ 	if (memcmp(buf1, buf2, 100) == 0) {
+ 		printf("  ERR: C_GenerateRandom returned twice the same value!!!\n");
+-		errors++;
++               errors++;
+ 	}
+ 
+-	printf("  seems to be OK\n");
++ 	if (!errors)
++ 		printf("  seems to be OK\n");
+ 
+-	return 0;
++    return errors;
+ }
+ 
+ static int test_card_detection(int wait_for_event)

--- a/security/opensc/files/patch-winscard.diff
+++ b/security/opensc/files/patch-winscard.diff
@@ -21,17 +21,3 @@ diff --git a/src/libopensc/internal-winscard.h b/src/libopensc/internal-winscard
  #include <winscard.h>
  #ifdef __APPLE__
  #include <wintypes.h>
-
-diff --git a/src/libopensc/reader-pcsc.c b/src/libopensc/reader-pcsc.c
---- a/src/libopensc/reader-pcsc.c
-+++ b/src/libopensc/reader-pcsc.c
-@@ -182,8 +182,10 @@
- 		return SC_ERROR_CARD_UNRESPONSIVE;
- 	case SCARD_E_SHARING_VIOLATION:
- 		return SC_ERROR_READER_LOCKED;
-+#ifdef SCARD_E_NO_READERS_AVAILABLE
- 	case SCARD_E_NO_READERS_AVAILABLE:
- 		return SC_ERROR_NO_READERS_FOUND;
-+#endif
- 	case SCARD_E_UNKNOWN_READER:
- 		return SC_ERROR_READER_DETACHED;


### PR DESCRIPTION
#### Description

Update opensc to 0.23.0.

###### Tested on

macOS 13.5.1 22G90 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`? (no tests exist)
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
