### PR TITLE
vis5d: Drop ImageMagick dependency

### DIFF
--- a/science/vis5d/Portfile
+++ b/science/vis5d/Portfile
@@ -130,6 +130,6 @@ variant g95 description {compiles fortran interface for g95} { \
 #}
 
 notes-append {
-ImageMagick's "convert" is no longer included by default. \
+ImageMagick's "convert" is no longer included by default.\
 To use convert, please "port install ImageMagick".
 }

--- a/science/vis5d/Portfile
+++ b/science/vis5d/Portfile
@@ -23,13 +23,13 @@ platforms       darwin
 master_sites    sourceforge:vis5d
 use_bzip2       yes
 
-checksums       md5    68df5737a4569c5f10749ca87959f9cb         \
-                sha1   14d673f533521ea402cf7bee14b6ebda54466ef8 \
-                rmd160 d8390deea19ec8bc1da0f27c779afd25dfa1a42a
+checksums       rmd160 d8390deea19ec8bc1da0f27c779afd25dfa1a42a \
+                sha256 f408c43f97df6b48e2a9f1241435d54bee5118e23b70468e0ee842a415867a2d \
+                size   1854911
 
 depends_build   port:pkgconfig \
-                port:libtool \
-                port:ImageMagick
+                port:libtool
+
 depends_lib     port:netcdf \
                 port:gettext \
                 port:tcl \
@@ -38,7 +38,6 @@ depends_lib     port:netcdf \
                 port:libGLU \
                 port:mesa \
                 port:xorg-libsm
-depends_run     port:ImageMagick
 
 patchfiles      patch-configure.diff \
                 patch-graph_labels.c.diff \
@@ -129,3 +128,8 @@ variant g95 description {compiles fortran interface for g95} { \
 #        configure.f77           ${prefix}/bin/gfortran-mp-4.3
 #        configure.env-delete    PTHREAD_LIBS=-lpthread
 #}
+
+notes-append {
+ImageMagick's "convert" is no longer included by default. \
+To use convert, please "port install ImageMagick".
+}


### PR DESCRIPTION
#### Description

* Remove optional, problematic ImageMagick dependency ("convert").
* Add completion note to install ImageMagick separately, if needed.
* Use modern checksums.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

CI only.
macOS 11, 12, 13, X86_64.

Preliminary commit was virtually identical, and was tested on:

macOS 12.6.7 21G651 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

This PR addresses issues from preliminary PR https://github.com/macports/macports-ports/pull/20351.

##### Justification

* I need vis5d to work on NCARG family ports.
* ImageMagick carries a large amount of dependency baggage.
* It was blocking build and test of NCARG family ports.
* Breakage of IM/cargo/rust is a recurring problem.
* IM use in vis5d is peripheral and optional, via command line only.
* It is simple for the user to `port install` it later, if needed.

The previous blocking issue was resolved only a few weeks ago, but IM/cargo/rust will break again.
https://trac.macports.org/ticket/68026