### PR TITLE
rust: support build under rosetta2

### DIFF
--- a/lang/rust/Portfile
+++ b/lang/rust/Portfile
@@ -152,8 +152,20 @@ if { ${os.platform} eq "darwin" && ${os.major} < 9 } {
     configure.args-append   --disable-rpath
 }
 if { ${os.platform} eq "darwin" && ${os.major} > 14 } {
-    configure.args-append   --set=rust.jemalloc
+    # check if running in rosetta2 and don't set jemalloc if so
+    try {
+        set in_rosetta2 [exec sysctl -n sysctl.proc_translated]
+        if { ${in_rosetta2} == 0 } {
+            configure.args-append   --set=rust.jemalloc
+        } else {
+            depends_build-append        port:libatomic_ops
+        }
+    } catch {
+        depends_build-append        port:libatomic_ops
+        # Handle non-zero return of proc_translated gracefully, optionally log the error.
+    }
     if { ${os.arch} eq "arm" } {
+        configure.args-append   --set=rust.jemalloc
         # specify the number of significant virtual address bits in jmalloc
         # the configure script calls cpuid, but it does not work properly on Rosetta 2
         # see https://github.com/jemalloc/jemalloc/issues/1997#issuecomment-1041589117


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Support building rust under rosetta2 (for x86_64). Otherwise it fails.

See bug report: https://trac.macports.org/ticket/68185

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6 22G120 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
