### PR TITLE
fd: Generate bash and fish completions

### DIFF
--- a/sysutils/fd/Portfile
+++ b/sysutils/fd/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        sharkdp fd 8.7.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         simple, fast and user-friendly alternative to find
 
@@ -27,11 +27,10 @@ checksums           ${distname}${extract.suffix} \
                     sha256  13da15f3197d58a54768aaad0099c80ad2e9756dd1b0c7df68c413ad2d5238c9 \
                     size    116286
 
-pre-build {
-    file mkdir ${worksrcpath}/shell_completions
+post-build {
+    system -W ${worksrcpath} "target/[cargo.rust_platform]/release/${name} --gen-completions bash > ${name}.bash"
+    system -W ${worksrcpath} "target/[cargo.rust_platform]/release/${name} --gen-completions fish > ${name}.fish"
 }
-
-build.env-append    SHELL_COMPLETIONS_DIR=shell_completions
 
 destroot {
     xinstall -m 0755 \
@@ -52,6 +51,16 @@ destroot {
     xinstall -m 0644 \
         ${worksrcpath}/contrib/completion/_fd \
         ${destroot}${prefix}/share/zsh/site-functions/_fd
+
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0644 \
+        ${worksrcpath}/${name}.bash \
+        ${destroot}${prefix}/share/bash-completion/completions/${name}
+
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 0644 \
+        ${worksrcpath}/${name}.fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d
 }
 
 cargo.crates \


### PR DESCRIPTION
#### Description

Generate bash and fish completions for `fd`. This prompts for a revision bump.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
