### PR TITLE
openjdk17-zulu: update to 17.44.53

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.44.15
-revision     1
+version      17.44.53
+revision     0
 
-set openjdk_version 17.0.8
+set openjdk_version 17.0.8.1
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  d60f2216d8128ad66bf35c0df2bb4f26b920ed84 \
-                 sha256  0a2d7c801900bff514210c3d2a59df89b710317c10446c7a2bb2ff34107b6fb4 \
-                 size    195814035
+    checksums    rmd160  750403b984a808b0f4c4ef2f4b70101485ca8a2b \
+                 sha256  640453e8afe8ffe0fb4dceb4535fb50db9c283c64665eebb0ba68b19e65f4b1f \
+                 size    194202587
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  6e54738912f5d771259c7c41bdd7aefff6ebb2b0 \
-                 sha256  f1bf35418e8319754eb1328cf100f32676235d5d22a426d859a6b3ea817603a9 \
-                 size    193606336
+    checksums    rmd160  f415986b245c5a1103f5dea14f1cbe4fb5ac508b \
+                 sha256  314b04568ec0ae9b36ba03c9cbd42adc9e1265f74678923b19297d66eb84dcca \
+                 size    191986484
 }
 
 worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.44.53 based on OpenJDK 17.0.8.1.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?