### PR TITLE
cmake-devel: update to 3.28.0-rc1

### DIFF
--- a/devel/cmake-devel/Portfile
+++ b/devel/cmake-devel/Portfile
@@ -7,7 +7,6 @@ if { ${os.platform} eq "darwin" && ${os.major} >= 20 && ${build_arch} eq "x86_64
     universal_variant no
 } else {
     PortGroup       muniversal 1.0
-
 }
 
 PortGroup           gitlab 1.0
@@ -36,12 +35,12 @@ homepage            https://cmake.org
 platforms           darwin freebsd
 gitlab.instance     https://gitlab.kitware.com
 
-gitlab.setup        cmake   cmake 51b34a5483dccc20edf6a3cc65f3bb19b31b1d72
-version             20230810-3.27.6-[string range ${gitlab.version} 0 7]
-checksums           rmd160  0fbaa779dd6cc2300acf0497fa128218847ccd9b \
-                    sha256  5bc96186235343be9e948b233dd6c58ffad3a097b35c7331645b45d90ee6b7d3 \
-                    size    8425873
-revision            1
+gitlab.setup        cmake   cmake 38643edc2de410311fbe76f7950190fc056b151a
+version             20231015-3.28.0-rc1-[string range ${gitlab.version} 0 7]
+checksums           rmd160  c5ec5a820ea4548568524ec7fbfa81607b258880 \
+                    sha256  c8ec6055c25779c4b62070408808f0f429cab68e649dbddfc61c7e12551b918d \
+                    size    8466316
+revision            0
 
 epoch               1
 
@@ -361,8 +360,11 @@ subport ${subport_docs} {
 
 if {${subport} eq ${name}} {
     notes "\
-        The CMake Gui and Docs are now provided as subports '${subport_gui}' and '${subport_docs}', respectively.
+        The CMake GUI and Docs are now provided as subports '${subport_gui}' and '${subport_docs}', respectively.
     "
+
+    test.run                yes
+    test.target             test
 
     # Ignore RC versions
     gitlab.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
 - update to 3.28.0-rc1
 - enable tests
 - minor cosmetic fixes

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
