### PR TITLE
Several py312 updates (zope-event, zopeinterface, hypothesis)

### DIFF
--- a/python/py-hypothesis/Portfile
+++ b/python/py-hypothesis/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-hypothesis
-version             6.82.6
+version             6.88.1
 revision            0
 categories-append   devel
 platforms           {darwin any}
 supported_archs     noarch
 license             MPL-2
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 maintainers         {khindenburg @kurthindenburg} \
                     {@catap korins.ky:kirill} \
@@ -26,9 +26,9 @@ long_description \
 
 homepage            https://pypi.python.org/pypi/hypothesis
 
-checksums           rmd160  9d1a73c22296195a4c19c1ee79cd58efbe596d2d \
-                    sha256  f52ac4180a16208224e3d648fbf0fef8b9ca24863ba4b41bfef30a78c42646bd \
-                    size    353353
+checksums           rmd160  ee87bfe7a9126af631523d66b8b9bc5b0bb6dff9 \
+                    sha256  f4c2c004b9ec3e0e25332ad2cb6b91eba477a855557a7b5c6e79068809ff8b51 \
+                    size    359984
 
 if {${name} ne ${subport}} {
     depends_build-append  port:py${python.version}-setuptools

--- a/python/py-zope-event/Portfile
+++ b/python/py-zope-event/Portfile
@@ -5,8 +5,8 @@ PortGroup           python 1.0
 
 name                py-zope-event
 python.rootname     zope.event
-version             4.5.0
-revision            1
+version             5.0
+revision            0
 categories-append   zope
 license             ZPL-2.1
 maintainers         nomaintainer
@@ -22,19 +22,31 @@ platforms           {darwin any}
 
 homepage            https://github.com/zopefoundation/zope.event
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
-checksums           rmd160  1de457c479b1c8421ee81f7106ca7d02a924fb8c \
-                    sha256  5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330 \
-                    size    18723
+checksums           rmd160  b18ff29ee3dfd489a8f3f20025a845c38aa2ceaf \
+                    sha256  bac440d8d9891b4068e2b5a2c5e2c9765a9df762944bda6955f96bb9b91e67cd \
+                    size    17350
 
 if {${name} ne ${subport}} {
     depends_build       port:py${python.version}-setuptools
+
+    if {${python.version} <= 36} {
+        version             4.6
+        revision            0
+
+        checksums           rmd160  97fd3e3cf7c0b0d147761d543d3743a697d301f1 \
+                            sha256  81d98813046fc86cc4136e3698fee628a3282f9c320db18658c21749235fce80 \
+                            size    17430
+
+        livecheck.type none
+    }
 
     variant tests description {Add dependencies needed to run tests} {
         test.run        yes
         depends_build   port:py${python.version}-nose
         test.cmd        nosetests-${python.branch}
+        test.args
         test.target
     }
 }

--- a/python/py-zopeinterface/Portfile
+++ b/python/py-zopeinterface/Portfile
@@ -5,9 +5,9 @@ PortGroup           python 1.0
 
 name                py-zopeinterface
 python.rootname     zope.interface
-version             5.5.1
+version             6.1
 revision            0
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 categories-append   zope
 license             ZPL-2.1
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -16,9 +16,9 @@ long_description    {*}${description}
 
 homepage            https://zopetoolkit.readthedocs.io/
 
-checksums           rmd160  9d4c18ef846cefd59b5809c7157571e625207478 \
-                    sha256  6d678475fdeb11394dc9aaa5c564213a1567cc663082e0ee85d52f78d1fbaab2 \
-                    size    300064
+checksums           rmd160  b47e79fef2bb5bee43e0156b46a819ce0e63a6ba \
+                    sha256  2fdc7ccbd6eb6b7df5353012fbed6c3c5d04ceaca0038f75e601060e95345309 \
+                    size    293914
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools
@@ -27,7 +27,19 @@ if {${name} ne ${subport}} {
     depends_test    port:py${python.version}-coverage \
                     port:py${python.version}-zope-event
 
+    if {${python.version} <= 36} {
+        version             5.5.2
+        revision            0
+
+        checksums           rmd160  b56a9e93853ccc43993cf3b6f893a9d1986e6917 \
+                            sha256  bfee1f3ff62143819499e348f5b8a7f3aa0259f9aca5e0ddae7391d059dce671 \
+                            size    300533
+
+        livecheck.type none
+    }
+
     test.run        yes
+    test.args       --pyargs zope.interface.common.tests
 
     post-destroot {
         xinstall -d ${destroot}${prefix}/share/doc/${subport}


### PR DESCRIPTION
#### Description

py-zope-event: update to 5.0 and add py312 subport

- update to 5.0
- add py312 subport
- update to version 4.6 for Python <= 3.6
- fix testing

py-zopeinterface: update to 6.1 and add py312 subport

- update to 6.1
- add py312 subport
- update to 5.5.2 for Python <= 3.6
- fix testing

py-hypothesis: update to 6.88.1 and add py312 subport

- update to 6.88.1
- add py312 subport


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
