### PR TITLE
dcw-gmt: change source to github

### DIFF
--- a/science/dcw-gmt/Portfile
+++ b/science/dcw-gmt/Portfile
@@ -1,13 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
 name                dcw-gmt
-version             2.1.2
+github.setup        GenericMappingTools dcw-gmt 2.1.2
 categories          science
 platforms           any
 supported_archs     noarch
-maintainers         {takeshi @tenomoto}
+maintainers         {takeshi @tenomoto} \
+                    {me.com:remko.scharroo @remkos} \
+                    openmaintainer
 license             LGPL-3
 description         Digital Chart of the World (DCW) for GMT 5
 long_description    DCW-GMT is an enhancement to the \
@@ -17,10 +20,6 @@ long_description    DCW-GMT is an enhancement to the \
     http://data.geocomm.com/readme/dcw/dcw.html. To read \
     and process the data you should install GMT, the Generic \
     Mapping Tools (port gmt5 or subport gmt6).
-
-homepage            http://www.soest.hawaii.edu/pwessel/dcw/index.html
-master_sites        http://www.soest.hawaii.edu/pwessel/dcw \
-                    ftp://ftp.soest.hawaii.edu/dcw
 
 checksums           rmd160  730f9ac8cd730a18ab6d1194e76c728428cd53e0 \
                     sha256  4bb840d075c8ba3e14aeb41cf17c24236bff787566314f9ff758ab9977745d99 \
@@ -34,6 +33,4 @@ destroot {
     copy ${worksrcpath} ${destroot}${prefix}/share/gmt/dcw
 }
 
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     {(?i)version ([0-9]+\.[0-9]+\.[0-9]+)}
+github.livecheck.regex      {([^"rba]+)}


### PR DESCRIPTION
#### Description

This changes the source of this package to github, since soest.hawaii.edu has become inoperative.
It does not need a revision bump since it does not change the package itself.

It does not matter immediately, not even for those building from source, since in that case the source will be retrieved from a macports mirror in any case.
But it is good to have this fixed before a next version is released.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5.2 22G91 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
