### PR TITLE
lighttpd: Update to 1.4.73

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -5,11 +5,11 @@ PortGroup                   legacysupport 1.0
 PortGroup                   lua 1.0
 
 name                        lighttpd
-version                     1.4.72
+version                     1.4.73
 revision                    0
-checksums                   rmd160  1e79163f3a620f6a74a24d741cde49477013c74e \
-                            sha256  f7cade4d69b754a0748c01463c33cd8b456ca9cc03bb09e85a71bcbcd54e55ec \
-                            size    1083676
+checksums                   rmd160  7524652b92a75f2f536191f6acea1aecf5c05162 \
+                            sha256  818816d0b314b0aa8728a7076513435f6d5eb227f3b61323468e1f10dbe84ca8 \
+                            size    1086680
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  www


### PR DESCRIPTION
#### Description

lighttpd: Update to 1.4.73

###### Type(s)

- [x] enhancement

###### Tested on
macOS 11.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?