### PR TITLE
bcprov: update to 1.76

### DIFF
--- a/java/bcprov/Portfile
+++ b/java/bcprov/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                bcprov
-version             1.74
+version             1.76
 revision            0
 
-checksums           rmd160  d12042ab8de08b6913e816a46eccacedb4d9bbb7 \
-                    sha256  56ede1472d78dc47b8a16fc5e90c02b9eeb970b55d8b5b8bfe760311907821e9 \
-                    size    8353376
+checksums           rmd160  64231398d456fab7c2eeea7b697746db4300757e \
+                    sha256  fda85d777aaae168015860b23a77cad9b8d3a1d5c904fda875313427bd560179 \
+                    size    8361943
 
 categories          java devel security
 license             MIT
@@ -29,6 +29,7 @@ worksrcdir          ${distname}
 
 java.version        1.8+
 java.fallback       openjdk11
+java.deptypes       run
 
 extract {
     file copy ${distpath}/${distname}.jar ${workpath}


### PR DESCRIPTION
No build dependency on Java since not building from source.

#### Description
https://www.bouncycastle.org/releasenotes.html

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Not tested.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
