### PR TITLE
go-md2man: Update to 2.0.3

### DIFF
--- a/textproc/go-md2man/Portfile
+++ b/textproc/go-md2man/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/cpuguy83/go-md2man 2.0.2 v
+go.setup            github.com/cpuguy83/go-md2man 2.0.3 v
 revision            0
 
 categories          textproc
@@ -14,9 +14,9 @@ description         Converts markdown into roff (man pages).
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  23c11486c5bc6f87cb13d2cb2aa7c2c68fd28f96 \
-                        sha256  c0fe49af2717cef631621cbbf010c7ee69b7e5c8afcde33779e07ecece9c00cc \
-                        size    64382
+                        rmd160  f44cb99228e4f418c00979bf850d568837755b76 \
+                        sha256  712375b6a4472b6eff9225cdf3e01a4d33e1e0753f713874ecd67a0d0c74bfea \
+                        size    64980
 
 go.vendors          github.com/russross/blackfriday \
                         lock    v2.1.0 \


### PR DESCRIPTION
#### Description

Update `go-md2man` to its latest release, 2.0.3.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
