### PR TITLE
vim, MacVim: update to vim version 9.0.1897

### DIFF
--- a/editors/MacVim/Portfile
+++ b/editors/MacVim/Portfile
@@ -8,9 +8,9 @@ PortGroup           compiler_blacklist_versions 1.0
 # is because they both share the same set of configuration files and ensures
 # that the user's configuration files will always work with both.
 set vim_version     9.0
-set release         177
+set release         178
 github.setup        macvim-dev macvim ${release} release-
-revision            3
+revision            0
 name                MacVim
 version             ${vim_version}.release${release}
 categories          editors
@@ -25,9 +25,9 @@ long_description \
 
 homepage            https://macvim.org
 
-checksums           rmd160  36c16994eedfc40c1e477ee9ab90b623e68cbcab \
-                    sha256  a942786b67486d906ef5ec75ee3bf896b9433a1fde4cd835215445aa3d6a9dbe \
-                    size    24759057
+checksums           rmd160  792e03eac8d6741fe4ac9f7b9098327407a0507b \
+                    sha256  eaa765e53963fbe6d2e0c1b48f0416e9fa7c0013f5b2d25a66d7a159281d3748 \
+                    size    24958039
 
 depends_lib         port:ncurses \
                     port:gettext \

--- a/editors/MacVim/files/patch-remove-Homebrew-python.diff
+++ b/editors/MacVim/files/patch-remove-Homebrew-python.diff
@@ -1,38 +1,47 @@
 --- src/MacVim/vimrc	2021-04-01 10:32:44.000000000 +0200
 +++ src/MacVim/vimrc	2021-04-05 14:56:37.000000000 +0200
-@@ -9,36 +9,4 @@
+@@ -9,45 +9,4 @@
  " more sensible value.  Add "set backspace&" to your ~/.vimrc to reset it.
  set backspace+=indent,eol,start
 
 -" Python2
--" MacVim is configured by default to use the pre-installed System python2
--" version. However, following code tries to find a Homebrew, MacPorts or
--" an installation from python.org:
+-" MacVim is configured by default in the binary release to use the
+-" pre-installed System python2 version. However, following code tries to
+-" find a Homebrew, MacPorts or an installation from python.org:
 -if exists("&pythondll") && exists("&pythonhome")
+-  " Homebrew python 2.7
 -  if filereadable("/usr/local/Frameworks/Python.framework/Versions/2.7/Python")
--    " Homebrew python 2.7
 -    set pythondll=/usr/local/Frameworks/Python.framework/Versions/2.7/Python
+-
+-  " MacPorts python 2.7
 -  elseif filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python")
--    " MacPorts python 2.7
 -    set pythondll=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python
+-
+-  " https://www.python.org/downloads/mac-osx/
 -  elseif filereadable("/Library/Frameworks/Python.framework/Versions/2.7/Python")
--    " https://www.python.org/downloads/mac-osx/
 -    set pythondll=/Library/Frameworks/Python.framework/Versions/2.7/Python
 -  endif
 -endif
 -
 -" Python3
--" MacVim is configured by default to use Homebrew python3 version
--" If this cannot be found, following code tries to find a MacPorts
--" or an installation from python.org:
+-" MacVim is configured by default in the binary release to set
+-" pythonthreedll to Homebrew python3. If it cannot be found, the following
+-" code tries to find Python3 from other popular locations.  Note that we are
+-" using "Current" for the version, because Vim supports the stable ABI and
+-" therefore any new version of Python3 will work.
 -if exists("&pythonthreedll") && exists("&pythonthreehome") &&
 -      \ !filereadable(&pythonthreedll)
--  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/3.11/Python")
--    " MacPorts python
--    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/3.11/Python
--  elseif filereadable("/Library/Frameworks/Python.framework/Versions/3.11/Python")
--    " https://www.python.org/downloads/mac-osx/
--    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/3.11/Python
+-  " MacPorts python
+-  if filereadable("/opt/local/Library/Frameworks/Python.framework/Versions/Current/Python")
+-    set pythonthreedll=/opt/local/Library/Frameworks/Python.framework/Versions/Current/Python
+-
+-  " macOS default Python, installed by 'xcode-select --install'
+-  elseif filereadable("/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/Current/Python3")
+-    set pythonthreedll=/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/Current/Python3
+-
+-  " https://www.python.org/downloads/mac-osx/
+-  elseif filereadable("/Library/Frameworks/Python.framework/Versions/Current/Python")
+-    set pythonthreedll=/Library/Frameworks/Python.framework/Versions/Current/Python
 -  endif
 -endif
 -

--- a/editors/MacVim/files/patch-remove-updater.diff
+++ b/editors/MacVim/files/patch-remove-updater.diff
@@ -113,3 +113,20 @@
                  <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="826">
                      <rect key="frame" x="18" y="218" width="449" height="56"/>
                      <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+@@ -633,16 +558,6 @@
+                         <binding destination="58" name="value" keyPath="values.MMUseInlineIm" id="1016"/>
+                     </connections>
+                 </button>
+-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="ere-oJ-WLd">
+-                    <rect key="frame" x="19" y="20" width="449" height="70"/>
+-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="Gdp-Ib-RGS">
+-                        <font key="font" metaFont="smallSystem"/>
+-                        <string key="title">Opt-in to the pre-release software update channel. Sofware updater will now also download early pre-release builds that will get new features faster, but will be less tested and occasionally have stability issues or incomplete features. Use this if you want to try out new features and help provide feedbacks early on, but don't use this if you need to rely on MacVim.</string>
+-                        <color key="textColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+-                    </textFieldCell>
+-                </textField>
+             </subviews>
+             <point key="canvasLocation" x="143.5" y="962.5"/>
+         </customView>

--- a/editors/vim/Portfile
+++ b/editors/vim/Portfile
@@ -18,12 +18,12 @@ if {${os.platform} eq "darwin" && ${os.major} <= 14} {
                     sha256  7185577d6cd3708b62b2079b69a29215bb6a6048070d34e960d2d565c18b8a9b \
                     size    16851486
 } else {
-    set vim_patchlevel 1677
-    set port_revision  1
+    set vim_patchlevel 1897
+    set port_revision  0
 
-    checksums       rmd160  9a62a3612177c661462dd218b305f92fc036d9f2 \
-                    sha256  996766187b040b67fe13721e1601584fcf5e89f3ff9d5986be87c3fd1fe5d7c5 \
-                    size    17069893
+    checksums       rmd160  03c9bc4d54789cbec843fbfbfa342de2f6af4384 \
+                    sha256  8b86cfb2b609e7a7e386b88a89b01522354990d4eef27e7001cc607d49d62ebf \
+                    size    17268335
 }
 
 github.setup        vim vim ${vim_version}.${vim_patchlevel} v


### PR DESCRIPTION
#### Description

* update Vim to v9.0.1897
* update MacVim to release-178
* remove remaining pre-release software update channel description textfield from Advanced Settings dialog

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
   - Unable to run with trace-mode due to [#66356](https://trac.macports.org/ticket/66358)
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
   - Tested Vim with `+cscope`, `+huge`, `+python311`, `+tcl`
   - Tested MacVim with `+cscope`, `+huge`, `+python311`

###### Notes

Vim patches `patch-python.diff`, `patch-python3.diff`, and `patch-tcl.diff` apply cleanly without changes.
MacVim patches `patch-python.diff` and `patch-tcl.diff` apply cleanly without changes.
MacVim patches `patch-remote-updater.diff` and `patch-remove-Homebrew-python.diff` updated in commit.
