### PR TITLE
cpp-peglib: update to 1.8.5

### DIFF
--- a/devel/cpp-peglib/Portfile
+++ b/devel/cpp-peglib/Portfile
@@ -2,18 +2,19 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        yhirose cpp-peglib 1.8.4 v
+github.setup        yhirose cpp-peglib 1.8.5 v
 revision            0
 categories          devel
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         A single file C++ header-only PEG (Parsing Expression Grammars) library
 long_description    {*}${description}
-checksums           rmd160  d576c912ee51bea296f7d384d48fd1e2d1754416 \
-                    sha256  002cec65f659180ba90c0b04ee30a349ca18f0732fbe00e7638f1ead44aeb701 \
-                    size    226350
+checksums           rmd160  d94b9b86aa009e87bdd1929eed93f2a73df62e0a \
+                    sha256  2813f7ffdeb570959b879ce2bf3921bf4f2edc0d9f1568c4429eceadff9ab114 \
+                    size    226230
 github.tarball_from archive
 installs_libs       no
 
@@ -29,12 +30,14 @@ platform darwin {
 }
 
 compiler.cxx_standard 2017
+compiler.blacklist-append \
+                    {clang < 902}
 
 configure.args-append \
                     -DBUILD_TESTS=ON \
                     -DTHREADS_PREFER_PTHREAD_FLAG=ON
 
-# We do not a conflict with Gtest port, so implement a manual destroot.
+# We do not want a conflict with Gtest port, so implement a manual destroot.
 destroot {
     copy ${worksrcpath}/peglib.h ${destroot}${prefix}/include/
     xinstall -d ${destroot}${prefix}/share/${name}


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
