### PR TITLE
InsightToolkit: new port InsightToolkit version 5.3.0, replacing InsightToolkit-devel

### DIFF
--- a/graphics/InsightToolkit-devel/Portfile
+++ b/graphics/InsightToolkit-devel/Portfile
@@ -1,77 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           cmake 1.0
+PortGroup           obsolete 1.0
+
+# Obsolete Date: 2023-09-23
 
 name                InsightToolkit-devel
 version             4.8.2
-revision            15
+revision            16
 categories          graphics devel
-platforms           darwin
-license             Apache
 
-maintainers         {stromnov @stromnov} openmaintainer
-
-description         Insight Segmentation and Registration Toolkit (ITK)
-
-long_description    Insight Segmentation and Registration Toolkit (ITK) \
-                    is an open-source, cross-platform system that provides \
-                    developers with an extensive suite of software tools \
-                    for image analysis.
-
-homepage            http://www.itk.org
-master_sites        sourceforge:itk
-
-distname            InsightToolkit-${version}
-
-checksums           rmd160  d42f13e86b11381409a4fca16458d0c871ff3d41 \
-                    sha256  d8d5e3aea700588c60b01418c440b2d95b517ea18dd4c834c5164354e53596af
-
-patchfiles-append   patch-CMakeLists.txt.diff
-
-cmake.out_of_source yes
-
-depends_build-append \
-                    port:castxml \
-                    port:swig
-
-depends_lib-append  port:dcmtk \
-                    port:expat \
-                    port:fftw-3 \
-                    port:hdf5 \
-                    path:include/turbojpeg.h:libjpeg-turbo \
-                    port:libpng \
-                    port:tiff \
-                    port:vxl \
-                    port:zlib
-
-configure.args-append \
-                    -DITK_FORBID_DOWNLOADS:BOOL=ON \
-                    -DITK_WRAP_PYTHON:BOOL=OFF \
-                    -DBUILD_SHARED_LIBS:BOOL=ON \
-                    -DBUILD_EXAMPLES:BOOL=OFF \
-                    -DVXL_DIR=${prefix}/share/vxl/cmake \
-                    -DITK_USE_GPU:BOOL=ON \
-                    -DITK_USE_SYSTEM_LIBRARIES:BOOL=ON \
-                    -DITK_USE_SYSTEM_DCMTK:BOOL=ON \
-                    -DITK_USE_SYSTEM_DOUBLECONVERSION:BOOL=OFF \
-                    -DITK_USE_SYSTEM_EXPAT:BOOL=ON \
-                    -DITK_USE_SYSTEM_FFTW:BOOL=ON \
-                    -DITK_USE_SYSTEM_CASTXML:BOOL=ON \
-                    -DITK_USE_SYSTEM_GDCM:BOOL=OFF \
-                    -DITK_USE_SYSTEM_HDF:BOOL=ON \
-                    -DITK_USE_SYSTEM_JPEG:BOOL=ON \
-                    -DITK_USE_SYSTEM_MINC:BOOL=OFF \
-                    -DITK_USE_SYSTEM_PNG:BOOL=ON \
-                    -DITK_USE_SYSTEM_SWIG:BOOL=ON \
-                    -DITK_USE_SYSTEM_SZIP:BOOL=ON \
-                    -DITK_USE_SYSTEM_TIFF:BOOL=ON \
-                    -DITK_USE_SYSTEM_VXL:BOOL=ON \
-                    -DITK_USE_SYSTEM_ZLIB:BOOL=ON
-
-configure.ldflags-append \
-                    -L${prefix}/lib/vxl
-
-livecheck.type      regex
-livecheck.url       http://www.itk.org/ITK/resources/software.html
-livecheck.regex     {InsightToolkit-(\d+(?:\.\d+)*)\.[tz]}
+replaced_by         InsightToolkit

--- a/graphics/InsightToolkit-devel/files/patch-CMakeLists.txt.diff
+++ b/graphics/InsightToolkit-devel/files/patch-CMakeLists.txt.diff
@@ -1,8 +1,0 @@
---- CMakeLists.txt.orig	2015-06-21 22:26:10.000000000 +0300
-+++ CMakeLists.txt	2015-06-21 22:26:27.000000000 +0300
-@@ -452,4 +452,4 @@
- 
- # Create target to download data from the ITKData group. This must come after
- # all tests have been added that reference the group, so we put it last.
--ExternalData_Add_Target(ITKData)
-+# ExternalData_Add_Target(ITKData)

