### PR TITLE
mupdf: reorder statements to fix compiler selection

### DIFF
--- a/graphics/mupdf/Portfile
+++ b/graphics/mupdf/Portfile
@@ -54,6 +54,9 @@ depends_lib         port:freetype \
 patchfiles          patch-build.diff
 
 use_configure       no
+use_parallel_build  no
+
+compiler.cxx_standard   2017
 
 build.args          PREFIX=${prefix}
 build.args-append   CC=${configure.cc} \
@@ -69,9 +72,6 @@ build.args-append   CC=${configure.cc} \
                     shared=yes \
                     verbose=yes \
                     shared-release
-
-compiler.cxx_standard   2017
-use_parallel_build  no
 
 destroot.destdir    prefix=${destroot}${prefix}
 destroot.args-append \


### PR DESCRIPTION
#### Description

Rework of PR #21135.

Two weeks ago, PR #20875 introduced `compiler.cxx_standard 2017` in the mupdf Portfile. Due to the order of the statements in the Portfile, the compiler variable is not updated early enough, so the default Clang version is used instead. Thus, on older platforms where the default Clang version does not understand `-std=c++17`, the compilation fails.

Fix: move `compiler.cxx_standard` before `build.args`, which sets the compiler. I also moved the other statement in that block (`use_parallel_build`) up as well to avoid cluttering the Portfile.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
