### PR TITLE
pdfjam: update to 3.08

### DIFF
--- a/textproc/pdfjam/Portfile
+++ b/textproc/pdfjam/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            rrthomas pdfjam 3.07 v
+github.setup            rrthomas pdfjam 3.08 v
 categories              textproc pdf
 maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 license                 GPL-2
@@ -22,9 +22,9 @@ long_description \
 
 github.tarball_from     releases
 
-checksums               rmd160  92495ccbc6b74c0d9ac7a73c1ae68821e6ca3214 \
-                        sha256  00dcd37db9a7f6246da225be31724faf3616db4f78a3dba521682d54d1e9eba5 \
-                        size    162640
+checksums               rmd160  85384299841dec357b30181e2b1fae8a06da727a \
+                        sha256  e929cd1b562f02640d70bf8e33396843a33b5a064a347c01e589cd5599378b31 \
+                        size    162657
 
 depends_run \
     bin:pdflatex:texlive-latex \


### PR DESCRIPTION
#### Description

Update to pdfjam 3.08.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?