### PR TITLE
libical: update to 3.0.17

### DIFF
--- a/devel/libical/Portfile
+++ b/devel/libical/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        libical libical 3.0.16 v
+github.setup        libical libical 3.0.17 v
 revision            0
-checksums           rmd160  b3610841bffa733f65735f9738f8dd6537a86467 \
-                    sha256  8fdb40c554404736c1cfe8c4e8092cee6ec731b3bb5a5ba2e0df5e9e918a9a62 \
-                    size    921189
+checksums           rmd160  25683e028bf50cd5812ac9fd062ed33dca6e8782 \
+                    sha256  0d15191fbb43c414855aec49b1824b3d2b5b25cf8a5d1fbae5e7173485608072 \
+                    size    909122
 
 categories          devel
 maintainers         nomaintainer


### PR DESCRIPTION
#### Description
-vst failed but -v didn't. -vst log attached just in case.
[libical-vst.log.gz](https://github.com/macports/macports-ports/files/13197183/libical-vst.log.gz)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`? (It failed. Will install with -v)
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
