### PR TITLE
pgmodeler: update to 1.0.6

### DIFF
--- a/databases/pgmodeler/Portfile
+++ b/databases/pgmodeler/Portfile
@@ -1,42 +1,55 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           qmake5 1.0
+PortGroup           github  1.0
+PortGroup           qt6     1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        pgmodeler pgmodeler 0.9.1 v
+github.setup        pgmodeler pgmodeler 1.0.6 v
+github.tarball_from archive
+revision            0
+
 categories          databases
-platforms           darwin
-maintainers         {l2dy @l2dy} openmaintainer
 license             GPL-3
+maintainers         {l2dy @l2dy} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 description         PostgreSQL Database Modeler
 
 long_description    pgModeler - {*}${description} - is an open source data \
                     modeling tool designed for PostgreSQL.
 
-checksums           rmd160  e51bf644f4f140b770abb4ae061b501261372f9f \
-                    sha256  ca5b577caa821b7394b48293578f0a4a0eddfa20fbdf7ec9163e73ab0f280216 \
-                    size    3569275
+checksums           rmd160  874a2a4316b55d8b69b27da00aa7311ebc4f84cb \
+                    sha256  cfc80f9311e6c3863b80fdf9891793f00da3362f5c016331831e7b35b4681ab9 \
+                    size    3482968
 
-compiler.cxx_standard     2011
+compiler.cxx_standard \
+                    2011
 # src/databaseexplorerwidget.cpp:1761:88: error: chosen constructor is explicit in copy-initialization
-compiler.blacklist-append {clang < 700}
+compiler.blacklist-append \
+                    {clang < 700}
 
-patchfiles          patch-pgmodeler.pri.diff
+patchfiles          patch-${name}.pri.diff
 
 post-patch {
-    reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/pgmodeler.pri
+    reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/${name}.pri
 }
 
 depends_lib-append  port:libxml2 \
-                    port:postgresql10
+                    port:postgresql15
 
-qt5.depends_component \
-                    qtsvg
+qt6.depends_lib     qtsvg
+
+configure.cmd       [option qt6.dir]/bin/qmake
 
 configure.args-append \
-                    pgmodeler.pro
+                    -r CONFIG+=release ${name}.pro
 configure.pre_args-replace \
-                    PREFIX=${prefix} PREFIX=${applications_dir}/${name}.app/Contents
+                    --prefix=${prefix} PREFIX=${applications_dir}/${name}.app/Contents
+
+github.livecheck.regex \
+                    {([0-9.]+)}
+
+destroot.args-append \
+                    INSTALL_ROOT=${destroot}

--- a/databases/pgmodeler/files/patch-pgmodeler.pri.diff
+++ b/databases/pgmodeler/files/patch-pgmodeler.pri.diff
@@ -1,17 +1,17 @@
---- pgmodeler.pri.orig	2018-05-14 00:35:36.000000000 +0000
-+++ pgmodeler.pri	2018-05-19 13:42:18.000000000 +0000
-@@ -146,10 +146,10 @@
+--- ./pgmodeler.pri	2023-10-17 15:23:08
++++ ./pgmodeler.pri	2023-10-17 15:26:09
+@@ -231,10 +231,10 @@
  }
  
  macx {
--  PGSQL_LIB = /Library/PostgreSQL/10/lib/libpq.dylib
--  PGSQL_INC = /Library/PostgreSQL/10/include
--  XML_INC = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libxml2
--  XML_LIB = /usr/lib/libxml2.dylib
-+  PGSQL_LIB = @@PREFIX@@/lib/postgresql10/libpq.dylib
-+  PGSQL_INC = @@PREFIX@@/include/postgresql10
-+  XML_INC = @@PREFIX@@/include/libxml2
-+  XML_LIB = @@PREFIX@@/lib/libxml2.dylib
-   INCLUDEPATH += $$PGSQL_INC $$XML_INC
+-  !defined(PGSQL_LIB, var): PGSQL_LIB = /Library/PostgreSQL/14/lib/libpq.dylib
+-  !defined(PGSQL_INC, var): PGSQL_INC = /Library/PostgreSQL/14/include
+-  !defined(XML_INC, var): XML_INC = /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libxml2
+-  !defined(XML_LIB, var): XML_LIB = /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libxml2.tbd
++  !defined(PGSQL_LIB, var): PGSQL_LIB = @@PREFIX@@/lib/postgresql15/libpq.dylib
++  !defined(PGSQL_INC, var): PGSQL_INC = @@PREFIX@@/include/postgresql15
++  !defined(XML_INC, var): XML_INC = @@PREFIX@@/include/libxml2
++  !defined(XML_LIB, var): XML_LIB = @@PREFIX@@/lib/libxml2.dylib
+   INCLUDEPATH += "$$PGSQL_INC" "$$XML_INC"
  }
  


### PR DESCRIPTION
This seems to be building and installing fine locally, but for some reason is crashing with SIGTRAP on startup....

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
