### PR TITLE
ldid-procursus: Restrict building on < OSX 10.13

### DIFF
--- a/devel/ldid-procursus/Portfile
+++ b/devel/ldid-procursus/Portfile
@@ -10,6 +10,7 @@ version             2.1.5-procursus7
 revision            1
 categories          devel
 license             AGPL-3
+platforms           {darwin >= 18}
 conflicts           ldid
 maintainers         {@therealketo procurs.us:team} openmaintainer
 description         Put real or fake signatures in a Mach-O.
@@ -24,6 +25,9 @@ checksums           rmd160 648697e84ac2b71fff24fdc1241f90d7390124d5 \
 depends_build       port:pkgconfig
 depends_lib-append  path:lib/libplist-2.0.dylib:libplist
 universal_variant   no
+
+compiler.cxx_standard \
+                    2011
 
 post-destroot {
     set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions


### PR DESCRIPTION
#### Description

Per upstream, there's no real reason for anyone to use this port on < OSX 10.13. The port is known to fail on legacy systems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.3.3 4E3002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
