### PR TITLE
tagtool: Don't link with C++ standard library nor with zlib, and clean up

### DIFF
--- a/audio/tagtool/Portfile
+++ b/audio/tagtool/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 
 name            tagtool
 version         0.12.3
-revision        3
+revision        4
 checksums       rmd160  9f5ae223580948c403cd44d82ecef0d03040ff09 \
                 sha256  273f41031dd2ad80c09d1865fdc71d9052831a5ce9cd8c53705cc518a9d3d411 \
                 size    303743
@@ -26,7 +26,8 @@ homepage        https://sourceforge.net/projects/tagtool/
 master_sites    sourceforge:project/${name}/${name}/${version}
 use_bzip2       yes
 
-patchfiles      patch-str_util-lp64.diff
+patchfiles      configure.ac.patch \
+                patch-str_util-lp64.diff
 
 depends_build   port:pkgconfig \
                 port:intltool
@@ -40,6 +41,7 @@ depends_lib     port:id3lib \
                 port:libffi
 
 # Don't do intltool's INTLTOOL_PERL dance
+# and we are patching configure.ac
 use_autoreconf  yes
 autoreconf.args -fvi
 

--- a/audio/tagtool/Portfile
+++ b/audio/tagtool/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem 1.0
 
 name            tagtool
@@ -8,7 +10,6 @@ checksums       rmd160  9f5ae223580948c403cd44d82ecef0d03040ff09 \
                 size    303743
 
 categories      audio
-platforms       darwin
 license         GPL-2
 maintainers     {raimue @raimue}
 

--- a/audio/tagtool/Portfile
+++ b/audio/tagtool/Portfile
@@ -3,6 +3,10 @@ PortSystem 1.0
 name            tagtool
 version         0.12.3
 revision        3
+checksums       rmd160  9f5ae223580948c403cd44d82ecef0d03040ff09 \
+                sha256  273f41031dd2ad80c09d1865fdc71d9052831a5ce9cd8c53705cc518a9d3d411 \
+                size    303743
+
 categories      audio
 platforms       darwin
 license         GPL-2
@@ -20,10 +24,6 @@ homepage        http://sourceforge.net/projects/tagtool/
 
 master_sites    sourceforge
 use_bzip2       yes
-checksums \
-    md5 447b3a505fee68a82f25dcda9377b676 \
-    sha1 e7ed4ebf8f9881cf38b2340b18e95947f658308e \
-    rmd160 9f5ae223580948c403cd44d82ecef0d03040ff09
 
 patchfiles      patch-str_util-lp64.diff
 

--- a/audio/tagtool/Portfile
+++ b/audio/tagtool/Portfile
@@ -20,9 +20,9 @@ long_description \
     but the most useful features are the ability to \
     easily tag or rename hundreds of files at once, in \
     any desired format.
-homepage        http://sourceforge.net/projects/tagtool/
 
-master_sites    sourceforge
+homepage        https://sourceforge.net/projects/tagtool/
+master_sites    sourceforge:project/${name}/${name}/${version}
 use_bzip2       yes
 
 patchfiles      patch-str_util-lp64.diff

--- a/audio/tagtool/files/configure.ac.patch
+++ b/audio/tagtool/files/configure.ac.patch
@@ -1,0 +1,24 @@
+Do not link with a C++ standard library nor with zlib; tagtool does not use them.
+id3lib uses them and, of course, links with them.
+--- configure.ac.orig	2007-02-26 16:12:54.000000000 -0600
++++ configure.ac	2023-09-18 01:57:06.000000000 -0500
+@@ -64,19 +64,10 @@
+ 		[enable_mp3=no;  disable_mp3_reason="(missing id3lib headers)"])
+ fi;
+ if test "$enable_mp3" = "yes"; then
+-	dnl Fix missing link dependencies in libid3.so  (some distros have fixed 
+-	dnl this in their own libid3 packages, others haven't...)
+-	SAVE_LDFLAGS=$LDFLAGS
+-	LDFLAGS="-lstdc++ -lz $LDFLAGS"
+-
+ 	AC_CHECK_LIB(id3, main,,
+ 		[enable_mp3=no;  disable_mp3_reason="(missing id3 library)"])
+ 	AC_CHECK_LIB(id3, ID3FrameInfo_LongName,, 
+ 		[AC_DEFINE(LIBID3_MISSING_ID3FRAMEINFO, 1, [Define to 1 if the ID3FrameInfo_* functions are missing from libid3])])
+-
+-	if test "$enable_mp3" = "no"; then
+-		LDFLAGS=$SAVE_LDFLAGS
+-	fi;
+ fi;
+ 
+ if test "$enable_vorbis" = "yes"; then


### PR DESCRIPTION
#### Description

Don't link with C++ standard library nor with zlib since they're not used and this causes a C++ standard library mismatch warning on Mac OS X 10.6–10.8. Closes https://trac.macports.org/ticket/68184.

While here, clean up the port: add modeline, remove platforms, avoid redirects in homepage and master_sites, and modernize checksums.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.7 21G651 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
