### PR TITLE
git-sizer: update to 1.5.0

### DIFF
--- a/devel/git-sizer/Portfile
+++ b/devel/git-sizer/Portfile
@@ -3,25 +3,29 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/github/git-sizer 1.2.0 v
+go.setup                github.com/github/git-sizer 1.5.0 v
+go.offline_build        no
+github.tarball_from     archive
+revision                0
+
 categories              devel
-maintainers             {@gerardsoleca gmail.com:g.sole.ca} openmaintainer
+installs_libs           no
 license                 MIT
+maintainers             {@gerardsoleca gmail.com:g.sole.ca} openmaintainer
 
 description             Compute various size metrics for a Git repository, \
                         flagging those that might cause problems
-long_description        Compute various size metrics for a Git repository, \
-                        flagging those that might cause problems like having \
-                        repositories too big (> 5GB), keep many branches or \
-                        tags, including gigantic blob files, storing large text \
-                        files with many changes, repeated files across paths, \
-                        detect long path names inside the repository, ...
+long_description        {*}${description} having repositories too big \
+                        (> 5GB), keep many branches or tags, including \
+                        gigantic blob files, storing large text files with \
+                        many changes, repeated files across paths, detect \
+                        long path names inside the repository, ...
 
-checksums               rmd160  8c6003f973ebaec06291d548c2ba7c471e7046dc \
-                        sha256  3c021a5f73b52ea309940f3a964e129cd40741dbbfcbec611991de40a3c55953 \
-                        size    102517
+checksums               rmd160  85d114ed1efabdf596de338d6aea177c49a552f4 \
+                        sha256  07a5ac5f30401a17d164a6be8d52d3d474ee9c3fb7f60fd83a617af9f7e902bb \
+                        size    78904
 
-build.args              -ldflags '-X main.BuildVersion=${version}'
+build.args              -ldflags '-X main.ReleaseVersion=${version}'
 
 destroot {
     xinstall ${worksrcpath}/${name} ${destroot}${prefix}/bin


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with ~`sudo port test`~ `sudo port -d destroot`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
