### PR TITLE
libplist-devel: Update to latest commit

### DIFF
--- a/textproc/libplist/Portfile
+++ b/textproc/libplist/Portfile
@@ -39,8 +39,8 @@ configure.args      --disable-silent-rules \
                     --without-cython
 
 subport libplist-devel {
-    github.setup    libimobiledevice libplist 21a432bc746e9d3897d4972a9c17ee99b0c1ecc0
-    version         20230514
+    github.setup    libimobiledevice libplist d45396aad911d496494a587bd2d3ef20c2e8a8d0
+    version         20230829
     revision        0
 
     checksums       rmd160  e80704e4645842d35ad063e1026503a0470d929d \


### PR DESCRIPTION
#### Description

Update subport `libplist-devel` to the latest available commit.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
