### PR TITLE
psqlODBC: update to 16.00.0000

### DIFF
--- a/databases/psqlODBC/Portfile
+++ b/databases/psqlODBC/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 
 name                psqlODBC
-version             09.03.0400
+version             16.00.0000
 categories          databases
-platforms           darwin
 maintainers         panulla.com:macports
 license             LGPL-2
 
@@ -15,13 +14,14 @@ long_description \
     psqlODBC allows ODBC-compliant applications to connect to \
     PostgreSQL database servers.
 
-homepage            http://psqlODBC.projects.postgresql.org
+homepage            https://odbc.postgresql.org
 master_sites        postgresql:odbc/versions/src/
 
 distname            psqlodbc-${version}
 
-checksums           rmd160  1434b39efe70b9930ba5e3e0e1819a8811844187 \
-                    sha256  de77dfa89dba0a159afc57b2e312ca6e9075dd92b761c7cc700c0450ba02b56b
+checksums           rmd160  b6ead34c855806f24bd0116cd35ffdf1031fbd97 \
+                    sha256  afd892f89d2ecee8d3f3b2314f1bd5bf2d02201872c6e3431e5c31096eca4c8b \
+                    size    946997
 
 depends_lib         port:libtool
 
@@ -39,7 +39,7 @@ if {![variant_isset iodbc]} {
     default_variants +unixodbc
 }
 
-set pgsql_suffixes {82 83 84 90 91 92 93}
+set pgsql_suffixes {82 83 84 90 91 92 93 94 95 96 10 11 12 13 14 15 16}
 
 set pgsql_ports {}
 foreach s ${pgsql_suffixes} {


### PR DESCRIPTION
- Change relocated homepage
- Add pgsql suffixes 94–16
- Remove implicit platforms darwin

Closes https://trac.macports.org/ticket/67668

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
