### PR TITLE
py-cachecontrol: update to 0.13.1

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 
 name                    poetry
 version                 1.6.1
-revision                0
+revision                1
 categories-append       devel
 platforms               {darwin any}
 license                 MIT
@@ -52,6 +52,7 @@ depends_lib-append \
     port:py${python.version}-poetry-plugin-export \
     port:py${python.version}-build \
     port:py${python.version}-cachecontrol \
+    port:py${python.version}-filelock \
     port:py${python.version}-cleo \
     port:py${python.version}-crashtest \
     port:py${python.version}-clikit \

--- a/python/py-cachecontrol/Portfile
+++ b/python/py-cachecontrol/Portfile
@@ -4,15 +4,18 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cachecontrol
-python.rootname     CacheControl
-version             0.12.11
+version             0.13.1
 revision            0
 categories-append   devel
 platforms           {darwin any}
 license             Apache-2
 supported_archs     noarch
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
+
+python.pep517       yes
+python.pep517_backend \
+                    flit
 
 maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 
@@ -21,11 +24,11 @@ long_description    \
     CacheControl is a port of the caching algorithms in \
     httplib2 for use with requests session object.
 
-homepage            https://github.com/ionrock/cachecontrol
+homepage            https://github.com/psf/cachecontrol
 
-checksums           rmd160  654fc1b57bdc6ae5b047da8629cf2bba88e493f2 \
-                    sha256  a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144 \
-                    size    16552
+checksums           rmd160  bf4659f482b388370b980094231cb4465f915eb3 \
+                    sha256  f012366b79d2243a6118309ce73151bf52a38d4a5dac8ea57f09bd29087e506b \
+                    size    29069
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68140

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.2 22G91 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
