### PR TITLE
mozjs115: new port

### DIFF
--- a/lang/mozjs115/Portfile
+++ b/lang/mozjs115/Portfile
@@ -1,0 +1,120 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           muniversal 1.0
+PortGroup           legacysupport 1.1
+
+# clock_gettime, TARGET_OS_SIMULATOR
+legacysupport.newest_darwin_requires_legacy 15
+
+name                mozjs115
+version             115.2.0
+revision            0
+set version_major   115
+
+# ld64.lld: error: undefined symbol: std::__1::__libcpp_verbose_abort(char const*, ...)
+platforms           {darwin >= 22}
+
+categories          lang
+license             {MPL-2 LGPL-2.1+}
+maintainers         nomaintainer
+
+# For Rust
+supported_archs     x86_64 arm64
+
+description         JavaScript-C Engine
+long_description    SpiderMonkey is Mozilla's JavaScript engine written in C/C++. \
+                    It is used in various Mozilla products, including Firefox, \
+                    and is available under the MPL2.
+homepage            https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey
+
+# build from GNOME releng tarball
+master_sites        https://ftp.gnome.org/pub/GNOME/teams/releng/tarballs-needing-help/mozjs/
+
+distname            mozjs-${version}gnome1
+worksrcdir          mozjs-${version}
+use_xz              yes
+
+checksums           rmd160  734650f45c0168949f9f4724b217a3fd84f49666 \
+                    sha256  e39c590c5175524eb3c388d4897f2d714454e602fe7fc548e950c7e0ca9170d5 \
+                    size    137246544
+
+depends_build       port:autoconf213 \
+                    port:cargo \
+                    port:pkgconfig \
+                    port:python311 \
+                    port:yasm
+
+depends_lib         port:xorg-libX11 \
+                    port:xorg-libXt
+
+# requires C++17 compiler to build
+compiler.cxx_standard 2017
+
+# Rust components require a MacPorts clang (i.e. one with llvm-config)
+compiler.blacklist  *gcc* clang macports-clang-3.*
+
+if {[regexp {macports-clang-(.*)} ${configure.compiler} -> llvm_ver]} {
+    configure.env-append \
+                    LLVM_CONFIG=${prefix}/bin/llvm-config-mp-${llvm_ver}
+}
+
+if { ${os.platform} eq "darwin" && ${os.major} < 11 } {
+    depends_build-append port:cctools
+    configure.env-append AR=${prefix}/bin/ar
+}
+
+patchfiles-append   patch-skip-sdk-check.diff \
+                    patch-mozglue-clock_gettime.diff \
+                    patch-mozglue-snow-leopard.diff
+
+# Use absolute path for install_name
+post-patch {
+    reinplace "s|@executable_path|${prefix}/lib|g" ${worksrcpath}/config/rules.mk
+}
+
+configure.perl      /usr/bin/perl
+configure.python    ${prefix}/bin/python3.11
+
+# The combination of JS_STANDALONE=1 and --disable-jemalloc are needed
+# to ensure that mozglue is statically linked.
+configure.env-append \
+                    PYTHON3=${configure.python} \
+                    SHELL=/bin/bash \
+                    JS_STANDALONE=1
+
+configure.dir       ${worksrcpath}/js/src/obj
+configure.cmd       ../configure
+
+configure.args      --disable-jemalloc \
+                    --disable-readline
+
+if {${configure.sdkroot} eq ""} {
+    configure.args-append --with-macos-sdk=/
+} else {
+    configure.args-append --with-macos-sdk=${configure.sdkroot}
+}
+
+configure.universal_args-delete --disable-dependency-tracking
+
+build.env-append    SHELL=/bin/bash
+build.dir           ${worksrcpath}/js/src/obj
+destroot.dir        ${worksrcpath}/js/src/obj
+
+post-destroot {
+    # make static lib name version specific to avoid conflict with other mozjs versions
+    move ${destroot}${prefix}/lib/libjs_static.ajs ${destroot}${prefix}/lib/libjs${version_major}_static.ajs
+}
+
+if {${universal_possible} && [variant_isset universal]} {
+    set merger_host(x86_64) x86_64-apple-${os.platform}${os.major}
+    set merger_host(arm64) arm64-apple-${os.platform}${os.major}
+    set merger_configure_args(x86_64) "--host=x86_64-apple-${os.platform}${os.major} --target=x86_64-apple-${os.platform}${os.major}"
+    set merger_configure_args(arm64) "--host=arm64-apple-${os.platform}${os.major} --target=arm64-apple-${os.platform}${os.major}"
+} else {
+    configure.args-append \
+        --host=${build_arch}-apple-${os.platform}${os.major} \
+        --target=${build_arch}-apple-${os.platform}${os.major}
+}
+
+livecheck.type      none

