### PR TITLE
google-cloud-sdk: update to 453.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             452.0.1
+version             453.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  8aa00dc7ff1452ad36d1eebc378084845c8625e3 \
-                    sha256  3e05a23768bcfda72f61be352f296ae4f160f89ee7453f302c2991962134f12a \
-                    size    121744975
+    checksums       rmd160  e9fcb573c702c32890b86c21f25f126ec7f0a84d \
+                    sha256  774f8aa095b0f0d971863d376c8898feedb4356240b9f14c4c032a905042805d \
+                    size    121350020
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  1c567217acd0e4749875ffcc68a8602182716a41 \
-                    sha256  9681aea1380e3e366039fd46fe409e4a0733513f11789813a77a30bab408bf3f \
-                    size    123030529
+    checksums       rmd160  7600bd87e3412fc466176ba89dd4bde1daec1eb3 \
+                    sha256  fa5c102e4199f9b98cf634e72cefdb8b1c3f9ef5744ef98cac354ff2b8059478 \
+                    size    122635582
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  25cb388303531049c742640d4c476018058b9fa1 \
-                    sha256  57b9460c87f3dcd8df2ffc921b50223a1b0b5f619bdee762c436bb3a716ffed6 \
-                    size    120107832
+    checksums       rmd160  9bb1a7bf0d15e2a39e2a08d9265f1ec08fd37370 \
+                    sha256  c065f7a8ff7f6ed625fe56ec22addf8163ba8c553ad58acef1c570f5a1321b38 \
+                    size    119715659
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 453.0.0.

###### Tested on

macOS 14.1 23B74 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?