### PR TITLE
ntfs-3g: update to 2022.10.3

### DIFF
--- a/fuse/ntfs-3g/Portfile
+++ b/fuse/ntfs-3g/Portfile
@@ -2,9 +2,9 @@
 
 PortSystem          1.0
 PortGroup           fuse 1.0
+PortGroup           github 1.0
 
-name                ntfs-3g
-version             2022.5.17
+github.setup        tuxera ntfs-3g 2022.10.3
 revision            0
 categories          fuse
 platforms           darwin
@@ -20,18 +20,15 @@ long_description    The NTFS-3G driver is an open source, freely available \
                     Also included are ntfsprogs, a set of utilities to create \
                     and manipulate NTFS file systems.
 
-homepage            http://www.tuxera.com/community/ntfs-3g-download/
+homepage            https://www.tuxera.com/company/open-source/
 distname            ntfs-3g_ntfsprogs-${version}
 extract.suffix      .tgz
 
-master_sites        http://tuxera.com/opensource/
+master_sites        https://tuxera.com/opensource/
 
-checksums           rmd160  48f76824ae38d1cef0f872290a44c2eaef576a29 \
-                    sha256  0489fbb6972581e1b417ab578d543f6ae522e7fa648c3c9b49c789510fd5eb93 \
-                    size    1318476
-
-livecheck.type      regex
-livecheck.regex     {stable version</span></b> is <a href="https://tuxera.com/opensource/ntfs-3g_ntfsprogs-(.+?)\.tgz"}
+checksums           rmd160  4f17aecd0a9e6ff1fd44e434d0484ac1e784ef1e \
+                    sha256  f20e36ee68074b845e3629e6bced4706ad053804cbaf062fbae60738f854170c \
+                    size    1324320
 
 depends_lib-append  port:ossp-uuid
 


### PR DESCRIPTION
#### Description

Update to ntfs-3g 2022.10.3, fixed links and livecheck.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] security fix

###### Tested on

macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?