### PR TITLE
MacVim: remove pre-release software updates button from preferences

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -10,7 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 set vim_version     9.0
 set release         177
 github.setup        macvim-dev macvim ${release} release-
-revision            2
+revision            3
 name                MacVim
 version             ${vim_version}.release${release}
 categories          editors

--- a/editors/MacVim/files/patch-remove-updater.diff
+++ b/editors/MacVim/files/patch-remove-updater.diff
@@ -95,3 +95,21 @@
              </subviews>
              <point key="canvasLocation" x="137.5" y="-27"/>
          </customView>
+@@ -558,17 +494,6 @@
+             <rect key="frame" x="0.0" y="0.0" width="483" height="367"/>
+             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+             <subviews>
+-                <button id="4Y5-mA-blQ" userLabel="Pre-release channel">
+-                    <rect key="frame" x="19" y="97" width="249" height="18"/>
+-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+-                    <buttonCell key="cell" type="check" title="Enable pre-release software updates" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="rTs-jS-K8M">
+-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+-                        <font key="font" metaFont="system"/>
+-                    </buttonCell>
+-                    <connections>
+-                        <binding destination="58" name="value" keyPath="values.MMUpdaterPrereleaseChannel" id="Kb1-yL-bmN"/>
+-                    </connections>
+-                </button>
+                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="826">
+                     <rect key="frame" x="18" y="218" width="449" height="56"/>
+                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>


### PR DESCRIPTION
#### Description

Removes the pre-release software updates channel opt-in button from the preferences displayed under Preferences → Advanced.

This option was already effectively disabled by dab2d43f685672a2603caf5ff9451d01aaaf2137 which removes the corresponding outlet property. 
This change to the `patch-remove-updater.diff` simply removes the button and associated description.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.6 22G120 arm64
Xcode 14.3.1 14E300c

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
  - Unable to run with trace-mode due to [#66356](https://trac.macports.org/ticket/66358)
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
