### PR TITLE
GPXSee: update to 13.8

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.7
+github.setup        tumic0 GPXSee 13.8
 revision            0
 
-checksums           rmd160  30d8c5c52768999594cbefd222277e18c8099b57 \
-                    sha256  d41d4cfb117006a47c298b4b54b9dd198995e4c8e136b3f103b9d04addc081d8 \
-                    size    5501892
+checksums           rmd160  ea17400862142e53c5a157681bf0a7b2c25302ce \
+                    sha256  26d4459249d0409824e486c8b4de9e4fa84c9f3e16d79f08b2cdb4bcc0e92ddf \
+                    size    5631226
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