--- a/graphics/InsightToolkit/Portfile
+++ b/graphics/InsightToolkit/Portfile
@@ -1,0 +1,162 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           active_variants 1.1
+PortGroup           cmake 1.1
+PortGroup           conflicts_build 1.0
+PortGroup           github 1.0
+
+name                InsightToolkit
+github.setup        InsightSoftwareConsortium ITK 5.3.0 v
+revision            0
+categories          graphics science devel
+license             Apache
+conflicts_build     InsightToolkit4
+
+maintainers         {stromnov @stromnov} {yahoo.com:n_larsson @nilason} openmaintainer
+
+description         Insight Segmentation and Registration Toolkit (ITK)
+
+long_description    {*}${description} is an open-source, cross-platform system that \
+                    provides developers with an extensive suite of software tools \
+                    for image analysis. Developed through extreme programming \
+                    methodologies, ITK builds on a proven, spatially-oriented \
+                    architecture for processing, segmentation, and registration \
+                    of scientific images in two, three, or more dimensions.
+
+homepage            https://itk.org
+
+distname            InsightToolkit-${version}
+dist_subdir         InsightToolkit
+
+checksums           rmd160  39799367b41bf86b49fcc8a96260c99db4996fd6 \
+                    sha256  aace3267f84da4f89d6de404fe07b2300ee5c3e65e44ba3eb8a4e7b5de5942fb \
+                    size    21843788
+
+# find out include dir for "mpi.h"
+set mpl_include_dir ""
+if {![catch {set result [active_variants hdf5 openmpi]}]} {
+    if {$result} {
+        set mpl_include_dir "-I${prefix}/include/openmpi-mp"
+    }
+}
+if {![catch {set result [active_variants hdf5 mpich]}]} {
+    if {$result} {
+        set mpl_include_dir "-I${prefix}/include/mpich-mp"
+    }
+}
+if {$mpl_include_dir ne ""} {
+    configure.cxxflags-append ${mpl_include_dir}
+}
+
+compiler.cxx_standard 2014
+
+patchfiles-append   patch-OpenCL-CMake.diff \
+                    patch-swigpy-sliceobject.diff
+
+depends_lib-append  path:include/turbojpeg.h:libjpeg-turbo \
+                    port:dcmtk \
+                    port:double-conversion \
+                    port:eigen3 \
+                    port:expat \
+                    port:fftw-3 \
+                    port:fftw-3-single \
+                    port:gdcm \
+                    port:gtest \
+                    port:hdf5 \
+                    port:libaec \
+                    port:libminc \
+                    port:libpng \
+                    port:tiff \
+                    port:vxl \
+                    port:zlib
+
+configure.args-append \
+                    -DBUILD_EXAMPLES=OFF \
+                    -DBUILD_SHARED_LIBS=ON \
+                    -DBUILD_TESTING=OFF \
+                    -DCMAKE_INSTALL_NAME_DIR=${prefix}/lib/itk \
+                    -DITK_FORBID_DOWNLOADS=ON \
+                    -DITK_INSTALL_LIBRARY_DIR=${prefix}/lib/itk \
+                    -DITK_USE_FFTWD=ON \
+                    -DITK_USE_FFTWF=ON \
+                    -DITK_USE_GPU=OFF \
+                    -DITK_USE_KWSTYLE=OFF \
+                    -DITK_USE_SYSTEM_DCMTK=ON \
+                    -DITK_USE_SYSTEM_DOUBLECONVERSION=ON \
+                    -DITK_USE_SYSTEM_EIGEN=ON \
+                    -DITK_USE_SYSTEM_EXPAT=ON \
+                    -DITK_USE_SYSTEM_FFTW=ON \
+                    -DITK_USE_SYSTEM_GDCM=ON \
+                    -DITK_USE_SYSTEM_JPEG=ON \
+                    -DITK_USE_SYSTEM_LIBRARIES=ON \
+                    -DITK_USE_SYSTEM_MINC=ON \
+                    -DITK_USE_SYSTEM_PNG=ON \
+                    -DITK_USE_SYSTEM_TIFF=ON \
+                    -DITK_USE_SYSTEM_VXL=ON \
+                    -DITK_USE_SYSTEM_ZLIB=ON \
+                    -DITK_WRAPPING=OFF \
+                    -DITK_WRAP_PYTHON=OFF \
+                    -DUSE_FFTWF=ON \
+                    -DVXL_DIR=${prefix}/share/vxl/cmake
+
+configure.ldflags-append \
+                    -L${prefix}/lib/vxl
+
+# create Python subports
+set python_versions {310 311}
+foreach v ${python_versions} {
+    subport py${v}-${name} {
+        PortGroup           python 1.0
+
+        categories          graphics science devel python
+
+        depends_build-append \
+                            port:castxml \
+                            port:swig \
+                            port:swig-python
+
+        depends_lib-append  port:${name}
+
+        use_configure       yes
+
+        python.default_version  ${v}
+        python.pep517       no
+
+        build.cmd           make
+        build.target
+        destroot.cmd        make install
+        destroot.destdir    DESTDIR=${destroot}
+
+        master_sites        ${github.master_sites}
+
+        post-patch {
+            fs-traverse f ${worksrcpath} {
+                if {[file extension ${f}] eq ".py"} {
+                    reinplace -q "s|/usr/bin/env python|${python.bin}|" ${f}
+                }
+            }
+        }
+    }
+}
+
+# Python bindings for supported Python versions
+if {[string match "py*" ${subport}]} {
+    description             Python ${python.branch} bindings for {*}${description}
+    long_description        This package provides {*}${description}.
+
+    configure.args-append   -DITK_USE_SYSTEM_CASTXML=ON \
+                            -DITK_USE_SYSTEM_SWIG=ON \
+                            -DPY_SITE_PACKAGES_PATH=${python.pkgd} \
+                            -DPython3_EXECUTABLE=${python.bin}
+
+    configure.args-replace  -DITK_WRAPPING=OFF    -DITK_WRAPPING=ON \
+                            -DITK_WRAP_PYTHON=OFF -DITK_WRAP_PYTHON=ON
+
+    post-destroot {
+        delete ${destroot}${prefix}/bin
+        delete ${destroot}${prefix}/include
+        delete ${destroot}${prefix}/lib
+        delete ${destroot}${prefix}/share
+    }
+}

