### PR TITLE
gaa: new port

### DIFF
--- a/devel/gaa/Portfile
+++ b/devel/gaa/Portfile
@@ -1,0 +1,63 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem               1.0
+PortGroup                github 1.0
+
+github.setup             cooljeanius gaa 1.6.6_1 v
+revision                 0
+categories               devel
+maintainers              {gwmail.gwu.edu:egall @cooljeanius} openmaintainer
+description              ${name} Argument Analyser
+license                  GPL-2+
+long_description         ${name} simplifies the life of the programmer: \
+                         you do NOT have to worry about the arguments \
+                         given to it! A short text written in GAA \
+                         language generates C-code which analyses \
+                         the arguments and creates your program's help.
+
+homepage                 http://${name}.sf.net
+
+fetch.type               git
+
+depends_build-append     port:bison \
+                         port:flex \
+                         port:gmake \
+                         bin:makeinfo:texinfo
+
+depends_lib-append       port:yydecode
+depends_lib-delete       port:gobject-introspection
+
+configure.ccache         no
+
+configure.args-append    --with-bison-bin=${prefix}/bin/bison
+
+build.type               gnu
+build.cmd                ${prefix}/bin/gmake
+
+variant autoreconf description {Regenerates configure script before \
+                                building. Also pulls in extra \
+                                dependencies.} {
+    depends_build-append port:gawk \
+                         port:grep \
+                         port:autoconf-archive
+    use_autoreconf       yes
+    autoreconf.args      -fvi -Wall
+    configure.args-append --disable-silent-rules
+}
+
+variant docs description {Generate additional documentation by \
+                          using latex2html} {
+    depends_build-append port:latex2html \
+                         port:texlive-latex
+    depends_lib-delete   port:poppler
+    use_parallel_build   no
+    post-build {
+        system -W ${worksrcpath}/doc "${prefix}/bin/latex2html *.tex"
+    }
+    post-destroot {
+        foreach docdir {gaa ref tut} {
+            xinstall -d ${destroot}${prefix}/share/doc/${name}/${docdir}
+            xinstall -m 644 {*}[glob ${worksrcpath}/doc/${docdir}/*] ${destroot}${prefix}/share/doc/${name}/${docdir}
+        }
+    }
+}


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/38159

#### Description

This is pretty much the same Portfile as the one I submitted in Trac 38159, except with the following differences:
- `# $Id$` line removed
- tabs converted to spaces
- `git://` protocol converted to `https://`
- `eval xinstall` converted to using modern globbing syntax

###### Type(s)
submission

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
