### PR TITLE
ldid-procursus: Include license file in destroot

### DIFF
--- a/devel/ldid-procursus/Portfile
+++ b/devel/ldid-procursus/Portfile
@@ -7,11 +7,11 @@ PortGroup           makefile 1.0
 
 name                ldid-procursus
 version             2.1.5-procursus7
+revision            1
 categories          devel
 license             AGPL-3
-platforms           darwin
 conflicts           ldid
-maintainers         @therealketo procurs.us:team openmaintainer
+maintainers         {@therealketo procurs.us:team} openmaintainer
 description         Put real or fake signatures in a Mach-O.
 long_description    ${description}
 
@@ -29,4 +29,8 @@ post-destroot {
     set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
     xinstall -d ${zsh_comp_path}
     xinstall -m 0644 ${worksrcpath}/_ldid ${zsh_comp_path}
+
+    set docpath ${destroot}${prefix}/share/doc/${name}
+    xinstall -d ${docpath}
+    xinstall -m 0644 -W ${worksrcpath} README.md COPYING ${docpath}
 }


### PR DESCRIPTION
#### Description

Include the license file in destroot when building `ldid-procursus`. This is a requirement, per the project's license.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
