### PR TITLE
libplist: Revision bump libimobiledevice projects

### DIFF
--- a/devel/ideviceinstaller/Portfile
+++ b/devel/ideviceinstaller/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        libimobiledevice ideviceinstaller 1.1.1
-revision            1
+revision            2
 
 categories          devel
 platforms           darwin

--- a/devel/ideviceinstaller/Portfile
+++ b/devel/ideviceinstaller/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        libimobiledevice ideviceinstaller 1.1.1
+revision            1
 
 categories          devel
 platforms           darwin

--- a/devel/libimobiledevice/Portfile
+++ b/devel/libimobiledevice/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        libimobiledevice libimobiledevice 1.3.0
-revision            1
+revision            2
 
 categories          devel
 
@@ -55,13 +55,13 @@ configure.args      --disable-silent-rules \
 subport libimobiledevice-devel {
     github.setup    libimobiledevice libimobiledevice 333eb1aec92f02b0b61f9ec23880861b93d42c60
     version         20200618
-    revision        1
+    revision        2
 
     checksums       rmd160  27591925392cbc0ee4076ab02491b1d8e832f7bc \
                     sha256  127cb57199e4538eee7e8e01f711cb1cb53d73b70181b0ba6c37c8371ab4faca \
                     size    261030
 
-    depends_lib-replace port:libusbmuxd port:libusbmuxd-devel   
+    depends_lib-replace port:libusbmuxd port:libusbmuxd-devel
     depends_lib-replace port:libplist port:libplist-devel
 
     conflicts       libimobiledevice

--- a/devel/libusbmuxd/Portfile
+++ b/devel/libusbmuxd/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        libimobiledevice libusbmuxd 2.0.2
+revision            1
 
 categories          devel
 platforms           darwin
@@ -37,11 +38,12 @@ subport libusbmuxd-devel {
     version         20200615
     # Epoch 1: Downgrade due to https://github.com/libimobiledevice/libusbmuxd/issues/71
     epoch           1
+    revision        1
 
     checksums       rmd160  f16ea53953c3c14140eb5d3c978521ce28d8b83f \
                     sha256  1bccb0e79a0f1bf455102e2c08298fe474252a4181479d5e64c0deba911ccaaf \
                     size    48941
-    
+
     depends_lib-replace port:libplist port:libplist-devel
 
     conflicts       libusbmuxd

--- a/devel/usbmuxd/Portfile
+++ b/devel/usbmuxd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        libimobiledevice usbmuxd 1.1.1
-revision            0
+revision            1
 
 categories          devel
 maintainers         {i0ntempest @i0ntempest} openmaintainer


### PR DESCRIPTION
#### Description

Several libimobiledevice projects have adopted libplist 2.3.0. However, they were never revision bumped, breaking linkage when installing.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
