### PR TITLE
java 1.0 portgroup: remove `java.enforce` option

### DIFF
--- a/_resources/port1.0/group/java-1.0.tcl
+++ b/_resources/port1.0/group/java-1.0.tcl
@@ -17,17 +17,13 @@
 # - "+" and "*" wildcards are supported
 #
 # If the required Java cannot be found, an error will be thrown at pre-fetch.
-#
-# Sometimes a port hard code inside produces scripts and other files used JVM,
-# then its true use java.enforce to enforce dependency.
 
-options java.version java.home java.fallback java.deptypes java.enforce
+options java.version java.home java.fallback java.deptypes
 
 default java.version  {}
 default java.home     {}
 default java.fallback {[java::java_get_default_fallback]}
 default java.deptypes lib
-default java.enforce  no
 
 # allow PortGroup to be used inside a variant (e.g. octave)
 global java_version_not_found
@@ -128,7 +124,7 @@ namespace eval java {
         }
 
         # Add dependency if required
-        if { (${java_version_not_found} || [option java.enforce]) && ${java.fallback} ne "" } {
+        if { ${java_version_not_found} && ${java.fallback} ne "" } {
             ui_debug "Adding dependency on JDK fallback ${java.fallback}"
             foreach deptype [option java.deptypes] {
                 depends_${deptype}-append port:${java.fallback}


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68449

#### Description
Reasons for removal:


- It would be better for ports to never hardcode JDK paths in build outputs.
- `java.enforce` does not actually force a port to build using `java.fallback`, because it does not force `JAVA_HOME` to point to `java.fallback` rather than some other Java installation.
- This option is no longer used by any ports (it was only briefly used by abcl).
<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
