### PR TITLE
PDAL: enable use of system libunwind, drop dependency of port

### DIFF
--- a/gis/pdal/Portfile
+++ b/gis/pdal/Portfile
@@ -7,7 +7,7 @@ PortGroup           github        1.0
 PortGroup           openssl       1.0
 
 github.setup        PDAL PDAL 2.5.6
-revision            1
+revision            2
 categories          gis
 license             BSD
 
@@ -45,17 +45,24 @@ depends_lib-append  port:geos \
                     port:zlib \
                     port:zstd \
                     port:libxml2 \
-                    port:curl \
-                    port:libunwind
+                    port:curl
 
-patchfiles-append   patch-powerpc.diff
+patchfiles-append   patch-powerpc.diff \
+                    patch-libunwind-cmake.diff
+
+# Starting with Xcode 15, the port libunwind is causing crashes,
+# see https://trac.macports.org/ticket/68250 and https://trac.macports.org/ticket/66250.
+if {[vercmp $xcodeversion >= 15.0]} {
+    conflicts       libunwind
+}
 
 configure.args      -DWITH_ZSTD=ON \
                     -DWITH_ZLIB=ON \
                     -DWITH_LZMA=OFF \
                     -DWITH_TESTS=OFF \
                     -DBUILD_TOOLS_NITFWRAP=OFF \
-                    -DWITH_COMPLETION=OFF
+                    -DWITH_COMPLETION=OFF \
+                    -DWITH_BACKTRACE=OFF
 
 configure.args-append \
                     -DBUILD_PLUGIN_CPD=OFF \

--- a/gis/pdal/files/patch-libunwind-cmake.diff
+++ b/gis/pdal/files/patch-libunwind-cmake.diff
@@ -1,0 +1,70 @@
+Committed 2023-09-29 upstreams to master:
+https://github.com/PDAL/PDAL/commit/a14f8648a2f43296e032901d75969ce9070dc563
+
+--- cmake/modules/FindLibunwind.cmake.orig
++++ cmake/modules/FindLibunwind.cmake
+@@ -2,14 +2,21 @@
+ # ~~~~~~~~~
+ # CMake module to search for LIBUNWIND
+ #
+- 
+-find_library(LIBUNWIND_LIBRARY unwind)
++
+ find_path(LIBUNWIND_INCLUDE_DIR libunwind.h)
+ 
+-find_package_handle_standard_args(LIBUNWIND REQUIRED_VARS
+-    LIBUNWIND_LIBRARY LIBUNWIND_INCLUDE_DIR)
++if(NOT APPLE)
++  find_library(LIBUNWIND_LIBRARY unwind)
++  find_package_handle_standard_args(
++    LIBUNWIND REQUIRED_VARS LIBUNWIND_LIBRARY LIBUNWIND_INCLUDE_DIR)
++else()
++  find_package_handle_standard_args(LIBUNWIND
++                                    REQUIRED_VARS LIBUNWIND_INCLUDE_DIR)
++endif()
+ 
+-if (LIBUNWIND_FOUND)
+-  set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARY})
++if(LIBUNWIND_FOUND)
++  if(LIBUNWIND_LIBRARY)
++    set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARY})
++  endif()
+   set(LIBUNWIND_INCLUDE_DIRS ${LIBUNWIND_INCLUDE_DIR})
+ endif()
+
+
+Make backtrace optional, committed 2023-10-02 upstreams to master:
+https://github.com/PDAL/PDAL/commit/95c5e378d6b31b88cbdbabcb75a71ffe9d6a1c10
+
+--- cmake/options.cmake.orig
++++ cmake/options.cmake
+@@ -109,6 +109,11 @@
+     "Choose if PDAL should be built with Abseil support for testing" FALSE)
+ add_feature_info("Abseil debugging support " WITH_ABSEIL "unit tests")
+ 
++option(WITH_BACKTRACE
++    "Build with backtrace" ON)
++add_feature_info("Backtrace" WITH_BACKTRACE
++    "build with backtrace (Libunwind/Libexecinfo) support")
++
+ #
+ # Choose dependent options
+ #
+
+
+--- pdal/util/CMakeLists.txt.orig
++++ pdal/util/CMakeLists.txt
+@@ -11,10 +11,10 @@
+ include(${PDAL_CMAKE_DIR}/unwind.cmake)
+ include(${PDAL_CMAKE_DIR}/utfcpp.cmake)
+ 
+-if(LIBUNWIND_FOUND)
++if(LIBUNWIND_FOUND AND WITH_BACKTRACE)
+     set(BACKTRACE_SOURCE BacktraceUnwind.cpp)
+     set(BACKTRACE_LIBRARIES ${LIBUNWIND_LIBRARIES} ${CMAKE_DL_LIBS})
+-elseif(LIBEXECINFO_FOUND)
++elseif(LIBEXECINFO_FOUND AND WITH_BACKTRACE)
+     set(BACKTRACE_SOURCE BacktraceExecinfo.cpp)
+     set(BACKTRACE_LIBRARIES ${LIBEXECINFO_LIBRARIES} ${CMAKE_DL_LIBS})
+ else()
+


### PR DESCRIPTION
#### Description

This doesn't solve the problem with Xcode 15, automatically linking to MacPorts' libunwind (if present) to all C++ based ports, but it makes it possible to some degree avoid installing the port in the first place.

See https://trac.macports.org/ticket/68250
See https://trac.macports.org/ticket/66250

The patch added with this PR is already committed to master upstreams.

This at least minimises the risk of "polluting" direct PDAL dependants qgis3, grass, saga with unwanted libunwind linking.


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
