### PR TITLE
openjdk17-sap: update to 17.0.8.1

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.8
-revision     1
+version      17.0.8.1
+revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
 long_description Sap builds of OpenJDK for everyone who wish to use OpenJDK to run their applications.
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  8f46006e183c89192ef128c90b33dd625fbf91f3 \
-                 sha256  c78bddc218c1548cf5d06c9c5c1baeb1ad951b9247bf8be539e73bb2b53af7e5 \
-                 size    180670179
+    checksums    rmd160  3e5a13c8a7a9d965342f9f81343740605e70d174 \
+                 sha256  db7611f5429f94f58f17c7b9e9c16f99b5e48d082291ff2757ca7f69065b2197 \
+                 size    180672306
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  5ef2cee1180fbfcede9a1efc50fae1c465703c44 \
-                 sha256  7650dd4daa01e5a0189180d945d2f8a93b1141c24c1ecc4a8fc78067e512e22b \
-                 size    178386578
+    checksums    rmd160  8e19f4c3c1ecbd2f065efcba9dead5f83b8f19af \
+                 sha256  8164e13176ca80cdf15d22ecb33b502721b42ef6b5f98c480089e2f7d79cf2fe \
+                 size    178387774
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.8.1.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?