### PR TITLE
openmpi: update to 4.1.6

### DIFF
--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -20,7 +20,7 @@ PortGroup           mpiutil 1.0
 #===============================================================================
 
 name                openmpi
-version             4.1.4
+version             4.1.6
 revision            0
 
 license             BSD
@@ -42,9 +42,9 @@ set branch          [join [lrange [split ${version} .] 0 1] .]
 set subdir          ompi/v${branch}/downloads/
 master_sites        https://www.open-mpi.org/software/${subdir}
 
-checksums           rmd160  b156f9f4084bb29b5835384ed82cb7c45d8ce22c \
-                    sha256  92912e175fd1234368c8730c03f4996fe5942e7479bb1d10059405e7f2b3930d \
-                    size    10042839
+checksums           rmd160  5857d47842ba5136807d359a94e3e3226624c06b \
+                    sha256  f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415 \
+                    size    10017002
 
 use_bzip2           yes
 
@@ -105,9 +105,10 @@ if { ${os.major} >= 10 && ${os.major} <= 14 } {
 if {${os.major} >= 11} {
     dict set clist clang15 {macports-clang-15}
     dict set clist clang16 {macports-clang-16}
+    dict set clist clang17 {macports-clang-17}
 } else {
     lappend clist_unsupported \
-        clang15 clang16
+        clang15 clang16 clang17
 }
 
 #-------------------------------------------------------------------------------

--- a/science/openmpi/files/portselect/openmpi-clang17
+++ b/science/openmpi/files/portselect/openmpi-clang17
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang17
+-
+bin/mpicxx-openmpi-clang17
+bin/mpiexec-openmpi-clang17
+bin/mpirun-openmpi-clang17
+-
+-
+-
+lib/openmpi-clang17/pkgconfig/ompi.pc
+lib/openmpi-clang17/pkgconfig/orte.pc
+-

--- a/science/openmpi/files/portselect/openmpi-clang17-fortran
+++ b/science/openmpi/files/portselect/openmpi-clang17-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang17
+-
+bin/mpicxx-openmpi-clang17
+bin/mpiexec-openmpi-clang17
+bin/mpirun-openmpi-clang17
+bin/mpif77-openmpi-clang17
+bin/mpif90-openmpi-clang17
+-
+lib/openmpi-clang17/pkgconfig/ompi.pc
+lib/openmpi-clang17/pkgconfig/orte.pc
+bin/mpifort-openmpi-clang17


### PR DESCRIPTION
### Description

* Update OpenMPI to 4.1.6 (from 4.1.4), which resolves a configuration issue under Xcode 15.
* Add clang-17 to list of supported compilers.

Closes: https://trac.macports.org/ticket/68226

### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->