### PR TITLE
openjdk21-microsoft: new submission

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -1,0 +1,95 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk21-microsoft
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-21
+supported_archs  x86_64 arm64
+
+version      21.0.0
+set build    35
+revision     0
+
+description  Microsoft Build of OpenJDK 21 (Long Term Support)
+long_description The Microsoft Build of OpenJDK is a no-cost distribution of OpenJDK that's open source \
+    and available for free for anyone to deploy anywhere.
+
+master_sites https://aka.ms/download-jdk/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     microsoft-jdk-${version}-macOS-x64
+    checksums    rmd160  989971673f263ad08cdb68c259392413ed520905 \
+                 sha256  831aa8af173908c74d9a1ea3762597aa3cbabd812d4a3a9bfe6112bec1e840bb \
+                 size    202519951
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     microsoft-jdk-${version}-macOS-aarch64
+    checksums    rmd160  00760983a040390f5d5ab368af75111a02339122 \
+                 sha256  4e9963c297baf857d33e858730a0ee28023d369b8e7d4e2b8f7f7fa901b9c9b1 \
+                 size    191756269
+}
+
+worksrcdir   jdk-21+${build}
+
+homepage     https://www.microsoft.com/openjdk
+
+livecheck.type      regex
+livecheck.url       https://docs.microsoft.com/en-us/java/openjdk/download
+livecheck.regex     microsoft-jdk-(21\.\[0-9\.\]+)-macOS-.*\.tar\.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-21-microsoft.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Microsoft OpenJDK 21.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?