### PR TITLE
symfony-cli: update to 5.6.1

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.6.0
+version             5.6.1
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  006d1b4690155aea56c274fd64c6b9f79e1f4ced \
-                        sha256  42adaf0af646bb7ddc0ba1720eaef93c58fc7891ba0ac0cd4e291f30b43b1f00 \
-                        size    256751
+    checksums           rmd160  ed335d72ee511fe150d1ec22bf5886a4508041e8 \
+                        sha256  2b8a8970216393e88bca60dc15dd6350b091341c3474b423e901992e2548dd95 \
+                        size    256792
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  2853dd977a8ddaea93934ee4c04416fa1e26175d \
-                        sha256  867790a63cfa9f20c8bec515bc38c4a52824dcea207ad6ff62ce68b05c3495bc \
-                        size    11130891
+    checksums           rmd160  4e20e2857e84f4404e3dce0bd6541e7e4ea4827c \
+                        sha256  dcdf1b7cc85f49eaed97846ac42cf53abee095d88d4de98af0f59bea7a0a7eda \
+                        size    11132001
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.6.1

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
