### PR TITLE
symfony-cli: update to 5.6.0

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.5.10
+version             5.6.0
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  b33fed779b263f597cfbd407d04c03d93bad5218 \
-                        sha256  372d9df1f9dde8ca5a20e0c94afc6a9d305f8d1df6d9cc9dbeb1fb98737a0082 \
-                        size    253096
+    checksums           rmd160  006d1b4690155aea56c274fd64c6b9f79e1f4ced \
+                        sha256  42adaf0af646bb7ddc0ba1720eaef93c58fc7891ba0ac0cd4e291f30b43b1f00 \
+                        size    256751
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  dbbe5874b8f38af8e265638eb4e78ffb6bd3bb62 \
-                        sha256  637bf7c16ca2abb6dec50b3e0c1dde0cf36de42af1e5df0c32b108831701d80c \
-                        size    10988442
+    checksums           rmd160  2853dd977a8ddaea93934ee4c04416fa1e26175d \
+                        sha256  867790a63cfa9f20c8bec515bc38c4a52824dcea207ad6ff62ce68b05c3495bc \
+                        size    11130891
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.6.0

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
