### PR TITLE
openjdk20-zulu: obsolete, replaced by openjdk21-zulu

### DIFF
--- a/java/openjdk20-zulu/Portfile
+++ b/java/openjdk20-zulu/Portfile
@@ -1,98 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+ # Remove after 2024-04-18
+ PortSystem  1.0
+ PortGroup   obsolete 1.0
 
-name             openjdk20-zulu
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://www.azul.com/downloads/?version=java-20-sts&os=macos&package=jdk
-version      20.32.11
-revision     1
-
-set openjdk_version 20.0.2
-
-description  Azul Zulu Community OpenJDK 20 (Short Term Support)
-long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
-                 specification that contains all the Java components needed to build and run Java SE applications. Zulu has been\
-                 verified by passing all tests of the OpenJDK Community Technology Compatibility Kit (TCK) as available for each\
-                 respective Java SE version.
-
-master_sites https://cdn.azul.com/zulu/bin/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  232cec730f1bfb0d53fc23a3cb866792e46f5f1c \
-                 sha256  12ff4a1ba0efb819ec66b3a0b8bb0ed4a433b9d1c205c24dc0a878e489e99dfa \
-                 size    205278797
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  c9978c8d529386e4420402ae6e5511d0fdc673c9 \
-                 sha256  d79b8d67ab8c7d2012577414daada803f8c19363c21ce7d28e7d4663bffba886 \
-                 size    202801603
-}
-
-worksrcdir   ${distname}/zulu-20.jdk
-
-homepage     https://www.azul.com/downloads/
-
-livecheck.type      regex
-livecheck.url       https://cdn.azul.com/zulu/bin/
-livecheck.regex     zulu(20\.\[0-9\.\]+)-ca-jdk\[0-9\.\]+-macosx_.*\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-20-azul-zulu.jdk
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}${jdk}
-    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
-    xinstall -m 755 -d ${destroot}${jvms}
-    ln -s ${prefix}${jdk} ${destroot}${jdk}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${jdk}/Contents/Home
-"
+ name        openjdk20-zulu
+ categories  java devel
+ version     20.32.11
+ revision    2
+ replaced_by openjdk21-zulu


### PR DESCRIPTION
#### Description

Support for Azul Zulu 20 ended, replace with `openjdk21-zulu`.