### PR TITLE
lagrange: update to 1.17.0

### DIFF
--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -10,8 +10,8 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 gitea.domain        git.skyjake.fi
-gitea.setup         skyjake the_Foundation 1.6.1 v
-revision            1
+gitea.setup         skyjake the_Foundation 1.7.0 v
+revision            0
 categories          devel
 license             BSD
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -19,9 +19,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Opinionated C11 library for low-level functionality
 long_description    {*}${description}
 
-checksums           rmd160  3997da598b85744da052d373b2d6451417ffc1b3 \
-                    sha256  fde92455755528778aa17a4a6bb0e4ef9fa4770a28adeb7e14ddcbb1a0ebf80c \
-                    size    212529
+checksums           rmd160  ef510b94deb04e1f06e4856579eab2ce1e9acc64 \
+                    sha256  c0b4b8b8ec583419d3fdec98a0850385deced9bfa3a7b39474ef06600bfb9dc8 \
+                    size    218322
 
 depends_build-append \
                     port:pkgconfig

--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.16.7 v
+gitea.setup         gemini lagrange 1.17.0 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  d89e33e1adb746b65f208637512139d5e4e5a251 \
-                    sha256  d7db7be2f6e706da0077813b53a019b0ba235c9778c88d38b426b8b1bddcdb2a \
-                    size    7543564
+checksums           rmd160  a1938a81b463b09640a6fc0298766d481dbaea00 \
+                    sha256  a5bcffcfc2df5b7034144631307aed907f767c9cd47456441e34b51aacc33605 \
+                    size    7661720
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
Changelog:
* https://github.com/skyjake/lagrange/releases/tag/v1.17.0
* https://git.skyjake.fi/skyjake/the_Foundation/releases/tag/v1.7.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
