### PR TITLE
google-cloud-sdk: update to 451.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             450.0.0
+version             451.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  656b146c288fe4f887de1c78c169c06a97554242 \
-                    sha256  eb6fe368326aef8acc0aafe6d4b1926b11c44cd2767c942ef5302cf7888fdaa1 \
-                    size    121073638
+    checksums       rmd160  53cf62b712e67d3404b415764291b47e881bf933 \
+                    sha256  f08e475b01574750a836896d2dc03120ee372560f403bc231c2e0c891c38f027 \
+                    size    121617447
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  dd3f65e4fae5e9b35eabc6e34044093980b344bd \
-                    sha256  9fab5e94a8da62e31340f1a7660e2bfe569124919e393c1f35acd5abd2412f82 \
-                    size    122358177
+    checksums       rmd160  b8656a21186fd70a694361a4112b22fb80669196 \
+                    sha256  4e4bf8c05bacc58854c84bf50b27db4f592196507009c772975bc889326d49f7 \
+                    size    122901693
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  5635af3fe67b9cd09f6928685be75f858a8b31fe \
-                    sha256  e10d849d973febfd23a56137bebe35bc26aa7cb34b5ec8e9e82393a474039e06 \
-                    size    119458664
+    checksums       rmd160  4566905250976a6c8a67a8c874587bb783d59a77 \
+                    sha256  817912e950f0da4f3ef8bd26eec31bb6eb95d08ab8f29c8baf4339cb7e9b6d81 \
+                    size    120003926
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 451.0.0.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?