### PR TITLE
openjdk11-temurin: update to 11.0.21

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      11.0.20.1
-set build    1
+version      11.0.21
+set build    9
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  cd84caf900e3c2b39c6eba9d3406ef7a88b2da54 \
-                 sha256  42fd1373ee3f7c24f13551be20c8a5ae7ade778f83c45476ea333b2e3e025267 \
-                 size    186910284
+    checksums    rmd160  7fc424cc69b7677034657fc73b2ab3df6b00334a \
+                 sha256  39e30e333d01f70765f0fdc57332bc2c5ae101392bcc315ef06f472d80d8e2d7 \
+                 size    188046241
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  59654c32b5a21481dea81298abc2717eeb23a663 \
-                 sha256  d36abd2f8a8cd2c73a7893306d65a5ae03eaa73565c1fc197a69d1d6fb02405e \
-                 size    185621787
+    checksums    rmd160  906927629a790cbca1cdd0be7de246fbcdd45270 \
+                 sha256  3be236f2cf9612cd38cd6b7cfa4b8eef642a88beab0cd37c6ccf1766d755b4cc \
+                 size    185950980
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.21.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?