### PR TITLE
libstdcxx-docs: update to 13.2.0

### DIFF
--- a/lang/libstdcxx-docs/Portfile
+++ b/lang/libstdcxx-docs/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 
 name                libstdcxx-docs
-version             12.2.0
+version             13.2.0
 revision            0
-conflicts           stdman
 categories          lang
 supported_archs     noarch
 license             GPL-3+
@@ -24,9 +23,9 @@ distname            gcc-${version}
 set major           [lindex [split ${version} .] 0]
 dist_subdir         gcc${major}
 
-checksums           rmd160  76d30c411227d6c3e87dd4f0a8ea1ae5d8ab9ffd \
-                    sha256  e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff \
-                    size    84645292
+checksums           rmd160  a6d646ed9765f973d3f63ef560edf4a50cf686c3 \
+                    sha256  e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da \
+                    size    87858592
 
 use_xz              yes
 

--- a/lang/stdman/Portfile
+++ b/lang/stdman/Portfile
@@ -5,7 +5,6 @@ PortGroup           github 1.0
 
 github.setup        jeaye stdman 2022.07.30
 github.tarball_from archive
-conflicts           libstdcxx-docs
 categories          lang
 supported_archs     noarch
 platforms           any


### PR DESCRIPTION
###### Tested on
macOS 13.6 22G120 x86_64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?