### PR TITLE
qdmr: update to 0.11.3

### DIFF
--- a/science/qdmr/Portfile
+++ b/science/qdmr/Portfile
@@ -8,7 +8,7 @@ PortGroup           qt5 1.0
 
 name                qdmr
 maintainers         @hmatuschek {ra1nb0w @ra1nb0w} openmaintainer
-version             0.11.2
+version             0.11.3
 
 categories          science
 license             GPL-3
@@ -25,9 +25,9 @@ homepage            https://dm3mat.darc.de/qdmr/
 
 github.setup        hmatuschek qdmr ${version} v
 
-checksums           rmd160  99e7c8b189692c76c3ce519e6122867fe01d4644 \
-                    sha256  09d01799c2d955271bebeff9729edaa534e64b54e35ef6d495eddc9fd7e6ba42 \
-                    size    6392736
+checksums           rmd160  a7c7cd08e9e098798f684aa9ff0826fce2a1e3d9 \
+                    sha256  c1e6549c8074984f5437670cbb42e4734444b8308960155a7e726776108cccc3 \
+                    size    6579311
 
 qt5.depends_build_component \
     qttools


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Updates qDMR from 0.11.2 to 0.11.3.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`? - This failed but seems to be a M1 problem.  -vs worked fine.
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
