### PR TITLE
R, R PG: use gcc7 for Leopard until it is moved to the modern one (no impact for 10.6+)

### DIFF
--- a/_resources/port1.0/group/R-1.0.tcl
+++ b/_resources/port1.0/group/R-1.0.tcl
@@ -91,7 +91,14 @@ compiler.blacklist-append   {macports-clang-1[6-9]}
 # Similarly, for gcc select the gcc12 variant of the compilers PG.
 # This setting should also be kept in sync with that in the R Port.
 # Updates should be coordinated with the R maintainers.
-default_variants-append     +gcc12
+# NOTE: upon the update to gcc13, please add a blacklist of newer gccs,
+# like it is done for clangs. We would prefer using the same version of gcc and gfortran.
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    # Until old platforms are switched to the new libgcc.
+    default_variants-append +gcc7
+} else {
+    default_variants-append +gcc12
+}
 
 port::register_callback R.add_dependencies
 

--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -47,7 +47,14 @@ compiler.blacklist-append   {macports-clang-1[6-9]}
 # Similarly, for gcc select the gcc12 variant of the compilers PG.
 # This setting should also be kept in sync with that in the R Portgroup.
 # Updates should be coordinated with the R maintainers.
-default_variants-append     +gcc12
+# NOTE: upon the update to gcc13, please add a blacklist of newer gccs,
+# like it is done for clangs. We would prefer using the same version of gcc and gfortran.
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    # Until old platforms are switched to the new libgcc.
+    default_variants-append +gcc7
+} else {
+    default_variants-append +gcc12
+}
 
 compilers.choose            fc f77
 compilers.setup             require_fortran


### PR DESCRIPTION
[skip ci]

#### Description

We forgot that Leopard in Macports is still on gcc7 :)
Fixed.

No need to revbump R, it would not have built with gcc12 in a non-modified Macports set-up on 10.5. (Those who used a custom set-up should know what to do.)

@cjones051073 @i0ntempest I skip CI here, since there is no impact on anything 10.6+.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
