### PR TITLE
ifuse: Add support for legacy systems

### DIFF
--- a/fuse/ifuse/Portfile
+++ b/fuse/ifuse/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 
 github.setup            libimobiledevice ifuse 1.1.4
 github.tarball_from     releases
-revision                0
+revision                1
 categories              fuse devel
 license                 LGPL-2.1
 maintainers             {@therealketo gmail.com:therealketo} openmaintainer
@@ -29,5 +29,10 @@ depends_lib-append      port:libplist \
                         port:glib2 \
                         port:libimobiledevice \
                         port:macfuse
+
+# Add support for legacy systems using osxfuse instead
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    depends_lib-replace port:macfuse port:osxfuse
+}
 
 configure.args          --disable-silent-rules


### PR DESCRIPTION
#### Description

Add support for legacy systems using osxfuse, since macfuse does not work on anything pre-macOS 10.12.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 10.7.5 11G63 x86_64
Xcode 4.3.3 4E3002

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