--- a/lang/mozjs115/files/patch-mozglue-clock_gettime.diff
+++ b/lang/mozjs115/files/patch-mozglue-clock_gettime.diff
@@ -1,0 +1,26 @@
+error: use of undeclared identifier 'CLOCK_UPTIME_RAW'
+
+--- mozglue/misc/AwakeTimeStamp.cpp.orig
++++ mozglue/misc/AwakeTimeStamp.cpp
+@@ -58,6 +58,9 @@
+ #  include <sys/time.h>
+ #  include <sys/types.h>
+ #  include <mach/mach_time.h>
++#endif
++
++#if defined(__APPLE__) && defined(__MACH__) && defined(CLOCK_UPTIME_RAW)
+ 
+ AwakeTimeStamp AwakeTimeStamp::NowLoRes() {
+   return AwakeTimeStamp(clock_gettime_nsec_np(CLOCK_UPTIME_RAW) / kNSperUS);
+--- mozglue/misc/Uptime.cpp.orig
++++ mozglue/misc/Uptime.cpp
+@@ -32,7 +32,9 @@
+ #  include <sys/time.h>
+ #  include <sys/types.h>
+ #  include <mach/mach_time.h>
++#endif
+ 
++#if defined(__APPLE__) && defined(__MACH__) && defined(CLOCK_UPTIME_RAW) && defined(CLOCK_MONOTONIC_RAW)
+ const uint64_t kNSperMS = 1000000;
+ 
+ Maybe<uint64_t> NowExcludingSuspendMs() {

--- a/lang/mozjs115/files/patch-mozglue-snow-leopard.diff
+++ b/lang/mozjs115/files/patch-mozglue-snow-leopard.diff
@@ -1,0 +1,24 @@
+Fix build errors on 10.6
+
+--- mozglue/misc/Mutex_posix.cpp.orig	2022-07-09 14:28:00.000000000 -0400
++++ mozglue/misc/Mutex_posix.cpp	2022-07-09 14:31:34.000000000 -0400
+@@ -11,7 +11,10 @@
+ #include <stdio.h>
+ 
+ #if defined(XP_DARWIN)
++#  include <Availability.h>
++#  if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+ #  include <pthread_spis.h>
++#  endif
+ #endif
+ 
+ #include "mozilla/PlatformMutex.h"
+@@ -65,7 +68,7 @@
+   TRY_CALL_PTHREADS(pthread_mutexattr_settype(&attr, MUTEX_KIND),
+                     "mozilla::detail::MutexImpl::MutexImpl: "
+                     "pthread_mutexattr_settype failed");
+-#  elif defined(POLICY_KIND)
++#  elif defined(POLICY_KIND) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+   if (__builtin_available(macOS 10.14, *)) {
+     TRY_CALL_PTHREADS(pthread_mutexattr_setpolicy_np(&attr, POLICY_KIND),
+                       "mozilla::detail::MutexImpl::MutexImpl: "

--- a/lang/mozjs115/files/patch-skip-sdk-check.diff
+++ b/lang/mozjs115/files/patch-skip-sdk-check.diff
@@ -1,0 +1,11 @@
+--- build/moz.configure/toolchain.configure.orig
++++ build/moz.configure/toolchain.configure
+@@ -113,7 +113,7 @@
+         if bootstrapped:
+             sdk = [bootstrapped]
+         if sdk:
+-            sdk = sdk[0]
++            return sdk[0]
+             try:
+                 version = get_sdk_version(sdk)
+             except Exception as e:


### PR DESCRIPTION
#### Description

Mostly copied from `mozjs102` with updated Python and a tweak to one patch.

Tested on macOS 13.6
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
