### PR TITLE
kitty: Add xxhash dependency

### DIFF
--- a/aqua/kitty/Portfile
+++ b/aqua/kitty/Portfile
@@ -4,6 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
+# TODO: Test port on the macOS 10.12 - macOS 10.15. Because kitty replaces the
+# librsync with libxxhash, new versions can work
+# correctly again.
 github.setup        kovidgoyal kitty 0.30.0 v
 github.tarball_from releases
 revision            1

--- a/aqua/kitty/Portfile
+++ b/aqua/kitty/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        kovidgoyal kitty 0.30.0 v
 github.tarball_from releases
-revision            0
+revision            1
 
 categories          aqua
 platforms           macosx
@@ -57,8 +57,8 @@ depends_lib-append  \
                     path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     port:lcms2 \
                     port:libpng \
-                    port:librsync \
-                    port:zlib
+                    port:zlib \
+                    port:xxhashlib
 
 build.cmd           "${python.bin} setup.py"
 build.target        kitty.app


### PR DESCRIPTION
#### Description

To address https://trac.macports.org/ticket/68326

Update Portfile to include dependency added in version 0.30.0 of kitty. 

https://github.com/kovidgoyal/kitty/commit/fabb6bd8cc7f4dcb4324fcb0a91cea2c40f2ea05

###### Type(s)

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.6 22G120 arm64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

