### PR TITLE
oof2: update to version 3.2.1, oofcanvas: update to version 1.1.1

### DIFF
--- a/graphics/oofcanvas/Portfile
+++ b/graphics/oofcanvas/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           python 1.0
+PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 name                oofcanvas
-version             1.0.2
+version             1.1.1
 revision            0
 
 license             public-domain
@@ -28,35 +28,65 @@ long_description    OOFCanvas is a replacement for libgnomecanvas, designed \
 homepage            https://www.ctcms.nist.gov/oof/oofcanvas
 master_sites        ${homepage}/source
 
-checksums           rmd160 f7f25039414ea999c2c6027789d6d196ea76549b \
-                    sha256 30d738e5047d46008363265ce50eac10cdadbed3b3430904a031f60139d9796f \
-                    size 1112119
-
-python.default_version  27
+checksums           rmd160 6fc895f62482b8e616952555a8945c71b84c0762 \
+                    sha256 78e14ac9226bf5831ff0a90a39d31cd0fb80e055a0ce92ddbf3b834a46960bad \
+                    size 98484
 
 compiler.cxx_standard 2011
+cmake.build_type    Release
 
 # clang 503.0.40 provided by Xcode 5.1.1 supports C++11 but apparently not <type_traits>
 # fatal error: 'type_traits' file not found
 # #include <type_traits>
 compiler.blacklist-append {clang < 600.0.57}
 
-depends_build       port:pkgconfig
+depends_build       port:cmake port:pkgconfig port:swig-python
 
 depends_lib-append  path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
-                    port:cairomm \
-                    port:adwaita-icon-theme
+                    port:cairomm
 
-variant pythonAPI description {Build the python API} {
-    build.args-append       --pythonAPI
-    destroot.args-append    --pythonAPI
-    depends_lib-append      port:py${python.version}-gobject3
+configure.args-append -DOOFCANVAS_SWIG_VERSION=4.1
+
+set python_versions {311 38 310 39}
+
+foreach v ${python_versions} {
+    set minor [string range ${v} 1 end]
+    # This variant conflicts with all other python variants
+    set conflictversions [lsearch -all -inline -not ${python_versions} $v]
+    set conflictswith {}
+    foreach cv ${conflictversions} {
+        lappend conflictswith python$cv
+    }
+    variant python${v} description "Build the API for Python 3.${minor}" \
+        conflicts {*}$conflictswith \
+        [ subst {
+            depends_lib-append   port:python${v} port:py${v}-gobject3
+            configure.args-append \
+              -DOOFCANVAS_PYTHON_API=Python3 \
+              -DOOFCANVAS_PYTHON3_VERSION=3.$minor \
+              -DOOFCANVAS_SYSTEM_INSTALL=ON
+        }]
 }
 
-variant magick description {Include code to display ImageMagick images} {
-    build.args-append       --magick
-    destroot.args-append    --magick
-    depends_lib-append      port:ImageMagick
+variant magick description {Add support for ImageMagick images} {
+    configure.args-append -DOOFCANVAS_USE_IMAGEMAGICK=ON
+    depends_lib-append     port:ImageMagick
 }
 
-default_variants    +pythonAPI +magick
+variant numpy description {Add support for NumPy images (at your own risk)} {
+    configure.args-append -DOOFCANVAS_USE_NUMPY=ON
+}
+
+# python311 is the default variant if no other python variant is set
+set vactive 0
+foreach v ${python_versions} {
+    if [variant_isset python$v] {
+        set vactive 1
+    }
+}
+if { !$vactive } {
+    default_variants +magick +python311
+} else {
+    default_variants +magick
+}
+

--- a/science/oof2/Portfile
+++ b/science/oof2/Portfile
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           python 1.0
+PortGroup           cmake 1.1
 PortGroup           active_variants 1.1
 
 name                oof2
-version             2.2.2
+version             2.3.1
 revision            0
 
 license             public-domain
@@ -20,20 +20,48 @@ long_description    OOF2 computes properties of materials with complex \
 homepage            https://www.ctcms.nist.gov/oof/oof2
 master_sites        ${homepage}/source
 
-checksums           rmd160 235ea0522056af5ac930e822ed4cd028196c6365 \
-                    sha256 b461dc614c2e7785b63cb52dbe2c59ddc230c06e27479623c281665a39b35ea1 \
-                    size 15103836
-
-python.default_version 27
+checksums           rmd160 fc3d4eec71a76e35c0d82a8be1978e22e557d136 \
+                    sha256 68736b827310783e16036df4faf827e1685f8e68fb33ab4948d03a68a27e383f \
+                    size 13800807
 
 compiler.cxx_standard 2011
 
-depends_build       port:pkgconfig
+depends_build       port:cmake port:pkgconfig port:swig-python
+depends_run         port:adwaita-icon-theme
 
-depends_lib-append  port:oofcanvas \
-                    port:py${python.version}-numpy \
-                    path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
-                    port:py${python.version}-gobject3 \
-                    port:ImageMagick
+configure.args-append -DOOF2_SWIG_VERSION=4.1
 
-require_active_variants oofcanvas   {pythonAPI magick}
+# Create a variant for each supported python version
+set python_versions {38 39 310 311}
+foreach v ${python_versions} {
+    # Create a list of the other python versions, which this variant
+    # is incompatible with.
+    set minor [string range ${v} 1 end]
+    set conflictswith {}
+    foreach vv ${python_versions} {
+        if {${vv} != ${v}} {
+            lappend conflictswith python${vv}
+        }
+    }
+    variant python${v} description "Use Python 3.${minor}" \
+        conflicts {*}${conflictswith} \
+        [ subst {
+            depends_lib-append port:oofcanvas
+            configure.args-append \
+                -DOOF2_PYTHON3_VERSION=3.$minor \
+                -DOOF2_SYSTEM_INSTALL=ON
+            require_active_variants oofcanvas {python${v} magick} {numpy}
+        }]
+}
+
+# python311 is the default variant if no other python variant is set
+set vactive 0
+foreach v ${python_versions} {
+    if [variant_isset python$v] {
+        set vactive 1
+    }
+}
+if { !$vactive } {
+    default_variants +python311
+}
+


### PR DESCRIPTION
Update to the latest versions. oof2 and oofcanvas must be updated together.

#### Description

OOF2 and OOFCanvas now use python3, and build with cmake.  The full changelog is at 
https://www.ctcms.nist.gov/oof/oof2/changes.html

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5.2 22G91 x86_64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [?] tried a full install with `sudo port -vst install`?   "Sandbox-exec quit unexpectedly" when I use -v.
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
