### PR TITLE
ffmpeg, ffmpeg-devel, ffmpeg6: fix compilation problems with Xcode 15

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.4
-revision            2
+revision            3
 epoch               2
 
 license             LGPL-2.1+
@@ -301,6 +301,15 @@ platform darwin {
         if {[variant_isset rav1e]} {
             error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
         }
+    }
+
+    # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
+    # this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
+    #
+    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
+    if { ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+        configure.ldflags-append \
+                    -ld_classic
     }
 }
 

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg-devel
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.4
-revision            2
+revision            3
 epoch               1
 
 license             LGPL-2.1+
@@ -301,6 +301,15 @@ platform darwin {
         if {[variant_isset rav1e]} {
             error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
         }
+    }
+
+    # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
+    # this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
+    #
+    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
+    if { ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+        configure.ldflags-append \
+                    -ld_classic
     }
 }
 

--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -17,7 +17,7 @@ name                ffmpeg6
 set my_name         ffmpeg
 
 version             6.0
-revision            3
+revision            4
 epoch               0
 
 license             LGPL-2.1+
@@ -298,6 +298,15 @@ platform darwin {
         if {[variant_isset rav1e]} {
             error "Variant rav1e not supported for macOS 10.5 and earlier, or PPC"
         }
+    }
+
+    # due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
+    # this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
+    #
+    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
+    if { ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+        configure.ldflags-append \
+                    -ld_classic
     }
 }
 


### PR DESCRIPTION
#### Description
Xcode 15 introduced a new linker, which is faster (said by Apple) but it cause some problems with existing software. Compiling ffmpeg port's cannot be done, because somewhere in the building process, multiple symbol exports are created with the same name, and the new linker cant link it. Apple introduced a new ldflag, which can bring back the old one, but this is a temporary solution, because this flag will be phased out in the future (date not disclosed yet).

Closes: https://trac.macports.org/ticket/68234

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
