### PR TITLE
fetchmail: update to 6.4.37

### DIFF
--- a/mail/fetchmail/Portfile
+++ b/mail/fetchmail/Portfile
@@ -3,10 +3,9 @@
 PortSystem          1.0
 
 name                fetchmail
-version             6.4.21
-revision            1
+version             6.4.37
+revision            0
 categories          mail
-platforms           darwin
 license             {GPL-2 OpenSSLException}
 maintainers         nomaintainer
 
@@ -31,8 +30,9 @@ long_description \
     mutt, or any standard mail user agent.
 
 if {${name} eq ${subport}} {
-    checksums       rmd160  c8c7e9ca1840e2f78a52b55a3db0eb10f35196a0 \
-                    sha256  6a459c1cafd7a1daa5cd137140da60c18c84b5699cd8e7249a79c33342c99d1d
+    checksums       rmd160  71d57e20c36780aba5d14c04e2e1071e2ec9d34c \
+                    sha256  4a182e5d893e9abe6ac37ae71e542651fce6d606234fc735c2aaae18657e69ea \
+                    size    1202860
 
     conflicts       fetchmail-devel
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
