### PR TITLE
py-jupyterlab and dependencies: update to version 4.0.5

### DIFF
--- a/python/py-async-lru/Portfile
+++ b/python/py-async-lru/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-async-lru
+version             2.0.4
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     38 39 310 311
+
+maintainers         openmaintainer
+
+description         Simple LRU cache for asyncio
+
+long_description    {*}${description}
+
+homepage            https://github.com/aio-libs/async-lru
+
+checksums           rmd160  597fb64512f28317f2fcf5b3ca5ac424d48591d4 \
+                    sha256  b8a59a5df60805ff63220b2a0c5b5393da5521b113cd5465a44eb037d81a5627 \
+                    size    10019
+
+if {${name} ne ${subport}} {
+    depends_build-append    port:py${python.version}-setuptools
+
+    if {${python.version} < 311} {
+        depends_build-append    port:py${python.version}-typing_extensions
+    }
+}

--- a/python/py-hatch_jupyter_builder/Portfile
+++ b/python/py-hatch_jupyter_builder/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-hatch_jupyter_builder
+version             0.8.3
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     38 39 310 311
+python.pep517       yes
+python.pep517_backend hatch
+
+maintainers         openmaintainer
+
+description         This provides a build hook plugin for Hatch that adds a build step for use with Jupyter packages
+long_description    {*}${description}
+
+homepage            https://github.com/jupyterlab/hatch-jupyter-builder
+
+checksums           rmd160  ab30666a9afe4efbeef5f94581c2bbbecf40b4cc \
+                    sha256  0dbd14a8aef6636764f88a8fd1fcc9a91921e5c50356e6aab251782f264ae960 \
+                    size    54754
+
+if {${name} ne ${subport}} {
+    # depends_lib-append
+}

--- a/python/py-ipykernel/Portfile
+++ b/python/py-ipykernel/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-ipykernel
-version             6.24.0
+version             6.25.2
 revision            0
 categories-append   devel
 license             BSD
@@ -22,9 +22,9 @@ long_description    {*}${description}
 
 homepage            https://ipython.org/
 
