### PR TITLE
openjdk11-sap: update to 11.0.20.1

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/11
 supported_archs  x86_64 arm64
 
-version      11.0.20
-revision     1
+version      11.0.20.1
+revision     0
 
 description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
 long_description Sap builds of OpenJDK for everyone who wish to use OpenJDK to run their applications.
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  6a2e72fd114ef24c7147cca9fb97d242e9d93727 \
-                 sha256  6c251b1d8fe46350c8bbfc94c88fee91115ba4966e158fa71d46190be81d8629 \
-                 size    187514176
+    checksums    rmd160  c7d70f27fa2c9d6afb2679b7a3eaf0aad52cb7d6 \
+                 sha256  98c0f8294644bec653e6b6fa788093501e049cf0321b56662a0dc28a07e93674 \
+                 size    187515130
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  919a2c382f2fd497028a70312f382143ec8c2b0c \
-                 sha256  52bb4d9840cacb05d23986bda75e908e65a552a3dd2ed6df2ab3e9b0e9f9681c \
-                 size    185615130
+    checksums    rmd160  c343b96d832926be9862ef5119894f1201b91439 \
+                 sha256  0d6387b711cc9fef11fbaaafde6c3f068ed0cc9a1088ece8c0fd90eb9a778b6b \
+                 size    185627674
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 11.0.20.1.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?