### PR TITLE
PageEdit: Update to 2.0.0

### DIFF
--- a/editors/PageEdit/Portfile
+++ b/editors/PageEdit/Portfile
@@ -8,9 +8,8 @@ PortGroup               qt5 1.0
 qt5.depends_component   qttools qtwebengine
 qt5.min_version         5.12.3
 
-github.setup            Sigil-Ebook PageEdit 0.9.5
+github.setup            Sigil-Ebook PageEdit 2.0.0
 revision                0
-platforms               darwin
 categories              editors
 maintainers             nomaintainer
 license                 GPL-3+
@@ -19,9 +18,9 @@ description             An ePub visual XHTML editor based on Sigil's Deprecated 
 
 long_description        ${description}
 
-checksums               rmd160  f965b5f490df6069878a9a45769b5abae6a7efd3 \
-                        sha256  464c26b9ad08c8d106db66b848fc1cb501f8515bd5cdda1062cea6c612f5f4c4 \
-                        size    6252075
+checksums               rmd160  d519448aa02866080a6c87f3cff8ff8c01b4da8d \
+                        sha256  e696f2fecac75642896d91f68bb91a04f8627b75bf8412166f1c6e51252373fa \
+                        size    7577279
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
#### Description

Update PageEdit to its latest released version, 2.0.0.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
