### PR TITLE
openjdk21-corretto: update to 21.0.1.12.1

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -6,7 +6,7 @@ name             openjdk21-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://github.com/corretto/corretto-21/blob/release-21.0.0.35.1/CHANGELOG.md
+# See https://github.com/corretto/corretto-21/blob/release-21.0.1.12.1/CHANGELOG.md
 # and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 platforms        {darwin any} {darwin >= 20}
 
@@ -19,7 +19,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-21/releases
-version      21.0.0.35.1
+version      21.0.1.12.1
 revision     0
 
 description  Amazon Corretto OpenJDK 21 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  54ba1e53a9e1f81fe7df1d323fd4eeb1f6e95098 \
-                 sha256  99dfd59df4e6c9ebb9ec64348283a285c62ea2debc0e99bcdfee55c7c3ff2f0e \
-                 size    202877464
+    checksums    rmd160  191a6fcd2423674560c580a343472fcf19ee8d2a \
+                 sha256  cafff566097c6f440afe5aac6e268073d8b5ceadcf7898eeb364753d00743074 \
+                 size    202914841
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  3fce0c6ad2287e466593636a7138c05a537eef25 \
-                 sha256  b4161b887ebbf68d6400608d2fccedb599bf18fd79e3e9c9dbfc0e27e1ed4ce1 \
-                 size    200694072
+    checksums    rmd160  0f0628ac3cc80773524b600784634d3416a52844 \
+                 sha256  0c4e08fc4b7c0c887651a97f315d6995eeac38627eb7bca0cb3c698d21af349f \
+                 size    200716011
 }
 
 worksrcdir   amazon-corretto-21.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 21.0.1.12.1.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?