### PR TITLE
google-cloud-sdk: update to 449.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             448.0.0
+version             449.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  40ce1d65aa01fa0589ba16c1f2dca7c18afc6ef9 \
-                    sha256  fb1132f54881af927cb4a4102dffb58d25323592d0d9981d2bfc4b7affd0533e \
-                    size    121017695
+    checksums       rmd160  f8f842da54cf8bbefb02f579fdae90b4f965e425 \
+                    sha256  06867c8ca89db2d0173e9b6121a41be5e27ebeaf969a88f30b71b69fe3ce8844 \
+                    size    120946834
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  7c9e31635443c5beb32dcd9a264b730d11b9361b \
-                    sha256  17f546644d19eae747078c6a5aaf7672d81df44283bd3173aff0e6c696574979 \
-                    size    122302715
+    checksums       rmd160  d927156831f43aa43f4778eb71d3d14cf6536fde \
+                    sha256  bf7abac36afa81e60d2e62b90228233c69e93234efd32e77eef910b6764e4be0 \
+                    size    122231063
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  ce40569fc49527232cb55503901d36b7de89a9cb \
-                    sha256  d71c0b989937a026172331c51a68ba6c4227f15db5969ae92e8d559c68597974 \
-                    size    119405758
+    checksums       rmd160  31af5a1dfbd6bace820026cdb0cf3d46795b1fea \
+                    sha256  7802f1cd747331ce0057ec2effb72b73c660fcd0c5554aae871e8843ef25b1d5 \
+                    size    119332381
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 449.0.0.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?