### PR TITLE
py-netcdf4: Update to 1.6.5

### DIFF
--- a/python/py-netcdf4/Portfile
+++ b/python/py-netcdf4/Portfile
@@ -6,8 +6,8 @@ PortGroup           mpi 1.0
 
 name                py-netcdf4
 python.rootname     netCDF4
-version             1.5.8
-revision            3
+version             1.6.5
+revision            0
 
 categories-append   science
 platforms           darwin
@@ -24,9 +24,9 @@ long_description    netCDF version 4 has many features not found in \
 
 homepage            https://unidata.github.io/netcdf4-python/
 
-checksums           rmd160  3164795f291cdba22de9b808096cca6aea36a4d9 \
-                    sha256  ca3d468f4812c0999df86e3f428851fb0c17ac34ce0827115c246b0b690e4e84 \
-                    size    767013
+checksums           rmd160  1f755b8e348196379e403f06fc4b0bf333f6510b \
+                    sha256  824881d0aacfde5bd982d6adedd8574259c85553781e7b83e0ce82b890bfa0ef \
+                    size    764969
 
 mpi.enforce_variant netcdf
 mpi.setup
@@ -35,6 +35,12 @@ build.env-append    USE_NCCONFIG=1
 destroot.env-append USE_NCCONFIG=1
 
 python.versions     27 35 36 37 38 39 310 311
+
+# Fixes "Missing dependencies: oldest-supported-numpy"
+# See https://trac.macports.org/ticket/67136
+# This fix copies the method used for py311-cftime:
+#   https://trac.macports.org/ticket/66898
+python.pep517       no
 
 if {${name} ne ${subport}} {
     if {${python.version} in "27 35"} {


### PR DESCRIPTION
#### Description

* Update to 1.6.5
* Fix "Missing dependencies: oldest-supported-numpy"

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

Github CI only.  OS 11, 12, 13.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
