### PR TITLE
libpixman-devel: update to 0.42.2

### DIFF
--- a/graphics/libpixman-devel/Portfile
+++ b/graphics/libpixman-devel/Portfile
@@ -9,11 +9,11 @@ PortGroup               muniversal 1.0
 name                    libpixman-devel
 conflicts               libpixman
 set my_name             pixman
-version                 0.38.4
+version                 0.42.2
 revision                0
-checksums               rmd160  106b73f871b5e0f8a739a47788fb9fd7a82cb8c5 \
-                        sha256  84abb7fa2541af24d9c3b34bf75d6ac60cc94ac4410061bbb295b66a29221550 \
-                        size    756898
+checksums               rmd160  282e3f6fc956391df67398a414b083d221ffdf4d \
+                        sha256  5747d2ec498ad0f1594878cc897ef5eb6c29e91c53b899f7f71b506785fc1376 \
+                        size    652984
 
 categories              graphics
 platforms               darwin
@@ -23,9 +23,9 @@ license                 X11
 homepage                http://www.pixman.org
 master_sites            https://www.x.org/archive/individual/lib/
 
+use_xz                  yes
 distname                ${my_name}-${version}
-use_bzip2               yes
-use_parallel_build      yes
+dist_subdir             ${my_name}
 
 description             Pixel region Library
 
@@ -34,6 +34,9 @@ long_description        libpixman is a generic library for manipulating pixel \
                         that cover the desired region.
 
 patchfiles              patch-pixman-pixman-vmx.c.diff
+
+depends_build-append \
+                        path:bin/pkg-config:pkgconfig
 
 # llvm-gcc-4.2 makes cairo fail to generate PDFs properly
 # clang on Xcode 4.1 cannot build libpixman


### PR DESCRIPTION
### Description

Update `libpixman-devel` to the latest upstream release, 0.42.2. Will allow us to test dependents, before updating the non-devel port.

See: [Ticket 68269 - libpixman{,-devel}: update to latest release; currently 0.42.x; required by latest release of cairo](https://trac.macports.org/ticket/68269)