### PR TITLE
lima: fix templates folder not found when creating VM

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/lima-vm/lima 0.17.2 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://lima-vm.io
 
@@ -52,10 +52,12 @@ destroot {
         {*}[glob ${worksrcpath}/_output/share/doc/lima/docs/*.md] \
         ${destroot}${prefix}/share/doc/lima/docs
 
-    xinstall -m 0755 -d ${destroot}${prefix}/share/lima/examples
+    xinstall -m 0755 -d ${destroot}${prefix}/share/lima/templates
     xinstall -m 0644 \
         {*}[glob ${worksrcpath}/_output/share/doc/lima/examples/*.yaml] \
-        ${destroot}${prefix}/share/lima/examples
+        ${destroot}${prefix}/share/lima/templates
+
+    ln -fs ${prefix}/share/lima/templates ${destroot}${prefix}/share/lima/examples
 }
 
 github.livecheck.regex {([0-9.]+)}


### PR DESCRIPTION
#### Description
See: lima-vm/lima#1679
The old examples folder is replaced with a symlink, to preserve any existing references, similarly to how it is done in official binary archives.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5.1 22G90 x86_64
Xcode 14.3.1 14E300c


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
