### PR TITLE
bazel: update to 6.4.0

### DIFF
--- a/devel/bazel/Portfile
+++ b/devel/bazel/Portfile
@@ -31,17 +31,16 @@ set extra_args "\
 
 # Note bazel-3.{1,5,7} build on OSX10.11 but fail at runtime with
 # dyld: lazy symbol binding failed: Symbol not found: _os_log_create
-
 set min_darwin      16
 
 if { ${name} eq ${subport} } {
 
     # Main port
-    github.setup    bazelbuild ${name} 6.3.2
+    github.setup    bazelbuild ${name} 6.4.0
     revision        0
-    checksums       rmd160  327f8429bfd02d5a3f0881d18dd2ad6cd2c5b015 \
-                    sha256  8cd7feac58193be2bcba451ba6688a46824d37ca6359ff58e0d44eb98f042948 \
-                    size    205660977
+    checksums       rmd160  8037f7fc0691fd1e4940782e7c945d807f4b66b6 \
+                    sha256  bd88ff602c8bbb29ee82ba2a6b12ad092d51ec668c6577f9628f18e48ff4e51e \
+                    size    206062629
 
     set bazel_min_xcode 10.3
     compiler.blacklist-append {clang < 1000}
@@ -118,7 +117,8 @@ github.tarball_from releases
 
 categories          devel
 
-maintainers         {tfmnet.com:mohamed.issa @missa-prime} \
+maintainers         {tfmnet.com:mohamed.issa @missa-prime}  \
+                    {gmail.com:herby.gillot @herbygillot}   \
                     openmaintainer
 
 description         A tool for automating builds and tests.
@@ -154,21 +154,18 @@ configure.sdk_version
 
 configure.ccache    no
 
-# python versions. Build needs both 'python2' and 'python3'
-set py3ver 3.10
-set py2ver 2.7
+# Use Python 3
+set py3ver 3.11
 
 depends_lib-append  port:cctools
 
 depends_build-append \
                     bin:zip:zip \
-                    port:python[string map {. {}} ${py2ver}] \
                     port:python[string map {. {}} ${py3ver}]
 
 post-extract {
     # Make dir with selected MP 'python2' and 'python3' and add to PATH during build below
     file mkdir ${workpath}/bin
-    ln -s ${prefix}/bin/python${py2ver} ${workpath}/bin/python2
     ln -s ${prefix}/bin/python${py3ver} ${workpath}/bin/python3
     ln -s ${prefix}/bin/python${py3ver} ${workpath}/bin/python
 }
@@ -350,12 +347,12 @@ post-destroot {
 
     # Copy documentation files
     xinstall -d ${destroot}${docdir}
-    xinstall -m 644 -W ${worksrcpath} AUTHORS \
-                                      CHANGELOG.md \
-                                      CONTRIBUTING.md \
-                                      CONTRIBUTORS \
-                                      LICENSE \
-                                      README.md \
+    xinstall -m 0644 -W ${worksrcpath}  AUTHORS \
+                                        CHANGELOG.md \
+                                        CONTRIBUTING.md \
+                                        CONTRIBUTORS \
+                                        LICENSE \
+                                        README.md \
                        ${destroot}${docdir}
 
     # Copy source files


### PR DESCRIPTION
- remove Python 2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
