### PR TITLE
alacritty: add command line interface

### DIFF
--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -5,7 +5,7 @@ PortGroup           cargo   1.0
 PortGroup           github  1.0
 
 github.setup        alacritty alacritty 0.12.3 v
-revision            0
+revision            1
 
 description         A cross-platform, GPU-accelerated terminal emulator
 
@@ -37,6 +37,28 @@ destroot {
     file mkdir ${destroot}${al_app_bindir}
 
     move ${worksrcpath}/${al_target_dir}/${name} ${destroot}${al_app_bindir}
+}
+
+post-destroot {
+    file rename ${worksrcpath}/extra/alacritty.man ${worksrcpath}/extra/alacritty.1
+    file rename ${worksrcpath}/extra/alacritty-msg.man ${worksrcpath}/extra/alacritty-msg.1
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 -W ${worksrcpath}/extra \
+        alacritty.1 \
+        alacritty-msg.1 \
+        ${destroot}${prefix}/share/man/man1
+
+    xinstall -d ${destroot}${prefix}/etc/bash_completion.d
+    xinstall -m 0644 ${worksrcpath}/extra/completions/alacritty.bash \
+        ${destroot}${prefix}/etc/bash_completion.d
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 0644 ${worksrcpath}/extra/completions/alacritty.fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0644 ${worksrcpath}/extra/completions/_alacritty \
+        ${destroot}${prefix}/share/zsh/site-functions
+
+    ln -s ${al_app_bindir}/${name} ${destroot}${prefix}/bin/${name}
 }
 
 github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
Alacritty standard macOS build only includes building the App.

Add man pages, shell completions and a symlink to alacritty binary.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification 
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
