### PR TITLE
openjdk11-microsoft: update to 11.0.21

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      11.0.20.1
-set build    1
+version      11.0.21
+set build    9
 revision     0
 
 description  Microsoft Build of OpenJDK 11 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  1beb37e09fd650036b1e136111c6164d8515a17f \
-                 sha256  023ddec42f85db9c26a80ad1e5b2f8081796f46437fba7e8f6282c3b47c73c28 \
-                 size    187733259
+    checksums    rmd160  fb0f2a6203312afadf14c1787a483e7f1b570a4e \
+                 sha256  f9dfe40bcb2bad3d55861122cb05951b5f369e67a674eb0f395d287340e8f72e \
+                 size    187832581
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  595a6b46a200e5d20eeb3ad4c2956432a7c7e5fa \
-                 sha256  e9773c9dfd72b62924aff4f1dbe8602d5889d02ad0d9aaf4f7e1e2cb0196bd75 \
-                 size    185294857
+    checksums    rmd160  477be288d50e361d072e31e306e74a843b6e25d3 \
+                 sha256  6c9aa53777f7033fa4230917ab2ee6ee2805b9ea1754dad2eb47c2e9ca1d0904 \
+                 size    185391194
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.21.

###### Tested on

macOS 14.1 23B74 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?