### PR TITLE
Upgrade vesion of fastapi to 0.103.1

### DIFF
--- a/python/py-fastapi/Portfile
+++ b/python/py-fastapi/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        tiangolo fastapi 0.78.0
-revision            1
+github.setup        tiangolo fastapi 0.103.1
+revision            0
 name                py-${github.project}
 
 categories-append   devel
@@ -20,23 +20,24 @@ long_description    FastAPI is a modern, fast (high-performance), web \
                     framework for building APIs with Python 3.6+ based \
                     on standard Python type hints.
 
-checksums           rmd160  a49377b829ca5849c8a8be00b0db90524665061d \
-                    sha256  278535022d140e2f75bb87e7926c82b04fd4aee908bbecd79d0c66c88e246882 \
-                    size    6861419
+checksums           rmd160  58bc385489e642b11490055fcdee5cd324ea0f9c \
+                    sha256  727fa4f8da1b683c2f6485375e0b99d6adf50400e92999a1fa27082b8bd8aea2 \
+                    size    11214418
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 python.pep517       yes
-python.pep517_backend   flit
+python.pep517_backend   hatchling
 
 if {${name} ne ${subport}} {
     patchfiles-append \
                    patch-pyproject_toml.diff
 
     depends_build-append \
-                    port:py${python.version}-flit
+                    port:py${python.version}-hatchling
 
     depends_run-append \
+                    port:py${python.version}-starlette \
                     port:py${python.version}-pydantic \
-                    port:py${python.version}-starlette
+                    port:py${python.version}-typing_extensions
 }

--- a/python/py-fastapi/files/patch-pyproject_toml.diff
+++ b/python/py-fastapi/files/patch-pyproject_toml.diff
@@ -1,11 +1,11 @@
---- ./pyproject.toml	2022-06-01 14:39:59.000000000 -0400
-+++ ./pyproject.toml	2022-06-01 14:40:29.000000000 -0400
-@@ -35,7 +35,7 @@
+--- ./pyproject.toml
++++ ./pyproject.toml
+@@ -40,7 +40,7 @@
      "Topic :: Internet :: WWW/HTTP",
  ]
- requires = [
--    "starlette==0.19.1",
-+    "starlette>=0.19.1",
-     "pydantic >=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0",
- ]
- description-file = "README.md"
+ dependencies = [
+-    "starlette>=0.27.0,<0.28.0",
++    "starlette>=0.27.0,<=0.31.1",
+     "pydantic>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0",
+     "typing-extensions>=4.8.0",
+     # TODO: remove this pin after upgrading Starlette 0.31.1


### PR DESCRIPTION
#### Description

Hi, this PR tries to solve the issue that the fastapi python package is currently broken (https://trac.macports.org/ticket/54100). I created myself that ticket and I have now decided to see how it can be fixed.

The solution is to bump the version of fastapi to 0.103.1. It seems that fastapi is still not compatible with starlette 0.31.1 (https://github.com/tiangolo/fastapi/pull/9939) although it seems that some compatibility is already done (https://github.com/tiangolo/fastapi/pull/10194). This is not ideal, since it might be that some functionality of fastapi does not work properly, but at least it is better that the current situation in which it does not work at all.

This PR also changes the build system from flit to hatchling, that has happened in the meantime (https://github.com/tiangolo/fastapi/pull/5240).

Additionally, it removed python37 support, since the starlette portfile does not support it anymore (https://github.com/macports/macports-ports/blob/master/python/py-starlette/Portfile)

The Portfile contain not tests, so I could not verify that, but I have tested it with an application that uses fastapi and things seems to be working fine, although admittedly such application does not exercise the full API of fastapi, of course.

Note that there is already a PR addressing something similar to this (https://github.com/macports/macports-ports/pull/19950). However, in this PR I don't try to support python 3.11 for the time being, since that gives an error with pydantic. It also needs to patch pyproject.toml, to ensure that the version of starlette in the metadata is consistent with the version in macports. Also, it changes the build system dependency as mentioned to hatchling. Also the typing-extensions dependency was missing.

All in all, this PR tries to solve the immediate problem of the broken fastapi currently shipped, even if there are potentially some fixes to be done in the future (full support for starlette 0.31.1 and fix the errors in python 3.11).

Closes: https://trac.macports.org/ticket/54100

###### Type(s)
- [X] bugfix

###### Tested on
macOS 13.3.1 22E261 arm64

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
