### PR TITLE
ecl: backport patch for old Darwin

### DIFF
--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -25,6 +25,8 @@ if {${name} eq ${subport}} {
     master_sites    https://common-lisp.net/project/ecl/static/files/release/
 
     extract.suffix  .tgz
+
+    patchfiles      environ-legacy-darwin.patch
 }
 
 checksums           rmd160  6ea701b142b78fc4c263e3aee7709f4254a8ccc9 \
@@ -76,7 +78,7 @@ if {${build_arch} eq "i386"} {
     configure.cxx_stdlib        libstdc++
 }
 
-patchfiles          patch-macports-xdg-data-dir.diff
+patchfiles-append   patch-macports-xdg-data-dir.diff
 
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/contrib/asdf/asdf.lisp

--- a/lang/ecl/files/environ-legacy-darwin.patch
+++ b/lang/ecl/files/environ-legacy-darwin.patch
@@ -1,0 +1,30 @@
+https://gitlab.com/embeddable-common-lisp/ecl/-/merge_requests/301
+
+diff --git src/c/main.d src/c/main.d
+index fbaae6674..532320792 100644
+--- src/c/main.d
++++ src/c/main.d
+@@ -46,6 +46,10 @@
+ #include "ecl_features.h"
+ #include "iso_latin_names.h"
+ 
++#if defined(__APPLE__) && defined(HAVE_ENVIRON)
++# include <crt_externs.h>
++#endif
++
+ /******************************* EXPORTS ******************************/
+ 
+ #if !defined(ECL_THREADS)
+@@ -899,7 +903,12 @@ si_environ(void)
+   cl_object output = ECL_NIL;
+ #ifdef HAVE_ENVIRON
+   char **p;
++/* Shared libraries do not have direct access to environ on Darwin */
++#if defined(__APPLE__)
++# define environ (*_NSGetEnviron())
++#elif !defined(environ)
+   extern char **environ;
++#endif
+   for (p = environ; *p; p++) {
+     output = CONS(ecl_make_constant_base_string(*p,-1), output);
+   }


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->