### PR TITLE
google-cloud-sdk: update to 446.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             446.0.0
+version             446.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  924127b24f83620e3d7c58f139085a1527fd7496 \
-                    sha256  f00c5e363a5633889a54bb80700af897f71ff29248f68f39ddebca4b29771b93 \
-                    size    101491864
+    checksums       rmd160  6ef197a4144afb2db29bad8de6019b1e85cdb891 \
+                    sha256  690471f8d29afdedcc902307699a55ac631ba995100785d003c644be324cd065 \
+                    size    101491839
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  43dff31335c6241b8bdd8263cc5d6fc378b3d4ef \
-                    sha256  43dd12b7926b42c857cbc1ab055f3b1906aa05d2e1c057b175a26bceb90e0fd9 \
-                    size    121762083
+    checksums       rmd160  f04cba9988205a0bf33f27adafb9315490ab1b68 \
+                    sha256  198f598a6505b6275cef6e8f4343fab084c2be56f3802e07af9e7d845a15d54a \
+                    size    121761867
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  3cc66f1bbf171781480a281158d73dd1a46182eb \
-                    sha256  2da7ef7eab4ff7bc036c5a41245afaa49015914857af972618f0aa75fd115413 \
-                    size    118916767
+    checksums       rmd160  a72b8b5f87dcfc49f660b15b2f805446915caf63 \
+                    sha256  11603be1284875e16f7c287816ade8a6d295f2a5b58fa47c8b26c1ace0206f96 \
+                    size    118916685
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 446.0.1.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?