### PR TITLE
minicom: update to 2.9

### DIFF
--- a/comms/minicom/Portfile
+++ b/comms/minicom/Portfile
@@ -2,14 +2,15 @@
 
 PortSystem          1.0
 
-name                minicom
-version             2.7.1
-revision            1
-set download_id     4215
+PortGroup           gitlab 1.0
+
+gitlab.instance     https://salsa.debian.org
+gitlab.setup        minicom-team minicom 2.9
+revision            0
 categories          comms
 maintainers         nomaintainer
 platforms           darwin
-license             GPL-2
+license             GPL-2+
 
 description         Menu driven communications program
 
@@ -17,12 +18,9 @@ long_description    Minicom is a menu driven communications program. It \
                     emulates ANSI and VT102 terminals. It has a dialing \
                     directory and auto zmodem download.
 
-homepage            https://alioth.debian.org/projects/minicom
-master_sites        https://alioth.debian.org/frs/download.php/file/${download_id}
-
-checksums           rmd160  cc538b69d3bbc0de13691ac6394f03e97c5dfb5d \
-                    sha256  532f836b7a677eb0cb1dca8d70302b73729c3d30df26d58368d712e5cca041f1 \
-                    size    875939
+checksums           rmd160  671b178a62b62c360b053baab943fdba9bacdcd9 \
+                    sha256  9efbb6458140e5a0de445613f0e76bcf12cbf7a9892b2f53e075c2e7beaba86c \
+                    size    681585
 
 depends_build       port:pkgconfig
 
@@ -30,22 +28,8 @@ depends_lib         port:gettext \
                     port:libiconv \
                     port:ncurses
 
-depends_run         port:lrzsz
+depends_run         port:lrzsz \
+                    port:kermit
 
-post-patch {
-    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/src/rwconf.c
-    reinplace "s|/usr/bin/ascii-xfr|${prefix}/bin/ascii-xfr|g" ${worksrcpath}/src/rwconf.c
-}
-
-configure.args      --enable-lock-dir=/tmp
-
-variant kermit description {Builds minicom with kermit support} {
-    depends_run-append      port:kermit
-    configure.args-append   --enable-kermit=${prefix}/bin
-}
-
-default_variants    +kermit
-
-livecheck.type      regex
-livecheck.url       ${homepage}
-livecheck.regex     "Source (\\d+(?:\\.\\d+)*) - Download"
+configure.args      --enable-lock-dir=/tmp \
+                    --enable-kermit=${prefix}/bin


### PR DESCRIPTION
Migrate to Debian Salsa
See: https://trac.macports.org/ticket/59057

Fix license (source code files specify version 2 or later)

Remove kermit variant (as suggested following #9272)
Reverts 1b0916ae5d8a

#### Description
https://salsa.debian.org/minicom-team/minicom/-/blob/2.9/NEWS?ref_type=tags
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.9
Xcode 14.2
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
