### PR TITLE
qt6-qtmultimedia: prevent Xcode 15 build failure

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -996,6 +996,9 @@ subport ${name}-qtmultimedia {
     #     https://code.qt.io/cgit/qt/qtmultimedia.git/tree/src/plugins/multimedia/gstreamer/CMakeLists.txt
     #     https://code.qt.io/cgit/qt/qtmultimedia.git/tree/src/multimedia/configure.cmake
     configure.args-append           -no-gstreamer
+
+    # std::unary_function removed in Xcode clang 15
+    patchfiles-append patch-qtmultimedia_no_std_unary_function.diff
 }
 
 subport ${name}-qt5compat {

--- a/aqua/qt6/files/patch-qtmultimedia_no_std_unary_function.diff
+++ b/aqua/qt6/files/patch-qtmultimedia_no_std_unary_function.diff
@@ -1,0 +1,31 @@
+From 82f7f3de0e90bb7d1447cb710ffd2e1b315ae479 Mon Sep 17 00:00:00 2001
+From: Artem Dyomin <artem.dyomin@qt.io>
+Date: Fri, 26 May 2023 15:15:52 +0200
+Subject: [PATCH] Remove std::unary_function usage
+
+std::unary_function was removed with c++17
+
+Pick-to: 6.5
+Task-number: QTBUG-113782
+Change-Id: I4e330cd1f89dc14936acbccdeee8378ea4938870
+Reviewed-by: Lars Knoll <lars@knoll.priv.no>
+Reviewed-by: Qt CI Bot <qt_ci_bot@qt-project.org>
+Reviewed-by: Pavel Dubsky <pavel.dubsky@qt.io>
+---
+
+diff --git a/src/plugins/multimedia/darwin/camera/avfcamerautility.mm b/src/plugins/multimedia/darwin/camera/avfcamerautility.mm
+index 4334613..fb73ba3 100644
+--- src/plugins/multimedia/darwin/camera/avfcamerautility.mm
++++ src/plugins/multimedia/darwin/camera/avfcamerautility.mm
+@@ -69,9 +69,9 @@
+     }
+ };
+ 
+-struct FormatHasNoFPSRange : std::unary_function<AVCaptureDeviceFormat *, bool>
++struct FormatHasNoFPSRange
+ {
+-    bool operator() (AVCaptureDeviceFormat *format)
++    bool operator() (AVCaptureDeviceFormat *format) const
+     {
+         Q_ASSERT(format);
+         return !format.videoSupportedFrameRateRanges || !format.videoSupportedFrameRateRanges.count;


### PR DESCRIPTION
See: https://trac.macports.org/ticket/68276#comment:7

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6 Intel
Command Line Tools 15

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
