### PR TITLE
ruby-build: Upgrade to 20230919

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230914.1 v
+github.setup        rbenv ruby-build 20230919 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  1382e918702e102718dde293ac0766e13a65eb62 \
-                    sha256  8f7c3ff2fffad1a28ecc17237ad842798b3fb784eb8da5de70f7022ec58378b9 \
-                    size    79031
+checksums           rmd160  4af01ad92c6ecc83da4877ae0bc4670724db7004 \
+                    sha256  85443c2796938d4865cc357dc4cf45efd1d0dce394892d3d3368f65f080c2906 \
+                    size    79381
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

```
What's Changed

- Add TruffleRuby and TruffleRuby GraalVM 23.1.0 by @eregon in #2254
```

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
