### PR TITLE
openjdk17-graalvm: update to 17.0.9

### DIFF
--- a/java/openjdk17-graalvm/Portfile
+++ b/java/openjdk17-graalvm/Portfile
@@ -14,8 +14,9 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version     17.0.8
-revision    3
+version     17.0.9
+set build 9
+revision    0
 epoch       1
 
 master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${version}/
@@ -37,17 +38,17 @@ if {${subport} eq ${name}} {
 
     if {${configure.build_arch} eq "x86_64"} {
         distname     graalvm-community-jdk-${version}_macos-x64_bin
-        checksums    rmd160  26e3d0b7238a6c7fbe10afeae0c4b0e8740b268a \
-                     sha256  cf4bb646018da8bf93f67e5cdae0f583b276d278d0b667d779a68d11d3b6873d \
-                     size    283915786
+        checksums    rmd160  3eae40f01c3fbc437ca8916c21d0b9edab978e49 \
+                     sha256  543dd286d99c04788847ef6366f794c059a69e77added577916186371e206e33 \
+                     size    284038595
     } elseif {${configure.build_arch} eq "arm64"} {
         distname     graalvm-community-jdk-${version}_macos-aarch64_bin
-        checksums    rmd160  858b540bd9d1ecaef6e89d6f4bb6893a21d6881c \
-                     sha256  89209bbf8346d8dd0847d431bd8654db7d4ff634745207f20af2045c4869fb49 \
-                     size    279784572
+        checksums    rmd160  c2beacba5aa97f89972e29cf3ddaa749f52c726a \
+                     sha256  3eccc4ffda01818172b7fc7cdf4379bc62ed7129ee30ca854c04da67057249c9 \
+                     size    280304421
     }
 
-    worksrcdir   graalvm-community-openjdk-${version}+7.1
+    worksrcdir   graalvm-community-openjdk-${version}+${build}.1
 
     variant Applets \
         description { Advertise the JVM capability "Applets".} {}


### PR DESCRIPTION
#### Description

Update to GraalVM for JDK 17 Community 17.0.9.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?