### PR TITLE
dblatex: Fix build by disabling pep517

### DIFF
--- a/textproc/dblatex/Portfile
+++ b/textproc/dblatex/Portfile
@@ -6,7 +6,7 @@ PortGroup           texlive 1.0
 
 name                dblatex
 version             0.3.12
-revision            1
+revision            2
 categories          textproc tex
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-2+
@@ -51,10 +51,8 @@ depends_lib         port:texlive-latex-extra \
 
 python.link_binaries no
 python.default_version 310
-
-default destroot.cmd {${python.bin} setup.py}
-destroot.destdir    --root=${destroot} \
-                    --catalogs=${destroot}${prefix}/etc/xml/catalog
+python.pep517 no
+destroot.target-append --catalogs=${prefix}/etc/xml/catalog
 
 # The mactex variant expects MacTeX to be installed
 # and installs dblatex's stylefiles to MacTeX's texmf (local)


### PR DESCRIPTION
#### Description

This broke when 3173d46b9a29bc9d79ddb6970e7f083ebe3f79c0 enabled pep517 by default for all python versions >= 3.7. dblatex does not properly build with the new tooling.

See: #20793

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 x86_64
Xcode 15.0 15A240d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
