### PR TITLE
py-greenlet: update to 3.0.0

### DIFF
--- a/python/py-greenlet/Portfile
+++ b/python/py-greenlet/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-greenlet
-version             2.0.2
+version             3.0.0
 categories-append   devel
 license             MIT PSF
 
@@ -43,12 +43,16 @@ long_description    The \"greenlet\" package is a spin-off of \
 
 homepage            https://github.com/python-greenlet/greenlet
 
-checksums           rmd160  260d2414cd1be4c7af131f482a4c82b6762d7f87 \
-                    sha256  e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0 \
-                    size    164980
+checksums           rmd160  4e4372dc541515f65c5bbc023a74d0eb5a7d5ad2 \
+                    sha256  19834e3f91f485442adc1ee440171ec5d9a4840a1f7bd5ed97833544719ce10b \
+                    size    174704
 
 if {${name} ne ${subport}} {
     if {${python.version} < 37} {
+        version             2.0.2
+        checksums           rmd160  260d2414cd1be4c7af131f482a4c82b6762d7f87 \
+                            sha256  e7c8dc13af7db097bed64a051d2dd49e9f0af495c26995c00a9ee842690d34c0 \
+                            size    164980
         python.pep517       no
         depends_build-append \
                             port:py${python.version}-setuptools


### PR DESCRIPTION
Last version to support python 36 is 2.0.2

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? (py310 and py36)
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
