### PR TITLE
ruby-build: Update to 20230912

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230904 v
+github.setup        rbenv ruby-build 20230912 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  0b7d6fe5de460afc8001cf31984b478f7339f38b \
-                    sha256  08e2a5ab0322004fa3d0e7ac2d15e21528b3fe702f5e02b6b08c1aabc342daa3 \
-                    size    78883
+checksums           rmd160  77068811d63800ee0ea04a2fcf603d3828730218 \
+                    sha256  d87a223b6413d8a87a00c6423adfca1ae1d56f5fd5e8778f09b198e5b68f2ab2 \
+                    size    78904
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

```markdown
- Bump actions/checkout from 3 to 4 by @dependabot in #2247
- Add JRuby 9.3.11.0 by @headius in #2248
```

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?