### PR TITLE
openjdk11-zulu: update to 11.66.19

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      11.66.15
-revision     1
+version      11.66.19
+revision     0
 
-set openjdk_version 11.0.20
+set openjdk_version 11.0.20.1
 
 description  Azul Zulu Community OpenJDK 11 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  02ed30d2b62b3fbe8f02a1024a8bb25713e8292b \
-                 sha256  bcaab11cfe586fae7583c6d9d311c64384354fb2638eb9a012eca4c3f1a1d9fd \
-                 size    196471694
+    checksums    rmd160  c73d8ba9ebf069e81f8e837e08cee460d732b4e5 \
+                 sha256  240a972d366585896d1ed64a19158894b9fd7964393de9131c65bd58d3e1f5de \
+                 size    194249744
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  222e921ed5ab547342430f952d34c68a46116616 \
-                 sha256  7632bc29f8a4b7d492b93f3bc75a7b61630894db85d136456035ab2a24d38885 \
-                 size    194993088
+    checksums    rmd160  03d3b9585a8e2156e999766a28720e0fc306e808 \
+                 sha256  266a37b597e685dc94253800df5c6debdb7445971c5e6109fc876cf62bbadfe8 \
+                 size    192377045
 }
 
 worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.66.19 based on OpenJDK 11.0.20.1.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?