### PR TITLE
openjdk21-zulu: new submission

### DIFF
--- a/java/openjdk21-zulu/Portfile
+++ b/java/openjdk21-zulu/Portfile
@@ -1,0 +1,98 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk21-zulu
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://www.azul.com/downloads/?version=java-21-lts&os=macos&package=jdk#zulu
+version      21.28.85
+revision     0
+
+set openjdk_version 21.0.0
+
+description  Azul Zulu Community OpenJDK 21 (Long Term Support)
+long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
+                 specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
+                 verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
+                 respective Java SE version.
+
+master_sites https://cdn.azul.com/zulu/bin/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
+    checksums    rmd160  ef73795ac36878fbfd1799ebcf4539a7a6419415 \
+                 sha256  9639b87db586d0c89f7a9892ae47f421e442c64b97baebdff31788fbe23265bd \
+                 size    208325813
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
+    checksums    rmd160  5c942a85ee416b8e175f00e8ab7d18ca9eda8412 \
+                 sha256  2a7a99a3ea263dbd8d32a67d1e6e363ba8b25c645c826f5e167a02bbafaff1fa \
+                 size    205964689
+}
+
+worksrcdir   ${distname}/zulu-21.jdk
+
+homepage     https://www.azul.com/downloads/
+
+livecheck.type      regex
+livecheck.url       https://cdn.azul.com/zulu/bin/
+livecheck.regex     zulu(21\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-21-azul-zulu.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Azul Zulu OpenJDK 21.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?