### PR TITLE
tree-sitter-cpp: add legacy-support for OSX 10.10 and older

### DIFF
--- a/devel/tree-sitter-cpp/Portfile
+++ b/devel/tree-sitter-cpp/Portfile
@@ -4,6 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           tree_sitter 1.0
 
+# Need static_assert in C11 mode
+PortGroup           legacysupport 1.1
+
+legacysupport.newest_darwin_requires_legacy 14
+
 github.setup        tree-sitter tree-sitter-cpp 0.20.3 v
 revision            0
 


### PR DESCRIPTION
#### Description

Fixes building in C11 mode on older OS X versions where static_assert isn't provided

Closes: https://trac.macports.org/ticket/68228

I'm pretty new to working on Portfiles, so I hope this is the correct way to add legacy-support. If not, please let me know how to do so properly and I'll fix it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
Mac OSX 10.5 PPC
GCC 12.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
