### PR TITLE
mbtileserver: update to 0.10.0

### DIFF
--- a/gis/mbtileserver/Portfile
+++ b/gis/mbtileserver/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/consbio/mbtileserver 0.9.0 v
+go.setup            github.com/consbio/mbtileserver 0.10.0 v
 revision            0
 categories          gis
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -13,9 +13,9 @@ description         A simple Go-based server for map tiles stored in mbtiles for
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  835497ccbfcaefe4597d689618cc8eaa817d4392 \
-                        sha256  3a094a792225b174e9b507b30f3fa4ce4f970a8f8361e4ddefe1b5a235263dee \
-                        size    1617064
+                        rmd160  cf00a2e47794b3457a3d3ef808d95acb5409328f \
+                        sha256  a4f38c0bdd8da27c74406fd9d85bdc61eb35312a0ec0d0aa983f4f9f7eaf91b6 \
+                        size    1509505
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
@@ -23,30 +23,30 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
                         size    91208 \
                     golang.org/x/time \
-                        lock    v0.1.0 \
-                        rmd160  5489d3c10b91016ebfe7ff73e6abb181664ebfb1 \
-                        sha256  69763dfe9bac5299bc5209254e6e8f7ffc492abb36e13633e1239ec680ea8893 \
-                        size    11114 \
+                        lock    v0.3.0 \
+                        rmd160  1db54fc6608ef07cc574d51db48fabe595579ade \
+                        sha256  2cc1d4590e17f17f5198c1b5a9f2830104bbd0427fb54a5374f6f7d3c6b35096 \
+                        size    12217 \
                     golang.org/x/text \
-                        lock    v0.4.0 \
-                        rmd160  a3215f5c266b2d6cc0ae945858b543031fcb5a54 \
-                        sha256  c4e794a9e732f422df4e005f87ddba1e640b5bb7d6ce10ad56e40fa8c7d56ee2 \
-                        size    8359157 \
+                        lock    v0.13.0 \
+                        rmd160  41adfd8809cec3b7d0d885c1d698bc2a0d73ab1c \
+                        sha256  b499b39462b190a30882184132b47afb02c2c76ee9fee315c0aebe477c4b8354 \
+                        size    8964803 \
                     golang.org/x/sys \
-                        lock    v0.1.0 \
-                        rmd160  91bc7e86c3eb8a828451af8e3fcddd77fb906209 \
-                        sha256  07c0119c0c16e4b5441b93138d1c83aa1103eef441fb1f36eab332207b868a19 \
-                        size    1410248 \
+                        lock    v0.13.0 \
+                        rmd160  6105681bf18684d55835bd5ba9b20f599488c623 \
+                        sha256  f35bdc78f45a0bab73411b3c117b134ae68eed96eb301f719f873fbbcd8abf33 \
+                        size    1442708 \
                     golang.org/x/net \
-                        lock    f25eb7ecb193 \
-                        rmd160  98d5de83aed4b3c2dfc7734e62fe64fb0c1bfb4b \
-                        sha256  ff7dfb7e8e56e1c513d2eaf39c4109371fad4a55ca2c6d1cb6cc7e75f95ea3e5 \
-                        size    1239696 \
+                        lock    v0.17.0 \
+                        rmd160  3e1d150fbede0be1af1b248e536930de2446ef0e \
+                        sha256  6bb73c8f9eef753cab2b18d4af7893ff955b4427c6d34c8f4d7c9127d09abcc0 \
+                        size    1456371 \
                     golang.org/x/crypto \
-                        lock    56aed061732a \
-                        rmd160  bc24a671816c7839d9115d98fad7c1beb917ce2d \
-                        sha256  7efc63941baeaf8c5ccec13f41a6a5056d95e76a5893263a825e1633059ab14c \
-                        size    1631972 \
+                        lock    v0.14.0 \
+                        rmd160  e47babd382d1c75f56ec60a945361dc7b7dc2c5a \
+                        sha256  673dbcc180bdbf773569fbff655915b5040200bb9b5f919e1cc3521b387b5ed2 \
+                        size    1797771 \
                     github.com/valyala/fasttemplate \
                         lock    v1.2.2 \
                         rmd160  c341ee599972d95a7f9235fc4886ac9d7466d600 \
@@ -58,25 +58,25 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  849a2f097cc06fb40219bd350225e99bfdeb1e9105b428d72f07953f44808531 \
                         size    5031 \
                     github.com/stretchr/testify \
-                        lock    v1.7.0 \
-                        rmd160  adae5096e8c4cfcc8e3f6d096646d1165b5ef49a \
-                        sha256  f7dde97d0c9634483ae6ea273968f80f3105c22382a1f841886cd20d57586642 \
-                        size    91096 \
+                        lock    v1.8.4 \
+                        rmd160  8e1645055c9b1d8e117df7974034e74b7f600d27 \
+                        sha256  6d0a77075bbe0f8f1c0cbed51dd4d174579db976fef39d9ae6b500aab8917d6a \
+                        size    104469 \
                     github.com/spf13/pflag \
                         lock    v1.0.5 \
                         rmd160  2ce81608a38c6f383a35bccd24d64361df5828c9 \
                         sha256  7f41acdcba65b1fab5b9b633947a139f9915b60f94bdab486cdbe9d90c54f61e \
                         size    50815 \
                     github.com/spf13/cobra \
