### PR TITLE
bzflag: update to 2.4.26, fix livecheck

### DIFF
--- a/games/bzflag/Portfile
+++ b/games/bzflag/Portfile
@@ -4,10 +4,9 @@ PortSystem          1.0
 PortGroup           app 1.0
 
 name                bzflag
-version             2.4.22
+version             2.4.26
 revision            0
 categories          games
-platforms           darwin
 maintainers         {allejo.io:me @allejo} openmaintainer
 license             {LGPL-2.1 MPL-2}
 
@@ -19,9 +18,9 @@ homepage            https://www.bzflag.org/
 master_sites        https://download.bzflag.org/bzflag/source/${version}/
 use_bzip2           yes
 
-checksums           rmd160  32c53a9c6a64faf8d25a4a70da174e1e7514c63c \
-                    sha256  9e64653302b657bd8b5f96fe1150a9ff80a1d53a6d7e8a35138c6b1b02006a4d \
-                    size    14169079
+checksums           rmd160  2aa5256083f20845b8bfddb3f7c3db7991324682 \
+                    sha256  01830405ff26ad1dc595a7e0695c824c2786e678868d9ff822aeb14ac7481014 \
+                    size    14107130
 
 depends_build       port:pkgconfig
 depends_lib         port:c-ares \
@@ -42,4 +41,4 @@ app.name            BZFlag
 app.icon            data/bzflag-256x256.png
 
 livecheck.url       https://download.bzflag.org/bzflag/source/
-livecheck.regex     {(\d+(?:\.\d+)*)/}
+livecheck.regex     {(\d+(?:\.(?:\d|\w)+)*)/}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files? (it opens, didn't join a game)
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
