### PR TITLE
qgis3{-ltr}: change linking from MacPorts' to the System's libunwind

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -425,9 +425,33 @@ post-configure {
     touch ${cmake.build_dir}/src/core/CMakeFiles/qgis_core_autogen.dir/build.make
 }
 
+# change $old to $new link, traverse through $dir
+proc change_link {old new dir} {
+    if {![file exists $dir] || ![file isdirectory $dir]} {
+        return -code error "$dir: No such directory"
+    }
+    fs-traverse f $dir {
+        if {[file isfile ${f}] && [file type ${f}] eq {file}} {
+            if {[string match "charset=binary" [lindex [exec /usr/bin/file -I ${f}] end]]} {
+                system "/usr/bin/install_name_tool -change ${old} ${new} ${f}"
+            }
+        }
+    }
+}
+
 post-destroot {
     # qgis_bench app doesn’t link properly. Who uses this anyway????
-    delete ${destroot}${applications_dir}/Qgis3.app/Contents/MacOS/bin/qgis_bench.app
+    delete ${destroot}${applications_dir}/QGIS3.app/Contents/MacOS/bin/qgis_bench.app
+
+    # workaround to mixed use of MacPorts' and system's libunwind, https://trac.macports.org/ticket/68250
+    set check_bin ${destroot}${applications_dir}/QGIS3.app/Contents/MacOS/QGIS3
+    set l [lindex [regexp -all -inline {\S+\/libunwind\S+dylib} [exec otool -L ${check_bin}]] 0]
+    if {$l ne ""} {
+        set sys /usr/lib/system/libunwind.dylib
+        change_link ${l} ${sys} ${destroot}${applications_dir}/QGIS3.app/Contents/MacOS
+        change_link ${l} ${sys} ${destroot}${applications_dir}/QGIS3.app/Contents/PlugIns
+        change_link ${l} ${sys} ${destroot}${applications_dir}/QGIS3.app/Contents/Frameworks
+    }
 }
 
 if {${subport} eq ${name-ltr}} {


### PR DESCRIPTION
#### Description

QGIS does not use libunwind, but due to it's dependence to PDAL (which does use libunwind) and the following presence of libunwind in $prefix/lib, causes the MacPorts version to be picked up by the linker instead of the system's version. A thrown exception is therefore wrongfully handled by both versions, causing crash.

This is a workaround, awaiting separate prefix for the port libunwind. See https://trac.macports.org/ticket/66250#comment:1

Closes https://trac.macports.org/ticket/68250

Putting up this initially as a draft, it works for me, but this workaround probably needs to be run conditionally depending on OS version.


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
