### PR TITLE
openjdk21-microsoft: update to 21.0.1

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-21
 supported_archs  x86_64 arm64
 
-version      21.0.0
-set build    35
+version      21.0.1
+set build    12
 revision     0
 
 description  Microsoft Build of OpenJDK 21 (Long Term Support)
@@ -26,17 +26,17 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  989971673f263ad08cdb68c259392413ed520905 \
-                 sha256  831aa8af173908c74d9a1ea3762597aa3cbabd812d4a3a9bfe6112bec1e840bb \
-                 size    202519951
+    checksums    rmd160  74b100ca28bcc314b99ac8db93acc47486a878cf \
+                 sha256  1853c84eb8bc3b4f3077eaaa88b51b005232b151c662ba29429eb7b2984cf43c \
+                 size    202563953
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  00760983a040390f5d5ab368af75111a02339122 \
-                 sha256  4e9963c297baf857d33e858730a0ee28023d369b8e7d4e2b8f7f7fa901b9c9b1 \
-                 size    191756269
+    checksums    rmd160  a16814940bbf2d6a61714defa57341d670b3fdb4 \
+                 sha256  e44086601c580bb7b2c5b77f14c0512f1715f6f90cb11ddb43c046322294f12b \
+                 size    191796793
 }
 
-worksrcdir   jdk-21+${build}
+worksrcdir   jdk-${version}+${build}
 
 homepage     https://www.microsoft.com/openjdk
 


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 21.0.1.

###### Tested on

macOS 14.1 23B74 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?