### PR TITLE
Bugfix: (various) Fix fish completion scripts destination

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 github.setup        dagger dagger 0.8.7 v
 github.tarball_from releases
-revision            0
+revision            1
 
 categories          devel
 maintainers         {judaew @judaew} openmaintainer
@@ -53,8 +53,8 @@ destroot {
     # Shell completion
     xinstall -d ${destroot}${prefix}/etc/bash_completion.d
     xinstall -d ${destroot}${prefix}/share/zsh/site-functions
-    xinstall -d ${destroot}${prefix}/share/fish/completions
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
     system "${destroot}${prefix}/bin/${name} completion bash > ${destroot}${prefix}/etc/bash_completion.d/${name}"
     system "${destroot}${prefix}/bin/${name} completion zsh > ${destroot}${prefix}/share/zsh/site-functions/_${name}"
-    system "${destroot}${prefix}/bin/${name} completion fish > ${destroot}${prefix}/share/fish/completions/${name}.fish"
+    system "${destroot}${prefix}/bin/${name} completion fish > ${destroot}${prefix}/share/fish/vendor_completions.d/${name}.fish"
 }

--- a/devel/flyctl/Portfile
+++ b/devel/flyctl/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/superfly/flyctl 0.1.113 v
 go.offline_build    no
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          devel
 installs_libs       no
@@ -44,13 +44,13 @@ destroot {
     # Shell completion
     xinstall -d "${destroot}${prefix}/etc/bash_completion.d"
     xinstall -d "${destroot}${prefix}/share/zsh/site-functions"
-    xinstall -d "${destroot}${prefix}/share/fish/completions"
+    xinstall -d "${destroot}${prefix}/share/fish/vendor_completions.d"
     system "${destroot}${prefix}/bin/${name} completion bash > \\
         ${destroot}${prefix}/etc/bash_completion.d/${name}"
     system "${destroot}${prefix}/bin/${name} completion zsh >  \\
         ${destroot}${prefix}/share/zsh/site-functions/_${name}"
     system "${destroot}${prefix}/bin/${name} completion fish > \\
-        ${destroot}${prefix}/share/fish/completions/${name}.fish"
+        ${destroot}${prefix}/share/fish/vendor_completions.d/${name}.fish"
 }
 
 # Only match releases. Pre-releaes have a "-pre-N" suffix

--- a/devel/fnm/Portfile
+++ b/devel/fnm/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo   1.0
 
 github.setup        Schniz fnm 1.35.1 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Fast and simple Node.js version manager, built in Rust
 
@@ -50,7 +50,7 @@ post-destroot {
 #    system "${fnm_bin} completions --shell=zsh > ${zsh_completion_dir}/_${name}"
 #
 #    # fish completion
-#    set fish_completion_dir ${destroot}${prefix}/share/fish/completions
+#    set fish_completion_dir ${destroot}${prefix}/share/fish/vendor_completions.d
 #    xinstall -d ${fish_completion_dir}
 #    system "${fnm_bin} completions --shell=fish > ${fish_completion_dir}/${name}.fish"
 }

--- a/devel/glab/Portfile
+++ b/devel/glab/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            gitlab.com/gitlab-org/cli 1.32.0 v
 name                glab
-revision            0
+revision            1
 categories          devel
 license             MIT
 
@@ -52,7 +52,7 @@ post-destroot {
     system -W ${worksrcpath} "${worksrcpath}/${name} completion --shell zsh > ${zsh_completion_dir}/_${name}"
 
     # fish completion
-    set fish_completion_dir ${destroot}${prefix}/share/fish/completions
+    set fish_completion_dir ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -d ${fish_completion_dir}
     system -W ${worksrcpath} "${worksrcpath}/${name} completion --shell fish > ${fish_completion_dir}/${name}.fish"
 }

--- a/devel/seaport/Portfile
+++ b/devel/seaport/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                seaport
 version             0.10.1
-revision            0
+revision            1
 categories-prepend  devel
 license             BSD
 supported_archs     noarch
@@ -42,7 +42,7 @@ post-destroot {
     xinstall -d ${zsh_completion_dir}
     xinstall -m 0644 ${autocomplete_dir}/${name}.zsh ${zsh_completion_dir}/_${name}
 
-    set fish_completion_dir ${destroot}${prefix}/share/fish/completions
+    set fish_completion_dir ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -d ${fish_completion_dir}
-    xinstall -m 0644 ${autocomplete_dir}/${name}.fish ${fish_completion_dir}/${name}.fish
+    xinstall -m 0644 ${autocomplete_dir}/${name}.fish ${fish_completion_dir}
 }

--- a/net/doggo/Portfile
+++ b/net/doggo/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/mr-karan/doggo 0.5.7 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Command-line DNS Client for Humans
 
