### PR TITLE
openjdk21-sap: update to 21.0.1

### DIFF
--- a/java/openjdk21-sap/Portfile
+++ b/java/openjdk21-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/21
-version      21
+version      21.0.1
 revision     0
 
 description  SAP Machine 21
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  52f652066ae1ad1aa0270ad0b542b4357a9a03fa \
-                 sha256  665f34d7730fd769383df9bbfadef1ea9819f06b151903e9219b570ca3b0dc73 \
-                 size    194299298
+    checksums    rmd160  bd3406baaabcf5d603a771c7820c14a6bca98415 \
+                 sha256  498bdb5635be4b784ccfe12f83dc4c83f6a5fb2f37666a4fec408a2fd4083afa \
+                 size    194338383
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  fd1453340c15bc5a3e9abde7054385d829bf2c9b \
-                 sha256  9075930a2fdc48c960b9dbac68418ecce9107696736c8eaf34720db3fa69ab4c \
-                 size    191986048
+    checksums    rmd160  52f9a18034224aec3a6144aefa1a615b213f1369 \
+                 sha256  8a052e50e4b48e87d6519489b0c7116df1e8f87a52480b81db27fee8259a5cc0 \
+                 size    192017068
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 21.0.1.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?