### PR TITLE
kokkos-devel: update to 2023.10.31

### DIFF
--- a/devel/kokkos/Portfile
+++ b/devel/kokkos/Portfile
@@ -18,13 +18,13 @@ checksums                   rmd160  b73fbb7e3cc532545100412415bcb602414f7656 \
                             size    2305267
 
 subport kokkos-devel {
-    github.setup            kokkos kokkos 58f53a6a2ec9aeb1e38f7cb282764e941461b3ac
-    version                 2023.10.14
+    github.setup            kokkos kokkos fd80cbef444a038f870cf58e5ba036ae8d6ca85c
+    version                 2023.10.31
     conflicts               kokkos
     maintainers-append      {@barracuda156 gmail.com:vital.had}
-    checksums               rmd160  ce250b31c2a70f11ccb2d75ba79318465f0e6056 \
-                            sha256  d7864561b432052427262b9cbd4deb82fbb5974c4505a4f40f72bb9baef2efbb \
-                            size    2419818
+    checksums               rmd160  9c0d96c0eb903c252858c1274edf312ee3e8b079 \
+                            sha256  a15535e25f56301ff0669b824edb62e77baa6e1257ad9a9c3665c1d4a084e879 \
+                            size    2414553
     github.tarball_from     archive
     # 32-bit support added in: https://github.com/kokkos/kokkos/pull/5916
 


### PR DESCRIPTION
#### Description

Update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
