### PR TITLE
maven3: update to 3.9.5

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.9.4
+version         3.9.5
 revision        0
 
 categories      java devel
@@ -35,9 +35,9 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  b679ca535806cbdd73ed1a5469afc1a204f26e7a \
-                sha256  ff66b70c830a38d331d44f6c25a37b582471def9a161c93902bac7bea3098319 \
-                size    9336368
+checksums       rmd160  f6f73dc201f34aba53a291e4d7aef71d031554cf \
+                sha256  5fd272b105041fe81e2e42f6399765e015fc4938ef3753ba4af9f0119d84ef7c \
+                size    9359994
 
 java.version    1.8+
 java.fallback   openjdk17


### PR DESCRIPTION
#### Description

Update to Apache Maven 3.9.5.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?