### PR TITLE
Upgrade lisp ports

### DIFF
--- a/lisp/cl-asdf-flv/Portfile
+++ b/lisp/cl-asdf-flv/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        didierverna asdf-flv 2.1 version-
+github.setup        didierverna asdf-flv 2.2 version-
 name                cl-asdf-flv
 revision            0
 
-checksums           rmd160  be17452bcb24aeb5dbd48724406aff3885fb1c17 \
-                    sha256  734e81632f0d34e3971bd1292439a52848d84bfb4fd1a684d7b0108d35a0c228 \
-                    size    2242
+checksums           rmd160  b6f54d987806a4def09526cd896dbbcfa8fd7dd3 \
+                    sha256  1ec7968518723f62e932dfc543de4345be62db4173d3d8985d89c025f71cdd7a \
+                    size    2372
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-bordeaux-threads/Portfile
+++ b/lisp/cl-bordeaux-threads/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        sionescu bordeaux-threads 0.9.1 v
+github.setup        sionescu bordeaux-threads 0.9.3 v
 name                cl-bordeaux-threads
 revision            0
 
-checksums           rmd160  6b2f561f0bf279a8978f8719024ee3380f86957f \
-                    sha256  f8e0a742edb9cd1638f28f2cefaf5b89e34cb28cb8349b5e1ba001ff34949784 \
-                    size    57875
+checksums           rmd160  33dea431fb18ed79dd050d25adf2299edf259aa0 \
+                    sha256  337f45ebcb641596cb31d50879dcaba9d1545b79ef4f3a45a51fa0cb2674fc90 \
+                    size    58486
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-clack/Portfile
+++ b/lisp/cl-clack/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               common_lisp 1.0
 
-github.setup            fukamachi clack 488cfb36381a4f4c56ad7f1184ea64b6ebcc2cee
+github.setup            fukamachi clack a49b63fb8df5690c03dbe5d6820d2958b9206022
 name                    cl-clack
-version                 20230331
+version                 20230823
 revision                0
 
-checksums               rmd160  c909c54499751fbf89962b07671ce4bd7da4c059 \
-                        sha256  2c100b0e13b4d962cdd01406ed280748ee26273ad6c9488aa0f8406ac193b1ff \
-                        size    171991
+checksums               rmd160  6bf794b0744e75aeca0f987f469a344386c67900 \
+                        sha256  bb476d364d85b238dc8a3e5545a004f11ebf8f8f2c8d29e86b9e989c06a9172c \
+                        size    172035
 
 categories-append       devel
 maintainers             {@catap korins.ky:kirill} openmaintainer
@@ -42,3 +42,6 @@ depends_test-append     port:cl-dexador
 # Tests stuck on CCL
 # See: https://github.com/fukamachi/clack/issues/188
 common_lisp.ccl         no
+
+# See: https://github.com/fukamachi/lack/issues/75
+test.run                no

--- a/lisp/cl-closer-mop/Portfile
+++ b/lisp/cl-closer-mop/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        pcostanza closer-mop 0a85d5f9326d91bf660c5d68df3a9f4abd9c2a32
+github.setup        pcostanza closer-mop 99b537f900dbf2c76b35b0e5cc32edf797b6ec42
 name                cl-closer-mop
-version             20230828
+version             20230916
 revision            0
 
-checksums           rmd160  62898391a443a72c882f59cba9579e3904d9ef0d \
-                    sha256  42414dcaa5950158a9b93b879cf90615cbcfcb8969f7902e7af65e7f5e2808bd \
-                    size    23109
+checksums           rmd160  0d500509516bb23e0540f52db04a2f3cbcf0a312 \
+                    sha256  6266a23d06b5c3be19e393d801cc0dd086cd302fed93cb0355cce2bf881abd71 \
+                    size    23125
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-clunit2/Portfile
+++ b/lisp/cl-clunit2/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           notabug 1.0
 PortGroup           common_lisp 1.0
 
-notabug.setup       cage clunit2 200839e8e47e9212ded2d36520d84b9be681037c
+notabug.setup       cage clunit2 596ac5505b8f91571fbad2660f494063fb8aea7d
 name                cl-clunit2
-version             20221002
+version             20230920
 revision            0
 
