### PR TITLE
R: fix port fetch for a few packages which used macports_distfiles

### DIFF
--- a/R/R-R6/Portfile
+++ b/R/R-R6/Portfile
@@ -3,23 +3,24 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             r-universe r-lib R6 2.5.1.9000
-revision            0
+R.setup             github r-lib R6 5782335928a1c3e5996555c0cfc66851e6b9bf39
+version             2.5.1.9000
+revision            1
 categories-append   devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
 description         Encapsulated object-oriented programming for R
 long_description    {*}${description}
 homepage            https://R6.r-lib.org
-checksums           rmd160  2e2df8de345f578b8c9f1790abc123e9963d10df \
-                    sha256  3322f681c107ace85aa99a69d688afe43414b437a5dde898799943fe15e5bc09 \
-                    size    171488
+checksums           rmd160  e2ffbed068b83057f3bb76d059311eb7e9585e12 \
+                    sha256  8fe9bf37d83f022c97ccf4e096e45665e4ea400f18c9dc99f5a4e321a2d163c3 \
+                    size    239214
 supported_archs     noarch
 
-# Move to GitHub commit-based or CRAN-based version with the next update.
-# Turned out, R-universe publishes packages from every master commit without increasing their versions.
-# That breaks checksums and is generally a recipe for a disaster.
-master_sites        macports_distfiles
+# Something went wrong with macports_distfiles here: https://trac.macports.org/ticket/68293
+# Switch to commit-based GitHub version for now.
+# Drop dist_subdir with the next version update.
+dist_subdir         ${name}/${version}_1
 
 depends_test-append port:R-pryr \
                     port:R-testthat

--- a/R/R-RcppEigen/Portfile
+++ b/R/R-RcppEigen/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             r-universe rcppcore RcppEigen 0.3.3.9.3.1
+R.setup             github rcppcore RcppEigen 56dc0cca08fdc796a9402ba0803d58e924ed7f67
+version             0.3.3.9.3.2
 revision            0
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -11,14 +12,9 @@ license             {GPL-2 GPL-3}
 description         Rcpp integration for the Eigen Templated Linear Algebra Library
 long_description    {*}${description}
 homepage            https://github.com/RcppCore/RcppEigen
-checksums           rmd160  16326313ec9a3eb1c431378b108b3cd8bec84b5d \
-                    sha256  405b2addf75f48e4b22d718ee6229f90000ef71202cf0bb1327462955f7ea760 \
-                    size    1897382
-
-# Move to GitHub commit-based or CRAN-based version with the next update.
-# Turned out, R-universe publishes packages from every master commit without increasing their versions.
-# That breaks checksums and is generally a recipe for a disaster.
-master_sites        macports_distfiles
+checksums           rmd160  845b8a218db925d14dac93bbda83b6d132324e65 \
+                    sha256  dd39707171e27918919b76d37503bd30fe8575e2505dd84e59ed830bc4805dce \
+                    size    3119694
 
 depends_lib-append  port:R-Rcpp
 

--- a/R/R-cli/Portfile
+++ b/R/R-cli/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             r-universe r-lib cli 3.6.1.9000
-revision            0
+R.setup             github r-lib cli 641fe8cb1c90f1e18245e124facd39af2253cb6e
+version             3.6.1.9000
+revision            1
 categories-append   devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
@@ -12,14 +13,14 @@ description         Tools for making beautiful & useful command line interfaces
 long_description    A suite of tools to build attractive command line interfaces (CLIs) \
                     from semantic elements: headings, lists, alerts, paragraphs etc.
 homepage            https://cli.r-lib.org
-checksums           rmd160  2783259b5d359d16aad9a8e55c165b198f7b0181 \
-                    sha256  17c5fc5fc2aec60acba81db1f40da341eb768aaef6430929565668f8696f9575 \
-                    size    1129467
+checksums           rmd160  b9a07c2c3ffbbf31cb555956bd783a447dec6d55 \
+                    sha256  4d015994a7a5c148d3b24e7bca983f7d55fb7aa9308f81c645676aa5791e54ae \
+                    size    566352
 
