### PR TITLE
aop: move to github, remove dead homepage, linting

### DIFF
--- a/games/aop/Portfile
+++ b/games/aop/Portfile
@@ -1,30 +1,34 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name	   aop
-version	   0.6
-revision    1
-categories	games
-license    GPL-2
-platforms	darwin
-maintainers	nomaintainer
+PortSystem          1.0
+PortGroup           github 1.0
 
-description	Curses based arcade game for UNIX with only 64 lines of sourcecode.
-long_description	The goal of Aop (Ambassador Of Pain) is is to drive the hoovercraft \
-			(O) trough the level into the 'at' sign (@) and reach as much points \
-			as possible by reducing the number of moves and not losing any time. \
-			Lost lifes (0) can easily be picked up by simply drive over them.
+github.setup        hit-sys Ambassador-Of-Pain c3f00fd32935bc463221db8433d29becb83ec749
+github.tarball_from archive
+name                aop
+version             0.6
+revision            2
+categories          games
+license             GPL-2
+maintainers         nomaintainer
 
-homepage	http://raffi.at/code/aop/
-master_sites	${homepage}
-checksums	md5 8057b3ec240db608253d653eb692d244
+description         Curses based arcade game for UNIX with only 64 lines of sourcecode.
+long_description    The goal of Aop (Ambassador Of Pain) is is to drive the hoovercraft \
+                    (O) trough the level into the 'at' sign (@) and reach as much points \
+                    as possible by reducing the number of moves and not losing any time. \
+                    Lost lifes (0) can easily be picked up by simply drive over them.
 
-depends_lib	port:ncurses
+checksums           rmd160  d3f6f5d0bbcd6bcaa07ec62eaaf6c0a50b9fe889 \
+                    sha256  0908fae4b824dfa8d98f27c361df9cf979c425262812ada67908dea9cc28e302 \
+                    size    57538
 
-use_configure	no
+depends_lib         port:ncurses
 
-pre-build	{
-		reinplace "s|/usr/local|${destroot}${prefix}|g" ${worksrcpath}/Makefile
-		reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/aop.c
+use_configure       no
+
+pre-build    {
+    reinplace "s|/usr/local|${destroot}${prefix}|g" ${worksrcpath}/Makefile
+    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/aop.c
 }
 
-build.target	aop
+build.target        aop


### PR DESCRIPTION
#### Description
An update of sorts, the Makefile has been changed since the move to github.
There's also now a LICENSE file with the GPL 3 in it, but COPYING is still GPL 2. Unless advised otherwise I'm keeping the port license GPL 2.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
