### PR TITLE
picocom: update to 2023-04

### DIFF
--- a/comms/picocom/Portfile
+++ b/comms/picocom/Portfile
@@ -2,13 +2,12 @@
 
 PortSystem 1.0
 
-PortGroup           github 1.0
+PortGroup           gitlab 1.0
 
-github.setup        npat-efault picocom 3.1
+gitlab.setup        wsakernel picocom 2023-04
 categories          comms
 maintainers         nomaintainer
-platforms           darwin
-license             GPL-2
+license             GPL-2+
 
 description         Minimal dumb-terminal emulation program
 long_description \
@@ -20,8 +19,9 @@ long_description \
         "open terminal window before / after dialing" feature). \
         It could also prove useful in many other similar tasks.
 
-checksums           rmd160  1dedceb6c582d17160bf6a7cc5ce6c24cec7ea25 \
-                    sha256  5ddaab587038e9aee3b1e56b8438f0b8b95f22b2b57a54d4528c157bffcea656
+checksums           rmd160  4ddac33b93c4ba9f226ee47784467559b38c58ec \
+                    sha256  23d07a9ce7d1058675c66c4c36e14a54149f8e613aa56f8ff07c1969a70213fe \
+                    size    114364
 
 use_configure       no
 


### PR DESCRIPTION
- Move to gitlab fork
- Correct license to GPL-2+

Closes https://trac.macports.org/ticket/65971

Supposedly this new version supports bash completion, I haven't looked into if anything needs to be changed to implement this.
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
