### PR TITLE
jdk17: update to 17.0.9

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk17-mac
-version      17.0.8
-revision     1
+version      17.0.9
+revision     0
 
 description  Oracle Java SE Development Kit 17
 long_description Java Platform, Standard Edition Development Kit (JDK). \
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/17/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  0d4189810e2b58ba803e0e277acf58ff8dc7819a \
-                 sha256  ddc4928be11642f35b3cb1e6a56463032705fccb74e10ed5a67a73a5fc7b639f \
-                 size    178850278
+    checksums    rmd160  53f15befd2ef0a6ca17de4a846b0c1638daa3e9e \
+                 sha256  336f3d0cfd3cac9b16c14830a43c1ee3f63810b0dae2f3e17a824185b83e3e85 \
+                 size    178913008
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  8e4bc916e34a68f975d7b9f90a25d9ad9409ce70 \
-                 sha256  89f26bda33262d70455e774b55678fc259ae4f29c0a99eb0377d570507be3d04 \
-                 size    176285053
+    checksums    rmd160  dfa7fddd185f6ccad9dc07b9652449702736fa9f \
+                 sha256  b65346d61ccfef1ba0fc994709295d196007d5fef1a0aa8c0f2eaf97bdd530b7 \
+                 size    176350219
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 17.0.9.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?