### PR TITLE
libtool: fix -single_module detection with Xcode 15

### DIFF
--- a/devel/libtool/Portfile
+++ b/devel/libtool/Portfile
@@ -5,7 +5,7 @@ PortGroup           clang_dependency 1.0
 
 name                libtool
 version             2.4.7
-revision            0
+revision            1
 categories          devel sysutils
 platforms           darwin freebsd
 # Scripts are GPL-2+, libltdl is LGPL-2+, but all parts that tend to be
@@ -26,7 +26,8 @@ checksums           rmd160  732c5329c8fc36cfaf36145c3c8ca301a0c41f88 \
                     size    1938886
 
 # hardcode the M4 executable, similar to other executables such as SED, GREP, LN ...
-patchfiles          hardcode-m4.patch
+patchfiles          hardcode-m4.patch \
+                    single_module.patch
 
 post-patch {
     # Stop build from trying to regenerate these after patching.

--- a/devel/libtool/files/single_module.patch
+++ b/devel/libtool/files/single_module.patch
@@ -1,0 +1,35 @@
+diff --git a/m4/libtool.m4 b/m4/libtool.m4
+index 79a2451e..973ab2aa 100644
+--- m4/libtool.m4
++++ m4/libtool.m4
+@@ -1081,6 +1081,21 @@ _LT_EOF
+     if test yes = "$lt_cv_apple_cc_single_mod"; then
+       _lt_dar_single_mod='$single_module'
+     fi
++    _lt_dar_needs_single_mod=no
++    case $host_os in
++    rhapsody* | darwin1.*)
++      _lt_dar_needs_single_mod=yes ;;
++    darwin*)
++      # When targeting Mac OS X 10.4 (darwin 8) or later,
++      # -single_module is the default and -multi_module is unsupported.
++      # The toolchain on macOS 10.14 (darwin 18) and later cannot
++      # target any OS version that needs -single_module.
++      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
++      10.0,*-darwin[[567]].*|10.[[0-3]],*-darwin[[5-9]].*|10.[[0-3]],*-darwin1[[0-7]].*)
++        _lt_dar_needs_single_mod=yes ;;
++      esac
++    ;;
++    esac
+     if test yes = "$lt_cv_ld_exported_symbols_list"; then
+       _lt_dar_export_syms=' $wl-exported_symbols_list,$output_objdir/$libname-symbols.expsym'
+     else
+@@ -1126,7 +1141,7 @@ m4_defun([_LT_DARWIN_LINKER_FEATURES],
+     _LT_TAGVAR(archive_expsym_cmds, $1)="$SED 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod$_lt_dar_export_syms$_lt_dsymutil"
+     _LT_TAGVAR(module_expsym_cmds, $1)="$SED -e 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags$_lt_dar_export_syms$_lt_dsymutil"
+     m4_if([$1], [CXX],
+-[   if test yes != "$lt_cv_apple_cc_single_mod"; then
++[   if test yes = "$_lt_dar_needs_single_mod" -a yes != "$lt_cv_apple_cc_single_mod"; then
+       _LT_TAGVAR(archive_cmds, $1)="\$CC -r -keep_private_externs -nostdlib -o \$lib-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$lib-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring$_lt_dsymutil"
+       _LT_TAGVAR(archive_expsym_cmds, $1)="$SED 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC -r -keep_private_externs -nostdlib -o \$lib-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$lib-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring$_lt_dar_export_syms$_lt_dsymutil"
+     fi


### PR DESCRIPTION
#### Description

Submitted upstream in https://savannah.gnu.org/support/index.php?110937

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Xcode 14.3.1 14E300c
