### PR TITLE
libutf8proc: Migrate to Makefile PortGroup

### DIFF
--- a/textproc/libutf8proc/Portfile
+++ b/textproc/libutf8proc/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
 
 github.setup        JuliaStrings utf8proc 2.8.0 v
 revision            0
@@ -19,18 +20,10 @@ checksums           rmd160  77a542977efcb5d8eab04497a24cda7b14d0fc39 \
                     sha256  573f552e95f00612fe801ea77bc8a1e08c597975386b19e24d975174de1f0455 \
                     size    190342
 
-use_configure       no
-
-variant universal   {}
-
 patchfiles          remove-Wsign-conversion.diff
 
-build.args          prefix="${prefix}" \
-                    CC=${configure.cc} \
-                    CFLAGS="${configure.cflags} [get_canonical_archflags cc]" \
-                    LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
-
-destroot.args       {*}${build.args}
+makefile.prefix_name \
+                    prefix
 
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${name}
@@ -45,4 +38,3 @@ post-destroot {
 depends_test        bin:curl:curl
 test.run            yes
 test.target         check
-test.args           {*}${build.args}


### PR DESCRIPTION
#### Description

Modernize libutf8proc's Portfile by migrating to the `makefile` PortGroup, which automatically configures the project (apart from the install prefix).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
