### PR TITLE
stripe-cli: disable telemetry

### DIFF
--- a/devel/stripe-cli/Portfile
+++ b/devel/stripe-cli/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/stripe/stripe-cli 1.17.2 v
 go.offline_build    no
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://stripe.com/docs/stripe-cli
 
@@ -28,6 +28,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 checksums           rmd160  ce2336624b5c86be0e45de04c613286f6fad12c3 \
                     sha256  dd21c4df533faa4c2006c508992ff5a44be3ee42b3f2f242e469fef131a21c6f \
                     size    1488303
+
+# disable stripe telemetry which is otherwise enabled by default
+patchfiles          patch-disable-telemetry.diff
 
 build.cmd           make
 build.target        build

--- a/devel/stripe-cli/files/patch-disable-telemetry.diff
+++ b/devel/stripe-cli/files/patch-disable-telemetry.diff
@@ -1,0 +1,36 @@
+--- cmd/stripe/main.go
++++ cmd/stripe/main.go
+@@ -2,31 +2,13 @@ package main
+ 
+ import (
+ 	"context"
+-	"net/http"
+-	"os"
+-	"time"
+ 
+ 	"github.com/stripe/stripe-cli/pkg/cmd"
+-	"github.com/stripe/stripe-cli/pkg/stripe"
+ )
+ 
+ func main() {
+ 	ctx := context.Background()
+ 
+-	if stripe.TelemetryOptedOut(os.Getenv("STRIPE_CLI_TELEMETRY_OPTOUT")) || stripe.TelemetryOptedOut(os.Getenv("DO_NOT_TRACK")) {
+-		// Proceed without the telemetry client if client opted out.
+-		cmd.Execute(ctx)
+-	} else {
+-		// Set up the telemetry client and add it to the context
+-		httpClient := &http.Client{
+-			Timeout: time.Second * 3,
+-		}
+-		telemetryClient := &stripe.AnalyticsTelemetryClient{HTTPClient: httpClient}
+-		contextWithTelemetry := stripe.WithTelemetryClient(ctx, telemetryClient)
+-
+-		cmd.Execute(contextWithTelemetry)
+-
+-		// Wait for all telemetry calls to finish before existing the process
+-		telemetryClient.Wait()
+-	}
++	// always proceed without the telemetry client
++	cmd.Execute(ctx)
+ }


### PR DESCRIPTION
#### Description

stripe-cli ships telemetry in its cli tool, turned on by default. This PR disables the telemetry completely.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.5.2 22G91 arm64
Xcode 14.3 14E222b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? TRACE MODE DISABLED
- [x] tested basic functionality of all binary files?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
