### PR TITLE
ImageMagick: update to 6.9.12-98

### DIFF
--- a/R/R-magick/Portfile
+++ b/R/R-magick/Portfile
@@ -5,7 +5,7 @@ PortGroup           R 1.0
 
 # GitHub version lags behind.
 R.setup             cran ropensci magick 2.8.0
-revision            0
+revision            1
 categories-append   graphics
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/aqua/LyX/Portfile
+++ b/aqua/LyX/Portfile
@@ -7,7 +7,7 @@ PortGroup           boost 1.0
 name                LyX
 conflicts           LyX1
 version             2.3.7
-revision            0
+revision            1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          aqua
 license             GPL-2+

--- a/aqua/LyX1/Portfile
+++ b/aqua/LyX1/Portfile
@@ -5,7 +5,7 @@ PortGroup           qt4 1.0
 
 name                LyX1
 version             1.6.10
-revision            3
+revision            4
 categories          aqua
 platforms           darwin
 license             GPL-2+

--- a/databases/psiconv/Portfile
+++ b/databases/psiconv/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                psiconv
 version             0.9.9
-revision            4
+revision            5
 categories          databases
 platforms           darwin
 license             GPL-2

--- a/devel/libpst/Portfile
+++ b/devel/libpst/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                libpst
 version             0.6.76
-revision            0
+revision            1
 checksums           rmd160  856fc7770e5d4d83dcbe0b283229b40ad04a3caa \
                     sha256  3d291beebbdb48d2b934608bc06195b641da63d2a8f5e0d386f2e9d6d05a0b42 \
                     size    12886768

--- a/devel/libtuxcap/Portfile
+++ b/devel/libtuxcap/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                libtuxcap
 version             1.4.0
-revision            7
+revision            8
 checksums           rmd160  43d236b65fd6bb28b3ceaa6ba3193ecbcc5e6675 \
                     sha256  dae27bad276bffce6eba8114cd0e3edc0db710306f627b984464c4f0ec1fab2f \
                     size    4622159

--- a/devel/virtuoso-5/Portfile
+++ b/devel/virtuoso-5/Portfile
@@ -9,7 +9,7 @@ openssl.branch      1.0
 name                virtuoso-5
 set myname          virtuoso
 version             5.0.15
-revision            0
+revision            1
 categories          devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL

--- a/devel/virtuoso-6/Portfile
+++ b/devel/virtuoso-6/Portfile
@@ -9,7 +9,7 @@ openssl.branch      1.0
 name                virtuoso-6
 set myname          virtuoso
 version             6.1.8
-revision            8
+revision            9
 categories          devel
 maintainers         {snc @nerdling} openmaintainer
 license             GPL

--- a/devel/virtuoso-7/Portfile
+++ b/devel/virtuoso-7/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 name                virtuoso-7
 set myname          virtuoso
 version             7.2.10
-revision            0
+revision            1
 categories          devel
 maintainers         {snc @nerdling} openmaintainer
 license             GPL

--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -9,13 +9,11 @@ PortGroup                   conflicts_build 1.0
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-# 6.9.11-61 changes the major version of libMagickCore which will
-# require increasing the revision of all ports that link with it.
-version                     6.9.11-60
-revision                    11
-checksums                   rmd160  1c293ba06fd43833be35efb4476e559bf137ccef \
-                            sha256  ba0fa683b0721d1f22b0ccb364e4092e9a7a34ffd3bd6348c82b50fd93b1d7ba \
-                            size    9167220
+version                     6.9.12-98
+revision                    0
+checksums                   rmd160  a3debcb411b43719d685b6ebb02177947f960b02 \
+                            sha256  05e3f1994bcd2dd35aad33739832deb5ac5a3db46b4bcf39c8cdc281d72ed7d7 \
+                            size    9276272
 
 categories                  graphics devel
 maintainers                 {ryandesign @ryandesign}

--- a/graphics/ale/Portfile
+++ b/graphics/ale/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                ale
 version             0.8.7
-revision            5
+revision            6
 categories          graphics
 platforms           darwin
 maintainers         nomaintainer

