### PR TITLE
linear_algebra: workaround for Xcode 15 linker bug when linking to OpenBLAS

### DIFF
--- a/_resources/port1.0/group/linear_algebra-1.0.tcl
+++ b/_resources/port1.0/group/linear_algebra-1.0.tcl
@@ -95,6 +95,15 @@ variant openblas conflicts accelerate atlas description {Build with linear algeb
     }
     linalglib               -lopenblas
     cmake_linalglib         -DBLA_VENDOR=OpenBLAS
+
+    # The new linker in Xcode 15 is buggy, causing build failures for many (but not all)
+    # ports that link to OpenBLAS. The -Wl,-ld_classic option below reverts to the
+    # classic linker.
+    #
+    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
+    if { ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+        linalglib-append    -Wl,-ld_classic
+    }
 }
 
 if {![variant_isset accelerate] && ![variant_isset openblas] && ![variant_isset atlas] } {


### PR DESCRIPTION
#### Description

Currently many ports that link to OpenBLAS fail to build due to bugs in the new linker that comes with Xcode 15.0. Several ports have workarounds. Grep the port tree for `-Wl,-ld_classic` to see examples of workarounds.

This PR attempts a central fix for all ports that use the `linear_algebra` portgroup, and do not build with CMake. I tried a few such ports: some fail to build, some don't. Those that fail are fixed by this change. Examples of such ports: `superlu`, `plumed`, and several SuiteSparse subports (see #20920).

Yes, this is a bit of a hack and we hope that Apple fixes the linker bugs soon.

Note that I have not found any CMake-based ports that fail, which is why the workaround is not included for those.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
