### PR TITLE
git: set perl as run dependency

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -149,7 +149,9 @@ build.args          CFLAGS="${CFLAGS}" \
                     V=1
 
 if {[variant_isset ${perl5.variant}]} {
+    depends_lib-delete  port:perl${perl5.major}
     depends_run-append \
+                    port:perl${perl5.major} \
                     port:p${perl5.major}-authen-sasl \
                     port:p${perl5.major}-error \
                     port:p${perl5.major}-net-smtp-ssl \


### PR DESCRIPTION
#### Description

Distribution of git is blocked by gdbm (GPL-3) which is a dependency of perl.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.1 23B74 x86_64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?