### PR TITLE
iTerm2: update to 3.4.21

### DIFF
--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -55,8 +55,8 @@ livecheck.regex     {sparkle:version="([\d\.]+)"}
 post-patch {
     # patch the python script out since it does not set the correct version and may cause trouble
     reinplace "s|exec tools/updateVersion.py|exec /usr/bin/true|g" ${worksrcpath}/iTerm2.xcodeproj/project.pbxproj
-    # macOS 13/Xcode 14 seems to be requiring code signing
-    if {${os.major} >= 22} {
+    # macOS 13/Xcode 14 seems to be requiring code signing (macOS 12 with XC14 now requires the same)
+    if {${os.major} >= 21} {
         reinplace "s|CODE_SIGN_IDENTITY = \".*\";|CODE_SIGN_IDENTITY = \"-\";|g" ${worksrcpath}/iTerm2.xcodeproj/project.pbxproj
     } else {
         reinplace "s|CODE_SIGN_IDENTITY = \".*\";|CODE_SIGN_IDENTITY = \"\";|g" ${worksrcpath}/iTerm2.xcodeproj/project.pbxproj

--- a/aqua/iTerm2/Portfile
+++ b/aqua/iTerm2/Portfile
@@ -6,11 +6,11 @@ PortGroup           xcodeversion 1.0
 
 
 if {${os.major} > 17} {
-    version             3.4.19
-    revision            1
-    checksums           rmd160  58f0ef9570d94a9940c3dddc8f7f972c657ed941 \
-                        sha256  5316d5bf3d83614b5c29026ece6cc6be56bd93d55490105e0921ceeebbf0a025 \
-                        size    28768995
+    version             3.4.21
+    revision            0
+    checksums           rmd160  00cc53ced493db0be593d730f518f56ba0ebe5a3 \
+                        sha256  175b03c9ab41b7c3a5c62967c442fa306639effb5641554c5f6ae739198e0be3 \
+                        size    28781228
     patchfiles          patch-Makefile-XC10.diff \
                         patch-remove-sparkle-3.4.diff \
                         patch-nsur.diff


### PR DESCRIPTION
#### Description

iTerm2: update to 3.4.21

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? no trace mode
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
