### PR TITLE
ghidra: build from source

### DIFF
--- a/devel/ghidra/Portfile
+++ b/devel/ghidra/Portfile
@@ -6,13 +6,11 @@ PortGroup           java 1.0
 PortGroup           app 1.0
 
 github.setup        NationalSecurityAgency ghidra 10.4 Ghidra_ _build
-set filedate        20230928
-revision            1
-checksums           rmd160  12d7691b89ca0d35be72df024e01098f234a849e \
-                    sha256  6911d674798f145f8ea723fdd3eb67a8fae8c7be92e117bca081e6ef66acac19 \
-                    size    370096003
+revision            2
+checksums           rmd160  26a4ac47398ebc0c54223ca1d53671af0c3248e2 \
+                    sha256  c1212cb3ff173bdde9d00ac805ec080d773c086817f3841a223bc029737fa8db \
+                    size    66829944
 
-supported_archs     noarch
 categories          devel
 license             Apache
 maintainers         {1e0.co.uk:dev @hexagonal-sun} {crowell.biz:jeff @crowell} openmaintainer
@@ -21,19 +19,21 @@ description         A software reverse engineering (SRE) suite of tools develope
 long_description    ${description}
 homepage            https://ghidra-sre.org/
 
-github.tarball_from releases
-use_zip             yes
-distname            ${name}_${version}_PUBLIC_${filedate}
-
 java.version        17+
 java.fallback       openjdk17
 
-use_configure       no
 universal_variant   no
-build {}
+depends_build-append    port:gradle
 
 set javadest        ${prefix}/share/java/${name}-${version}
-set worksrcpath     ${workpath}/${name}_${version}_PUBLIC
+configure.env-append    GRADLE_USER_HOME=${worksrcpath}
+configure.pre_args  ""
+configure.cmd       gradle -I gradle/support/fetchDependencies.gradle init
+build.env-append    GRADLE_USER_HOME=${worksrcpath}
+build.env-append    _JAVA_OPTIONS=-Duser.home=${worksrcpath}
+build.cmd           gradle
+build.target        buildGhidra
+
 set ghidra_copy_list \
 [list \
     Extensions \
@@ -48,13 +48,14 @@ set ghidra_copy_list \
 ]
 
 destroot {
+    system "unzip ${worksrcpath}/build/dist/ghidra*.zip -d ${worksrcpath}/ghbuild"
     xinstall -d ${destroot}${javadest}
     foreach item ${ghidra_copy_list} {
-        copy ${worksrcpath}/${item} ${destroot}${javadest}/
+        copy ${worksrcpath}/ghbuild/ghidra_${version}_DEV/${item} ${destroot}${javadest}/
     }
 }
 
 # app settings
 app.executable      ${javadest}/ghidraRun
-app.icon            ${worksrcpath}/support/ghidra.ico
+app.icon            ${worksrcpath}/Ghidra/RuntimeScripts/Windows/support/ghidra.ico
 app.retina          yes


### PR DESCRIPTION
#### Description
Previous Portfile was taking pre-built versions. This builds from source so it's built by MacPorts instead of the developer.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
