### PR TITLE
nmap: fixes for 32-bit and pre-C++11 platforms

### DIFF
--- a/net/nmap/Portfile
+++ b/net/nmap/Portfile
@@ -4,6 +4,7 @@ PortSystem 1.0
 
 name		nmap
 version		7.94
+revision	1
 categories	net
 maintainers	{darkart.com:opendarwin.org @ghosthound} {geeklair.net:dluke @danielluke}
 description	Port scanning utility for large networks
@@ -30,6 +31,12 @@ master_sites	https://nmap.org/dist/
 checksums      rmd160  8418fcef96848a6ae6bbbeee935b34ce047eab5e \
                sha256  d71be189eec43d7e099bac8571509d316c4577ca79491832ac3e1217bc8f92cc \
                size    11102195
+
+# see https://trac.macports.org/ticket/68543
+patchfiles  nmap-7.94-fix-32bit.patch
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+  patchfiles-append pre-cxx11-workarounds.patch
+}
 
 depends_lib	port:libpcap \
             port:zlib \

--- a/net/nmap/files/nmap-7.94-fix-32bit.patch
+++ b/net/nmap/files/nmap-7.94-fix-32bit.patch
@@ -1,0 +1,13 @@
+Upstream-Status: Submitted [https://github.com/nmap/nmap/pull/2732]
+
+--- MACLookup.cc
++++ MACLookup.cc
+@@ -158,7 +158,7 @@ static void mac_prefix_init() {
+     std::pair<MacMap::iterator, bool> status = MacTable.insert(std::pair<u64, const char *>(pfx, string_pool_substr(vendor, endptr)));
+ 
+     if (!status.second && o.debugging > 1)
+-      error("MAC prefix %0*lX is duplicated in %s; ignoring duplicates.", (int)(pfx >> 36), pfx & 0xfffffffffL, filename);
++      error("MAC prefix %0*" PRIX64 " is duplicated in %s; ignoring duplicates.", (int)(pfx >> 36), pfx & 0xfffffffffL, filename);
+   }
+ 
+   fclose(fp);

--- a/net/nmap/files/pre-cxx11-workarounds.patch
+++ b/net/nmap/files/pre-cxx11-workarounds.patch
@@ -1,0 +1,26 @@
+--- nbase/nbase.h
++++ nbase/nbase.h
+@@ -93,8 +93,12 @@
+  *
+  * * Various Windows -> UNIX compatibility definitions are added (such as defining EMSGSIZE to WSAEMSGSIZE)
+  */
+ 
++#ifndef __STDC_FORMAT_MACROS
++#define __STDC_FORMAT_MACROS
++#endif
++
+ #if HAVE_CONFIG_H
+ #include "nbase_config.h"
+ #else
+ #ifdef WIN32
+--- MACLookup.cc
++++ MACLookup.cc
+@@ -158,7 +158,7 @@ static void mac_prefix_init() {
+     std::pair<MacMap::iterator, bool> status = MacTable.insert(std::pair<u64, const char *>(pfx, string_pool_substr(vendor, endptr)));
+ 
+     if (!status.second && o.debugging > 1)
+-      error("MAC prefix %0*" PRIX64 " is duplicated in %s; ignoring duplicates.", (int)(pfx >> 36), pfx & 0xfffffffffL, filename);
++      error("MAC prefix %0*" PRIX64 " is duplicated in %s; ignoring duplicates.", (int)(pfx >> 36), pfx & 0xfffffffffLL, filename);
+   }
+ 
+   fclose(fp);


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68543

#### Description



<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Not tested on affected macOS versions.
32-bit fix tested on IA-32 Linux; only eliminates a compiler warning on 64-bit platforms.


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
