### PR TITLE
openjdk20-sap: obsolete, replaced by openjdk21-sap

### DIFF
--- a/java/openjdk20-sap/Portfile
+++ b/java/openjdk20-sap/Portfile
@@ -1,93 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2024-04-18
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             openjdk20-sap
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://sap.github.io/SapMachine/latest/20
-version      20.0.2
-revision     1
-
-description  SAP Machine 20
-long_description An OpenJDK 20 release maintained and supported by SAP
-
-master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  38f2ac23deaa728a7cfbbdca9dbfc071d4d98221 \
-                 sha256  3565914dffecafbccb31c7768b8efd804ee47144cff8a593685d06f6945ece94 \
-                 size    189349299
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  ce87c75024c6d0ac396374b9e2263825775b6f19 \
-                 sha256  5cedd9a935ed094df5f6ccecbb937f1c65b0db11ede2ca3e1a41de92084c42c6 \
-                 size    187089134
-}
-
-worksrcdir   sapmachine-jdk-${version}.jdk
-
-homepage     https://sap.github.io/SapMachine/
-
-livecheck.type      regex
-livecheck.url       https://github.com/SAP/SapMachine/releases
-livecheck.regex     sapmachine-jdk-(20\.\[0-9\.\]+)_macos-.*_bin\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-20-sapmachine.jdk
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}${jdk}
-    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
-    xinstall -m 755 -d ${destroot}${jvms}
-    ln -s ${prefix}${jdk} ${destroot}${jdk}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${jdk}/Contents/Home
-"
+name        openjdk20-sap
+categories  java devel
+version     20.0.2
+revision    2
+replaced_by openjdk21-sap


### PR DESCRIPTION
#### Description

Support for SapMachine 20 ended, replace with `openjdk21-sap`.