### PR TITLE
osxphotos: update to 0.64.2

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.64.0
+version                 0.64.2
 revision                0
 
 categories              graphics python
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  742be18c10d5ee655b2707709fc82282cebe811a \
-                        sha256  2dc01c0e079aa8b66c3dcc99fd8782b632134f80f018727cf8ea2b64ea805b07 \
-                        size    2044637
+checksums               rmd160  3c572d24d6553329996052970b026179f4ad5df1 \
+                        sha256  cc537510f59f061b0d9015e338d0920e9953bedffc023584e53d4fdc6cc7cbda \
+                        size    2044433
 
 python.default_version  311
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.64.2.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?