### PR TITLE
R: [forgotten] revbump; update for one of recommended packages

### DIFF
--- a/R/R-rpart/Portfile
+++ b/R/R-rpart/Portfile
@@ -6,16 +6,16 @@ PortGroup           R 1.0
 R.recommended       yes
 
 # This is a recommended package. Keep it CRAN-sourced.
-R.setup             cran bethatkinson rpart 4.1.19
+R.setup             cran bethatkinson rpart 4.1.21
 revision            0
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             {GPL-2 GPL-3}
 description         Recursive partitioning and regression trees
 long_description    {*}${description}. Recommended package.
 homepage-append     https://github.com/bethatkinson/rpart
-checksums           rmd160  350b1099aa97d3757239fded7ebdd911a674e145 \
-                    sha256  fe723ed0b5583fae8b40e6fecc29b357229cb11f2339b02a4e4f812926249565 \
-                    size    859025
+checksums           rmd160  3a60675aa17e02f8c7c8607c216924e56806004e \
+                    sha256  e77c1c675b211705be18181913a97b67379ccae699c1406acf7814ad8a45622b \
+                    size    617857
 
 depends_test-append port:R-survival
 

--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -9,7 +9,7 @@ name                        R
 # Remember to set revision to 0 when bumping version
 # And also to update Rversion in R PortGroup
 version                     4.3.1
-revision                    3
+revision                    4
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  math science


### PR DESCRIPTION
#### Description

1. In multiple rebases I have lost revbump to `R`. It is needed, otherwise we get an activation conflict when it tries to install recommended packages.
2. Recent update for `R-rpart`, one of recommended packages.

@i0ntempest @cjones051073 Sorry for revbumping thing. I hope this is our last update to `R` itself until we move to the new compilers versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
