### PR TITLE
qt6: Add macdeployqt patch

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -106,7 +106,7 @@ array set modules {
          "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 3"
+        "revision 4"
         "License: "
     }
     qtsvg {
@@ -1029,6 +1029,13 @@ if { ${subport} eq "${name}-qtbase" || ${subport} eq "${name}-qtbase-docs" } {
 
     # see https://trac.macports.org/ticket/67980
     patchfiles-append               patch-qtbase-memory_resource.diff
+
+    # Fixes deploying application libraries with .so extension.
+    # glib gio modules, this also applies to gstreamer since macports
+    # currently uses an older version of gstreamer which uses .so
+    # extensions for plugins.
+    # see https://codereview.qt-project.org/c/qt/qtbase/+/507393
+    patchfiles-append               patch-qtbase-macdeployqt.diff
 
     configure.pre_args-replace      --prefix=${prefix} \
                                     "-prefix ${qt6.dir}"

--- a/aqua/qt6/files/patch-qtbase-macdeployqt.diff
+++ b/aqua/qt6/files/patch-qtbase-macdeployqt.diff
@@ -1,0 +1,33 @@
+From c66dab56b20a47062c74fa6ecf8ea438bdc07b24 Mon Sep 17 00:00:00 2001
+From: Jonas Kvinge <jonas@jkvinge.net>
+Date: Tue, 26 Sep 2023 19:02:47 +0200
+Subject: [PATCH] macdeployqt: Also look for app libraries with .so extension
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf8
+Content-Transfer-Encoding: 8bit
+
+Fixes deploying glib-networking gio modules which uses .so file
+extension.
+
+Change-Id: I6b4c4e9c3bb5745ffa33d7e83c5853a9372f1ca6
+Reviewed-by: Tor Arne VestbÃ¸ <tor.arne.vestbo@qt.io>
+---
+ src/tools/macdeployqt/shared/shared.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tools/macdeployqt/shared/shared.cpp b/src/tools/macdeployqt/shared/shared.cpp
+index 0671ebf2f32f..413f8413f69f 100644
+--- src/tools/macdeployqt/shared/shared.cpp
++++ src/tools/macdeployqt/shared/shared.cpp
+@@ -435,7 +435,7 @@ QStringList findAppLibraries(const QString &appBundlePath)
+ {
+     QStringList result;
+     // dylibs
+-    QDirIterator iter(appBundlePath, QStringList() << QString::fromLatin1("*.dylib"),
++    QDirIterator iter(appBundlePath, QStringList() << QString::fromLatin1("*.dylib") << QString::fromLatin1("*.so"),
+             QDir::Files | QDir::NoSymLinks, QDirIterator::Subdirectories);
+     while (iter.hasNext()) {
+         iter.next();
+-- 
+2.16.3
+


### PR DESCRIPTION
#### Description

Fixes deploying application libraries with .so extension such as glib gio modules, this also applies to gstreamer since macports currently uses an older version of gstreamer which uses .so extensions for plugins. See https://codereview.qt-project.org/c/qt/qtbase/+/507393

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
