### PR TITLE
borgmatic: update to version 1.8.3

### DIFF
--- a/sysutils/borgmatic/Portfile
+++ b/sysutils/borgmatic/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                borgmatic
-version             1.7.12
+version             1.8.3
 revision            0
 
-checksums           rmd160  9746870d677ce99d772964d95a2572a2a026fd8f \
-                    sha256  f0557760d42c654ffc9851f8e078b6ed0c0cae93fbd6d39080880b38f4e6401c \
-                    size    371090
+checksums           rmd160  df6cf84a347c151e861f320edbdd45f6db972603 \
+                    sha256  980851fa10b0ca3f9879ddb6e2fc4c12839cff583e97a8d5c9cc5f2c908b25ff \
+                    size    399031
 
 categories          sysutils
 platforms           {darwin any}


### PR DESCRIPTION
#### Description


###### Type(s)


- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.0 23A344 x86_64
Command Line Tools 15.0.0.0.1.1694021235


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?