### PR TITLE
moar, MoarVM: declare mutual conflict

### DIFF
--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -22,6 +22,8 @@ long_description    MoarVM is a modern virtual machine built for the Rakudo \
 homepage            https://moarvm.org/
 master_sites        https://moarvm.org/releases/
 
+conflicts           moar
+
 checksums           rmd160  c22c09c79b656d5156e8d74f35569b0b2e211d39 \
                     sha256  143f92510eaa3452c712e4aae9f44d84cd078f16517b40252bab7dd5e224ecdb \
                     size    14929053

--- a/textproc/moar/Portfile
+++ b/textproc/moar/Portfile
@@ -8,6 +8,8 @@ go.offline_build    no
 github.tarball_from archive
 revision            0
 
+conflicts           MoarVM
+
 description         Moar is a pager. It's designed to just do the right thing \
                     without any configuration.
 


### PR DESCRIPTION
#### Description

This is the first step of a possible multiple-step realignment so that people who wish to do so might be able to use both `moar` and MoarVM (required for NQP and Rakudo).

This step is required even if no other steps are taken, as trying to install either of these ports after the other without this results in a delayed error rather than an upfront prevention.

Addresses the first step in https://trac.macports.org/ticket/68491, but does not complete it.

###### Type(s)

- [x] enhancement

###### Tested on

macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

I have not tried to run existing tests or installs because the only thing added was `conflicts` and I currently use neither port. However, I did check `port info` for each port and they properly indicate mutual conflict.
