### PR TITLE
tuist: new port

### DIFF
--- a/devel/tuist/Portfile
+++ b/devel/tuist/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=portfile:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        tuist tuist 3.31.2
+revision            0
+categories          devel
+license             MIT
+maintainers         {woolsweater.net:macports @woolsweater} \
+                    openmaintainer
+supported_archs     x86_64 arm64
+
+checksums           rmd160  d2b3d9d81b13f2b99b7d2791038b6ea59f16e374 \
+                    sha256  eb069e2622423fd1d9d34cb7ee7687faa4e6cdc78bc654c1c0b2f80469ec0980 \
+                    size    14636003
+
+description         Create, maintain, and interact with Xcode projects at scale
+long_description    {*}${description}
+
+use_configure       no
+use_xcode           yes
+
+# Avoid header conflicts when building on Ventura
+compiler.cpath
+
+set product_name     tuistenv
+
+build.cmd           swift
+build.target        build
+build.args          --configuration release \
+                    --disable-sandbox \
+                    --sdk ${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
+                    --product ${product_name}
+
+set xcodeversion_min_required 15.0.1
+if {[vercmp ${xcodeversion} ${xcodeversion_min_required}] < 0} {
+    known_fail yes
+    pre-fetch {
+        ui_error "${name} @${version} requires Xcode ${xcodeversion_min_required} or later but you have Xcode ${xcodeversion}."
+        ui_error "See https://guide.macports.org/chunked/installing.xcode.html for download links."
+        return -code error "incompatible Xcode version"
+    }
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/.build/release/${product_name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

Add tuist, https://tuist.io, a CLI tool that generates Xcode projects.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.4 22F66 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
