### PR TITLE
ruby-build: update to 20231012

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20230919 v
+github.setup        rbenv ruby-build 20231012 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  4af01ad92c6ecc83da4877ae0bc4670724db7004 \
-                    sha256  85443c2796938d4865cc357dc4cf45efd1d0dce394892d3d3368f65f080c2906 \
-                    size    79381
+checksums           rmd160  f84d26efd461d5558c3893136866701e5cb65202 \
+                    sha256  052ad105aeb7be30fd17d9899a786bc95c9c5ed87cbc0278c461b9a7df7a434c \
+                    size    80206
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

```
## What's Changed

- Bump up OpenSSL 3.1.3 by @hsbt in #2257
- Bump mislav/bump-homebrew-formula-action from 2 to 3 by @dependabot in
  #2259
- Bump redhat-plumbers-in-action/differential-shellcheck from 4 to 5 by
  @dependabot in #2265
- Set default MAKE=make on FreeBSD by @Freaky in #2263
- Pass ruby configuration flags on the command line by @mislav in #2267
- Enable shellcheck parsing of ruby-build source by @mislav in #2268
- Use builds from ruby/truffleruby-dev-builder for truffleruby-dev on
  macos-arm64 by @eregon in #2269

## New Contributors

- @Freaky made their first contribution in #2263

Full Changelog: v20230919...v20231012
```

###### Tested on

macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
