### PR TITLE
Obsession: support aarch64 builds

### DIFF
--- a/www/Obsession/Portfile
+++ b/www/Obsession/Portfile
@@ -1,12 +1,35 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           qmake 1.0
 PortGroup           github 1.0
 
-github.setup        tjohnman Obsession c33eebc782d152fe88bdc9794f28c139b5c527b4
-version             2023.07.12
-revision            0
+# The current upstream uses Qt4, however our qt4-mac at the moment is broken on aarch64.
+# We revert to an older version for it. Notice also, PowerPC systems should stay on Qt4.
+if {${os.arch} eq "arm"} {
+    PortGroup       qmake5 1.0
+
+    qt5.depends_component qtmultimedia
+
+    github.setup    tjohnman Obsession 8c31bea6d25c685ebaba8afb4922e3ca7f667549
+    version         2020.08.08
+    revision        0
+
+    checksums       rmd160  eded338200211a3e39c576ab7be612c33be7fe6d \
+                    sha256  54bae6e4186a354aacb0e78b76763ddc291ee6cfbf380764fb24c742226349f2 \
+                    size    21703059
+} else {
+    PortGroup       qmake 1.0
+
+    github.setup    tjohnman Obsession c33eebc782d152fe88bdc9794f28c139b5c527b4
+    version         2023.07.12
+    revision        0
+
+    checksums       rmd160  2857a5c3b028faa14de3908a43333d570f439207 \
+                    sha256  56932965a3ef04ee3dbfbb2eeeea6db68acc93f4f3260d3a3a8d1f5081e4c377 \
+                    size    21656604
+
+    depends_build   port:qt4-mac
+}
 
 categories          www hotline
 license             GPL-3
@@ -16,12 +39,6 @@ description         A Hotline client written in Qt featuring Shift-JIS support a
 long_description    The Obsession Hotline client aims to be a modern alternative for macOS, Linux and Windows users. \
                     It supports Shift-JIS encoding for Japanese users or for browsing Japanese servers. \
                     It is written using Qt and should compile and work out of the box on macOS, Linux and Windows.
-
-checksums           rmd160  2857a5c3b028faa14de3908a43333d570f439207 \
-                    sha256  56932965a3ef04ee3dbfbb2eeeea6db68acc93f4f3260d3a3a8d1f5081e4c377 \
-                    size    21656604
-
-depends_build       port:qt4-mac
 
 # error: ISO C++ forbids initialization of member ‘encryption’
 # https://github.com/tjohnman/Obsession/issues/41


### PR DESCRIPTION
#### Description

Add a version to build on aarch64.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14
Xcode 15

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

![obsession](https://github.com/macports/macports-ports/assets/92015510/cd8a9cc8-a830-456e-9c3e-b096473c55f8)
