### PR TITLE
lilypond-devel: upgrade to 2.25.8

### DIFF
--- a/textproc/lilypond/Portfile
+++ b/textproc/lilypond/Portfile
@@ -53,12 +53,12 @@ if {${subport} eq ${name}} {
 
     set livecheck_url "source.html"
 } else {
-    version         2.25.7
-    revision        1
+    version         2.25.8
+    revision        0
     conflicts       lilypond
-    checksums       rmd160  b76ac58bfe46f5e4076d972b8495aeab33492aae \
-                    sha256  6fba6b6dee259d47e22c672659bae35d34d7a894d7e0fb003016d2bd98072f02 \
-                    size    18978409
+    checksums       rmd160  95fa8dc7cd037fd69096db4a7d0b8b50b3cc9428 \
+                    sha256  a7271b1a6569dc754a3801a97b88049815a3313d81aab4aa2884ac019084931d \
+                    size    18987566
 
     set livecheck_url "development.html"
 }


### PR DESCRIPTION
Note that '+docs' is currently broken.  However, it doesn't make sense to fix this version because in the soon to be released version 2.25.9 the ancient `texi2html` script (for which there never was a port in MacPorts) will be no longer needed, which means that a thorough revision of this Portfile is in order to build the complete documentation (and not just the info files).

#### Description

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
