### PR TITLE
dotnet-7: checksum fix

### DIFF
--- a/dotnet/aspnetcore-runtime-7/Portfile
+++ b/dotnet/aspnetcore-runtime-7/Portfile
@@ -26,15 +26,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            aspnetcore-runtime-${version}-osx-x64
-        checksums           rmd160  6bca0b45a72848d2bf221547b10c6510c08e0364 \
-                            sha256  7ffa110d221081681021c6d6df9f37f63bd0db152ed5e2b65d4e8cf61a03e87a \
-                            size    40602853
+        checksums           rmd160  90a6c10cb32f4997696409c5bf94185d79c44481 \
+                            sha256  57bbc50410abbf7410d256490b7e5fb73400ba1273a977d1504db75492146048 \
+                            size    40581403
     }
     arm64 {
         distname            aspnetcore-runtime-${version}-osx-arm64
-        checksums           rmd160  ff0c1538241c4835613a1385c5e6f620677c0b1a \
-                            sha256  e265d2a083425ec4c9fcbab5c911580910df3661e1974196671475e274325f1d \
-                            size    38687377
+        checksums           rmd160  c37b43bf82b9f65222f50a2b7cc82a79abc15fb2 \
+                            sha256  05ac90128eb39a25f6e4dba0ccea97a19b819c095d158eea46ae5ee2d94c6636 \
+                            size    38653000
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-cli/Portfile
+++ b/dotnet/dotnet-cli/Portfile
@@ -52,15 +52,15 @@ master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  4059918e8dfa0e40180589363d54ebe46acb84e1 \
-                            sha256  5d4847009e78846278a5ed83cef3a367a02e274e4582a5c89259810e7146bf9e \
-                            size    30866950
+        checksums           rmd160  7a49a3fe40a18b71f043bcb50a6c070cc747620e \
+                            sha256  6eae5723e5a4a63eb29c279b210ffb5fc8c3011d0b1a9f09bcfabe777675deea \
+                            size    30844773
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  8e9024427b4a7426060afd8cdb36ee9db04656f0 \
-                            sha256  43a129205152389a201d921fcf14565a316bc2a6a271354a08879ad5e4f9d990 \
-                            size    29186244
+        checksums           rmd160  50f8e9c908b78888c28106ad816be31e2c2b1d79 \
+                            sha256  5118d80ced9d34a1d940321f966d578521e7ab0e1d8451dc02b6f4043be0214f \
+                            size    29178298
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-7/Portfile
+++ b/dotnet/dotnet-runtime-7/Portfile
@@ -25,15 +25,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  4059918e8dfa0e40180589363d54ebe46acb84e1 \
-                            sha256  5d4847009e78846278a5ed83cef3a367a02e274e4582a5c89259810e7146bf9e \
-                            size    30866950
+        checksums           rmd160  7a49a3fe40a18b71f043bcb50a6c070cc747620e \
+                            sha256  6eae5723e5a4a63eb29c279b210ffb5fc8c3011d0b1a9f09bcfabe777675deea \
+                            size    30844773
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  8e9024427b4a7426060afd8cdb36ee9db04656f0 \
-                            sha256  43a129205152389a201d921fcf14565a316bc2a6a271354a08879ad5e4f9d990 \
-                            size    29186244
+        checksums           rmd160  50f8e9c908b78888c28106ad816be31e2c2b1d79 \
+                            sha256  5118d80ced9d34a1d940321f966d578521e7ab0e1d8451dc02b6f4043be0214f \
+                            size    29178298
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-sdk-7/Portfile
+++ b/dotnet/dotnet-sdk-7/Portfile
@@ -27,16 +27,16 @@ switch ${build_arch} {
     x86_64 {
         set dotnet_rid osx-x64
         distname            dotnet-sdk-${version}-osx-x64
-        checksums           rmd160  444deae0c79ea37a661cac863e8dc1bdaeafe7f2 \
-                            sha256  0fe47601e926fbb037a0074e09848b1fbfd85230fcff84e3abe0598de351c6c6 \
-                            size    217976520
+        checksums           rmd160  d27ed4686ba134a5f9db3516072c79544bc4c32a \
+                            sha256  3e1a003243960847fd976f5e155173bbd345f6c9f1c2f6c3d72fd1f1828fb9bb \
+                            size    217007906
     }
     arm64 {
         set dotnet_rid osx-arm64
         distname            dotnet-sdk-${version}-osx-arm64
-        checksums           rmd160  589dfb0debb0ba0604b64d2e6d7343b8c5f21c9d \
-                            sha256  649a197230ee39096986cd33cd19343e4feec0fe1072cb34ea73db157bef3495 \
-                            size    212844464
+        checksums           rmd160  3fb492d21f877b0b571fc6260045c823009b2ad6 \
+                            sha256  94521e4d619f39b4c5ae85c4c9694957e979f7d952ad962a52f1a2d3d075ad55 \
+                            size    211888227
     }
     default {
         known_fail yes


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Closes https://trac.macports.org/ticket/68580

Looks like Microsoft re-released the version while we were working on last PR.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.1 22G313 arm64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
