### PR TITLE
blockout2: fix livecheck

### DIFF
--- a/games/blockout2/Portfile
+++ b/games/blockout2/Portfile
@@ -8,7 +8,6 @@ version                 2.4
 revision                1
 set short_version       [strsed ${version} {g/\.//}]
 categories              games
-platforms               darwin
 maintainers             rixon.org:jeremy
 license                 GPL-2+
 installs_libs           no
@@ -22,7 +21,8 @@ distname                bl${short_version}-src-linux-i586
 worksrcdir              bl${short_version}_lin_src
 
 checksums               rmd160  3ddbf10a71b748687f335cd5ec55a8fbf8f9e138 \
-                        sha256  c95766b8d6fce9820e14a23cd1bdea28591c01d8fdf5ece06cca1071f082c088
+                        sha256  c95766b8d6fce9820e14a23cd1bdea28591c01d8fdf5ece06cca1071f082c088 \
+                        size    5017393
 
 depends_lib             port:libsdl \
                         port:libsdl_mixer
@@ -58,3 +58,7 @@ destroot.args           PREFIX=${prefix}
 
 app.name                BlockOut II
 app.executable          ${prefix}/bin/blockout2
+
+livecheck.type          regex
+livecheck.url           ${homepage}
+livecheck.regex         Release (\[0-9.\]+)


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
