### PR TITLE
gallery-dl: updated to 1.26.1

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        mikf gallery-dl 1.26.0 v
+github.setup        mikf gallery-dl 1.26.1 v
 github.tarball_from releases
 distname            gallery_dl-${github.version}
 
@@ -12,9 +12,9 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  af864f58fda879c5bc173a946d337133c934c6b2 \
-                    sha256  fa0e2d7ebed117daeb8a641c5e1733de8fc2c7dc4b36b4c3575171ed74b187b2 \
-                    size    469926
+checksums           rmd160  88008d8959f46e59f904d7d6db470140dde641a6 \
+                    sha256  489b2111dbe63c3419e66aa241f26959c438dd61975313ef30c26263fe02c6c7 \
+                    size    472767
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites


### PR DESCRIPTION
#### Description

gallery-dl: updated to 1.26.1

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.6 22G120 arm64
Xcode 15.0 15A240d


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
