### PR TITLE
pdns-recursor: Update to 4.9.1

### DIFF
--- a/net/pdns-recursor/Portfile
+++ b/net/pdns-recursor/Portfile
@@ -2,12 +2,12 @@
 
 PortSystem          1.0
 PortGroup           boost 1.0
+PortGroup           openssl 1.0
 
 name                pdns-recursor
-version             4.7.0
+version             4.9.1
 revision            0
 categories          net
-platforms           darwin
 maintainers         {l2dy @l2dy} openmaintainer
 license             {GPL-2 OpenSSLException}
 
@@ -24,13 +24,11 @@ homepage            https://www.powerdns.com/recursor.html
 master_sites        https://downloads.powerdns.com/releases/
 use_bzip2           yes
 
-checksums           rmd160  a59846abb90072f507ca55612b4ea6eadee397c5 \
-                    sha256  e4872a1b11a35fc363f354d69ccb4ec88047bfc7d9308087497dc2ad3af3498c \
-                    size    1596954
+checksums           rmd160  fb9fa2bca8133178ae7c403c6b30b02d0abeabad \
+                    sha256  0a1edc13e8f2bd661f39e316387d941e22de6a03b8a7a2fc662fdf8b942ea2be \
+                    size    1566613
 
 depends_build       port:pkgconfig
-
-depends_lib         path:lib/libssl.dylib:openssl
 
 boost.version       1.76
 


### PR DESCRIPTION
#### Description

Update pdns-recursor to 4.9.1 to fix building, modernizing the Portfile by using the openssl PortGroup as well.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
