### PR TITLE
mupdf: set compiler.cxx_standard 2017, fix build on macOS ≤ 10.12

### DIFF
--- a/graphics/mupdf/Portfile
+++ b/graphics/mupdf/Portfile
@@ -70,6 +70,7 @@ build.args-append   CC=${configure.cc} \
                     verbose=yes \
                     shared-release
 
+compiler.cxx_standard   2017
 use_parallel_build  no
 
 destroot.destdir    prefix=${destroot}${prefix}


### PR DESCRIPTION
With `USE_TESSERACT=YES`, the mupdf build uses `-std=c++17` to compile tessocr.cpp.

As far as the system default compiler is concerned, `-std=c++17` is only supported since Xcode 9.3, which only runs on macOS ≥ 10.13.2. This should fix the build on macOS ≤ 10.12.

mupdf was updated to use `USE_TESSERACT` at a6096d890d26. The CI run to build this port appears at 37c3dfd057ed. A failure on macOS 10.12 appears at https://build.macports.org/builders/ports-10.12_x86_64-builder/builds/247533.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@reneeotten Thanks for your help with #20709. This fix appears necessary to fix the build on macOS ≤ 10.12, which wasn’t apparent until a6096d890d26 was committed and a full CI run ran on older OS versions.