### PR TITLE
QtPass: new port

### DIFF
--- a/aqua/QtPass/Portfile
+++ b/aqua/QtPass/Portfile
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               qt5 1.0
+PortGroup               qmake5 1.0
+
+github.setup            IJHack QtPass 1.4.0 v
+revision                0
+categories              aqua security
+license                 GPL-3+
+maintainers             nomaintainer
+
+description \
+    QtPass is a multi-platform GUI for pass, the standard unix password manager.
+long_description \
+    QtPass is part of the pass ecosystem. This means you are not stuck with \
+    QtPass, you can use the same password store with many clients. \
+    \
+    Contrary to many Free, Libre and OpenSource password managers, pass and by \
+    extension QtPass are not bound to one user or device. Since we are based on \
+    GnuPG we have multi-key, multi recipient encryption out of the box. The use \
+    of external encryption devices like OpenPGP or x509/CMS based smartcards or \
+    USB tokens and per-folder ACL makes it easy to grant or take away privileges \
+    from users.
+
+homepage                https://qtpass.org
+
+github.tarball_from     releases
+checksums               rmd160  136092a5e9b14445524bc30ca82826233807da6e \
+                        sha256  9abe9cde35a412b26b6376a5e8996dfeeeb5910fe6a723b78bcf954656fca0e6 \
+                        size    581368
+
+compiler.cxx_standard   2011
+
+qt5.min_version         5.10
+qt5.depends_component   qtsvg qttools qttranslations
+qt5.mac_sdk             macosx
+
+configure.args-append   CONFIG+=release
+
+destroot {
+    copy ${worksrcpath}/main/${name}.app ${destroot}${applications_dir}
+}
+
+test.run                yes
+test.target             check
+
+github.livecheck.regex  {^v?[0-9.]+)}


### PR DESCRIPTION
#### Description

Adds a new port aqua/QtPass for the [QtPass](https://qtpass.org/) password manager.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7 21G816 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