-checksums           rmd160  4f2351703446946a63c45e451c989301ad33f052 \
-                    sha256  29cea0a716b1176d002a61d0b0c851f34536495bc4ef7dd0222c88b41b816123 \
-                    size    154452
+checksums           rmd160  9081d11a789ee847dce72b7ef438dd95aad7c876 \
+                    sha256  f468ddd1f17acb48c8ce67fcfa49ba6d46d4f9ac0438c1f441be7c3d1372230b \
+                    size    156247
 
 if {${name} ne ${subport}} {
 

--- a/python/py-jsonschema/Portfile
+++ b/python/py-jsonschema/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jsonschema
-version             4.17.3
+version             4.19.1
 revision            0
 categories-append   devel
 license             MIT
@@ -22,22 +22,12 @@ long_description    {*}${description}
 
 homepage            https://github.com/python-jsonschema/jsonschema
 
-checksums           rmd160  86637e335ef60176700311eb93e0d5dbbcb8d457 \
-                    sha256  0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d \
-                    size    297785
+checksums           rmd160  9344c735429814aaf4d9a3fa036605053ccfbd2a \
+                    sha256  ec84cc37cfa703ef7cd4928db24f9cb31428a5d0fa77747b8b51a847458e0bbf \
+                    size    318089
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools_scm \
-                        port:py${python.version}-hatch-vcs \
-                        port:py${python.version}-hatch-fancy-pypi-readme
-
-    # CLI depends on pkg_resources.py from setuptools
-    depends_lib-append  port:py${python.version}-attrs \
-                        port:py${python.version}-pyrsistent \
-                        port:py${python.version}-setuptools
-
-    if {${python.version} < 37} {
+    if {${python.version} < 38} {
         version             3.2.0
         revision            0
         distname            ${python.rootname}-${version}
@@ -45,23 +35,28 @@ if {${name} ne ${subport}} {
                             sha256  c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a \
                             size    167226
         python.pep517       no
-        depends_build-delete \
-                        port:py${python.version}-hatch-vcs \
-                        port:py${python.version}-hatch-fancy-pypi-readme
-        depends_lib-append  port:py${python.version}-six
+
+        depends_build-append  port:py${python.version}-setuptools_scm
+        depends_lib-append    port:py${python.version}-attrs \
+                              port:py${python.version}-importlib-metadata \
+                              port:py${python.version}-pyrsistent \
+                              port:py${python.version}-setuptools \
+                              port:py${python.version}-six
     } else {
-        patchfiles-append   patch-setup.py.diff
-        if {${python.version} < 38} {
-            depends_lib-append  port:py${python.version}-typing_extensions
-        }
+        # CLI depends on pkg_resources.py from setuptools
+
+        depends_build-append  port:py${python.version}-hatch-vcs \
+                              port:py${python.version}-hatch-fancy-pypi-readme
+
+        depends_lib-append    port:py${python.version}-attrs \
+                              port:py${python.version}-jsonschema_specifications \
+                              port:py${python.version}-referencing \
+                              port:py${python.version}-rpds_py
+
         if {${python.version} < 39} {
             depends_lib-append  port:py${python.version}-importlib-resources \
                                 port:py${python.version}-pkgutil_resolve_name
         }
-    }
-
-    if {${python.version} < 38} {
-        depends_lib-append  port:py${python.version}-importlib-metadata
     }
 
     livecheck.type      none

--- a/python/py-jsonschema/files/patch-setup.py.diff
+++ b/python/py-jsonschema/files/patch-setup.py.diff
@@ -1,9 +1,0 @@
---- /dev/null	2021-10-01 10:44:52.000000000 +0300
-+++ setup.py	2021-10-01 10:44:35.000000000 +0300
-@@ -0,0 +1,6 @@
-+#!/usr/bin/env python
-+
-+import setuptools
-+
-+if __name__ == "__main__":
-+    setuptools.setup()

--- a/python/py-jsonschema_specifications/Portfile
+++ b/python/py-jsonschema_specifications/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-jsonschema_specifications
+version             2023.7.1
+revision            0
+categories-append   devel
+license             MIT
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     38 39 310 311
+python.pep517       yes
+python.pep517_backend hatch
+
+maintainers         openmaintainer
+
+description         "JSON support files from the JSON Schema Specifications (metaschemas, vocabularies, etc.),
+packaged for runtime access from Python as a referencing-based Schema Registry."
+long_description    {*}${description}
+
+homepage            https://github.com/python-jsonschema/jsonschema-specifications
+
+checksums           rmd160  c3533cbd28ecf7856222ec13b3c5ebe8039cf3ce \
+                    sha256  c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb \
+                    size    12689
+
+if {${name} ne ${subport}} {
+    depends_build-append  port:py${python.version}-hatch-vcs
+    depends_lib-append    port:py${python.version}-referencing
+
+    if {${python.version} < 39} {
+        depends_lib-append  port:py${python.version}-importlib-resources
+    }
+
+    livecheck.type      none
+}

--- a/python/py-jupyter-lsp/Portfile
+++ b/python/py-jupyter-lsp/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-jupyter-lsp
+version             2.2.0
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     38 39 310 311
+
+maintainers         openmaintainer
+
+description         Multi-Language Server WebSocket proxy for Jupyter Notebook/Lab server
+
+long_description    {*}${description}
+
+homepage            https://github.com/jupyter-lsp/jupyterlab-lsp
+
+checksums           rmd160  45c49e032b47e491175d0326d895afb50b4f5b39 \
+                    sha256  8ebbcb533adb41e5d635eb8fe82956b0aafbf0fd443b6c4bfa906edeeb8635a1 \
+                    size    45769
+
+if {${name} ne ${subport}} {
+    depends_lib-append  port:py${python.version}-jupyter_server
+
+    if {${python.version} < 310} {
+        depends_lib-append    port:py${python.version}-importlib_metadata
+    }
+}

--- a/python/py-jupyter_core/Portfile
+++ b/python/py-jupyter_core/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jupyter_core
-version             5.2.0
+version             5.3.1
 revision            0
 license             BSD
 supported_archs     noarch
@@ -21,9 +21,9 @@ long_description    {*}${description}
 
 homepage            https://jupyter.org
 
-checksums           rmd160  39c8fdaca347fc7aaad55c8506d9f7e80daa1726 \
-                    sha256  1407cdb4c79ee467696c04b76633fc1884015fa109323365a6372c8e890cc83f \
-                    size    83861
+checksums           rmd160  0519d252fe0354626cbf4c13a80108f26e20d7f7 \
+                    sha256  5ba5c7938a7f97a6b0481463f7ff0dbac7c15ba48cf46fa4035ca6e838aa1aba \
+                    size    84448
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-platformdirs \

--- a/python/py-jupyter_events/Portfile
+++ b/python/py-jupyter_events/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-jupyter_events
+version             0.7.0
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     37 38 39 310 311
+python.pep517       yes
+python.pep517_backend hatch
+
+maintainers         {stromnov @stromnov} openmaintainer
+
+description         An event system for Jupyter Applications and extensions
+long_description    Jupyter Events enables Jupyter Python Applications (e.g. Jupyter Server, JupyterLab Server, JupyterHub, etc.)\
+  to emit events—structured data describing things happening inside the application. Other software\
+  (e.g. client applications like JupyterLab) can listen and respond to these events.
+
+
+homepage            https://ipython.org/
+
+checksums           rmd160  dfe734e8c9eed440fb83b11e8564538efbce35c8 \
+                    sha256  7be27f54b8388c03eefea123a4f79247c5b9381c49fb1cd48615ee191eb12615 \
+                    size    59717
+
+if {${name} ne ${subport}} {
+    depends_build-append  port:py${python.version}-rfc3339_validator \
+                          port:py${python.version}-rfc3986_validator
+
+    depends_lib-append    port:py${python.version}-referencing \
+                          port:py${python.version}-jsonschema \
+                          port:py${python.version}-python-json-logger \
+                          port:py${python.version}-yaml \
+                          port:py${python.version}-traitlets
+
+    livecheck.type        none
+}

--- a/python/py-jupyter_server/Portfile
+++ b/python/py-jupyter_server/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jupyter_server
-version             1.6.0
+version             2.7.3
 revision            0
 categories-append   devel
 license             BSD
@@ -12,6 +12,8 @@ supported_archs     noarch
 platforms           {darwin any}
 
 python.versions     37 38 39 310 311
+python.pep517       yes
+python.pep517_backend hatch
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -20,24 +22,29 @@ long_description    {*}${description}
 
 homepage            https://jupyter.org/
 
-checksums           rmd160  dc0b8fac7d780d1e3f4ca7318b0e1600385eb48b \
-                    sha256  348f2c744d1fa1676d314475e0be357a95b21cbe6e19d15c2a25a9ea647f99d2 \
-                    size    407632
+checksums           rmd160  9a3da90ecc900c78c3cefd24c3054554fd9064f6 \
+                    sha256  d4916c8581c4ebbc534cebdaa8eca2478d9f3bfdd88eae29fcab0120eac57649 \
+                    size    705798
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-setuptools \
-                        port:py${python.version}-jinja2 \
-                        port:py${python.version}-tornado \
-                        port:py${python.version}-zmq \
-                        port:py${python.version}-argon2-cffi \
-                        port:py${python.version}-ipython_genutils \
-                        port:py${python.version}-traitlets \
-                        port:py${python.version}-jupyter_core \
-                        port:py${python.version}-jupyter_client \
-                        port:py${python.version}-nbformat \
-                        port:py${python.version}-nbconvert \
-                        port:py${python.version}-send2trash \
-                        port:py${python.version}-terminado \
-                        port:py${python.version}-prometheus_client \
-                        port:py${python.version}-anyio
+    depends_build-append  port:py${python.version}-packaging \
+                          port:py${python.version}-hatch_jupyter_builder
+
+    depends_lib-append    port:py${python.version}-anyio \
+                          port:py${python.version}-argon2-cffi \
+                          port:py${python.version}-jinja2 \
+                          port:py${python.version}-jupyter_client \
+                          port:py${python.version}-jupyter_core \
+                          port:py${python.version}-jupyter_server_terminals \
+                          port:py${python.version}-nbconvert \
+                          port:py${python.version}-nbformat \
+                          port:py${python.version}-prometheus_client \
+                          port:py${python.version}-zmq \
+                          port:py${python.version}-send2trash \
+                          port:py${python.version}-terminado \
+                          port:py${python.version}-tornado \
+                          port:py${python.version}-traitlets \
+                          port:py${python.version}-websocket-client \
+                          port:py${python.version}-jupyter_events \
+                          port:py${python.version}-overrides
 }

--- a/python/py-jupyter_server_terminals/Portfile
+++ b/python/py-jupyter_server_terminals/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-jupyter_server_terminals
+version             0.4.4
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     37 38 39 310 311
+python.pep517       yes
+python.pep517_backend hatch
+
+maintainers         {stromnov @stromnov} openmaintainer
+
+description         Jupyter Server Terminals is a Jupyter Server Extension providing support for terminals
+long_description    {*}${description}
+
+homepage            https://ipython.org/
+
+checksums           rmd160  eb21e1a739e8c8b873b5dd8df344631fbc523145 \
+                    sha256  57ab779797c25a7ba68e97bcfb5d7740f2b5e8a83b5e8102b10438041a7eac5d \
+                    size    29850
+
+if {${name} ne ${subport}} {
+    depends_lib-append  port:py${python.version}-terminado
+
+    livecheck.type      none
+}

--- a/python/py-jupyterlab/Portfile
+++ b/python/py-jupyterlab/Portfile
@@ -4,14 +4,16 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jupyterlab
-version             3.0.13
+version             4.0.5
 revision            0
 categories-append   devel
 license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
+python.pep517       yes
+python.pep517_backend hatch
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,35 +26,34 @@ long_description    JupyterLab enables you to work with documents and \
 
 homepage            https://jupyter.org/
 
-checksums           rmd160  60908e7b6ec964f1c9a159f8423837b0297cef7d \
-                    sha256  6aefaf11251309ffdd66ef20025f5165aeec26d59a83c76e4d02cc8f593bc9dc \
-                    size    9843200
+checksums           rmd160  ba5e36f3c20202a3b4dd9e3efe87eed08f9fc561 \
+                    sha256  de49deb75f9b9aec478ed04754cbefe9c5d22fd796a5783cdc65e212983d3611 \
+                    size    18235811
 
 if {${name} ne ${subport}} {
-    python.pep517       no
-    depends_build-append \
-                        port:py${python.version}-jupyter_packaging
-    depends_lib-append  port:py${python.version}-setuptools \
-                        port:py${python.version}-ipython \
-                        port:py${python.version}-packaging \
-                        port:py${python.version}-tornado \
-                        port:py${python.version}-jupyter_core \
-                        port:py${python.version}-jupyter_packaging \
-                        port:py${python.version}-jupyterlab_server \
-                        port:py${python.version}-jupyter_server \
-                        port:py${python.version}-nbclassic \
-                        port:py${python.version}-jinja2
+    depends_build-append  port:py${python.version}-hatch_jupyter_builder
 
-    post-patch {
-        # relax package requirements
-        reinplace "s|jupyter_packaging~=0.7.3|jupyter_packaging|" ${worksrcpath}/setup.py
-        reinplace "s|jupyterlab_server~=2.3|jupyterlab_server|" ${worksrcpath}/setup.py
-        reinplace "s|jupyter_server~=1.4|jupyter_server|" ${worksrcpath}/setup.py
-        reinplace "s|nbclassic~=0.2|nbclassic|" ${worksrcpath}/setup.py
+    depends_lib-append    port:py${python.version}-async-lru \
+                          port:py${python.version}-ipykernel \
+                          port:py${python.version}-jinja2 \
+                          port:py${python.version}-jupyter_core \
+                          port:py${python.version}-jupyter-lsp \
+                          port:py${python.version}-jupyter_server \
+                          port:py${python.version}-jupyterlab_server \
+                          port:py${python.version}-notebook_shim \
+                          port:py${python.version}-packaging \
+                          port:py${python.version}-traitlets \
+                          port:py${python.version}-tornado
+
+    if {${python.version} < 311} {
+        depends_lib-append  port:py${python.version}-tomli
     }
 
-    build.args-append   --skip-npm
+    if {${python.version} < 310} {
+        depends_lib-append  port:py${python.version}-importlib-metadata
+    }
 
-    destroot.args-append \
-                        --skip-npm
+    if {${python.version} < 39} {
+        depends_lib-append  port:py${python.version}-importlib-resources
+    }
 }

--- a/python/py-jupyterlab_server/Portfile
+++ b/python/py-jupyterlab_server/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jupyterlab_server
-version             2.4.0
+version             2.25.0
 revision            0
 categories-append   devel
 license             BSD
@@ -12,26 +12,31 @@ supported_archs     noarch
 platforms           {darwin any}
 
 python.versions     37 38 39 310 311
+python.pep517       yes
+python.pep517_backend hatch
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         This package is used to launch an application built using JupyterLab.
 long_description    {*}${description}
 
-homepage            https://jupyter.org/
+homepage            https://github.com/jupyterlab/jupyterlab_server
 
-checksums           rmd160  bd06e2f3c2eff402a9ffdd63d597eb13c51a0d41 \
-                    sha256  2a7f0b125a59a7cc543f62e5f9dea50b44b3459b3f679db7e3dbe0f8616f90bc \
-                    size    36297
+checksums           rmd160  2c5d41db3703981f04200231f1e0b6b529068847 \
+                    sha256  77c2f1f282d610f95e496e20d5bf1d2a7706826dfb7b18f3378ae2870d272fb7 \
+                    size    72251
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
-    depends_lib-append  port:py${python.version}-babel \
-                        port:py${python.version}-jinja2 \
-                        port:py${python.version}-json5 \
-                        port:py${python.version}-jsonschema \
-                        port:py${python.version}-packaging \
-                        port:py${python.version}-requests \
-                        port:py${python.version}-jupyter_server
+    depends_build-append  port:py${python.version}-packaging
+
+    depends_lib-append    port:py${python.version}-babel \
+                          port:py${python.version}-jinja2 \
+                          port:py${python.version}-json5 \
+                          port:py${python.version}-jsonschema \
+                          port:py${python.version}-jupyter_server \
+                          port:py${python.version}-requests
+
+    if {${python.version} < 310} {
+        depends_lib-append  port:py${python.version}-importlib-metadata
+    }
 }

--- a/python/py-nbclient/Portfile
+++ b/python/py-nbclient/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-nbclient
-version             0.5.3
+version             0.8.0
 revision            0
 categories-append   devel
 platforms           {darwin any}
@@ -12,6 +12,8 @@ license             BSD
 supported_archs     noarch
 
 python.versions     37 38 39 310 311
+python.pep517       yes
+python.pep517_backend hatch
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -20,16 +22,26 @@ long_description    {*}${description}
 
 homepage            https://jupyter.org/
 
-checksums           rmd160  cfd462e15b90bff88987a7a24d580c8048a9728a \
-                    sha256  db17271330c68c8c88d46d72349e24c147bb6f34ec82d8481a8f025c4d26589c \
-                    size    78529
+checksums           rmd160  9005366db96b038bb67c164d02e13ef18cbd5c5f \
+                    sha256  f9b179cd4b2d7bca965f900a2ebf0db4a12ebff2f36a711cb66861e4ae158e55 \
+                    size    60673
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
-    depends_lib-append  port:py${python.version}-traitlets \
-                        port:py${python.version}-jupyter_client \
-                        port:py${python.version}-nbformat \
-                        port:py${python.version}-async_generator \
-                        port:py${python.version}-nest_asyncio
+    if {${python.version} < 38} {
+        version               0.5.3
+        python.pep517         no
+
+        depends_build-append  port:py${python.version}-setuptools
+
+        depends_lib-append    port:py${python.version}-traitlets \
+                              port:py${python.version}-jupyter_client \
+                              port:py${python.version}-nbformat \
+                              port:py${python.version}-async_generator \
+                              port:py${python.version}-nest_asyncio
+    } else {
+        depends_lib-append    port:py${python.version}-jupyter_client \
+                              port:py${python.version}-jupyter_core \
+                              port:py${python.version}-nbformat \
+                              port:py${python.version}-traitlets
+    }
 }

--- a/python/py-nest_asyncio/Portfile
+++ b/python/py-nest_asyncio/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-nest_asyncio
-version             1.5.6
+version             1.5.8
 revision            0
 categories-append   devel
 license             BSD
@@ -21,11 +21,10 @@ long_description    {*}${description}
 
 homepage            https://github.com/erdewit/nest_asyncio
 
-checksums           rmd160  5eeb3941927b567cba3bc430e7c8406b41074d39 \
-                    sha256  d267cc1ff794403f7df692964d1d2a3fa9418ffea2a3f6859a439ff482fef290 \
-                    size    7444
+checksums           rmd160  63e446ada02b7b6c618d4f69871997d9c06af657 \
+                    sha256  25aa2ca0d2a5b5531956b9e273b45cf664cae2b145101d73b86b199978d48fdb \
+                    size    6105
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools_scm
+    depends_build-append  port:py${python.version}-setuptools_scm
 }

