### PR TITLE
spirv-cross: new port

### DIFF
--- a/graphics/spirv-cross/Portfile
+++ b/graphics/spirv-cross/Portfile
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        KhronosGroup SPIRV-Cross 1.1.5 MoltenVK-
+github.tarball_from archive
+
+name                spirv-cross
+# This version number is taken from the spirv-cross-c library (i.e.
+# the C API), and is obtained by looking in the file
+# ${worksrcpath}/spirv_cross_c.h, as defined by SPVC_C_API_VERSION_*.
+version             0.48.0
+revision            0
+
+categories          graphics
+license             Apache-2
+maintainers         @jasonliu-- openmaintainer
+
+description         tool for parsing and converting SPIR-V to and from \
+                    other shader languages
+long_description    ${github.project} is a tool and library for \
+                    performing reflection on SPIR-V and disassembling \
+                    SPIR-V back to high-level languages.
+
+checksums           rmd160  ac0aab7c3fb854ab95dcee09cb0c0f0b2ef85fd9 \
+                    sha256  e11845d9a4ccb4666923a8b678935cf78acad2b4fc131aba779f5bcc6def5191 \
+                    size    1514658
+
+compiler.cxx_standard   2011
+
+configure.args-append   -DSPIRV_CROSS_SHARED=ON \
+                        -DSPIRV_CROSS_FORCE_PIC=ON \
+                        -DSPIRV_CROSS_ENABLE_TESTS=OFF
+
+pre-test {
+    if {![variant_isset tests]} {
+        ui_error "'tests' variant must be activated to enable test support"
+        error "Please enable the 'tests' variant and try again"
+    }
+}
+
+variant tests description {Build unit tests} {
+    set py_ver              3.11
+    set py_ver_nodot        [string map {. {}} ${py_ver}]
+
+    depends_lib-append      port:glslang \
+                            port:spirv-tools
+
+    post-patch {
+        # Make it so that the CMake build is able to find the tools
+        # that are available through MacPorts
+        reinplace -E \
+            "/(glslang|spirv-tools)-build/s,(PATHS ).*(bin),\\1${prefix}/\\2," \
+            ${worksrcpath}/CMakeLists.txt
+    }
+
+    depends_test-append     port:python${py_ver_nodot}
+    configure.python        ${prefix}/bin/python${py_ver}
+    configure.args-append   -DPYTHON_EXECUTABLE:FILEPATH=${configure.python}
+
+    configure.args-replace  -DSPIRV_CROSS_ENABLE_TESTS=OFF \
+                            -DSPIRV_CROSS_ENABLE_TESTS=ON
+    test.run yes
+}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

[SPIRV-Cross](https://github.com/KhronosGroup/SPIRV-Cross) is a tool for parsing and converting SPIR-V to and from other shader languages.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
