### PR TITLE
adept2: update to 2023.10.03

### DIFF
--- a/math/adept2/Portfile
+++ b/math/adept2/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        rjhogan Adept-2 dd32a415bebba998c581395251cc8055dea8db15
+github.setup        rjhogan Adept-2 74492d7fbc9fca1ab62705c86d53f2e298cdb096
 name                adept2
-version             2023.03.30
+version             2023.10.03
 revision            0
 categories          math
 license             Apache-2
@@ -14,9 +14,10 @@ maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Fast automatic differentiation library in C++
 long_description    Combined array and automatic differentiation library in C++.
 homepage            https://www.met.reading.ac.uk/clouds/adept
-checksums           rmd160  b7fef7d082c7fa312a763ada72cd3bdc89bb4295 \
-                    sha256  5ccaf2fd2a0042b58cbdc65d23220c51a8824c28e41ea6464e1288c1d3f80e1b \
-                    size    327227
+checksums           rmd160  1a43dfac902646c7a51a727d8d34a5caf59158a4 \
+                    sha256  529472e8a7b57bfe6ff6836e3bdc5b28a4200aa7b7b8a3d4d7f27e4b856cff19 \
+                    size    328130
+github.tarball_from archive
 
 use_autoreconf      yes
 
@@ -25,10 +26,6 @@ depends_lib-append  path:lib/libopenblas.dylib:OpenBLAS
 compilers.choose    fc f90 f77
 compilers.setup     require_fortran
 
-# https://github.com/rjhogan/Adept-2/issues/25
-# Until this is fixed: https://github.com/iains/darwin-toolchains-start-here/discussions/41
-compiler.blacklist-append \
-                    macports-gcc-12
 compiler.thread_local_storage yes
 
 # https://github.com/rjhogan/Adept-2/issues/24


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