--- a/graphics/autotrace/Portfile
+++ b/graphics/autotrace/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            autotrace autotrace 20200219.65 travis-
 version                 0.40.0-${github.version}
-revision                0
+revision                1
 checksums               rmd160  cbb9bb78ac51ab24835043cac02d4aef99db3d95 \
                         sha256  74ca2555aff1a968290f13602a90f836872e08d37ecaf80c5296ad223f6cd69a \
                         size    7880004

--- a/graphics/chafa/Portfile
+++ b/graphics/chafa/Portfile
@@ -7,7 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 github.setup        hpjansson chafa 1.12.5
 # Please switch to the release xz tarball at the next version and stop using autoreconf.
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://hpjansson.org/chafa
 

--- a/graphics/converseen/Portfile
+++ b/graphics/converseen/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 PortGroup           qt5 1.0
 
 github.setup        Faster3ck converseen 0.11.0.1 v
-revision            0
+revision            1
 categories          graphics
 license             GPL-3
 maintainers         {mps @Schamschula} openmaintainer

--- a/graphics/dmtx-utils/Portfile
+++ b/graphics/dmtx-utils/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        dmtx dmtx-utils 0.7.6 v
-revision            1
+revision            2
 categories          graphics
 platforms           darwin
 maintainers         nomaintainer

--- a/graphics/gscan2pdf/Portfile
+++ b/graphics/gscan2pdf/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 name                gscan2pdf
 version             2.13.2
-revision            0
+revision            1
 
 categories          graphics
 maintainers         nomaintainer

--- a/graphics/inkscape-devel/Portfile
+++ b/graphics/inkscape-devel/Portfile
@@ -14,7 +14,7 @@ set ver_date        2023-07-21
 set ver_hash        0e150ed6c4
 set ver_gal_item    42328
 version             ${ver_num}
-revision            0
+revision            1
 epoch               2
 
 categories          graphics gnome

--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -14,7 +14,7 @@ set ver_date        2023-07-21
 set ver_hash        0e150ed6c4
 set ver_gal_item    42328
 version             ${ver_num}
-revision            3
+revision            4
 epoch               0
 
 categories          graphics gnome

--- a/graphics/oofcanvas/Portfile
+++ b/graphics/oofcanvas/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                oofcanvas
 version             1.1.1
-revision            1
+revision            2
 
 license             public-domain
 categories          graphics

--- a/graphics/pstoedit/Portfile
+++ b/graphics/pstoedit/Portfile
@@ -8,7 +8,7 @@ legacysupport.redirect_bins pstoedit
 
 name                pstoedit
 version             4.00
-revision            1
+revision            2
 categories          graphics
 platforms           darwin
 maintainers         nomaintainer

