### PR TITLE
colima: update to 0.5.6

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.5.5 v
+go.setup            github.com/abiosoft/colima 0.5.6 v
 github.tarball_from archive
 revision            0
 
@@ -17,9 +17,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  7dc0b3a7d0081152436d00bea5eaa777c5ec7d96 \
-                    sha256  60b3edf5e363d44d280abc1d15173f5f0f051e45b2113d6a813c925582a8b7e2 \
-                    size    613676
+checksums           rmd160  21a14801a7fd24b1190fc2740695d502456783ce \
+                    sha256  76e53fb9fa003ba328b191c289049aeb9829b1c933384eee58e90f92636767b9 \
+                    size    614617
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

Colima 0.5.5 broke on Sonoma: https://trac.macports.org/ticket/68275 

So I requested its maintainer (@abiosoft) issue a new release with the fix.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->


