### PR TITLE
micronaut: update to 4.1.4

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.1.3 v
+github.setup    micronaut-projects micronaut-starter 4.1.4 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  475ed00d2113e7214403c4005583a9e51339aad7 \
-                sha256  350bbb349bdcf21c18973c53bee9c90d6e8f827291bdd72edfaa9f5bc1dc41cf \
-                size    20289285
+checksums       rmd160  2a1f90ccc11d3063ccff456898520b82acb39c61 \
+                sha256  bcd766fe8ab5474b3d0b1988ebfe3f5f5fbc7594a18f66a47a93d37d0ad681ee \
+                size    20296933
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.1.4.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?