### PR TITLE
clang_compilers: include clang-14 on macOS ≥ 14 again

### DIFF
--- a/_resources/port1.0/compilers/clang_compilers.tcl
+++ b/_resources/port1.0/compilers/clang_compilers.tcl
@@ -21,13 +21,13 @@ if {${os.major} >= 11 || ${os.platform} ne "darwin"} {
         # For now limit exposure of clang-16 to ports needing c++14 or newer
         lappend compilers macports-clang-16
     }
-    lappend compilers macports-clang-15
+    lappend compilers macports-clang-15 \
+                      macports-clang-14
     if {${os.major} < 23} {
         # https://trac.macports.org/ticket/68257
-        # clang-14 (and probably older) have build issues on macOS14+
-        # Until resolved do not append to fallback list
-        lappend compilers macports-clang-14 \
-                          macports-clang-13 \
+        # Versions of clang older than clang-14 probably have build issues on
+        # macOS14+. Until resolved do not append to fallback list.
+        lappend compilers macports-clang-13 \
                           macports-clang-12
     }
 }


### PR DESCRIPTION
This undoes the portion of a95b034a84d5 that applied to clang-14, since https://trac.macports.org/ticket/68257 has been fixed and clang-14 now works with Xcode 15.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@cjones051073, I found that you made another commit that pessimized clang-14 on macOS 14. After 93df94134805 and c04f7bf1e4b0, that should no longer be necessary.