### PR TITLE
mackup: update to 0.8.37

### DIFF
--- a/sysutils/mackup/Portfile
+++ b/sysutils/mackup/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                mackup
-version             0.8.36
+version             0.8.37
 
 categories-prepend  sysutils
-license             GPL-3
+license             GPL-3+
 maintainers         {gmail.com:newtonne.github @newtonne} openmaintainer
 platforms           {darwin any}
 supported_archs     noarch
@@ -21,11 +21,11 @@ long_description    Mackup backs ups your application settings in a safe \
 
 homepage            https://github.com/lra/mackup
 
-checksums           rmd160  cb669f52b1c7d85d4c4a819387087f8a0270b3c0 \
-                    sha256  052d8a46b918d8711fd50f103ad905403466feed6bd3d6676fa9805e8c13661b \
-                    size    70778
+checksums           rmd160  5a8d24a583b399c1e2293c679ac9e906305e4573 \
+                    sha256  7e86c3bc427f4ec4be56b23a225a9f1482fb2aeb917e4240f7fb9f54626f32d6 \
+                    size    72554
 
-python.default_version 310
+python.default_version 311
 
 depends_lib-append \
     port:py${python.version}-docopt \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
