### PR TITLE
py-pytest-xdist: update to 3.3.1

### DIFF
--- a/python/py-pytest-xdist/Portfile
+++ b/python/py-pytest-xdist/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pytest-xdist
-version             2.2.1
+version             3.3.1
 revision            0
 
 categories-append   devel
@@ -18,9 +18,9 @@ long_description    {*}${description}
 
 homepage            https://github.com/pytest-dev/pytest-xdist
 
-checksums           rmd160  b720976b2924ac7e660cb342e4b59545f6d44bb3 \
-                    sha256  718887296892f92683f6a51f25a3ae584993b06f7076ce1e1fd482e59a8220a2 \
-                    size    64956
+checksums           rmd160  9283fac66adbe218c9fba602b1c621b9d02e39bf \
+                    sha256  d5ee0520eb1b7bcca50a60a518ab7a7707992812c578198f8b44fdfac78e8c93 \
+                    size    77751
 
 python.versions     37 38 39 310 311
 
@@ -30,14 +30,11 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-execnet \
-                    port:py${python.version}-pytest \
-                    port:py${python.version}-pytest-forked \
-                    port:py${python.version}-setuptools \
-                    port:py${python.version}-six
+                    port:py${python.version}-pytest
 
     post-destroot {
         xinstall -d ${destroot}${prefix}/share/doc/${subport}
         xinstall -m 0644 -W ${worksrcpath} CHANGELOG.rst README.rst LICENSE \
-            OVERVIEW.md ${destroot}${prefix}/share/doc/${subport}
+            ${destroot}${prefix}/share/doc/${subport}
     }
 }


### PR DESCRIPTION
#### Description
https://github.com/pytest-dev/pytest-xdist/blob/v3.3.1/CHANGELOG.rst
https://github.com/pytest-dev/pytest-xdist/compare/v2.2.1...v3.3.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
