### PR TITLE
openjdk11-sap: update to 11.0.21

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/11
 supported_archs  x86_64 arm64
 
-version      11.0.20.1
+version      11.0.21
 revision     0
 
 description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  c7d70f27fa2c9d6afb2679b7a3eaf0aad52cb7d6 \
-                 sha256  98c0f8294644bec653e6b6fa788093501e049cf0321b56662a0dc28a07e93674 \
-                 size    187515130
+    checksums    rmd160  364e644607b4c338e9f185e377882f1504c6f0a5 \
+                 sha256  76d90d33a25ff61227e178034876c6877dc051933d0af57403b43e8a4b2feb65 \
+                 size    187603436
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  c343b96d832926be9862ef5119894f1201b91439 \
-                 sha256  0d6387b711cc9fef11fbaaafde6c3f068ed0cc9a1088ece8c0fd90eb9a778b6b \
-                 size    185627674
+    checksums    rmd160  3e730cb01d85a4aff8b8972ec77c4ad1febaf707 \
+                 sha256  3a1a0e45d6de1fdc6874ea91f63713e3cd3e3663865bbe97941e0f8872b2907e \
+                 size    185731157
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 11.0.21.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?