### PR TITLE
google-cloud-sdk: update to 451.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             451.0.0
+version             451.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  53cf62b712e67d3404b415764291b47e881bf933 \
-                    sha256  f08e475b01574750a836896d2dc03120ee372560f403bc231c2e0c891c38f027 \
-                    size    121617447
+    checksums       rmd160  d3baa979134e585f022d14aa3cb32d19ab3b94bc \
+                    sha256  8a7bf70952fcba3d5d06a8c755295322c54a9439ff03f04676bc7ac5160bb323 \
+                    size    121618374
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b8656a21186fd70a694361a4112b22fb80669196 \
-                    sha256  4e4bf8c05bacc58854c84bf50b27db4f592196507009c772975bc889326d49f7 \
-                    size    122901693
+    checksums       rmd160  2b7a7dbe4abcabe04cde053776e3356ed19b6a30 \
+                    sha256  512f3bb29887ec934a8ec629436dafc023c5acaea0f6739d906498d8abe401b7 \
+                    size    122902329
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  4566905250976a6c8a67a8c874587bb783d59a77 \
-                    sha256  817912e950f0da4f3ef8bd26eec31bb6eb95d08ab8f29c8baf4339cb7e9b6d81 \
-                    size    120003926
+    checksums       rmd160  20ae81f33dabc8ca8cb13bfdc2cb9abf1af8b43c \
+                    sha256  bdd94c06f0216ceb846a2a6797d73df31a0e92c2b1196477d2765fd2765f8a1d \
+                    size    120005010
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -42,7 +42,7 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 worksrcdir          ${name}
 
 # Most recent supported Python version according to https://cloud.google.com/sdk/docs/install#mac
-python.default_version 39
+python.default_version 310
 
 post-patch {
     # Default to the MacPorts Python binary


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 451.0.1, update Python version dependency to 3.10.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?