### PR TITLE
hugo: update to 0.120.3

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.120.1 v
+go.setup            github.com/gohugoio/hugo 0.120.3 v
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  dc113f622f827d3cf16bdb5bfca30e760f8d30ac \
-                    sha256  8e461a9bc7abfe31e7a8c128b5e4a6b6baee7ed921f9f9be7239fa677cded46b \
-                    size    20735295
+checksums           rmd160  186a63a899bf23603ed44ef2439a60a00fbfbce6 \
+                    sha256  c392ccf23042e967a8faca19a2995c516e388807540e35d791a82b3b808f8ae8 \
+                    size    20735227
 
 categories          www
 installs_libs       no
@@ -24,7 +24,7 @@ long_description    {*}${description}
 # FIXME: This port currently can't be built without allowing go mod to fetch
 # dependencies during the build phase. See
 # https://trac.macports.org/ticket/61192
-go.offline_build no
+go.offline_build    no
 
 build.pre_args-append \
     -ldflags \"-X ${go.package}/common/hugo.vendorInfo=macports\"
@@ -49,4 +49,14 @@ post-destroot {
     system -W ${worksrcpath} "${worksrcpath}/${name} completion bash > hugo.sh"
     xinstall -d ${destroot}${prefix}/share/bash-completion/completions/
     xinstall -m 0644 ${worksrcpath}/hugo.sh ${destroot}${prefix}/share/bash-completion/completions/${name}
+
+    # generation fish completion then install them
+    system -W ${worksrcpath} "${worksrcpath}/${name} completion fish > hugo.fish"
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d/
+    xinstall -m 644 ${worksrcpath}/hugo.fish ${destroot}${prefix}/share/fish/vendor_completions.d/
+
+    # generation zsh completion then install them
+    system -W ${worksrcpath} "${worksrcpath}/${name} completion zsh > _hugo"
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions/
+    xinstall -m 644 ${worksrcpath}/_hugo ${destroot}${prefix}/share/zsh/site-functions/
 }


### PR DESCRIPTION
#### Description
hugo: update to 0.120.3
* generate and install {fish, zsh} completion files
* make spacing consistent

###### Tested on
macOS 12.7 21G816 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?