### PR TITLE
qt6-qtwebengine: nodejs is not needed at runtime

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -340,8 +340,8 @@ array set modules {
             55f85af736a1dc79a41b8d95014ba27d8fce0be44293a69e64fece7fa12b2925
             440562844
         }
-        "port:python${python_version} port:py${python_version}-html5lib"
-        "path:bin/node:nodejs20 port:re2 path:lib/pkgconfig/icu-uc.pc:icu port:webp \
+        "path:bin/node:nodejs20 port:python${python_version} port:py${python_version}-html5lib"
+        "port:re2 path:lib/pkgconfig/icu-uc.pc:icu port:webp \
             port:libopus path:lib/libavcodec.dylib:ffmpeg path:lib/pkgconfig/vpx.pc:libvpx \
             port:snappy path:lib/pkgconfig/glib-2.0.pc:glib2 port:zlib port:minizip port:libevent \
             port:libxml2 port:libxslt port:lcms2 port:libpng path:include/turbojpeg.h:libjpeg-turbo \
@@ -350,7 +350,7 @@ array set modules {
         {"Qt WebEngine Qt" "Qt PDF"}
         ""
         "variant overrides: "
-        "revision 3"
+        "revision 4"
         "License: "
     }
     qtwebview {


### PR DESCRIPTION
[skip ci]

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Not tested beyond `port info`.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
