### PR TITLE
openjdk8-temurin: update to 8u392

### DIFF
--- a/java/openjdk8-temurin/Portfile
+++ b/java/openjdk8-temurin/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64
 
-version      8u382
-set build    05
+version      8u392
+set build    08
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 8
@@ -26,9 +26,9 @@ master_sites https://github.com/adoptium/temurin8-binaries/releases/download/jdk
 distname     OpenJDK8U-jdk_x64_mac_hotspot_${version}b${build}
 worksrcdir   jdk${version}-b${build}
 
-checksums    rmd160  35c5cdf652d4cb933b690073f7fb95a63f7643a6 \
-             sha256  f314bfcafebbf2fe22867b577bf55423c0b5da7baf6ba7f5bfbfa48b09091f82 \
-             size    107309922
+checksums    rmd160  d31bab8af590c3260da5d78b4955de549469388e \
+             sha256  d152f5b2ed8473ee0eb29c7ee134958d75ea86c8ccbafb5ee04a5545dd76108f \
+             size    109468323
 
 homepage     https://adoptium.net
 


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 8u392.

###### Tested on

macOS 14.0 23A344 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?