### PR TITLE
openjdk11-corretto: update to 11.0.21.9.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -6,7 +6,7 @@ name             openjdk11-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://github.com/corretto/corretto-11/blob/release-11.0.20.9.1/CHANGELOG.md
+# See https://github.com/corretto/corretto-11/blob/release-11.0.21.9.1/CHANGELOG.md
 # and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
 platforms        {darwin any} {darwin >= 20}
 
@@ -19,7 +19,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      11.0.20.9.1
+version      11.0.21.9.1
 revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  a83da1a31bfa0fb10266394a9206ce802fada46a \
-                 sha256  bbb6dbb917b8def5fa2c7e94a52c8b92020d6e38c5f55634296facff3168e4b4 \
-                 size    188004395
+    checksums    rmd160  3d707310a4f54d0b5ca97718e9c27abd6a07576f \
+                 sha256  2ce6100b43b102dbd631ec53c14b39b5251e319e431dc4cae2abf5059d2e04fd \
+                 size    188103525
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  6b3efea37d384ab3e26cb8f522f29a301cac8b7f \
-                 sha256  32c81583c291153662b39e199129ec77303651593f531ca3839f78f7a37121c0 \
-                 size    186292265
+    checksums    rmd160  8f0fb57a27b258995a5b5bded86bdd59bc4b6043 \
+                 sha256  c5f5a059203de3b1b3c239331082f36dcad0f261c80a1766e2dc7ab46807f6bd \
+                 size    186393704
 }
 
 worksrcdir   amazon-corretto-11.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.21.9.1.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?