### PR TITLE
openjdk20-oracle: obsolete, replaced by openjdk21-oracle

### DIFF
--- a/java/openjdk20-oracle/Portfile
+++ b/java/openjdk20-oracle/Portfile
@@ -1,93 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2024-04-18
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk20-oracle
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://jdk.java.net/20/
-version      20.0.2
-revision     1
-
-description  Oracle OpenJDK 20
-long_description Open-source Oracle build of OpenJDK 20, the Java Development Kit, an implementation of the Java SE Platform.
-
-master_sites https://download.java.net/java/GA/jdk${version}/6e380f22cbe7469fa75fb448bd903d8e/9/GPL/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  7a4d111f12cb49c6374a488305f05f6c51ebff19 \
-                 sha256  c65ba92b73d8076e2a10029a0674d40ce45c3e0183a8063dd51281e92c9f43fc \
-                 size    194664908
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  b7d50885fc35a311ec851e97a87bd3945bdc009e \
-                 sha256  2e6522bb574f76cd3f81156acd59115a014bf452bbe4107f0d31ff9b41b3da57 \
-                 size    192225913
-}
-
-worksrcdir   jdk-${version}.jdk
-
-homepage     https://jdk.java.net/20/
-
-livecheck.type      regex
-livecheck.url       https://jdk.java.net/20/
-livecheck.regex     OpenJDK JDK (20\.\[0-9\.\]+)
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-20-oracle-openjdk.jdk
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}${jdk}
-    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
-    xinstall -m 755 -d ${destroot}${jvms}
-    ln -s ${prefix}${jdk} ${destroot}${jdk}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${jdk}/Contents/Home
-"
+name        openjdk20-oracle
+categories  java devel
+version     20.0.2
+revision    2
+replaced_by openjdk21-oracle


### PR DESCRIPTION
#### Description

Support for Oracle OpenJDK 20 ended, replace with `openjdk21-oracle`.