### PR TITLE
openjdk20-corretto: obsolete, replaced by openjdk21-corretto

### DIFF
--- a/java/openjdk20-corretto/Portfile
+++ b/java/openjdk20-corretto/Portfile
@@ -1,98 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2024-04-18
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk20-corretto
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-
-# See https://github.com/corretto/corretto-20/blob/release-20.0.2.10.1/CHANGELOG.md
-# and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms        {darwin any} {darwin >= 20}
-
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://github.com/corretto/corretto-20/releases
-version      20.0.2.10.1
-revision     0
-
-description  Amazon Corretto OpenJDK 20 (Short Term Support)
-long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
-
-master_sites https://corretto.aws/downloads/resources/${version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  3e1269f2439de09d1ecba8b3d40811f031151941 \
-                 sha256  d394f4364488501bf63444e9e31c55d7b4890409cf00e3d6b0fe0fcfb0ea9a4e \
-                 size    197821869
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  588e4935de0981382fb5c9a196833c7094b69128 \
-                 sha256  30e6d956f3d674e09e7d211e47d2880a17e70ad62460aaa0b6628ed091611c3c \
-                 size    195686408
-}
-
-worksrcdir   amazon-corretto-20.jdk
-
-homepage     https://aws.amazon.com/corretto/
-
-livecheck.type      regex
-livecheck.url       https://github.com/corretto/corretto-20/releases
-livecheck.regex     amazon-corretto-(20\.\[0-9\.\]+)-macosx-.*\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-20-amazon-corretto.jdk
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}${jdk}
-    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
-    xinstall -m 755 -d ${destroot}${jvms}
-    ln -s ${prefix}${jdk} ${destroot}${jdk}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${jdk}/Contents/Home
-"
+name        openjdk20-corretto
+categories  java devel
+version     20.0.2.10.1
+revision    1
+replaced_by openjdk21-corretto


### PR DESCRIPTION
#### Description

Support for Amazon Corretto 20 ended, replace with `openjdk21-corretto`.