### PR TITLE
libgdata, gvfs: unbreak builds on systems where webkit2-gtk is broken

### DIFF
--- a/devel/gvfs/Portfile
+++ b/devel/gvfs/Portfile
@@ -55,8 +55,7 @@ depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:openssh \
                     path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
                     port:libxml2 \
-                    port:libsecret \
-                    port:gnome-online-accounts
+                    port:libsecret
 
 patchfiles          patch-test-run-in-tree.sh.diff \
                     patch-test-gvfs-test.diff
@@ -76,13 +75,24 @@ configure.args      --disable-avahi \
                     --disable-afc \
                     --disable-bluray \
                     --disable-libmtp \
-                    --enable-goa \
-                    --enable-google \
+                    --disable-goa \
+                    --disable-google \
                     --enable-http \
                     --enable-archive \
                     --enable-afp \
                     --enable-always-build-tests \
                     --disable-silent-rules
+
+platform darwin {
+    if {${os.major} > 10 || (${os.major} == 10 && ${configure.build_arch} eq "x86_64")} {
+        # This depends on webkit2-gtk, which is broken presently on < 10.6 and 32-bit 10.6:
+        depends_lib-append \
+                    port:gnome-online-accounts
+        configure.args-replace \
+                    --disable-goa --enable-goa \
+                    --disable-google --enable-google
+    }
+}
 
 test.run            yes
 test.target         check

--- a/devel/gvfs/Portfile
+++ b/devel/gvfs/Portfile
@@ -10,7 +10,6 @@ set branch          [join [lrange [split ${version} .] 0 1] .]
 maintainers         {devans @dbevans} openmaintainer
 categories          devel
 license             {LGPL GPL-3}
-platforms           darwin
 description         The Gnome Virtual File System.
 
 long_description    gvfs is a userspace virtual filesystem designed \
@@ -59,6 +58,11 @@ depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
 
 patchfiles          patch-test-run-in-tree.sh.diff \
                     patch-test-gvfs-test.diff
+
+post-patch {
+    # gettext version in configure.ac should match; having 0.19 breaks the build on some systems.
+    reinplace "s|0.19.4|0.21.1|" ${worksrcpath}/configure.ac
+}
 
 configure.cmd       ./autogen.sh
 

--- a/gnome/libgdata/Portfile
+++ b/gnome/libgdata/Portfile
@@ -16,7 +16,6 @@ long_description    ${description} \
 maintainers         {devans @dbevans} openmaintainer
 categories          gnome net
 license             LGPL-2.1+
-platforms           darwin
 homepage            https://wiki.gnome.org/Projects/${name}
 master_sites        gnome:sources/${name}/${branch}/
 
@@ -33,14 +32,24 @@ depends_build-append \
 depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:gcr \
                     path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
-                    port:gnome-online-accounts \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     port:json-glib \
                     path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
                     port:libxml2 \
                     port:uhttpmock
 
-configure.args      -Dgtk_doc=true
+configure.args      -Dgoa=disabled \
+                    -Dgtk_doc=true
+
+platform darwin {
+    if {${os.major} > 10 || (${os.major} == 10 && ${configure.build_arch} eq "x86_64")} {
+        # This depends on webkit2-gtk, which is broken presently on < 10.6 and 32-bit 10.6:
+        depends_lib-append \
+                    port:gnome-online-accounts
+        configure.args-replace \
+                    -Dgoa=disabled -Dgoa=enabled
+    }
+}
 
 test.run            yes
 


### PR DESCRIPTION
#### Description

For both ports support for `gnome-online-accounts` (which requires `webkit2-gtk`) is optional, but currently forced across the board, which breaks the build on systems where `webkit2-gtk` is broken.
Disable it there.

No revbump needed, as I understand, since nothing changes for systems where builds worked.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
