### PR TITLE
py-luma.emulator: new port along with new dependencies py-luma.core, py-pyftdi, py-smbus2

### DIFF
--- a/python/py-cbor2/Portfile
+++ b/python/py-cbor2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-cbor2
-version             5.2.0
+version             5.4.6
 platforms           darwin
 license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
@@ -15,9 +15,9 @@ long_description    {*}${description}
 
 homepage            https://github.com/agronholm/cbor2
 
-checksums           rmd160  3085abd98292c515ffb75e5ec246ba56f3f29f40 \
-                    sha256  a33aa2e5534fd74401ac95686886e655e3b2ce6383b3f958199b6e70a87c94bf \
-                    size    81467
+checksums           rmd160  4451a31fe532b7dc9bf654d6125129740838d1d7 \
+                    sha256  b893500db0fe033e570c3adc956af6eefc57e280026bd2d86fd53da9f1e594d7 \
+                    size    86909
 
 python.versions     38 39 310 311
 
@@ -25,4 +25,5 @@ if {${name} ne ${subport}} {
     depends_build-append \
                     port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm
+    test.run        yes
 }

--- a/python/py-luma.core/Portfile
+++ b/python/py-luma.core/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+name                py-luma.core
+
+github.setup        rm-hull luma.core 2.4.1
+github.tarball_from archive
+
+revision            0
+maintainers         nomaintainer
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+
+description         Drawing and text rendering for small displays, core module
+long_description    luma.core is a component library providing a \
+                    Pillow-compatible drawing canvas for Python 3, and other \
+                    functionality to support drawing primitives and \
+                    text-rendering capabilities for small displays.
+
+checksums           rmd160  69f9aea882e320ff1429f59dcf04f25aa177d444 \
+                    sha256  e6610de6db55b9ae81a5825961b85f9cf39e27a29940c34b1ae437e37d9a135e \
+                    size    572562
+python.versions     38 39 310 311
+python.pep517       yes
+
+if {${name} ne ${subport}} {
+    depends_run-append \
+                    port:py${python.version}-Pillow \
+                    port:py${python.version}-cbor2 \
+                    port:py${python.version}-smbus2 \
+                    port:py${python.version}-pyftdi
+    depends_test-append \
+                    port:py${python.version}-pytest-timeout
+    test.run        yes
+}

--- a/python/py-luma.emulator/Portfile
+++ b/python/py-luma.emulator/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+name                py-luma.emulator
+
+github.setup        rm-hull luma.emulator 1.5.0
+github.tarball_from archive
+
+revision            0
+maintainers         nomaintainer
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+
+description         Drawing and text rendering for small displays, emulator \
+                    module
+long_description    luma.emulator provides a series of pseudo-display devices \
+                    which allow the luma.core components to be used without \
+                    running a physical device.
+
+checksums           rmd160  3ead715baa2b76ee830f4409852370d42d3ba54e \
+                    sha256  903da7fdb736822c69e6ce1e7141e37674cbb664567e04ef3b30b1bc3f261b5f \
+                    size    903555
+python.versions     38 39 310 311
+python.pep517       yes
+
+if {${name} ne ${subport}} {
+    depends_run-append \
+                    port:py${python.version}-luma.core \
+                    port:py${python.version}-game
+    depends_test-append \
+                    port:py${python.version}-pytest-timeout
+    test.run        yes
+    test.env-append PYTHONPATH=${worksrcpath}/build/lib:${worksrcpath}
+    test.args
+}

--- a/python/py-pyftdi/Portfile
+++ b/python/py-pyftdi/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+name                py-pyftdi
+
+github.setup        eblot pyftdi 0.55.0 v
+github.tarball_from archive
+
+revision            0
+maintainers         nomaintainer
+platforms           {darwin any}
+supported_archs     noarch
+license             BSD
+
+description         PyFtdi aims at providing a user-space driver for popular \
+                    FTDI devices, implemented in pure Python language.
+long_description    {*}${description}
+
+checksums           rmd160  dd4a6928cf7a0c93faea0e801655815b9ae3d671 \
+                    sha256  6d55af8cb67f8282aea284df5d73605295e61db5d65da72a810282b25cc9ff2c \
+                    size    186282
+python.versions     38 39 310 311
+python.pep517       yes
+
+if {${name} ne ${subport}} {
+    patchfiles      patch-1_test_module_setup.diff \
+                    patch-2_test_untestable_base.diff
+
+    depends_run-append \
+                    port:py${python.version}-pyusb \
+                    port:py${python.version}-serial
+    depends_test-append \
+                    port:py${python.version}-ruamel-yaml
+    test.run        yes
+    test.env-append FTDI_VIRTUAL=1
+
+    # This isn't all tests, because many tests require specific devices to be
+    # connected. This only includes tests that don't require specific devices,
+    # and tests that can be mocked (some via FTDI_VIRTUAL above) so that they
+    # don't require specific devices. See pyftdi/.github/workflows.
+    test.target     pyftdi/tests/toolsimport.py \
+                    pyftdi/tests/mockusb.py \
+                    pyftdi/tests/gpio.py \
+                    pyftdi/tests/eeprom_mock.py
+}

