### PR TITLE
qt5-qtspeech: depend on flite, fix build failure

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -584,12 +584,12 @@ array set modules {
             104996
         }
         ""
-        ""
+        "port:flite"
         "qtbase qtdeclarative qtmultimedia"
         {"Qt Speech"}
         ""
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtsvg {
@@ -1919,6 +1919,15 @@ foreach {module module_info} [array get modules] {
             # special case
             if { ${module} eq "qtsvg" } {
                 patchfiles-append CVE-2023-32573-qtsvg-5.15.diff
+            }
+
+            # special case
+            if { ${module} eq "qtspeech" } {
+                # see https://trac.macports.org/ticket/67593
+                # error: library not found for -lasound
+                configure.post_args-append  \
+                    --                      \
+                    -no-flite-alsa
             }
         }
     }


### PR DESCRIPTION
#### Description
Closes: https://trac.macports.org/ticket/67593
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.0 23A344 x86_64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->