### PR TITLE
qtkeychain-qt4: disable livecheck

### DIFF
--- a/security/qtkeychain/Portfile
+++ b/security/qtkeychain/Portfile
@@ -29,6 +29,8 @@ foreach qt_major {4 5 6} {
             checksums   rmd160  9f587e90344fe2661f967a29ec7464a1977c2af1 \
                         sha256  77fc6841c1743d9e6bd499989481cd9239c21bc9bf0760d41a4f4068d2f0a49d \
                         size    41001
+
+            livecheck.type none
         } else {
             github.setup frankosterfeld qtkeychain ${version} v
 


### PR DESCRIPTION
[ci skip]

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