-# Move to GitHub commit-based or CRAN-based version with the next update.
-# Turned out, R-universe publishes packages from every master commit without increasing their versions.
-# That breaks checksums and is generally a recipe for a disaster.
-master_sites        macports_distfiles
+# Something went wrong with macports_distfiles here: https://trac.macports.org/ticket/68293
+# Switch to commit-based GitHub version for now.
+# Drop dist_subdir with the next version update.
+dist_subdir         ${name}/${version}_1
 
 depends_test-append port:R-callr \
                     port:R-covr \

--- a/R/R-ps/Portfile
+++ b/R/R-ps/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             r-universe r-lib ps 1.7.5.9000
-revision            0
+R.setup             github r-lib ps 357f9c01f5db95b67ce9e230282391bc835afca4
+version             1.7.5.9000
+revision            1
 categories-append   sysutils
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
@@ -12,14 +13,14 @@ description         R package to query, list and manipulate system processes
 long_description    ps implements an API to query and manipulate system processes. \
                     Most of its code is based on the psutil Python package.
 homepage            https://ps.r-lib.org
-checksums           rmd160  83924507dda8d3deaf1fc8b74396e4237e3890ea \
-                    sha256  a2060084f48345fd290085f956dd9186b04bce7956752552856b75ce3c8614a6 \
-                    size    365600
+checksums           rmd160  63f8cfe40f15e94a232ddcc0b3f841bce3388d63 \
+                    sha256  0475be42b8f727ef93c73e8fc2a589d8b0f138278e179a26405cc8dbe2bb0a5c \
+                    size    131854
 
-# Move to GitHub commit-based or CRAN-based version with the next update.
-# Turned out, R-universe publishes packages from every master commit without increasing their versions.
-# That breaks checksums and is generally a recipe for a disaster.
-master_sites        macports_distfiles
+# Something went wrong with macports_distfiles here: https://trac.macports.org/ticket/68293
+# Switch to commit-based GitHub version for now.
+# Drop dist_subdir with the next version update.
+dist_subdir         ${name}/${version}_1
 
 configure.env-append \
                     RBIN=${r.cmd}
@@ -35,5 +36,5 @@ depends_test-append port:R-callr \
                     port:R-testthat \
                     port:R-webfakes
 
-# Some tests fail on older macOS: https://github.com/r-lib/ps/issues/137
+# FIXME: some tests fail on older macOS: https://github.com/r-lib/ps/issues/137
 test.run            yes

--- a/R/R-rlang/Portfile
+++ b/R/R-rlang/Portfile
@@ -3,22 +3,23 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             r-universe r-lib rlang 1.1.1.9000
-revision            0
+R.setup             github r-lib rlang c55f6027928d3104ed449e591e8a225fcaf55e13
+version             1.1.1.9000
+revision            1
 categories-append   devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
 description         Low-level API for programming with R
 long_description    rlang is a collection of frameworks and APIs for programming with R.
 homepage            https://rlang.r-lib.org
-checksums           rmd160  74ec15990adaf23bf72d79be1950130d3196c0dd \
-                    sha256  6030b21a5ea9d5c9361d854591554e72973022c161bc14e928dca674b80dcde1 \
-                    size    1345259
+checksums           rmd160  5b4470d674fd455d740fd194ab3f20067547fa6e \
+                    sha256  52bdffd23fe42a13b4dc6241fc7f60f255b3dd6e2f7ef23ada8a95c6c5bbeefd \
+                    size    818084
 
-# Move to GitHub commit-based or CRAN-based version with the next update.
-# Turned out, R-universe publishes packages from every master commit without increasing their versions.
-# That breaks checksums and is generally a recipe for a disaster.
-master_sites        macports_distfiles
+# Something went wrong with macports_distfiles here: https://trac.macports.org/ticket/68293
+# Switch to commit-based GitHub version for now.
+# Drop dist_subdir with the next version update.
+dist_subdir         ${name}/${version}_1
 
 depends_test-append port:R-cli \
                     port:R-covr \


### PR DESCRIPTION
#### Description

Something got broken with `macports_distfiles`: https://trac.macports.org/ticket/68293
Switch all ports using it to GitHub commits. (The issue initially arose due to `r-universe` odd manner of stealth-updating.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->