### PR TITLE
SuiteSparse: update to 5.13.0

### DIFF
--- a/math/SuiteSparse/Portfile
+++ b/math/SuiteSparse/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                DrTimothyAldenDavis SuiteSparse 5.9.0 v
+github.setup                DrTimothyAldenDavis SuiteSparse 5.13.0 v
 # subports have independent revisions
 revision                    0
 epoch                       20200517
@@ -18,9 +18,9 @@ long_description            SuiteSparse is a single archive that contains all pa
 
 homepage                    https://people.engr.tamu.edu/davis/suitesparse.html
 
-checksums                   rmd160  bedf435c5ee9a5d15a923b361ef033a89e01c9a7 \
-                            sha256  f62709c67d6f545b709099ff5afaa54fef4743c1ae3bb3e955a4e71c35303550 \
-                            size    59609016
+checksums                   rmd160  c418ad3400283e59ea528fe1d80c1dd9422bb998 \
+                            sha256  8eb2e49e14c0a1a497ed147bc13608e791200e190306ffa50f00be5150fc5306 \
+                            size    65007739
 
 use_parallel_build          no
 
@@ -35,7 +35,7 @@ configure.cppflags-replace  -I${prefix}/include \
                             -isystem${prefix}/include
 
 subport SuiteSparse_config {
-    version                 5.9.0
+    version                 5.13.0
     revision                0
     # from the README.txt:
     #    "[n]o licensing restrictions apply"
@@ -43,7 +43,7 @@ subport SuiteSparse_config {
 }
 
 subport SuiteSparse_GraphBLAS {
-    version                 4.0.3
+    version                 7.2.0
     revision                0
     license                 Apache-2
     long_description-append ${subport}: graph algorithms in the language of linear algebra.
@@ -175,8 +175,8 @@ subport SuiteSparse_RBio {
 subport SuiteSparse_SPQR {
     PortGroup               linear_algebra 1.0
 
-    version                 2.0.9
-    revision                1
+    version                 2.1.0
+    revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CHOLMOD port:SuiteSparse_COLAMD
     pre-build {
         build.args-append   BLAS="-L${prefix}/lib ${linalglib}" \
@@ -188,6 +188,8 @@ subport SuiteSparse_SPQR {
 }
 
 subport SuiteSparse_SLIP_LU {
+    # This version is incorrect. The real version number is 1.0.2.
+    # Remember to fix this when the port is next updated.
     version                 2.0.9
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_COLAMD \


### PR DESCRIPTION
 - update to 5.13.0
 - fix SuiteSparse_SLIP_LU version (should have been 1.0.2)
 - ref: https://trac.macports.org/ticket/67084

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
