### PR TITLE
swig3-*: should depends on swig3, not swig

### DIFF
--- a/devel/swig3/Portfile
+++ b/devel/swig3/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 
 name            swig3
 version         3.0.12
-revision        3
+revision        4
 checksums       rmd160  41877e9de3ff598731ef36161f77fa66dec3c301 \
                 sha256  7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d \
                 size    8149820
@@ -93,6 +93,12 @@ foreach lang [lsort [array names bindings]] {
     }
 }
 
+subport swig3-d {
+    # MacPorts has DMD at which supports macOS up to 12
+    # See: https://forum.dlang.org/thread/yrmpzhhpuwdgnfaldstz@forum.dlang.org
+    platforms               {darwin <= 21}
+}
+
 subport swig3-java {
     PortGroup               java 1.0
 
@@ -170,6 +176,9 @@ subport swig3-php {
 }
 
 subport swig3-gcj {
+    # gcc4x is supported up to 10.6
+    platforms               {darwin <= 10}
+
     variant gcc43 conflicts gcc44 gcc45 gcc47 gcc48 description {build using GCJ 4.3} {
         depends_lib-delete port:gcc47
         depends_lib-append port:gcc43
@@ -212,6 +221,13 @@ subport swig3-gcj {
         ui_error "\n\nA +gcc4X variant must be selected; the variant '-gcc47' cannot be used alone.\n"
         return -code error "Invalid variant selection"
     }
+}
+
+subport swig3-pike {
+    # See:
+    #  - https://trac.macports.org/ticket/31384
+    #  - https://trac.macports.org/ticket/68011
+    known_fail              yes
 }
 
 subport swig3-ruby {
@@ -325,7 +341,7 @@ if {${swig.lang} eq ""} {
         SWIG is a software development tool that connects programs written in C \
         and C++ with a variety of high-level programming languages. This is the \
         $prettynames(${swig.lang}) binding.
-    depends_lib-append  port:swig
+    depends_lib-append  port:swig3
     livecheck.type      none
     post-destroot {
         delete ${destroot}${prefix}/bin


### PR DESCRIPTION
#### Description

Here a fix of wrong dependencies. `swig3` and `swig` are different ports, and all subports of `swig3` should depends on `swig3`, not `swig`.

Thus, CI is failing because `swig3-gcj` is too old to be compiled by modern OS :(

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->