### PR TITLE
port-whatsnew: new port

### DIFF
--- a/sysutils/port-whatsnew/Portfile
+++ b/sysutils/port-whatsnew/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        macports macports-contrib 29259cdad5f470bb1ebbcf3627f498aa7b2dfb2b
+github.tarball_from archive
+
+name                port-whatsnew
+version             0.1
+revision            0
+categories          sysutils macports
+maintainers         {gwmail.gwu.edu:egall @cooljeanius} openmaintainer
+platforms           any
+license             BSD
+supported_archs     noarch
+
+description         Show the log from the MacPorts version control system of \
+                    what changed since this port was installed. This script was \
+                    originally written when the MacPorts VCS was still svn, but \
+                    the intention is to migrate it to use git, just like the \
+                    MacPorts VCS has done.
+long_description    ${description}
+homepage            https://github.com/${github.author}/${github.project}/blob/master/${name}
+
+livecheck.type      none
+
+fetch.type          git
+
+worksrcdir          ${name}
+
+use_configure       no
+
+build {
+    ui_debug "${name} has no build step."
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name}/${name} ${destroot}${prefix}/bin/${name}
+}
+

--- a/sysutils/port-whatsnew/Portfile
+++ b/sysutils/port-whatsnew/Portfile
@@ -21,8 +21,6 @@ homepage            ${github.homepage}/blob/master/${name}
 
 fetch.type          git
 
-worksrcdir          ${name}
-
 use_configure       no
 
 build {

--- a/sysutils/port-whatsnew/Portfile
+++ b/sysutils/port-whatsnew/Portfile
@@ -15,12 +15,8 @@ platforms           any
 license             BSD
 supported_archs     noarch
 
-description         Show the log from the MacPorts version control system of \
-                    what changed since this port was installed. This script was \
-                    originally written when the MacPorts VCS was still svn, but \
-                    the intention is to migrate it to use git, just like the \
-                    MacPorts VCS has done.
-long_description    ${description}
+description         shows a log of what changed since this port was installed
+long_description    ${name} {*}${description}.
 homepage            ${github.homepage}/blob/master/${name}
 
 livecheck.type      none

--- a/sysutils/port-whatsnew/Portfile
+++ b/sysutils/port-whatsnew/Portfile
@@ -19,7 +19,11 @@ description         shows a log of what changed since this port was installed
 long_description    ${name} {*}${description}.
 homepage            ${github.homepage}/blob/master/${name}
 
-fetch.type          git
+checksums           rmd160  999a9ebc5326f579fa6a1d5027cef810cc542335 \
+                    sha256  6a0c03aa0013b71fba090bca6adb22fd3134b301f4a16edb73a6339dcb0ad8d0 \
+                    size    239776
+
+dist_subdir         macports-contrib
 
 use_configure       no
 

--- a/sysutils/port-whatsnew/Portfile
+++ b/sysutils/port-whatsnew/Portfile
@@ -28,6 +28,6 @@ build {
 }
 
 destroot {
-    xinstall -m 755 ${worksrcpath}/${name}/${name} ${destroot}${prefix}/bin/${name}
+    xinstall ${worksrcpath}/${name}/${name} ${destroot}${prefix}/bin/
 }
 

--- a/sysutils/port-whatsnew/Portfile
+++ b/sysutils/port-whatsnew/Portfile
@@ -19,8 +19,6 @@ description         shows a log of what changed since this port was installed
 long_description    ${name} {*}${description}.
 homepage            ${github.homepage}/blob/master/${name}
 
-livecheck.type      none
-
 fetch.type          git
 
 worksrcdir          ${name}

--- a/sysutils/port-whatsnew/Portfile
+++ b/sysutils/port-whatsnew/Portfile
@@ -21,7 +21,7 @@ description         Show the log from the MacPorts version control system of \
                     the intention is to migrate it to use git, just like the \
                     MacPorts VCS has done.
 long_description    ${description}
-homepage            https://github.com/${github.author}/${github.project}/blob/master/${name}
+homepage            ${github.homepage}/blob/master/${name}
 
 livecheck.type      none
 

--- a/sysutils/port-whatsnew/Portfile
+++ b/sysutils/port-whatsnew/Portfile
@@ -28,7 +28,6 @@ dist_subdir         macports-contrib
 use_configure       no
 
 build {
-    ui_debug "${name} has no build step."
 }
 
 destroot {


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/38110

#### Description

As with PR #20951, this is basically just the same Portfile that I submitted in the original Trac ticket (38110 in this case), albeit with the `# $Id$` line removed, and revision reset to `0`. The actual script that the port installs probably needs to be updated to reflect the migration from `svn` to `git`, but that's an issue for `macports-contrib`, not `macports-ports`, and it can be reflected with an update to the port once the script is updated.

###### Type(s)
submission

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
