### PR TITLE
hugin-app: Switch to wxWidgets version 3.2

### DIFF
--- a/graphics/hugin-app/Portfile
+++ b/graphics/hugin-app/Portfile
@@ -11,7 +11,7 @@ PortGroup               conflicts_build 1.0
 
 name                    hugin-app
 version                 2022.0.0
-revision                5
+revision                6
 set branch              [join [lrange [split ${version} .] 0 1] .]
 categories              graphics
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} {mascguy @mascguy} openmaintainer
@@ -33,7 +33,12 @@ use_bzip2               yes
 compiler.cxx_standard   2011
 
 perl5.branches          5.34
-wxWidgets.use           wxWidgets-3.0-cxx11
+# use wxWidget-3.2 on macOS Mojave (10.14) and later for dark mode support
+if {${os.platform} eq "darwin" && ${os.major} >= 18} {
+    wxWidgets.use           wxWidgets-3.2
+} else {
+    wxWidgets.use           wxWidgets-3.0-cxx11
+}
 boost.version           1.78
 
 checksums               rmd160  50485c0a6fe10dbcf07f3d4e10cdb3ada291925e \


### PR DESCRIPTION
#### Description
Previously if the system uses the dark theme, this resulted in white font on white buttons. By moving from wxWidgets 3.0 to 3.2 the Hugin UI correctly adopts to the used theme.

For reference: Darkmode support was added to wxWidget in version 3.1.3 according to the [changelog](https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.1.3/docs/changes.txt)

If wxWidgets 3.0 should be required on older macOS versions, one might consider adding a `if`-`else` block to select version 3.0 on those systems, but I think on modern systems the default should be to use version 3.2 for seamless system integration.

Here some screenshots showing the GUI before/after the change with dark mode enabled and disabled

Before change with dark mode enabled:
![Screenshot 2023-10-23 at 19 34 57](https://github.com/macports/macports-ports/assets/59110786/f5b65f8e-837f-409a-8b92-163a10c2b732)

After change with dark mode enabled:
![Screenshot 2023-10-23 at 19 30 17](https://github.com/macports/macports-ports/assets/59110786/86d98743-1ba6-4728-a35a-a5e8256f4fb9)

Before change with dark mode disabled:
![Screenshot 2023-10-23 at 19 35 12](https://github.com/macports/macports-ports/assets/59110786/9f3bb140-5e1a-4703-bbd4-e488c1ee00e1)

After change with dark mode disabled:
![Screenshot 2023-10-23 at 19 30 49](https://github.com/macports/macports-ports/assets/59110786/1b2d2b4d-77b3-4fcd-882f-1a203d06b590)


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
