### PR TITLE
ruby-build: Update to 20231025

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20231014 v
+github.setup        rbenv ruby-build 20231025 v
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +16,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  f057cdb4e3413a5a775d998c93cca9ac1ad4a185 \
-                    sha256  b3a4bb1c329019e3f7f43da7d171a41fb5f6d7e2fbcd52031ae06da344b7bb65 \
-                    size    80350
+checksums           rmd160  8a5cd21f7ffc30662e856b3a43bb9afdfc8e5edf \
+                    sha256  aaf8f6a6bbccc7bcb7f53bbe459805a451d097d2ff68d11d584f4d77373b3dd6 \
+                    size    81637
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

https://github.com/rbenv/ruby-build/releases/tag/v20231025

- Cleanup in truffleruby+graalvm installation
- Avoid compiling OpenSSL if the user supplied --with-openssl-dir on the
  command line
- Cleanup in OpenSSL compilation step
- Avoiding excessive cd when fetching git repos
- Remove implicit LDFLAGS, CPPFLAGS, and "ldflags_dirs" build step
- Add tests for functionality related to linking to OpenSSL
- Add JRuby 9.4.4.0
- Remove strict openssl@1.1 requirement from TruffleRuby, jruby-dev
  definitions
- Fix fixing JRuby shebangs on macOS
- Skip ri/rdoc when installing jruby-launcher
- Bump up OpenSSL 3.1.4
- Add TruffleRuby and TruffleRuby GraalVM 23.1.1

###### Tested on

macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
