### PR TITLE
weechat: update to 4.1.1, update python variants, fix +doc build

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.0.2
+version             4.1.1
 revision            0
-checksums           rmd160  86a96f18563a1558b7d7b5b11f3fa44da37dbe9e \
-                    sha256  0e648ee0d024c8099425ee60d41b272924ec8e19800ee8f1441090708834023c \
-                    size    2573044
+checksums           rmd160  2b50be557e1dc324042878cb205b1e43f1c35410 \
+                    sha256  774238614d8e63e4d3d5a73a6cb640ec76fe06cc982b87a8c923651579277675 \
+                    size    2634896
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes
@@ -75,41 +75,41 @@ configure.args-append \
                     -DENABLE_TCL=OFF \
                     -DENABLE_TESTS=OFF
 
-variant python requires python311 description {Compatibility variant, requires +python311} {}
+variant python requires python312 description {Compatibility variant, requires +python312} {}
 
-variant python37 description "Bindings for Python 3.7 plugins" conflicts python38 python39 python310 python311 {
-    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
-    configure.pkg_config_path-append \
-                            ${frameworks_dir}/Python.framework/Versions/3.7/lib/pkgconfig
-    depends_lib-append      port:python37
-}
-
-variant python38 description "Bindings for Python 3.8 plugins" conflicts python37 python39 python310 python311 {
+variant python38 description "Bindings for Python 3.8 plugins" conflicts python39 python310 python311 python312 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.pkg_config_path-append \
                             ${frameworks_dir}/Python.framework/Versions/3.8/lib/pkgconfig
     depends_lib-append      port:python38
 }
 
-variant python39 description "Bindings for Python 3.9 plugins" conflicts python37 python38 python310 python311 {
+variant python39 description "Bindings for Python 3.9 plugins" conflicts python38 python310 python311 python312 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.pkg_config_path-append \
                             ${frameworks_dir}/Python.framework/Versions/3.9/lib/pkgconfig
     depends_lib-append      port:python39
 }
 
-variant python310 description "Bindings for Python 3.10 plugins" conflicts python37 python38 python39 python311 {
+variant python310 description "Bindings for Python 3.10 plugins" conflicts python38 python39 python311 python312 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.pkg_config_path-append \
                             ${frameworks_dir}/Python.framework/Versions/3.10/lib/pkgconfig
     depends_lib-append      port:python310
 }
 
-variant python311 description "Bindings for Python 3.11 plugins" conflicts python37 python38 python39 python310 {
+variant python311 description "Bindings for Python 3.11 plugins" conflicts python38 python39 python310 python312 {
     configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
     configure.pkg_config_path-append \
                             ${frameworks_dir}/Python.framework/Versions/3.11/lib/pkgconfig
     depends_lib-append      port:python311
+}
+
+variant python312 description "Bindings for Python 3.12 plugins" conflicts python38 python39 python310 python311 {
+    configure.args-replace  -DENABLE_PYTHON=OFF -DENABLE_PYTHON=ON
+    configure.pkg_config_path-append \
+                            ${frameworks_dir}/Python.framework/Versions/3.12/lib/pkgconfig
+    depends_lib-append      port:python312
 }
 
 variant ruby requires ruby32 description {Compatibility variant, requires +ruby32} {}
@@ -159,8 +159,10 @@ variant aspell description {Support for Spellcheck (aspell)} {
 }
 
 variant doc description {Build HTML Documentation and Plugin API} {
-    configure.args-append   -DENABLE_DOC=ON
+    configure.args-append   -DENABLE_DOC=ON -DENABLE_DOC_INCOMPLETE=ON
     depends_build-append    port:source-highlight
+
+    notes-append "Documentation is not built for disabled plugins."
 }
 
 variant lua description {Bindings for Lua plugins} {


### PR DESCRIPTION
#### Description
weechat: update to 4.1.1, update python variants, fix +doc build
* adds +python312 for python 3.12, and updates +python to use +python312
* drops end-of-life +python37
* updates +doc to build documentation without requiring all plugins to be enabled

Closes: https://trac.macports.org/ticket/67933

###### Tested on
macOS 12.7 21G816 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?