### PR TITLE
py-pyerfa: fix py37-pyerfa, py38-pyerfa

### DIFF
--- a/python/py-pyerfa/Portfile
+++ b/python/py-pyerfa/Portfile
@@ -34,6 +34,7 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-numpy
 
     if {${python.version} < 39} {
+        version     2.0.0.3
         revision    0
 
         checksums   rmd160  6bfd3a77504e6a282831c4bca4e092b852965196 \


### PR DESCRIPTION
73554fcf193f added `github.setup` without `PortGroup github 1.0`, referenced the unset `github.author` and `github.project`, and broke py37-pyerfa. The subsequent 4f9b9569588f expanded the breakage to include py38-pyerfa. f6f88d7d8184 later attempted to fix, but removed the 2.0.0.3 version pin from py37-pyerfa and py38-pyerfa, and resulted in a checksum verification failure.

It is not necessary to obtain pyerfa 2.0.0.3 from GitHub. PyPI is sufficient. This change provides that fix, reintroduces the desired pin, unbreaks these two subports, and unbreaks MacPorts CI.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@Schamschula 