### PR TITLE
gdal: portfile clean-up

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           active_variants 1.1
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
-PortGroup           github 1.0
 PortGroup           legacysupport 1.0
 PortGroup           muniversal 1.0
 
-github.setup        OSGeo gdal 3.7.2 v
+name                gdal
+version             3.7.2
 revision            1
 
 checksums           rmd160  7b7ef05f3322065516335516932b5668c845c62f \
@@ -502,7 +502,7 @@ variant poppler description {Enable Poppler support} {
 }
 
 # PostgreSQL variants
-set pg_suffixes {95 96 10 11 12 13 14 15}
+set pg_suffixes {12 13 14 15}
 set pg_variants {}
 set pg_default_variant "if {"
 foreach v ${pg_suffixes} {

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -4,12 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           muniversal 1.0
 PortGroup           cmake   1.1
-PortGroup           mpi 1.0
 PortGroup           active_variants   1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.0
-
-mpi.setup
 
 github.setup        OSGeo gdal 3.7.2 v
 revision            1
@@ -385,45 +382,24 @@ variant hdf4 description {Enable HDF4 file format} {
 }
 
 variant hdf5 description {Enable HDF5 file format} {
-
-    if {![catch {set result [active_variants hdf5 openmpi]}]} {
-        if {$result} {
-            if {![variant_isset openmpi]} {
-                return -code error "HDF5 has openmpi enabled, please use the same variant."
+    pre-configure {
+        # If HDF5 is built with a mpi variant, we need to know the path to "mpi.h".
+        # Figure out HDF5's mpi include directory:
+        set mpl_include_dir ""
+        if {![catch {set result [active_variants hdf5 openmpi]}]} {
+            if {$result} {
+                set mpl_include_dir "-I${prefix}/include/openmpi-mp"
             }
         }
-    }
-
-    if {![catch {set result [active_variants hdf5 openmpi-devel]}]} {
-        if {$result} {
-            if {![variant_isset openmpi-devel]} {
-                return -code error "HDF5 has openmpi_devel enabled, please use the same variant."
+        if {![catch {set result [active_variants hdf5 mpich]}]} {
+            if {$result} {
+                set mpl_include_dir "-I${prefix}/include/mpich-mp"
             }
         }
-    }
-
-    if {![catch {set result [active_variants hdf5 mpi]}]} {
-        if {$result} {
-            if {![variant_isset mpi]} {
-                return -code error "HDF5 has mpi enabled, please use the same variant."
-            }
+        if {$mpl_include_dir ne ""} {
+            configure.cxxflags-append ${mpl_include_dir}
         }
     }
-
-    if {![catch {set result [active_variants hdf5 mpich-devel]}]} {
-        if {$result} {
-            if {![variant_isset mpich-devel]} {
-                return -code error "HDF5 has mpich-devel enabled, please use the same variant."
-            }
-        }
-    }
-
-    if {[variant_isset mpich] || [variant_isset mpich-devel] || \
-        [variant_isset openmpi] || [variant_isset openmpi_devel]} {
-
-        mpi.enforce_variant     hdf5
-    }
-
     depends_lib-append      port:hdf5
     configure.args-replace  -DGDAL_USE_HDF5=OFF    -DGDAL_USE_HDF5=ON
     configure.args-append   -DGDAL_ENABLE_DRIVER_HDF5=ON
@@ -436,12 +412,24 @@ variant heif description {Enable HEIF support} {
 }
 
 variant netcdf description {Enable NetCDF file format} {
-    if {[variant_isset mpich] || [variant_isset mpich-devel] || \
-        [variant_isset openmpi] || [variant_isset openmpi_devel]} {
-
-        mpi.enforce_variant     netcdf
+    pre-configure {
+        # If NetCDF is built with a mpi variant, we need to know the path to "mpi.h".
+        # Figure out NetCDF's mpi include directory:
+        set mpl_include_dir ""
+        if {![catch {set result [active_variants netcdf openmpi]}]} {
+            if {$result} {
+                set mpl_include_dir "-I${prefix}/include/openmpi-mp"
+            }
+        }
+        if {![catch {set result [active_variants netcdf mpich]}]} {
+            if {$result} {
+                set mpl_include_dir "-I${prefix}/include/mpich-mp"
+            }
+        }
+        if {$mpl_include_dir ne ""} {
+            configure.cxxflags-append ${mpl_include_dir}
+        }
     }
-
     depends_lib-append      port:netcdf
     configure.args-replace  -DGDAL_USE_NETCDF=OFF    -DGDAL_USE_NETCDF=ON
     configure.args-append   -DGDAL_ENABLE_DRIVER_NETCDF=ON

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -1,37 +1,35 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           muniversal 1.0
-PortGroup           cmake   1.1
-PortGroup           active_variants   1.1
+PortGroup           active_variants 1.1
+PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           github 1.0
 PortGroup           legacysupport 1.0
+PortGroup           muniversal 1.0
 
 github.setup        OSGeo gdal 3.7.2 v
 revision            1
+
 checksums           rmd160  7b7ef05f3322065516335516932b5668c845c62f \
                     sha256  40c0068591d2c711c699bbb734319398485ab169116ac28005d8302f80b923ad \
                     size    8619608
 
 categories          gis
 license             MIT BSD
-platforms           darwin
-
 maintainers         {vince @Veence} {yahoo.com:n_larsson @nilason} openmaintainer
 
 description         GDAL - Geospatial Data Abstraction Library
-
-long_description    GDAL is a translator library for raster geospatial \
-                    data formats that is released under an X/MIT style \
-                    Open Source license. As a library, it presents \
-                    a single abstract data model to the calling application \
-                    for all supported formats. The related OGR library \
-                    (which lives within the GDAL source tree) provides \
-                    a similar capability for simple features vector data.
+long_description    GDAL is a translator library for raster and vector         \
+                    geospatial data formats that is released under an MIT      \
+                    style Open Source License by the Open Source Geospatial    \
+                    Foundation. As a library, it presents a single raster      \
+                    abstract data model and single vector abstract data model  \
+                    to the calling application for all supported formats. It   \
+                    also comes with a variety of useful command line utilities \
+                    for data translation and processing
 
 homepage            https://www.gdal.org/
-
 master_sites        https://download.osgeo.org/gdal/${version}
 use_xz              yes
 
@@ -44,30 +42,33 @@ cmake.set_cxx_standard yes
 # See https://trac.macports.org/ticket/56908
 compiler.thread_local_storage yes
 
+configure.optflags  -DGDAL_COMPILATION
+
 depends_build-append \
                     port:bash-completion \
                     port:pkgconfig
 
-depends_lib-append  port:zlib \
-                    port:libdeflate \
-                    port:zstd \
-                    port:libpng \
+depends_lib-append \
+                    port:blosc \
                     port:brunsli \
-                    port:lerc \
+                    port:charls \
+                    port:curl \
                     port:expat \
+                    port:giflib \
+                    path:include/turbojpeg.h:libjpeg-turbo \
+                    port:lerc \
+                    port:libdeflate \
+                    port:libpng \
                     port:libxml2 \
                     port:lz4 \
-                    port:blosc \
-                    port:webp \
-                    port:giflib \
-                    port:qhull \
-                    port:pcre2 \
-                    port:sqlite3 \
-                    port:spatialite \
-                    port:curl \
                     path:lib/libssl.dylib:openssl \
-                    path:include/turbojpeg.h:libjpeg-turbo \
-                    port:charls
+                    port:pcre2 \
+                    port:qhull \
+                    port:spatialite \
+                    port:sqlite3 \
+                    port:webp \
+                    port:zlib \
+                    port:zstd
 
 # By default, disable all drivers
 configure.args-append                                        \
@@ -297,22 +298,19 @@ pre-configure {
 # Set target to none
 build.target
 
-variant opencl description {Enable OpenCL} {
-     configure.args-replace  -DGDAL_USE_OPENCL=OFF    -DGDAL_USE_OPENCL=ON
+variant arrow description {Enable (Geo)Arrow IPC File Format / Stream and (Geo)Parquet support} {
+    depends_lib-append      port:apache-arrow
+    configure.args-replace  -DGDAL_USE_ARROW=OFF            -DGDAL_USE_ARROW=ON \
+                            -DGDAL_USE_PARQUET=OFF          -DGDAL_USE_PARQUET=ON \
+                            -DOGR_ENABLE_DRIVER_ARROW=OFF   -DOGR_ENABLE_DRIVER_ARROW=ON \
+                            -DOGR_ENABLE_DRIVER_PARQUET=OFF -DOGR_ENABLE_DRIVER_PARQUET=ON
+    configure.args-append   -DARROW_USE_STATIC_LIBRARIES=OFF
 }
 
-variant lto description {Enable Link Time Optimization} {
-    configure.args-append   -DENABLE_IPO=ON
-}
-
-variant libarchive description {Enable libarchive support} {
-    depends_lib-append      port:libarchive
-    configure.args-replace  -DGDAL_USE_ARCHIVE=OFF    -DGDAL_USE_ARCHIVE=ON
-}
-
-variant lzma description {Enable LZMA (7Z) compression support} {
-    depends_lib-append      port:lzma
-    configure.args-replace  -DGDAL_USE_LIBLZMA=OFF    -DGDAL_USE_LIBLZMA=ON
+variant cfitsio description {Enable FITS support} {
+    depends_lib-append      port:cfitsio
+    configure.args-replace  -DGDAL_USE_CFITSIO=OFF    -DGDAL_USE_CFITSIO=ON
+    configure.args-append   -DGDAL_ENABLE_DRIVER_FITS=ON
 }
 
 variant cryptopp description {Enable Crypto++ support} {
@@ -320,28 +318,10 @@ variant cryptopp description {Enable Crypto++ support} {
     configure.args-replace  -DGDAL_USE_CRYPTOPP=OFF    -DGDAL_USE_CRYPTOPP=ON
 }
 
-variant libkml description {Enable libkml} {
-    pre-configure {
-        set boost_includedir  [exec ${prefix}/bin/pkg-config --variable=boost_includedir libkml]
-        configure.cxxflags-append -I${boost_includedir}
-    }
-
-    depends_lib-append        port:libkml
-    configure.args-replace    -DGDAL_USE_LIBKML=OFF    -DGDAL_USE_LIBKML=ON
-    configure.args-append     -DOGR_ENABLE_DRIVER_LIBKML=ON
-}
-
-variant mrsid description {Enable MrSID file format} {
-    depends_lib-append      port:geoexpress-sdk
-    configure.args-replace  -DGDAL_USE_MRSID=OFF    -DGDAL_USE_MRSID=ON \
-                            -DGDAL_USE_JP2MRSID=OFF -DGDAL_USE_JP2MRSID=ON
-}
-
 variant ecw description {Enable ECW file format} {
     configure.args-replace  -DGDAL_USE_ECW=OFF    -DGDAL_USE_ECW=ON
     configure.args-append   -DECW_ROOT=${prefix}/lib/ECW \
                             -DGDAL_ENABLE_DRIVER_ECW=ON
-
     pre-configure {
         if {(![file exists ${prefix}/lib/ECW]) && \
         (![file exists /Intergraph/ERDASEcwJpeg2000SDK5.1.1/Desktop_Read-Only])} {
@@ -411,6 +391,61 @@ variant heif description {Enable HEIF support} {
     configure.args-append   -DGDAL_ENABLE_DRIVER_HEIF=ON
 }
 
+variant libarchive description {Enable libarchive support} {
+    depends_lib-append      port:libarchive
+    configure.args-replace  -DGDAL_USE_ARCHIVE=OFF    -DGDAL_USE_ARCHIVE=ON
+}
+
+variant libkml description {Enable libkml} {
+    pre-configure {
+        set boost_includedir  [exec ${prefix}/bin/pkg-config --variable=boost_includedir libkml]
+        configure.cxxflags-append -I${boost_includedir}
+    }
+    depends_lib-append        port:libkml
+    configure.args-replace    -DGDAL_USE_LIBKML=OFF    -DGDAL_USE_LIBKML=ON
+    configure.args-append     -DOGR_ENABLE_DRIVER_LIBKML=ON
+}
+
+variant lto description {Enable Link Time Optimization} {
+    configure.args-append   -DENABLE_IPO=ON
+}
+
+variant lzma description {Enable LZMA (7Z) compression support} {
+    depends_lib-append      port:lzma
+    configure.args-replace  -DGDAL_USE_LIBLZMA=OFF    -DGDAL_USE_LIBLZMA=ON
+}
+
+variant mrsid description {Enable MrSID file format} {
+    depends_lib-append      port:geoexpress-sdk
+    configure.args-replace  -DGDAL_USE_MRSID=OFF    -DGDAL_USE_MRSID=ON \
+                            -DGDAL_USE_JP2MRSID=OFF -DGDAL_USE_JP2MRSID=ON
+}
+
+variant mysql57 conflicts mysql8 description {Enable MySQL 5.7 support} {
+    depends_lib-append      port:mysql57
+    configure.args-replace  -DGDAL_USE_MYSQL=OFF    -DGDAL_USE_MYSQL=ON
+    configure.args-append   -DMYSQL_INCLUDE_DIR=${prefix}/include/mysql57/mysql \
+                            -DMYSQL_LIBRARY=${prefix}/lib/mysql57/mysql/libmysqlclient.dylib
+}
+
+variant mysql8 conflicts mysql57 description {Enable MySQL 8 support} {
+    depends_lib-append      port:mysql8
+    configure.args-replace  -DGDAL_USE_MYSQL=OFF    -DGDAL_USE_MYSQL=ON
+    configure.args-append   -DMYSQL_INCLUDE_DIR=${prefix}/include/mysql8/mysql \
+                            -DMYSQL_LIBRARY=${prefix}/lib/mysql8/mysql/libmysqlclient.dylib
+}
+
+variant native description {Optimize for speed} {
+    if {${os.arch} eq "arm"} {
+        configure.optflags  -O3 -pipe -mcpu=apple-m1 -DGDAL_COMPILATION
+    } elseif {${os.arch} eq "powerpc"} {
+        # https://github.com/macports/macports-ports/pull/18587#issuecomment-1540025830
+        configure.optflags  -O3 -pipe -mtune=native -mcpu=native -DGDAL_COMPILATION
+    } else {
+        configure.optflags  -O3 -pipe -march=native -DGDAL_COMPILATION
+    }
+}
+
 variant netcdf description {Enable NetCDF file format} {
     pre-configure {
         # If NetCDF is built with a mpi variant, we need to know the path to "mpi.h".
@@ -431,128 +466,81 @@ variant netcdf description {Enable NetCDF file format} {
         }
     }
     depends_lib-append      port:netcdf
-    configure.args-replace  -DGDAL_USE_NETCDF=OFF    -DGDAL_USE_NETCDF=ON
+    configure.args-replace  -DGDAL_USE_NETCDF=OFF  -DGDAL_USE_NETCDF=ON
     configure.args-append   -DGDAL_ENABLE_DRIVER_NETCDF=ON
-}
-
-variant openexr description {Enable OpenEXR image file format} {
-    depends_lib-append      port:openexr
-    configure.args-replace  -DGDAL_USE_OPENEXR=OFF          -DGDAL_USE_OPENEXR=ON \
-                            -DGDAL_ENABLE_DRIVER_EXR=OFF    -DGDAL_ENABLE_DRIVER_EXR=ON
-}
-
-variant openjpeg description {Enable OpenJPEG JPEG-2000 format support} {
-    depends_lib-append      port:openjpeg
-    configure.args-replace  -DGDAL_USE_OPENJPEG=OFF   -DGDAL_USE_OPENJPEG=ON
-    configure.args-append   -DGDAL_ENABLE_DRIVER_JP2OPENJPEG=ON
-}
-
-variant xerces description {Enable Xerces XML support for GML file format} {
-    depends_lib-append      path:include/xercesc/util/XercesVersion.hpp:xercesc3
-    configure.args-replace  -DGDAL_USE_XERCESC=OFF   -DGDAL_USE_XERCESC=ON
-
-    # These drivers need xerces-c
-    configure.args-append   -DOGR_ENABLE_DRIVER_NAS=ON \
-                            -DOGR_ENABLE_DRIVER_ILI=ON \
-                            -DOGR_ENABLE_DRIVER_GMLAS=ON
-}
-
-# Database variants
-set postgresql_suffixes {95 96 10 11 12 13 14 15}
-
-set portsgresql_variants {}
-set postgresql_default_variant "if {"
-
-foreach s ${postgresql_suffixes} {
-    lappend portsgresql_variants postgresql${s}
-    set postgresql_default_variant "${postgresql_default_variant}!\[variant_isset postgresql${s}] && "
-}
-
-set postgresql_default_variant [string range ${postgresql_default_variant} 0 end-4]
-set postgresql_default_variant "${postgresql_default_variant}} {default_variants +postgresql${s}}"
-eval $postgresql_default_variant
-
-foreach s ${postgresql_suffixes} {
-    set p postgresql${s}
-    set v [string index ${s} 0].[string index ${s} 1]
-    set i [lsearch -exact ${portsgresql_variants} ${p}]
-    set c [lreplace ${portsgresql_variants} ${i} ${i}]
-    variant ${p} description "Enable PostgreSQL ${v} support" conflicts {*}${c} "
-        depends_lib-append      port:${p}
-        configure.args-replace  -DOGR_ENABLE_DRIVER_PG=OFF    -DOGR_ENABLE_DRIVER_PG=ON
-        configure.args-append   -DPostgreSQL_INCLUDE_DIR=${prefix}/include/postgresql${s} \
-                                -DPostgreSQL_LIBRARY_DIR=${prefix}/lib/postgresql${s} \
-                                -DPostgreSQL_ADDITIONAL_VERSIONS=${s}
-    "
-}
-
-variant mysql57 conflicts mysql8 description {Enable MySQL 5.7 support} {
-    depends_lib-append      port:mysql57
-    configure.args-replace  -DGDAL_USE_MYSQL=OFF    -DGDAL_USE_MYSQL=ON
-    configure.args-append   -DMYSQL_INCLUDE_DIR=${prefix}/include/mysql57/mysql \
-                            -DMYSQL_LIBRARY=${prefix}/lib/mysql57/mysql/libmysqlclient.dylib
-}
-
-variant mysql8 conflicts mysql57 description {Enable MySQL 8 support} {
-    depends_lib-append      port:mysql8
-    configure.args-replace  -DGDAL_USE_MYSQL=OFF    -DGDAL_USE_MYSQL=ON
-    configure.args-append   -DMYSQL_INCLUDE_DIR=${prefix}/include/mysql8/mysql \
-                            -DMYSQL_LIBRARY=${prefix}/lib/mysql8/mysql/libmysqlclient.dylib
 }
 
 variant odbc description {Enable ODBC support} {
     depends_lib-append      port:unixODBC
-    configure.args-replace  -DGDAL_USE_ODBC=OFF    -DGDAL_USE_ODBC=ON
-
+    configure.args-replace  -DGDAL_USE_ODBC=OFF  -DGDAL_USE_ODBC=ON
     # These drivers depend on odbc
     configure.args-append   -DOGR_ENABLE_DRIVER_ODBC=ON \
                             -DOGR_ENABLE_DRIVER_PGEO=ON \
                             -DOGR_ENABLE_DRIVER_MSSQLSPATIAL=ON
 }
 
+variant opencl description {Enable OpenCL} {
+    configure.args-replace  -DGDAL_USE_OPENCL=OFF  -DGDAL_USE_OPENCL=ON
+}
+
+variant openexr description {Enable OpenEXR image file format} {
+    depends_lib-append      port:openexr
+    configure.args-replace  -DGDAL_USE_OPENEXR=OFF        -DGDAL_USE_OPENEXR=ON \
+                            -DGDAL_ENABLE_DRIVER_EXR=OFF  -DGDAL_ENABLE_DRIVER_EXR=ON
+}
+
+variant openjpeg description {Enable OpenJPEG JPEG-2000 format support} {
+    depends_lib-append      port:openjpeg
+    configure.args-replace  -DGDAL_USE_OPENJPEG=OFF  -DGDAL_USE_OPENJPEG=ON
+    configure.args-append   -DGDAL_ENABLE_DRIVER_JP2OPENJPEG=ON
+}
+
 variant poppler description {Enable Poppler support} {
     depends_lib-append      path:lib/pkgconfig/poppler.pc:poppler
-    configure.args-replace  -DGDAL_USE_POPPLER=OFF    -DGDAL_USE_POPPLER=ON
+    configure.args-replace  -DGDAL_USE_POPPLER=OFF  -DGDAL_USE_POPPLER=ON
     configure.args-append   -DGDAL_ENABLE_DRIVER_PDF=ON
 }
 
-variant cfitsio description {Enable FITS support} {
-    depends_lib-append      port:cfitsio
-    configure.args-replace  -DGDAL_USE_CFITSIO=OFF    -DGDAL_USE_CFITSIO=ON
-    configure.args-append   -DGDAL_ENABLE_DRIVER_FITS=ON
+# PostgreSQL variants
+set pg_suffixes {95 96 10 11 12 13 14 15}
+set pg_variants {}
+set pg_default_variant "if {"
+foreach v ${pg_suffixes} {
+    lappend pg_variants postgresql${v}
+    set pg_default_variant "${pg_default_variant}!\[variant_isset postgresql${v}] && "
+}
+set pg_default_variant [string range ${pg_default_variant} 0 end-4]
+set pg_default_variant "${pg_default_variant}} {default_variants +postgresql${v}}"
+eval $pg_default_variant
+foreach v ${pg_suffixes} {
+    set p postgresql${v}
+    set i [lsearch -exact ${pg_variants} ${p}]
+    set c [lreplace ${pg_variants} ${i} ${i}]
+    variant ${p} description "Enable PostgreSQL ${v} support" conflicts {*}${c} "
+        depends_lib-append      port:${p}
+        configure.args-replace  -DOGR_ENABLE_DRIVER_PG=OFF    -DOGR_ENABLE_DRIVER_PG=ON
+        configure.args-append   -DPostgreSQL_INCLUDE_DIR=${prefix}/include/${p} \
+                                -DPostgreSQL_LIBRARY_DIR=${prefix}/lib/${p} \
+                                -DPostgreSQL_ADDITIONAL_VERSIONS=${v}
+    "
 }
 
-variant arrow description {Enable (Geo)Arrow IPC File Format / Stream and (Geo)Parquet support} {
-    depends_lib-append      port:apache-arrow
-    configure.args-replace  -DGDAL_USE_ARROW=OFF            -DGDAL_USE_ARROW=ON \
-                            -DGDAL_USE_PARQUET=OFF          -DGDAL_USE_PARQUET=ON \
-                            -DOGR_ENABLE_DRIVER_ARROW=OFF   -DOGR_ENABLE_DRIVER_ARROW=ON \
-                            -DOGR_ENABLE_DRIVER_PARQUET=OFF -DOGR_ENABLE_DRIVER_PARQUET=ON
-    configure.args-append   -DARROW_USE_STATIC_LIBRARIES=OFF
-}
-
-configure.optflags  -DGDAL_COMPILATION
-
-# Set PROJ
+# PROJ variants
 set proj_versions {6 7 8 9}
 set proj_variants {}
 foreach pjver ${proj_versions} {
     lappend proj_variants proj${pjver}
 }
 foreach proj_ver ${proj_versions} {
-
     set index [lsearch -exact ${proj_variants} proj${proj_ver}]
     set cflcts [lreplace ${proj_variants} ${index} ${index}]
-
-        variant proj${proj_ver} description "Use Proj${proj_ver}" conflicts {*}${cflcts} "
-
-            depends_lib-append      port:proj${proj_ver}
-            configure.args-append   -DGDAL_USE_PROJ=ON \
-                                    -DPROJ_INCLUDE_DIR=${prefix}/lib/proj${proj_ver}/include \
-                                    -DPROJ_LIBRARY_RELEASE=${prefix}/lib/proj${proj_ver}/lib/libproj.dylib
-        "
+    variant proj${proj_ver} description "Use Proj${proj_ver}" conflicts {*}${cflcts} "
+        depends_lib-append      port:proj${proj_ver}
+        configure.args-append   -DGDAL_USE_PROJ=ON \
+                                -DPROJ_INCLUDE_DIR=${prefix}/lib/proj${proj_ver}/include \
+                                -DPROJ_LIBRARY_RELEASE=${prefix}/lib/proj${proj_ver}/lib/libproj.dylib
+    "
 }
-
 set projdf "if {"
 foreach pv ${proj_versions} {
     set projdf "${projdf}!\[variant_isset proj${pv}\] && "
@@ -561,16 +549,13 @@ set projdf [string range ${projdf} 0 end-4]
 set projdf "${projdf}} { default_variants +proj${pv} }"
 eval ${projdf}
 
-
-variant native description {Optimize for speed} {
-    if {${os.arch} eq "arm"} {
-        configure.optflags  -O3 -pipe -mcpu=apple-m1 -DGDAL_COMPILATION
-    } elseif {${os.arch} eq "powerpc"} {
-        # https://github.com/macports/macports-ports/pull/18587#issuecomment-1540025830
-        configure.optflags  -O3 -pipe -mtune=native -mcpu=native -DGDAL_COMPILATION
-    } else {
-        configure.optflags  -O3 -pipe -march=native -DGDAL_COMPILATION
-    }
+variant xerces description {Enable Xerces XML support for GML file format} {
+    depends_lib-append      path:include/xercesc/util/XercesVersion.hpp:xercesc3
+    configure.args-replace  -DGDAL_USE_XERCESC=OFF   -DGDAL_USE_XERCESC=ON
+    # These drivers need xerces-c
+    configure.args-append   -DOGR_ENABLE_DRIVER_NAS=ON \
+                            -DOGR_ENABLE_DRIVER_ILI=ON \
+                            -DOGR_ENABLE_DRIVER_GMLAS=ON
 }
 
 set jpeg2k 0
@@ -582,7 +567,6 @@ foreach jpeg2kVariant {openjpeg ecw} {
 if {${jpeg2k} > 1} {
     notes-append "Multiple drivers are able to open JPEG-2000 datasets. See https://trac.osgeo.org/gdal/wiki/ConfigOptions#GDAL_SKIP."
 }
-
 
 post-destroot {
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This is a general overhaul and clean-up of the `gdal` portfile. Besides reorganising the (many) variants in alphabetical order and minor formatting changes, the notable changes are:

- removal of dependency of PG mpi, which was unnecessary even from the start. GDAL does **not** use MPI, but it needs to know the path to `mpi.h` in case hdf5 and/or netcdf is built with mpi support.
- removal of inclusion of PG github, which also never made much sense. Official release packages are located at and fetched from osgeo.org.
- removal of PostgreSQL pre-12 variants (which are all depending on deprecated ports)

(In all, this reduces the number of variants from 59 to 32!)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
