### PR TITLE
osxphotos: update to 0.63.5

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,8 +4,8 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.63.4
-revision                1
+version                 0.63.5
+revision                0
 
 categories              graphics python
 
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  8acd8cc153ad7c49d91d4882d2deb3aef81f7421 \
-                        sha256  d35bc94ba33658b633a7a29d8e29c631f505d159c83312fe833456aed808544f \
-                        size    1974971
+checksums               rmd160  fdeec4c28af72fc5d959f461516098612c1e6ee5 \
+                        sha256  0e34a08aa05f38d827de4772006623c0a12873d6421e8acdc437a920cfd3bc70 \
+                        size    1964050
 
 python.default_version  311
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.63.5.

###### Tested on

macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?