### PR TITLE
libheif: update to 1.17.0

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -5,12 +5,12 @@ PortGroup                   github 1.0
 PortGroup                   cmake 1.1
 PortGroup                   compiler_blacklist_versions 1.0
 
-github.setup                strukturag libheif 1.16.2 v
-revision                    2
+github.setup                strukturag libheif 1.17.0 v
+revision                    0
 
-checksums                   rmd160  47615c2fa85ee1163bd4ad787aedd44b90f71d4f \
-                            sha256  7f97e4205c0bd9f9b8560536c8bd2e841d1c9a6d610401eb3eb87ed9cdfe78ea \
-                            size    1339068
+checksums                   rmd160  3f391ef213c3d21930ed9fc24362a8cd8af39c15 \
+                            sha256  c86661e9ef9c43ad8de9d2b38b7b508df5322580b24d22fc25a977e7fdb26f3c \
+                            size    1430211
 
 categories                  multimedia
 license                     LGPL-3+


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68485

###### Tested on
macOS 13.6 22G120 x86_64
Xcode 15.0 15A240d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?