### PR TITLE
bat: Add generated bash shell completion

### DIFF
--- a/textproc/bat/Portfile
+++ b/textproc/bat/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        sharkdp bat 0.23.0 v
 github.tarball_from archive
-revision            3
+revision            4
 
 description         A cat(1) clone with syntax highlighting and Git integration.
 
@@ -47,8 +47,7 @@ destroot {
     # Install shell completions
     set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
     xinstall -d ${bash_comp_path}
-    # Use simple _longopt-based completions file until bat ships with its own bash completions file
-    xinstall -m 0644 ${filespath}/bat.bash ${bash_comp_path}/${name}
+    xinstall -m 0644 ${assets_path}/completions/bat.bash ${bash_comp_path}/${name}
 
     set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
     xinstall -d ${zsh_comp_path}

--- a/textproc/bat/files/bat.bash
+++ b/textproc/bat/files/bat.bash
@@ -1,1 +1,0 @@
-complete -F _longopt bat


### PR DESCRIPTION
#### Description

Add generated bash shell completion. When building, shell completions for zsh, bash, and fish are generated by bat. This was likely missed in a previous change, but this should make the use of a _longopt-based completion unnecessary.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
