### PR TITLE
mupdf: reorder Portfile statements to fix compiler selection

### DIFF
--- a/graphics/mupdf/Portfile
+++ b/graphics/mupdf/Portfile
@@ -54,6 +54,9 @@ depends_lib         port:freetype \
 patchfiles          patch-build.diff
 
 use_configure       no
+use_parallel_build  no
+
+compiler.cxx_standard   2017
 
 build.args          PREFIX=${prefix}
 build.args-append   CC=${configure.cc} \
@@ -69,9 +72,6 @@ build.args-append   CC=${configure.cc} \
                     shared=yes \
                     verbose=yes \
                     shared-release
-
-compiler.cxx_standard   2017
-use_parallel_build  no
 
 destroot.destdir    prefix=${destroot}${prefix}
 destroot.args-append \


### PR DESCRIPTION
#### Description

Two weeks ago, PR #20875 introduced `compiler.cxx_standard 2017` in the mupdf Portfile. On older platforms, the default Clang version (e.g., clang-600, based on llvm-3.5, on OS X 10.9) does not understand `-std=c++17`, so the compilation fails (I do not know why the port still passed CI on these Mac OS X versions). ~~A quick Internet search revealed that the first C++17 compliant Clang version was Clang 5.0, upon which AppleClang 10.0 (clang-1000) is based. Therefore I am adding blacklist entries for `clang < 1000` and `macports-clang-[3-4].*`.~~

~~For this change to work, however, I had to move the `build.args` stuff (which is where the CXX variable is set) a bit further down in the Portfile, hence the extra lines in the diff.~~

Update after feedback: simply moving the `cxx_standard` statement up is sufficient. I also moved the other statement in that block (`use_parallel_build`) up as well to avoid cluttering the Portfile.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