--- a/graphics/synfig/Portfile
+++ b/graphics/synfig/Portfile
@@ -28,7 +28,7 @@ if {${subport} in [list ${name} ${name}studio]} {
 }
 
 if {${subport} eq ${name}} {
-    revision            3
+    revision            4
     checksums           rmd160  35f55a26bdc7bce9a4675ed5ac259edb52d254ab \
                         sha256  cd9882a091433e22e484e47d7bfe542aaefd3f62bfd746d306be4ce964756f06 \
                         size    5177728

--- a/graphics/t-rec/Portfile
+++ b/graphics/t-rec/Portfile
@@ -7,7 +7,7 @@ PortGroup           github  1.0
 github.setup        sassman t-rec-rs 0.7.6 v
 github.tarball_from archive
 name                t-rec
-revision            0
+revision            1
 
 homepage            https://crates.io/crates/t-rec
 

--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -6,7 +6,7 @@ PortGroup           gobject_introspection 1.0
 PortGroup           meson 1.0
 
 github.setup        libvips libvips 8.14.5 v
-revision            0
+revision            1
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.

--- a/graphics/zbar/Portfile
+++ b/graphics/zbar/Portfile
@@ -6,7 +6,7 @@ PortGroup               active_variants 1.1
 
 github.setup            mchehab zbar 0.23.92
 github.tarball_from     archive
-revision                0
+revision                1
 
 checksums               rmd160  043e4904f567261148aa2223502c0ba2fc740ef1 \
                         sha256  dffc16695cb6e42fa318a4946fd42866c0f5ab735f7eaf450b108d1c3a19b4ba \

--- a/kde/digikam/Portfile
+++ b/kde/digikam/Portfile
@@ -7,7 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                digikam
 version             4.9.0
-revision            15
+revision            16
 
 # TODO: Remove, if/when this port is fixed
 known_fail          yes

--- a/math/pyxplot/Portfile
+++ b/math/pyxplot/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                pyxplot
 version             0.9.2
-revision            24
+revision            25
 categories          math science
 maintainers         {mps @Schamschula} openmaintainer
 license             GPL-3+

--- a/multimedia/dvdauthor/Portfile
+++ b/multimedia/dvdauthor/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                dvdauthor
 version             0.7.2
-revision            3
+revision            4
 categories          multimedia
 platforms           darwin
 maintainers         {perry.ch:maurice @robbyn}

--- a/multimedia/dvdrip/Portfile
+++ b/multimedia/dvdrip/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 name                dvdrip
 perl5.branches      5.34
 perl5.setup         ${name} 0.98.11
-revision            7
+revision            8
 categories          multimedia
 maintainers         nomaintainer
 license             {Artistic-1 GPL}

--- a/multimedia/libopenshot/Portfile
+++ b/multimedia/libopenshot/Portfile
@@ -7,6 +7,7 @@ PortGroup           github 1.0
 
 github.setup        OpenShot libopenshot 0.3.2 v
 github.tarball_from archive
+revision            1
 checksums           rmd160  56febba77be0cc7f837ac26f211c9a6808d3f499 \
                     sha256  58765cfc8aec199814346e97ce31a5618a261260b380670a6fb2bf6f68733638 \
                     size    26132237

--- a/multimedia/tovid/Portfile
+++ b/multimedia/tovid/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        tovid-suite tovid 0.35.2
-revision            2
+revision            3
 categories          multimedia
 maintainers         nomaintainer
 installs_libs       no

--- a/multimedia/transcode/Portfile
+++ b/multimedia/transcode/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 
 name        transcode
 version     1.1.7
-revision    28
+revision    29
 epoch       1
 license     GPL-2+
 categories  multimedia

--- a/multimedia/vapoursynth/Portfile
+++ b/multimedia/vapoursynth/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            vapoursynth vapoursynth 62 R
 github.tarball_from     archive
-revision                0
+revision                1
 
 description             A video processing framework with simplicity in mind
 

--- a/multimedia/xine-lib/Portfile
+++ b/multimedia/xine-lib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xine-lib
 version             1.2.13
-revision            0
+revision            1
 checksums           rmd160  2b1045e3dfe475c92a442f3506ee8b570b73da32 \
                     sha256  5f10d6d718a4a51c17ed1b32b031d4f9b80b061e8276535b2be31e5ac4b75e6f \
                     size    5004196

--- a/perl/p5-image-sane/Portfile
+++ b/perl/p5-image-sane/Portfile
@@ -14,7 +14,7 @@ checksums           rmd160  f313d74d543823d613938306067ae4670f6bbdd9 \
                     sha256  229aa0e9f049efa760f3c2f6e61d9d539af43d8f764b50a6e03064b4729a35ff \
                     size    47781
 
-revision            2
+revision            3
 
 if {${perl5.major} != ""} {
     depends_lib-append \

--- a/perl/p5-pdf-builder/Portfile
+++ b/perl/p5-pdf-builder/Portfile
@@ -5,7 +5,7 @@ PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
 perl5.setup         PDF-Builder 3.025
-revision            1
+revision            2
 license             LGPL-2.1
 maintainers         nomaintainer
 description         PDF::Builder - Facilitates the creation and modification of PDF files

--- a/perl/p5-perlmagick/Portfile
+++ b/perl/p5-perlmagick/Portfile
@@ -7,11 +7,11 @@ PortGroup           perl5 1.0
 
 epoch               1
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         PerlMagick 6.9.11-60
+perl5.setup         PerlMagick 6.9.12-98
 revision            0
-checksums           rmd160  1c293ba06fd43833be35efb4476e559bf137ccef \
-                    sha256  ba0fa683b0721d1f22b0ccb364e4092e9a7a34ffd3bd6348c82b50fd93b1d7ba \
-                    size    9167220
+checksums           rmd160  a3debcb411b43719d685b6ebb02177947f960b02 \
+                    sha256  05e3f1994bcd2dd35aad33739832deb5ac5a3db46b4bcf39c8cdc281d72ed7d7 \
+                    size    9276272
 
 set my_name         ImageMagick
 maintainers         {ryandesign @ryandesign}

--- a/perl/p5-perlmagick/files/no-usr-include-ImageMagick.patch
+++ b/perl/p5-perlmagick/files/no-usr-include-ImageMagick.patch
@@ -1,34 +1,34 @@
 Don't look in /usr/include/ImageMagick.
---- PerlMagick/Makefile.PL.in.orig	2019-11-29 12:39:22.000000000 -0600
-+++ PerlMagick/Makefile.PL.in	2019-12-01 05:51:53.000000000 -0600
+--- PerlMagick/Makefile.PL.in.orig	2023-10-09 01:37:25
++++ PerlMagick/Makefile.PL.in	2023-10-11 13:42:44
 @@ -161,7 +161,7 @@
  }
  
  # defaults for LIBS & INC & CCFLAGS params that we later pass to Writemakefile
 -my $INC_magick = '-I../ -I@top_srcdir@ @CPPFLAGS@ -I"' . $Config{'usrinc'} . '/ImageMagick"';
 +my $INC_magick = '-I../ -I@top_srcdir@ @CPPFLAGS@';
- my $LIBS_magick = '-L../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ -lperl @MATH_LIBS@';
+ my $LIBS_magick = '-L../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ @MATH_LIBS@ -L' . $Config{'archlib'} . '/CORE';
  my $CCFLAGS_magick = "$Config{'ccflags'} @CFLAGS@";
  my $LDFLAGS_magick   = "-L../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ $Config{'ldflags'} @LDFLAGS@";
---- PerlMagick/default/Makefile.PL.in.orig	2019-11-29 12:39:22.000000000 -0600
-+++ PerlMagick/default/Makefile.PL.in	2019-12-01 05:52:00.000000000 -0600
+--- PerlMagick/default/Makefile.PL.in.orig	2023-10-09 01:37:25
++++ PerlMagick/default/Makefile.PL.in	2023-10-11 13:43:20
 @@ -161,7 +161,7 @@
  }
  
  # defaults for LIBS & INC & CCFLAGS params that we later pass to Writemakefile
 -my $INC_magick = '-I../.. -I@top_srcdir@ @CPPFLAGS@ -I"' . $Config{'usrinc'} . '/ImageMagick"';
 +my $INC_magick = '-I../.. -I@top_srcdir@ @CPPFLAGS@';
