### PR TITLE
python3*: fix for Rosetta case where pthread_threadid_np is unsupported

### DIFF
--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -38,8 +38,14 @@ patchfiles          patch-setup.py.diff \
 
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     # work around no copyfile and/or pthread_threadid_np on older systems
-    patchfiles-append  patch-no-copyfile-on-Tiger.diff \
-                       patch-threadid-older-systems.diff
+    patchfiles-append   patch-no-copyfile-on-Tiger.diff
+    if {${configure.build_arch} in [list ppc ppc64]} {
+        patchfiles-append 
+                        patch-threadid-powerpc.diff
+    } else {
+        patchfiles-append 
+                        patch-threadid-older-systems.diff
+    }
 }
 
 depends_build       port:pkgconfig

--- a/lang/python310/files/patch-threadid-powerpc.diff
+++ b/lang/python310/files/patch-threadid-powerpc.diff
@@ -1,0 +1,22 @@
+diff --git Python/thread_pthread.h Python/thread_pthread.h
+index e6910b3..ff9bb1f 100644
+--- Python/thread_pthread.h
++++ Python/thread_pthread.h
+@@ -331,7 +331,17 @@ PyThread_get_thread_native_id(void)
+         PyThread_init_thread();
+ #ifdef __APPLE__
+     uint64_t native_id;
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060 || defined(__POWERPC__)
++    native_id = pthread_mach_thread_np(pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    if (&pthread_threadid_np != NULL) {
++        (void) pthread_threadid_np(NULL, &native_id);
++    } else {
++        native_id = pthread_mach_thread_np(pthread_self());
++    }
++#else
+     (void) pthread_threadid_np(NULL, &native_id);
++#endif
+ #elif defined(__linux__)
+     pid_t native_id;
+     native_id = syscall(SYS_gettid);

--- a/lang/python311/Portfile
+++ b/lang/python311/Portfile
@@ -36,8 +36,14 @@ patchfiles          patch-setup.py.diff \
 
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     # work around no copyfile and/or pthread_threadid_np on older systems
-    patchfiles-append  patch-no-copyfile-on-Tiger.diff \
-                       patch-threadid-older-systems.diff
+    patchfiles-append   patch-no-copyfile-on-Tiger.diff
+    if {${configure.build_arch} in [list ppc ppc64]} {
+        patchfiles-append 
+                        patch-threadid-powerpc.diff
+    } else {
+        patchfiles-append 
+                        patch-threadid-older-systems.diff
+    }
 }
 
 if {${configure.build_arch} in "ppc ppc64"} {

--- a/lang/python311/files/patch-threadid-powerpc.diff
+++ b/lang/python311/files/patch-threadid-powerpc.diff
@@ -1,0 +1,22 @@
+diff --git Python/thread_pthread.h Python/thread_pthread.h
+index e6910b3..ff9bb1f 100644
+--- Python/thread_pthread.h
++++ Python/thread_pthread.h
+@@ -331,7 +331,17 @@ PyThread_get_thread_native_id(void)
+         PyThread_init_thread();
+ #ifdef __APPLE__
+     uint64_t native_id;
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060 || defined(__POWERPC__)
++    native_id = pthread_mach_thread_np(pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    if (&pthread_threadid_np != NULL) {
++        (void) pthread_threadid_np(NULL, &native_id);
++    } else {
++        native_id = pthread_mach_thread_np(pthread_self());
++    }
++#else
+     (void) pthread_threadid_np(NULL, &native_id);
++#endif
+ #elif defined(__linux__)
+     pid_t native_id;
+     native_id = syscall(SYS_gettid);

--- a/lang/python312/Portfile
+++ b/lang/python312/Portfile
@@ -35,8 +35,14 @@ patchfiles          patch-Lib-cgi.py.diff \
 
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     # work around no copyfile and/or pthread_threadid_np on older systems
-    patchfiles-append  patch-no-copyfile-on-Tiger.diff \
-                       patch-threadid-older-systems.diff
+    patchfiles-append   patch-no-copyfile-on-Tiger.diff
+    if {${configure.build_arch} in [list ppc ppc64]} {
+        patchfiles-append 
+                        patch-threadid-powerpc.diff
+    } else {
+        patchfiles-append 
+                        patch-threadid-older-systems.diff
+    }
 }
 
 depends_build       port:pkgconfig

--- a/lang/python312/files/patch-threadid-powerpc.diff
+++ b/lang/python312/files/patch-threadid-powerpc.diff
@@ -1,0 +1,22 @@
+diff --git Python/thread_pthread.h Python/thread_pthread.h
+index e6910b3..ff9bb1f 100644
+--- Python/thread_pthread.h
++++ Python/thread_pthread.h
+@@ -331,7 +331,17 @@ PyThread_get_thread_native_id(void)
+         PyThread_init_thread();
+ #ifdef __APPLE__
+     uint64_t native_id;
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060 || defined(__POWERPC__)
++    native_id = pthread_mach_thread_np(pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    if (&pthread_threadid_np != NULL) {
++        (void) pthread_threadid_np(NULL, &native_id);
++    } else {
++        native_id = pthread_mach_thread_np(pthread_self());
++    }
++#else
+     (void) pthread_threadid_np(NULL, &native_id);
++#endif
+ #elif defined(__linux__)
+     pid_t native_id;
+     native_id = syscall(SYS_gettid);

--- a/lang/python38/Portfile
+++ b/lang/python38/Portfile
@@ -42,8 +42,14 @@ patchfiles          patch-setup.py.diff \
 
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     # work around no copyfile and/or pthread_threadid_np on older systems
-    patchfiles-append  patch-no-copyfile-on-Tiger.diff \
-                       patch-threadid-older-systems.diff
+    patchfiles-append   patch-no-copyfile-on-Tiger.diff
+    if {${configure.build_arch} in [list ppc ppc64]} {
+        patchfiles-append 
+                        patch-threadid-powerpc.diff
+    } else {
+        patchfiles-append 
+                        patch-threadid-older-systems.diff
+    }
 }
 
 depends_build       port:pkgconfig

--- a/lang/python38/files/patch-threadid-powerpc.diff
+++ b/lang/python38/files/patch-threadid-powerpc.diff
@@ -1,0 +1,23 @@
+--- Python/thread_pthread.h.orig	2020-03-07 12:42:06.000000000 -0800
++++ Python/thread_pthread.h	2020-03-07 12:48:22.000000000 -0800
+@@ -325,9 +325,19 @@
+ {
+     if (!initialized)
+         PyThread_init_thread();
+ #ifdef __APPLE__
+     uint64_t native_id;
+-    (void) pthread_threadid_np(NULL, &native_id);
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060 || defined(__POWERPC__)
++    native_id = pthread_mach_thread_np(pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    if (&pthread_threadid_np) {
++        (void) pthread_threadid_np(NULL, &native_id);
++    } else {
++        native_id = pthread_mach_thread_np(pthread_self());
++    }
++#else
++    (void) pthread_threadid_np(NULL, &native_id);
++#endif
+ #elif defined(__linux__)
+     pid_t native_id;
+     native_id = syscall(SYS_gettid);

--- a/lang/python39/Portfile
+++ b/lang/python39/Portfile
@@ -37,8 +37,14 @@ patchfiles          patch-setup.py.diff \
 
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     # work around no copyfile and/or pthread_threadid_np on older systems
-    patchfiles-append  patch-no-copyfile-on-Tiger.diff \
-                       patch-threadid-older-systems.diff
+    patchfiles-append   patch-no-copyfile-on-Tiger.diff
+    if {${configure.build_arch} in [list ppc ppc64]} {
+        patchfiles-append 
+                        patch-threadid-powerpc.diff
+    } else {
+        patchfiles-append 
+                        patch-threadid-older-systems.diff
+    }
 }
 
 depends_build       port:pkgconfig

--- a/lang/python39/files/patch-threadid-powerpc.diff
+++ b/lang/python39/files/patch-threadid-powerpc.diff
@@ -1,0 +1,22 @@
+diff --git Python/thread_pthread.h Python/thread_pthread.h
+index e6910b3..ff9bb1f 100644
+--- Python/thread_pthread.h
++++ Python/thread_pthread.h
+@@ -331,7 +331,17 @@ PyThread_get_thread_native_id(void)
+         PyThread_init_thread();
+ #ifdef __APPLE__
+     uint64_t native_id;
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060 || defined(__POWERPC__)
++    native_id = pthread_mach_thread_np(pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    if (&pthread_threadid_np != NULL) {
++        (void) pthread_threadid_np(NULL, &native_id);
++    } else {
++        native_id = pthread_mach_thread_np(pthread_self());
++    }
++#else
+     (void) pthread_threadid_np(NULL, &native_id);
++#endif
+ #elif defined(__linux__)
+     pid_t native_id;
+     native_id = syscall(SYS_gettid);


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68383

#### Description

Fix for Rosetta. The problem in fact is known and has been correctly fixed for a number of ports earlier (`ruby`, `spdlog` etc.), however with pythons prior to `python312` there was no explicit failure, so it remained unfixed. Now `python312` fails to build on 10.6.8 Rosetta. This PR fixes that, and backports the fix.

Nothing besides `ppc` build on 10.6.x is affected.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
