### PR TITLE
spdlog-fmt8: new port (1.12.0)

### DIFF
--- a/devel/spdlog/Portfile
+++ b/devel/spdlog/Portfile
@@ -21,8 +21,11 @@ checksums           rmd160  06bfcd66f06a9eea8544edfa81df85cf1f71ac08 \
                     sha256  4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9 \
                     size    251037
 
-compiler.cxx_standard   2011
-compiler.thread_local_storage yes
+# Default libfmt version, customize when adding subports
+set libfmt_ver      10
+
+compiler.cxx_standard           2011
+compiler.thread_local_storage   yes
 
 # Clear optflags; controlled by project, via cmake build type
 configure.optflags
@@ -33,12 +36,11 @@ if {[variant_isset debug]} {
     cmake.build_type RelWithDebInfo
 }
 
-if { [string match *clang* ${configure.compiler}] } {
-    # Quiet warnings
+if {[string match *clang* ${configure.compiler}]} {
     configure.cxxflags-append \
-                    -Wno-macro-redefined \
-                    -Wno-error=unknown-warning-option \
-                    -Wno-unknown-warning-option
+                     -Wno-macro-redefined \
+                     -Wno-error=unknown-warning-option \
+                     -Wno-unknown-warning-option
 }
 
 configure.args-append \
@@ -51,12 +53,24 @@ variant fmt_external description {Use external fmt library instead of bundled} {
     patchfiles-append \
                     patch-spdlog-fmt-external.diff
     cmake.module_path-append \
-                    ${prefix}/lib/libfmt10/cmake
+                    ${prefix}/lib/libfmt${libfmt_ver}/cmake
     depends_lib-append \
-                    port:libfmt10
+                    port:libfmt${libfmt_ver}
     configure.args-replace \
                     -DSPDLOG_FMT_EXTERNAL=OFF \
                     -DSPDLOG_FMT_EXTERNAL=ON
+}
+
+# Remove this subport when nheko and mtxclient have a new release.
+subport ${name}-fmt8 {
+    set libfmt_ver      8
+    revision            0
+    long_description    {*}${description} This port exists to support stable the \
+                        latest stable release of mtxclient and nheko.
+
+    # Allow this subport to coexist with other spdlog interations
+    cmake.install_prefix \
+                    ${prefix}/libexec/${subport}
 }
 
 variant tests description {Enable test support} {


### PR DESCRIPTION
#### Description

Add `spdlog`, specifically linked with `libfmt8`.

While working on #20537, `nheko` failed to build due to its dependencies (e.g `mtxclient`) not being linked with `libfmt8`, which is what the latest release of the project supports. Having a different port rather than downgrading `spdlog` to `libfmt8` would prevent chaos.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
