### PR TITLE
pdfjam: update to 3.10

### DIFF
--- a/textproc/pdfjam/Portfile
+++ b/textproc/pdfjam/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            rrthomas pdfjam 3.09 v
+github.setup            rrthomas pdfjam 3.10 v
 categories              textproc pdf
 maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 license                 GPL-2
@@ -22,9 +22,9 @@ long_description \
 
 github.tarball_from     releases
 
-checksums               rmd160  6c4057b827c94cbba7c1de91802dfc9cc2e2a433 \
-                        sha256  d4fc7485c92c9aa5d33c8a52af1bf7084043d84eeb47581ec6b96df9007d2bd9 \
-                        size    121986
+checksums               rmd160  07464b84e6d2af74f0136f301b3de302ce0ca66c \
+                        sha256  a1a2e422949ece10190034283ac5267d1ec160369cbc56b4a524dfdf1adf2310 \
+                        size    121928
 
 depends_run \
     bin:pdflatex:texlive-latex \


### PR DESCRIPTION
#### Description

Update to pdfjam 3.10.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?