--- a/python/py-notebook_shim/Portfile
+++ b/python/py-notebook_shim/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-notebook_shim
+version             0.2.3
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     37 38 39 310 311
+python.pep517       yes
+python.pep517_backend hatch
+
+maintainers         openmaintainer
+
+description         This project provides a way for JupyterLab and other frontends to switch to Jupyter Server for their Python Web application backend
+
+long_description    {*}${description}
+
+homepage            https://pypi.org/project/notebook-shim/
+
+checksums           rmd160  a77aef173296e932bb3c21f32e4ea61a08eb0b86 \
+                    sha256  f69388ac283ae008cd506dda10d0288b09a017d822d5e8c7129a152cbd3ce7e9 \
+                    size    13082
+
+if {${name} ne ${subport}} {
+    depends_lib-append  port:py${python.version}-jupyter_server
+}

--- a/python/py-python-json-logger/Portfile
+++ b/python/py-python-json-logger/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-python-json-logger
+version             2.0.7
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     36 37 38 39 310 311
+
+maintainers         openmaintainer
+
+description         A python library adding a json log formatter
+long_description    {*}${description}
+
+homepage            http://github.com/madzak/python-json-logger
+
+checksums           rmd160  92c6a181d3b23ef784a7cb1c882474f207e021e7 \
+                    sha256  23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c \
+                    size    10508
+
+if {${name} ne ${subport}} {
+    depends_build-append  port:py${python.version}-setuptools
+}

