### PR TITLE
pure-ftpd: delete unusable EOL variants

### DIFF
--- a/net/pure-ftpd/Portfile
+++ b/net/pure-ftpd/Portfile
@@ -88,17 +88,9 @@ post-destroot {
 variant uploadscript description "Configures ${name} to support post processing of uploaded files" {
     configure.args-append --with-uploadscript
 }
-variant mysql5 \
-    conflicts mysql51 mysql55 mysql56 mysql57 mariadb percona \
-    description "Enable MySQL 5.1 support" {
-
-    depends_lib-append          port:mysql5
-    configure.env-append        PATH=${prefix}/lib/mysql5/bin:$env(PATH)
-    configure.args-append       --with-mysql
-}
 
 variant mysql51 \
-    conflicts mysql5 mysql55 mysql56 mysql57 mariadb percona \
+    conflicts mysql55 mysql56 mysql57 mariadb percona \
     description "Enable MySQL 5.1 support" {
 
     depends_lib-append          port:mysql51
@@ -107,7 +99,7 @@ variant mysql51 \
 }
 
 variant mysql55 \
-    conflicts mysql5 mysql51 mysql56 mysql57 mariadb percona \
+    conflicts mysql51 mysql56 mysql57 mariadb percona \
     description "Enable MySQL 5.5 support" {
 
     depends_lib-append          port:mysql55
@@ -116,7 +108,7 @@ variant mysql55 \
 }
 
 variant mysql56 \
-    conflicts mysql5 mysql51 mysql55 mysql57 mariadb percona \
+    conflicts mysql51 mysql55 mysql57 mariadb percona \
     description "Enable MySQL 5.6 support" {
 
     depends_lib-append          port:mysql56
@@ -125,7 +117,7 @@ variant mysql56 \
 }
 
 variant mysql57 \
-    conflicts mysql5 mysql51 mysql55 mysql56 mariadb percona \
+    conflicts mysql51 mysql55 mysql56 mariadb percona \
     description "Enable MySQL 5.6 support" {
 
     depends_lib-append          port:mysql57
@@ -134,7 +126,7 @@ variant mysql57 \
 }
 
 variant mariadb \
-    conflicts mysql5 mysql51 mysql55 mysql56 mysql57 percona \
+    conflicts mysql51 mysql55 mysql56 mysql57 percona \
     description "Enable MariaDB (MySQL) support" {
 
     depends_lib-append          port:mariadb
@@ -143,7 +135,7 @@ variant mariadb \
 }
 
 variant percona \
-    conflicts mysql5 mysql51 mysql55 mysql56 mysql57 mariadb \
+    conflicts mysql51 mysql55 mysql56 mysql57 mariadb \
     description "Enable Percona (MySQL) support" {
 
     depends_lib-append          port:percona
@@ -151,32 +143,14 @@ variant percona \
     configure.args-append       --with-mysql=yes
 }
 
-variant postgresql82 \
-    conflicts mysql5 postgresql83 postgresql84 \
-    description "Enable PostgreSQL 8.2 support" {
-
-    depends_lib-append port:postgresql82
-    configure.args-append --with-pgsql
-    configure.env-append PATH=${prefix}/lib/postgresql82/bin:$env(PATH)
-}
-
-variant postgresql83 \
-    conflicts mysql5 postgresql82 postgresql84 \
-    description "Enable PostgreSQL 8.3 support" {
-
-    depends_lib-append port:postgresql83
-    configure.args-append --with-pgsql
-    configure.env-append PATH=${prefix}/lib/postgresql83/bin:$env(PATH)
-}
-
-variant postgresql84 \
-    conflicts mysql5 postgresql82 postgresql83 \
-    description "Enable PostgreSQL 8.4 support" {
-
-    depends_lib-append port:postgresql84
-    configure.args-append --with-pgsql
-    configure.env-append PATH=${prefix}/lib/postgresql84/bin:$env(PATH)
-}
+#variant postgresql84 \
+#    conflicts postgresql82 postgresql83 \
+#    description "Enable PostgreSQL 8.4 support" {
+#
+#    depends_lib-append port:postgresql84
+#    configure.args-append --with-pgsql
+#    configure.env-append PATH=${prefix}/lib/postgresql84/bin:$env(PATH)
+#}
 
 variant tls \
     description "Encryption of ftp control and data channels using SSL/TLS" {


### PR DESCRIPTION
Not deprecating first: for over 4 years, these have been unusable because their dependency cannot build.

See: https://trac.macports.org/ticket/43431

#### Description

Proposed in hopes of eventually removing EOL versions of MySQL, PostgreSQL, etc. from MacPorts. If desirable, I am leaving behind a commented-out postgresql example in case someone else wants to update it.

<!-- Note: it is best to make pull requests from a branch rather than from master -->



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
