### PR TITLE
msdfgen: new port

### DIFF
--- a/graphics/msdfgen/Portfile
+++ b/graphics/msdfgen/Portfile
@@ -1,0 +1,71 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        Chlumsky msdfgen 1.9 v
+github.tarball_from archive
+revision            0
+
+categories          graphics textproc games devel print
+license             MIT
+maintainers         @jasonliu--
+
+description         multi-channel signed distance field generator
+long_description    MSDFgen is a utility for generating signed \
+                    distance fields from vector shapes and font \
+                    glyphs, which serve as a texture representation \
+                    that can be used in real-time graphics to \
+                    efficiently reproduce said shapes. This is often \
+                    applicable to, for example, using texture maps to \
+                    represent \"line-art\" images, such as text, \
+                    signs, and UI elements, that need to be rendered \
+                    in real-time in computer games.
+
+checksums           rmd160  849ca3125c1122e9f03eed2debf1076648b0f059 \
+                    sha256  909eb88c71268dc00cdda244a1fa40a0feefae45f68a779fbfddd5463559fa40 \
+                    size    1807089
+
+compiler.cxx_standard   2011
+
+depends_lib-append      port:freetype \
+                        port:libpng \
+                        port:zlib
+
+configure.args-append   -DFREETYPE_WITH_PNG=ON \
+                        -DBUILD_SHARED_LIBS=ON
+
+post-destroot {
+    # Create a pkg-config file (needed by Godot)
+    xinstall -d ${destroot}${prefix}/lib/pkgconfig
+    set fp [open ${destroot}${prefix}/lib/pkgconfig/${name}.pc w]
+    foreach line [list \
+        "prefix=${prefix}" \
+        "exec_prefix=\${prefix}" \
+        "libdir=\${prefix}/lib" \
+        "includedir=\${prefix}/include" \
+        "" \
+        "Name: ${name}" \
+        "Description: ${description}" \
+        "URL: ${homepage}" \
+        "Version: ${version}" \
+        "" \
+        "Requires:" \
+        "Requires.private: freetype2 libpng zlib" \
+        "Libs: -L\${libdir} -l${name}" \
+        "Cflags: -I\${includedir}/${name}" \
+    ] {
+        puts $fp $line
+    }
+    close $fp
+}
+
+variant openmp description {Enable OpenMP support} {
+    compiler.openmp_version     3.1
+
+    configure.args-append       -DMSDFGEN_USE_OPENMP=ON
+    configure.ldflags-append    -L${prefix}/lib/libomp -lomp
+}
+
+default_variants    +openmp


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

MSDFgen is a utility for generating signed distance fields from vector shapes and font glyphs, which serve as a texture representation that can be used in real-time graphics to efficiently reproduce said shapes. This is often applicable to, for example, using texture maps to represent "line-art" images, such as text, signs, and UI elements, that need to be rendered in real-time in computer games.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 8.2.1 8C1002

macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
