### PR TITLE
R-lava: drop explicit test dependencies due to possible CI failures

### DIFF
--- a/R/R-lava/Portfile
+++ b/R/R-lava/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran kkholst lava 1.7.2.1
-revision            2
+revision            3
 categories-append   math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3
-description         Latent Variable Models
+description         Latent Variable models
 long_description    {*}${description}
 homepage            https://kkholst.github.io/lava
 checksums           rmd160  fc3f85a255c19451dc89f5410001f522fadd0a25 \
@@ -21,26 +21,11 @@ depends_lib-append  port:R-future.apply \
                     port:R-progressr \
                     port:R-SQUAREM
 
-depends_test-append port:R-bookdown \
-                    port:R-data.table \
-                    port:R-ellipse \
-                    port:R-fields \
-                    port:R-geepack \
-                    port:R-igraph \
-                    port:R-knitr \
-                    port:R-lavaSearch2 \
-                    port:R-lme4 \
-                    port:R-mets \
-                    port:R-optimx \
-                    port:R-polycor \
-                    port:R-quantreg \
-                    port:R-R.rsp \
-                    port:R-rgl \
-                    port:R-Rgraphviz \
-                    port:R-rmarkdown \
-                    port:R-targeted \
-                    port:R-testthat \
-                    port:R-visNetwork \
-                    port:R-zoo
-
-test.run            yes
+# As to why no explicit depends_test here, see discussion in:
+# https://github.com/macports/macports-ports/pull/20736
+notes "
+In order to run port test for ${name}, the following dependencies are needed:\
+R-bookdown, R-data.table, R-ellipse, R-fields, R-geepack, R-igraph, R-knitr,\
+R-lavaSearch2, R-lme4, R-mets, R-optimx, R-polycor, R-quantreg, R-R.rsp, R-rgl,\
+R-Rgraphviz, R-rmarkdown, R-targeted, R-testthat, R-visNetwork, R-zoo
+"


### PR DESCRIPTION
#### Description

_Nothing will be added here._

(This PR does not depend on recommended packages update one. It can be merged once CI pass.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
