### PR TITLE
py-librosa: update to 0.10.1 and submit new dependencies

### DIFF
--- a/python/py-lazy_loader/Portfile
+++ b/python/py-lazy_loader/Portfile
@@ -5,6 +5,8 @@ PortGroup           python 1.0
 
 name                py-lazy_loader
 version             0.3
+revision            0
+
 platforms           {darwin any}
 supported_archs     noarch
 maintainers         nomaintainer
@@ -15,7 +17,7 @@ description         load subpackages and functions on demand
 long_description    ${python.rootname} makes it easy to load \
                     subpackages and functions on demand.
 
-homepage            https://pypi.org/project/lazy_loader/
+homepage            https://scientific-python.org/specs/spec-0001/
 
 checksums           md5 6b0f19ab63de5d00b862325bbeca7ea7 \
                     rmd160 e80499d84d692de89011de5658465b75320dd54c \
@@ -23,3 +25,14 @@ checksums           md5 6b0f19ab63de5d00b862325bbeca7ea7 \
 
 python.versions     38 39 310 311 312
 python.pep517_backend   flit
+
+if {${name} ne ${subport}} {
+    test.run        yes
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE.md README.md \
+            ${destroot}${docdir}
+    }
+}

--- a/python/py-librosa/Portfile
+++ b/python/py-librosa/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        librosa librosa 0.8.0
+github.setup        librosa librosa 0.10.1
 revision            0
 name                py-${github.project}
 
@@ -17,42 +17,36 @@ maintainers         nomaintainer
 description         A python package for music and audio analysis.
 long_description    {*}${description}
 
-checksums           rmd160  eb0af487a176a8c7f89d7fb9a58e707ef0e05ab5 \
-                    sha256  4f7421f91a6049483e4cdd567e2c308e4c7673720cd619ae8565e3395b0a6627 \
-                    size    4708361
+checksums           rmd160  25ae847aac6b9effde1b864637bcc86b1be0e564 \
+                    sha256  63e913b0060bb85e8a21ac06a33803d659c1139b2756442ee419012cf6a1df38 \
+                    size    2210477
 
 python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
     depends_run-append \
                     port:py${python.version}-audioread \
-                    port:py${python.version}-contextlib2 \
                     port:py${python.version}-decorator \
                     port:py${python.version}-joblib \
+                    port:py${python.version}-lazy_loader \
                     port:py${python.version}-matplotlib \
+                    port:py${python.version}-msgpack \
                     port:py${python.version}-numba \
                     port:py${python.version}-numpy \
                     port:py${python.version}-pooch \
-                    port:py${python.version}-resampy \
                     port:py${python.version}-scikit-learn \
                     port:py${python.version}-scipy \
-                    port:py${python.version}-six \
+                    port:py${python.version}-soxr \
                     port:py${python.version}-soundfile \
-                    port:py${python.version}-threadpoolctl
+                    port:py${python.version}-typing_extensions
 
     depends_test-append \
-                    port:py${python.version}-pytest \
                     port:py${python.version}-pytest-mpl \
-                    port:py${python.version}-samplerate
+                    port:py${python.version}-resampy \
+                    port:py${python.version}-samplerate \
+                    port:py${python.version}-types-decorator
 
     test.run        yes
-    test.cmd        py.test-${python.branch}
-    test.target
-    test.env-append \
-                    PYTHONPATH=${worksrcpath}/build/lib
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
@@ -60,6 +54,4 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} LICENSE.md README.md \
             ${destroot}${docdir}
     }
-
-    livecheck.type  none
 }

--- a/python/py-samplerate/Portfile
+++ b/python/py-samplerate/Portfile
@@ -18,16 +18,23 @@ checksums           rmd160  5438099cc157130fe9f2f87184d6a11ce567bab3 \
                     sha256  75ef725e6cd9c4545569caf4c47147beab7b53b2c36e5122e8c285d348f88847 \
                     size    4044998
 
-python.versions     37 38 39
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-pytest-runner \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-pytest-runner
 
     depends_lib-append \
                     port:py${python.version}-cffi \
                     port:py${python.version}-numpy \
 
-    livecheck.type  none
+    post-patch {
+        if {${python.version} >= 312} {
+            # workaround from https://github.com/pydata/pandas-datareader/issues/969
+            reinplace "s|configparser\.SafeConfigParser|configparser.ConfigParser|" \
+                ${worksrcpath}/versioneer.py
+            reinplace "s|parser\.readfp|parser.read_file|" \
+                ${worksrcpath}/versioneer.py
+        }
+    }
 }

--- a/python/py-soxr/Portfile
+++ b/python/py-soxr/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-soxr
+version             0.3.7
+revision            0
+
+categories-append   audio
+platforms           {darwin any}
+supported_archs     noarch
+license             LGPL-2.1+
+maintainers         nomaintainer
+
+description         High quality, one-dimensional sample-rate conversion library for Python
+long_description    {*}${description}
+
+homepage            https://github.com/dofuuz/python-soxr
+
+checksums           rmd160  f2441bee743b8c598e49c19a87057ec9ba473431 \
+                    sha256  436ddff00c6eb2c75b79c19cfdca7527b1e31b5fad738652f044045ba6258593 \
+                    size    296432
+
+python.versions     38 39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    path:bin/cython:py${python.version}-cython \
+                    port:py${python.version}-setuptools_scm
+
+    depends_run-append \
+                    port:py${python.version}-numpy
+
+    test.run        yes
+
+    post-patch {
+        reinplace "s|oldest-supported-numpy|numpy|" ${worksrcpath}/pyproject.toml
+    }
+
+    post-destroot {
+        set docdir ${prefix}/share/doc/${subport}
+        xinstall -d ${destroot}${docdir}
+        xinstall -m 0644 -W ${worksrcpath} LICENSE.txt README.md \
+            ${destroot}${docdir}
+    }
+}

--- a/python/py-types-decorator/Portfile
+++ b/python/py-types-decorator/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-types-decorator
+version             5.1.8.20240106
+revision            0
+
+categories-append   devel
+supported_archs     noarch
+platforms           {darwin any}
+license             Apache-2
+maintainers         nomaintainer
+
+description         Decorator factory for signature-preserving decorators.
+long_description    {*}${description}
+
+homepage            https://github.com/python/typeshed
+
+python.versions     38 39 310 311 312
+
+checksums           rmd160  03030f44825d884a3d29b75c1a0277bb3e3504f0 \
+                    sha256  32ff92b33615060d23b9d3760124bdb3506c4aa8d9eb50963cf1a3c20b9ecbbf \
+                    size    3675


### PR DESCRIPTION
#### Description

Updating py-librosa to 0.10.1 and submitting new dependencies py-lazy_loader, py-soxr, and py-types-decorator.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.2 12B45b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
