### PR TITLE
spring-boot-cli: update to 3.1.4

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.1.3
+version         3.1.4
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  da5c0d538c1bf5007d499369e80065a47466fd7e \
-                sha256  f3cdd1d354a6b244b15a3c7e49b182be07e70a513c2981ef6fcb399246c0d3bc \
-                size    5145966
+checksums       rmd160  f6c158296a84c3696b9ae9e99505b693537c2b98 \
+                sha256  1150935bd0d7359a28fb5190f0ff01ffccf244f5b584b9e110a0d7328196ac7d \
+                size    5149036
 
 worksrcdir      spring-${version}
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.1.4.

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?