### PR TITLE
libretroshare: update to 2023.09.05

### DIFF
--- a/net/libretroshare/Portfile
+++ b/net/libretroshare/Portfile
@@ -6,8 +6,8 @@ PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 PortGroup               openssl 1.0
 
-github.setup            RetroShare libretroshare dae2d71c89a3b9c8979c3ea293e3bee4c8a7a32e
-version                 2023.08.11
+github.setup            RetroShare libretroshare 0d99d8dc24b3b6604813123de74773e9c9813d42
+version                 2023.09.05
 revision                0
 categories              net devel
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -17,9 +17,9 @@ long_description        {*}${description} RetroShare functionalities (file shari
                         are implemented under the hood by libretroshare which offer a documented C++ and JSON API. \
                         While RetroShare is an application on its own, libretroshare is meant to be used as part of other programs.
 homepage                https://retroshare.cc
-checksums               rmd160  1faffd4d966646788ae1398338cc8824840edc66 \
-                        sha256  7341c60ebd38faaa7ec25819cb9d279105f3ae972938ceb978f9a31204b3ad6a \
-                        size    1922361
+checksums               rmd160  a2887322674f0692ac33db700bae7e9fb08228ce \
+                        sha256  c0847e1dc477af8d814543e7dd9ee3b04fd6c391bb0c355616aa304ff92652a0 \
+                        size    1923055
 
 # getline, strnlen
 # On <10.15 built-in libc++ has no support for std::filesystem


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
