### PR TITLE
py-numba: update to 0.58.0

### DIFF
--- a/python/py-numba/Portfile
+++ b/python/py-numba/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 PortGroup           compiler_wrapper 1.0
 
-github.setup        numba numba 0.57.1
+github.setup        numba numba 0.58.0
 name                py-numba
 revision            0
 categories-append   devel
@@ -24,9 +24,9 @@ long_description    Numba is an Open Source NumPy-aware optimizing compiler \
 
 homepage            https://numba.pydata.org/
 
-checksums           rmd160  3ea4f374f2aaa369e762bd82c0bdd4770cf578a4 \
-                    sha256  c2c146181980f31f5417e978baa43bc91f0c11b4ad95bccb117eb31e8449c651 \
-                    size    2617274
+checksums           rmd160  02d12eb84ad4a4ef29ba0ef540db18c09bdad880 \
+                    sha256  092c21b4f832ad18a34b1408f7f411ce29bc7b7b3be18a824ad41c3553466a66 \
+                    size    2691724
 
 variant tbb description "Add support for TBB" {
     depends_lib-append  port:onetbb
@@ -38,6 +38,10 @@ if {${name} ne ${subport}} {
 
     depends_lib-append  port:py${python.version}-llvmlite \
                         port:py${python.version}-numpy
+
+    if {${python.version} < 39} {
+        depends_lib-append  port:py${python.version}-importlib-metadata
+    }
 } else {
     github.livecheck.regex  {([0-9.]+)}
 }


### PR DESCRIPTION
#### Description
py-numba: update to 0.58.0

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6 22G120 arm64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`? Without -t option.
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