--- a/python/py-referencing/Portfile
+++ b/python/py-referencing/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-referencing
+version             0.30.2
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     37 38 39 310 311
+python.pep517       yes
+python.pep517_backend hatch
+
+maintainers         openmaintainer
+
+description         JSON referencing + Python
+
+long_description    An implementation-agnostic implementation of JSON reference resolution
+
+homepage            https://github.com/python-jsonschema/referencing
+
+checksums           rmd160  67c778ca6c31968e7558d50a66063e0795796081 \
+                    sha256  794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0 \
+                    size    53386
+
+if {${name} ne ${subport}} {
+    depends_build-append  port:py${python.version}-hatch-vcs
+
+    depends_lib-append    port:py${python.version}-attrs \
+                          port:py${python.version}-rpds_py
+}

--- a/python/py-rfc3339_validator/Portfile
+++ b/python/py-rfc3339_validator/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-rfc3339_validator
+version             0.1.4
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     27 37 38 39 310 311
+python.pep517       no
+
+maintainers         {stromnov @stromnov} openmaintainer
+
+description         A pure python RFC3339 validator
+long_description    {*}${description}
+
+
+homepage            https://github.com/naimetti/rfc3339-validator
+
+checksums           rmd160  fede1549109fc745688fc914624a0f6c465b9f34 \
+                    sha256  138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
+                    size    5513
+
+if {${name} ne ${subport}} {
+    depends_build-append  port:py${python.version}-setuptools
+    depends_lib-append    port:py${python.version}-six
+
+    livecheck.type        none
+}

