### PR TITLE
GPXSee: update to 13.9

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.8
+github.setup        tumic0 GPXSee 13.9
 revision            0
 
-checksums           rmd160  ea17400862142e53c5a157681bf0a7b2c25302ce \
-                    sha256  26d4459249d0409824e486c8b4de9e4fa84c9f3e16d79f08b2cdb4bcc0e92ddf \
-                    size    5631226
+checksums           rmd160  437fee0be128036f29a11b300924a78b885658e6 \
+                    sha256  b4fc2c7a13879fef88244ae4f43b66d942a6a4d634ecd8dc3a8e7233d430e627 \
+                    size    5632895
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
