### PR TITLE
rename: new port

### DIFF
--- a/sysutils/rename/Portfile
+++ b/sysutils/rename/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        ap rename 0da9faa241093c90a40b15a9ff4b36e9858d4516
+name                rename
+version             1.601
+revision            0
+categories          sysutils
+license             GPL-1+
+maintainers         @dylanarmstrong openmaintainer
+
+description         rename files using regexp passed from command line
+long_description    This program renames files according to modification \
+                    rules specified on the command line. If no filenames \
+                    are given on the command line, a list of filenames \
+                    will be expected on standard input.
+
+homepage            http://plasmasturm.org/code/rename
+
+checksums           rmd160  e7b89cf872310d7a97134df0d182dbd52ed01360 \
+                    sha256  a146b7968d8ecf39e559cf76b62270c961ba153a8ab46092cf22ace9ef3905fa \
+                    size    14907
+
+depends_lib-append  path:bin/perl:perl5
+
+use_configure       no
+build               {}
+destroot            {
+    file copy ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}.pl
+}
+
+notes "
+    ${name} has been installed as ${name}.pl to avoid conflicts with util-linux.
+"


### PR DESCRIPTION
#### Description

Adds `rename` package.

This is my first Portfile, and this is a slightly odd package. It's not built, it's just a perl script that's copied to bin. I don't think this depends on having any perl specifics as it uses the already existing system perl. Please let me know if there's something I'm missing, thanks!

Please note, this currently conflicts with the `util-linux` package, so I believe this file needs to be renamed when copied to `bin/`. Anyone have any thoughts on what it should be renamed to?

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.0 23A344 x86_64
Xcode 15.0 15A240d

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

