### PR TITLE
ruby-build: Update to 20230914.1

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230914 v
+github.setup        rbenv ruby-build 20230914.1 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  b5a275c64fe1451ceb178924cba0056fe3f418be \
-                    sha256  e04f6bbdc240ba993e1cc19f9c9eab455b639f766334e5f9f639daf22f62d5d7 \
-                    size    79053
+checksums           rmd160  1382e918702e102718dde293ac0766e13a65eb62 \
+                    sha256  8f7c3ff2fffad1a28ecc17237ad842798b3fb784eb8da5de70f7022ec58378b9 \
+                    size    79031
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

```
What's Changed

- Use the TruffleRuby JVM Standalones for truffleruby+graalvm-dev by
  @eregon in #2251
- Update URLs for truffleruby+graalvm-dev by @eregon in #2252
```

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
