### PR TITLE
openjdk21-zulu: update to 21.30.15

### DIFF
--- a/java/openjdk21-zulu/Portfile
+++ b/java/openjdk21-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-21-lts&os=macos&package=jdk#zulu
-version      21.28.85
+version      21.30.15
 revision     0
 
-set openjdk_version 21.0.0
+set openjdk_version 21.0.1
 
 description  Azul Zulu Community OpenJDK 21 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  ef73795ac36878fbfd1799ebcf4539a7a6419415 \
-                 sha256  9639b87db586d0c89f7a9892ae47f421e442c64b97baebdff31788fbe23265bd \
-                 size    208325813
+    checksums    rmd160  9265ab20f0b1dd6584daac510d84faca2a521ece \
+                 sha256  667e3945ffd394317b5faf1f5bd4847d1f1d091f76543df27d9b3a2ee7bf7a7e \
+                 size    208363599
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  5c942a85ee416b8e175f00e8ab7d18ca9eda8412 \
-                 sha256  2a7a99a3ea263dbd8d32a67d1e6e363ba8b25c645c826f5e167a02bbafaff1fa \
-                 size    205964689
+    checksums    rmd160  211facdfdf2c5f495905ac358d3c733e1bbff18b \
+                 sha256  6e89b6ed60c0efcc1b5bb7c6b36710ce746751b316a16cc3f9915470c4eb2a00 \
+                 size    206002057
 }
 
 worksrcdir   ${distname}/zulu-21.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 21.30.15 (OpenJDK 21.0.1).

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?