### PR TITLE
libhv: update to 1.3.2

### DIFF
--- a/devel/libhv/Portfile
+++ b/devel/libhv/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           openssl 1.0
 
-github.setup        ithewei libhv 1.3.1 v
+github.setup        ithewei libhv 1.3.2 v
 github.tarball_from archive
 revision            0
 
@@ -17,9 +17,9 @@ license             BSD
 description         A c/c++ network library for developing TCP/UDP/SSL/HTTP/WebSocket/MQTT client/server
 long_description    {*}${description}
 
-checksums           rmd160  27c3bb6613ede4ae8ce5c685b7987a41eeed70b0 \
-                    sha256  da4757c3520854cf2081f796733f7bc023651d60baab448a06fcf66435a859be \
-                    size    880367
+checksums           rmd160  3464245d617a73d27a7f6d40ac29d3ecd8a24a1c \
+                    sha256  fd88f0beb2bdad2f9fc642bfc699b21dffdf30dc06107e8108633b7ee3869169 \
+                    size    911703
 
 compiler.cxx_standard 2011
 


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/ithewei/libhv/releases/tag/v1.3.2)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
