### PR TITLE
gnuastro: update to 0.21

### DIFF
--- a/science/gnuastro/Portfile
+++ b/science/gnuastro/Portfile
@@ -3,8 +3,8 @@
 PortSystem              1.0
 
 name                    gnuastro
-version                 0.20
-revision                2
+version                 0.21
+revision                0
 categories              science
 license                 GPL-3+
 maintainers             {@sikmir disroot.org:sikmir} openmaintainer
@@ -15,9 +15,9 @@ long_description        The GNU Astronomy Utilities (Gnuastro) is an official GN
 homepage                https://www.gnu.org/software/gnuastro/
 master_sites            gnu
 
-checksums               rmd160  77750b89a58e33332b5190b553ab068c1ad86d55 \
-                        sha256  924b8bb6ac1cd15163ddadc3a9bfdb8b88cac7b5099d5f821ecedbc3f0b069cd \
-                        size    7318098
+checksums               rmd160  bb31d76785a71ba58c88f6903c6b04cd274b6ff4 \
+                        sha256  2fba993d8422391517b55f7eb511788946d7a886aa1584984fd4678bdd27537f \
+                        size    7601435
 
 depends_build-append    port:libtool
 


### PR DESCRIPTION
#### Description
[Changelog](https://git.savannah.gnu.org/cgit/gnuastro.git/plain/NEWS?id=gnuastro_v0.21)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
