### PR TITLE
gaa: update to 1.6.6_6

### DIFF
--- a/devel/gaa/Portfile
+++ b/devel/gaa/Portfile
@@ -3,7 +3,7 @@
 PortSystem               1.0
 PortGroup                github 1.0
 
-github.setup             cooljeanius gaa 1.6.6_1 v
+github.setup             cooljeanius gaa 1.6.6_6 v
 revision                 0
 categories               devel
 maintainers              {gwmail.gwu.edu:egall @cooljeanius} openmaintainer
@@ -22,24 +22,36 @@ fetch.type               git
 depends_build-append     port:bison \
                          port:flex \
                          port:gmake \
-                         bin:makeinfo:texinfo
+                         bin:makeinfo:texinfo \
+                         bin:tex:texlive-basic \
+                         bin:latex:texlive-latex \
+                         port:latex2html \
+                         port:texlive-fonts-recommended
 
 depends_lib-append       port:yydecode
-depends_lib-delete       port:gobject-introspection
+depends_lib-delete       port:gobject-introspection \
+                         port:poppler
 
 configure.ccache         no
 
-configure.args-append    --with-bison-bin=${prefix}/bin/bison
+configure.args-append    --with-bison-bin=${prefix}/bin/bison \
+                         --without-docs
 
 build.type               gnu
 build.cmd                ${prefix}/bin/gmake
+
+test.run                 yes
+test.target              check
 
 variant autoreconf description {Regenerates configure script before \
                                 building. Also pulls in extra \
                                 dependencies.} {
     depends_build-append port:gawk \
                          port:grep \
-                         port:autoconf-archive
+                         port:autoconf-archive \
+                         bin:ar:cctools \
+                         bin:file:file \
+                         bin:gsed:gsed
     use_autoreconf       yes
     autoreconf.args      -fvi -Wall
     configure.args-append --disable-silent-rules
@@ -47,9 +59,9 @@ variant autoreconf description {Regenerates configure script before \
 
 variant docs description {Generate additional documentation by \
                           using latex2html} {
-    depends_build-append port:latex2html \
-                         port:texlive-latex
-    depends_lib-delete   port:poppler
+    # (latex2html and texlive-latex are now unconditional dependencies)
+    depends_build-append port:texlive-plain-generic
+    configure.args-replace --without-docs --with-docs
     use_parallel_build   no
     post-build {
         system -W ${worksrcpath}/doc "${prefix}/bin/latex2html *.tex"


### PR DESCRIPTION
#### Description

When doing #20972 I noticed that livecheck reminded me that I actually had some updates available to the `gaa` port that I was submitting. This PR actually performs those updates. Unfortunately building documentation now happens by default, meaning that there are some additional dependencies required. I tried to figure out how I might be able to avoid this, but my efforts were unsuccessful. The `+docs` variant is still there, as it still does some extra stuff that isn't included with the default documentation build, but some of its dependencies have been moved out of it. Also I paid a bit closer attention to trace mode's output this time around, and added some additional dependencies that it picked up, as well. Also now there are tests.

###### Type(s)
update

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
