### PR TITLE
py-pdbpp, deps: add python 3.9, 3.10, 3.11 subports

### DIFF
--- a/python/py-fancycompleter/Portfile
+++ b/python/py-fancycompleter/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  8fb1c940b900c35ea1958e95567246d3b5506688 \
                     sha256  09e0feb8ae242abdfd7ef2ba55069a46f011814a80fe5476be48f51b00247272 \
                     size    10866
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pdbpp/Portfile
+++ b/python/py-pdbpp/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  065b1e7e92ff2b461af73ad3ec0e4ca42612cfd8 \
                     sha256  73ff220d5006e0ecdc3e2705d8328d8aa5ac27fef95cc06f6e42cd7d22d55eb8 \
                     size    62282
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-repl/Portfile
+++ b/python/py-repl/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  77f60e1788a2123929bcebec6f366fff92c0c17e \
                     sha256  292570f34b5502e871bbb966d639474f2b57fbfcd3373c2d6a2f3d56e681a775 \
                     size    48744
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-wmctrl/Portfile
+++ b/python/py-wmctrl/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  3bb58717433e5062c44b95349af4dabf21afca37 \
                     sha256  d806f65ac1554366b6e31d29d7be2e8893996c0acbb2824bbf2b1f49cf628a13 \
                     size    2505
 
-python.versions     37 38
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

PDB and all dependencies now have python3.9, 3.10 and 3.11 variants
dependents:
- python/py-fancycompleter/Portfile
- python/py-repl/Portfile
- python/py-wmctrl/Portfile

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.2 22G91 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
