### PR TITLE
emacs-app: remove emoji from default font

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -103,7 +103,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         29.1
-    revision        1
+    revision        2
 
     checksums       rmd160  c306a0554d77ee472600ed28af4751211dc1ec70 \
                     sha256  5b80e0475b0e619d2ad395ef5bc481b7cb9f13894ed23c301210572040e4b5b1 \
@@ -116,7 +116,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     github.setup    emacs-mirror emacs d0b1e3647fb4e6d889f9f999388c53daf0e67f0d
     epoch           5
     version         20230920
-    revision        0
+    revision        1
 
     master_sites    ${github.master_sites}
 

--- a/editors/emacs/files/site-start-app.el
+++ b/editors/emacs/files/site-start-app.el
@@ -11,10 +11,6 @@
 ;; Info-directory-list contains ${prefix}/share/info. See #32148.
 (setq Info-default-directory-list (cons "__PREFIX__/share/info" Info-default-directory-list))
 
-;; Use the OS X Emoji font for Emoticons
-(when (fboundp 'set-fontset-font)
-  (set-fontset-font t 'emoji '("Apple Color Emoji" . "iso10646-1") nil 'prepend))
-
 ;; Look in MacPorts ${prefix} for tree-sitter parser libraries
 (when (boundp 'treesit-extra-load-path)
   (setq treesit-extra-load-path (cons "__PREFIX__/lib" treesit-extra-load-path)))


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

It's hasn't been necessary to prepend Apple Color Emoji to the default font set since Emacs 28. This PR just cleans it up.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14
Xcode 15 / Command Line Tools 15

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
