### PR TITLE
micronaut: update to 4.1.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.1.1 v
+github.setup    micronaut-projects micronaut-starter 4.1.2 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  5cf003ecf8813a4fef9483ab71ae53bd5da66a0e \
-                sha256  f0424d8067d22b56dce4b90945fa2e2398de249cdaf7d7caaabc3327b796fd03 \
-                size    20286087
+checksums       rmd160  e65bdbefe4db22acf90993f4a8cc348a5c746b5b \
+                sha256  4e5ea7d6b376cff1875b64be1693c926dbae36598eef4662b33e6a88a106e214 \
+                size    20291378
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.1.2.

###### Tested on

macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?