### PR TITLE
asitop: new port (version 0.0.24)

### DIFF
--- a/sysutils/asitop/Portfile
+++ b/sysutils/asitop/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+name                    asitop
+version                 0.0.24
+revision                0
+
+homepage                https://tlkh.github.io/asitop/
+
+description             Performance monitoring CLI tool for Apple Silicon
+
+long_description        \
+    {*}${description}. ${name} uses the built-in powermetrics utility on \
+    macOS, which allows access to a variety of hardware performance counters. \
+    Note that it requires sudo to run due to powermetrics needing root access \
+    to run. ${name} is lightweight and has minimal performance impact. \
+    ${name} only works on Apple Silicon Macs.
+
+categories              sysutils python
+license                 MIT
+maintainers             {gmail.com:herby.gillot @herbygillot} \
+                        openmaintainer
+supported_archs         arm64
+
+checksums               rmd160  fc30e5b79fca16fef8a886f3ffb6d56ed0481cc3 \
+                        sha256  5df7b59304572a948f71cf94b87adc613869a8a87a933595b1b3e26bf42c3e37 \
+                        size    9153
+
+python.default_version  311
+
+depends_build-append    port:py${python.version}-setuptools
+
+depends_lib-append      port:py${python.version}-dashing \
+                        port:py${python.version}-psutil


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
