### PR TITLE
lf: Update to r31

### DIFF
--- a/sysutils/lf/Portfile
+++ b/sysutils/lf/Portfile
@@ -3,23 +3,25 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gokcehan/lf 30 r
+go.setup            github.com/gokcehan/lf 31 r
 revision            0
 categories          sysutils
 maintainers         {judaew @judaew} openmaintainer
 license             MIT
 
 description         Terminal file manager
-long_description    \
-    lf (as in \"list files\") is a terminal file manager written in Go. It is \
-    heavily inspired by ranger with some missing and extra features. Some of \
-    the missing features are deliberately omitted since they are better \
-    handled by external tools.
+long_description    ${name} (as in \"list files\") is a terminal file manager \
+                    written in Go. It is heavily inspired by ranger with some \
+                    missing and extra features. Some of the missing features \
+                    are deliberately omitted since they are better handled by \
+                    external tools.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  8acb76f551a3cebd8dcc22b2996f409f78ce4e85 \
-                        sha256  d846199f2ceeea697fa4627ab922cd0b40c82a23246a87fa094d183301c7d1eb \
-                        size    125229
+                    rmd160  f7ec574e615f6be93f8865649200575b0e2694a9 \
+                    sha256  74269e2030bf33b0f858729a5aae42ff83991b43f04999b0de66ab3b1bc5bd36 \
+                    size    138747
+
+build.pre_args      -ldflags \"-s -w -X main.gVersion=${version}\"
 
 go.vendors          golang.org/x/text \
                         lock    v0.7.0 \
@@ -77,31 +79,30 @@ destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
 
     # Install shell completion files
-    set bash_complete ${prefix}/share/bash-completion/completions
-    xinstall -d ${destroot}${bash_complete}
+    set bash_complete ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${bash_complete}
     xinstall -m 0644 ${worksrcpath}/etc/${name}.bash \
-        ${destroot}${bash_complete}/${name}
+        ${bash_complete}/${name}
 
-    set zsh_complete ${prefix}/share/zsh/site-functions
-    xinstall -d ${destroot}${zsh_complete}
+    set zsh_complete ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_complete}
     xinstall -m 0644 ${worksrcpath}/etc/${name}.zsh \
-        ${destroot}${zsh_complete}/_${name}
+        ${zsh_complete}/_${name}
 
-    set fish_complete ${prefix}/share/fish/vendor_completions.d
-    xinstall -d ${destroot}${fish_complete}
+    set fish_complete ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${fish_complete}
     xinstall -m 0644 ${worksrcpath}/etc/${name}.fish \
-        ${destroot}${fish_complete}/${name}.fish
+        ${fish_complete}/${name}.fish
 
-    set tcsh_complete ${prefix}/etc/profile.d
-    xinstall -d ${destroot}${tcsh_complete}
+    set tcsh_complete ${destroot}${prefix}/etc/profile.d
+    xinstall -d ${tcsh_complete}
     xinstall -m 0644 ${worksrcpath}/etc/${name}.csh \
-        ${destroot}${tcsh_complete}/${name}.csh
+        ${tcsh_complete}/${name}.csh
 
     # Install vim plugin, man-page, lfcd shell scripts and docs
-    set vim_plugin ${prefix}/share/vim/vimfiles/ftdetect
-    xinstall -d ${destroot}${vim_plugin}
-    xinstall -m 0644 ${worksrcpath}/etc/${name}.vim \
-        ${destroot}${vim_plugin}/
+    set vim_plugin ${destroot}${prefix}/share/vim/vimfiles/ftdetect
+    xinstall -d ${vim_plugin}
+    xinstall -m 0644 ${worksrcpath}/etc/${name}.vim ${vim_plugin}/
 
     xinstall -m 0644 ${worksrcpath}/${name}.1 \
         ${destroot}${prefix}/share/man/man1


### PR DESCRIPTION
#### Description

Update lf to its latest release, r31. The output of the version flag has been fixed in the process, with some small refactors in the Portfile.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
