### PR TITLE
openjdk17-sap: update to 17.0.9

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.8.1
+version      17.0.9
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  3e5a13c8a7a9d965342f9f81343740605e70d174 \
-                 sha256  db7611f5429f94f58f17c7b9e9c16f99b5e48d082291ff2757ca7f69065b2197 \
-                 size    180672306
+    checksums    rmd160  6392ec3c2a38083a96da87bcf1cdae6bd4c612c5 \
+                 sha256  b025d24f1ae1ab0834b262ea0ff4c4f0fd823ad88732d444a3ec676d8d2d1952 \
+                 size    180760527
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  8e19f4c3c1ecbd2f065efcba9dead5f83b8f19af \
-                 sha256  8164e13176ca80cdf15d22ecb33b502721b42ef6b5f98c480089e2f7d79cf2fe \
-                 size    178387774
+    checksums    rmd160  de1be3a553635868d5580176d7a312d0d865240a \
+                 sha256  dd731745e9b43e589bde40535368376b4e11452377a40848ff05eca19c54bf24 \
+                 size    178654317
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.9.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?