--- a/python/py-rfc3986_validator/Portfile
+++ b/python/py-rfc3986_validator/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-rfc3986_validator
+version             0.1.1
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     27 37 38 39 310 311
+python.pep517       no
+
+maintainers         {stromnov @stromnov} openmaintainer
+
+description         A pure python RFC3986 validator
+long_description    {*}${description}
+
+
+homepage            https://github.com/naimetti/rfc3986-validator
+
+checksums           rmd160  88e91a36f95480a21e4798c86992d9b92ac9b9d1 \
+                    sha256  3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055 \
+                    size    6760
+
+if {${name} ne ${subport}} {
+    depends_build-append  port:py${python.version}-setuptools \
+                          port:py${python.version}-pytest-runner
+
+    livecheck.type        none
+}

--- a/python/py-rpds_py/Portfile
+++ b/python/py-rpds_py/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-rpds_py
+version             0.10.3
+revision            0
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     37 38 39 310 311
+python.pep517       yes
+python.pep517_backend maturin
+
+maintainers         openmaintainer
+
+description         Python bindings to Rust's persistent data structures (rpds)
+long_description    {*}${description}
+
+homepage            https://github.com/crate-py/rpds
+
+checksums           rmd160  224a271f3f36677610a36f9959b6ddb13941c680 \
+                    sha256  fcc1ebb7561a3e24a6588f7c6ded15d80aec22c66a070c757559b57b17ffd1cb \
+                    size    17164
+
+if {${name} ne ${subport}} {
+    # depends_build-append
+}

