### PR TITLE
google-cloud-sdk: update to 452.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             452.0.0
+version             452.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  7ab65c26dd3ae6c2c115bcaba06a140719732b73 \
-                    sha256  2eeaaf09695e3c7d51c37cd3e2959e33a448fd6b9341b8fe318aec22d48cfa67 \
-                    size    121703021
+    checksums       rmd160  8aa00dc7ff1452ad36d1eebc378084845c8625e3 \
+                    sha256  3e05a23768bcfda72f61be352f296ae4f160f89ee7453f302c2991962134f12a \
+                    size    121744975
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  22cade29bbc1d43fe054a556c88d9b53d60e8bcb \
-                    sha256  26441a36fbc0f62083c18fa392072096591cb3b5cf781a36117388dca85b314a \
-                    size    122988545
+    checksums       rmd160  1c567217acd0e4749875ffcc68a8602182716a41 \
+                    sha256  9681aea1380e3e366039fd46fe409e4a0733513f11789813a77a30bab408bf3f \
+                    size    123030529
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  9946b2f90f51d4d40d139ef552067519fca2e3ec \
-                    sha256  ec19baff8ba2cc981a4ba65684a4ff592d274b9cb89b3a8b030077078ea511ef \
-                    size    120065606
+    checksums       rmd160  25cb388303531049c742640d4c476018058b9fa1 \
+                    sha256  57b9460c87f3dcd8df2ffc921b50223a1b0b5f619bdee762c436bb3a716ffed6 \
+                    size    120107832
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 452.0.1.

###### Tested on

macOS 14.1 23B74 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?