### PR TITLE
ifuse: new port (1.1.4)

### DIFF
--- a/fuse/ifuse/Portfile
+++ b/fuse/ifuse/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            libimobiledevice ifuse 1.1.4
+github.tarball_from     releases
+revision                0
+categories              fuse devel
+license                 LGPL-2.1
+maintainers             {@therealketo gmail.com:therealketo} openmaintainer
+description             A fuse filesystem to access the contents of iOS devices
+long_description        {*}${description}.
+
+homepage                https://libimobiledevice.org/
+
+checksums               rmd160  03c646a374a2724db9eed0e4ffbe6acbc9fa5062 \
+                        sha256  3550702ef94b2f5f16c7db91c6b3282b2aed1340665834a03e47458e09d98d87 \
+                        size    94137
+
+use_bzip2               yes
+
+depends_build-append    port:autoconf \
+                        port:automake \
+                        port:libtool \
+                        port:pkgconfig
+
+depends_lib-append      port:libplist \
+                        port:glib2 \
+                        port:libimobiledevice \
+                        port:macfuse
+
+configure.args          --disable-silent-rules


### PR DESCRIPTION
#### Description

Add ifuse, from the libimobiledevice project.

Closes: https://trac.macports.org/ticket/62117

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
