### PR TITLE
miniflux: update to 2.0.48

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,12 +3,14 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.46
-go.package          miniflux.app
+go.setup            github.com/miniflux/v2 2.0.48 v
+go.package          miniflux.app/v2
 name                miniflux
 revision            0
 categories          net
-maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+maintainers         {@sikmir disroot.org:sikmir} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 license             Apache-2
 
 description         Minimalist and opinionated feed reader
@@ -16,9 +18,9 @@ long_description    {*}${description}
 homepage            https://miniflux.app
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  1b9ef683a91720b68b3a7fae64eaf417419f7f44 \
-                        sha256  591f585ba5cd323f473022e88a0badaf3a44fe1047b53ad53a8b3886bb3d1ab9 \
-                        size    586323
+                        rmd160  3c447d7797d40e45b27735b59d2c7ba82129efbb \
+                        sha256  57a39ffddec5e4a50922ffb6cb6f09b22910cb7c21ec7526178222793ccc0f07 \
+                        size    604020
 
 go.vendors          mvdan.cc/xurls \
                         repo    github.com/mvdan/xurls \
@@ -44,60 +46,55 @@ go.vendors          mvdan.cc/xurls \
                         sha256  3669d59598e4bd657ec079f151fab47b3aa130adfec35daeb05e079220970cd2 \
                         size    333026 \
                     golang.org/x/text \
-                        lock    v0.11.0 \
-                        rmd160  c4603f279575a9642b4444914247fdbb0e9954c4 \
-                        sha256  43460e0115cf4129f1de68b767e0f87f9988456e83873d89877c6af5d99e790f \
-                        size    8971482 \
-                    golang.org/x/term \
-                        lock    v0.10.0 \
-                        rmd160  3fe74cc1e896e699905f977770d03fb18d57446e \
-                        sha256  9aecdd02affdb29761beced82234ea873f6452500e7338482be692816c29d6e1 \
-                        size    14801 \
-                    golang.org/x/sys \
-                        lock    v0.10.0 \
-                        rmd160  83368c420a37696a8f102d9409b238b89a9c9d82 \
-                        sha256  131890e51d97b703ad20cebc231370408213b554c32231001d204bfac7ac96d5 \
-                        size    1441834 \
-                    golang.org/x/oauth2 \
-                        lock    v0.10.0 \
-                        rmd160  4f169fe6bfb54e5e56a8ed08d69d552ce5b323ec \
-                        sha256  095faa5b40de1e5f3e1f6982af50d2fc30a1eaa278055f340ed31d38eb8ea24d \
-                        size    140845 \
-                    golang.org/x/net \
                         lock    v0.12.0 \
-                        rmd160  d599e183fa279c044432d748157f06265fe5d787 \
-                        sha256  b0f10ee750ae27d7761d93c01c01aceea2f5b25a591acbb9bc91f378cf04920d \
-                        size    1371560 \
-                    golang.org/x/crypto \
+                        rmd160  9ecc2cc78c5ea0f2448e035b0885e94ecf0669c9 \
+                        sha256  9a367a26f3c6768b6e84bb91abc54b72593b01e588fa5701b39d7caf2e8987fb \
+                        size    8964843 \
+                    golang.org/x/term \
                         lock    v0.11.0 \
-                        rmd160  c00277dedc81b9ed173fb03d8d8c1293ff659463 \
-                        sha256  bb0cd20fd6f6bc93d8546af593d8763ff89875078758563a1881c0316283f80e \
-                        size    1789100 \
+                        rmd160  20a06ba4119a4149a8a82c5f396790048d3fe7e4 \
+                        sha256  54900fa5f46599e22f84bcb56b99e701725fd597ddefd94a47d10cbd8e54680e \
+                        size    14800 \
+                    golang.org/x/sys \
+                        lock    v0.11.0 \
+                        rmd160  c7caf23614dccb94ca13c90ef9de5ad06ea7b458 \
+                        sha256  c6bb27dfd6309f9353492ceddeb653fcdd7c545ab416606089a7d8222ca8f301 \
+                        size    1445926 \
+                    golang.org/x/oauth2 \
+                        lock    v0.11.0 \
+                        rmd160  132baefba7eb34d54741c9211a1065797a77d0f3 \
+                        sha256  7757c20096466faecf6e01c80b562b7b340be48745af2b75323050901cfd3e3d \
+                        size    87096 \
+                    golang.org/x/net \
+                        lock    v0.14.0 \
+                        rmd160  bfb1747ff8c70fccc739d8e9dfe9d727e10f2249 \
+                        sha256  9d15e9df855fa31660611b401e386ee9c38963ceb21263a5ca83c4cb3244c852 \
+                        size    1421702 \
+                    golang.org/x/crypto \
+                        lock    v0.12.0 \
+                        rmd160  8ce373fa203f6e005c1407926c866fd9f1959819 \
+                        sha256  55012d52b78d8f1ecbbfbd85a8d4928638465dd7296fa4bc9062226402def61b \
+                        size    1792003 \
                     github.com/yuin/goldmark \
