### PR TITLE
mu: update to 1.10.7, build with meson

### DIFF
--- a/mail/mu/Portfile
+++ b/mail/mu/Portfile
@@ -3,12 +3,14 @@
 PortSystem          1.0
 PortGroup           elisp 1.0
 PortGroup           github 1.0
+PortGroup           meson 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        djcb mu 1.8.14 v
-checksums           rmd160  f8b3f167df7951844fbf18ac6d02dc9be1a1519d \
-                    sha256  0699c7bc8a8bc991152f025ac213967e4f8119adea6593fd9e4e95718842576a \
-                    size    734755
+github.setup        djcb mu 1.10.7 v
+github.tarball_from archive
+checksums           rmd160  abe7446735554a25419269776c6859035e9ff136 \
+                    sha256  11b70d632764ad5b6d08e30649e1b61e3398a9034d9e1f4e893042a6f40dba38 \
+                    size    768281
 revision            0
 
 platforms           darwin
@@ -30,33 +32,20 @@ compiler.cxx_standard 2017
 # https://trac.macports.org/ticket/63364
 compiler.blacklist {clang < 900}
 
-depends_build-append \
-    port:pkgconfig
-
 depends_lib-append \
     port:gmime3 \
     port:xapian-core
-
-use_autoreconf  yes
-configure.args  \
-    --disable-silent-rules \
-    --with-gui=none \
-    --disable-mu4e \
-    --disable-webkit \
-    --disable-guile \
-    --disable-gtk \
-    --disable-readline
 
 variant emacs description {Build with emacs bindings} {
     depends_lib-append     path:${emacs_binary}:${emacs_binary_provider}
     configure.env-append   EMACS=${emacs_binary}
     build.env-append       ELCFLAGS=-Q
-    configure.args-replace --disable-mu4e --enable-mu4e
+    configure.args-append -Demacs=${emacs_binary}
 }
 
 variant guile description {Build with Guile/Scheme bindings} {
     depends_lib-append     port:guile
-    configure.args-replace --disable-guile --enable-guile
+    configure.args-append -Dguile=enabled
 }
 
 # disable "-rc" versions for livecheck

--- a/mail/mu/Portfile
+++ b/mail/mu/Portfile
@@ -32,6 +32,9 @@ compiler.cxx_standard 2017
 # https://trac.macports.org/ticket/63364
 compiler.blacklist {clang < 900}
 
+depends_build-append \
+    port:pkgconfig
+
 depends_lib-append \
     port:gmime3 \
     port:xapian-core


### PR DESCRIPTION
#### Description

`mu` switched from autotools to the meson build system with v1.8. As of v1.10 the deprecated autotools build has been removed. This PR switches the build from autotools to meson to support an update to v1.10.7. 

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.5.2 22G91 x86_64
Xcode 15.0.1 15A507


###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?