### PR TITLE
ruby-build: Update to 20231014

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20231012 v
+github.setup        rbenv ruby-build 20231014 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  f84d26efd461d5558c3893136866701e5cb65202 \
-                    sha256  052ad105aeb7be30fd17d9899a786bc95c9c5ed87cbc0278c461b9a7df7a434c \
-                    size    80206
+checksums           rmd160  f057cdb4e3413a5a775d998c93cca9ac1ad4a185 \
+                    sha256  b3a4bb1c329019e3f7f43da7d171a41fb5f6d7e2fbcd52031ae06da344b7bb65 \
+                    size    80350
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

```
What's Changed

- Add RUBY_BUILD_TARBALL_OVERRIDE to override the ruby tarball URL by @eregon
```

###### Tested on

macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