--- a/graphics/InsightToolkit/files/patch-OpenCL-CMake.diff
+++ b/graphics/InsightToolkit/files/patch-OpenCL-CMake.diff
@@ -1,0 +1,23 @@
+--- Modules/Core/GPUCommon/src/CMakeLists.txt.orig	2022-11-24 14:15:41.000000000 +0100
++++ Modules/Core/GPUCommon/src/CMakeLists.txt	2023-06-09 12:30:50.000000000 +0200
+@@ -14,5 +14,6 @@
+   write_gpu_kernels("${ITKGPUCommon_Kernels}" ITKGPUCommon_SRCS)
+ 
+   itk_module_add_library(ITKGPUCommon ${ITKGPUCommon_SRCS})
+-  target_link_libraries(ITKGPUCommon LINK_PUBLIC ${OPENCL_LIBRARIES})
++  target_link_libraries(ITKGPUCommon LINK_PUBLIC ${OpenCL_LIBRARIES})
+ endif()
++
+--- Modules/Core/GPUCommon/CMakeLists.txt.orig	2022-11-24 14:15:41.000000000 +0100
++++ Modules/Core/GPUCommon/CMakeLists.txt	2023-06-09 12:30:45.000000000 +0200
+@@ -25,9 +25,7 @@
+ 
+ if(ITK_USE_GPU)
+   set(ITKGPUCommon_LIBRARIES ITKGPUCommon ${OpenCL_LIBRARIES})
+-  if(APPLE)
+-    list(APPEND ITKGPUCommon_LIBRARIES "-framework OpenCL")
+-  elseif(WINDOWS)
++  if(WINDOWS)
+     list(APPEND ITKGPUCommon_LIBRARIES cfgmgr32 OneCoreUAP)
+   endif()
+ 

--- a/graphics/InsightToolkit/files/patch-swigpy-sliceobject.diff
+++ b/graphics/InsightToolkit/files/patch-swigpy-sliceobject.diff
@@ -1,0 +1,18 @@
+Issue filed at https://github.com/InsightSoftwareConsortium/ITK/issues/3782
+Patch accepted upstreams with https://github.com/InsightSoftwareConsortium/ITK/commit/d2361b89fefb07b669b4cf67257fc3bf06afd9f5
+
+--- Wrapping/Generators/Python/module_ext.i.in.orig
++++ Wrapping/Generators/Python/module_ext.i.in
+@@ -10,9 +10,12 @@
+ #include <iostream>
+ 
+ #if PY_VERSION_HEX >= 0x03020000
++
+ # define SWIGPY_SLICE_ARG(obj) ((PyObject*) (obj))
++# define SWIGPY_SLICEOBJECT PyObject
+ #else
+ # define SWIGPY_SLICE_ARG(obj) ((PySliceObject*) (obj))
++# define SWIGPY_SLICEOBJECT PySliceObject
+ #endif
+ %}
+ 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Create new port `InsightToolkit` 5.3.0, replacing `InsightToolkit-devel`. Also add Python subports, along with general Portfile overhaul.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.6 21G646 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
