### PR TITLE
glslang: build shared libraries; revbump dependents

### DIFF
--- a/graphics/glslang/Portfile
+++ b/graphics/glslang/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           legacysupport 1.1
 
 github.setup        KhronosGroup glslang 13.0.0
-revision            1
+revision            2
 
 categories          graphics devel
 license             {BSD Permissive}
@@ -40,4 +40,5 @@ depends_build-append    port:python${py_ver_nodot}
 configure.python        ${prefix}/bin/python${py_ver}
 configure.args-append   -DPYTHON_EXECUTABLE:FILEPATH=${configure.python}
 
-configure.args-append   -DENABLE_GLSLANG_INSTALL=ON
+configure.args-append   -DBUILD_SHARED_LIBS=ON \
+                        -DENABLE_GLSLANG_INSTALL=ON

--- a/graphics/ogre/Portfile
+++ b/graphics/ogre/Portfile
@@ -8,14 +8,15 @@ PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        OGRECave ogre 14.0.1 v
 github.tarball_from archive
-revision            0
+revision            1
+
 license             MIT
 categories          graphics
 maintainers         {@catap korins.ky:kirill} openmaintainer
-description         Object-Oriented Graphics Rendering Engine
 
-long_description    OGRE (Object-Oriented Graphics Rendering Engine) is a \
-                    scene-oriented, flexible 3D engine written in \
+description         Object-Oriented Graphics Rendering Engine
+long_description    OGRE (Object-Oriented Graphics Rendering Engine) \
+                    is a scene-oriented, flexible 3D engine written in \
                     C++ designed to make it easier and more intuitive \
                     for developers to produce applications utilising \
                     hardware-accelerated 3D graphics. The class \

--- a/graphics/vulkan-validationlayers/Portfile
+++ b/graphics/vulkan-validationlayers/Portfile
@@ -7,7 +7,7 @@ PortGroup           cmake 1.1
 github.setup        KhronosGroup Vulkan-ValidationLayers 1.3.261.1 sdk-
 github.tarball_from archive
 name                vulkan-validationlayers
-revision            0
+revision            1
 
 categories          graphics
 license             Apache-2


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Build glslang as a shared library instead of static. Revbump dependent ports so that they link against `libglslang.dylib` instead of `libglslang.a`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
