### PR TITLE
tmux: Add default terminal to fix backspaces

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -9,13 +9,13 @@ legacysupport.newest_darwin_requires_legacy 8
 
 github.setup    tmux tmux 3.3a
 if {${subport} eq ${name}} {
-    revision        0
+    revision        1
     conflicts       tmux-devel
 }
 subport tmux-devel {
     github.setup    tmux tmux 96ad8280b28283eb01e7789f5bafd2e1f6cde139
     version         20210610-[string range ${github.version} 0 6]
-    revision        0
+    revision        1
     conflicts       tmux
 }
 categories      sysutils
@@ -31,6 +31,9 @@ platforms       darwin
 license         BSD
 
 depends_lib     port:libevent port:ncurses
+
+# Use screen by default to display tmux correctly when backspacing
+configure.args-append   --with-TERM=screen
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
@@ -83,6 +86,9 @@ post-destroot {
     xinstall -m 0644 ${filespath}/ftdetect-tmux.vim ${destroot}${prefix}/share/vim/vimfiles/ftdetect/tmux.vim
 }
 
-notes "If you want integration with system pasteboard consider installing port tmux-pasteboard as well"
+notes {
+    On legacy systems, consider installing port tmux-pasteboard to \
+    intergrate the system pasteboard with tmux.
+}
 
 github.livecheck.regex {([0-9.]+[a-z]?)}


### PR DESCRIPTION
#### Description

Without specifying a default terminal while configuring, tmux fails to correctly display itself when backspacing.

Closes: https://trac.macports.org/ticket/65923

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
