### PR TITLE
virt-manager: add patch to support hvf hypervisor

### DIFF
--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           app 1.0
 
 github.setup        virt-manager virt-manager 4.1.0 v
-revision            1
+revision            2
 checksums           rmd160  75b773577e04827d808cc85f3a781d1135026215 \
                     sha256  950681d7b32dc61669278ad94ef31da33109bf6fcf0426ed82dfd7379aa590a2 \
                     size    3151412
@@ -34,6 +34,7 @@ long_description \
 patchfiles-append   patch-gtk-update-icon-cache.diff
 patchfiles-append   patch-no-kvm-warning.diff
 patchfiles-append   patch-not-in-usr.diff
+patchfiles-append   patch-hvf-support.diff
 
 python.default_version  311
 python.pep517           no

--- a/gnome/virt-manager/files/patch-hvf-support.diff
+++ b/gnome/virt-manager/files/patch-hvf-support.diff
@@ -1,0 +1,36 @@
+From 9357536a087750c5865c873aa5f77ddb2a96c24c Mon Sep 17 00:00:00 2001
+From: Mohamed Akram <mohd.akram@outlook.com>
+Date: Sun, 17 Sep 2023 17:34:22 +0400
+Subject: [PATCH] Add support for hvf domain type
+
+---
+ virtManager/connection.py | 2 ++
+ virtinst/capabilities.py  | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/virtManager/connection.py b/virtManager/connection.py
+index 8e7df402e..a052cdf82 100644
+--- virtManager/connection.py
++++ virtManager/connection.py
+@@ -220,6 +220,8 @@ def pretty_hv(gtype, domtype):
+             label = "QEMU TCG"
+         elif domtype == "kvm":
+             label = "KVM"
++        elif domtype == "hvf":
++            label = "Hypervisor.framework"
+ 
+         return label
+ 
+diff --git a/virtinst/capabilities.py b/virtinst/capabilities.py
+index 533c0d9a4..5549a65ce 100644
+--- virtinst/capabilities.py
++++ virtinst/capabilities.py
+@@ -236,7 +236,7 @@ def _bestDomainType(self, guest, dtype, machine):
+         if not domains:
+             return None
+ 
+-        priority = ["kvm", "xen", "qemu"]
++        priority = ["kvm", "xen", "hvf", "qemu"]
+ 
+         for t in priority:
+             for d in domains:


### PR DESCRIPTION
#### Description

Add patch to support hvf hypervisor for better performance.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 13.5.2 22G91 x86_64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?