### PR TITLE
google-cloud-sdk: update to 450.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             449.0.0
+version             450.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  f8f842da54cf8bbefb02f579fdae90b4f965e425 \
-                    sha256  06867c8ca89db2d0173e9b6121a41be5e27ebeaf969a88f30b71b69fe3ce8844 \
-                    size    120946834
+    checksums       rmd160  656b146c288fe4f887de1c78c169c06a97554242 \
+                    sha256  eb6fe368326aef8acc0aafe6d4b1926b11c44cd2767c942ef5302cf7888fdaa1 \
+                    size    121073638
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  d927156831f43aa43f4778eb71d3d14cf6536fde \
-                    sha256  bf7abac36afa81e60d2e62b90228233c69e93234efd32e77eef910b6764e4be0 \
-                    size    122231063
+    checksums       rmd160  dd3f65e4fae5e9b35eabc6e34044093980b344bd \
+                    sha256  9fab5e94a8da62e31340f1a7660e2bfe569124919e393c1f35acd5abd2412f82 \
+                    size    122358177
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  31af5a1dfbd6bace820026cdb0cf3d46795b1fea \
-                    sha256  7802f1cd747331ce0057ec2effb72b73c660fcd0c5554aae871e8843ef25b1d5 \
-                    size    119332381
+    checksums       rmd160  5635af3fe67b9cd09f6928685be75f858a8b31fe \
+                    sha256  e10d849d973febfd23a56137bebe35bc26aa7cb34b5ec8e9e82393a474039e06 \
+                    size    119458664
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 450.0.0.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?