--- a/python/py-pyftdi/files/patch-1_test_module_setup.diff
+++ b/python/py-pyftdi/files/patch-1_test_module_setup.diff
@@ -1,0 +1,112 @@
+https://github.com/eblot/pyftdi/pull/356
+https://github.com/eblot/pyftdi/commit/c131ff2c302b1bfe2ec6ec53331f55cae16b4b66.patch
+
+From b82c5e264e82052440cf98da070d86f81c734c4a Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Wed, 16 Aug 2023 12:00:04 -0400
+Subject: [PATCH 1/2] tests: use module_setup to establish virtual mock
+ environment
+
+This makes it possible to run these virtual mock tests under pytest,
+which does not run main.
+---
+ pyftdi/tests/eeprom_mock.py | 12 ++++++------
+ pyftdi/tests/gpio.py        | 12 ++++++------
+ pyftdi/tests/mockusb.py     |  6 +++---
+ 3 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git pyftdi/tests/eeprom_mock.py pyftdi/tests/eeprom_mock.py
+index 7acf99f3048d..78665789c4c8 100644
+--- pyftdi/tests/eeprom_mock.py
++++ pyftdi/tests/eeprom_mock.py
+@@ -269,7 +269,7 @@ def virtualize():
+         raise AssertionError('Cannot load virtual USB backend')
+ 
+ 
+-def main():
++def setup_module():
+     import doctest
+     doctest.testmod(modules[__name__])
+     debug = to_bool(environ.get('FTDI_DEBUG', 'off'))
+@@ -288,10 +288,6 @@ def main():
+     FtdiLogger.set_level(loglevel)
+     FtdiLogger.set_formatter(formatter)
+     virtualize()
+-    try:
+-        ut_main(defaultTest='suite')
+-    except KeyboardInterrupt:
+-        pass
+ 
+ 
+ if __name__ == '__main__':
+@@ -300,4 +296,8 @@ if __name__ == '__main__':
+     #  FTDI_LOGLEVEL: a Logger debug level, to define log verbosity
+     #  FTDI_DEBUG: to enable/disable debug mode
+     #  FTDI_VIRTUAL: to use a virtual device rather than a physical device
+-    main()
++    setup_module()
++    try:
++        ut_main(defaultTest='suite')
++    except KeyboardInterrupt:
++        pass
+diff --git pyftdi/tests/gpio.py pyftdi/tests/gpio.py
+index 4d159d51ac78..bdb0cbc892ea 100755
+--- pyftdi/tests/gpio.py
++++ pyftdi/tests/gpio.py
+@@ -633,7 +633,7 @@ def virtualize():
+         raise AssertionError('Cannot load virtual USB backend') from exc
+ 
+ 
+-def main():
++def setup_module():
+     import doctest
+     doctest.testmod(modules[__name__])
+     debug = to_bool(environ.get('FTDI_DEBUG', 'off'))
+@@ -652,10 +652,6 @@ def main():
+     FtdiLogger.set_level(loglevel)
+     FtdiLogger.set_formatter(formatter)
+     virtualize()
+-    try:
+-        ut_main(defaultTest='suite')
+-    except KeyboardInterrupt:
+-        pass
+ 
+ 
+ if __name__ == '__main__':
+@@ -664,4 +660,8 @@ if __name__ == '__main__':
+     #  FTDI_LOGLEVEL: a Logger debug level, to define log verbosity
+     #  FTDI_DEBUG: to enable/disable debug mode
+     #  FTDI_VIRTUAL: to use a virtual device rather than a physical device
+-    main()
++    setup_module()
++    try:
++        ut_main(defaultTest='suite')
++    except KeyboardInterrupt:
++        pass
+diff --git pyftdi/tests/mockusb.py pyftdi/tests/mockusb.py
+index 57d03e46d2cc..17553b1e7d88 100755
+--- pyftdi/tests/mockusb.py
++++ pyftdi/tests/mockusb.py
+@@ -839,7 +839,7 @@ def suite():
+     return suite_
+ 
+ 
+-def main():
++def setup_module():
+     testmod(modules[__name__])
+     debug = to_bool(environ.get('FTDI_DEBUG', 'off'))
+     if debug:
+@@ -866,8 +866,8 @@ def main():
+         MockLoader = backend.create_loader()
+     except AttributeError as exc:
+         raise AssertionError('Cannot load virtual USB backend') from exc
+-    ut_main(defaultTest='suite')
+ 
+ 
+ if __name__ == '__main__':
+-    main()
++    setup_module()
++    ut_main(defaultTest='suite')
+-- 
+2.41.0
+

