### PR TITLE
jdk17-graalvm: update to 17.0.9

### DIFF
--- a/java/jdk17-graalvm/Portfile
+++ b/java/jdk17-graalvm/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava17-mac
 supported_archs  x86_64 arm64
 
-version     17.0.8
+version     17.0.9
 revision    0
 
 master_sites https://download.oracle.com/graalvm/17/archive/
@@ -33,17 +33,17 @@ long_description Oracle GraalVM for JDK 17 compiles your Java applications ahead
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  e6d45b8ae862b14dfc176dc74b71bfa2564c5868 \
-                 sha256  325c1c5adce1e8b569e87f1e4dffe852f73e7c25e720ea15977f2ca1d7dba1bb \
-                 size    313376026
+    checksums    rmd160  18ad02606012513fb15ed2a4f5963640baf30080 \
+                 sha256  29dc9855874e6633df21fd00902ca99ae4a6527add708cee58c84ac61e78c626 \
+                 size    313382790
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  fa5d56c0b2f8d88cf2e195b5af0f54e23136c3bc \
-                 sha256  c73d2917c1b681679d90a7e3851b553c328e4028137e19adb301040fe0d43cfd \
-                 size    366820701
+    checksums    rmd160  69b2ecc375b7ec5147a13130d599b1865339bd05 \
+                 sha256  2214b6ecb32faacc84dffcbfae930450abe77c31730c4b6310e22d8f743959a5 \
+                 size    367115949
 }
 
-worksrcdir   graalvm-jdk-${version}+9.1
+worksrcdir   graalvm-jdk-${version}+11.1
 
 variant Applets \
     description { Advertise the JVM capability "Applets".} {}


### PR DESCRIPTION
#### Description

Update to Oracle GraalVM for JDK 17.0.9.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?