### PR TITLE
google-cloud-sdk: update to 452.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             451.0.1
+version             452.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  d3baa979134e585f022d14aa3cb32d19ab3b94bc \
-                    sha256  8a7bf70952fcba3d5d06a8c755295322c54a9439ff03f04676bc7ac5160bb323 \
-                    size    121618374
+    checksums       rmd160  7ab65c26dd3ae6c2c115bcaba06a140719732b73 \
+                    sha256  2eeaaf09695e3c7d51c37cd3e2959e33a448fd6b9341b8fe318aec22d48cfa67 \
+                    size    121703021
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  2b7a7dbe4abcabe04cde053776e3356ed19b6a30 \
-                    sha256  512f3bb29887ec934a8ec629436dafc023c5acaea0f6739d906498d8abe401b7 \
-                    size    122902329
+    checksums       rmd160  22cade29bbc1d43fe054a556c88d9b53d60e8bcb \
+                    sha256  26441a36fbc0f62083c18fa392072096591cb3b5cf781a36117388dca85b314a \
+                    size    122988545
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  20ae81f33dabc8ca8cb13bfdc2cb9abf1af8b43c \
-                    sha256  bdd94c06f0216ceb846a2a6797d73df31a0e92c2b1196477d2765fd2765f8a1d \
-                    size    120005010
+    checksums       rmd160  9946b2f90f51d4d40d139ef552067519fca2e3ec \
+                    sha256  ec19baff8ba2cc981a4ba65684a4ff592d274b9cb89b3a8b030077078ea511ef \
+                    size    120065606
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 452.0.0.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?