### PR TITLE
pgpointcloud: new port, version 1.2.5

### DIFF
--- a/databases/pgpointcloud/Portfile
+++ b/databases/pgpointcloud/Portfile
@@ -1,0 +1,71 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+
+github.setup        pgpointcloud pointcloud 1.2.5 v
+revision            0
+github.tarball_from archive
+
+name                pgpointcloud
+license             BSD
+categories          databases gis
+maintainers         {yahoo.com:n_larsson @nilason} openmaintainer
+
+description         pgPointcloud is a PostgreSQL extension for storing point cloud (LIDAR) data
+long_description    {*}${description}
+
+homepage            https://pgpointcloud.github.io/pointcloud/
+
+checksums           rmd160  54e0784994a458e9591ea416caf7ae106c0d7007 \
+                    sha256  f3924f283345f2da46a971e65f0c6ce602640ecf88a2057293443ec2a7a56774 \
+                    size    348678
+
+configure.cmd       autoupdate && ./autogen.sh && ./configure
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:pkgconfig
+
+depends_lib-append  port:libxml2 \
+                    port:lzma \
+                    port:icu \
+                    port:libiconv \
+                    port:zlib
+
+configure.args-append \
+                    --with-xml2config=${prefix}/bin/xml2-config \
+                    --without-lazperf \
+                    --without-cunit
+
+# PostgreSQL database variants
+set postgresql_suffixes {12 13 14 15}
+
+set portsgresql_variants {}
+set postgresql_default_variant "if {"
+foreach s ${postgresql_suffixes} {
+    lappend portsgresql_variants postgresql${s}
+    set postgresql_default_variant "${postgresql_default_variant}!\[variant_isset postgresql${s}] && "
+}
+set postgresql_default_variant [string range ${postgresql_default_variant} 0 end-4]
+set postgresql_default_variant "${postgresql_default_variant}} {default_variants +postgresql${s}}"
+eval $postgresql_default_variant
+
+foreach s ${postgresql_suffixes} {
+    set p postgresql${s}
+    set v [string index ${s} 0].[string index ${s} 1]
+    set i [lsearch -exact ${portsgresql_variants} ${p}]
+    set c [lreplace ${portsgresql_variants} ${i} ${i}]
+    variant ${p} description "Use PostgreSQL ${s}" conflicts {*}${c} "
+        depends_lib-append      port:${p}
+        configure.args-append   --with-pgconfig=${prefix}/lib/${p}/bin/pg_config
+    "
+}
+
+variant tests description {Enable tests} {
+    depends_test-append     port:cunit
+    configure.args-replace  --without-cunit --with-cunit=${prefix}
+    test.run        yes
+    test.target     check
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

New `pgpointcloud` port, version 1.2.5.

(pgPointcloud is a PostgreSQL extension for storing point cloud (LIDAR) data, https://pgpointcloud.github.io/pointcloud/ )


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
