### PR TITLE
py-rfc3339-validator, py-rfc3986-validator: new ports

### DIFF
--- a/python/py-rfc3339-validator/Portfile
+++ b/python/py-rfc3339-validator/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-rfc3339-validator
+version             0.1.4
+revision            0
+distname            rfc3339_validator-${version}
+
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     38 39 310 311
+
+maintainers         nomaintainer
+
+description         A pure python RFC3339 validator
+long_description    {*}${description}
+
+homepage            https://github.com/naimetti/rfc3339-validator
+
+checksums           rmd160  fede1549109fc745688fc914624a0f6c465b9f34 \
+                    sha256  138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
+                    size    5513
+
+if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-six
+}

--- a/python/py-rfc3986-validator/Portfile
+++ b/python/py-rfc3986-validator/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim: fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-rfc3986-validator
+version             0.1.1
+revision            0
+distname            rfc3986_validator-${version}
+
+categories-append   devel
+license             BSD
+supported_archs     noarch
+platforms           {darwin any}
+
+python.versions     38 39 310 311
+
+maintainers         nomaintainer
+
+description         A pure python RFC3986 validator
+long_description    {*}${description}
+
+homepage            https://github.com/naimetti/rfc3986-validator
+
+checksums           rmd160  88e91a36f95480a21e4798c86992d9b92ac9b9d1 \
+                    sha256  3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055 \
+                    size    6760
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-pytest-runner
+}


### PR DESCRIPTION
#### Description
Two new ports required for a later Jupyter upgrade

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.1 22G313 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] ~~squashed and [minimized your commits](https://guide.macports.org/#project.github)?~~
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~ <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] ~~tried existing tests with `sudo port test`?~~
- [x] tried a full install with `sudo port -vst install`?
- [ ] ~~tested basic functionality of all binary files?~~
- [ ] ~~checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?~~

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
