### PR TITLE
ejdb2: new port

### DIFF
--- a/databases/ejdb2/Portfile
+++ b/databases/ejdb2/Portfile
@@ -1,0 +1,57 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+
+# strndup, clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
+
+github.setup        Softmotions ejdb 42a71a9a876e7d6a38efd67943b6be6f9fff6cde
+version             2023.10.26
+name                ejdb2
+revision            0
+categories          databases
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Embeddable JSON database engine
+long_description    {*}${description}. Single-file database, online backups support, \
+                    Fault-tolerant storage, HTTP REST/websockets network endpoints.
+homepage            https://ejdb.org
+checksums           rmd160  243e9f6ba98186e95dd157af236be34b36ef3b3c \
+                    sha256  922ade02f8c6cc2a571f83756a703dc9d3137aed84e6443649d20c8f9ef70356 \
+                    size    815080
+github.tarball_from archive
+
+depends_build-append \
+                    port:cunit
+depends_lib-append  port:iowow
+
+compiler.c_standard 2011
+
+configure.args-append \
+                    -DASAN:BOOL=OFF \
+                    -DBUILD_ANDROID_LIBS:BOOL=OFF \
+                    -DBUILD_BENCHMARKS:BOOL=OFF \
+                    -DBUILD_DART_BINDING:BOOL=OFF \
+                    -DBUILD_EXAMPLES:BOOL=OFF \
+                    -DBUILD_FLUTTER_BINDING:BOOL=OFF \
+                    -DBUILD_FRAMEWORK:BOOL=OFF \
+                    -DBUILD_JNI_BINDING:BOOL=OFF \
+                    -DBUILD_NODEJS_BINDING:BOOL=OFF \
+                    -DBUILD_REACT_NATIVE_BINDING:BOOL=OFF \
+                    -DBUILD_SHARED_LIBS:BOOL=ON \
+                    -DBUILD_SWIFT_BINDING:BOOL=OFF \
+                    -DBUILD_TESTS:BOOL=ON \
+                    -DENABLE_HTTP:BOOL=ON \
+                    -DPACKAGE_TGZ:BOOL=OFF \
+                    -DPACKAGE_ZIP:BOOL=OFF
+
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.ldflags-append \
+                    -latomic
+}
+
+# FIXME: on PowerPC tests fail.
+test.run            yes


### PR DESCRIPTION
#### Description

New port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14
Xcode 15

macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

Tests pass on `aarch64`:
```
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_svacchanda_SonomaPorts_databases_ejdb2/ejdb2/work/build
    Start 1: jql_test1
1/7 Test #1: jql_test1 ........................   Passed    0.48 sec
    Start 2: jbr_test1
2/7 Test #2: jbr_test1 ........................   Passed    0.26 sec
    Start 3: ejdb_test1
3/7 Test #3: ejdb_test1 .......................   Passed    0.25 sec
    Start 4: ejdb_test2
4/7 Test #4: ejdb_test2 .......................   Passed    0.27 sec
    Start 5: ejdb_test3
5/7 Test #5: ejdb_test3 .......................   Passed    0.31 sec
    Start 6: ejdb_test4
6/7 Test #6: ejdb_test4 .......................   Passed    0.26 sec
    Start 7: ejdb_test5
7/7 Test #7: ejdb_test5 .......................   Passed    0.45 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) =   2.30 sec
```
(On `ppc` this builds, but tests fail. I added a note about that.)