### PR TITLE
openjdk21-sap: new submission

### DIFF
--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -1,0 +1,93 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk21-sap
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://sap.github.io/SapMachine/latest/21
+version      21
+revision     0
+
+description  SAP Machine 21
+long_description An OpenJDK 21 release maintained and supported by SAP
+
+master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     sapmachine-jdk-${version}_macos-x64_bin
+    checksums    rmd160  52f652066ae1ad1aa0270ad0b542b4357a9a03fa \
+                 sha256  665f34d7730fd769383df9bbfadef1ea9819f06b151903e9219b570ca3b0dc73 \
+                 size    194299298
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     sapmachine-jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  fd1453340c15bc5a3e9abde7054385d829bf2c9b \
+                 sha256  9075930a2fdc48c960b9dbac68418ecce9107696736c8eaf34720db3fa69ab4c \
+                 size    191986048
+}
+
+worksrcdir   sapmachine-jdk-${version}.jdk
+
+homepage     https://sap.github.io/SapMachine/
+
+livecheck.type      regex
+livecheck.url       https://github.com/SAP/SapMachine/releases
+livecheck.regex     sapmachine-jdk-(21\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-21-sapmachine.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for SapMachine OpenJDK 21.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?