### PR TITLE
kvazaar: new port

### DIFF
--- a/multimedia/kvazaar/Portfile
+++ b/multimedia/kvazaar/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        ultravideo kvazaar 2.2.0 v
+github.tarball_from releases
+revision            0
+categories          multimedia devel
+license             BSD
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         Open-source HEVC encoder
+
+long_description    An open-source HEVC encoder licensed under 3-clause BSD.
+
+depends_build       port:yasm
+
+checksums           rmd160  36e351494fba5f81226e66820aafe948e2dc4b32 \
+                    sha256  a3c35dc24f587145afacf537bdc43176b763be48cc05e1f597cce2c4e515689a \
+                    size    1007269


### PR DESCRIPTION
#### Description

[An open-source HEVC encoder licensed under 3-clause BSD](https://github.com/ultravideo/kvazaar)

###### Tested on
macOS 13.6 22G120 x86_64
Xcode 15.0 15A240d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?