--- a/python/py-terminado/Portfile
+++ b/python/py-terminado/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-terminado
-version             0.13.3
+version             0.17.1
 revision            0
 categories-append   devel
 supported_archs     noarch
@@ -13,19 +13,19 @@ license             BSD
 
 python.versions     37 38 39 310 311
 python.pep517       yes
+python.pep517_backend hatch
 
 maintainers         {stromnov @stromnov} openmaintainer
 
-description         Terminals served by tornado websockets.
+description         This is a Tornado websocket backend for the Xterm.js Javascript terminal emulator library.
 long_description    {*}${description}
 
-homepage            https://github.com/takluyver/terminado
+homepage            https://github.com/jupyter/terminado
 
-checksums           rmd160  3c13317e5d58894b1a251b87f642f60e684f5293 \
-                    sha256  94d1cfab63525993f7d5c9b469a50a18d0cdf39435b59785715539dd41e36c0d \
-                    size    17060
+checksums           rmd160  f41e9d97b394d93e7e17408ac50a003ddf3d45a1 \
+                    sha256  6ccbbcd3a4f8a25a5ec04991f39a0b8db52dfcd487ea0e578d977e6752380333 \
+                    size    30603
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-ptyprocess \
-                        port:py${python.version}-tornado
+    depends_lib-append  port:py${python.version}-tornado
 }

