### PR TITLE
py-circuitbreaker: submission

### DIFF
--- a/python/py-circuitbreaker/Portfile
+++ b/python/py-circuitbreaker/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-circuitbreaker
+version             2.0.0
+revision            0
+
+license             BSD
+platforms           {darwin any}
+supported_archs     noarch
+maintainers         nomaintainer
+
+description         Python implementation of the \"Circuit Breaker\" Pattern
+long_description    {*}${description}
+
+homepage            https://github.com/fabfuel/circuitbreaker
+
+checksums           md5     0fc04e58267a46ac371aac0f3e2b0105 \
+                    rmd160  992822cb56baf69b33a3da002c9ebbf5dfa56ddd \
+                    sha256  28110761ca81a2accbd6b33186bc8c433e69b0933d85e89f280028dbb8c1dd14 \
+                    size    10736
+
+python.versions     38 39 310 311
+
+if {${subport} ne ${name}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    test.run        yes
+}


### PR DESCRIPTION
#### Description

This PR adds the `circuitbreaker` PyPI package (https://pypi.org/project/circuitbreaker/) which is a Python implementation of the "Circuit Breaker" pattern (https://martinfowler.com/bliki/CircuitBreaker.html)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

This is my first submission with the `python` PortGroup, if there are any improvements to be made, feel free to reply.