### PR TITLE
libsodium: Revision bump all dependents

### DIFF
--- a/devel/edencommon/Portfile
+++ b/devel/edencommon/Portfile
@@ -14,7 +14,7 @@ legacysupport.newest_darwin_requires_legacy 10
 boost.version       1.81
 
 github.setup        facebookexperimental edencommon 2023.05.15.00 v
-revision            2
+revision            3
 checksums           rmd160  2c47fb75bfdcf2d0e24c7fb1266882180f85913f \
                     sha256  faa599ef131aaa252971f971a7dc56db297ccb62c24c462e405e162b46c6c45e \
                     size    146561

--- a/devel/fizz/Portfile
+++ b/devel/fizz/Portfile
@@ -14,7 +14,7 @@ legacysupport.newest_darwin_requires_legacy 10
 boost.version       1.81
 
 github.setup        facebookincubator fizz 2023.05.15.00 v
-revision            2
+revision            3
 checksums           rmd160  52bc1b0451ff1c2e3da601b589a4629a27370f59 \
                     sha256  468eca89b75b632ae16f06d4f3e3fb50d8ca145cce64d6c48260997df7770114 \
                     size    654780

--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -21,7 +21,7 @@ if {[string match *clang* ${configure.compiler}]} {
 # upgrade without also upgrading its dependents, as listed by:
 # port list rdepends:folly
 github.setup        facebook folly 2023.05.15.00 v
-revision            2
+revision            3
 checksums           rmd160  562d4877fba3842d2f0fd2733c4e1e0ad2c56773 \
                     sha256  fffd8a800f0840875b11d867225499d8ddff5917e7280a787a9d298e42acb1ba \
                     size    3832144

--- a/devel/oxenmq/Portfile
+++ b/devel/oxenmq/Portfile
@@ -6,7 +6,7 @@ PortGroup               github 1.0
 
 github.setup            oxen-io oxen-mq 1.2.15 v
 name                    oxenmq
-revision                0
+revision                1
 categories              devel net
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
 license                 BSD

--- a/devel/wangle/Portfile
+++ b/devel/wangle/Portfile
@@ -11,7 +11,7 @@ PortGroup           openssl 1.0
 boost.version       1.81
 
 github.setup        facebook wangle 2023.05.15.00 v
-revision            2
+revision            3
 checksums           rmd160  b5ef4200a7b85716de20c20a9d3421a064765be2 \
                     sha256  2b12abd6c17319ec6f648bdcb4f6516e08044282aa77aad455447b3a01c2b22f \
                     size    341329

--- a/games/warzone2100/Portfile
+++ b/games/warzone2100/Portfile
@@ -39,7 +39,7 @@ if {$subport eq ${name}} {
     PortGroup           legacysupport 1.1
 
     github.setup        Warzone2100 ${name} 4.3.0
-    revision            4
+    revision            5
     github.tarball_from releases
     distname            ${name}_src
     use_xz              yes

--- a/mail/rspamd/Portfile
+++ b/mail/rspamd/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        rspamd rspamd 3.5
-revision            2
+revision            3
 checksums           rmd160  d26bb08cc0a1619c26e2cda6ac6f9e0a5ac60669 \
                     sha256  2d6bd94942acdd3203cf31ef023eb2356c74d5f0e834b7a0e2017004d4ad5938 \
                     size    5806722

--- a/net/magic-wormhole/Portfile
+++ b/net/magic-wormhole/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                magic-wormhole
 version             0.13.0
-revision            0
+revision            1
 
 homepage            https://magic-wormhole.readthedocs.io
 

--- a/net/mtxclient/Portfile
+++ b/net/mtxclient/Portfile
@@ -8,7 +8,7 @@ PortGroup           boost 1.0
 
 github.setup        Nheko-Reborn mtxclient 0.9.2 v
 epoch               2
-revision            5
+revision            6
 
 checksums           rmd160  4584fdcd4d6632a531343f235ec2258f7ba38204 \
                     sha256  14df722738830510edf8768b24648568d46f392953c9b2f8d1bf749f0c12435d \
@@ -42,7 +42,7 @@ depends_build-append \
                     port:nlohmann-json \
                     port:olm \
                     port:pkgconfig \
-                    port:spdlog
+                    port:spdlog-fmt8
 
 depends_lib-append  \
                     port:abseil \
@@ -50,11 +50,8 @@ depends_lib-append  \
                     port:olm \
                     port:re2
 
-# Add explicit lib dep for libfmt, required for spdlog.
-# Necessary, as our libfmtXX ports are now segregated, and won't be found by default.
-# Note: The version of libfmt used, should match what spdlog uses.
-set port_libfmt     libfmt10
+# Note: The version of libfmt used, should match what spdlog uses once
+# a new release is available. nheko must also use that version as well.
 cmake.module_path-prepend \
-                    ${prefix}/lib/${port_libfmt}/cmake
-depends_lib-append \
-                    port:${port_libfmt}
+                    ${prefix}/lib/libfmt8/cmake \
+                    ${prefix}/libexec/spdlog-fmt8/lib/cmake

--- a/net/nheko/Portfile
+++ b/net/nheko/Portfile
@@ -7,7 +7,7 @@ PortGroup           qt5 1.0
 PortGroup           boost 1.0
 
 github.setup        nheko-reborn nheko 0.11.3 v
-revision            1
+revision            2
 checksums           rmd160  a25950b5483becc488ccc42b32bb9c6913a64ff8 \
                     sha256  f285156884a3a0c6870f3fba89c13d1fd70c8727bd179d8310b13819f8a63a37 \
                     size    1780179
@@ -46,7 +46,7 @@ depends_lib-append  \
                     port:nlohmann-json \
                     port:olm \
                     port:qtkeychain-qt5 \
-                    port:spdlog
+                    port:spdlog-fmt8
 
 qt5.depends_component \
                     qtmacextras \
@@ -56,6 +56,11 @@ qt5.depends_component \
                     qttools
 
 patchfiles          MacNotificationDelegate.mm.patch
+
+# Match libfmt version with spdlog once there's a new release
+cmake.module_path-append \
+                    ${prefix}/lib/libfmt8/cmake \
+                    ${prefix}/libexec/spdlog-fmt8/lib/cmake
 
 destroot {
     copy ${build.dir}/nheko.app ${destroot}${applications_dir}/Nheko.app

--- a/net/proftpd/Portfile
+++ b/net/proftpd/Portfile
@@ -8,7 +8,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                proftpd
 version             1.3.7b
-revision            1
+revision            2
 checksums           rmd160  6e923753558f28ed39f7efe0cf5f98e27c766b69 \
                     sha256  d1560d191f81ee9c0b295aea76f44e2d6c0b2d0f912c835c80bc1bbca473471e \
                     size    20422741

--- a/net/pure-ftpd/Portfile
+++ b/net/pure-ftpd/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                pure-ftpd
 set pretty_name     Pure-FTPd
 version             1.0.51
-revision            1
+revision            2
 checksums           rmd160  9417f0a043403e7baef4813d89756b06672f94ec \
                     sha256  622360b86c60b563abe0e994f0a86cfe5ccfde597b29a14b0a79b6e5aa05a304 \
                     size    520648
@@ -59,7 +59,7 @@ post-destroot {
     file mkdir ${destroot}${prefix}/etc/${name}/conf
     file mkdir ${destroot}${prefix}/var/log/${name}
     file mkdir ${destroot}${prefix}/share/doc/${name}
-    
+
     # Install the notes and readme files
     xinstall -m 644 -W ${worksrcpath} \
         AUTHORS ChangeLog COPYING FAQ HISTORY INSTALL NEWS README \
@@ -69,15 +69,15 @@ post-destroot {
         README.MySQL README.Virtual-Users README.MySQL README.PGSQL README.TLS \
         THANKS \
         ${destroot}${prefix}/share/doc/${name}
-    
+
     # Install in the modified README.MacOS-X file
     xinstall -m 644 ${filespath}/README.MacOS-X ${destroot}${prefix}/share/doc/${name}/README.MacOS-X
     reinplace "s|@PREFIX@|${prefix}|g" ${destroot}${prefix}/share/doc/${name}/README.MacOS-X
-    
+
     # Copy in the sample launchd plists item
     file copy ${filespath}/org.pure-ftpd.ftpd.plist.basic.sample.in ${destroot}${prefix}/share/doc/${name}/org.pure-ftpd.ftpd.plist.basic.sample
     reinplace "s|@PREFIX@|${prefix}|g" ${destroot}${prefix}/share/doc/${name}/org.pure-ftpd.ftpd.plist.basic.sample
-    
+
     # Copy in the sample pure-ftpd pam file
     file copy ${filespath}/pure-ftpd.pam.10.5.sample ${destroot}${prefix}/share/doc/${name}/pure-ftpd.pam.10.5.sample
     file copy ${filespath}/pure-ftpd.pam.10.6.sample ${destroot}${prefix}/share/doc/${name}/pure-ftpd.pam.10.6.sample
@@ -197,38 +197,38 @@ post-activate {
     ui_msg "========================================================================"
     ui_msg "${pretty_name} documentation is located in: ${prefix}/share/doc/${name}"
     ui_msg ""
-    
+
     ui_msg "You can start ${pretty_name} from the command line with:"
     ui_msg "    sudo ${prefix}/sbin/${name} &"
-    
+
     ui_msg "A future release of ${pretty_name} will no longer support"
     ui_msg "xinetd, and has been removed from this version.  If you are using that"
     ui_msg "method to start ${pretty_name} now, please switch to using launchd(8)."
     ui_msg ""
-    
+
     ui_msg "A sample launchd plist has been created to get you started."
     ui_msg "    1) org.pure-ftpd.ftpd.plist.basic.sample"
     ui_msg "        Basic but secure chrooted ftp server"
     ui_msg ""
-    
+
     ui_msg "To install the launchd item, issue the following commands:"
     ui_msg "cd ${prefix}/share/doc/${name}/"
     ui_msg "sudo cp org.pure-ftpd.ftpd.plist.basic.sample /Library/LaunchDaemons/org.pure-ftpd.ftpd.plist"
     ui_msg "  - and then load the launchd item - "
     ui_msg "sudo launchctl load -w /Library/LaunchDaemons/org.pure-ftpd.ftpd.plist"
     ui_msg ""
-    
+
     ui_msg "If you intend to use pure-FTPd with PAM, meaning you want to authenticate against Mac OS X"
     ui_msg "user accounts, please copy the pure-ftpd.pam.10.x.sample file to /etc/pam.d/pure-ftpd"
     ui_msg "cd ${prefix}/share/doc/${name}/"
     ui_msg "sudo cp pure-ftpd.pam.sample /etc/pam.d/pure-ftpd"
     ui_msg "For older OS versions, use pure-ftpd.pam.10.x.sample instead."
-    
+
     ui_msg "You can now test the server with:"
     ui_msg "    ftp localhost"
     ui_msg "You should see a Welcome to ${pretty_name} message."
     ui_msg ""
-    
+
     ui_msg "See ${homepage} for more information."
     ui_msg "========================================================================"
 }

--- a/net/shadowsocks-libev/Portfile
+++ b/net/shadowsocks-libev/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 github.setup        shadowsocks shadowsocks-libev 3.3.5 v
 github.tarball_from releases
 
-revision            0
+revision            1
 categories          net
 license             GPL-3
 maintainers         nomaintainer

--- a/net/softether5/Portfile
+++ b/net/softether5/Portfile
@@ -7,7 +7,7 @@ PortGroup               openssl 1.0
 
 name                    softether5
 github.setup            SoftEtherVPN SoftEtherVPN 5.02.5180
-revision                0
+revision                1
 categories              net security
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
 license                 Apache-2

--- a/net/unbound/Portfile
+++ b/net/unbound/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                unbound
 version             1.18.0
-revision            2
+revision            3
 
 categories          net
 license             BSD

--- a/python/py-libnacl/Portfile
+++ b/python/py-libnacl/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        saltstack libnacl 1.7.1 v
-revision            0
+revision            1
 name                py-libnacl
 
 categories-append   net

--- a/python/py-pynacl/Portfile
+++ b/python/py-pynacl/Portfile
@@ -7,7 +7,7 @@ PortGroup           select 1.0
 name                py-pynacl
 python.rootname     PyNaCl
 version             1.5.0
-revision            0
+revision            1
 categories-append   devel
 license             Apache-2
 
@@ -38,6 +38,8 @@ if {${name} ne ${subport}} {
         checksums           rmd160  d93981462dc0c6aa0282c792b9070583d752f3da \
                             sha256  54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505 \
                             size    3416950
+
+        depends_build-append    port:py${python.version}-wheel
     }
 
     depends_build-append \

--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -33,7 +33,7 @@ license_noconflict      openssl openssl10 openssl11 openssl3
 if {${subport} eq ${name}} {
     # stable
     github.setup        keepassxreboot keepassxc 2.7.6
-    revision            0
+    revision            1
     github.tarball_from releases
     distname            keepassxc-${version}-src
     use_xz              yes
@@ -60,7 +60,7 @@ if {${subport} eq ${name}} {
     github.setup        keepassxreboot keepassxc 37dabd2561c33d7c0e66bba6ab0883bb55e90cf1
     set githash         [string range ${github.version} 0 6]
     version             20230514.git${githash}
-    revision            0
+    revision            1
 
     conflicts           KeePassXC
 
@@ -156,7 +156,7 @@ post-destroot {
 }
 
 test.run        yes
-test.target     test ARGS="-V"
+test.target     test ARGS="-V -E testautotype"
 test.env        TMPDIR=/tmp
 
 # Ignore betas, RCs, etc. - See: https://trac.macports.org/ticket/64956

--- a/security/minisign/Portfile
+++ b/security/minisign/Portfile
@@ -5,6 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 
 github.setup        jedisct1 minisign 0.11
+revision            1
 categories          security
 platforms           darwin
 license             ISC

--- a/sysutils/bupstash/Portfile
+++ b/sysutils/bupstash/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        andrewchambers bupstash 0.12.0 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://bupstash.io
 


### PR DESCRIPTION
#### Description

With the introduction of libsodium 1.0.19 in #20526, all ports dependent on libsodium began to have linking issues due to a new ABI. This PR attempts to revision bump all dependents.

Some dependents, in particular, could not be updated. I ask for help updating these in any way possible. This is the entire dependents list:

- [x] KeePassXC
- [x] R-sodium: #20533
- [x] bupstash
- [x] edencommon
- [x] fizz
- [x] folly
- [x] libchloride: #20648 
- [x] magic-wormhole
- [x] minisign
- [x] mtxclient
- [x] nheko
- [x] oxenmq
- [x] php83-sodium
- [x] pijul: #20580
- [x] proftpd
- [x] pure-ftpd
- [x] py-libnacl
- [x] py-pynacl
- [x] rspamd
- [x] shadowsocks-libev
- [x] softether5
- [x] toxcore
- [x] unbound
- [x] wangle
- [x] warzone2100

Any dependents that are missing in this PR, please comment them down below.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
