### PR TITLE
qtkeychain-qt5, qtkeychain-qt6: attempt to fix build

### DIFF
--- a/security/qtkeychain/Portfile
+++ b/security/qtkeychain/Portfile
@@ -41,12 +41,14 @@ foreach qt_major {4 5 6} {
 
         switch ${qt_major} {
             6 {
+                qt6.depends_build-append qttools
                 qt6.depends_lib-append  qttranslations
                 configure.args-append -DBUILD_WITH_QT6=ON
                 configure.args-append -DBUILD_WITH_QT4=OFF
             }
 
             5 {
+                qt5.depends_build_component qttools
                 qt5.depends_component qttranslations
                 configure.args-append -DBUILD_WITH_QT4=OFF
             }


### PR DESCRIPTION
#### Description
See https://build.macports.org/builders/ports-14_x86_64-builder/builds/3248/steps/install-port/logs/stdio
```
CMake Error at /opt/local/lib/cmake/Qt5/Qt5Config.cmake:28 (find_package):
  Could not find a package configuration file provided by "Qt5LinguistTools"
  with any of the following names:

    Qt5LinguistToolsConfig.cmake
    qt5linguisttools-config.cmake

  Add the installation prefix of "Qt5LinguistTools" to CMAKE_PREFIX_PATH or
  set "Qt5LinguistTools_DIR" to a directory containing one of the above
  files.  If "Qt5LinguistTools" provides a separate development package or
  SDK, be sure it has been installed.
```

I believe this is due to qt5-qttranslations and qt6-qttranslations no longer depending on qt5-qttools and qt6-qttools at runtime (#20078). I have not checked if other qttranslations dependents are affected by the same issue.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Untested
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