- my $LIBS_magick = '-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ -lperl @MATH_LIBS@';
+ my $LIBS_magick = '-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ @MATH_LIBS@ -L' . $Config{'archlib'} . '/CORE';
  my $CCFLAGS_magick = "$Config{'ccflags'} @CFLAGS@";
  my $LDFLAGS_magick   = "-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ $Config{'ldflags'} @LDFLAGS@";
---- PerlMagick/quantum/Makefile.PL.in.orig	2019-11-29 12:39:22.000000000 -0600
-+++ PerlMagick/quantum/Makefile.PL.in	2019-12-01 05:51:42.000000000 -0600
+--- PerlMagick/quantum/Makefile.PL.in.orig	2023-10-09 01:37:25
++++ PerlMagick/quantum/Makefile.PL.in	2023-10-11 13:46:41
 @@ -161,7 +161,7 @@
  }
  
  # defaults for LIBS & INC & CCFLAGS params that we later pass to Writemakefile
 -my $INC_magick = '-I../../ -I@top_srcdir@ @CPPFLAGS@ -I"' . $Config{'usrinc'} . '/ImageMagick"';
 +my $INC_magick = '-I../../ -I@top_srcdir@ @CPPFLAGS@';
- my $LIBS_magick = '-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ -lperl @MATH_LIBS@';
+ my $LIBS_magick = '-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ @MATH_LIBS@ -L' . $Config{'archlib'} . '/CORE';
  my $CCFLAGS_magick = "$Config{'ccflags'} @CFLAGS@";
  my $LDFLAGS_magick   = "-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ $Config{'ldflags'} @LDFLAGS@";

