### PR TITLE
jdk21: update to 21.0.1

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      21
+version      21.0.1
 revision     0
 
 description  Oracle Java SE Development Kit 21
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/21/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  e1f541c35b095ec0e50063fc2ff0c8a3afa6e4ad \
-                 sha256  0dc6ee3c46e91322f59bcc17efc60c11e744b6ee865a0489545883aa7c550bea \
-                 size    193085094
+    checksums    rmd160  719e5af9e8dc49947c2fd2cb02720d24c5098ad9 \
+                 sha256  1aba93aea7da081df4ad393fb7eca69e04111d7c4a395b43d5d7d45945d6a671 \
+                 size    193119291
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  1864b74c0837847e95e0114a6e749a0aabcdb8bc \
-                 sha256  bec4222f43ac021ca120ca6ea409148709414e898ee74668e157f0dcfd3c9ffb \
-                 size    190719697
+    checksums    rmd160  1f9430e284d5ec4b35eeb63937b3bb6145919991 \
+                 sha256  465a7a6cb2144b63876aa86ac4e294157db9eabad9740542218d198515071e6f \
+                 size    190761631
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 21.0.1.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?