### PR TITLE
grc: Switch to Python 3.11

### DIFF
--- a/textproc/grc/Portfile
+++ b/textproc/grc/Portfile
@@ -5,12 +5,11 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        garabik grc 1.13 v
-revision            0
+revision            1
 
 conflicts           cc65
 
 categories          textproc
-platforms           darwin
 license             GPL-2
 maintainers         nomaintainer
 supported_archs     noarch
@@ -25,7 +24,7 @@ checksums           rmd160  06578c83ffae331825fc1b5fe8ac1b5279f1f44a \
                     sha256  1468c50237fc260840384cc2063f3031689e95e5c6dc22533aa5d25a3d17f2f9 \
                     size    49236
 
-python.default_version 39
+python.default_version 311
 
 build {}
 destroot {}


### PR DESCRIPTION
#### Description

Switch `grc` to use Python 3.11. Platform `darwin` is always assumed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
