### PR TITLE
portfile-gen: new port

### DIFF
--- a/sysutils/portfile-gen/Portfile
+++ b/sysutils/portfile-gen/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        macports macports-contrib 5447906b1c3be5b6189e61c6256dc75c291c59e5
+github.tarball_from archive
+
+name                portfile-gen
+version             0.2
+revision            0
+categories          sysutils macports
+maintainers         {gwmail.gwu.edu:egall @cooljeanius} openmaintainer
+platforms           any
+license             BSD
+supported_archs     noarch
+
+description         Generate a basic template Portfile given a few bits \
+                    of information
+long_description    {*}${description}.
+homepage            ${github.homepage}/blob/master/${name}
+
+checksums           rmd160  d008955be3cf87379edf6ed1d757dc344c8248df \
+                    sha256  8351094444336e69f965bb1f8e79418581d5059c2047f0aa5a8e93b7be1d36b7 \
+                    size    243251
+
+dist_subdir         macports-contrib
+
+use_configure       no
+
+build {
+    # Please leave this; it's good to inform users when overriding steps:
+    ui_debug "${name} has no build step"
+}
+
+destroot {
+    xinstall ${worksrcpath}/${name}/${name} ${destroot}${prefix}/bin/
+}
+


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/37797

#### Description

This is basically just the same Portfile that I submitted in Trac 37797, with the `# $Id$` line removed, and `revision` reset to `0`.

###### Type(s)
submission

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
