### PR TITLE
py-urllib3: update to 2.0.7

### DIFF
--- a/python/py-urllib3/Portfile
+++ b/python/py-urllib3/Portfile
@@ -4,15 +4,17 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-urllib3
-version             1.26.15
+version             2.0.7
 revision            0
 categories-append   devel net
 platforms           {darwin any}
 supported_archs     noarch
 license             MIT
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 python.pep517       yes
+python.pep517_backend \
+                    hatch
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -21,11 +23,21 @@ long_description    ${description}
 
 homepage            https://urllib3.readthedocs.io/
 
-checksums           rmd160  84aa9f5e76f4e59a13e6cde842f8675fa2e0b65c \
-                    sha256  8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305 \
-                    size    301444
+checksums           rmd160  01eb3bf5f1ead972c7fba37edeef22924db3b4c2 \
+                    sha256  c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84 \
+                    size    282546
 
 if {${name} ne ${subport}} {
+    if {${python.version} <= 311} {
+        version             1.26.18
+        revision            0
+        python.pep517_backend \
+                            setuptools
+        checksums           rmd160  247563ce0f574a1bc5efe229baebd1ce5a041042 \
+                            sha256  f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0 \
+                            size    305687
+    }
+
     if {${python.version} < 37} {
         python.pep517       no
         depends_build-append \


### PR DESCRIPTION
#### Description

This is the followup for https://lists.macports.org/pipermail/macports-dev/2023-October/045214.html

I didn't think of it at the time but urllib3 promises to drop its deprecated APIs in the 2.1 release. I don't know when it's coming out and would not be surprised if it was for another year+. I don't know how hard people will find 1.x / 2.x compatibility with that release but I suspect it will be a challenge. That release may also need to be coupled to the eventual python 3.13 release like this one is coupled with 3.12.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