@@ -31,13 +31,13 @@ destroot {
         ${worksrcpath}/bin/${name}.bin \
         ${destroot}${prefix}/bin/${name}
 
-    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
-    xinstall ${worksrcpath}/completions/${name}.zsh \
+    xinstall -d -m 0755 ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0644 ${worksrcpath}/completions/${name}.zsh \
         ${destroot}${prefix}/share/zsh/site-functions/_${name}
 
-    xinstall -d ${destroot}${prefix}/share/fish/completions
-    xinstall ${worksrcpath}/completions/${name}.fish \
-        ${destroot}${prefix}/share/fish/completions/${name}.fish
+    xinstall -d -m 0755 ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 0644 ${worksrcpath}/completions/${name}.fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d/
 
     xinstall -d ${destroot}${prefix}/share/${name}/examples
     copy ${worksrcpath}/config-api-sample.toml \

--- a/science/scientiaCLI/Portfile
+++ b/science/scientiaCLI/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/goDoCer/scientiaCLI 93a18e9
 github.tarball_from archive
 version             0.0.1
-revision            0
+revision            1
 categories          science education
 license             GPL-3
 
@@ -50,7 +50,7 @@ post-destroot {
     xinstall -d ${zsh_completion_dir}
     system -W ${destroot}${prefix}/bin "./scientia-cli completion zsh > ${zsh_completion_dir}/_${bin_name}"
 
-    set fish_completion_dir ${destroot}${prefix}/share/fish/completions
+    set fish_completion_dir ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -d ${fish_completion_dir}
     system -W ${destroot}${prefix}/bin "./scientia-cli completion fish > ${fish_completion_dir}/${bin_name}.fish"
 }

--- a/sysutils/eza/Portfile
+++ b/sysutils/eza/Portfile
@@ -7,7 +7,7 @@ PortGroup           cargo   1.0
 
 github.setup        eza-community eza 0.15.1 v
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://eza.rocks
 
@@ -90,9 +90,10 @@ destroot {
     xinstall -m 0644 ${worksrcpath}/completions/zsh/_${name} \
         ${destroot}${prefix}/share/zsh/site-functions/_${name}
 
-    xinstall -d ${destroot}${prefix}/share/fish/completions
-    xinstall -m 0644 ${worksrcpath}/completions/fish/${name}.fish \
-        ${destroot}${prefix}/share/fish/completions/${name}.fish
+
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -d ${fish_comp_path}
+    xinstall -m 0644 ${worksrcpath}/completions/fish/${name}.fish ${fish_comp_path}
 }
 
 cargo.crates \

--- a/sysutils/folderify/Portfile
+++ b/sysutils/folderify/Portfile
@@ -6,7 +6,7 @@ PortGroup           cargo 1.0
 
 github.setup        lgarron folderify 3.0.11 v
 github.tarball_from archive
-revision            0
+revision            1
 categories          sysutils amusements
 maintainers         {@harens harens} openmaintainer
 license             MIT
@@ -34,7 +34,7 @@ destroot {
     xinstall -d ${zsh_completion_dir}
     system -W ${destroot}${prefix}/bin "./${name} --completions zsh > ${zsh_completion_dir}/_${name}"
 
-    set fish_completion_dir ${destroot}${prefix}/share/fish/completions
+    set fish_completion_dir ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -d ${fish_completion_dir}
     system -W ${destroot}${prefix}/bin "./${name} --completions fish > ${fish_completion_dir}/${name}.fish"
 

--- a/sysutils/kubectx/Portfile
+++ b/sysutils/kubectx/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        ahmetb kubectx 0.9.5 v
-revision            0
+revision            1
 categories          sysutils
 platforms           any
 supported_archs     noarch
@@ -51,8 +51,8 @@ destroot    {
     xinstall -m 644 ${src_completion_dir}/kubectx.bash ${bash_completion_dir}/kubectx
     xinstall -m 644 ${src_completion_dir}/kubens.bash ${bash_completion_dir}/kubens
 
-    set fish_completion_dir ${destroot}${prefix}/share/fish/completions
+    set fish_completion_dir ${destroot}${prefix}/share/fish/vendor_completions.d
     xinstall -d ${fish_completion_dir}
-    xinstall -m 644 ${src_completion_dir}/kubectx.fish ${fish_completion_dir}/kubectx
-    xinstall -m 644 ${src_completion_dir}/kubens.fish ${fish_completion_dir}/kubens
+    xinstall -m 644 ${src_completion_dir}/kubectx.fish ${fish_completion_dir}/
+    xinstall -m 644 ${src_completion_dir}/kubens.fish ${fish_completion_dir}/
 }

--- a/textproc/ripgrep/Portfile
+++ b/textproc/ripgrep/Portfile
@@ -6,6 +6,7 @@ PortGroup           cargo 1.0
 
 github.setup        BurntSushi ripgrep 13.0.0
 github.tarball_from archive
+revision            1
 categories          textproc
 platforms           darwin
 maintainers         {raimue @raimue} \
@@ -92,8 +93,8 @@ destroot {
     xinstall -m 644 ${outpath}/rg.1 ${destroot}${prefix}/share/man/man1/
     xinstall -d -m 755 ${destroot}${prefix}/share/bash-completion/completions
     xinstall -m 644 ${outpath}/rg.bash ${destroot}${prefix}/share/bash-completion/completions/rg
-    xinstall -d -m 755 ${destroot}${prefix}/share/fish/completions
-    xinstall -m 644 ${outpath}/rg.fish ${destroot}${prefix}/share/fish/completions/
+    xinstall -d -m 755 ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 644 ${outpath}/rg.fish ${destroot}${prefix}/share/fish/vendor_completions.d/
     xinstall -d -m 755 ${destroot}${prefix}/share/zsh/site-functions
     xinstall -m 644 ${worksrcpath}/complete/_rg ${destroot}${prefix}/share/zsh/site-functions/
 }

--- a/www/buku/Portfile
+++ b/www/buku/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        jarun buku 4.8 v
-revision            0
+revision            1
 checksums           rmd160  ff1f9c8a01360e6f47e3e2c4d71bab7140ecec28 \
                     sha256  6962f7c493abacc8cba063e62f7f7fff7093ffb1aca0ceb4d1c40ceafbb92504 \
                     size    591956
@@ -62,8 +62,8 @@ post-destroot {
     # install shell completions (bash, fish, zsh)
     xinstall -d ${destroot}${prefix}/share/bash-completion/completions/
     xinstall -m 644 ${worksrcpath}/auto-completion/bash/buku-completion.bash ${destroot}${prefix}/share/bash-completion/completions/${name}
-    xinstall -d ${destroot}${prefix}/share/fish/completions/
-    xinstall -m 644 ${worksrcpath}/auto-completion/fish/buku.fish ${destroot}${prefix}/share/fish/completions/
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d/
+    xinstall -m 644 ${worksrcpath}/auto-completion/fish/buku.fish ${destroot}${prefix}/share/fish/vendor_completions.d/
     xinstall -d ${destroot}${prefix}/share/zsh/site-functions/
     xinstall -m 644 ${worksrcpath}/auto-completion/zsh/_buku ${destroot}${prefix}/share/zsh/site-functions/
 }


### PR DESCRIPTION
#### Description

All twelve of the ports in this PR have the same issue:

`$destroot/$prefix/share/fish/completions` is for the completion files included with fish, not for use by package managers installing additional files. The correct location is `$destroot/$prefix/share/fish/vendor_completions.d`.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 13.6 22G120 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?

  - Ports `scientiaCLI`, `doggo`, ripgrep`, `folderify`, and `fem` report the same number of warnings before and after.

- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

No to all of the above, but I ran the following tests because these are all *installation* changes, not source or build changes:

1. Installed all of the ports: `sudo port install --unrequested {buku,kubectx,scientiaCLI,doggo,seaport,glab,flyctl,dagger,ripgrep,folderify,fnm,eza}`
2. Listed the completions:

   ```console
   $ ls /opt/local/share/fish/{completions,vendor_completions.d}/{buku,dagger,doggo,eza,flyctl,fnm,folderify,glab,kubectx,kubens,rg,ripgrep,scientia-cli,seaport}*
   /opt/local/share/fish/completions/buku.fish
   /opt/local/share/fish/completions/dagger.fish
   /opt/local/share/fish/completions/doggo.fish*
   /opt/local/share/fish/completions/eza.fish
   /opt/local/share/fish/completions/flyctl.fish
   /opt/local/share/fish/completions/folderify.fish
   /opt/local/share/fish/completions/glab.fish
   /opt/local/share/fish/completions/kubectx
   /opt/local/share/fish/completions/kubens
   /opt/local/share/fish/completions/rg.fish
   /opt/local/share/fish/completions/scientia-cli.fish
   /opt/local/share/fish/completions/seaport.fish
   ```
3. Uninstalled the ports: `sudo port uninstall {buku,kubectx,scientiaCLI,doggo,seaport,glab,flyctl,dagger,ripgrep,folderify,fnm,eza}`
4. Reinstalled from tree (fish format):

   ```fish
   for p in {buku,kubectx,scientiaCLI,doggo,seaport,glab,flyctl,dagger,ripgrep,folderify,fnm,eza}
     pushd */$p
     sudo port install --unrequested
     popd end
   end
   ```
5. Listed the completions again:

   ```console
   $ ls /opt/local/share/fish/{completions,vendor_completions.d}/{buku,dagger,doggo,eza,flyctl,fnm,folderify,glab,kubectx,kubens,rg,ripgrep,scientia-cli,seaport}*
   /opt/local/share/fish/vendor_completions.d/buku.fish
   /opt/local/share/fish/vendor_completions.d/dagger.fish
   /opt/local/share/fish/vendor_completions.d/doggo.fish
   /opt/local/share/fish/vendor_completions.d/eza.fish
   /opt/local/share/fish/vendor_completions.d/flyctl.fish
   /opt/local/share/fish/vendor_completions.d/folderify.fish
   /opt/local/share/fish/vendor_completions.d/glab.fish
   /opt/local/share/fish/vendor_completions.d/kubectx.fish
   /opt/local/share/fish/vendor_completions.d/kubens.fish
   /opt/local/share/fish/vendor_completions.d/rg.fish
   /opt/local/share/fish/vendor_completions.d/scientia-cli.fish
   /opt/local/share/fish/vendor_completions.d/seaport.fish
   ```