### PR TITLE
libpaper: Switch to another incarnation that is LGPL

### DIFF
--- a/graphics/xpdf/Portfile
+++ b/graphics/xpdf/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xpdf
 version             3.04
-revision            3
+revision            4
 description         Xpdf is a viewer for PDF files.
 long_description    Xpdf is a viewer for Portable Document Format \
                     (PDF) files.  These are also sometimes also called \

--- a/print/a2ps/Portfile
+++ b/print/a2ps/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                a2ps
 version             4.15.5
-revision            0
+revision            1
 
 categories          print
 license             GPL-3+

--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -5,7 +5,7 @@ PortGroup           muniversal 1.0
 
 name                ghostscript
 version             10.02.1
-revision            0
+revision            1
 
 categories          print
 license             AGPL-3 BSD

--- a/print/libpaper/Portfile
+++ b/print/libpaper/Portfile
@@ -1,55 +1,67 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       github 1.0
 
-name            libpaper
-set mainversion 1.1.29
-# Keep in case need again in the future
-#set nmuversion  5
-#set realversion ${mainversion}+nmu${nmuversion}
-#version         ${mainversion}.${nmuversion}
-set realversion ${mainversion}
-version         ${mainversion}
+github.setup    rrthomas libpaper 2.1.2 v
+revision        0
+checksums       rmd160  6b3898d28155228927fa78f55bc747fbcd8e0bc2 \
+                sha256  1fda0cf64efa46b9684a4ccc17df4386c4cc83254805419222c064bf62ea001f \
+                size    1264200
+
+github.tarball_from  releases
+
 categories      print
-license         GPL-2
+# libpaper is LGPLv2.1+, paperspecs is public domain
+license         LGPL-2.1+ public-domain
 maintainers     nomaintainer
-platforms       darwin
 description     A library providing routines for paper size management
 long_description \
                 The paper library and accompanying files are intended \
                 to provide a simple way for applications to take \
                 actions based on a system- or user-specified paper size.
 
-homepage        https://packages.qa.debian.org/libp/libpaper.html
-master_sites    debian:libp/${name}/
-
-distname        ${name}_${realversion}
-worksrcdir      ${name}-${realversion}
-
-checksums       rmd160  8ab9f62014375cc307d3b3a21b813af030032e11 \
-                sha256  26330e21e9a3124658d515fd850b0cde546ff42d89b2596a5264c5f1677f0547 \
-                size    44942
-
-post-patch {
-    set fd [open [file join ${worksrcpath}/lib paperspecs] a 0644]
-    # additional paper sizes
-    foreach {n x y} {jisb0 2920 4127
-                     jisb1 2064 2920
-                     jisb2 1460 2064
-                     jisb3 1032 1460
-                     jisb4  729 1032
-                     jisb5  516  729
-                     jisb6  363  516} {
-        puts ${fd} "${n} ${x} ${y}"
-    }
-    close ${fd}
+subport libpaper-utils {
+    # We introduce a subport for files with different licenses.
+    # Including them in the 'libpaper' port would prevent the
+    # distribution of MacPorts binary archives for some prominent
+    # tools like Ghostscript or ImagicMagick.
+    description       The executables of the libpaper package
+    long_description  Provide the new 'paper' and deprecated 'paperconf' \
+                      utility programs that come with the libpaper \
+                      library. Both are used to print paper size \
+                      information.
+    # `paper` is GPL-3+, `paperconf` is GPL-2
+    license           GPL-3+ GPL-2
 }
 
 use_autoreconf  yes
 
-configure.args  --mandir=${prefix}/share/man    \
-                --sysconfdir=${prefix}/etc
+configure.args  --enable-relocatable \
+                --disable-silent-rules
 
-livecheck.type      regex
-livecheck.version   ${realversion}
-livecheck.regex     {"stable">([^<]+)}
+if {${subport} eq ${name}} {
+    test.run     yes
+    test.target  check
+
+    post-destroot {
+        # XXX: Why is this necessary?
+        system "install_name_tool -id \
+                  ${prefix}/lib/libpaper.2.dylib \
+                  ${destroot}${prefix}/lib/libpaper.2.dylib"
+        # remove `paper` and `paperconf`
+        delete "${destroot}${prefix}/bin"
+        delete "${destroot}${prefix}/share/man/man1"
+    }
+} else {
+    depends_lib-append  port:libpaper
+
+    post-destroot {
+        # remove library-related files (which are already present)
+        delete "${destroot}${prefix}/etc"
+        delete "${destroot}${prefix}/include"
+        delete "${destroot}${prefix}/lib"
+        delete "${destroot}${prefix}/share/doc/libpaper"
+        delete "${destroot}${prefix}/share/man/man5"
+    }
+}

--- a/tex/texlive-bin/Portfile
+++ b/tex/texlive-bin/Portfile
@@ -10,7 +10,7 @@ PortGroup       muniversal 1.1
 
 name            texlive-bin
 version         2023.66589
-revision        1
+revision        2
 
 categories      tex
 maintainers     {dports @drkp}

--- a/textproc/barcode/Portfile
+++ b/textproc/barcode/Portfile
@@ -5,7 +5,7 @@ PortGroup           gnu_info 1.0
 
 name                barcode
 version             0.99
-revision            1
+revision            2
 checksums           rmd160  44c1574c0a48efae2fc267aab914c03577a4ec4a \
                     sha256  7c031cf3eb811242f53664379aebbdd9fae0b7b26b5e5d584c31a9f338154b64
 
@@ -43,4 +43,7 @@ post-destroot {
     file rename ${destroot}${prefix}/bin/sample ${destroot}${prefix}/bin/${name}-sample
 }
 
-depends_lib         port:libpaper
+depends_build-append \
+                    port:gettext
+depends_lib-append  port:libpaper \
+                    port:gettext-runtime

--- a/textproc/xmlto/Portfile
+++ b/textproc/xmlto/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xmlto
 version             0.0.28
-revision            6
+revision            7
 categories          textproc
 license             GPL-2+
 installs_libs       no
@@ -33,7 +33,7 @@ depends_build       port:util-linux
 depends_run         port:docbook-xml \
                     port:docbook-xsl-nons \
                     port:fop \
-                    port:libpaper \
+                    port:libpaper-utils \
                     port:libxml2 \
                     port:libxslt \
                     port:w3m \


### PR DESCRIPTION
A bunch of programs (most notably `gs`, `gimp`, and `ImageMagick`) couldn't be distributed as pre-built binary bundles because the previous version of 'libpaper' was GPL-2 only.
