### PR TITLE
libpsl, python31[01]: move to python311, update

### DIFF
--- a/lang/python310/Portfile
+++ b/lang/python310/Portfile
@@ -2,12 +2,12 @@
 
 PortSystem 1.0
 PortGroup select 1.0
-PortGroup clang_dependency 1.0
 
 name                python310
 
 # Remember to keep py310-tkinter and py310-gdbm's versions sync'd with this
 version             3.10.13
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang

--- a/lang/python311/Portfile
+++ b/lang/python311/Portfile
@@ -2,11 +2,13 @@
 
 PortSystem 1.0
 PortGroup select 1.0
+PortGroup clang_dependency 1.0
 
 name                python311
 
 # Remember to keep py311-tkinter and py311-gdbm's versions sync'd with this
 version             3.11.6
+revision            1
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang

--- a/net/libpsl/Portfile
+++ b/net/libpsl/Portfile
@@ -8,7 +8,7 @@ github.setup        rockdaboot libpsl 0.21.2
 # when incrementing version or revision please check
 # that psl_data_commit and psl_data_date refer to latest
 # https://github.com/publicsuffix/list git master commit
-revision            0
+revision            1
 license             MIT
 description         A C library and utility to handle the Public Suffix List
 long_description    ${description}
@@ -19,8 +19,8 @@ platforms           darwin
 github.tarball_from releases
 set main_distfile   ${distfiles}
 
-set psl_data_commit     19f2225196dcf2b8f624a279b448eee7894a92b1
-set psl_data_date       20230117
+set psl_data_commit     15d84102d12cce502fd169e5ded4d093f96716e8
+set psl_data_date       20230930
 set psl_data_worksrcdir list-${psl_data_commit}
 set psl_data_distname   publicsuffix-list-[string range ${psl_data_commit} 0 6]
 set psl_data_distfile   ${psl_data_distname}${extract.suffix}
@@ -38,9 +38,9 @@ checksums           ${main_distfile} \
                     sha256  e35991b6e17001afa2c0ca3b10c357650602b92596209b7492802f3768a6285f \
                     size    7617025 \
 ${psl_data_distfile} \
-                    rmd160  6c7a3c3284d3b07bb00f228d0d2677150db101a9 \
-                    sha256  c0c4532569c6f779ae439c08bb7079755e51b4a5766d02f8d9cfe45ed0af8016 \
-                    size    111898
+                    rmd160  ed51785aebd8d8147b8d0d2f496eb000e19cdc81 \
+                    sha256  4a2716bfe7c390f3ab87697ef8621cbcbdec07540d4b273db154eea53db55899 \
+                    size    114072
 
 # Please note this port is (indirectly, via cmake) a dependency of the
 # various clang-X ports. When updating the port versions (e.g. python)
@@ -49,7 +49,7 @@ ${psl_data_distfile} \
 # See e.g. https://trac.macports.org/ticket/60419
 
 # DO NOT change this unless you have understood and acted on the above comment!
-set py_ver          3.10
+set py_ver          3.11
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build-append \


### PR DESCRIPTION
#### Description

Updates libpsl to use python311 instead of python310. While I was at it, I updated the publicsuffix/list commit to the latest one per instructions in libpsl's Portfile.

This also adds python311 to PortGroup clang_dependency.

As a quick scan of the other ports in clang_dependency revealed no other dependencies on python310, I've also removed it from the group. Notably, devel/glib2 seems to already depend on python311 -- perhaps it should've already been in the group?

I bumped revisions on both python310 and python311 - not sure if this was necessary, please advise.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
