### PR TITLE
lighttpd: Update to 1.4.72

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -5,11 +5,11 @@ PortGroup                   legacysupport 1.0
 PortGroup                   lua 1.0
 
 name                        lighttpd
-version                     1.4.71
+version                     1.4.72
 revision                    0
-checksums                   rmd160  f5bc2f06b28ace577dc9b92cd1c4c3efdf78ec09 \
-                            sha256  b8b6915da20396fdc354df3324d5e440169b2e5ea7859e3a775213841325afac \
-                            size    1070904
+checksums                   rmd160  1e79163f3a620f6a74a24d741cde49477013c74e \
+                            sha256  f7cade4d69b754a0748c01463c33cd8b456ca9cc03bb09e85a71bcbcd54e55ec \
+                            size    1083676
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  www


### PR DESCRIPTION
#### Description

lighttpd: Update to 1.4.72

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.7

###### Verification

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?