### PR TITLE
scrcpy: update to version 2.2, fix build on 10.10

### DIFF
--- a/multimedia/scrcpy/Portfile
+++ b/multimedia/scrcpy/Portfile
@@ -9,7 +9,7 @@ PortGroup           legacysupport 1.1
 # needed for clock_gettime and static_assert to work on older OS X versions
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        Genymobile scrcpy 2.1.1 v
+github.setup        Genymobile scrcpy 2.2 v
 revision            0
 github.tarball_from archive
 
@@ -29,13 +29,13 @@ extract.only        ${distfiles}
 distfiles-append    ${name}-server-v${version}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  4e8c471f497cf55d75297ecfba9b1622620c3c81 \
-                    sha256  6f3d055159cb125eabe940a901bef8a69e14e2c25f0e47554f846e7f26a36c4d \
-                    size    386002 \
+                    rmd160  6be8397a6f4813e55e62475431f36f5f01f47eff \
+                    sha256  9c96ce84129e6a4c15da8b907e4576c945732e666fcc52cf94ff402b9dd10c2c \
+                    size    396529 \
                     ${name}-server-v${version} \
-                    rmd160  a14eb333812990610d424790b775492673c23196 \
-                    sha256  9558db6c56743a1dc03b38f59801fb40e91cc891f8fc0c89e5b0b067761f148e \
-                    size    56995
+                    rmd160  bd8bcbde62f6e0324d7c503b447d1ed481c299e3 \
+                    sha256  c85c4aa84305efb69115cd497a120ebdd10258993b4cf123a8245b3d99d49874 \
+                    size    64363
 
 depends_build-append \
                     port:pkgconfig
@@ -55,4 +55,4 @@ configure.args-append \
 compiler.c_standard 2011
 # Work around cfm: fatal error: 'stdatomic.h' file not found
 # https://trac.macports.org/ticket/60429
-compiler.blacklist-append {clang < 700}
+compiler.blacklist-append {clang < 701}


### PR DESCRIPTION
* update to version 2.2
* change clang blacklist from 700 to 701 to support 10.10

Closes: https://trac.macports.org/ticket/68420

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
