### PR TITLE
py-oci: submission

### DIFF
--- a/python/py-oci/Portfile
+++ b/python/py-oci/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-oci
+version             2.113.0
+revision            0
+
+categories-append   net
+
+license             {Permissive Apache-2}
+platforms           {darwin any}
+supported_archs     noarch
+maintainers         nomaintainer
+
+description         Oracle Cloud Infrastructure Python SDK
+long_description    {*}${description}
+
+homepage            https://docs.oracle.com/en-us/iaas/tools/python/latest/index.html
+
+checksums           rmd160  535d9c52c75e811973421484c604dc25db15e153 \
+                    sha256  dc5b5e6410d729fde41d67912fbf9177af4efe354c10d558076af27643e349d5 \
+                    size    11396545
+
+python.versions     38 39
+
+if {${subport} ne ${name}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools
+
+    depends_run-append \
+                    port:py${python.version}-tz \
+                    port:py${python.version}-certifi \
+                    port:py${python.version}-openssl \
+                    port:py${python.version}-dateutil \
+                    port:py${python.version}-cryptography \
+                    port:py${python.version}-circuitbreaker
+}


### PR DESCRIPTION
#### Description

This PR adds the py-oci Portfile for the Oracle Cloud Infrastructure Python SDK available at https://github.com/oracle/oci-python-sdk.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
