### PR TITLE
pulumi: update to version 3.86.0

### DIFF
--- a/sysutils/pulumi/Portfile
+++ b/sysutils/pulumi/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/pulumi/pulumi 3.79.0 v
+go.setup            github.com/pulumi/pulumi 3.86.0 v
 revision            0
 
 homepage            https://www.pulumi.com


### PR DESCRIPTION
#### Description

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.0 23A344 x86_64
Command Line Tools 15.0.0.0.1.1694021235


###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

