### PR TITLE
passage: submission security/passage 1.7.4a1

### DIFF
--- a/security/passage/Portfile
+++ b/security/passage/Portfile
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        FiloSottile passage 1.7.4a1
+revision            0
+github.tarball_from archive
+categories          security
+license             GPL-2+
+platforms           any
+supported_archs     noarch
+
+maintainers         {macports.halostatue.ca:austin @halostatue} \
+                    openmaintainer
+
+description         ${name} passage is a fork of password-store \
+                    that uses age as a backend instead of GnuPG.
+long_description    {*}${description}
+
+# passage depends on either `age` or `rage`
+depends_run         port:git \
+                    port:tree \
+                    port:qrencode \
+                    port:util-linux \
+                    bin:age:age
+
+checksums           rmd160  ab2c87d6515588e8e36c7b5dc86760424c392312 \
+                    sha256  0705ff409d4a6160ade347e63be623170da023ec199116dac83b406a18f7e0d7 \
+                    size    19594
+
+patchfiles          patch-getopt-path.diff
+
+post-patch {
+    reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/src/platform/darwin.sh
+}
+
+use_configure       no
+build {}
+
+destroot.env-append PREFIX=${prefix} \
+                    SYSCONFDIR=${prefix}/etc \
+                    WITH_ALLCOMP=yes
+
+notes {
+    To use passage bash completion, add the following lines at the end of your
+    .bash_profile:
+
+      [[ -r "${prefix}/share/bash-completion/completions/passage" ]] &&
+         source "${prefix}/share/bash-completion/completions/passage"
+
+    No additional steps are required for zsh and fish shells installed from
+    MacPorts.
+
+    To use these completions with the system version of zsh, include the
+    directory with shell completion via fpath to your .zprofile:
+
+      fpath=(${prefix}/share/zsh/site-functions $fpath)
+}

--- a/security/passage/files/patch-getopt-path.diff
+++ b/security/passage/files/patch-getopt-path.diff
@@ -1,0 +1,11 @@
+--- src/platform/darwin.sh.orig	2021-06-11 19:49:06.000000000 +0300
++++ src/platform/darwin.sh	2021-06-12 20:53:28.000000000 +0300
+@@ -39,6 +39,6 @@ qrcode() {
+ 	fi
+ }
+
+-GETOPT="$({ test -x /usr/local/opt/gnu-getopt/bin/getopt && echo /usr/local/opt/gnu-getopt; } || brew --prefix gnu-getopt 2>/dev/null || { command -v port &>/dev/null && echo /opt/local; } || echo /usr/local)/bin/getopt"
++GETOPT=@@PREFIX@@/bin/getopt
+ SHRED="srm -f -z"
+ BASE64="openssl base64"
+


### PR DESCRIPTION
#### Description

> passage is a fork of password-store (https://www.passwordstore.org)
> that uses age (https://age-encryption.org) as a backend instead of
> GnuPG.

###### Tested on

macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
