### PR TITLE
star:  add +universal variant

### DIFF
--- a/archivers/star/Portfile
+++ b/archivers/star/Portfile
@@ -59,7 +59,7 @@ checksums               rmd160  e154278ecbe7d778bc1d6766ed163c9963b1cc82 \
                         sha256  a4270cdcca5dd69c0114079277b06e5efad260b0a099c9c09d31e16e99a23ff5 \
                         size    5896292
 
-patch {
+post-patch {
                         reinplace -locale C "s|gnutar|sgnutar|g" \
                         ${worksrcpath}/star/gnutar.1
 
@@ -112,6 +112,65 @@ compiler.blacklist-append \
 
 configure.ldflags-append -lintl
 
+pre-build {
+    if { $universal_possible && [variant_isset universal] } {
+#       Big Sur and Later
+        if { ${os.platform} eq "darwin" && ${os.major} >= 20 } {
+            platform i386 {
+                build.args-append   COPTX="-arch x86_64 -arch arm64" \
+                                    C++OPTX="-arch x86_64 -arch arm64" \
+                                    LDOPTX="-arch x86_64 -arch arm64"
+            }
+            platform arm {
+                build.args-append   COPTX="-arch x86_64 -arch arm64" \
+                                    C++OPTX="-arch x86_64 -arch arm64" \
+                                    LDOPTX="-arch x86_64 -arch arm64"
+            }
+#       Lion to Catalina
+        } elseif { ${os.platform} eq "darwin" && ${os.major} >=11 } {
+            platform i386 {
+                build.args-append   COPTX="-arch x86_64 -arch i386" \
+                                    C++OPTX="-arch x86_64 -arch i386" \
+                                    LDOPTX="-arch x86_64 -arch i386"
+            }
+#       Snow Leopard
+        } elseif { ${os.platform} eq "darwin" && ${os.major} ==10 } {
+            platform i386 {
+                build.args-append   COPTX="-arch x86_64 -arch i386" \
+                                    C++OPTX="-arch x86_64 -arch i386" \
+                                    LDOPTX="-arch x86_64 -arch i386"
+            }
+#           Note: Snow Leopard can only run 32bit ppc apps via Rosetta
+            platform powerpc {
+                build.args-append   COPTX="-arch ppc -arch i386" \
+                                    C++OPTX="-arch ppc -arch i386" \
+                                    LDOPTX="-arch ppc -arch i386"
+            }
+#       Tiger and Leopard
+        } elseif { ${os.platform} eq "darwin" && ${os.major} >= 8 } {
+#           Note: One could change ppc to ppc64 if so desired
+            platform i386 {
+                build.args-append   COPTX="-arch ppc -arch i386" \
+                                    C++OPTX="-arch ppc -arch i386" \
+                                    LDOPTX="-arch ppc -arch i386"
+            }
+#           Note: One could change ppc to ppc64 if so desired
+            platform powerpc {
+                build.args-append   COPTX="-arch ppc -arch i386" \
+                                    C++OPTX="-arch ppc -arch i386" \
+                                    LDOPTX="-arch ppc -arch i386"
+            }
+#       Panther and earlier
+        } else {
+            platform powerpc {
+                build.args-append   COPTX="-arch ppc -arch ppc64" \
+                                    C++OPTX="-arch ppc -arch ppc64" \
+                                    LDOPTX="-arch ppc -arch ppc64"
+            }
+        }
+    }
+}
+
 depends_build-append    port:smake \
                         port:gettext
 
@@ -123,7 +182,6 @@ build.cmd               smake
 #
 # Must specify INS_BASE and INS_RBASE in both the build and destroot phases
 #
-
 build.args-append       INS_BASE="${destroot}${prefix}" \
                         INS_RBASE="${destroot}${prefix}" \
                         DEFOSINCDIRS="${prefix}/include" \
@@ -140,8 +198,6 @@ destroot.destdir        INS_BASE="${destroot}${prefix}" \
 # i.e. smake does not support the -j flag
 #
 use_parallel_build      no
-
-universal_variant       no
 
 post-destroot {
                         move    ${destroot}${prefix}/bin/gnutar \
@@ -215,7 +271,7 @@ post-destroot {
 }
 
 notes "
-    The gnutar binary provided in the star port has been prefixed with the character 's' \
+    The gnutar binary provided in the star port has been prefixed with the character 's'
     (i.e. sgnutar) to distinguish it from the official gnutar binary.
     The correspondng man page has also been renamed and updated accordingly.
 "


### PR DESCRIPTION
#### Description

* add +universal variant

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
