### PR TITLE
boost178, boost181: backport `BOOST_CLANG_VERSION` fix for LLVM clang

### DIFF
--- a/devel/boost178/Portfile
+++ b/devel/boost178/Portfile
@@ -121,6 +121,10 @@ post-patch {
     reinplace "s|__MACPORTS_CXX__|${configure.cxx}|g" ${worksrcpath}/tools/build/src/tools/clang-darwin.jam
 }
 
+# Define BOOST_CLANG_VERSION correctly when LLVM.org clang is used instead of Apple clang.
+# https://github.com/boostorg/config/pull/487
+patchfiles-append patch-boost-clang-version-llvmorg-on-apple.diff
+
 # Build issue on some older systems
 # ld: warning: option -s is obsolete and being ignored
 # ld: internal error: atom not found in symbolIndex(__ZNSt3__1plIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_12basic_stringIT_T0_T1_EERKS9_SB_) for architecture x86_64
@@ -364,7 +368,7 @@ subport ${name}-numpy {
 
 if {$subport eq $name} {
 
-    revision 6
+    revision 7
 
     patchfiles-append patch-disable-numpy-extension.diff
 

--- a/devel/boost178/files/patch-boost-clang-version-llvmorg-on-apple.diff
+++ b/devel/boost178/files/patch-boost-clang-version-llvmorg-on-apple.diff
@@ -1,0 +1,13 @@
+--- boost/config/compiler/clang_version.hpp
++++ boost/config/compiler/clang_version.hpp
+@@ -1,9 +1,9 @@
+ // Copyright 2021 Peter Dimov
+ // Distributed under the Boost Software License, Version 1.0.
+ // https://www.boost.org/LICENSE_1_0.txt)
+ 
+-#if !defined(__APPLE__)
++#if !defined(__apple_build_version__)
+ 
+ # define BOOST_CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+ 
+ #else

--- a/devel/boost181/Portfile
+++ b/devel/boost181/Portfile
@@ -139,6 +139,10 @@ post-patch {
     reinplace "s|__MACPORTS_CXX__|${configure.cxx}|g" ${worksrcpath}/tools/build/src/tools/clang-darwin.jam
 }
 
+# Define BOOST_CLANG_VERSION correctly when LLVM.org clang is used instead of Apple clang.
+# https://github.com/boostorg/config/pull/487
+patchfiles-append patch-boost-clang-version-llvmorg-on-apple.diff
+
 # Build issue on some older systems
 # ld: warning: option -s is obsolete and being ignored
 # ld: internal error: atom not found in symbolIndex(__ZNSt3__1plIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_12basic_stringIT_T0_T1_EERKS9_SB_) for architecture x86_64
@@ -377,7 +381,7 @@ subport ${name}-numpy {
 
 if {$subport eq $name} {
 
-    revision 7
+    revision 8
 
     patchfiles-append patch-disable-numpy-extension.diff
 

--- a/devel/boost181/files/patch-boost-clang-version-llvmorg-on-apple.diff
+++ b/devel/boost181/files/patch-boost-clang-version-llvmorg-on-apple.diff
@@ -1,0 +1,13 @@
+--- boost/config/compiler/clang_version.hpp
++++ boost/config/compiler/clang_version.hpp
+@@ -1,9 +1,9 @@
+ // Copyright 2021 Peter Dimov
+ // Distributed under the Boost Software License, Version 1.0.
+ // https://www.boost.org/LICENSE_1_0.txt)
+ 
+-#if !defined(__APPLE__)
++#if !defined(__apple_build_version__)
+ 
+ # define BOOST_CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__ % 100)
+ 
+ #else


### PR DESCRIPTION
#### Description
I have not observed a specific error in MacPorts which this fixes, but since MacPorts often uses LLVM clang instead of Apple clang, it seems it would be beneficial to have this fix.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Not tested from MacPorts.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
