### PR TITLE
hdf5: Fix build with Sonoma/CLT 15.0

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -40,7 +40,8 @@ use_bzip2           yes
 depends_lib         port:zlib port:libaec
 use_parallel_build  yes
 
-patchfiles          patch-tools-src-misc-h5cc.in.diff
+patchfiles          patch-no-commons.diff \
+                    patch-tools-src-misc-h5cc.in.diff
 
 # llvm-gcc-4.2 produced code fails type conversion tests
 # Upstream suggestion is use -O0. Clang-produced code passes all tests.

--- a/science/hdf5/files/patch-no-commons.diff
+++ b/science/hdf5/files/patch-no-commons.diff
@@ -1,5 +1,5 @@
---- a/configure	2023-08-10 16:57:56.000000000 -0600
-+++ b/configure	2023-09-22 23:08:25.000000000 -0600
+--- configure.orig	2023-08-10 16:57:56.000000000 -0600
++++ configure	2023-09-22 23:08:25.000000000 -0600
 @@ -11228,14 +11228,6 @@
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if shared Fortran libraries are supported" >&5
  printf %s "checking if shared Fortran libraries are supported... " >&6; }

--- a/science/hdf5/files/patch-no-commons.diff
+++ b/science/hdf5/files/patch-no-commons.diff
@@ -1,0 +1,17 @@
+--- a/configure	2023-08-10 16:57:56.000000000 -0600
++++ b/configure	2023-09-22 23:08:25.000000000 -0600
+@@ -11228,14 +11228,6 @@
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if shared Fortran libraries are supported" >&5
+ printf %s "checking if shared Fortran libraries are supported... " >&6; }
+   H5_FORTRAN_SHARED="yes"
+-  ## tell libtool to do the right thing with COMMON symbols, this fixes
+-  ## corrupt values with COMMON and EQUIVALENCE when building shared
+-  ## Fortran libraries on OSX with gnu and Intel compilers (HDFFV-2772).
+-  case "`uname`" in
+-    Darwin*)
+-    H5_LDFLAGS="$H5_LDFLAGS -Wl,-commons,use_dylibs"
+-    ;;
+-  esac
+ 
+   ## Report results of check(s)
+ 


### PR DESCRIPTION
#### Description

* Remove `-commons` from configure, not supported in Sonoma/CLT 15.0.
* `-commons` no longer needed for HDF5 series 10.0 and later.

Closes:  https://trac.macports.org/ticket/68194
Was fixed upstream:  https://github.com/HDFGroup/hdf5/pull/3581

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
CI only
macOS 11, 12, 13, x86_64 only

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
