### PR TITLE
libgpg-error: additionally build static libs

### DIFF
--- a/devel/libgpg-error/Portfile
+++ b/devel/libgpg-error/Portfile
@@ -16,7 +16,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
 
 name            libgpg-error
 version         1.47
-revision        0
+revision        1
 categories      devel
 license         LGPL-2.1+
 maintainers     {mps @Schamschula} openmaintainer
@@ -49,6 +49,10 @@ configure.awk   /usr/bin/awk
 # can be removed when this is no longer necessary
 # see libgpg-error NOTES for more details
 configure.args  --enable-install-gpg-error-config
+
+# Also enable the building of static libs
+configure.args-append \
+                --enable-static
 
 # fix build on Tiger see https://trac.macports.org/ticket/55145
 platform darwin 8 {


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
