### PR TITLE
libcue: update to 2.3.0

### DIFF
--- a/textproc/libcue/Portfile
+++ b/textproc/libcue/Portfile
@@ -4,18 +4,17 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        lipnitsk libcue 2.2.1 v
+github.setup        lipnitsk libcue 2.3.0 v
 revision            0
-checksums           rmd160  2a4fdafff1615c145af0cc0dcfaac5dc4f477191 \
-                    sha256  f27bc3ebb2e892cd9d32a7bee6d84576a60f955f29f748b9b487b173712f1200 \
-                    size    24177
+checksums           rmd160  4f673f4c6cf0589169c6ac7b0b1bb221560fd839 \
+                    sha256  cc1b3a65c60bd88b77a1ddd1574042d83cf7cc32b85fe9481c99613359eb7cfe \
+                    size    24326
 
 categories          textproc
 maintainers         nomaintainer
 description         CUE Sheet Parser Library
 long_description    LibCUE is intended to parse a so called CUE sheet from a char string or a file pointer.
 license             GPL-2+ GPL-3+
-platforms           darwin
 
 github.tarball_from archive
 


### PR DESCRIPTION
Fixes CVE-2023-43641

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
