### PR TITLE
postgresql16-server: set shell explicitly for daemondo

### DIFF
--- a/databases/postgresql16-server/Portfile
+++ b/databases/postgresql16-server/Portfile
@@ -4,6 +4,7 @@ PortSystem 1.0
 
 name                postgresql16-server
 version             16.0
+revision            1
 categories          databases
 platforms           {darwin any}
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -41,9 +42,9 @@ startupitem.create  yes
 startupitem.init    \
     "PGCTL=${libdir}/bin/pg_ctl"
 startupitem.start    \
-    "su ${dbuser} -c \"\${PGCTL} -D \${POSTGRESQL16DATA:=${dbdir}} start -l ${logdir}/postgres.log\""
+    "sudo -u ${dbuser} /bin/sh -c \"\${PGCTL} -D \${POSTGRESQL16DATA:=${dbdir}} start -l ${logdir}/postgres.log\""
 startupitem.stop    \
-"su ${dbuser} -c \"\${PGCTL} -D \${POSTGRESQL16DATA:=${dbdir}} stop -s -m fast\""
+"sudo -u ${dbuser} /bin/sh -c \"\${PGCTL} -D \${POSTGRESQL16DATA:=${dbdir}} stop -s -m fast\""
 
 destroot {
     xinstall -m 755 -d ${destroot}${logdir}


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68412

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
