### PR TITLE
openjdk21-temurin: new submission

### DIFF
--- a/java/openjdk20-temurin/Portfile
+++ b/java/openjdk20-temurin/Portfile
@@ -1,89 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2024-04-18
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk20-temurin
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-# See https://adoptium.net/supported-platforms/
-platforms        {darwin any} {darwin >= 16}
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-# https://adoptium.net/temurin/releases/?version=20
-supported_archs  x86_64 arm64
-
-version      20.0.2
-set build    9
-revision     1
-
-description  Eclipse Temurin, based on OpenJDK 20
-long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
-
-master_sites https://github.com/adoptium/temurin20-binaries/releases/download/jdk-${version}%2B${build}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     OpenJDK20U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  a5defd42d992ae97a136edebdf3495df859ef873 \
-                 sha256  bdeb37322a7c9292434e417d4db9f5debd7477cf413335d3a653a4e5e50a2473 \
-                 size    197502362
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     OpenJDK20U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  382a90eb6a9580d316f10e843f51341a0b91de17 \
-                 sha256  6ef42b63581c0265c5a6b734e203bb922ee720571a8de46532ecca50a804c596 \
-                 size    186697641
-}
-
-worksrcdir   jdk-${version}+${build}
-
-homepage     https://adoptium.net
-
-livecheck.type      regex
-livecheck.url       https://github.com/adoptium/temurin20-binaries/releases
-livecheck.regex     OpenJDK20U-.*_mac_hotspot_(20\[0-9\.\]*)_\[0-9\]+.tar.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-20-eclipse-temurin.jdk
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}${jdk}
-    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
-    xinstall -m 755 -d ${destroot}${jvms}
-    ln -s ${prefix}${jdk} ${destroot}${jdk}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${jdk}/Contents/Home
-"
+name        openjdk20-temurin
+categories  java devel
+version     20.0.2
+revision    2
+replaced_by openjdk21-temurin

--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk21-temurin
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://adoptium.net/temurin/releases/
+supported_archs  x86_64 arm64
+
+version      21.0.1
+set build    12
+revision     0
+
+description  Eclipse Temurin, based on OpenJDK 21
+long_description Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes.
+
+master_sites https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${version}%2B${build}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     OpenJDK21U-jdk_x64_mac_hotspot_${version}_${build}
+    checksums    rmd160  4a820fe6cfd7077e32c3d8224f0ca6a00d3c0d85 \
+                 sha256  35f3cbc86d7ff0a01facefd741d5cfb675867e0a5ec137f62ba071d2511a45c9 \
+                 size    194340703
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     OpenJDK21U-jdk_aarch64_mac_hotspot_${version}_${build}
+    checksums    rmd160  41fa00ef620467e55ce56d06b942845c5ea7b8ff \
+                 sha256  0d29257c9bcb5f20f5c4643ef9437f36b10376863eddaf6248d09093796c6b30 \
+                 size    191704753
+}
+
+worksrcdir   jdk-${version}+${build}
+
+homepage     https://adoptium.net
+
+livecheck.type      regex
+livecheck.url       https://github.com/adoptium/temurin21-binaries/releases
+livecheck.regex     OpenJDK21U-jdk_.*_mac_hotspot_(\[0-9\.\]+)_\[0-9\]+.tar.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-21-eclipse-temurin.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for Eclipse Temurin 21.

Also obsoletes Eclipse Temurin 20, because support ended, replacing it with this new `openjdk21-temurin` port.