### PR TITLE
angband: update to 4.2.5

### DIFF
--- a/games/angband/Portfile
+++ b/games/angband/Portfile
@@ -1,17 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
 
-name                angband
-version             4.2.1
-checksums           rmd160  ee9563a318770a3f81d71839ddcbb201a7588826 \
-                    sha256  acd735c9d46bf86ee14337c71c56f743ad13ec2a95d62e7115604621e7560d0f \
-                    size    24938593
+github.setup        angband angband 4.2.5
+github.tarball_from archive
+checksums           rmd160  3c667f7b154d0b510083ceb66e809bf68809238e \
+                    sha256  2a27ce296310c4cbf960e2eb41ef55d383e546f24533446cf224119498a99651 \
+                    size    25801900
 
-set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          games
 license             Noncommercial
-platforms           darwin
 
 maintainers         nomaintainer
 
@@ -21,8 +20,7 @@ based (loosely) on the books of J.R.R.Tolkien. You explore a very deep \
 dungeon, kill monsters, try to equip yourself with the best weapons and \
 armor you can find, and finally face Morgoth - The Dark Enemy.
 
-homepage            http://rephial.org/
-master_sites        ${homepage}downloads/${branch}
+homepage            https://rephial.org/
 
 patchfiles-append   patch-makefile-osx.diff
 
@@ -85,5 +83,5 @@ if {![variant_exists aqua] || ![variant_isset aqua]} {
                     --without-x
 }
 
-livecheck.type      regex
+livecheck.url       ${homepage}
 livecheck.regex     ${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}

--- a/games/angband/files/patch-makefile-osx.diff
+++ b/games/angband/files/patch-makefile-osx.diff
@@ -1,15 +1,6 @@
---- src/Makefile.osx.orig	2020-12-29 13:17:51.000000000 -0600
-+++ src/Makefile.osx	2020-12-29 13:30:06.000000000 -0600
-@@ -18,7 +18,7 @@
- WARNINGS = -W -Wall -Wno-unused-parameter -Wno-missing-field-initializers \
- 	-Wunused-macros
- JUST_C = -std=c99
--OBJ_CFLAGS = -std=c99 -x objective-c -fobjc-arc -mmacosx-version-min=10.9
-+OBJ_CFLAGS = -std=c99 -x objective-c -fobjc-arc 
- CFLAGS = -g -I. $(WARNINGS) $(OPT) -DMACH_O_CARBON -DHAVE_MKSTEMP \
- 	-fno-stack-protector $(ARCHFLAGS)
- LIBS = -framework Cocoa
-@@ -63,7 +63,6 @@
+--- src/Makefile.osx.orig
++++ src/Makefile.osx
+@@ -73,14 +73,13 @@ OSX_OBJS = main-cocoa.o
  
  $(EXE).o: $(OBJS)
  	@for A in $(ARCHS); do \
@@ -17,8 +8,7 @@
  		$(LD) -r -arch $$A -o $@.$$A $(OBJS); \
  		LIPO_ARGS="$$LIPO_ARGS -arch $$A $@.$$A"; \
  	done; \
-@@ -72,7 +71,7 @@
- izzywizzy: $(OBJS) izzywizzy.o
+ 	lipo $$LIPO_ARGS -create -output $@
  
  $(EXE): $(EXE).o $(OSX_OBJS)
 -	$(DEPLOYMENT_TARGET) $(CC) $(CFLAGS) $(LDFLAGS) -o $(EXE) $(EXE).o $(OSX_OBJS) $(LIBS) 
@@ -26,7 +16,7 @@
  
  #
  # Clean up old junk
-@@ -87,11 +86,9 @@
+@@ -95,11 +94,9 @@ clean:
  #
  
  %.o : %.m


### PR DESCRIPTION
* Move to github. Keep old livecheck, too many pre-releases so github livecheck fails to match when excluding them
* Remove OBJ_CFLAGS override now in source from patch

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
