### PR TITLE
libosmium: update to 2.20.0, osmium-tool: update to 1.16.0

### DIFF
--- a/gis/libosmium/Portfile
+++ b/gis/libosmium/Portfile
@@ -5,9 +5,9 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           boost 1.0
 
-github.setup        osmcode libosmium 2.19.0 v
+github.setup        osmcode libosmium 2.20.0 v
 github.tarball_from archive
-revision            4
+revision            0
 
 categories          gis
 maintainers         {@frankdean fdsd.co.uk:frank.dean} openmaintainer
@@ -25,9 +25,9 @@ long_description    Low-level: this is designed to be a building block \
                     generated with the Google Protobufs protoc \
                     program.
 
-checksums           rmd160  a1c24ae0e4cf67eee1127cb4858703688638987a \
-                    sha256  6911a8ca8e81d49205357177982df908af11376919f93b814cccf02f1d4d63e3 \
-                    size    565486
+checksums           rmd160  9eaf7f451e11967dc247b43c920db77220f6fb71 \
+                    sha256  3d3e0873c6aaabb3b2ef4283896bebf233334891a7a49f4712af30ca6ed72477 \
+                    size    565349
 
 installs_libs       no
 

--- a/gis/osmium-tool/Portfile
+++ b/gis/osmium-tool/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           boost 1.0
 
-github.setup        osmcode osmium-tool 1.15.0 v
+github.setup        osmcode osmium-tool 1.16.0 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ description         A command line tool for working with OpenStreetMap
 long_description    A multipurpose command line tool for working with \
                     OpenStreetMap data based on the Osmium library
 
-checksums           rmd160  f376ec33bce1d509c2ef99f1d33a7999f9cff1ec \
-                    sha256  0b3be2f07d60dfb93f65d6a9f1af1fc9cf6ef68e5a460997d841c93079c3377b \
-                    size    490366
+checksums           rmd160  9f0442c2ea00f5714835ea8f29f2e4a056fd318f \
+                    sha256  f98454d9f901be42e0b6751aef40106d734887ee35190c224b174c2f27ef1c0f \
+                    size    491176
 
 compiler.cxx_standard 2014
 


### PR DESCRIPTION
#### Description
* [libosmium changelog](https://github.com/osmcode/libosmium/releases)
* [osmium-tool changelog](https://github.com/osmcode/osmium-tool/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.2
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

