### PR TITLE
scrcpy: Update to version 2.1.1, add legacysupport PortGroup

### DIFF
--- a/multimedia/scrcpy/Portfile
+++ b/multimedia/scrcpy/Portfile
@@ -4,9 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           meson 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
 
-github.setup        Genymobile scrcpy 2.1 v
+# needed for clock_gettime and static_assert to work on older OS X versions
+legacysupport.newest_darwin_requires_legacy 15
+
+github.setup        Genymobile scrcpy 2.1.1 v
 revision            0
+github.tarball_from archive
 
 categories          multimedia
 platforms           darwin
@@ -24,13 +29,13 @@ extract.only        ${distfiles}
 distfiles-append    ${name}-server-v${version}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  8981f4fcc6f5ee731b6e4b4aac7462294779de06 \
-                    sha256  3272c42f4f8ef6572af52c28912a1c7a088a6ad80d72897d1bdf40054ec81447 \
-                    size    385865 \
+                    rmd160  4e8c471f497cf55d75297ecfba9b1622620c3c81 \
+                    sha256  6f3d055159cb125eabe940a901bef8a69e14e2c25f0e47554f846e7f26a36c4d \
+                    size    386002 \
                     ${name}-server-v${version} \
-                    rmd160  9ca3608d5555e5118e8c8163295875d89912f94a \
-                    sha256  5b8bf1940264b930c71a1c614c57da2247f52b2d4240bca865cc6d366dff6688 \
-                    size    56955
+                    rmd160  a14eb333812990610d424790b775492673c23196 \
+                    sha256  9558db6c56743a1dc03b38f59801fb40e91cc891f8fc0c89e5b0b067761f148e \
+                    size    56995
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description

* update to version 2.1.1
* add legacysupport PortGroup to try to support older OS X versions

Closes: https://trac.macports.org/ticket/68338
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505 / Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
