### PR TITLE
jdk21-graalvm: new submission

### DIFF
--- a/java/jdk21-graalvm/Portfile
+++ b/java/jdk21-graalvm/Portfile
@@ -1,0 +1,94 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             jdk21-graalvm
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+# GraalVM Free Terms and Conditions: https://www.oracle.com/downloads/licenses/graal-free-license.html
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GFTC NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://www.oracle.com/java/technologies/downloads/#graalvmjava21-mac
+supported_archs  x86_64 arm64
+
+version     21
+revision    0
+
+master_sites https://download.oracle.com/graalvm/21/archive/
+
+homepage     https://www.oracle.com/java/graalvm/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+description  Oracle GraalVM for JDK 21
+long_description Oracle GraalVM for JDK 21 compiles your Java applications ahead of time into standalone \
+    binaries that start instantly, provide peak performance with no warmup, and use fewer cloud resources.
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     graalvm-jdk-${version}_macos-x64_bin
+    checksums    rmd160  43121b03a77aa4e2db1b11e117a00fd5afef5164 \
+                 sha256  0744ab104998f8f45d9ae582134963f5d273286dff9aff586aed24f5f8434660 \
+                 size    313139510
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     graalvm-jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  961b69b180a3b78611365129b81a09200556ee3b \
+                 sha256  c2ca434adef1e497c8a4d942ae1dbf6bbd1c8174a6fcdafc65cde0e853285300 \
+                 size    325626507
+}
+
+worksrcdir   graalvm-jdk-${version}+35.1
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-21-oracle-graalvm.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"
+


### PR DESCRIPTION
#### Description

New port for Oracle GraalVM 21.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?