### PR TITLE
openjdk8-corretto: update to 8.392.08.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -6,7 +6,7 @@ name             openjdk8-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://github.com/corretto/corretto-8/blob/release-8.382.05.1/CHANGELOG.md for minimum supported OS version
+# See https://github.com/corretto/corretto-8/blob/release-8.392.08.1/CHANGELOG.md for minimum supported OS version
 # macOS 11 → Darwin 20 (https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version)
 platforms        {darwin any} {darwin >= 20}
 
@@ -19,8 +19,8 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      8.382.05.1
-revision     1
+version      8.392.08.1
+revision     0
 
 description  Amazon Corretto OpenJDK 8 (Long Term Support)
 long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  e1e7fd02328844cb1f86c34065e24c0f4cb7b916 \
-                 sha256  12fe21fc3f3a3bdaed6a04c89f43f59baf47ac48c5846f73951d1961e4ec4d91 \
-                 size    118754745
+    checksums    rmd160  4a055f2b8cacf5acb5cc277b1ac5df25986b4ddf \
+                 sha256  2ea69e415912f7ad5358d016b1a82068e36c2a625d8573cd28c1c2a9a5b39cba \
+                 size    118773590
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  4c885687ba223c04f718a4686a238e08a7f8dd21 \
-                 sha256  d8988d8b15dc276e9664abbb108ef112a43f0627b6dfb8e2250aa97dda39ef3a \
-                 size    103754800
+    checksums    rmd160  063ccc2bd0d79220a6472ba3c30dd169584c2d2c \
+                 sha256  eb1aedaad5505605f17a81692f9882edbcb69f34494330dd5cd2a31f65bbd0e0 \
+                 size    103788913
 }
 
 worksrcdir   amazon-corretto-8.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.392.08.1.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?