### PR TITLE
csv2strings: new submission

### DIFF
--- a/devel/csv2strings/Portfile
+++ b/devel/csv2strings/Portfile
@@ -1,0 +1,44 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcodeversion 1.0
+
+github.setup        csknns csv2strings 1.1.2
+github.tarball_from archive
+revision            0
+
+description         Apple's strings file convertor
+long_description    \
+    Parse & convert Apple's strings file to and from a csv file, with first \
+    column the translation key, second column the translation value, and the \
+    third the comments.
+
+categories          devel
+license             GLP-3.0
+maintainers         {@csknns gmail.com:christos.koninis} openmaintainer
+
+checksums           rmd160  bf1d396e8d953462f2388333c67829af395011c6 \
+                    sha256  1ea7ba5fcace0b330462b4e27156253050acb21dba8a56064c34649838abfa50 \
+                    size    37806
+
+use_configure       no
+use_xcode           yes
+
+# Clearing CPATH because ncurses is also supplied by MacOSX13.sdk and leads to conflicts
+compiler.cpath
+
+build.cmd           swift
+build.target        build
+build.args          --configuration release --disable-sandbox
+
+test.run            yes
+test.cmd            swift
+test.target         test
+test.args           --disable-sandbox
+
+set builtproductdir ${worksrcpath}/.build/release
+
+destroot {
+    xinstall -m 0755 ${builtproductdir}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

A new portfile for [https://github.com/csknns/csv2strings csv2strings], a simple command line utility & library to parse & convert an Apple's strings file(translations keys/values) to and from a csv file, with first column the translation key and second column the translation value.

###### Tested on
macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
