### PR TITLE
nco: update to 5.1.8

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.1.7
+github.setup        nco nco 5.1.8
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
@@ -21,9 +21,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  07dcb9004ed34bb9abe87109aec7303053041a80 \
-                    sha256  25ca60e1cb96a9ddb5bab0ff5dee3c8075a22b7eb5af7597b7d3fbfe0ba6fca7 \
-                    size    6465975
+checksums           rmd160  f1df26d62fa13a330a8441ddf23f63d5df88425b \
+                    sha256  c43bf20ce9ed5e229d6b44a4b3e1bf21755500f42705fc335f57938e9f1c9b90 \
+                    size    6476573
 
 homepage            http://nco.sourceforge.net/
 long_description \
@@ -37,14 +37,9 @@ long_description \
 
 depends_lib         port:curl \
                     port:gettext \
-                    port:libiconv \
-                    port:libxml2 \
                     port:netcdf \
-                    path:lib/libssl.dylib:openssl \
                     port:udunits2 \
-                    port:zlib \
                     port:gsl \
-                    port:hdf5 \
                     port:xercesc3
 depends_build       port:antlr \
                     port:bison \


### PR DESCRIPTION
#### Description

Simple update to upstream version 5.1.8.

En passant, removed from `depends_lib` all the packages that `nco` does not _directly_ depend on.
Particularly, the dependency on `hdf5` was confusing, since it would suggest that `nco` would need to have a revbump on every `hdf5` version update. But `nco` only _indirectly_ depends on `hdf5` through `netcdf`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.2 22G91 x86_64
Command Line Tools 14.3.1.0.1.1683849156

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
