### PR TITLE
samba4: Update to 4.19.0

### DIFF
--- a/net/samba4/Portfile
+++ b/net/samba4/Portfile
@@ -6,15 +6,16 @@ PortGroup           perl5 1.0
 
 # O_CLOEXEC, AT_FDCWD
 PortGroup           legacysupport 1.1
+
 legacysupport.newest_darwin_requires_legacy 13
 
 name                samba4
 conflicts           samba3
-version             4.15.5
-revision            5
-checksums           rmd160  0f16f05626b8b146f150292f89a7bbdfafc13548 \
-                    sha256  69115e33831937ba5151be0247943147765aece658ba743f44741672ad68d17f \
-                    size    19279071
+version             4.19.0
+revision            0
+checksums           rmd160  22ca67ddd19aad01024a3db7fc3d369fb90ce6b6 \
+                    sha256  28f98ceab75a6a59432912fa110fc8c716abcab1ed6d8bdd4393d178acff3d20 \
+                    size    41816190
 
 categories          net
 maintainers         nomaintainer
@@ -71,6 +72,7 @@ platform darwin {
 # rather than not having samba4 at all. Can be removed when
 # doc build issues are resolved.
 patchfiles-append patch-no-xsltproc.diff
+patchfiles-append patch-bug-15030.diff
 
 configure.perl      ${perl5.bin}
 configure.python    ${prefix}/bin/python3.10
@@ -89,12 +91,10 @@ configure.args      -C \
                     --with-gpgme \
                     --disable-spotlight
 
-build.cmd           ${configure.python} ./buildtools/bin/waf -v
 build.pre_args
-build.env-append    DESTDIR=${destroot}
+build.env-append    PYTHON=${configure.python} DESTDIR=${destroot}
 
-destroot.cmd        ${configure.python} ./buildtools/bin/waf -v
-destroot.env-append DESTDIR=${destroot}
+destroot.env-append PYTHON=${configure.python} DESTDIR=${destroot}
 destroot.destdir
 
 # this will be used on Darwin, to correct the IDs of a binary's library dependencies

--- a/net/samba4/files/patch-bug-15030.diff
+++ b/net/samba4/files/patch-bug-15030.diff
@@ -1,0 +1,26 @@
+Upstream-Status: Submitted [https://bugzilla.samba.org/show_bug.cgi?id=15030]
+--- ./lib/replace/wscript
++++ ./lib/replace/wscript
+@@ -961,7 +961,10 @@ def build(bld):
+                         target='stdbool.h',
+                         enabled = not bld.CONFIG_SET('HAVE_STDBOOL_H'))
+ 
+-    bld.SAMBA_SUBSYSTEM('samba_intl', source='', use_global_deps=False,deps=bld.env.intl_libs)
++    bld.SAMBA_SUBSYSTEM('samba_intl', source='',
++                        provide_builtin_linking=True,
++                        use_global_deps=False,
++                        deps=bld.env.intl_libs)
+ 
+ def testonly(ctx):
+     '''run talloc testsuite'''
+--- ./third_party/heimdal_build/wscript_build.orig	2023-09-18 00:12:49.000000000 +0200
++++ ./third_party/heimdal_build/wscript_build	2023-09-18 00:13:03.000000000 +0200
+@@ -1104,7 +1104,7 @@
+         includes='../heimdal/lib/asn1',
+         group='hostcc_build_main',
+         deps='ROKEN_HOSTCC HEIMBASE_HOSTCC LIBREPLACE_HOSTCC HEIMDAL_VERS_HOSTCC '
+-             'HEIMDAL_ASN1_GEN_HOSTCC',
++             'HEIMDAL_ASN1_GEN_HOSTCC intl',
+         install=False
+     )
+     bld.env['ASN1_COMPILE'] = os.path.join(bld.bldnode.parent.abspath(), 'asn1_compile')


### PR DESCRIPTION
#### Description

Switch to using the Makefile, since the build fails when using waf directly. Add a patch to link against libitl for gettext support.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.9 21G726 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