-                        lock    v1.5.4 \
-                        rmd160  7e428750043e781507d94e54431c488a2e07110a \
-                        sha256  125ebf860067caab104024f6b3072c86b8b94f131a9bbf8346b459724b097a54 \
-                        size    260013 \
-                    github.com/technoweenie/multipartstreamer \
-                        lock    v1.0.1 \
-                        rmd160  f1ac41924fe0ca28bf79b5737680452a907b70b4 \
-                        sha256  4d7559e4d965a056e8dc4c32f852a23451ad47cd639123bc7a4bf7268ff94861 \
-                        size    3248 \
+                        lock    v1.5.6 \
+                        rmd160  7a63c194c76fea834b2af4d3e2546ac86835672d \
+                        sha256  0480aaaa32b304a60a11dbefed9bae1f0ca8f4d9c359d10e1af0384b72df920f \
+                        size    248088 \
                     github.com/tdewolff/test \
                         lock    v1.0.9 \
                         rmd160  6b9a086f0d9479d652817a3a0fb074a00bd075d5 \
                         sha256  38f2a2130a529983eb487812a4f577000c6894a80f126f7377fc08f88d02da57 \
                         size    3089 \
                     github.com/tdewolff/parse \
-                        lock    v2.6.6 \
-                        rmd160  0f1f426a750662d5da5d71e94f2b4695022cbc2e \
-                        sha256  6fbe7ffc7d2a7bb64586b6582f00325c292625e51fc27282b15bdae545bcef90 \
-                        size    104809 \
+                        lock    v2.6.7 \
+                        rmd160  a7d43fb2a8512ae58648c6e42249c25e3c6fd11a \
+                        sha256  e66d81a5429f7ff92a999686bde9071114411808195a40ef208af2d932cf33b9 \
+                        size    105216 \
                     github.com/tdewolff/minify \
-                        lock    v2.12.7 \
-                        rmd160  79fb17402eb3cd6e5bccac075c6c3a75e7a77415 \
-                        sha256  d1a9e47ff59fd04c4bc87421cda4f956f032607ff98c10239a63f671569bf4b8 \
-                        size    7029578 \
+                        lock    v2.12.8 \
+                        rmd160  414819df9e7c25aca857995ecdecdf4378d25783 \
+                        sha256  732a0aec7a9b7204c03a538c2afb4de07ab12a9105526144990d70c76e95a25a \
+                        size    7037562 \
                     github.com/stretchr/testify \
                         lock    v1.8.0 \
                         rmd160  5c390a4b7ea60de6cf9f69ece1cfc664e52c52b7 \
@@ -134,20 +131,15 @@ go.vendors          mvdan.cc/xurls \
                         sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
                         size    11409 \
                     github.com/mccutchen/go-httpbin \
-                        lock    v2.10.0 \
-                        rmd160  df8404586a47ad0d47b0e1888c84d3f8e2321c6f \
-                        sha256  22896a125762309ba98c42eefb20c2b5cc1b009fb201873e5b8485a894a72bc8 \
-                        size    124367 \
+                        lock    v2.11.0 \
+                        rmd160  b3109acfb8320bdefea8899bd814e7e041353cf2 \
+                        sha256  9481838fae9ebf098eb0d1259527d9712f8e29ce354ea2c88cbffd584400d338 \
+                        size    126564 \
                     github.com/matttproud/golang_protobuf_extensions \
                         lock    v1.0.4 \
                         rmd160  5cd0af4220838331f336b1dca99297e11441be69 \
                         sha256  6c32596468a03ca847e3cc29e74d64e0b7a0bba64166343494696c418415d114 \
                         size    37528 \
-                    github.com/matrix-org/gomatrix \
-                        lock    ceba4d9f7530 \
-                        rmd160  9f447aad7e63fbd3dd4167f0921833e03b82e360 \
-                        sha256  96ecd3f6db41b69df8ea8ae4eff694b2fc1916c40bef88e488fed3241ce3a31e \
-                        size    26592 \
                     github.com/lib/pq \
                         lock    v1.10.9 \
                         rmd160  beb0e233773f49d8d08ee991abf23bc8febf69d0 \
@@ -168,11 +160,6 @@ go.vendors          mvdan.cc/xurls \
                         rmd160  b4e09ad842f6dcd3aea36b28ec64d6d9563fd1d8 \
                         sha256  12e830fab630cabd279fca57e7089eeb1556e2c22b58eee64bb21bd3c8dfc706 \
                         size    171856 \
-                    github.com/go-telegram-bot-api/telegram-bot-api \
-                        lock    v4.6.4 \
-                        rmd160  80821ad149f661570509a35adcf2d1d73fcf0c10 \
-                        sha256  98e078b4f8909436790f12c39fcc589ac7b4e9b39e342966d60470aa2f14fad8 \
-                        size    2076483 \
                     github.com/go-jose/go-jose \
                         lock    v3.0.0 \
                         rmd160  adc3ad2bfe484fe710cb86640cb797b3d3182e5e \
@@ -209,12 +196,14 @@ go.vendors          mvdan.cc/xurls \
                         sha256  59d4df67e0aa0c11ae7f019ef5462d38f3e7200ed7aea48412bef8cc486eb880 \
                         size    106576
 
-build.args-append   -ldflags=\"-s -w -X '${go.package}/version.Version=${version}'\"
+build.args-append   \
+    -ldflags=\"-s -w -X '${go.package}/internal/version.Version=${version}'\" \
+    -o ${name}
 
 destroot {
     set mandir ${prefix}/share/man/man1
-    xinstall -m 755 -d ${destroot}${mandir}
+    xinstall -m 0755 -d ${destroot}${mandir}
 
-    xinstall -m 755 ${worksrcpath}/${go.package} ${destroot}${prefix}/bin/${name}
-    xinstall -m 644 ${worksrcpath}/${name}.1 ${destroot}${mandir}/
+    xinstall -m 0755 ${worksrcpath}/${name}     ${destroot}${prefix}/bin/
+    xinstall -m 0644 ${worksrcpath}/${name}.1   ${destroot}${mandir}/
 }


### PR DESCRIPTION
- add @herbygillot as co-maintainer

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
