### PR TITLE
bossa: Fix build with clang ≥ 15

### DIFF
--- a/cross/bossa/Portfile
+++ b/cross/bossa/Portfile
@@ -28,7 +28,8 @@ default_variants    +wxwidgets
 depends_lib-append  port:readline
 
 # Remove default CXXFLAGS so MacPorts can set them.
-patchfiles          patch-Makefile
+patchfiles          patch-Makefile \
+                    patch-clang_Wunqualified-std-cast-call.diff
 
 # The Makefile is racy
 use_parallel_build  no

--- a/cross/bossa/files/patch-clang_Wunqualified-std-cast-call.diff
+++ b/cross/bossa/files/patch-clang_Wunqualified-std-cast-call.diff
@@ -1,0 +1,28 @@
+From 6e54973c3c758674c3d04b5e2cf12e097006f6a3 Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Fri, 29 Sep 2023 11:03:26 -0400
+Subject: [PATCH] Fix build with clang -Wunqualified-std-cast-call
+
+This warning is enabled by default since clang 15. This fixes a build
+error with those recent versions of clang because BOSSA builds with
+-Werror.
+---
+ src/Samba.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git src/Samba.cpp src/Samba.cpp
+index 490e3936a445..e2076bb6c194 100644
+--- src/Samba.cpp
++++ src/Samba.cpp
+@@ -141,7 +141,7 @@ Samba::init()
+ bool
+ Samba::connect(SerialPort::Ptr port, int bps)
+ {
+-    _port = move(port);
++    _port = std::move(port);
+ 
+     // Try to connect at a high speed if USB
+     _isUsb = _port->isUsb();
+-- 
+2.42.0
+


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@quentinmit