### PR TITLE
clang-17: fix build on macOS 10.5

### DIFF
--- a/lang/llvm-17/Portfile
+++ b/lang/llvm-17/Portfile
@@ -141,7 +141,8 @@ patchfiles-append \
     0019-10.6-and-less-use-emulated-TLS-before-10.7.patch \
     0025-lldb-add-defines-needed-for-older-SDKs.patch \
     0026-llvm-set-memrchr-unavailable.patch \
-    0999-i386-fix.diff
+    0999-i386-fix.diff \
+    add-missed-i386-host.diff
 
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     patchfiles-append \
@@ -160,7 +161,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
     patchfiles-append \
         0022-10.5-and-less-default-to-fno-blocks.patch \
         0024-10.5-and-less-compiler-rt-work-around-no-libdispatch.patch \
-        0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch
+        0027-libcxx-link-gcc_s.1-on-macOS-before-10.6.patch \
+        0028-libcxx-use-malloc-free-only-on-macOS-before-10.6.patch
 
     # inverse limit of building for macOS 10.7+
     # See: https://github.com/llvm/llvm-project/commit/49d2071572d484a2b5dc356f59050bb173c8c77c

--- a/lang/llvm-17/files/0028-libcxx-use-malloc-free-only-on-macOS-before-10.6.patch
+++ b/lang/llvm-17/files/0028-libcxx-use-malloc-free-only-on-macOS-before-10.6.patch
@@ -1,0 +1,26 @@
+From b040bc83342fd066fc2de96b18e9ee60f474ffa9 Mon Sep 17 00:00:00 2001
+From: "Kirill A. Korinsky" <kirill@korins.ky>
+Date: Thu, 28 Sep 2023 09:32:08 +0200
+Subject: [PATCH] [libcxx] use malloc/free only on macOS before 10.6
+
+---
+ libcxx/include/__memory/aligned_alloc.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/libcxx/include/__memory/aligned_alloc.h b/libcxx/include/__memory/aligned_alloc.h
+index 786963c72dfc..9094dc87deef 100644
+--- a/libcxx/include/__memory/aligned_alloc.h
++++ b/libcxx/include/__memory/aligned_alloc.h
+@@ -31,6 +31,9 @@ inline _LIBCPP_HIDE_FROM_ABI
+ void* __libcpp_aligned_alloc(std::size_t __alignment, std::size_t __size) {
+ #  if defined(_LIBCPP_MSVCRT_LIKE)
+     return ::_aligned_malloc(__size, __alignment);
++#  elif defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1060
++    // macOS before 10.6 hasn't got alligned malloc, fallback to just malloc
++    return ::malloc(__size);
+ #  elif _LIBCPP_STD_VER >= 17 && !defined(_LIBCPP_HAS_NO_C11_ALIGNED_ALLOC)
+     // aligned_alloc() requires that __size is a multiple of __alignment,
+     // but for C++ [new.delete.general], only states "if the value of an
+-- 
+2.42.0
+

--- a/lang/llvm-17/files/add-missed-i386-host.diff
+++ b/lang/llvm-17/files/add-missed-i386-host.diff
@@ -1,0 +1,16 @@
+https://github.com/llvm/llvm-project/commit/a5e10e248efc72e7909e4067060e89c35a456a18
+
+diff --git a/llvm/lib/TargetParser/Host.cpp b/llvm/lib/TargetParser/Host.cpp
+index 81309280a44b..8e9d3e97f5a3 100644
+--- a/llvm/lib/TargetParser/Host.cpp
++++ b/llvm/lib/TargetParser/Host.cpp
+@@ -1912,6 +1912,9 @@ static Triple withHostArch(Triple T) {
+ #elif defined(__x86_64__)
+   T.setArch(Triple::x86_64);
+   T.setArchName("x86_64");
++#elif defined(__i386__)
++  T.setArch(Triple::x86);
++  T.setArchName("i386");
+ #elif defined(__powerpc__)
+   T.setArch(Triple::ppc);
+   T.setArchName("powerpc");


### PR DESCRIPTION
#### Description

Fix requires two patches:
 - one was backported from llvm-16 port;
 - one was already merged to upstream.

###### Type(s)

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->