### PR TITLE
py-nclib: Update to 1.0.5 & enable support for Python 3.9 to 3.12

### DIFF
--- a/python/py-nclib/Portfile
+++ b/python/py-nclib/Portfile
@@ -4,7 +4,7 @@ PortSystem           1.0
 PortGroup            python 1.0
 
 name                 py-nclib
-version              0.8.3
+version              1.0.5
 
 description          A Python socket library that wants to be your friend
 long_description     nclib provides easy-to-use interfaces for connecting to \
@@ -24,9 +24,9 @@ maintainers          {@F30 f30.me:f30} openmaintainer
 
 python.versions      37 38
 
-checksums            rmd160  a1044012c12cba1ced18bc493f732ab6fc18b056 \
-                     sha256  7ee56ca74ade02796c01923b117d7192b7a2381ab06464b4168b0f4e0e0deb1d \
-                     size    13445
+checksums            rmd160  3d78346ef327a3827d7194114abdd748da32f727 \
+                     sha256  b0a6c84a52f984e06ed63eb359289bd878c90af12832ba9dc33806da478ca831 \
+                     size    21830
 
 if {${name} ne ${subport}}  {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-nclib/Portfile
+++ b/python/py-nclib/Portfile
@@ -22,7 +22,7 @@ platforms            {darwin any}
 supported_archs      noarch
 maintainers          {@F30 f30.me:f30} openmaintainer
 
-python.versions      37 38
+python.versions      37 38 39 310 311 312
 
 checksums            rmd160  3d78346ef327a3827d7194114abdd748da32f727 \
                      sha256  b0a6c84a52f984e06ed63eb359289bd878c90af12832ba9dc33806da478ca831 \


### PR DESCRIPTION
#### Description
Update py-nclib to the latest release and enable support for newer Python versions.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.1 22G313 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?