### PR TITLE
spice-gtk: Fix build failure with recent toolchain

### DIFF
--- a/gnome/spice-gtk/Portfile
+++ b/gnome/spice-gtk/Portfile
@@ -30,7 +30,8 @@ use_xz              yes
 set python_version  3.11
 set python_ver_no_dot [string map {. {}} ${python_version}]
 
-patchfiles-append   patch-meson-python.diff
+patchfiles-append   patch-meson-python.diff \
+                    1511f0ad5ea67b4657540c631e3a8c959bb8d578.patch
 
 post-patch {
     reinplace "s|@@PYTHON_BIN@@|${prefix}/bin/python${python_version}|g" \

--- a/gnome/spice-gtk/files/1511f0ad5ea67b4657540c631e3a8c959bb8d578.patch
+++ b/gnome/spice-gtk/files/1511f0ad5ea67b4657540c631e3a8c959bb8d578.patch
@@ -1,0 +1,280 @@
+From 1511f0ad5ea67b4657540c631e3a8c959bb8d578 Mon Sep 17 00:00:00 2001
+From: Frediano Ziglio <freddy77@gmail.com>
+Date: Wed, 21 Jun 2023 18:43:59 +0100
+Subject: [PATCH] Do not use libtool -export-symbols option
+
+This option is intended for libtool, not for any linker.
+Check the support of --version-script option using an empty
+list of symbols to catch some faulty linker supporting that
+option but not allowing not existing symbols (some buggy mold
+versions).
+
+Signed-off-by: Frediano Ziglio <freddy77@gmail.com>
+Upstream-Status: Backport [https://gitlab.freedesktop.org/spice/spice-gtk/-/commit/1511f0ad5ea67b4657540c631e3a8c959bb8d578]
+---
+ src/meson.build         |  20 ++---
+ src/spice-glib-sym-file | 169 ----------------------------------------
+ src/spice-gtk-sym-file  |  22 ------
+ src/test-map-file       |   4 +
+ 4 files changed, 14 insertions(+), 201 deletions(-)
+ delete mode 100644 src/spice-glib-sym-file
+ delete mode 100644 src/spice-gtk-sym-file
+ create mode 100644 src/test-map-file
+
+diff --git a/src/meson.build b/src/meson.build
+index daff1aaa..852217ac 100644
+--- ./src/meson.build
++++ ./src/meson.build
+@@ -181,14 +181,19 @@ endif
+ #
+ 
+ # version-script
++test_syms_path = meson.current_source_dir() / 'test-map-file'
++test_version_script = '-Wl,--version-script=@0@'.format(test_syms_path)
++spice_has_version_script = compiler.has_link_argument(test_version_script)
++
+ spice_client_glib_syms = files('map-file')
+ spice_client_glib_syms_path = meson.current_source_dir() / 'map-file'
+ spice_gtk_version_script = '-Wl,--version-script=@0@'.format(spice_client_glib_syms_path)
+-spice_gtk_has_version_script = compiler.has_link_argument(spice_gtk_version_script)
+-if not spice_gtk_has_version_script
+-  spice_client_glib_syms = files('spice-glib-sym-file')
+-  spice_client_glib_syms_path = meson.current_source_dir() / 'spice-glib-sym-file'
+-  spice_gtk_version_script = ['-export-symbols', spice_client_glib_syms_path]
++if not spice_has_version_script
++  if host_machine.system() == 'linux'
++    error('Version scripts should be supported on Linux')
++  endif
++  spice_client_glib_syms = []
++  spice_gtk_version_script = []
+ endif
+ 
+ # soversion
+@@ -373,11 +378,6 @@ if spice_gtk_has_gtk
+   # libspice-client-gtk.so
+   #
+   spice_client_gtk_syms = spice_client_glib_syms
+-  if not spice_gtk_has_version_script
+-    spice_client_gtk_syms = files('spice-gtk-sym-file')
+-    spice_client_gtk_syms_path = meson.current_source_dir() / 'spice-gtk-sym-file'
+-    spice_gtk_version_script = ['-export-symbols', spice_client_gtk_syms_path]
+-  endif
+ 
+   # soversion
+   # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+diff --git a/src/spice-glib-sym-file b/src/spice-glib-sym-file
+deleted file mode 100644
+index ccaad1ac..00000000
+--- ./src/spice-glib-sym-file
++++ /dev/null
+@@ -1,169 +0,0 @@
+-spice_audio_get
+-spice_audio_get_type
+-spice_audio_new
+-spice_channel_connect
+-spice_channel_destroy
+-spice_channel_disconnect
+-spice_channel_event_get_type
+-spice_channel_flush_async
+-spice_channel_flush_finish
+-spice_channel_get_error
+-spice_channel_get_type
+-spice_channel_new
+-spice_channel_open_fd
+-spice_channel_set_capability
+-spice_channel_string_to_type
+-spice_channel_test_capability
+-spice_channel_test_common_capability
+-spice_channel_type_to_string
+-spice_client_error_quark
+-spice_cursor_channel_get_type
+-spice_cursor_shape_get_type
+-spice_display_change_preferred_compression
+-spice_display_change_preferred_video_codec_type
+-spice_display_channel_change_preferred_compression
+-spice_display_channel_change_preferred_video_codec_type
+-spice_display_channel_change_preferred_video_codec_types
+-spice_display_channel_get_gl_scanout
+-spice_display_channel_get_primary
+-spice_display_channel_get_type
+-spice_display_channel_gl_draw_done
+-spice_display_get_gl_scanout
+-spice_display_get_primary
+-spice_display_gl_draw_done
+-spice_file_transfer_task_cancel
+-spice_file_transfer_task_get_filename
+-spice_file_transfer_task_get_progress
+-spice_file_transfer_task_get_total_bytes
+-spice_file_transfer_task_get_transferred_bytes
+-spice_file_transfer_task_get_type
+-spice_get_option_group
+-spice_gl_scanout_free
+-spice_gl_scanout_get_type
+-spice_g_signal_connect_object
+-spice_inputs_button_press
+-spice_inputs_button_release
+-spice_inputs_channel_button_press
+-spice_inputs_channel_button_release
+-spice_inputs_channel_get_type
+-spice_inputs_channel_key_press
+-spice_inputs_channel_key_press_and_release
+-spice_inputs_channel_key_release
+-spice_inputs_channel_motion
+-spice_inputs_channel_position
+-spice_inputs_channel_set_key_locks
+-spice_inputs_key_press
+-spice_inputs_key_press_and_release
+-spice_inputs_key_release
+-spice_inputs_lock_get_type
+-spice_inputs_motion
+-spice_inputs_position
+-spice_inputs_set_key_locks
+-spice_main_agent_test_capability
+-spice_main_channel_agent_test_capability
+-spice_main_channel_clipboard_selection_grab
+-spice_main_channel_clipboard_selection_notify
+-spice_main_channel_clipboard_selection_release
+-spice_main_channel_clipboard_selection_request
+-spice_main_channel_file_copy_async
+-spice_main_channel_file_copy_finish
+-spice_main_channel_get_type
+-spice_main_channel_request_mouse_mode
+-spice_main_channel_send_monitor_config
+-spice_main_channel_update_display
+-spice_main_channel_update_display_enabled
+-spice_main_channel_update_display_mm
+-spice_main_clipboard_grab
+-spice_main_clipboard_notify
+-spice_main_clipboard_release
+-spice_main_clipboard_request
+-spice_main_clipboard_selection_grab
+-spice_main_clipboard_selection_notify
+-spice_main_clipboard_selection_release
+-spice_main_clipboard_selection_request
+-spice_main_file_copy_async
+-spice_main_file_copy_finish
+-spice_main_request_mouse_mode
+-spice_main_send_monitor_config
+-spice_main_set_display
+-spice_main_set_display_enabled
+-spice_main_update_display
+-spice_main_update_display_enabled
+-spice_playback_channel_get_type
+-spice_playback_channel_set_delay
+-spice_port_channel_event
+-spice_port_channel_get_type
+-spice_port_channel_write_async
+-spice_port_channel_write_finish
+-spice_port_event
+-spice_port_write_async
+-spice_port_write_finish
+-spice_qmp_port_get
+-spice_qmp_port_get_type
+-spice_qmp_port_query_status_async
+-spice_qmp_port_query_status_finish
+-spice_qmp_port_vm_action_async
+-spice_qmp_port_vm_action_finish
+-spice_qmp_status_get_type
+-spice_qmp_status_ref
+-spice_qmp_status_unref
+-spice_record_channel_get_type
+-spice_record_channel_send_data
+-spice_record_send_data
+-spice_session_connect
+-spice_session_disconnect
+-spice_session_get_channels
+-spice_session_get_proxy_uri
+-spice_session_get_read_only
+-spice_session_get_type
+-spice_session_has_channel_type
+-spice_session_is_for_migration
+-spice_session_migration_get_type
+-spice_session_new
+-spice_session_open_fd
+-spice_session_verify_get_type
+-spice_set_session_option
+-spice_smartcard_channel_get_type
+-spice_smartcard_manager_get
+-spice_smartcard_manager_get_readers
+-spice_smartcard_manager_get_type
+-spice_smartcard_manager_insert_card
+-spice_smartcard_manager_remove_card
+-spice_smartcard_reader_get_type
+-spice_smartcard_reader_insert_card
+-spice_smartcard_reader_is_software
+-spice_smartcard_reader_remove_card
+-spice_uri_get_hostname
+-spice_uri_get_password
+-spice_uri_get_port
+-spice_uri_get_scheme
+-spice_uri_get_type
+-spice_uri_get_user
+-spice_uri_set_hostname
+-spice_uri_set_password
+-spice_uri_set_port
+-spice_uri_set_scheme
+-spice_uri_set_user
+-spice_uri_to_string
+-spice_usb_device_get_description
+-spice_usb_device_get_libusb_device
+-spice_usb_device_get_type
+-spice_usb_device_manager_can_redirect_device
+-spice_usb_device_manager_connect_device_async
+-spice_usb_device_manager_connect_device_finish
+-spice_usb_device_manager_disconnect_device
+-spice_usb_device_manager_disconnect_device_async
+-spice_usb_device_manager_disconnect_device_finish
+-spice_usb_device_manager_get
+-spice_usb_device_manager_get_devices
+-spice_usb_device_manager_get_devices_with_filter
+-spice_usb_device_manager_get_type
+-spice_usb_device_manager_is_device_connected
+-spice_usb_device_manager_is_redirecting
+-spice_usb_device_manager_allocate_device_for_file_descriptor
+-spice_usbredir_channel_get_type
+-spice_util_get_debug
+-spice_util_get_version_string
+-spice_util_set_debug
+-spice_uuid_to_string
+-spice_webdav_channel_get_type
+diff --git a/src/spice-gtk-sym-file b/src/spice-gtk-sym-file
+deleted file mode 100644
+index 5ba57cb6..00000000
+--- ./src/spice-gtk-sym-file
++++ /dev/null
+@@ -1,22 +0,0 @@
+-spice_display_get_grab_keys
+-spice_display_get_pixbuf
+-spice_display_get_type
+-spice_display_key_event_get_type
+-spice_display_keyboard_ungrab
+-spice_display_mouse_ungrab
+-spice_display_new
+-spice_display_new_with_monitor
+-spice_display_send_keys
+-spice_display_set_grab_keys
+-spice_grab_sequence_as_string
+-spice_grab_sequence_copy
+-spice_grab_sequence_free
+-spice_grab_sequence_get_type
+-spice_grab_sequence_new
+-spice_grab_sequence_new_from_string
+-spice_gtk_session_copy_to_guest
+-spice_gtk_session_get
+-spice_gtk_session_get_type
+-spice_gtk_session_paste_from_guest
+-spice_usb_device_widget_get_type
+-spice_usb_device_widget_new
+diff --git a/src/test-map-file b/src/test-map-file
+new file mode 100644
+index 00000000..3f25abe9
+--- /dev/null
++++ ./src/test-map-file
+@@ -0,0 +1,4 @@
++TEST_LIB {
++local:
++*;
++};
+-- 
+GitLab
+


### PR DESCRIPTION
#### Description

No revbump because this either builds correctly, or not at all.

Closes: https://trac.macports.org/ticket/68284

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
