### PR TITLE
py-gnupg: Update to 0.5.1, enable support for Python 3.9 to 3.12, fix tests

### DIFF
--- a/python/py-gnupg/Portfile
+++ b/python/py-gnupg/Portfile
@@ -37,4 +37,9 @@ if {${subport} ne ${name}} {
 
     test.run        yes
     test.cmd        ${python.bin} test_gnupg.py
+    test.target     ""
+    test.args       ""
+    # `TMPDIR` being set to a path within `${workpath}` can easily result in a "socket name '...' is
+    # too long" error from gpg-agent
+    test.env        TMPDIR=/tmp
 }

--- a/python/py-gnupg/Portfile
+++ b/python/py-gnupg/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-gnupg
 python.rootname     python-gnupg
-version             0.4.6
+version             0.5.1
 
 description         A Python wrapper for GnuPG
 long_description    The gnupg module allows Python programs to make use of \
@@ -24,9 +24,9 @@ maintainers         {@F30 f30.me:f30} openmaintainer
 
 python.versions     37 38
 
-checksums           rmd160  808403c8ee70a114bd20ee72c83d2e8e5297c1bc \
-                    sha256  3aa0884b3bd414652c2385b9df39e7b87272c2eca1b8fcc3089bc9e58652019a \
-                    size    52527
+checksums           rmd160  1bb779e2243cccc8f4d8ed0770c93e84866fc88b \
+                    sha256  5674bad4e93876c0b0d3197e314d7f942d39018bf31e2b833f6788a6813c3fb8 \
+                    size    64377
 
 if {${subport} ne ${name}} {
     depends_build-append \

--- a/python/py-gnupg/Portfile
+++ b/python/py-gnupg/Portfile
@@ -22,7 +22,7 @@ homepage            https://pythonhosted.org/python-gnupg/
 categories-append   crypto security
 maintainers         {@F30 f30.me:f30} openmaintainer
 
-python.versions     37 38
+python.versions     37 38 39 310 311 312
 
 checksums           rmd160  1bb779e2243cccc8f4d8ed0770c93e84866fc88b \
                     sha256  5674bad4e93876c0b0d3197e314d7f942d39018bf31e2b833f6788a6813c3fb8 \


### PR DESCRIPTION
#### Description
* Update py-gnupg to the latest release
* Enable support for newer Python versions
* Actually run tests and fix their execution

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.1 22G313 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?