### PR TITLE
c3270: Update port to 4.3ga4

### DIFF
--- a/comms/c3270/Portfile
+++ b/comms/c3270/Portfile
@@ -1,13 +1,12 @@
 PortSystem          1.0
 
 name                c3270
-version             3.3.15ga9
-revision            3
-set branch          [join [lrange [split ${version} .] 0 1] .]
+version             4.3ga4
+revision            0
+set branch          4.3
 categories          comms
-platforms           darwin
 license             BSD
-maintainers         nomaintainer
+maintainers         {icloud.com:willian.nieckarz @sinskinner} openmaintainer
 
 description         A console-based IBM3270 terminal emulator.
 long_description    A console-based emulator for the IBM3270 terminal. \
@@ -26,18 +25,20 @@ depends_lib         path:lib/libssl.dylib:openssl  \
                     port:libiconv
 
 distfiles           suite3270-${version}-src.tgz
-dist_subdir         x3270
-checksums           md5     e8106ab4240d996bd2cea53df14634ae \
-                    sha1    e911b66fc73048b8d99bbc1c27a88b27d6fdd1b6 \
-                    rmd160  64dafc97841c773b5236c2aeebca62882203d089 \
-                    sha256  e22f40360170acf70b6de521173c633072582315b4879aef276fb8c97102e848
+dist_subdir         c3270
+checksums           rmd160  23a1e80cd56ea914dc682a23dec598bcbf61a395 \
+                    sha256  3b7bf11de9a05a5f203cb845bd8e7fb805c2a06ca606ccf8cdee4ff5c80caa4b \
+                    size    13163509
 
-worksrcdir          ${name}-${branch}
-configure.args      --disable-apl \
-                    --disable-dbcs \
-                    --disable-script \
-                    --enable-history \
-                    --bindir=${prefix}/bin \
-                    --mandir=${prefix}/share/man
+worksrcdir          suite3270-${branch}
+configure.args      --bindir=${prefix}/bin \
+                    --mandir=${prefix}/share/man \
+                    --enable-c3270 \
+                    --disable-windows
 
 universal_variant   no
+
+variant stransport description {Build with Secure Transport instead of OpenSSL for TLS support (not recommended)} {
+    configure.args-append    --enable-stransport
+    depends_lib-delete       path:lib/libssl.dylib:openssl
+}


### PR DESCRIPTION
#### Description

- Updates the port from 3.3.15ga9 to 4.3ga4
- Changes the dist_subir to c3270
- Removes deprecated configuration args.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.5.2 22G91 arm64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`? *
- [x] tested basic functionality of all binary files?

* For some reason, using -vst fails to build with the following log, but with -vs works fine:
`Command failed:  cd "/opt/local/var/macports/build/_private_var_tmp_macports-ports_comms_c3270/c3270/work" && /usr/bin/gzip -dc '/opt/local/var/macports/distfiles/c3270/suite3270-4.3ga4-src.tgz' | /usr/bin/tar -xf -`
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
