### PR TITLE
pict2pdf: does not build on 10.7 or later

### DIFF
--- a/graphics/pict2pdf/Portfile
+++ b/graphics/pict2pdf/Portfile
@@ -9,7 +9,7 @@ long_description	\
 	pict2pdf converts files in Apple's PICT format to Adobe's PDF \
 	format. The conversion retains any vector information in \
 	the PICT image.  
-platforms	darwin
+platforms	{darwin < 11}
 supported_archs i386 ppc
 homepage	http://pict2pdf.sourceforge.net/
 master_sites	sourceforge


### PR DESCRIPTION

Closes: https://trac.macports.org/ticket/56593


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