--- a/python/py-tornado/Portfile
+++ b/python/py-tornado/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-tornado
-version             6.3.2
+version             6.3.3
 revision            0
 categories-append   www
 license             Apache-2
@@ -25,9 +25,9 @@ long_description    \
 
 homepage            https://www.tornadoweb.org/
 
-checksums           rmd160  97c6be2bfd5716806e766c839d6d9fa5d45c1d2c \
-                    sha256  4b927c4f19b71e627b13f3db2324e4ae660527143f9e1f2e2fb404f3a187e2ba \
-                    size    508776
+checksums           rmd160  9370d187ff56a1a33a619de47f0d0d578eae7efa \
+                    sha256  e7d8db41c0181c80d76c982aacc442c0783a2c54d6400fe028954201a2e032fe \
+                    size    509872
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-zmq/Portfile
+++ b/python/py-zmq/Portfile
@@ -6,13 +6,14 @@ PortGroup           legacysupport 1.1
 
 name                py-zmq
 
-version             24.0.1
-checksums           rmd160  0ac801641ec647e106f6d42f985bb14cdd780cd0 \
-                    sha256  216f5d7dbb67166759e59b0479bca82b8acf9bed6015b526b8eb10143fb08e77 \
-                    size    1219822
+version             25.1.1
+checksums           rmd160  a285ec4f094290d034b0442289c8c9407eec04f9 \
+                    sha256  259c22485b71abacdfa8bf79720cd7bcf4b9d128b30ea554f01ae71fdbfdaa23 \
+                    size    1365724
 revision            0
 
 python.versions     27 35 36 37 38 39 310 311
+python.pep517       yes
 
 maintainers         {gmail.com:jrjsmrtn @jrjsmrtn} {michaelld @michaelld} openmaintainer
 
@@ -30,7 +31,7 @@ master_sites        pypi:p/pyzmq
 
 if {${name} ne ${subport}} {
 
-    depends_lib-append path:lib/libzmq.dylib:zmq 
+    depends_lib-append path:lib/libzmq.dylib:zmq
 
     if {${python.version} == 27} {
 
@@ -60,8 +61,11 @@ if {${name} ne ${subport}} {
 
     } else {
 
-        depends_lib-append  port:py${python.version}-setuptools \
-                            port:py${python.version}-packaging
+        depends_lib-append  port:py${python.version}-setuptools_scm \
+                            port:py${python.version}-packaging \
+                            port:py${python.version}-wheel \
+                            port:py${python.version}-cffi \
+                            port:py${python.version}-cython
         livecheck.regex     {"filename":"pyzmq-([0-9.]+).tar.gz",}
 
     }


### PR DESCRIPTION
#### Description
* updates py-jupyterlab
* updates and adds all breaking and missing dependencies

https://trac.macports.org/ticket/68224

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? Note, without -t option. That option fails on MacOS 13.
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
