### PR TITLE
gifski, libgifski: new ports (version 1.12.2)

### DIFF
--- a/graphics/gifski/Portfile
+++ b/graphics/gifski/Portfile
@@ -1,0 +1,164 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo   1.0
+PortGroup           github  1.0
+
+github.setup        ImageOptim gifski 1.12.2
+github.tarball_from archive
+revision            0
+
+homepage            https://gif.ski/
+
+description         \
+    GIF encoder based on libimagequant \(pngquant\). Squeezes maximum \
+    possible quality from the awful GIF format.
+
+long_description    \
+    Highest-quality GIF encoder based on pngquant. ${name} converts video \
+    frames to GIF animations using pngquant\'s fancy features for efficient \
+    cross-frame palettes and temporal dithering. It produces animated GIFs \
+    that use thousands of colors per frame.
+
+categories          graphics
+license             AGPL-3
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  adaec2377677aacdfa013fce26d5d2abc2465824 \
+                    sha256  daaeefd21d8328282d2c1082faddbc1f4870c60c1453e6e85e1a421aa77738d6 \
+                    size    76109
+
+build.pre_args-delete \
+                   --frozen --offline
+
+if {${name} eq ${subport}} {
+    destroot {
+        xinstall -m 0755 \
+            ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+            ${destroot}${prefix}/bin/
+    }
+}
+
+# C library for gifski
+subport lib${name}  {
+
+    description     \
+        C library for ${name}, a {*}${description}
+
+    long_description \
+        C library for ${name}, which is the {*}${long_description}
+
+    depends_build-append \
+                    port:cargo-c \
+                    port:pkgconfig
+
+    build.cmd       ${cargo.bin} cbuild
+    build.pre_args-append \
+                    --prefix=${prefix}
+
+    destroot {
+        system -W ${worksrcpath} \
+            "${cargo.bin} cinstall ${build.pre_args} --destdir=${destroot}"
+    }
+
+}
+
+cargo.crates_github \
+    ffmpeg-sys-next kornelski/rust-ffmpeg-sys-1 master \
+        94d5496d88900bdc0cad66733138134d0ea3cf31 \
+        43960d0ddd2244309530e87286118c9c68f468ed5c9fd2b5f59c0236b725e4a6
+
+cargo.crates \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    ahash                            0.8.3  2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f \
+    aho-corasick                     1.1.1  ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab \
+    anstream                         0.5.0  b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c \
+    anstyle                          1.0.3  b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46 \
+    anstyle-parse                    0.2.1  938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333 \
+    anstyle-query                    1.0.0  5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b \
+    anstyle-wincon                   2.1.0  58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd \
+    arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    bindgen                         0.64.0  c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4 \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bytemuck                        1.14.0  374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6 \
+    cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
+    cexpr                            0.6.0  6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    clang-sys                        1.6.1  c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f \
+    clap                             4.4.4  b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136 \
+    clap_builder                     4.4.4  5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56 \
+    clap_lex                         0.5.1  cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961 \
+    colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
+    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
+    crossbeam-channel                0.5.8  a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200 \
+    crossbeam-deque                  0.8.3  ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef \
+    crossbeam-epoch                 0.9.15  ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7 \
+    crossbeam-utils                 0.8.16  5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294 \
+    dunce                            1.0.4  56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b \
+    either                           1.9.0  a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07 \
+    fallible_collections             0.4.9  a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd \
+    ffmpeg-next                      6.0.0  8af03c47ad26832ab3aabc4cdbf210af3d3b878783edd5a7ba044ba33aab7a60 \
+    flate2                          1.0.27  c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010 \
+    gif                             0.12.0  80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045 \
+    gif-dispose                      4.0.1  347afae04a03ca25a3a76d130abb63e7e6e7367b895470fdc3d996aec916c3d7 \
+    gifsicle                        1.93.0  0d2c35b9670c2a3313343ce54d00669ca18a8236fe727f52e0cf8c5a77acac07 \
+    glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
+    hashbrown                       0.13.2  43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e \
+    hermit-abi                       0.3.3  d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7 \
+    imagequant                       4.2.1  9427afad20d287aad11e5981db8beb68d0a20e2e4cbd8280e05f95e05b31668a \
+    imgref                           1.9.4  b2cf49df1085dcfb171460e4592597b84abe50d900fb83efb6e41b20fefd6c2c \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    lazycell                         1.3.0  830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55 \
+    libc                           0.2.148  9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b \
+    libloading                       0.7.4  b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f \
+    lodepng                          3.8.2  73c81862c9e16a943631de5160969379758f13fb3c788110db4ab49430b4feab \
+    loop9                            0.1.4  81a837f917de41d61ab531ba255d1913208d02325cab0d6a66a706e0dbaa699d \
+    memchr                           2.6.3  8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c \
+    memoffset                        0.9.0  5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
+    minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
+    miniz_oxide                      0.7.1  e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7 \
+    natord                           1.0.9  308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c \
+    nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
+    num-traits                      0.2.16  f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2 \
+    num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
+    once_cell                       1.18.0  dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d \
+    pbr                              1.1.1  ed5827dfa0d69b6c92493d6c38e633bbaa5937c153d0d7c28bf12313f8c6d514 \
+    peeking_take_while               0.1.2  19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099 \
+    pkg-config                      0.3.27  26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964 \
+    proc-macro2                     1.0.67  3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328 \
+    quick-error                      2.0.1  a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3 \
+    quote                           1.0.33  5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae \
+    rayon                            1.8.0  9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1 \
+    rayon-core                      1.12.0  5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed \
+    regex                            1.9.5  697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47 \
+    regex-automata                   0.3.8  c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795 \
+    regex-syntax                     0.7.5  dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da \
+    resize                           0.8.2  8ce43c0220eff4793a20c120ff89ee01499ba3c882957021dcdc12f5e4ca97c8 \
+    rgb                             0.8.36  20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59 \
+    rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    shlex                            1.2.0  a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380 \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+    thread_local                     1.1.7  3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152 \
+    unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
+    utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
+    vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    weezl                            0.1.7  9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb \
+    wild                             2.2.0  10d01931a94d5a115a53f95292f51d316856b68a035618eb831bbba593a30b67 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538


### PR DESCRIPTION
Seems to be building fine, but has not been tested on actual image files.

Fixes: https://trac.macports.org/ticket/68492

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
