### PR TITLE
vtk: Update 9.1.0 --> 9.2.6

### DIFF
--- a/graphics/vtk/Portfile
+++ b/graphics/vtk/Portfile
@@ -14,15 +14,17 @@ compiler.cxx_standard 2011
 compiler.blacklist-append {clang < 900}
 
 name                vtk
-version             9.1.0
-revision            4
+version             9.2.6
+revision            0
 categories          graphics devel
 platforms           darwin
 license             BSD
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
-maintainers         {stromnov @stromnov} {@rdbisme gmail.com:rubendibattista} openmaintainer
+maintainers         {stromnov @stromnov} \
+                    {@Dave-Allured noaa.gov:dave.allured} \
+                    openmaintainer
 
 description         Visualization Toolkit (VTK)
 
@@ -35,9 +37,9 @@ master_sites        http://www.vtk.org/files/release/${branch}
 
 distname            VTK-${version}
 
-checksums           rmd160  bfdaaa9ddc5723becf338e1c0374b0acab740ef1 \
-                    sha256  8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96 \
-                    size    47871165
+checksums           rmd160  50c1a39c75e95262bf66b8424ae891b6ac39f25b \
+                    sha256  06fc8d49c4e56f498c40fcb38a563ed8d4ec31358d0101e8988f0bb4d539dd12 \
+                    size    53810904
 
 mpi.setup
 


### PR DESCRIPTION
#### Description

* Update to VTK 9.2.6, latest stable as of 2023 Oct 1.
* Add myself as co-maintainer.
* On request, remove a previous co-maintainer.
* Clean up issues from preliminary PR https://github.com/macports/macports-ports/pull/20476.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  11_x86, 12_x86, 13_x86.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] **(N/A)** referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
