### PR TITLE
zsh-history-substring-search: Update to 1.1.0

### DIFF
--- a/sysutils/zsh-history-substring-search/Portfile
+++ b/sysutils/zsh-history-substring-search/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        zsh-users zsh-history-substring-search 1.0.2 v
+github.setup        zsh-users zsh-history-substring-search 1.1.0 v
 github.tarball_from archive
 
 categories          sysutils shells
@@ -15,22 +15,18 @@ description         Zsh port of Fish shell's history search.
 long_description    This is a clean-room implementation of the Fish shell's \
                     history search feature, where you can type in any part of \
                     any command from history and then press chosen keys, such \
-                    as the UP and DOWN arrows, to cycle through matches. \
-                    \
-                    Please note that you must load zsh-history-substring-search \
-                    after all other custom widgets, at the end of your .zshrc \
-                    file.
+                    as the UP and DOWN arrows, to cycle through matches.
 
 license             BSD
 
+platforms           any
 supported_archs     noarch
 
-checksums           sha256  c1bb21490bd31273fb511b23000fb7caf49c258a79c4b8842f3e1f2ff76fd84c \
-                    rmd160  637c943ecb719780209e61fd861883e48d3ac624 \
-                    size    9074
+checksums           rmd160  758ea5e80668724140d6b955dfe62b148ca3d02c \
+                    sha256  9b52eca6c894dd98caa5f07160199f3f3179ff017575d5acc9fdc467b1ac70f8 \
+                    size    9984
 
 depends_run         path:bin/zsh:zsh
-
 use_configure       no
 
 build { }
@@ -42,3 +38,13 @@ destroot {
 }
 
 github.livecheck.regex {([^"-]+)}
+
+notes "
+To activate the history search, add this line to your configuration:\
+
+    source '${prefix}/share/${name}/${name}.zsh'\
+
+Please note that this line must be after loading all custom widgets,\
+at the end of your .zshrc. You will need to restart your terminal for\
+this change to take effect.\
+"


### PR DESCRIPTION
#### Description

Update zsh-history-substring-search to its latest version, 1.1.0. Add notes on how to use the port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
