### PR TITLE
pgpool-II: delete unusable EOL variants

### DIFF
--- a/databases/pgpool-II/Portfile
+++ b/databases/pgpool-II/Portfile
@@ -36,17 +36,6 @@ livecheck.type	regex
 livecheck.url	http://pgfoundry.org/frs/?group_id=1000055
 livecheck.regex	pgpool-II-(\[0-9\\.\]+)\\.tar\\.gz
 
-variant postgresql82 description {uses postgresql82 installation} {
-	depends_build		port:postgresql82
-	configure.env		PATH=$env(PATH):${prefix}/lib/postgresql82/bin
-}
-
-
-variant postgresql83 description {uses postgresql83 installation} {
-	depends_build		port:postgresql83
-	configure.env		PATH=$env(PATH):${prefix}/lib/postgresql83/bin
-}
-
 variant postgresql84 description {uses postgresql84 installation} {
 	depends_build		port:postgresql84
 	configure.env		PATH=$env(PATH):${prefix}/lib/postgresql84/bin


### PR DESCRIPTION
Not deprecating first: for over 4 years, these have been unusable because their dependency cannot build.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
