### PR TITLE
ruby-devel: update to upstream (2023.10.02)

### DIFF
--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -1,23 +1,27 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           select 1.0
-PortGroup           openssl 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           conflicts_build 1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
+PortGroup           openssl 1.0
+PortGroup           select 1.0
 
 # MAP_ANONYMOUS
+# TODO: submit a fix to the upstream.
 legacysupport.newest_darwin_requires_legacy 14
 
-github.setup        ruby ruby 1bbce42964a29f86f28b51285bf976c4a28a1a9e
+# ruby/openssl since ruby-3.2 supports openssl-3
+openssl.branch      3
+
+github.setup        ruby ruby 9059dfce12995451a4374330baab49177fa717be
 
 set ruby_ver        3.3
 set ruby_patch      0
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby-devel
-version             2023.08.18
+version             2023.10.02
 revision            0
 
 categories          lang ruby
@@ -30,17 +34,15 @@ long_description    Ruby is the interpreted scripting language \
                     and to do system management tasks (as in Perl). \
                     It is simple, straight-forward, extensible and portable.
 
-homepage            https://www.ruby-lang.org/
+homepage            https://www.ruby-lang.org
 license             {Ruby BSD}
 
-checksums           rmd160  a700787bfd2a62c7565ca92ecced5d1f83cfc693 \
-                    sha256  c1d6cb8c8b3573edefbec7e13a733180b033ea0c3a2370d821a35de1b156f6a4 \
-                    size    15914995
+checksums           rmd160  b0f3b51d1db89c58a91a37bc687800094ebc5cb8 \
+                    sha256  49b1756aeef973194ed762b527134a318f61e5ae0ae96fb9fca812befd197c4e \
+                    size    16183633
+github.tarball_from archive
 
 universal_variant   no
-
-# ruby/openssl since ruby-3.2 supports openssl-3
-openssl.branch      3
 
 # We need baseruby to build from upstream/master.
 # Minimum required version is 2.7. However ruby27 is broken on PPC: https://trac.macports.org/ticket/64906


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
