### PR TITLE
terraform: fix checksums for 1.2 and 1.3

### DIFF
--- a/sysutils/terraform/Portfile
+++ b/sysutils/terraform/Portfile
@@ -93,36 +93,42 @@ subport terraform-1.4 {
 
 subport terraform-1.3 {
     set patchNumber     9
-    revision            0
+    revision            1
 
     set armAvailable    yes
+    # Keep dist_subdir since version has been stealth updated and there might be conflicts with the checksums.
+    # It is not needed for other subports since there are no conflicts.
+    dist_subdir         ${name}/[terraformDistBase]_1
 
     checksums           [terraformDistBase]_amd64.zip \
-                        rmd160  e10a29ec679629de7631538fbcd93af6c949b89c \
-                        sha256  ca78815afd657f887de7f9b74014dc4bddffe80fd28028179b271a3c4f64f29a \
-                        size    21194874 \
+                        rmd160  0683c695a7c3c40bdb5949a7a021e1c38a89880a \
+                        sha256  a73326ea8fb06f6976597e005f8047cbd55ac76ed1e517303d8f6395db6c7805 \
+                        size    21194871 \
                         [terraformDistBase]_arm64.zip \
-                        rmd160  28012de87d77b5f8c29da38ea4b4b2e3c07e709f \
-                        sha256  9df6fc8a9264bba1058e6e9383f43af2ee816088e61925e5bc45128ad8b6e9ad \
-                        size    19793375
+                        rmd160  3a13916d9c3722586242daeda5536ca20e75f2ec \
+                        sha256  d8a59a794a7f99b484a07a0ed2aa6520921d146ac5a7f4b1b806dcf5c4af0525 \
+                        size    19793371
 
     set customDistSubDir no
 }
 
 subport terraform-1.2 {
     set patchNumber     9
-    revision            1
+    revision            2
 
     set armAvailable    yes
+    # Keep dist_subdir since version has been stealth updated and there might be conflicts with the checksums.
+    # It is not needed for other subports since there are no conflicts.
+    dist_subdir         ${name}/[terraformDistBase]_1
 
     checksums           [terraformDistBase]_amd64.zip \
-                        rmd160  04de8ebe3f669749633baaf8fbffbb0bd0e3af2a \
-                        sha256  2c4d2b425a0680c6a4d65601a5f42f8b5c23e4ccd3332cf649ce14eaa646b967 \
-                        size    21672801 \
+                        rmd160  02ba5fe97460e154341311b9a7730cd0774d8d45 \
+                        sha256  84a678ece9929cebc34c7a9a1ba287c8b91820b336f4af8437af7feaa0117b7c \
+                        size    21672810 \
                         [terraformDistBase]_arm64.zip \
-                        rmd160  fd4c14e6069779bd37fafc555f56b741d946e03a \
-                        sha256  91f51a352027f338b7673f23ee3c438ca8575933b7f58bfd7a92ffccf552158b \
-                        size    20280537
+                        rmd160  64b51950c5c8d14099b5ff58cd9656101817b611 \
+                        sha256  bc3b94b53cdf1be3c4988faa61aad343f48e013928c64bfc6ebeb61657f97baa \
+                        size    20280541
 }
 
 subport terraform-1.1 {


### PR DESCRIPTION
#### Description

Versions 1.2 and 1.3 of terraform port seem to be broken, at least in my setup I cannot install them. This affects terragrunt port too. Since some versions relay on terraform-1.2 and cannot be installed due to checksum mismatch.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
