### PR TITLE
fortran-stdlib: update to 2023.10.13

### DIFF
--- a/lang/fortran-stdlib/Portfile
+++ b/lang/fortran-stdlib/Portfile
@@ -7,17 +7,17 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 
 name                fortran-stdlib
-github.setup        fortran-lang stdlib d379587a760376e5663ffe47b10425912faf32c2
-version             2023.09.19
+github.setup        fortran-lang stdlib 42040790c1748e0aacb7f9d491672cafc9e494b6
+version             2023.10.13
 revision            0
 categories-append   lang fortran devel
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Fortran Standard Library
 long_description    {*}${description}
-checksums           rmd160  45d96e10e81071ae8f020409d913c2ae11676bbf \
-                    sha256  ee5be0c53f0930dd9434ea5eaab53d6ad4b2e40cd5753b7e0b104917b41f7cc7 \
-                    size    388301
+checksums           rmd160  26a293adb70f932751d0bc95438f098bea00ea8e \
+                    sha256  544ef503b11bd3fbeece2987425b1f6093e52b8765521e54490e46b650d3b9fa \
+                    size    388354
 github.tarball_from archive
 
 cmake.generator     Ninja
@@ -65,9 +65,12 @@ platform darwin powerpc {
     } elseif {[string match macports-gcc-12 ${configure.compiler}]} {
         set gcc_v_major 12
         set gcc_v_full  ${gcc_v_major}.3.0
+    } elseif {[string match macports-gcc-13 ${configure.compiler}]} {
+        set gcc_v_major 13
+        set gcc_v_full  ${gcc_v_major}.2.0
     } elseif {[string match macports-gcc-devel ${configure.compiler}]} {
         set gcc_v_major -devel
-        set gcc_v_full  13.0.1
+        set gcc_v_full  14.0.0
     }
     
     if {${build_arch} eq "ppc"} {


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
