### PR TITLE
qt4-mac: allow build on Sonoma and fix for Xcode 15

### DIFF
--- a/aqua/qt4-mac/Portfile
+++ b/aqua/qt4-mac/Portfile
@@ -60,6 +60,9 @@ platform darwin 10 {
 platform darwin 22 {
      macosx_deployment_target 12.0
 }
+platform darwin 23 {
+     macosx_deployment_target 12.0
+}
 
 # find a way to specify the OS MINOR version.  For OSX 10.X, this
 # value will be X.  The type is this variable is integer, so we can
@@ -91,10 +94,8 @@ if {${macosx_deployment_target} ne ""} {
 # Error out if trying to build on a new macOS version. We do this
 # because this port is so old and thus we want to make sure this
 # port works on these newer macOS versions first.
-
 platform darwin {
-    if { ( ${MAJOR} == 10 && ${MINOR} > 15 ) || ${MAJOR} > 13 } {
-        # This project needs to be updated to build with clang++ against libc++
+    if { ${os.major} > 23 } {
         depends_lib
         depends_run
         pre-fetch {
@@ -422,6 +423,20 @@ patchfiles-append patch-test_compiler_version.diff
 # ASM keyword; removing it should not hurt other compilers; if it does
 # we'll add an "if" to narrow the scope of application
 patchfiles-append patch-src_3rdparty_javascriptcore_JavaScriptCore_jit_JITStubs.cpp_remove_volatile.diff
+
+# the wtf_ceil workaround in wtf/MathExtras.h is causing a build error with Xcode 15
+# this workaround was deleted long ago here in the upstream source:
+# (wtf_ceil): Deleted. This was a workaround for a bug that was introduced in Leopard and
+# fixed in Snow Leopard <rdar://problem/6286405>, so we don't need the workaround any more.
+# https://github.com/WebKit/WebKit/commit/8fadbd7385e0
+# this workaround could theoretically be removed on all systems from SnowLeopard up, but
+# that would require extensive testing, so only remove it where needed (Sonoma for sure)
+# this may also need to be added to Ventura if using Xcode 15
+platform darwin {
+    if { ${os.major} > 22 } {
+        patchfiles-append patch-webkit-remove-wtf_ceil-workaround.diff
+    }
+}
 
 # the version header file is part of C++20
 # newer versions of Clang find VERSION instead

--- a/aqua/qt4-mac/files/patch-webkit-remove-wtf_ceil-workaround.diff
+++ b/aqua/qt4-mac/files/patch-webkit-remove-wtf_ceil-workaround.diff
@@ -1,0 +1,13 @@
+diff --git src/3rdparty/javascriptcore/JavaScriptCore/wtf/MathExtras.h src/3rdparty/javascriptcore/JavaScriptCore/wtf/MathExtras.h
+index 9e2e638d..3dfa0244 100644
+--- src/3rdparty/javascriptcore/JavaScriptCore/wtf/MathExtras.h
++++ src/3rdparty/javascriptcore/JavaScriptCore/wtf/MathExtras.h
+@@ -62,7 +62,7 @@ const double piOverFourDouble = M_PI_4;
+ const float piOverFourFloat = static_cast<float>(M_PI_4);
+ #endif
+ 
+-#if OS(DARWIN)
++#if OS(DARWIN) && 0
+ 
+ // Work around a bug in the Mac OS X libc where ceil(-0.1) return +0.
+ inline double wtf_ceil(double x) { return copysign(ceil(x), x); }


### PR DESCRIPTION
closes: https://trac.macports.org/ticket/68370
closes: https://trac.macports.org/ticket/68366

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
