### PR TITLE
fig2dev: update to 3.2.9

### DIFF
--- a/print/fig2dev/Portfile
+++ b/print/fig2dev/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                fig2dev
-version             3.2.8b
-revision            2
+version             3.2.9
+revision            0
 categories          print graphics
 platforms           darwin
 license             Permissive
@@ -22,13 +22,13 @@ long_description    Fig2dev is a set of tools for creating TeX documents \
                     languages: (E)EPIC macros, LaTeX picture environment, PIC, \
                     PiCTeX, PostScript, and TeXtyl.
 
-homepage            http://xfig.org/
+homepage            https://mcj.sourceforge.net
 master_sites        sourceforge:project/mcj
 use_xz              yes
 
-checksums           rmd160  358809c798ba0960838b0997eefb73d86dd1af6d \
-                    sha256  418a164aa9fad72d25bb4fec8d7b452fe3a2f12f990cf22e05c0eb16cecb68cb \
-                    size    522756
+checksums           rmd160  b7afc99d61fba9372336e34f5530e587ab5de7cb \
+                    sha256  15e246c8d13cc72de25e08314038ad50ce7d2defa9cf1afc172fd7f5932090b1 \
+                    size    529892
 
 depends_lib         port:ghostscript \
                     port:libpng \


### PR DESCRIPTION
#### Description

Simple update to upstream version 3.2.9.
Just needed update of version and checksums/sizes.
Also updated the homepage.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.2 22G91 x86_64
Command Line Tools 14.3.1.0.1.1683849156


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
