### PR TITLE
py-ruamel-yaml: update to 0.17.35

### DIFF
--- a/python/py-ruamel-yaml-clib/Portfile
+++ b/python/py-ruamel-yaml-clib/Portfile
@@ -5,10 +5,10 @@ PortGroup           python 1.0
 
 name                py-ruamel-yaml-clib
 
-version             0.2.7
-checksums           rmd160  8f28c76ed2535bc4a80332c22b46ddc5013115e1 \
-                    sha256  1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497 \
-                    size    182535
+version             0.2.8
+checksums           rmd160  58caef0372063cfa06e27a75fea1e85c43b1c891 \
+                    sha256  beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512 \
+                    size    213824
 revision            0
 
 license             MIT
@@ -19,7 +19,7 @@ long_description    {*}${description}.
 
 homepage            https://yaml.readthedocs.io/
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-ruamel-yaml/Portfile
+++ b/python/py-ruamel-yaml/Portfile
@@ -5,10 +5,10 @@ PortGroup           python 1.0
 
 name                py-ruamel-yaml
 
-version             0.17.32
-checksums           rmd160  58309f5892bf225d944df0e580ee1e0cb9943d68 \
-                    sha256  ec939063761914e14542972a5cba6d33c23b0859ab6342f61cf070cfc600efc2 \
-                    size    134455
+version             0.17.35
+checksums           rmd160  e3a7713a00df9ac29bd3a1a76eb7987d34209190 \
+                    sha256  801046a9caacb1b43acc118969b49b96b65e8847f29029563b29ac61d02db61b \
+                    size    136131
 revision            0
 
 license             MIT
@@ -20,7 +20,7 @@ long_description    ${description}. \
 
 homepage            https://yaml.readthedocs.io/
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

Also includes the bump for Python 3.12 and an update to ruamel.yaml.clib. Tested out with some simple documents on Python 3.12

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
