### PR TITLE
google-cloud-sdk: update to 447.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             446.0.1
+version             447.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  6ef197a4144afb2db29bad8de6019b1e85cdb891 \
-                    sha256  690471f8d29afdedcc902307699a55ac631ba995100785d003c644be324cd065 \
-                    size    101491839
+    checksums       rmd160  f7fd820c9f0c97382427a6ceb04adf2cec8babcc \
+                    sha256  04cbee2f9777b84bbb5af14fde12b2526ba51beb43a063140cb9758de7eea304 \
+                    size    120897289
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  f04cba9988205a0bf33f27adafb9315490ab1b68 \
-                    sha256  198f598a6505b6275cef6e8f4343fab084c2be56f3802e07af9e7d845a15d54a \
-                    size    121761867
+    checksums       rmd160  1c1f4f95a364b63f5e38cbdd9ffe76bb5157528f \
+                    sha256  e450bd19f193713f0c5bce7f639770c318410ba124b01204af5fffd9a9a35d17 \
+                    size    122182369
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  a72b8b5f87dcfc49f660b15b2f805446915caf63 \
-                    sha256  11603be1284875e16f7c287816ade8a6d295f2a5b58fa47c8b26c1ace0206f96 \
-                    size    118916685
+    checksums       rmd160  7e59e4b5db968d5b41f3be677fb2ece0d6cf5e2b \
+                    sha256  58fc8c88cf7d01ee045f2352505b6f9b93d251fbab8c07a667ee8d4542bb149d \
+                    size    119287165
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 447.0.0.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?