### PR TITLE
google-cloud-sdk: update to 446.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             445.0.0
+version             446.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  60aebc87593162f71ff3d870bea3eace6683a16c \
-                    sha256  2d201e2100433da1e46d949411118f5f245529aed654cb33322ec2d148c2d100 \
-                    size    101427200
+    checksums       rmd160  924127b24f83620e3d7c58f139085a1527fd7496 \
+                    sha256  f00c5e363a5633889a54bb80700af897f71ff29248f68f39ddebca4b29771b93 \
+                    size    101491864
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a3d9ef35515f8c25493e83597af3e98670c0e2af \
-                    sha256  c11c6b84cecf95455c9ca7889575f7ccc02c9e85213b7b5e3be1d1e88a1709ab \
-                    size    121693069
+    checksums       rmd160  43dff31335c6241b8bdd8263cc5d6fc378b3d4ef \
+                    sha256  43dd12b7926b42c857cbc1ab055f3b1906aa05d2e1c057b175a26bceb90e0fd9 \
+                    size    121762083
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  aa448eff7927455343973bfa55626fdfc7c54532 \
-                    sha256  2bd8c05a49e47d30cc678f3245b46cf975991bf9305f937f511244f97fcc9cce \
-                    size    118847528
+    checksums       rmd160  3cc66f1bbf171781480a281158d73dd1a46182eb \
+                    sha256  2da7ef7eab4ff7bc036c5a41245afaa49015914857af972618f0aa75fd115413 \
+                    size    118916767
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 446.0.0.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?