-checksums           rmd160  1f3243c6f97894f0662d6cc5662e16389fbc5d5d \
-                    sha256  b6bda85757986882177baaf2200b2eeaf2c69093a84942c6741df59d28ef004f \
-                    size    39670
+checksums           rmd160  1a94db89d5e12a4795791d703441d939bbc7518d \
+                    sha256  4b84a0962ac821ea5b6394037236b68160b8fad71db83c95cd45295ee3747513 \
+                    size    39671
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-dbi/Portfile
+++ b/lisp/cl-dbi/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        fukamachi cl-dbi 3d4b48c7b6736a4257043cde60687614775714d6
-version             20230417
-revision            1
+github.setup        fukamachi cl-dbi 5c25cace5a349b87d629707f0c87abd40cc4a589
+version             20230917
+revision            0
 
-checksums           rmd160  ab006654ea419289995bb8c3a4b2e5ef4ab617f3 \
-                    sha256  f5eb74204be7db60dc2f30c519a8e1eb540b7e6a9cdb1915e77eb35d5593ad90 \
-                    size    19522
+checksums           rmd160  e9ac26116144bd6c0a1978d2fb71d9346018c2ad \
+                    sha256  e93f06f35a1a1354c1a07a7c7e48d3ffdc26ac41976f1dfd6a25bc2bcc8bd3c9 \
+                    size    19539
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-dexador/Portfile
+++ b/lisp/cl-dexador/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        fukamachi dexador 843d2622941fcb29ff0baf263435787e0196b4ec
+github.setup        fukamachi dexador d5bdd0b9ddd554f10fd50d2c217ed8da86db0277
 name                cl-dexador
-version             20230613
+version             20230917
 revision            0
 
-checksums           rmd160  46be3b3f0efe0ddba3049d6a741fe47380fab6ee \
-                    sha256  c0a7e1d1ceaa0ce6a9cfa0c54c496c9aa5ebb015b4ebc13e25890117883a0ded \
-                    size    212639
+checksums           rmd160  67d053d0d0436fc082b60f9b84738b46a315d551 \
+                    sha256  624c6ae2192313ad3dd7e2d899328e4cdd2dfaf8f84cbba31c13133ef2bf37ed \
+                    size    212646
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-isaac/Portfile
+++ b/lisp/cl-isaac/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        thephoeron cl-isaac 51ee06091fb67ba48693108999cf1197726852f4
+version             20230627
+revision            0
+
+checksums           rmd160  31e8e8abbfa6eddc5cca36d0395e13c708b853ee \
+                    sha256  2cd3d85db33d2f5f02dbee552d6dabe193ccf6a7accbacadc93b4832cf747102 \
+                    size    15250
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Optimized Common Lisp version of Bob Jenkins' ISAAC-32 and ISAAC-64 algorithms, fast cryptographic random number generators.
+
+long_description    {*}${description}

--- a/lisp/cl-lack/Portfile
+++ b/lisp/cl-lack/Portfile
@@ -4,14 +4,14 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               common_lisp 1.0
 
-github.setup            fukamachi lack 3745924e4682523b0969a7042bcdb39aa8f73e8f
+github.setup            fukamachi lack 2c6a93acd983b1fe476671707ce7ec920eb10613
 name                    cl-lack
-version                 20230527
+version                 20230920
 revision                0
 
-checksums               rmd160  62105cfa4d5b101d0101c06e3224c9f3539f7517 \
-                        sha256  ab21f3d61c89d26f34e90b761f186bd2b3ed2933be77e77be2c36650de00717c \
-                        size    180585
+checksums               rmd160  711910e51efbc14718c44aa095ce6f13836f64f0 \
+                        sha256  d6b5781d06dd1a98ea62cacecbfb94154b1c041711a776950ff51ff3626bc158 \
+                        size    180840
 
 categories-append       devel
 maintainers             {@catap korins.ky:kirill} openmaintainer
@@ -34,6 +34,7 @@ depends_lib-append      port:cl-alexandria \
                         port:cl-ironclad \
                         port:cl-local-time \
                         port:cl-marshal \
+                        port:cl-isaac \
                         port:cl-ppcre \
                         port:cl-prove \
                         port:cl-quri \

