### PR TITLE
zmq, zmq-devel: unbreak build on darwin < 16; zmq-devel: update to upstream master

### DIFF
--- a/devel/zmq/Portfile
+++ b/devel/zmq/Portfile
@@ -51,6 +51,12 @@ if {${name} eq ${subport}} {
         patch-fix-no-librt-APPLE.release.diff \
         patch-tests.diff
 
+    # https://github.com/zeromq/libzmq/issues/4595
+    if {${os.platform} eq "darwin" && ${os.major} < 16} {
+        patchfiles-append \
+            patch-clock.hpp.diff
+    }
+
     # overload the github livecheck regex to look for versions that
     # are just numbers and '.', no letters (e.g., "3.7.3_rc2").
 
@@ -102,12 +108,12 @@ subport zmq22 {
 subport zmq-devel {
     PortGroup cmake 1.1
 
-    github.setup    zeromq libzmq 8c725093ac4b44a97e6cb64566989ef12b71986c
-    version         20230206-[string range ${github.version} 0 7]
-    checksums       rmd160  c870f927dc0418a401bbe0847bb8ce0aa3576168 \
-                    sha256  4dc235243ae91cbe16680d3408fa16ae777c6f277190f44cd271292ae4a231db \
-                    size    939179
-    revision        1
+    github.setup    zeromq libzmq b30a19ebde6a1b2490749c754be2818901a00587
+    version         20231013-[string range ${github.version} 0 7]
+    checksums       rmd160  ec42c268475dc45c4e6a7b68fc9ca3106b8a25fa \
+                    sha256  fe39446005b668d731cc51828ba556127497937f23beba698a966e9cb9c04267 \
+                    size    876691
+    revision        0
 
     conflicts zmq zmq22 zmq3
 
@@ -129,6 +135,12 @@ subport zmq-devel {
     patchfiles-append \
         patch-fix-docs-dir.devel.diff \
         patch-fix-no-librt-APPLE.devel.diff
+
+    # https://github.com/zeromq/libzmq/issues/4595
+    if {${os.platform} eq "darwin" && ${os.major} < 16} {
+        patchfiles-append \
+            patch-clock.hpp.diff
+    }
 
     compiler.c_standard     2011
     compiler.cxx_standard   2011

--- a/devel/zmq/files/patch-clock.hpp.diff
+++ b/devel/zmq/files/patch-clock.hpp.diff
@@ -1,0 +1,19 @@
+# https://trac.macports.org/ticket/68213
+
+--- a/src/clock.hpp	2023-08-27 04:19:35.000000000 +0700
++++ b/src/clock.hpp	2023-09-24 23:52:51.000000000 +0700
+@@ -7,14 +7,6 @@
+ #include "stdint.hpp"
+ 
+ #if defined ZMQ_HAVE_OSX
+-// TODO this is not required in this file, but condition_variable.hpp includes
+-// clock.hpp to get these definitions
+-#ifndef CLOCK_REALTIME
+-#define CLOCK_REALTIME 0
+-#endif
+-#ifndef HAVE_CLOCK_GETTIME
+-#define HAVE_CLOCK_GETTIME
+-#endif
+ 
+ #include <mach/clock.h>
+ #include <mach/mach.h>


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68213

#### Description

(UPD. Apparently the patch can be used unconditionally.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
