### PR TITLE
netcdf-fortran: fix nf-config --flibs output

### DIFF
--- a/science/netcdf-fortran/Portfile
+++ b/science/netcdf-fortran/Portfile
@@ -21,7 +21,7 @@ PortGroup                   github 1.0
 mpi.enforce_variant         netcdf
 
 github.setup                Unidata netcdf-fortran 4.6.1 v
-revision                    1
+revision                    2
 maintainers                 {takeshi @tenomoto} openmaintainer
 categories                  science
 license                     Permissive

--- a/science/netcdf-fortran/files/patch-nf-config.diff
+++ b/science/netcdf-fortran/files/patch-nf-config.diff
@@ -16,7 +16,7 @@
  has_f90="@HAS_F90@"
  has_f03="@HAS_F03@"
 -flibs="-L${libdir} @NC_FLIBS@"
-+flibs="-L${libdir} -lnetcdf"
++flibs="-L${libdir} -lnetcdff"
  version="@PACKAGE_NAME@ @PACKAGE_VERSION@"
  
  usage()


### PR DESCRIPTION
#### Description

Fixing an unfortunate mistake in PR #20510.
Output of nf-config should contain -lnetcdff, not -lnetcdf

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
