### PR TITLE
fortran-stdlib: update to 2023.09.19

### DIFF
--- a/lang/fortran-stdlib/Portfile
+++ b/lang/fortran-stdlib/Portfile
@@ -7,17 +7,19 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 
 name                fortran-stdlib
-github.setup        fortran-lang stdlib bdec19113dbaa0a83166f5511851d9af8f1ed1f4
-version             2023.08.08
+github.setup        fortran-lang stdlib d379587a760376e5663ffe47b10425912faf32c2
+version             2023.09.19
 revision            0
 categories-append   lang fortran devel
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Fortran Standard Library
 long_description    {*}${description}
-checksums           rmd160  01e2a39681d6591de0b101b155848da8db9c34b7 \
-                    sha256  2443dd6805a631bca8aaf3a0c727a787fe0145b2e0a483fdb31823a05695263b \
-                    size    386756
+checksums           rmd160  45d96e10e81071ae8f020409d913c2ae11676bbf \
+                    sha256  ee5be0c53f0930dd9434ea5eaab53d6ad4b2e40cd5753b7e0b104917b41f7cc7 \
+                    size    388301
+github.tarball_from archive
+
 cmake.generator     Ninja
 
 set py_ver          3.11
@@ -45,6 +47,8 @@ configure.args-append \
                     -DBUILD_SHARED_LIBS=ON \
                     -DBUILD_TESTING=OFF
 
+# TODO: add gcc13 after it is tested and confirmed to build fine.
+# The experimental port was added in https://github.com/macports/macports-ports/pull/20607
 platform darwin powerpc {
     # https://github.com/fortran-lang/stdlib/issues/690
     # This will normally fail, since atm GCC does not support ieee_arithmetic on Darwin PPC;


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
