### PR TITLE
ruby-build: Update to 20230914

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230912 v
+github.setup        rbenv ruby-build 20230914 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  77068811d63800ee0ea04a2fcf603d3828730218 \
-                    sha256  d87a223b6413d8a87a00c6423adfca1ae1d56f5fd5e8778f09b198e5b68f2ab2 \
-                    size    78904
+checksums           rmd160  b5a275c64fe1451ceb178924cba0056fe3f418be \
+                    sha256  e04f6bbdc240ba993e1cc19f9c9eab455b639f766334e5f9f639daf22f62d5d7 \
+                    size    79053
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

```
What's Changed

- workaround jruby#7799 by updating rubygems for JRuby 9.2.x by @jsvd in
  #2246
- Added 3.3.0-preview2 by @hsbt in #2249
- Bump up openssl-1.1.1w by @hsbt in #2250

New Contributors

- @jsvd made their first contribution in #2246
```

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification

Have you

- [x] followed our [Commit Message Guidelines][guidelines]?
- [x] squashed and [minimized your commits][minimized]?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?

[guidelines]: https://trac.macports.org/wiki/CommitMessages?
[minimized]: https://guide.macports.org/#project.github