### PR TITLE
librsvg, libsrvg-devel (fallback ports): update to 2.40.21

### DIFF
--- a/graphics/librsvg-devel/Portfile
+++ b/graphics/librsvg-devel/Portfile
@@ -63,13 +63,13 @@ if {${librsvg_fallback}} {
     # revert to latest pre-cargo version
     PortGroup       gobject_introspection 1.0
 
-    version         2.40.20
-    revision        5
+    version         2.40.21
+    revision        0
     epoch           1
 
-    checksums       rmd160  e697e1220779f77e81a890718ef5cda5b5e6b740 \
-                    sha256  cff4dd3c3b78bfe99d8fcfad3b8ba1eee3289a0823c0e118d78106be6b84c92b \
-                    size    1796376
+    checksums       rmd160  5135ad75e976658936d03655faa37f9ed1c11a3e \
+                    sha256  f7628905f1cada84e87e2b14883ed57d8094dca3281d5bcb24ece4279e9a92ba \
+                    size    1655860
 
     # https://trac.macports.org/ticket/65407
     patchfiles-append patch-librsvg-makefile-in-vapi-deps.diff

--- a/graphics/librsvg/Portfile
+++ b/graphics/librsvg/Portfile
@@ -63,13 +63,13 @@ if {${librsvg_fallback}} {
     # revert to latest pre-cargo version
     PortGroup       gobject_introspection 1.0
 
-    version         2.40.20
-    revision        5
+    version         2.40.21
+    revision        0
     epoch           1
 
-    checksums       rmd160  e697e1220779f77e81a890718ef5cda5b5e6b740 \
-                    sha256  cff4dd3c3b78bfe99d8fcfad3b8ba1eee3289a0823c0e118d78106be6b84c92b \
-                    size    1796376
+    checksums       rmd160  5135ad75e976658936d03655faa37f9ed1c11a3e \
+                    sha256  f7628905f1cada84e87e2b14883ed57d8094dca3281d5bcb24ece4279e9a92ba \
+                    size    1655860
 
     # https://trac.macports.org/ticket/65407
     patchfiles-append patch-librsvg-makefile-in-vapi-deps.diff


### PR DESCRIPTION
#### Description
https://download.gnome.org/sources/librsvg/2.40/librsvg-2.40.21.news
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Untested
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
