### PR TITLE
aacplusenc: new port

### DIFF
--- a/audio/aacplusenc/Portfile
+++ b/audio/aacplusenc/Portfile
@@ -1,0 +1,67 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                aacplusenc
+version             0.17.5
+categories          audio
+license             GPL-2
+maintainers         nomaintainer
+description         HE-AACv2/AAC+ encoder
+long_description    aacplusenc is a command line HE-AAC encoder based on 3GPP \
+                    sources.
+
+homepage            https://teknoraver.net/software/mp4tools/
+# https://github.com/teknoraver/aacplusenc
+
+master_sites        http://ppa.launchpad.net/teknoraver/ppa/ubuntu/pool/main/a/${name}/:teknoraver-ppa
+distname            ${name}_${version}
+
+distfiles           ${name}_${version}${extract.suffix}:teknoraver-ppa
+
+checksums           ${name}_${version}${extract.suffix} \
+                    rmd160  c59efc3a3f8126b4650b304a043f176b80078d82 \
+                    sha256  318df58a86ac0647d6bfbcd8766fe301ad2ed08ffb4ef4e016e088f4dceb1669 \
+                    size    547953
+
+extract.only        ${distname}${extract.suffix}
+
+depends_lib         path:lib/libfftw3f.dylib:fftw-3-single
+
+worksrcdir          aacplusenc
+
+patchfiles-append   configure.patch
+
+configure.env-append \
+                    PREFIX=${prefix}
+configure.pre_args  {}
+build.pre_args-append \
+                    EXTRACFLAGS=${configure.cflags}
+
+destroot {
+    # Don't use make install because it does not respect the common
+    # $(DESTDIR)$(prefix) and does not install the man page.
+    xinstall -m 0755 ${worksrcpath}/aacplusenc ${destroot}${prefix}/bin/aacplusenc
+    xinstall -m 0444 ${worksrcpath}/aacplusenc.1 ${destroot}${prefix}/share/man/man1/aacplusenc.1
+}
+
+variant test description {Enable testing} {
+    test.run        yes
+    test.target     test
+    depends_test    bin:mplayer:MPlayer
+
+    # Sample .wav file needed for tests. Download from Samplelib:
+    master_sites-append https://download.samplelib.com/wav/:samplelib
+
+    distfiles-append    sample-3s.wav:samplelib
+
+    checksums-append    sample-3s.wav \
+                        rmd160  37e56eacf829951d3a5c4586bafb6cc6613c3ce7 \
+                        sha256  b3726eac5c9612ea20e245314812575bf9df5fb6b8024b80c7cfe9033452bb2b \
+                        size    563756
+
+    post-extract {
+        # Install .wav file as test.wav
+        file copy ${distpath}/sample-3s.wav ${worksrcpath}/test.wav
+    }
+}

--- a/audio/aacplusenc/files/configure.patch
+++ b/audio/aacplusenc/files/configure.patch
@@ -1,0 +1,62 @@
+--- configure.orig
++++ configure
+@@ -6,9 +6,9 @@
+ #define _CONFIG_H
+ EOF
+ 
+-echo -n 'Checking for libfftw3f...'
++printf 'Checking for libfftw3f... '
+ 
+-gcc -o test-fft -Wall -x c -lfftw3f -I/usr/local/include -L/usr/local/lib - <<'EOF'
++gcc -o test-fft -Wall -x c -lfftw3f -I"${PREFIX:-/usr/local}/include" -L"${PREFIX:-/usr/local}/lib" - <<'EOF'
+ #include <fftw3.h>
+ 
+ #define N 128
+@@ -31,12 +31,12 @@
+ 
+ if ./test-fft
+ then
+-	echo OK
+-	echo '#define _FFTW3' >> config.h
+-	echo 'export FFTW3=1' >> config.mak
++	printf 'OK\n'
++	printf '#define _FFTW3\n' >> config.h
++	printf 'export FFTW3=1\n' >> config.mak
+ fi
+ 
+-echo -n 'Detecting endianness...'
++printf 'Detecting endianness... '
+ 
+ gcc -o test-endian -Wall -x c - <<'EOF'
+ #include <stdint.h>
+@@ -63,17 +63,19 @@
+ if ./test-endian > /dev/null
+ then
+ 	ENDIAN=$(./test-endian)
+-	if [ $ENDIAN = EL ]
+-	then
+-		echo 'Little Endian'
+-		echo '#define _EL_ARCH' >> config.h
+-	elif [ $ENDIAN = BE ]
+-	then
+-		echo 'Big Endian'
+-		echo '#define _BE_ARCH' >> config.h
+-	fi
++	case ${ENDIAN}
++	in
++		(EL)
++			printf 'Little Endian\n'
++			printf '#define _EL_ARCH\n' >> config.h
++			;;
++		(BE)
++			printf 'Big Endian\n'
++			printf '#define _BE_ARCH\n' >> config.h
++			;;
++	esac
+ fi
+ 
+-echo '#endif' >> config.h
++printf '#endif\n' >> config.h
+ 
+-echo 'Now run make'
++# printf 'Now run make\n'


### PR DESCRIPTION
#### Description

This PR adds a new port for the [aacplusenc](https://github.com/teknoraver/aacplusenc) utility which is needed by an XLD plugin (cf. #20766).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
* macOS 12.7 21G816 x86_64
  Xcode 14.2 14C18
* Mac OS X 10.5.8 9L31a Power Macintosh
  Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
