### PR TITLE
ecl: fix build on old macOS after update

### DIFF
--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 name                ecl
@@ -34,7 +35,6 @@ conflicts           ecl-devel
 
 subport ecl-devel {
     PortGroup       gitlab  1.0
-    PortGroup       legacysupport 1.1
 
     gitlab.setup    embeddable-common-lisp ecl c646799145538997d84ed6d8755be7e7837eb7ef
     version         20230826
@@ -45,10 +45,10 @@ subport ecl-devel {
     checksums       rmd160  2a34a31aeba8c90c44841039f53d1f088ed9bdc0 \
                     sha256  a042e37ccaa383160b96da93c3f9881c4fe45c1f0f0968b021a5fe4fcf03607b \
                     size    6564563
-
-    # requires clock_gettime()
-    legacysupport.newest_darwin_requires_legacy 15
 }
+
+# requires clock_gettime()
+legacysupport.newest_darwin_requires_legacy 15
 
 extract.rename      yes
 


### PR DESCRIPTION
#### Description

Simple move out required legacy support from `-devel` subport.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->