### PR TITLE
py-terminaltables: fix builds

### DIFF
--- a/python/py-terminaltables/Portfile
+++ b/python/py-terminaltables/Portfile
@@ -15,7 +15,10 @@ description         Generate simple tables in terminals from a nested list of st
 long_description    Easily draw tables in terminal/console applications from \
                     a list of lists of strings. Supports multi-line rows.
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311
+python.pep517       yes
+python.pep517_backend \
+                    poetry
 
 homepage            https://robpol86.github.io/${python.rootname}/
 
@@ -24,7 +27,7 @@ checksums           rmd160  9d02523f89d32c890ae9c40212155e221584e279 \
                     size    12264
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
-
-    livecheck.type  none
+    patch.pre_args  -p1
+    patchfiles-append \
+                    0001-switch-to-poetry-core.patch
 }

--- a/python/py-terminaltables/files/0001-switch-to-poetry-core.patch
+++ b/python/py-terminaltables/files/0001-switch-to-poetry-core.patch
@@ -1,0 +1,29 @@
+From 0f8c7a493f3a44407652209ca97a5cdd88f889d3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C4=B0lteri=C5=9F=20Ya=C4=9F=C4=B1ztegin=20Ero=C4=9Flu?=
+ <ilteris@asenkron.com.tr>
+Date: Mon, 16 Oct 2023 02:19:24 +0300
+Subject: [PATCH] switch to poetry-core
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: İlteriş Yağıztegin Eroğlu <ilteris@asenkron.com.tr>
+---
+ pyproject.toml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index bdcd0ce..bf5518c 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -62,5 +62,5 @@ python = ">=2.6 || >=3.0"
+ pytest = "==6.0.1"
+ 
+ [build-system]
+-requires = ["poetry>=0.12"]
+-build-backend = "poetry.masonry.api"
++requires = ["poetry-core>=1.0.0"]
++build-backend = "poetry.core.masonry.api"
+-- 
+2.42.0
+


### PR DESCRIPTION
#### Description

This PR fixes other ports utilizing terminaltables, which will fail if `-s` flag is used. The underlying issue is caused by the upstream not changing the wheel packager from just `poetry` to `poetry-core`. Although the _git repository_ has this patched, the PyPi repository doesn't.

~~Also be vary that the patchfile is CLRF/DOS formatted, because the upstream `pyproject.toml` file is encoded as such.~~ See https://github.com/macports/macports-ports/pull/20836#issuecomment-1758678707 for an update on this.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
