### PR TITLE
openjdk21-graalvm: update to 21.0.1

### DIFF
--- a/java/openjdk21-graalvm/Portfile
+++ b/java/openjdk21-graalvm/Portfile
@@ -14,7 +14,8 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version     21.0.0
+version     21.0.1
+set build 12
 revision    0
 
 description  GraalVM Community Edition based on OpenJDK 21
@@ -25,17 +26,17 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-community-jdk-${version}_macos-x64_bin
-    checksums    rmd160  1b8a735770c4457ba9e07b2f492d580c89c8043d \
-                 sha256  935a32c4621d5144b4678dd135884435de3185683025cf0258dc1ed95d1f7fe1 \
-                 size    281411300
+    checksums    rmd160  0b88d7e121eb9ae0c9c9a7f68d70fd04930f94f0 \
+                 sha256  dafe240fb9e420cfef84ad8871b85cffc64988fd5520c4601e15b04687317a6a \
+                 size    281488634
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-community-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  9720f19ab1f24a452cb80c40eec4597abfba05f6 \
-                 sha256  c58de71e60af7970ca087cb9f5af9a8770562aee0cac99d6017b63b8c0d50f37 \
-                 size    294179424
+    checksums    rmd160  2a8d93b1ce44dd0c77497fef12237dc6b83a9d3d \
+                 sha256  50c42bc748e528a9702eaa66e894cf6d125a19b91f1df1c3a484bdcf02feff44 \
+                 size    294239130
 }
 
-worksrcdir   graalvm-community-openjdk-21+35.1
+worksrcdir   graalvm-community-openjdk-${version}+${build}.1
 
 homepage     https://www.graalvm.org
 


### PR DESCRIPTION
#### Description

Update to GraalVM for JDK 21 Community 21.0.1.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?