### PR TITLE
xfig: update to 3.2.9

### DIFF
--- a/graphics/xfig/Portfile
+++ b/graphics/xfig/Portfile
@@ -3,8 +3,8 @@
 PortSystem 1.0
 
 name                xfig
-version             3.2.8b
-revision            5
+version             3.2.9
+revision            0
 categories          graphics x11
 license             Permissive
 maintainers         nomaintainer
@@ -17,24 +17,28 @@ long_description    \
     printers or converted to a variety of other formats (e.g. to \
     allow inclusion in LaTeX documents).
 
-homepage            http://xfig.org/
+homepage            https://mcj.sourceforge.net
 platforms           darwin
 master_sites        sourceforge:project/mcj
 use_xz              yes
 
-checksums           rmd160  0e8d85fc54027d3c19d8168937eeb1237b82d571 \
-                    sha256  b2cc8181cfb356f6b75cc28771970447f69aba1d728a2dac0e0bcf1aea7acd3a \
-                    size    5382524
+checksums           rmd160  e31e95f5d4da6c4e03d01f4df3d7f3371155f7a0 \
+                    sha256  13ed9d04d1bbc2dec09da7ef49ceec278382d290f6cd926474c2f2d016fec2f7 \
+                    size    5368544
 
 depends_lib         port:ghostscript \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libpng \
                     port:Xaw3d \
+                    port:Xft2 \
                     port:xorg-libXaw \
-                    port:xorg-libXi \
                     port:zlib
 
+depends_build       port:gsed
+
 depends_run         port:fig2dev
+
+configure.cppflags-append   -I${prefix}/include/freetype2
 
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update to upstream version 3.2.9 (Aug 2023).

This also required changing the depends_lib xorg-libXi to Xft2, since xfig is now using freetype.
That also required adding -I${prefix}/include/freetype2 to the CPPFLAGS.
Finally, gsed is needed during the build since sed fails on one of the lengthy sed commands used there.

I also updated the homepage to one that directly links to xfig.
This update comes along with on update to fig2dev (by the same developer) in PR #20468.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.2 22G91 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
