### PR TITLE
oof2: Update to 2.3.1_1

### DIFF
--- a/science/oof2/Portfile
+++ b/science/oof2/Portfile
@@ -3,10 +3,11 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           active_variants 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
 name                oof2
 version             2.3.1
-revision            0
+revision            1
 
 license             public-domain
 categories          science
@@ -25,6 +26,9 @@ checksums           rmd160 fc3d4eec71a76e35c0d82a8be1978e22e557d136 \
                     size 13800807
 
 compiler.cxx_standard 2011
+
+# fails to build on macOS < 10.12
+compiler.blacklist-append {clang < 900}
 
 depends_build       port:cmake port:pkgconfig port:swig-python
 depends_run         port:adwaita-icon-theme


### PR DESCRIPTION
Blacklist clang < 900, in response to build failure on macOS < 10.12.

#### Description

Blacklisting clang < 900 in response to build failure on macOS < 10.12
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5.2 22G91 x86_64
Xcode 15.0 15A240d
###### Verification <!-- (delete not applicable items) -->

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
