### PR TITLE
py-igraph: update to 0.11.2

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -6,13 +6,13 @@ PortGroup           python 1.0
 name                py-igraph
 python.rootname     igraph
 python.pep517       yes
-version             0.10.8
+version             0.11.2
 revision            0
 categories-append   math science
 platforms           darwin
 license             GPL-2+
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311 312
 
 maintainers         {snc @nerdling} {gmail.com:szhorvat @szhorvat} openmaintainer
 
@@ -24,9 +24,9 @@ long_description    Python interface to the igraph library for network analysis 
 
 homepage            https://igraph.org/python/
 
-checksums           rmd160  5c57e4b58a45edb07e49c9270db22844278d31dd \
-                    sha256  d3b7893573060d117917e4f2121e524ed849bbf9f9a63a082001e1a4c5225b46 \
-                    size    4239123
+checksums           rmd160  5d6e0632c822a9cb849d7ec83b7a6949a7adcf91 \
+                    sha256  c4053e47156d7685ad48bd72e6ff400d46b09deeebc746b96b5cf9737939fa2d \
+                    size    4472699
 
 variant external_igraph description {Use external igraph library} { }
 
@@ -37,8 +37,6 @@ if {${name} ne ${subport}} {
     compiler.cxx_standard   2011
 
     depends_lib-append      port:py${python.version}-texttable
-
-    depends_build-append    port:py${python.version}-setuptools port:py${python.version}-wheel
 
     if {[variant_isset external_igraph]} {
         # Build with external igraph library
@@ -77,20 +75,22 @@ if {${name} ne ${subport}} {
         build.env-append        IGRAPH_CMAKE_EXTRA_ARGS=[join $extra_cmake_args]
     }
 
-    # python-igraph optionally makes use of these, and some tests depend on them.
-    # If they are not installed, the corresponding tests will simply be skipped..
-    depends_test-append     port:py${python.version}-matplotlib \
-                            port:py${python.version}-networkx \
-                            port:py${python.version}-numpy \
-                            port:py${python.version}-pandas \
-                            port:py${python.version}-scipy
+    # Testing py312-igraph disabled until all test dependencies get py312 subports.
+    if {${subport} ne "py312-${python.rootname}"} {
+        # python-igraph optionally makes use of these, and some tests depend on them.
+        # If they are not installed, the corresponding tests will simply be skipped..
+        depends_test-append     port:py${python.version}-matplotlib \
+                                port:py${python.version}-networkx \
+                                port:py${python.version}-numpy \
+                                port:py${python.version}-pandas \
+                                port:py${python.version}-scipy
 
-    pre-test {
-        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+        pre-test {
+            test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+        }
+
+        test.run yes
     }
-
-    test.run                yes
-    test.target
 
     livecheck.type          none
 }

--- a/python/py-iniconfig/Portfile
+++ b/python/py-iniconfig/Portfile
@@ -11,7 +11,7 @@ platforms           {darwin any}
 license             MIT
 supported_archs     noarch
 
-python.versions     36 37 38 39 310 311
+python.versions     36 37 38 39 310 311 312
 python.pep517       yes
 python.pep517_backend   hatch
 

--- a/python/py-py/Portfile
+++ b/python/py-py/Portfile
@@ -11,7 +11,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-pytest/Portfile
+++ b/python/py-pytest/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-pytest
-version             7.4.0
+version             7.4.2
 revision            0
 
 categories-append   devel
@@ -13,7 +13,7 @@ platforms           {darwin any}
 license             MIT
 supported_archs     noarch
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 maintainers         {stromnov @stromnov} {@catap korins.ky:kirill} openmaintainer
 
@@ -25,9 +25,9 @@ long_description    The pytest framework makes it easy to write small tests, \
 
 homepage            https://pytest.org
 
-checksums           rmd160  6682638f50729199b423849df499001a117215cd \
-                    sha256  b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a \
-                    size    1349733
+checksums           rmd160  00e64e27997d4186ff7ddb789bd6cca4f9b41577 \
+                    sha256  a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069 \
+                    size    1354640
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pytest/files/pytest312
+++ b/python/py-pytest/files/pytest312
@@ -1,0 +1,2 @@
+bin/pytest-3.12
+bin/py.test-3.12

--- a/python/py-texttable/Portfile
+++ b/python/py-texttable/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-texttable
-version             1.6.7
+version             1.7.0
 revision            0
 
 categories-append   textproc
@@ -18,25 +18,19 @@ long_description    {*}${description}
 
 homepage            https://github.com/foutaise/texttable/
 
-checksums           rmd160  e8f0be8d7afb9ba4eb62b2758b2537c0a6470704 \
-                    sha256  290348fb67f7746931bcdfd55ac7584ecd4e5b0846ab164333f0794b121760f2 \
-                    size    12891
+checksums           rmd160  0e46398bd04bca5c8cf531e3bdbb0962fc3e3138 \
+                    sha256  2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638 \
+                    size    12831
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 0644 -W ${worksrcpath} README.md LICENSE \
             CHANGELOG.md ${destroot}${docdir}
     }
-
-    depends_test-append \
-                    port:py${python.version}-pytest
 
     test.run        yes
     test.cmd        py.test-${python.branch} tests.py


### PR DESCRIPTION
 - update to 0.11.2
 - add python.version 312
 - remove python.version 37 (support dropped)
 - fix testing

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
