### PR TITLE
aqua/alacritty: Add variant with Nerd Font support

### DIFF
--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -5,7 +5,7 @@ PortGroup           cargo   1.0
 PortGroup           github  1.0
 
 github.setup        alacritty alacritty 0.12.3 v
-revision            1
+revision            2
 
 description         A cross-platform, GPU-accelerated terminal emulator
 
@@ -24,6 +24,11 @@ checksums           ${distname}${extract.suffix} \
                     rmd160  96cc1c45ff400f19c6c8d26ea44435a9060201c1 \
                     sha256  94d31b7662582a1a1dd3d5e5a6f7f6e5416524838d03466b158d5b19cf8deb0d \
                     size    1494120
+
+variant nerdfont description {Use Nerd Font Symbols as default fallback} {
+    patchfiles              crossfont-nerd-symbols.patch
+    patch.pre_args          -p0
+}
 
 set al_app_name     Alacritty.app
 set al_app_dir      ${applications_dir}/${al_app_name}
@@ -48,6 +53,10 @@ post-destroot {
         alacritty-msg.1 \
         ${destroot}${prefix}/share/man/man1
 
+    xinstall -d ${destroot}${prefix}/share/examples/alacritty
+    xinstall -m 0644 ${worksrcpath}/alacritty.yml \
+        ${destroot}${prefix}/share/examples/alacritty
+
     xinstall -d ${destroot}${prefix}/etc/bash_completion.d
     xinstall -m 0644 ${worksrcpath}/extra/completions/alacritty.bash \
         ${destroot}${prefix}/etc/bash_completion.d
@@ -62,6 +71,28 @@ post-destroot {
 }
 
 github.livecheck.regex  {([0-9.]+)}
+
+set help "
+    A sample configuration is provided at
+    * ${prefix}/share/examples/${name}/${name}.yml
+
+    You're encouraged to copy this file to
+    * ~/.config/${name}/${name}.yml
+    and adjust it to your needs.
+"
+set nerdhelp "
+    The installed nerdfont variant allows using 'Symbols Nerd Font'
+    as primary fallback for anything lacking in current font set.
+
+    To take advantage of this, make the 'Symbols Nerd Font' available
+    by copying font file(s) to ~/Library/Fonts, or adding them via Font Book.
+"
+
+if {[variant_isset nerdfont]} {
+    notes "${help} ${nerdhelp}"
+} else {
+    notes "${help}"
+}
 
 cargo.crates \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \

--- a/aqua/alacritty/files/crossfont-nerd-symbols.patch
+++ b/aqua/alacritty/files/crossfont-nerd-symbols.patch
@@ -1,0 +1,14 @@
+index 13acd4c..b1ca472 100644
+--- ../.home/.cargo/macports/crossfont-0.5.1/src/darwin/mod.rs
++++ ../.home/.cargo/macports/crossfont-0.5.1/src/darwin/mod.rs
+@@ -77,6 +77,10 @@ impl Descriptor {
+                 .map(|desc| desc.to_font(size, false))
+                 .collect::<Vec<_>>();
+ 
++            if let Ok(nerd_symbols) = new_from_name("Symbols Nerd Font", size) {
++                fallbacks.push(Font { ct_font: nerd_symbols, fallbacks: Vec::new() })
++            } else
++
+             // TODO, we can't use apple's proposed
+             // .Apple Symbol Fallback (filtered out below),
+             // but not having these makes us not able to render


### PR DESCRIPTION
Alacritty has long lacked proper fallback mechanism for displaying any missing characters/symbols. This patch adds a new default choice 'Symbols Nerd Font', effectively allowing to display the Nerd Font glyphs with any typeface.

###### Description

See commit msg. Also added the full commented example configuration file which I missed from previous update, and some notes to get started.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.0 23A344 arm64
Xcode 15.0 15A240d

###### Verification
Have you

- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`? -> `0 errors and 465 warnings found.` .. all unrelated
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
