### PR TITLE
ki-shell: fix download location

### DIFF
--- a/java/ki-shell/Portfile
+++ b/java/ki-shell/Portfile
@@ -5,7 +5,7 @@ PortGroup       java 1.0
 
 name            ki-shell
 version         0.5.2
-revision        0
+revision        1
 
 categories      java
 platforms       darwin
@@ -23,13 +23,15 @@ long_description The shell is an extensible implementation of Kotlin REPL with r
                 \n* List declared symbols
 
 homepage        https://github.com/Kotlin/kotlin-interactive-shell
-master_sites    https://search.maven.org/remotecontent?filepath=org/jetbrains/kotlinx/${name}/${version}/
+master_sites    https://github.com/Kotlin/kotlin-interactive-shell/releases/download/v${version}/
 
-distname        ${name}-${version}-archive
+distname        ki-archive
 
-checksums       rmd160  95ae27c30a938e3d3bd04d35e231446a89161c1b \
-                sha256  4c1269882f4da8647cb0ad436cc84acf9c2b5f403175de94cc16326dd8b2eb13 \
-                size    64151244
+worksrcdir      ki
+
+checksums       rmd160  3b4577b367997d2b476c9076949f4417d400acfc \
+                sha256  9bd5697f9ec29cd63eaf0b503f46edce377bac73e46552aa12231ac5dbda21e4 \
+                size    64151230
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Fix the installation.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?