### PR TITLE
FAudio: update to 23.09

### DIFF
--- a/audio/FAudio/Portfile
+++ b/audio/FAudio/Portfile
@@ -3,8 +3,9 @@
 PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
+PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            FNA-XNA FAudio 23.08
+github.setup            FNA-XNA FAudio 23.09
 revision                0
 
 license                 zlib
@@ -17,9 +18,9 @@ long_description        an XAudio reimplementation that focuses solely on develo
 
 depends_lib-append      port:libsdl2
 
-checksums               rmd160  d4e51ac0af74c3d990aa5c0f5c17d0d6888b062a \
-                        sha256  bd35be172b27b8347cd2b5a50ac638da1d72cf3f529167c3828bceb1959caf97 \
-                        size    1119994
+checksums               rmd160  1edff632e8179a6afd793c30168363b8520ba020 \
+                        sha256  9b59cd8f218a4a7b3452d9d4e3ec584166b488712882e2c94726daefa9f5a0bb \
+                        size    1120019
 
 # remove set deployment target and hard-coded RPATH setting
 patchfiles              patch-faudio-remove-deployment-target.diff
@@ -41,7 +42,10 @@ if {${os.major} <= 10} {
 }
 
 # https://github.com/FNA-XNA/FAudio/issues/321
-compiler.blacklist-append *gcc-4.*
+# Xcode clang on 10.6 also fails to build it.
+# FAudio.h: error: wrong number of arguments specified for ‘deprecated’ attribute
+compiler.blacklist-append \
+                        *gcc-4.* {clang < 421}
 
 #pre-destroot {
 #    there are some utilities to consider, but the facttool segfaulted when I tried to open an audio engine


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
