### PR TITLE
skaffold: update to 2.8.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.7.1 v
+github.setup        GoogleContainerTools skaffold 2.8.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  fbe9d54cda8e099430239c7faa0d5d16caf61bca \
-                    sha256  432ab099d6cf3b84f30f66372b190935b0eaedfefc88aa76a1e2d7cdcbb1ee87 \
-                    size    60455737
+checksums           rmd160  a2d99c3dc7966c50004852174f7dbf35f4c084b2 \
+                    sha256  36c107dd7736e8ce4f652937b09bbfec8a7c8edb816b3b70b68dcbce54c7c43a \
+                    size    60513049
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.8.0.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?