### PR TITLE
qtads: update to 3.4.0

### DIFF
--- a/games/qtads/Portfile
+++ b/games/qtads/Portfile
@@ -4,11 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-# https://trac.macports.org/ticket/65293
-use_xcode           yes
-
-github.setup        realnc qtads 3.3.0 v
-revision            1
+github.setup        realnc qtads 3.4.0 v
+revision            0
 github.tarball_from releases
 
 categories          games
@@ -17,6 +14,7 @@ license             GPL-3+
 maintainers         nomaintainer
 
 distname            ${github.project}-${github.version}-source
+worksrcdir          ${name}-${version}
 
 description         A multimedia TADS interactive fiction player.
 long_description    QTads is a so called \"interpreter\" for games created with the Text \
@@ -26,9 +24,9 @@ long_description    QTads is a so called \"interpreter\" for games created with 
 
 homepage            https://realnc.github.io/qtads/
 
-checksums           rmd160  2a85fcc0c606a3cf81fec00eb953cfc93cdeab0f \
-                    sha256  02d62f004adbcf1faaa24928b3575a771d289df0fea9a97705d3bc528d9164a1 \
-                    size    6085960
+checksums           rmd160  9647ec92b0a68d95a05d60c8416e15161278b623 \
+                    sha256  3c8f1b47ee42d89753d68e7c804ca3677b0c89a5d765d1fd4f80f9cdc29d3473 \
+                    size    6059316
 
 use_xz              yes
 


### PR DESCRIPTION

#### Description

 - update to 3.4.0
 - fix "Could not resolve SDK Path" by removing use_xcode, see https://trac.macports.org/ticket/65293
 - fixes https://trac.macports.org/ticket/67687

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
