### PR TITLE
openssl11: Update to 1.1.1w

### DIFF
--- a/devel/openssl11/Portfile
+++ b/devel/openssl11/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.0
 set short_v         1.1
 name                openssl[string map {. {}} $short_v]
 
-version             ${short_v}.1v
+version             ${short_v}.1w
 revision            1
 
 categories          devel security
@@ -38,9 +38,9 @@ master_sites        ${homepage}/source \
                     ftp://ftp.linux.hr/pub/openssl/source/ \
                     ftp://guest.kuria.katowice.pl/pub/openssl/source/
 
-checksums           rmd160  8e282801eed093dbd9667333cc6259606c9309da \
-                    sha256  d6697e2871e77238460402e9362d47d18382b15ef9f246aba6c7bd780d38a6b0 \
-                    size    9893443
+checksums           rmd160  09f13793ced2360999e244d9627f0ee4a43457a0 \
+                    sha256  cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8 \
+                    size    9893384
 
 platform darwin 8 {
     # No Availability.h on Tiger
@@ -139,6 +139,8 @@ destroot.args       MANDIR=${prefix}/share/man MANSUFFIX=ssl
 variant rfc3779 description {enable RFC 3779: X.509 Extensions for IP Addresses and AS Identifiers} {
     configure.args-append   enable-rfc3779
 }
+
+notes-append        "This is the last release of OpenSSL 1.1. No further public security updates will be provided. Please migrate to the openssl3 port."
 
 livecheck.type      regex
 #livecheck.url       https://www.openssl.org/source/old/1.1.1/


### PR DESCRIPTION
#### Description
This is the last release in the 1.1 series, so I'm adding a note to highlight that this port must now be considered out of support.

See https://www.openssl.org/news/secadv/20230908.txt for the advisory. The CVE does not affect macOS, but there are some other minor bug fixes in the release.

CVE: CVE-2023-4807

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
macOS 13.5.2 22G91 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
