### PR TITLE
py-virtualenvwrapper: python 3.11 support

### DIFF
--- a/python/py-virtualenvwrapper/Portfile
+++ b/python/py-virtualenvwrapper/Portfile
@@ -28,7 +28,7 @@ checksums           rmd160  1d7791e2df3689b44e3293757825bd89405c2af1 \
                     sha256  51a1a934e7ed0ff221bdd91bf9d3b604d875afbb3aa2367133503fee168f5bfa \
                     size    334920
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-pbr \

--- a/python/py-virtualenvwrapper/files/virtualenvwrapper311
+++ b/python/py-virtualenvwrapper/files/virtualenvwrapper311
@@ -1,0 +1,2 @@
+bin/virtualenvwrapper.sh-3.11
+bin/virtualenvwrapper_lazy.sh-3.11


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Xcode 15.0 15A240d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
