### PR TITLE
vim,MacVim: avoid opportunistic linking with libsodium

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -10,7 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 set vim_version     9.0
 set release         177
 github.setup        macvim-dev macvim ${release} release-
-revision            1
+revision            2
 name                MacVim
 version             ${vim_version}.release${release}
 categories          editors
@@ -75,6 +75,7 @@ configure.args      --enable-gui=macvim \
                     --disable-sparkle \
                     --disable-gpm \
                     --disable-canberra \
+                    --disable-libsodium \
                     --with-tlib=ncurses \
                     --enable-multibyte \
                     --enable-fail-if-missing \

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -12,14 +12,14 @@ if {${os.platform} eq "darwin" && ${os.major} <= 14} {
     # Fallback to previous port version, for 10.10 and earlier
     # https://trac.macports.org/ticket/67209
     set vim_patchlevel 0472
-    set port_revision  0
+    set port_revision  1
 
     checksums       rmd160  ee809eb300deaf735c86b6e5b7f4bc4a8fe79a41 \
                     sha256  7185577d6cd3708b62b2079b69a29215bb6a6048070d34e960d2d565c18b8a9b \
                     size    16851486
 } else {
     set vim_patchlevel 1677
-    set port_revision  0
+    set port_revision  1
 
     checksums       rmd160  9a62a3612177c661462dd218b305f92fc036d9f2 \
                     sha256  996766187b040b67fe13721e1601584fcf5e89f3ff9d5986be87c3fd1fe5d7c5 \
@@ -42,8 +42,7 @@ long_description    Vim is an advanced text editor that seeks to provide the\
 homepage            https://www.vim.org/
 
 
-depends_lib-append \
-                    port:ncurses \
+depends_lib-append  port:ncurses \
                     port:gettext \
                     port:libiconv
 
@@ -64,6 +63,7 @@ configure.args-append \
                     --without-local-dir \
                     --disable-gpm \
                     --disable-canberra \
+                    --disable-libsodium \
                     --mandir=${prefix}/share/man \
                     --with-tlib=ncurses \
                     --enable-multibyte \


### PR DESCRIPTION
#### Description
The [recent upgrade of `libsodium`](86381201edd2b233a20f15a542eae461de5eabb6) broke my `vim` installation as it opportunistically linked to it (I presumably build it locally because of a non-default variant). In any case, it looks like that since [patch 8.2.3003](https://github.com/vim/vim/commit/f573c6e1ed58d46d694c802eaf5ae3662a952744 ) `libsodium` will be used by default if available. 

There is a configure argument `--disable-libsodium` that should be added to the `vim` and `MacVim` ports as done in this PR, or if you prefer, I can change it to explicitly add a dependency on the `libsodium` port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.2 22G91 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
