### PR TITLE
hdf5: Fix build with Xcode/CLT 15.0

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -40,7 +40,11 @@ use_bzip2           yes
 depends_lib         port:zlib port:libaec
 use_parallel_build  yes
 
-patchfiles          patch-tools-src-misc-h5cc.in.diff
+# Remove patch-no-commons.diff when resolved in a future version.
+# Expected for HDF5-1.14.3.
+
+patchfiles          patch-no-commons.diff \
+                    patch-tools-src-misc-h5cc.in.diff
 
 # llvm-gcc-4.2 produced code fails type conversion tests
 # Upstream suggestion is use -O0. Clang-produced code passes all tests.

--- a/science/hdf5/files/patch-no-commons.diff
+++ b/science/hdf5/files/patch-no-commons.diff
@@ -1,0 +1,22 @@
+--- configure.orig	2023-08-10 16:57:56.000000000 -0600
++++ configure	2023-09-24 08:05:13.000000000 -0600
+@@ -11228,14 +11228,11 @@
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if shared Fortran libraries are supported" >&5
+ printf %s "checking if shared Fortran libraries are supported... " >&6; }
+   H5_FORTRAN_SHARED="yes"
+-  ## tell libtool to do the right thing with COMMON symbols, this fixes
+-  ## corrupt values with COMMON and EQUIVALENCE when building shared
+-  ## Fortran libraries on OSX with gnu and Intel compilers (HDFFV-2772).
+-  case "`uname`" in
+-    Darwin*)
+-    H5_LDFLAGS="$H5_LDFLAGS -Wl,-commons,use_dylibs"
+-    ;;
+-  esac
++
++## REMOVED HERE FOR MACPORTS, 2023 SEPT 24:
++## case Darwin ... H5_LDFLAGS="$H5_LDFLAGS -Wl,-commons,use_dylibs"
++## Xcode/CLT 15.0 does not accept "-commons".
++## See upstream PR:  https://github.com/HDFGroup/hdf5/pull/3581
+ 
+   ## Report results of check(s)
+ 


### PR DESCRIPTION
#### Description

* Remove -commons from configure, not supported in Xcode/CLT 15.0.
* -commons is no longer needed for HDF5 series 10.0 and later.

Closes:  https://trac.macports.org/ticket/68194
Upstream PR:  https://github.com/HDFGroup/hdf5/pull/3581
Resolves issues in preliminary PR:  https://github.com/macports/macports-ports/pull/20553

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only
macOS 11, 12, 13, x86_64 only

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
