### PR TITLE
py-cffi: update to 1.16.0

### DIFF
--- a/python/py-cffi/Portfile
+++ b/python/py-cffi/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           compiler_wrapper 1.0
 
 name                py-cffi
-version             1.15.1
+version             1.16.0
 revision            0
 categories-append   devel
 license             MIT
@@ -22,9 +22,9 @@ long_description    Foreign Function Interface for Python calling C code. \
 
 homepage            https://cffi.readthedocs.org/
 
-checksums           rmd160  9cc1d96670ad9df27e3be8dc3132e439347542ea \
-                    sha256  d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9 \
-                    size    508501
+checksums           rmd160  f3302f109d1d851fa459aef31f3ea1281c26751e \
+                    sha256  bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0 \
+                    size    512873
 
 if {${name} ne ${subport}} {
     patchfiles-append   patch-setup.py.diff


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
