### PR TITLE
the: Update to 4.0

### DIFF
--- a/editors/THE/Portfile
+++ b/editors/THE/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 
 name                THE
-version             3.2
-revision            1
+version             4.0
+revision            0
 categories          editors
-platforms           darwin
+license             GPL-2+
 maintainers         nomaintainer
 
 description         The Hessling Editor
@@ -14,22 +14,23 @@ description         The Hessling Editor
 long_description    The Hessling Editor (THE) is a text editor modeled after \
                     the XEDIT editor for IBM mainframe operating systems.
 
-homepage            http://hessling-editor.sourceforge.net/
+homepage            https://hessling-editor.sourceforge.net/
 master_sites        sourceforge:hessling-editor
+distname            the-${version}
 
-checksums           sha1    7b86275c764efadbfb61c8f7c7507b0db1812db3 \
-                    rmd160  586f5ab46ad483fb9036651b5ca2bfe1f7b8652d
+checksums           rmd160  2c5328333322ad3729ff0ba6517971cfbb260c5e \
+                    sha256  a3fb152543d91a57aec4a38886f765863e33a49d49bee6524b369e6da923d039 \
+                    size    1545276
 
-depends_lib         port:rexx \
+depends_lib-append  port:rexx \
                     port:ncurses
 
-configure.args      --with-ncurses \
-                    --with-curseslibdir=${prefix}/lib \
-                    --with-cursesincdir=${prefix}/include \
-                    --mandir=${prefix}/share/man \
+depends_build-append \
+                    port:pkgconfig
+
+configure.args      --with-curses=ncurses \
                     --with-rexx=regina
 
 post-destroot {
-    # Rename nthe to the, since it's the only one installed.
-    file rename ${destroot}${prefix}/bin/nthe ${destroot}${prefix}/bin/the
+    xinstall -m 0644 ${worksrcpath}/COPYING ${destroot}${prefix}/share/the
 }


### PR DESCRIPTION
#### Description

Update `THE` to latest release, 4.0, while modernizing Portfile.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