--- a/lisp/cl-legion/Portfile
+++ b/lisp/cl-legion/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        fukamachi legion 599cca19f0e34246814621f7fe90322221c2e263
+github.setup        fukamachi legion 281dba5e509dad85b4638a92f33dabf7a2dd96f0
 name                cl-legion
-version             20171116
-revision            1
+version             20230917
+revision            0
 
-checksums           rmd160  41bc58205cf31cde951ad0ece7e3a049e949cf0d \
-                    sha256  cb45a18ca39b03753218e6906eabdbfc243abb716fde3483f697a495f6005755 \
-                    size    6323
+checksums           rmd160  00fea1e3a5ac8801b915b730ba189507ff42d62d \
+                    sha256  5a9e5bdb320b8972e890e2354505f8ffa9a7c24b4e8c8c111eabcbcaec3a6a0d \
+                    size    6295
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-mgl-pax/Portfile
+++ b/lisp/cl-mgl-pax/Portfile
@@ -4,14 +4,14 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 PortGroup                   common_lisp 1.0
 
-github.setup                melisgl mgl-pax ca8d82757f3dd66a543e3ae5895e92015e15438f
+github.setup                melisgl mgl-pax f7a6c51b187b10dc39470b77fac05aaeb7b4e781
 name                        cl-mgl-pax
 version                     20230828
 revision                    0
 
-checksums                   rmd160  ce36a71c7792eacacdca63e15422aa8ba4aafd29 \
-                            sha256  8a2a83c5b084e85008a0b89edc4e492b8e3d55bd1749cc833b35961da89b1c6e \
-                            size    980096
+checksums                   rmd160  1cd0e3aaecdd00f2908815e6f0c6f6e38ee461b9 \
+                            sha256  c2ee801268c9d5c8efbbd790903b4e0d207dc74e6938b7ef51f4b51387fce2a6 \
+                            size    980141
 
 categories-append           devel textproc
 maintainers                 {@catap korins.ky:kirill} openmaintainer
