### PR TITLE
proselint: update to python3.11

### DIFF
--- a/textproc/proselint/Portfile
+++ b/textproc/proselint/Portfile
@@ -6,7 +6,7 @@ PortGroup               github 1.0
 
 name                    proselint
 github.setup            amperser proselint 0.13.0
-revision                0
+revision                1
 categories              textproc python
 platforms               darwin
 license                 BSD
@@ -23,7 +23,7 @@ checksums               rmd160  78a06d129c183eaa867367514e5135d8f5b21a2c \
 
 python.pep517           yes
 python.pep517_backend   poetry
-python.default_version  310
+python.default_version  311
 
 depends_lib-append      port:py${python.version}-click \
                         port:py${python.version}-future


### PR DESCRIPTION
#### Description

proselint: update to python3.11

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.2 22G91 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? NO TRACE MODE
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
