### PR TITLE
openjdk21-corretto: fix description

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -22,7 +22,7 @@ supported_archs  x86_64 arm64
 version      21.0.0.35.1
 revision     0
 
-description  Amazon Corretto OpenJDK 21 (Short Term Support)
+description  Amazon Corretto OpenJDK 21 (Long Term Support)
 long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
 
 master_sites https://corretto.aws/downloads/resources/${version}/


### PR DESCRIPTION
#### Description

Amazon Corretto 21 is a Long Term Support release, but the port incorrectly said it was a Short Term Support release.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?