### PR TITLE
kvazaar: fix build on < 10.7, support testing

### DIFF
--- a/multimedia/kvazaar/Portfile
+++ b/multimedia/kvazaar/Portfile
@@ -19,3 +19,14 @@ depends_build       port:yasm
 checksums           rmd160  36e351494fba5f81226e66820aafe948e2dc4b32 \
                     sha256  a3c35dc24f587145afacf537bdc43176b763be48cc05e1f597cce2c4e515689a \
                     size    1007269
+
+# https://github.com/ultravideo/kvazaar/commit/fac849e7158589380941ad90e90b8c5495a86e12
+patchfiles          0001-threads.h-fix-for-older-macOS-builds.patch
+
+# With gcc-4.2 already configure fails.
+compiler.blacklist-append \
+                    *gcc-4.*
+
+# All main tests pass; valgrind-based scripts may fail: https://github.com/ultravideo/kvazaar/issues/374
+test.run            yes
+test.target         check

--- a/multimedia/kvazaar/files/0001-threads.h-fix-for-older-macOS-builds.patch
+++ b/multimedia/kvazaar/files/0001-threads.h-fix-for-older-macOS-builds.patch
@@ -1,0 +1,46 @@
+From fac849e7158589380941ad90e90b8c5495a86e12 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 18 Oct 2023 17:31:59 +0800
+Subject: [PATCH] threads.h: fix for older macOS builds
+
+---
+ src/threads.h | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git src/threads.h src/threads.h
+index fa4e0b4d..75c21497 100644
+--- src/threads.h
++++ src/threads.h
+@@ -42,6 +42,10 @@
+ 
+ #include <pthread.h>
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ #if defined(__GNUC__) && !defined(__MINGW32__) 
+ #include <unistd.h> // IWYU pragma: export
+ #include <time.h> // IWYU pragma: export
+@@ -84,9 +88,9 @@
+ 
+ #endif //__GNUC__
+ 
+-#ifdef __APPLE__
+-// POSIX semaphores are deprecated on Mac so we use Grand Central Dispatch
+-// semaphores instead.
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
++// POSIX semaphores are deprecated on Mac so we use Grand Central Dispatch semaphores instead.
++// However GCD is supported only on 10.6+, and is not supported on any ppc, including 10.6 Rosetta.
+ #include <dispatch/dispatch.h>
+ typedef dispatch_semaphore_t kvz_sem_t;
+ 
+@@ -113,7 +117,7 @@ static INLINE void kvz_sem_destroy(kvz_sem_t *sem)
+ }
+ 
+ #else
+-// Use POSIX semaphores.
++// Use POSIX semaphores. This is also a fallback for old Darwin.
+ #include <semaphore.h>
+ 
+ typedef sem_t kvz_sem_t;


### PR DESCRIPTION
#### Description

Fix for old macOS versions, merged to upstream. We also need to blacklist archaic Xcode gcc, it fails already at configure.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
