### PR TITLE
openjdk11: update to 11.0.21

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk11
 # See https://github.com/openjdk/jdk11u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             11.0.20.1
-set build 1
+version             11.0.21
+set build 9
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,9 +19,9 @@ master_sites        https://git.openjdk.java.net/jdk11u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk11u-${distname}
 
-checksums           rmd160  28af98dd0a68ce252016e713cd147d5cb63d88de \
-                    sha256  fe8012c253573536990ad0f987e0ffeae75a12f1dbd7c02caed8ea899006c313 \
-                    size    116165519
+checksums           rmd160  e7dfdc7ff99070622fe746304623c503bf4a2292 \
+                    sha256  b89e87c38640c586857ae6108b3f9c3211337e4cd5d8913c8d56d66bdccab014 \
+                    size    116292058
 
 depends_lib         port:freetype
 depends_build       port:autoconf \


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.21.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?