### PR TITLE
kealib, gdal: update to version 1.5.1 and new gdal +kea variant

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -295,6 +295,11 @@ pre-configure {
     }
 }
 
+if {[variant_isset kea] && ![variant_isset hdf5]} {
+    ui_msg "NOTE: KEA driver support depends on HDF5, +hdf5 variant is added."
+    default_variants +hdf5
+}
+
 # Set target to none
 build.target
 
@@ -389,6 +394,11 @@ variant heif description {Enable HEIF support} {
     depends_lib-append      port:libheif
     configure.args-replace  -DGDAL_USE_HEIF=OFF    -DGDAL_USE_HEIF=ON
     configure.args-append   -DGDAL_ENABLE_DRIVER_HEIF=ON
+}
+
+variant kea description {Enable KEA support} {
+    depends_lib-append      port:kealib
+    configure.args-append   -DGDAL_ENABLE_DRIVER_KEA=ON
 }
 
 variant libarchive description {Enable libarchive support} {

--- a/gis/kealib/Portfile
+++ b/gis/kealib/Portfile
@@ -1,43 +1,52 @@
-PortSystem          1.0
-PortGroup           cmake 1.0
-PortGroup           bitbucket 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-bitbucket.setup     chchrsc kealib 1.4.10
-revision            12
+PortSystem          1.0
+PortGroup           active_variants 1.1
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        ubarsc kealib 1.5.1 kealib-
+revision            0
+
 categories          gis
 license             MIT
 maintainers         {vince @Veence}
-description         KEAlib - Implements KEA file format into HDF5 format
-long_description    The KEA file format developed by the OSGEO is a GIS \
-                    oriented format that supports the GDAL model and allows \
-                    raster attribute tables for raster GIS operations. It is \
-                    built atop HDF5.
-platforms           darwin
-bitbucket.tarball_from  downloads
+description         KEAlib - An HDF5 Based Raster File Format
+long_description    KEALib provides an implementation of the GDAL data model.  \
+                    The format supports raster attribute tables, image         \
+                    pyramids, meta-data and in-built statistics while also     \
+                    handling very large files and compression throughout.
 
-checksums           rmd160  a378fce28c2cc996dd070efc4c9d373a7242bb65 \
-                    sha256  b1bd2d6834d2fe09ba456fce77f7a9452b406dbe302f7ef1aabe924e45e6bb5e \
-                    size    116331
+homepage            http://www.kealib.org
+
+checksums           rmd160  81490694aa6cb9988ed9381358a164bcd2fdc8cb \
+                    sha256  5c624e91a454823be213077ed78e0649e6a1d5aec3beb57f8884aefe6650c0bc \
+                    size    144039
 
 depends_lib-append  port:gdal \
                     port:hdf5
 
-#worksrcdir          ${worksrcdir}/trunk
+compiler.cxx_standard  2011
+cmake.set_cxx_standard yes
 
-compiler.cxx_standard 2011
-configure.cxxflags-append   -std=c++11
-configure.ldflags-append    -std=c++11
+configure.args-append \
+                    -DGDAL_INCLUDE_DIR=${prefix} \
+                    -DHDF5_INCLUDE_DIR=${prefix}
 
-configure.args-append   -DGDAL_INCLUDE_DIR=${prefix} \
-                        -DGDAL_LIB_PATH=${prefix} \
-                        -DHDF5_INCLUDE_DIR=${prefix} \
-                        -DHDF5_LIB_PATH=${prefix}
+# Find out path to "mpi.h" (if) used by HDF5
+set mpl_include_dir ""
+if {![catch {set result [active_variants hdf5 openmpi]}]} {
+    if {$result} {
+        set mpl_include_dir "-I${prefix}/include/openmpi-mp"
+    }
+}
+if {![catch {set result [active_variants hdf5 mpich]}]} {
+    if {$result} {
+        set mpl_include_dir "-I${prefix}/include/mpich-mp"
+    }
+}
+if {$mpl_include_dir ne ""} {
+    configure.cxxflags-append ${mpl_include_dir}
+}
 
-cmake.out_of_source     no
-
-use_parallel_build      no
-
-notes "
-To be able to use KEA format in GDAL, set and export (or setenv) the\
-variable GDAL_DRIVER_PATH to ${prefix}/lib/gdalplugins.
-"
+notes "Enable the GDAL driver for KEA files by installing 'gdal' with the '+kea' variant."


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

Update `kealib` to version 1.5.1.
Add `+kea` variant to `gdal` for KEA driver support.

Closes https://trac.macports.org/ticket/68610


- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.1 22G313 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
