### PR TITLE
castxml: add clang port to depends_lib

### DIFF
--- a/lang/castxml/Portfile
+++ b/lang/castxml/Portfile
@@ -64,8 +64,8 @@ if {!$has_variant} { default_variants +clang15 }
 foreach ver ${clang_vers} {
     set v_name [variant_name ${ver}]
     if {[variant_isset ${v_name}]} {
-        depends_lib-append          port:llvm-${ver}
-        depends_build-append        port:clang-${ver}
+        depends_lib-append          port:llvm-${ver} \
+                                    port:clang-${ver}
         configure.args-append       -DLLVM_DIR=${prefix}/libexec/llvm-${ver}/lib/cmake/llvm
         cmake.install_rpath-append  ${prefix}/libexec/llvm-${ver}/lib
     }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The castxml binary file links to clang and installing pre-build package doesn't install the clang port as a dependent (if adding it to "depends_build").

```bash
otool -L /opt/local/bin/castxml
/opt/local/bin/castxml:
	@rpath/libclang-cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libLLVM.dylib (compatibility version 1.0.0, current version 15.0.7)
	/opt/local/libexec/llvm-15/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
```

Working on #20399 this problem surfaced on the CI builds, complaining of not being able to find "libclang-cpp.dylib".


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.6 21G646 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
