### PR TITLE
openjdk17-corretto: update to 17.0.9.8.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -6,7 +6,7 @@ name             openjdk17-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://github.com/corretto/corretto-17/blob/release-17.0.8.8.1/CHANGELOG.md
+# See https://github.com/corretto/corretto-17/blob/release-17.0.9.8.1/CHANGELOG.md
 # and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 platforms        {darwin any} {darwin >= 20}
 
@@ -19,7 +19,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.8.8.1
+version      17.0.9.8.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  e51445248da6b5b78a55c486c0dc14d71ce2d2a3 \
-                 sha256  edb6d0406a8c16b44b7bd81b3d23d2a3de054c06ec8d86a25872093eee501ba0 \
-                 size    188403389
+    checksums    rmd160  7022d6eac1e19f4ae0ea4d0d6c737c59b5534ef8 \
+                 sha256  7eed832eb25b6bb9fed5172a02931804ed0bf65dc86a2ddc751aa7648bb35c43 \
+                 size    188321953
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  6db542f6f8c7f3af83912e0fbe0377f0d0725c66 \
-                 sha256  08833433222ddb241a448eab92e0926d96287986f85dd5a6a065ae724e1bce43 \
-                 size    186434619
+    checksums    rmd160  3f8134fe8c3c1c28beef2dcf827ea123eeb9b150 \
+                 sha256  8a0c542e78e47cb5de1db40763692d55b977f1d0b31c5f0ebf2dd426fa33a2f4 \
+                 size    186351524
 }
 
 worksrcdir   amazon-corretto-17.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.9.8.1.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?