### PR TITLE
lerc: correct license

### DIFF
--- a/gis/lerc/Portfile
+++ b/gis/lerc/Portfile
@@ -14,8 +14,8 @@ checksums           rmd160  4db543ea71fe126c94bce3ae8559107b483a4668 \
 
 categories          gis
 platforms           darwin
-maintainers         {vince @Veence}
-license             GPL-2+
+maintainers         {vince @Veence} openmaintainer
+license             Apache-2
 
 description         Limited Error Raster Compression: a library to compress raster images
 


### PR DESCRIPTION
#### Description

License is [here](https://github.com/Esri/lerc/blob/master/LICENSE)

- Add openmaintainer

###### Type(s)

- [x] bugfix

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?