### PR TITLE
py-cleo, py-clikit, py-crashtest: drop python 3.7

### DIFF
--- a/python/py-cleo/Portfile
+++ b/python/py-cleo/Portfile
@@ -11,7 +11,7 @@ platforms           {darwin any}
 license             MIT
 supported_archs     noarch
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 maintainers         {gmail.com:davidgilman1 @dgilman} openmaintainer
 

--- a/python/py-clikit/Portfile
+++ b/python/py-clikit/Portfile
@@ -11,7 +11,7 @@ platforms           {darwin any}
 license             MIT
 supported_archs     noarch
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 python.pep517       yes
 python.pep517_backend \
                     poetry

--- a/python/py-crashtest/Portfile
+++ b/python/py-crashtest/Portfile
@@ -21,6 +21,6 @@ checksums           rmd160  7ed7e18f113900997801c79a602a08577ae45ffd \
                     sha256  80d7b1f316ebfbd429f648076d6275c877ba30ba48979de4191714a75266f0ce \
                     size    4708
 
-python.versions         37 38 39 310 311
+python.versions         38 39 310 311
 python.pep517           yes
 python.pep517_backend   poetry


### PR DESCRIPTION
#### Description

The only dependency here is poetry which hard dropped python 3.7 in the previous release.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
