### PR TITLE
openjdk17-microsoft: update to 17.0.9

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      17.0.8.1
-set build    1
+version      17.0.9
+set build    8
 revision     0
 
 description  Microsoft Build of OpenJDK 17 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  eb353efe0e7471734553ee5fa7a650761c681d83 \
-                 sha256  e67ed748b9ef6d4557da24beefe9d9ec193e9d9f843be5ff6559a275e0d230b6 \
-                 size    188011209
+    checksums    rmd160  057e9f5b04239844584e48d7c6e05b1b0a0b1095 \
+                 sha256  36050e3a2457c970ebc74c53ccd2cf116f9306c1649520fe3f31ad9cf63fbe62 \
+                 size    187921151
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  9bdfe98e710d86404718d3d330fe2bd42c5040e9 \
-                 sha256  8acda4fa59946902180a9283ee191b3db19b8c1146fb8dfa209d316ec78f9a5f \
-                 size    178140824
+    checksums    rmd160  b6e3315ae3d7fd5a00463bcfe32cebd08aa9eda8 \
+                 sha256  fe3c923b35dbc47177debc551dbadcd50c9c336c697b324ea8958af3ad8905b0 \
+                 size    178408153
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.9.

###### Tested on

macOS 14.1 23B74 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?