### PR TITLE
include-what-you-use: new port

### DIFF
--- a/devel/include-what-you-use/Portfile
+++ b/devel/include-what-you-use/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        include-what-you-use include-what-you-use 0.20
+github.tarball_from archive
+revision            0
+categories          devel
+license             NCSA
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         A tool for use with clang to analyze #includes in C and C++ \
+                    source files
+
+long_description    {*}${description}
+
+checksums           rmd160  7e6da7cc8c3e9300516597bcfceba56c66b5c1a0 \
+                    sha256  4fe4bd5581ee60bb2bcf1bf40f087a8c5b090d943d0376233638f30f29af0e2e \
+                    size    766208
+
+set llvm_version    16
+set llvm_dir        ${prefix}/libexec/llvm-${llvm_version}
+
+depends_lib-append  port:clang-${llvm_version}
+
+cmake.install_rpath-append  ${llvm_dir}/lib
+
+configure.args-append   -DLLVM_DIR=${llvm_dir}/lib/cmake/llvm \
+                        -DClang_DIR=${llvm_dir}/lib/cmake/clang
+
+post-destroot {
+    # Move the binary next to clang so it picks up its include directory one
+    # level above. Run it via xcrun so it picks up system include directories.
+    xinstall -d ${destroot}${llvm_dir}/bin
+    move ${destroot}${prefix}/bin/${name} ${destroot}${llvm_dir}/bin
+    system -W "${destroot}${prefix}/bin" \
+        "echo '#!/bin/sh\nexec xcrun ${llvm_dir}/bin/${name} \"$@\"' > ${name} && chmod +x ${name}"
+}


### PR DESCRIPTION
#### Description

[A tool for use with clang to analyze #includes in C and C++ source files.](https://github.com/include-what-you-use/include-what-you-use/)

###### Tested on
macOS 13.5.2 22G91 x86_64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?