### PR TITLE
ntpsec: add python312 variant

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -40,7 +40,7 @@ if { ${os.platform} eq "darwin" && ${os.major} < 10 } {
 # We skip 2.6 and 3.3, but keep 2.7 and 3.4+.
 # Some variants may force a more restricted list.
 #
-set pythons_suffixes {27 34 35 36 37 38 39 310 311}
+set pythons_suffixes {27 34 35 36 37 38 39 310 311 312}
 
 set pythons_ports {}
 foreach s ${pythons_suffixes} {
@@ -102,6 +102,13 @@ openssl.branch      3
 
 depends_build-append port:bison port:pkgconfig
 #depends_lib-append  port:python${pyver_no_dot}
+
+# Python 3.12+ has deprecated distutils, which is needed by the build.
+# It remains available via setuptools, so we add the dependency.
+# This seems to have been fixed upstream, so the next release can remove this.
+if {${pyver_no_dot} >= 312} {
+    depends_build-append port:py${pyver_no_dot}-setuptools
+}
 
 # Consolidated patchfile, based on GitHub/fhgwright/macports-releases
 patchfiles          patch-allfixes.diff


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68554

As usual, this includes the patches for compatibility with macOS<10.13, which can also be seen (more readably) at:

    https://gitlab.com/fhgwright/ntpsec/tree/macports-1_2_2a

Note that 10.5 x86_64 remains broken and is disabled, as is the untested 10.4 x86_64.

TESTED:
Built and ran tests with all variants on 10.4-10.5 ppc, 10.4-10.6 i386, 10.6-10.15 x86_64, and 11.x-14.x arm64.  Successful except where pythonXY was unavailable or broken on the OS/CPU combination.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.1 21G920, arm64, Xcode 14.2 14C18
macOS 13.6.1 22G313, arm64, Xcode 15.0.1 15A507
macOS 14.1 23B74, arm64, Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
