### PR TITLE
thrift: update to 0.19.0, fix build on Sonoma/Ventura, do not opportunistically build lisp lib

### DIFF
--- a/devel/apache-arrow/Portfile
+++ b/devel/apache-arrow/Portfile
@@ -15,7 +15,7 @@ legacysupport.newest_darwin_requires_legacy 15
 boost.version       1.81
 
 github.setup        apache arrow 13.0.0 apache-arrow-
-revision            2
+revision            3
 name                ${github.author}-${github.project}
 
 categories          devel
@@ -28,9 +28,13 @@ long_description    Apache Arrow is a development platform for in-memory \
                     analytics. It contains a set of technologies that \
                     enable big data systems to process and move data fast.
 
-checksums           rmd160  cf775adc9440e6200bdee8ce37d78fe6b5b186fe \
-                    sha256  286ad68b17702caaa46b9f8de5797d9511a01748728221ed9921171166928d5b \
-                    size    20213466
+checksums           rmd160  7a811ff28eadc2c20da253814d02f07b74a9e05f \
+                    sha256  99c27e6a517c750f29c3e6b264836e31251bb8e978dbbf11316680ca3eb8ebda \
+                    size    20216422
+github.tarball_from archive
+
+# Drop with the next update. See: https://trac.macports.org/ticket/68025
+dist_subdir         ${name}/${version}_1
 
 compiler.cxx_standard \
                     2017

--- a/devel/thrift/Portfile
+++ b/devel/thrift/Portfile
@@ -4,19 +4,20 @@ PortSystem      1.0
 PortGroup       conflicts_build 1.0
 PortGroup       boost 1.0
 
+boost.version   1.81
+
 name            thrift
 
 # NOTE: This port must be kept at the same version as port:py-thrift and port:p5-thrift
-version         0.18.1
-checksums       rmd160  71f2fe5fd0ebebd0575c747c01157dbf27aa4774 \
-                sha256  04c6f10e5d788ca78e13ee2ef0d2152c7b070c0af55483d6b942e29cff296726 \
-                size    4310494
+version         0.19.0
+checksums       rmd160  6a9560b841762a260bb8e6cc7f9d69d663c5e99c \
+                sha256  d49c896c2724a78701e05cfccf6cf70b5db312d82a17efe951b441d300ccf275 \
+                size    4335656
 revision        0
 
 categories      devel
 license         Apache-2
 maintainers     nomaintainer
-platforms       darwin
 
 description     framework for scalable cross-language services development
 long_description \
@@ -75,6 +76,14 @@ configure.args  --with-c_glib=no \
                 --with-boost=[boost::install_area]
 
 configure.cppflags-append -DBOOST_TEST_DYN_LINK
+
+if {${os.platform} eq "darwin" && ${os.major} > 21} {
+    # https://trac.macports.org/ticket/68475
+    if {[string match *clang* ${configure.compiler}]} {
+        configure.cxxflags-append \
+                -Wno-error=unused-but-set-variable
+    }
+}
 
 variant java description "enable the Java library" {
     depends_build-append    bin:ant:apache-ant

--- a/devel/thrift/Portfile
+++ b/devel/thrift/Portfile
@@ -58,6 +58,7 @@ pre-configure {
 conflicts_build     ${name}
 
 configure.args  --with-c_glib=no \
+                --with-cl=no \
                 --with-csharp=no \
                 --with-d=no \
                 --with-erlang=no \
@@ -152,6 +153,13 @@ variant swift description "enable the Swift library" {
 
     # require XCode
     use_xcode yes
+}
+
+# Fails on PowerPC at the moment: https://trac.macports.org/ticket/68477
+variant lisp description "enable the CL library" {
+    configure.args-delete   --with-cl=no
+    configure.args-append   --with-cl=yes
+    depends_lib-append      port:sbcl
 }
 
 test.run        yes

--- a/perl/p5-thrift/Portfile
+++ b/perl/p5-thrift/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         Thrift 0.18.1
+perl5.setup         Thrift 0.19.0
 platforms           {darwin any}
 maintainers         nomaintainer
 license             BSD
@@ -24,9 +24,9 @@ dist_subdir         thrift
 distname            thrift-${version}
 
 # NOTE: This port must be kept at the same version as port:thrift and port:py-thrift
-checksums           rmd160  71f2fe5fd0ebebd0575c747c01157dbf27aa4774 \
-                    sha256  04c6f10e5d788ca78e13ee2ef0d2152c7b070c0af55483d6b942e29cff296726 \
-                    size    4310494
+checksums           rmd160  6a9560b841762a260bb8e6cc7f9d69d663c5e99c \
+                    sha256  d49c896c2724a78701e05cfccf6cf70b5db312d82a17efe951b441d300ccf275 \
+                    size    4335656
 revision            0
 
 if {${perl5.major} != ""} {

--- a/python/py-thrift/Portfile
+++ b/python/py-thrift/Portfile
@@ -6,10 +6,10 @@ PortGroup       python 1.0
 name            py-thrift
 
 # NOTE: This port must be kept at the same version as port:thrift and port:p5-thrift
-version         0.18.1
-checksums       rmd160  71f2fe5fd0ebebd0575c747c01157dbf27aa4774 \
-                sha256  04c6f10e5d788ca78e13ee2ef0d2152c7b070c0af55483d6b942e29cff296726 \
-                size    4310494
+version         0.19.0
+checksums       rmd160  6a9560b841762a260bb8e6cc7f9d69d663c5e99c \
+                sha256  d49c896c2724a78701e05cfccf6cf70b5db312d82a17efe951b441d300ccf275 \
+                size    4335656
 revision        0
 
 license         Apache-2


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68475
Closes: https://trac.macports.org/ticket/68025

#### Description

Update and fix for Sonoma/Ventura.
Do not build lisp portion opportunistically; make it a variant.
Switch to Boost 1.81 to match `apache-arrow`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14
Xcode 15

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
