### PR TITLE
clang-14: Fix build under Xcode 15, re-enabling sanitizers on macOS 14

### DIFF
--- a/lang/llvm-14/Portfile
+++ b/lang/llvm-14/Portfile
@@ -27,7 +27,7 @@ version                 ${llvm_version}.0.6
 name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision 0 }
-subport                 clang-${llvm_version} { revision 1 }
+subport                 clang-${llvm_version} { revision 2 }
 subport                 lldb-${llvm_version}  { revision 1 }
 subport                 flang-${llvm_version} { revision 0 }
 
@@ -136,7 +136,8 @@ patchfiles-append \
     MachOWriter.cpp-types.patch \
     SyntheticSections.cpp-types.patch \
     patch-lldb-stdc-macros-134877.diff \
-    patch-lldb-fix-swig-lvalue-2128646.diff
+    patch-lldb-fix-swig-lvalue-2128646.diff \
+    patch-xcode-15.diff
 
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     patchfiles-append \
@@ -326,14 +327,6 @@ if { ${subport} eq "clang-${llvm_version}" || ${subport} eq "flang-${llvm_versio
         # sanitizers in compiler_rt fail to build on older systems
         # might be fixable with the use of newer SDK and/or effort if motivated
         # all three toggles are needed to force them off
-        configure.args-append    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
-                                 -DCOMPILER_RT_BUILD_XRAY=OFF \
-                                 -DCOMPILER_RT_BUILD_MEMPROF=OFF
-    }
-
-    if {${os.platform} eq "darwin" && ${os.major} > 22} {
-        # sanitizers also fail to build on macOS14
-        # https://trac.macports.org/ticket/68257
         configure.args-append    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
                                  -DCOMPILER_RT_BUILD_XRAY=OFF \
                                  -DCOMPILER_RT_BUILD_MEMPROF=OFF
@@ -537,6 +530,20 @@ if {${subport} eq "clang-${llvm_version}"} {
     }
     if { ${cxx_stdlib} eq "libstdc++" } {
         default_variants-append +libstdcxx
+    }
+
+    post-configure {
+	# -Wl,-syslibroot referencing the macOS SDK must not appear when linking
+	# runtime libraries for non-macOS platforms, which are cross-built and
+	# used for cross-platform support. The clang build will provide the
+	# proper -isysroot for the platform in these cases. Remove the macOS
+	# SDK.
+        foreach rtl_dir {asan lsan stats tsan/rtl ubsan ubsan_minimal} {
+            set rtl [lindex [split ${rtl_dir} /] 0]
+            foreach rtl_os {ios iossim} {
+                reinplace "s|-Wl,-syslibroot,${configure.sdkroot}||" "${workpath}/build/projects/compiler-rt/lib/${rtl_dir}/CMakeFiles/clang_rt.${rtl}_${rtl_os}_dynamic.dir/link.txt"
+            }
+        }
     }
 }
 

--- a/lang/llvm-14/files/patch-xcode-15.diff
+++ b/lang/llvm-14/files/patch-xcode-15.diff
@@ -1,0 +1,47 @@
+From 786c10cd82a78c210379700b72cf18a018e1e1f7 Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Thu, 28 Sep 2023 11:18:41 -0400
+Subject: [PATCH] [sanitizer] Use consistent checks for XDR
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This is a backport of 28800c2e18972935cd4f942aa428c5e6cc4c1670
+(https://reviews.llvm.org/D130060), which is in llvm-15, to llvm-14,
+however it’s been adapted to be
+pre-8246b2e156568c31e71e16cbaf4c14d316e7c06e
+(https://reviews.llvm.org/D126263), which renamed SANITIZER_MAC (the
+macro in llvm-14) to SANITIZER_APPLE (the macro in llvm-15 and later).
+
+The original change’s description:
+
+> sanitizer_platform_limits_posix.h defines `__sanitizer_XDR ` if
+> `SANITIZER_LINUX && !SANITIZER_ANDROID`, but
+> sanitizer_platform_limits_posix.cpp tries to check it if
+> `HAVE_RPC_XDR_H`. This coincidentally works because macOS has a broken
+> <rpc/xdr.h> which causes `HAVE_RPC_XDR_H` to be 0, but if <rpc/xdr.h>
+> is fixed then clang fails to compile on macOS. Restore the platform
+> checks so that <rpc/xdr.h> can be fixed on macOS.
+
+This has become important with Xcode 15, which contains the macOS 14
+SDK, which does have a fixed <rpc/xdr.h>.
+---
+ .../lib/sanitizer_common/sanitizer_platform_limits_posix.cpp    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 32b8f47ed633..6cefef3f3327 100644
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -1250,7 +1250,7 @@ CHECK_SIZE_AND_OFFSET(group, gr_passwd);
+ CHECK_SIZE_AND_OFFSET(group, gr_gid);
+ CHECK_SIZE_AND_OFFSET(group, gr_mem);
+ 
+-#if HAVE_RPC_XDR_H
++#if HAVE_RPC_XDR_H && !SANITIZER_MAC
+ CHECK_TYPE_SIZE(XDR);
+ CHECK_SIZE_AND_OFFSET(XDR, x_op);
+ CHECK_SIZE_AND_OFFSET(XDR, x_ops);
+-- 
+2.42.0
+


### PR DESCRIPTION
This also reverts the following as they relate to clang-14:

370d81aeeea1 llvm-14: Allow build on darwin23 but disable sanitizers
0c2af4734924 llvm-{10-14}: Restrict to darwin < 23

Note that the actual incompatibility was not strictly between clang-14 and Darwin 23 (macOS 14) as these previous commits suggest. The incompatibility existed between clang-14 and the macOS 14 SDK, which is part of Xcode 15. The incompatibility equally affected clang-14 on macOS 13 (Darwin 22) using Xcode 15.

This also makes the compiler-rt build for various runtimes targeting iOS and iOS Simulator work correctly by removing the macOS SDK -syslibroot when linking, allowing the platform-specific SDK provided by the Clang build to be effective.

Fixes: https://trac.macports.org/ticket/68257

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@cjones051073