-                        lock    v1.6.0 \
-                        rmd160  f44b255ef7a061fe502bc6734331d4c9c648cccd \
-                        sha256  21984b349f556a1441b7ed87504ac38ef76623ea3e237609c9369431be98f37d \
-                        size    110708 \
+                        lock    v1.7.0 \
+                        rmd160  2d0592a4c5aca1ba5daa45cd1d4e662adadd0703 \
+                        sha256  913afd358ab699baf7773e7a5661c9f6436c6f825da2a1d61623e69d2c0b4b2d \
+                        size    187188 \
                     github.com/sirupsen/logrus \
-                        lock    v1.9.0 \
-                        rmd160  7298932f511bd852fe27d6227e945256ac512479 \
-                        sha256  559f22c05df7f356b90074d4b19035d9a5a8119fe504882fe413105a4f3b4675 \
-                        size    49102 \
+                        lock    v1.9.3 \
+                        rmd160  db211aeb52d4a85a7dc8acf83f7475b5f4fa9092 \
+                        sha256  36a05391b8c6cef99e9a9c78b598f3a8da8feed318b385eadcdede08ae5cc229 \
+                        size    50327 \
                     github.com/pmezard/go-difflib \
                         lock    v1.0.0 \
                         rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
@@ -88,10 +88,10 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
                         size    13422 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.16 \
-                        rmd160  dcdf01553caa079315f2293c109de17fc72f0c6b \
-                        sha256  391d25a98e2cc92a2ed5c6abd07cde1053411706bb24e5843562931e6085ab46 \
-                        size    4693 \
+                        lock    v0.0.20 \
+                        rmd160  ef20ccdf87de8b704c0c7118625b2beb31d8f1b4 \
+                        sha256  397549e98cf5d40df585f31dc7902f017c37be88c64311dd2b4aeccab4009949 \
+                        size    4717 \
                     github.com/mattn/go-colorable \
                         lock    v0.1.13 \
                         rmd160  c9e8ab9d0773c0984f36235e3c9f8c033552ac1a \
@@ -103,15 +103,15 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  18193f7f4461c6e5c182785fc7975f75822aac8612f6efa68183f875ba1d3be0 \
                         size    13205 \
                     github.com/labstack/echo \
-                        lock    v4.9.1 \
-                        rmd160  6a3bb892429f90008835564eddcc097c2a9788ba \
-                        sha256  ed2bcc87bfccdd1d430db899cbbb597be604ac41b1f4f74b2300486feaf90efa \
-                        size    381789 \
+                        lock    v4.11.2 \
+                        rmd160  ef3e040f7eae559312e9dd50a7b7b38f0a1c4b1a \
+                        sha256  b10c0f0f7be3c24d3e931ce3a693f614835bac3e415549c4f2db5e55f09fbb4b \
+                        size    398846 \
                     github.com/inconshreveable/mousetrap \
-                        lock    v1.0.1 \
-                        rmd160  d5dd7c9ef19fef8876014ae3b08a3f6a2a813bf7 \
-                        sha256  57bdbba1b25456bc66319f0ad5ba00b92dcfddd8431df9152e046fe079ad85b2 \
-                        size    5944 \
+                        lock    v1.1.0 \
+                        rmd160  88f9577df93ac0f8801d8960adc7f28e38867f3e \
+                        sha256  f69af10ff08c0e87f92dac3ee5172d8ed02463725b74edfc8943ef018a1a632d \
+                        size    5343 \
                     github.com/golang-jwt/jwt \
                         lock    v3.2.2 \
                         rmd160  358c4daf19c2fba8917970b6dfa258ba7a834123 \
@@ -143,16 +143,16 @@ go.vendors          gopkg.in/yaml.v3 \
                         sha256  a06bb1869b1ef9fa2253eaaffc738deed98535e65c04b5fea6e03cbfb5879ec0 \
                         size    121737 \
                     github.com/brendan-ward/mbtiles-go \
-                        lock    a6cb9b848bab \
-                        rmd160  938711dfe2cfd3ecd9601979963a9629bbf954e9 \
-                        sha256  813c51740196cfe4050b507dc66baf4e4c0e14f20729270b88a46cb3e53ef700 \
-                        size    1235657 \
+                        lock    6c48cea51706 \
+                        rmd160  4691fe3bdaffcd2b6099218eab137c1f38315f0c \
+                        sha256  d250995718af6d9425a74b83264bf65c2f85ee2b736667c9e05394f6b8419f7f \
+                        size    1235647 \
                     crawshaw.io/sqlite \
                         repo    github.com/crawshaw/sqlite \
-                        lock    2cdb5c1a86a1 \
-                        rmd160  46706e35093a4ea33a886d7fcc8fa1613db90791 \
-                        sha256  02077208fa27cc36eac945c5142bb238dc82a9b92f08275cca0098301d456c72 \
-                        size    2361692 \
+                        lock    d1964889ea3c \
+                        rmd160  cc6c82a7031328f1d2f6330ee41d91d949e5f848 \
+                        sha256  6f08529682f401096b68aeae6f524e4bd1e021415b95f938fec67ab0ea46cbfd \
+                        size    2407355 \
                     crawshaw.io/iox \
                         repo    github.com/crawshaw/iox \
                         lock    c51c3df30797 \


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/consbio/mbtileserver/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
