### PR TITLE
ecCodes: update to 2.32.0

### DIFF
--- a/science/ecCodes/Portfile
+++ b/science/ecCodes/Portfile
@@ -5,7 +5,7 @@ PortGroup cmake     1.1
 PortGroup compilers 1.0
 
 name                ecCodes
-version             2.31.0
+version             2.32.0
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
@@ -18,9 +18,11 @@ homepage            https://confluence.ecmwf.int/display/ECC
 master_sites        https://confluence.ecmwf.int/download/attachments/45757960
 distname            eccodes-${version}-Source
 
-checksums           rmd160  2ed7aaad6fa390ecd8205961a029f7ac04bf7436 \
-                    sha256  808ecd2c11fbf2c3f9fc7a36f8c2965b343f3151011b58a1d6e7cc2e6b3cac5d \
-                    size    12142911
+checksums           rmd160  8b220aae32c66a994303debd729b261684767667 \
+                    sha256  b57e8eeb0eba0c05d66fda5527c4ffa84b5ab35c46bcbc9a2227142973ccb8e6 \
+                    size    12067757
+
+patchfiles          patch-pkg-config.diff
 
 long_description \
     ecCodes is a package developed by ECMWF which provides an application programming interface and \

--- a/science/ecCodes/files/patch-pkg-config.diff
+++ b/science/ecCodes/files/patch-pkg-config.diff
@@ -1,0 +1,21 @@
+--- cmake/pkg-config.cmake.in.orig	2023-10-03 12:39:59
++++ cmake/pkg-config.cmake.in	2023-10-04 11:59:43
+@@ -10,5 +10,7 @@
+ string(REGEX REPLACE "%SHORTEN:lib" "%SHORTEN:" _content "${_content}")
+ string(REGEX REPLACE "\\.(a|so|dylib|dll|lib)(\\.[0-9]+)*%" "%" _content "${_content}")
+ string(REGEX REPLACE "%SHORTEN:([^%]+)%" "\\1" _content "${_content}")
++string(REGEX REPLACE "-Wl,-rpath,([^ ]+) " "" _content "${_content}")
++string(REGEX REPLACE "-leccodes_f90.+-leccodes" "-leccodes_f90" _content "${_content}")
+ 
+ file(WRITE @PKGCONFIG_DIR@/@_PAR_FILENAME@ "${_content}")
+--- cmake/pkg-config.pc.in.orig	2023-10-03 12:39:59
++++ cmake/pkg-config.pc.in	2023-10-04 12:38:14
+@@ -3,7 +3,7 @@
+ 
+ git_tag=@PKGCONFIG_GIT_TAG@
+ 
+-prefix=${pcfiledir}/../..
++prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+ libdir=${prefix}/@INSTALL_LIB_DIR@
+ includedir=${prefix}/@INSTALL_INCLUDE_DIR@


### PR DESCRIPTION
#### Description

This is an update to the upstream version 2.32.0.
En passant, I made changes to the `libs` entry in the pkgconfig files to be more user friendly.

`pkg-config eccodes_f90 --libs` used to produce the rather lengthy `-L/opt/local/lib/pkgconfig/../../lib -Wl,-rpath,/opt/local/lib/pkgconfig/../../lib -leccodes_f90 -Wl,-rpath,/opt/local/lib/pkgconfig/../../lib -leccodes`. This is now reduced to `-L/opt/local/lib -leccodes_f90`, which is sufficient. This also avoids a warning under XCode 15 that duplicate rpath entries are deprecated.

Similar for `pkg-config eccodes --libs`, which now yields `-L/opt/local/lib -leccodes`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
