### PR TITLE
borgmatic: Add missing py-packaging dependency

### DIFF
--- a/sysutils/borgmatic/Portfile
+++ b/sysutils/borgmatic/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                borgmatic
 version             1.8.3
-revision            0
+revision            1
 
 checksums           rmd160  df6cf84a347c151e861f320edbdd45f6db972603 \
                     sha256  980851fa10b0ca3f9879ddb6e2fc4c12839cff583e97a8d5c9cc5f2c908b25ff \
@@ -34,6 +34,7 @@ depends_run-append  \
                     port:borgbackup \
                     port:py${python.version}-colorama \
                     port:py${python.version}-jsonschema \
+                    port:py${python.version}-packaging \
                     port:py${python.version}-requests \
                     port:py${python.version}-ruamel-yaml \
                     port:py${python.version}-ruamel-yaml-clib


### PR DESCRIPTION
#### Description

```
:) cllang@cllang-mac:[…]/sysutils/borgmatic$ borgmatic --help
Traceback (most recent call last):
[…]
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/borgmatic/borg/feature.py", line 3, in <module>
    from packaging.version import parse
ModuleNotFoundError: No module named 'packaging'
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
