### PR TITLE
vim, MacVim: add libsodium as explicit dependency

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -10,7 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 set vim_version     9.0
 set release         177
 github.setup        macvim-dev macvim ${release} release-
-revision            1
+revision            2
 name                MacVim
 version             ${vim_version}.release${release}
 categories          editors
@@ -31,7 +31,8 @@ checksums           rmd160  36c16994eedfc40c1e477ee9ab90b623e68cbcab \
 
 depends_lib         port:ncurses \
                     port:gettext \
-                    port:libiconv
+                    port:libiconv \
+                    port:libsodium
 
 # MacVim does not build for arch i386
 # https://trac.macports.org/ticket/54666

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -12,14 +12,14 @@ if {${os.platform} eq "darwin" && ${os.major} <= 14} {
     # Fallback to previous port version, for 10.10 and earlier
     # https://trac.macports.org/ticket/67209
     set vim_patchlevel 0472
-    set port_revision  0
+    set port_revision  1
 
     checksums       rmd160  ee809eb300deaf735c86b6e5b7f4bc4a8fe79a41 \
                     sha256  7185577d6cd3708b62b2079b69a29215bb6a6048070d34e960d2d565c18b8a9b \
                     size    16851486
 } else {
     set vim_patchlevel 1677
-    set port_revision  0
+    set port_revision  1
 
     checksums       rmd160  9a62a3612177c661462dd218b305f92fc036d9f2 \
                     sha256  996766187b040b67fe13721e1601584fcf5e89f3ff9d5986be87c3fd1fe5d7c5 \
@@ -45,7 +45,8 @@ homepage            https://www.vim.org/
 depends_lib-append \
                     port:ncurses \
                     port:gettext \
-                    port:libiconv
+                    port:libiconv \
+                    port:libsodium
 
 post-patch {
     set features [open ${worksrcpath}/src/feature.h a+]


### PR DESCRIPTION
#### Description

https://github.com/macports/macports-ports/commit/86381201edd2b233a20f15a542eae461de5eabb6 updates libsodium, vim links against libsodium but doesn't explicitly declare the dependency. This PR bumps revision so that vim gets rebuilt. I haven't tested this locally, but given that vim is failing to launch on my machine, I'm not sure whether a regression is possible.

```
$ vim
dyld[44996]: Library not loaded: '/opt/local/lib/libsodium.23.dylib'
  Referenced from: '/opt/local/bin/vim'
  Reason: tried: '/opt/local/lib/libsodium.23.dylib' (no such file), '/usr/local/lib/libsodium.23.dylib' (no such file), '/usr/lib/libsodium.23.dylib' (no such file)
Abort trap: 6
[Exit 134 (ABRT)]
```

Of note, there may very well be other implicit dependencies. I didn't check

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on


###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
