### PR TITLE
openjdk17-temurin: update to 17.0.9

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.8.1
-set build    1
+version      17.0.9
+set build    9
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  157a217fa0c676f7f0feab64f29027b9f4305499 \
-                 sha256  18be56732c1692ef131625d814dcb02ee091a43fdd6f214a33d87cc14842fc3f \
-                 size    187618128
+    checksums    rmd160  b14a19d55b727969e69cea17170626de54fb3c6f \
+                 sha256  c69b37ea72136df49ce54972408803584b49b2c91b0fbc876d7125e963c7db37 \
+                 size    180411874
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  5c46b4f219da55ab60e8f7fb91b7d7bf67c47d24 \
-                 sha256  2e95eed48650f00650e963c8213b6c6ecda54458edf8d254ebc99d6a6966ffad \
-                 size    177735753
+    checksums    rmd160  eaa606a250ad3ee825b9f21ed73802c4d2ce9d57 \
+                 sha256  823777266415347983bbd87ccd8136537242ff27e62f307b7e8521494c665f0d \
+                 size    177999702
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.9.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?