### PR TITLE
openjdk20-graalvm: obsolete, replaced by openjdk21-graalvm

### DIFF
--- a/java/openjdk20-graalvm/Portfile
+++ b/java/openjdk20-graalvm/Portfile
@@ -1,92 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2024-04-18
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk20-graalvm
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-# https://github.com/graalvm/graalvm-ce-builds/releases
-supported_archs  x86_64 arm64
-
+name        openjdk20-graalvm
+categories  java devel
 version     20.0.2
-revision    1
-
-description  GraalVM Community Edition based on OpenJDK 20
-long_description GraalVM is a universal virtual machine for running applications written in JavaScript, Python, Ruby, R,\
-                 JVM-based languages like Java, Scala, Groovy, Kotlin, Clojure, and LLVM-based languages such as C and C++.
-
-master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     graalvm-community-jdk-${version}_macos-x64_bin
-    checksums    rmd160  6684d7bf1a0f724d0042f38e55e15c92e43dd7bd \
-                 sha256  5e57fffa27282f27976a07d27611256ea4219f02756612fe500a5ff80ed5fc2a \
-                 size    294990467
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     graalvm-community-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  4adc0d1ad0af8318fb18f9578fbfd231f642c800 \
-                 sha256  96e2227c4319ecb5eed755f8abb1411a56f51dd8f30e9770127bcd1cce2cd644 \
-                 size    290805758
-}
-
-worksrcdir   graalvm-community-openjdk-${version}+9.1
-
-homepage     https://www.graalvm.org
-
-livecheck.type  none
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-20-oracle-graalvm-community.jdk
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}${jdk}
-    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
-    xinstall -m 755 -d ${destroot}${jvms}
-    ln -s ${prefix}${jdk} ${destroot}${jdk}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${jdk}/Contents/Home
-"
+revision    2
+replaced_by openjdk21-graalvm


### PR DESCRIPTION
#### Description

Support for GraalVM Community Edition 20 ended, replace with `openjdk21-graalvm`.