### PR TITLE
vorbis-tools: update to 1.4.2

### DIFF
--- a/audio/vorbis-tools/Portfile
+++ b/audio/vorbis-tools/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 
 name                vorbis-tools
-version             1.4.0
-revision            2
+version             1.4.2
+revision            0
 categories          audio
 maintainers         nomaintainer
 
@@ -21,9 +21,12 @@ license             GPL-2+ BSD LGPL-2+
 homepage            http://www.vorbis.com/
 master_sites        https://ftp.osuosl.org/pub/xiph/releases/vorbis/
 
-checksums           md5     567e0fb8d321b2cd7124f8208b8b90e6 \
-                    sha1    fc6a820bdb5ad6fcac074721fab5c3f96eaf6562 \
-                    rmd160  ff21e5c9456ac0a82b8eda4e53931db8522a2ccd
+patchfiles          c99-compatibility-fix.diff \
+                    recursive-a-fix.diff
+
+checksums           rmd160  f0f4f859b3a280dfe7ea9a13dc4c39ed3ed37c80 \
+                    sha256  db7774ec2bf2c939b139452183669be84fda5774d6400fc57fde37f77624f0b0 \
+                    size    1389947
 
 depends_lib \
                     port:libogg \
@@ -32,6 +35,7 @@ depends_lib \
                     port:libao \
                     port:gettext
 
+
 configure.args \
     --mandir=${prefix}/share/man \
     --with-ao \
@@ -39,6 +43,9 @@ configure.args \
     --without-flac \
     --without-speex \
     --enable-vcut
+
+use_autoreconf      yes
+autoreconf.args        --force --install --verbose
 
 variant flac description "Enable FLAC support" {
   depends_lib-append    port:flac

--- a/audio/vorbis-tools/files/c99-compatibility-fix.diff
+++ b/audio/vorbis-tools/files/c99-compatibility-fix.diff
@@ -1,0 +1,11 @@
+# https://gitlab.xiph.org/xiph/vorbis-tools/-/commit/ec3a1a1de87168f575b93bc9cedcfaeb82c048a4
+--- ogginfo/codec_skeleton.c.orig	2021-01-08 15:13:55.000000000 -0800
++++ ogginfo/codec_skeleton.c	2023-09-22 08:35:40.000000000 -0700
+@@ -25,6 +25,7 @@
+ #include <ogg/ogg.h>
+ 
+ #include "i18n.h"
++#include "utf8.h"
+ 
+ #include "private.h"
+ 

--- a/audio/vorbis-tools/files/recursive-a-fix.diff
+++ b/audio/vorbis-tools/files/recursive-a-fix.diff
@@ -1,0 +1,12 @@
+# https://github.com/Homebrew/homebrew-core/pull/130403/commits/d2669dc292397c7b2d51c3640c58584bcc1ba183
+--- share/Makefile.am.orig	2021-01-03 08:35:46.000000000 -0800
++++ share/Makefile.am	2023-09-24 13:51:18.000000000 -0700
+@@ -11,7 +11,7 @@
+ libbase64_a_SOURCES = base64.c
+ 
+ libpicture_a_SOURCES = picture.c
+-libpicture_a_LIBADD = libbase64.a
++libpicture_a_LIBADD = base64.o
+ 
+ EXTRA_DIST = charmaps.h makemap.c charset_test.c charsetmap.h
+ 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
