### PR TITLE
libirecovery: Add libusb variant

### DIFF
--- a/devel/libirecovery/Portfile
+++ b/devel/libirecovery/Portfile
@@ -34,8 +34,7 @@ depends_build-append \
                     port:libtool \
                     port:pkgconfig
 
-depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb \
-                    port:readline \
+depends_lib         port:readline \
                     port:libimobiledevice-glue
 
 # See https://github.com/libimobiledevice/libimobiledevice-glue/commit/0e7b8b42ce4cbeb32eb3103b0ff97916cb273d78
@@ -59,6 +58,12 @@ subport libirecovery-devel {
     depends_lib-replace port:libimobiledevice-glue port:libimobiledevice-glue-devel
 
     livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
+}
+
+# libirecovery will still link with IOKit, but libusb will be priority
+variant libusb description {Use libusb over IOKit.framework when linking} {
+    depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb
+    configure.args          --with-iokit=no
 }
 
 if {${subport} eq ${name}} {


### PR DESCRIPTION
#### Description

By default, libirecovery will link against IOKit.framework, so depending on libusb by default is unnecessary. However, the option to use libusb over IOKit can be given to users.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
