### PR TITLE
android-platform-tools: update to version 34.0.5, expand support

### DIFF
--- a/java/android-platform-tools/Portfile
+++ b/java/android-platform-tools/Portfile
@@ -3,41 +3,114 @@
 PortSystem          1.0
 
 name                android-platform-tools
-version             34.0.4
+version             34.0.5
 categories          java devel
 installs_libs       no
 maintainers         {judaew @judaew} openmaintainer
 
 homepage            https://developer.android.com/studio/
 description         Platform-Tools for Google Android SDK (adb and fastboot)
-long_description    ${description}
+long_description    {*}${description}
 # different files are covered with different licenses. See
 # platform-tools/NOTICE.txt for details
 license             BSD MIT NCSA Apache-2 GPL-2 LGPL-2.1
-
-supported_archs     x86_64
 
 master_sites        https://dl.google.com/android/repository
 distname            platform-tools_r${version}-darwin
 use_zip             yes
 
-checksums           rmd160  d3fa505c1df870918aec9e7aee5f668abc957668 \
-                    sha256  bd09b834c150181a383deba63e157e9a53a6eb5a9cf4849b2b79dd89d0a2ddf1 \
-                    size    11208053
+checksums           rmd160  5c3e0f5cf838a317b79e985b6c023e000be64ee2 \
+                    sha256  b2c9757744a9d01fcc616b893ac6236233caf1bdf2ef384d73371ab68bfc4a43 \
+                    size    11194858
 
 use_configure       no
 
 worksrcdir          platform-tools
 
+# detect which version to depend on based on HW capabilities
+if {$subport eq $name} {
+    switch ${configure.build_arch} {
+        arm64 {
+            depends_run port:android-platform-tools-latest
+        }
+        x86_64 {
+            if {![catch {sysctl hw.optional.sse4_1} sse4] && $sse4 == 1} {
+                depends_run port:android-platform-tools-latest
+            } else {
+                depends_run port:android-platform-tools-no_sse4
+            }
+        }
+        i386 {
+            depends_run port:android-platform-tools-i386
+        }
+        default {
+            depends_run port:android-platform-tools-latest
+        }
+    }
+}
+
+# define versioned subports
+subport android-platform-tools-latest {
+    supported_archs x86_64 arm64
+}
+
+subport android-platform-tools-no_sse4 {
+    version         31.0.3
+    description     Platform-Tools for Google Android SDK (adb and fastboot): \
+                    legacy version for non-SSE4 64-bit Intel CPUs
+    supported_archs x86_64
+    set ver_hash    e8b2b4cbe47c728c1e54c5f524440b52d4e1a33c
+    distname        ${ver_hash}.platform-tools_r${version}-darwin
+    checksums       rmd160  26a2d4602ddd7537798bacd3adf6d5c376dc3e77 \
+                    sha256  773c08cfa31cec1bb4568ce5b374366e6310a5ffc21875024604a0f65bc831b1 \
+                    size    13227985
+    notes-append    "The current version of ${name} requires SSE4.1, which is not \
+                    supported by your CPU. The last version compatible with your CPU \
+                    (${version}) has been installed instead."
+}
+
+subport android-platform-tools-i386 {
+    version         23.0.1
+    description     Platform-Tools for Google Android SDK (adb and fastboot): \
+                    legacy version for 32-bit Intel CPUs
+    supported_archs i386
+    distname        platform-tools_r${version}-macosx
+    checksums       rmd160  7d0d3fbfdf2bbb8e1d6430373da88c2e77b9c6de \
+                    sha256  d2439f5de236c3831c048b678653c5955487351be8e196c65923b4eca5c47692 \
+                    size    2489850
+    notes-append    "The current version of ${name} requires a 64-bit CPU. The last \
+                    version compatible with your CPU (${version}) has been installed \
+                    instead."
+}
+
 build {}
 
-destroot {
-    set sdk_dir ${prefix}/share/java/android-sdk-macosx
-    xinstall -d ${destroot}${sdk_dir}
-    file copy ${worksrcpath} ${destroot}${sdk_dir}/platform-tools
+if {$subport ne $name} {
+    destroot {
+        set sdk_dir ${prefix}/share/java/android-sdk-macosx
+        xinstall -d ${destroot}${sdk_dir}
+        file copy ${worksrcpath} ${destroot}${sdk_dir}/platform-tools
 
-    foreach bin {adb fastboot} {
-        ln -s ${sdk_dir}/platform-tools/${bin} ${destroot}${prefix}/bin/${bin}
+        foreach bin {adb fastboot} {
+            ln -s ${sdk_dir}/platform-tools/${bin} ${destroot}${prefix}/bin/${bin}
+        }
+    }
+} else {
+    supported_archs noarch
+    platforms       any
+    distfiles
+    destroot {
+        xinstall -d  ${destroot}${prefix}/share/doc/${name}/
+        system "echo $name is a stub port > ${destroot}${prefix}/share/doc/${name}/ReadMe.txt"
+    }
+}
+
+pre-activate {
+    if {![catch {lindex [registry_active android-platform-tools] 0} installed]} {
+        set _version [lindex $installed 1]
+        if {[vercmp $_version 34.0.5] < 0} {
+            registry_deactivate_composite android-platform-tools "" [list ports_nodepcheck 1]
+        }
     }
 }
 


### PR DESCRIPTION
* update to version 34.0.5
* add arm64 and i386 supported_archs
* refactor using subports
* add -latest subport for current version
* add -no_sse4 subport for x86_64 machines with no SSE4
* add -i386 subport for 32-bit x86 machines
* automatically select legacy subports as needed

Closes: https://trac.macports.org/ticket/66670

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Command Line Tools 8.2.0.0.1.1480973914

macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