@@ -23,6 +23,8 @@ long_description            {*}${description}
 
 subport cl-mgl-pax-bootstrap {
     common_lisp.systems     mgl-pax-bootstrap.asd
+
+    livecheck.type          none
 }
 
 subport cl-dref {

--- a/lisp/cl-nasdf/Portfile
+++ b/lisp/cl-nasdf/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        atlas-engineer ntemplate dd9fb2df7174464b54561b2a2f3c3e00fdd5d4f7
+github.setup        atlas-engineer ntemplate da2efaed2323d8679a550e9acf80df958420bb51
 name                cl-nasdf
-version             20230814
+version             20230923
 revision            0
 
-checksums           rmd160  284195ebe4dfdb841d741ba5c65795e0d31dd224 \
-                    sha256  b069a57f1904ee225ec540ef168cf3df13a34569c07076ef2e5624cdf28b4ee4 \
-                    size    18401
+checksums           rmd160  86a056ad62d3ada285df56f9912ae752317074ee \
+                    sha256  f7966ed355969cd27c96f22bb51f62a8e6a2f4f3c9e5b7f3d843f580fd5d32ba \
+                    size    18529
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-njson/Portfile
+++ b/lisp/cl-njson/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        atlas-engineer njson 1.1.1
+github.setup        atlas-engineer njson 1.2.1
 name                cl-njson
 revision            0
 
-checksums           rmd160  bd9df1ce9d6f06ead5557dea9ead41cbb8eee5a7 \
-                    sha256  66d3d482a9468b4730924496a9cc6d3330a82f3b0a572e5b86d7a755531f9101 \
-                    size    35770
+checksums           rmd160  9604a700145455927120fb3eb3ffec13a9c7bb88 \
+                    sha256  8c1e7b277043c6a71125862a4421cf299f29099fa6a2de0c149292f4419df035 \
+                    size    37050
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-nkeymaps/Portfile
+++ b/lisp/cl-nkeymaps/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        atlas-engineer nkeymaps 1.0.0
+github.setup        atlas-engineer nkeymaps 1.1.0
 name                cl-nkeymaps
-revision            1
+revision            0
 
-checksums           rmd160  271c0406cb9b2ccf5cb6223bcf7b5d67457c6262 \
-                    sha256  86148f1bcb4f2136d26961c9ad011b62dc361f4cf13604b81e45357ab2203276 \
-                    size    19613
+checksums           rmd160  4da3b10a8a7c3587523780e56a6305fe4e8cdaef \
+                    sha256  ea64d2fb2c7d53c749961288f04d65438419b6a05b377016fb87092b01047c83 \
+                    size    34733
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -24,7 +24,11 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-fset \
                     port:cl-lisp-unit2 \
                     port:cl-nasdf \
+                    port:cl-str \
                     port:cl-trivial-package-local-nicknames
 
 # *** - EVAL: undefined function EXT::ADD-PACKAGE-LOCAL-NICKNAME
 common_lisp.clisp   no
+
+# See: https://github.com/atlas-engineer/nkeymaps/issues/16
+common_lisp.abcl    no

--- a/lisp/cl-rove/Portfile
+++ b/lisp/cl-rove/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        fukamachi rove 576727b1452cbe1e4f528954b1f3e32d3badfe42
+github.setup        fukamachi rove f168cd177b5f83f171dd970dc1a9abb6eb43f044
 name                cl-rove
-version             20230818
+version             20230917
 revision            0
 
-checksums           rmd160  4bc5bd450d7538bf35cb7b7cc2c62d9e8a031fce \
-                    sha256  57548df0d457011e47b8933a8bc7fe47c534ff5afd5f37948c3dacaf02ceb649 \
-                    size    17242
+checksums           rmd160  41f44a6d02071d192b1c7352fece91c330212621 \
+                    sha256  dd83f08e3aac0577a197827c7efd643a8575071246df13dfe5c479e7c44ef582 \
+                    size    17866
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer

--- a/lisp/cl-serapeum/Portfile
+++ b/lisp/cl-serapeum/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        ruricolist serapeum ccb027bd26454e9d8e6c4c581ab20c762da723d0
+github.setup        ruricolist serapeum 81c5f54fcd3d97c868935a12221639dedcfb8841
 name                cl-serapeum
-version             20230828
+version             20230912
 revision            0
 
-checksums           rmd160  df491a8f0483f5edbfecb0068e3e1edb28eda18f \
-                    sha256  db29b8d8d043ac17f172a01cc91680b882239ba6ed3de6a2d5dbf92254b3a9b6 \
-                    size    251972
+checksums           rmd160  6048c9f23b2fb372bdcbe79afd176f045ef4ead6 \
+                    sha256  a17bfb546b0eb8362d5e12d30e5eaa236d7a5a98ca575910d4d4740cbffbbba5 \
+                    size    251969
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -22,9 +22,11 @@ description         Utilities beyond Alexandria.
 long_description    {*}${description}
 
 depends_lib-append  port:cl-alexandria \
+                    port:cl-atomics \
                     port:cl-bordeaux-threads \
                     port:cl-global-vars \
                     port:cl-introspect-environment \
+                    port:cl-local-time \
                     port:cl-parse-declarations \
                     port:cl-parse-number \
                     port:cl-split-sequence \
@@ -34,8 +36,5 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-trivial-file-size \
                     port:cl-trivial-garbage \
                     port:cl-trivial-macroexpand-all
-
-depends_test-append port:cl-atomics \
-                    port:cl-local-time
 
 common_lisp.threads yes

--- a/lisp/cl-spinneret/Portfile
+++ b/lisp/cl-spinneret/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        ruricolist spinneret 620e0ad92cbee5a290b081312d8d5999375b84ee
+github.setup        ruricolist spinneret d82aea82b8570800a73aa6b6295735f7f5125a9c
 name                cl-spinneret
-version             20230820
+version             20230918
 revision            0
 
-checksums           rmd160  ea80756bd2a0ebf20986e44b9dd2bf24cf404458 \
-                    sha256  f8743939ad1f6aeb8028ed08dd93279b277e4516e6b258c1e10e152501a7813c \
-                    size    31296
+checksums           rmd160  ce769362796efe5c8b1d1d644e4732b43a0120a2 \
+                    sha256  aca7d90ceb28a36b4b8676078f87ead2d37f9f14f831d112bb45a359feed036d \
+                    size    31472
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer


### PR DESCRIPTION
#### Description

This is a major upgrade for lisp ports.

CI probably will fails by failed build on ECL which is addresses at https://github.com/macports/macports-ports/pull/20581

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->