### PR TITLE
py-cachy: obsolete

### DIFF
--- a/python/py-cachy/Portfile
+++ b/python/py-cachy/Portfile
@@ -2,33 +2,11 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           obsolete 1.0
 
 name                py-cachy
 version             0.3.0
-revision            0
-categories-append   devel
-platforms           {darwin any}
-license             MIT
-supported_archs     noarch
 
 python.versions     37 38 39 310
 
-maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
-
-description         Cachy provides a simple yet effective caching library.
-long_description    {*}${description}
-
-homepage            https://github.com/sdispater/cachy
-
-checksums           rmd160  88f49c70f7e52483733531ddf0f8a2a08bcd9698 \
-                    sha256  186581f4ceb42a0bbe040c407da73c14092379b1e4c0e327fdb72ae4a9b269b1 \
-                    size    15654
-
-if {${name} ne ${subport}} {
-    post-destroot {
-        # https://github.com/sdispater/cachy/issues/9
-        delete ${destroot}${python.pkgd}/tests
-    }
-
-    livecheck.type  none
-}
+# Can be removed after 2024-10-05


### PR DESCRIPTION
#### Description

This is a leaf dependency, poetry no longer requires it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