--- a/php/php-imagick/Portfile
+++ b/php/php-imagick/Portfile
@@ -20,7 +20,7 @@ long_description        Imagick is a native PHP extension for creating and \
 if {[vercmp ${php.branch} 5.4] >= 0} {
     epoch               1
     version             3.7.0
-    revision            0
+    revision            1
     checksums           rmd160  60d5c6cc154b65bdfd31be6980633ff1e659bc73 \
                         sha256  5a364354109029d224bcbb2e82e15b248be9b641227f45e63425c06531792d3e \
                         size    360138
@@ -29,7 +29,7 @@ if {[vercmp ${php.branch} 5.4] >= 0} {
     # https://pecl.php.net/package-info.php?package=imagick&version=3.4.0RC1
     epoch               2
     version             3.3.0
-    revision            0
+    revision            1
     checksums           rmd160  5746dc20ed455049a6eb5cea8dfe2b6c702c8f7c \
                         sha256  bd69ebadcedda1d87592325b893fa78a5710a0ca7307f8e18c5e593949b1db2d \
                         size    179978

--- a/php/php-magickwand/Portfile
+++ b/php/php-magickwand/Portfile
@@ -5,7 +5,7 @@ PortGroup           php 1.1
 
 name                php-magickwand
 version             1.0.9-2
-revision            5
+revision            6
 categories-append   graphics
 platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer

--- a/python/py-djvubind/Portfile
+++ b/python/py-djvubind/Portfile
@@ -6,7 +6,7 @@ PortGroup                       deprecated 1.0
 
 name                            py-djvubind
 version                         1.2.1
-revision                        2
+revision                        3
 python.versions                 35 36
 platforms                       darwin
 supported_archs                 noarch

--- a/python/py-wand/Portfile
+++ b/python/py-wand/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 name                py-wand
 python.rootname     Wand
 version             0.6.11
-revision            0
+revision            1
 categories-append   graphics
 license             MIT
 supported_archs     noarch

--- a/ruby/rb-rmagick/Portfile
+++ b/ruby/rb-rmagick/Portfile
@@ -5,7 +5,7 @@ PortGroup               ruby 1.0
 
 ruby.branches           3.2 3.1 3.0 2.7 2.6 2.5 2.4 2.3
 ruby.setup              rmagick 5.0.0 gem
-revision                0
+revision                1
 categories-append       graphics
 maintainers             nomaintainer
 license                 MIT

--- a/science/opendx/Portfile
+++ b/science/opendx/Portfile
@@ -5,7 +5,7 @@ PortGroup               deprecated 1.0
 
 name                    opendx
 version                 4.4.4
-revision                11
+revision                12
 categories              science
 license                 Permissive
 # "IBM PUBLIC LICENSE", http://opendx.org/dlSource.html

--- a/science/xastir/Portfile
+++ b/science/xastir/Portfile
@@ -17,7 +17,7 @@ github.setup        Xastir Xastir 2.1.8 Release-
 checksums           rmd160  8e32480f5bd43d262d3ca2153fb69c492273ad25 \
                     sha256  8b010e0ae665c1dd5f83c609940b6b8b56ad0f777bac0f637f599311111bf973 \
                     size    2222069
-revision            6
+revision            7
 
 use_autoconf        yes
 autoconf.cmd        ./bootstrap.sh

--- a/textproc/cuneiform/Portfile
+++ b/textproc/cuneiform/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 
 name                    cuneiform
 version                 1.1.0
-revision                7
+revision                8
 set branch              [join [lrange [split ${version} .] 0 1] .]
 platforms               darwin
 maintainers             nomaintainer


### PR DESCRIPTION
#### Description

Dependents bumped via `port echo depends_lib:ImageMagick | xargs ./port-revbump`. Script [here](https://gist.github.com/mohd-akram/92912470caec3c6bc99dea748eab3779).

###### Tested on
macOS 13.6 22G120 x86_64
Xcode 15.0 15A240d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?