### PR TITLE
swiftlint: new submission

### DIFF
--- a/devel/swiftlint/Portfile
+++ b/devel/swiftlint/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcodeversion 1.0
+
+
+github.setup        realm swiftlint 0.52.4
+github.tarball_from archive
+revision            0
+
+platforms           {darwin >= 21}
+categories          devel
+license             MIT
+maintainers         {gmail.com:christos.koninis @csknns} \
+                    openmaintainer
+description         Swift linter
+long_description    A tool to enforce Swift style and conventions
+
+checksums           rmd160  87761a71e6c412ab19b055992a6659799dc65a8c \
+                    sha256  fb6ab7676f8c46d48b2f548cc95c74c2b063fd8b0e342cfca10083ce496737ab \
+                    size    828745
+
+# Clearing CPATH because of header conflicts with MacOSX13.sdk when using swiftPM build system
+compiler.cpath
+
+use_configure       no
+use_xcode           yes
+
+build.cmd           swift
+build.target        build
+build.args          --configuration release --disable-sandbox
+
+test.run            yes
+test.cmd            swift
+test.target         test
+test.args           --disable-sandbox
+
+set builtproductdir ${worksrcpath}/.build/release
+
+destroot {
+    xinstall -m 755 ${builtproductdir}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

A new portfile for [https://github.com/realm/SwiftLint swiftlint], a simple command line tool to enforce Swift style and and conventions.

###### Tested on
macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

