### PR TITLE
py-gnureadline: Fix build when Python's readline module uses editline

### DIFF
--- a/python/py-gnureadline/Portfile
+++ b/python/py-gnureadline/Portfile
@@ -31,6 +31,7 @@ if {${name} ne ${subport}} {
     depends_lib-append  port:ncurses
 
     patchfiles          build.sh.patch \
+                        patch-readline_not_editline.diff \
                         setup.py.patch
 
     post-patch {

--- a/python/py-gnureadline/files/patch-readline_not_editline.diff
+++ b/python/py-gnureadline/files/patch-readline_not_editline.diff
@@ -1,0 +1,49 @@
+From c980529c281ad67b9f08348f1dc3446d015a2590 Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Fri, 29 Sep 2023 10:55:53 -0400
+Subject: [PATCH] =?UTF-8?q?3.x:=20don=E2=80=99t=20include=20editline/readl?=
+ =?UTF-8?q?ine.h,=20use=20the=20embedded=20readline?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When building for a Python whose own readline module has been configured
+to use editline, WITH_EDITLINE will be defined during the
+python-gnureadline build, by virtue of its inclusion of "pyconfig.h"
+(via "Python.h"). This macro being defined caused python-gnureadline to
+a problem because python-gnureadline is expecting and has configured
+itself to use its own embedded copy of GNU readline.
+
+This removes the HAVE_EDITLINE branch to allow the expected readline
+headers to be included.
+
+See https://trac.macports.org/ticket/68265.
+---
+ Modules/3.x/readline.c | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
+
+diff --git Modules/3.x/readline.c Modules/3.x/readline.c
+index fa8cf6f32b10..f35ce10c2406 100644
+--- Modules/3.x/readline.c
++++ Modules/3.x/readline.c
+@@ -28,14 +28,10 @@
+ #  define RESTORE_LOCALE(sl)
+ #endif
+ 
+-#ifdef WITH_EDITLINE
+-#  include <editline/readline.h>
+-#else
+ /* GNU readline definitions */
+-#  undef HAVE_CONFIG_H /* Else readline/chardefs.h includes strings.h */
+-#  include <readline/readline.h>
+-#  include <readline/history.h>
+-#endif
++#undef HAVE_CONFIG_H /* Else readline/chardefs.h includes strings.h */
++#include <readline/readline.h>
++#include <readline/history.h>
+ 
+ #ifdef HAVE_RL_COMPLETION_MATCHES
+ #define completion_matches(x, y) \
+-- 
+2.42.0
+


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68265

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
