### PR TITLE
graphicsmagick: Add OpenMP variant

### DIFF
--- a/graphics/GraphicsMagick/Portfile
+++ b/graphics/GraphicsMagick/Portfile
@@ -101,4 +101,10 @@ if {![variant_isset q16] && ![variant_isset q32]} {
     default_variants +q8
 }
 
+variant openmp description { Build with OpenMP support} {
+    # OpenMP is beneficial for GM: http://www.graphicsmagick.org/OpenMP.html
+    compiler.openmp_version 4.0
+    configure.args-append   --enable-openmp
+}
+
 livecheck.regex         /${name}-(\\d+(?:\\.\\d{1,5})+)[quotemeta ${extract.suffix}]


### PR DESCRIPTION
Significant performance improvement is available with OpenMP and graphicsmagick:

```
$ gm benchmark -stepthreads 1 -duration 10 convert \
>   -size 2048x1080 pattern:granite -operator all Noise-Gaussian 30% null:
Results: 1 threads 30 iter 10.11s user 10.123330s total 2.963 iter/s 2.967 iter/cpu 1.00 speedup 1.000 karp-flatt
Results: 2 threads 60 iter 20.29s user 10.146444s total 5.913 iter/s 2.957 iter/cpu 2.00 speedup 0.002 karp-flatt
Results: 3 threads 89 iter 30.23s user 10.080159s total 8.829 iter/s 2.944 iter/cpu 2.98 speedup 0.003 karp-flatt
Results: 4 threads 117 iter 40.10s user 10.043595s total 11.649 iter/s 2.918 iter/cpu 3.93 speedup 0.006 karp-flatt
Results: 5 threads 144 iter 49.90s user 10.016252s total 14.377 iter/s 2.886 iter/cpu 4.85 speedup 0.008 karp-flatt
Results: 6 threads 171 iter 59.97s user 10.024464s total 17.058 iter/s 2.851 iter/cpu 5.76 speedup 0.008 karp-flatt
```

http://www.graphicsmagick.org/OpenMP.html

This patch adds an optional +openmp variant that makes use of `compiler.openmp_version` to pull in the required dependencies. Builds and runs well on my system.