--- a/python/py-pyftdi/files/patch-2_test_untestable_base.diff
+++ b/python/py-pyftdi/files/patch-2_test_untestable_base.diff
@@ -1,0 +1,74 @@
+https://github.com/eblot/pyftdi/pull/356
+https://github.com/eblot/pyftdi/commit/ed33b4916d382f8653d40c9f66d05f5efcf66a97.patch
+
+From 915fc5b461ed2b142f1e23ab7f1e3595fbaea3b1 Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Wed, 16 Aug 2023 14:31:52 -0400
+Subject: [PATCH 2/2] tests: don't present untestable base classes via pytest
+
+---
+ pyftdi/tests/eeprom_mock.py | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git pyftdi/tests/eeprom_mock.py pyftdi/tests/eeprom_mock.py
+index 78665789c4c8..ced748d2c902 100644
+--- pyftdi/tests/eeprom_mock.py
++++ pyftdi/tests/eeprom_mock.py
+@@ -18,7 +18,7 @@ from pyftdi.ftdi import FtdiError
+ VirtLoader = None
+ 
+ 
+-class FtdiTestCase(TestCase):
++class FtdiBaseCase:
+     """Common features for all tests.
+     """
+ 
+@@ -37,7 +37,7 @@ class FtdiTestCase(TestCase):
+         pass
+ 
+ 
+-class EepromMirrorTestCase(FtdiTestCase):
++class EepromMirrorBaseCase(FtdiBaseCase):
+     """Test FTDI EEPROM mirror feature (duplicate eeprom data over 2 eeprom
+     sectors). Generally this is tested with a virtual eeprom (by setting
+     environment variable FTDI_VIRTUAL=on), however you may also test with an
+@@ -52,7 +52,7 @@ class EepromMirrorTestCase(FtdiTestCase):
+ 
+     @classmethod
+     def setUpClass(cls):
+-        FtdiTestCase.setUpClass()
++        FtdiBaseCase.setUpClass()
+         if VirtLoader:
+             cls.loader = VirtLoader()
+             with open(cls.TEST_CONFIG_FILENAME, 'rb') as yfp:
+@@ -180,15 +180,15 @@ class EepromMirrorTestCase(FtdiTestCase):
+                 eeprom.data[ii + eeprom.mirror_sector])
+ 
+ 
+-class EepromMirrorFt232hTestCase(EepromMirrorTestCase):
++class EepromMirrorFt232hTestCase(EepromMirrorBaseCase, TestCase):
+     TEST_CONFIG_FILENAME = 'pyftdi/tests/resources/ft232h.yaml'
+ 
+ 
+-class EepromMirrorFt2232hTestCase(EepromMirrorTestCase):
++class EepromMirrorFt2232hTestCase(EepromMirrorBaseCase, TestCase):
+     TEST_CONFIG_FILENAME = 'pyftdi/tests/resources/ft2232h.yaml'
+ 
+ 
+-class EepromMirrorFt230xTestCase(FtdiTestCase):
++class EepromMirrorFt230xTestCase(FtdiBaseCase, TestCase):
+     """Test FTDI eeprom with non-mirroring capabilities to ensure it works as
+        expected.
+     """
+@@ -196,7 +196,7 @@ class EepromMirrorFt230xTestCase(FtdiTestCase):
+ 
+     @classmethod
+     def setUpClass(cls):
+-        FtdiTestCase.setUpClass()
++        FtdiBaseCase.setUpClass()
+         if VirtLoader:
+             cls.loader = VirtLoader()
+             with open(cls.TEST_CONFIG_FILENAME, 'rb') as yfp:
+-- 
+2.41.0
+

--- a/python/py-smbus2/Portfile
+++ b/python/py-smbus2/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-smbus2
+version             0.4.3
+revision            0
+maintainers         nomaintainer
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+
+description         A drop-in replacement for smbus-cffi/smbus-python in pure \
+                    Python
+long_description    smbus2 is (yet another) pure Python implementation of of \
+                    the python-smbus package.
+
+homepage            https://github.com/kplindegaard/smbus2
+
+checksums           rmd160  bbcdb5b8753033ef74f2790c930aa41a84c8cb32 \
+                    sha256  36f2288a8e1a363cb7a7b2244ec98d880eb5a728a2494ac9c71e9de7bf6a803a \
+                    size    16801
+python.versions     38 39 310 311
+python.pep517       yes
+
+if {${name} ne ${subport}} {
+    test.run        yes
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

The py-pyftdi patches are being upstreamed at https://github.com/eblot/pyftdi/pull/356.

When I developed this, py-smbus2 needed patches, but they’ve already been upstreamed at https://github.com/kplindegaard/smbus2/pull/92.