### PR TITLE
glances: add missing run deps

### DIFF
--- a/sysutils/glances/Portfile
+++ b/sysutils/glances/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        nicolargo glances 3.4.0.3 v
-revision            0
+revision            1
 categories          sysutils
 license             GPL-3
 maintainers         nomaintainer
@@ -27,6 +27,9 @@ python.default_version 311
 depends_lib-append  port:py${python.version}-psutil \
                     port:py${python.version}-future \
                     port:py${python.version}-setuptools
+
+depends_run-append  port:py${python.version}-defusedxml \
+                    port:py${python.version}-ujson
 
 patch {
     reinplace "s|/usr/local|${prefix}|" glances/config.py


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68211

#### Description

Add run dependencies.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

P. S. I can verify that dependencies are okay now, but the port still does not run correctly on 10.6.8: https://trac.macports.org/ticket/68215

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
