### PR TITLE
py-mapclassify: now pep517 compatible, only Python 3.9+ supported

### DIFF
--- a/python/py-mapclassify/Portfile
+++ b/python/py-mapclassify/Portfile
@@ -24,13 +24,27 @@ checksums           rmd160  df017a4a0f924f0418f367a0410633f4e31e50fe \
                     sha256  4441798d55a051e75206bf46dccfc8a8f8323aac8596d19961d11660c98677ca \
                     size    3577980
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
+python.pep517       yes
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
+    depends_build-append    port:py${python.version}-setuptools_scm
+
     depends_lib-append      port:py${python.version}-networkx \
                             port:py${python.version}-numpy \
                             port:py${python.version}-pandas \
                             port:py${python.version}-scikit-learn \
                             port:py${python.version}-scipy
+
+    if {${python.version} == 38} {
+        python.pep517   no
+        version         2.6.0
+        revision        0
+        checksums       rmd160  a710e5119ef948116f6415cbb4cca34d4d3e58fa \
+                        sha256  4fd8039cd4c147d16108bf5abac3e1be6827eb90fc52a916513bdd0f3df03acf \
+                        size    63450
+
+        depends_build-append port:py${python.version}-setuptools
+        depends_build-delete port:py${python.version}-setuptools_scm
+    }
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

`py-mapclassify` is now pep517 compatible, only Python 3.9+ is supported.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
