### PR TITLE
gdal: add 'arrow' variant for Arrow/Parquet support

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -222,6 +222,13 @@ configure.args-append                                        \
 configure.args-append                                        \
                      -DGDAL_ENABLE_DRIVER_EXR=OFF
 
+# These drivers require Apache Arrow
+configure.args-append                                        \
+                    -DGDAL_USE_ARROW=OFF                     \
+                    -DGDAL_USE_PARQUET=OFF                   \
+                    -DOGR_ENABLE_DRIVER_ARROW=OFF            \
+                    -DOGR_ENABLE_DRIVER_PARQUET=OFF
+
 # Miscellaneous drivers
 configure.args-append                                        \
                     -DBUILD_CSHARP_BINDINGS=OFF              \
@@ -525,6 +532,15 @@ variant cfitsio description {Enable FITS support} {
     depends_lib-append      port:cfitsio
     configure.args-replace  -DGDAL_USE_CFITSIO=OFF    -DGDAL_USE_CFITSIO=ON
     configure.args-append   -DGDAL_ENABLE_DRIVER_FITS=ON
+}
+
+variant arrow description {Enable (Geo)Arrow IPC File Format / Stream and (Geo)Parquet support} {
+    depends_lib-append      port:apache-arrow
+    configure.args-replace  -DGDAL_USE_ARROW=OFF            -DGDAL_USE_ARROW=ON \
+                            -DGDAL_USE_PARQUET=OFF          -DGDAL_USE_PARQUET=ON \
+                            -DOGR_ENABLE_DRIVER_ARROW=OFF   -DOGR_ENABLE_DRIVER_ARROW=ON \
+                            -DOGR_ENABLE_DRIVER_PARQUET=OFF -DOGR_ENABLE_DRIVER_PARQUET=ON
+    configure.args-append   -DARROW_USE_STATIC_LIBRARIES=OFF
 }
 
 configure.optflags  -DGDAL_COMPILATION


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

`gdal`: add 'arrow' variant for Apache Arrow/Parquet support.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
