### PR TITLE
libgit2: link against libiconv to ensure build succeeds on arm64

### DIFF
--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -79,6 +79,8 @@ configure.args-append \
                     -DUSE_SSH:BOOL=ON \
                     -DUSE_THREADS:BOOL=OFF
 
+configure.ldflags-append -liconv
+
 variant threadsafe description {Build with threadsafe option} {
     configure.args-replace \
                     -DUSE_THREADS:BOOL=OFF \


### PR DESCRIPTION
#### Description

libgit2 builds fail on arm64. Closes https://trac.macports.org/ticket/68409

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`? NO TESTS
- [x] tried a full install with `sudo port -vst install`? NO TRACE ON ARM64
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
