### PR TITLE
tcc: new port

### DIFF
--- a/lang/tcc/Portfile
+++ b/lang/tcc/Portfile
@@ -1,0 +1,67 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
+
+name                tcc
+version             0.9.26
+categories          lang devel
+platforms           darwin
+maintainers         {gwmail.gwu.edu:egall @cooljeanius} openmaintainer
+license             LGPL-2.1+
+supported_archs     i386
+
+if {${os.platform} eq "darwin" && ${os.major} > 10} {
+    # x86_64 failed for me on darwin 10, but I had included it by default
+    # when I wrote this Portfile at school, which had a newer OS, so I
+    # assume that x86_64 must have worked on the newer OS...
+    supported_archs-append x86_64
+}
+
+# does NOT accept multiple -arch flags:
+universal_variant   no
+
+# it bootstraps itself, so it is necessary to have it built before
+# other steps can continue:
+use_parallel_build  no
+
+description         ${name} is the Tiny C Compiler.
+
+long_description    ${name} is Fabrice Bellard's Tiny C Compiler. It \
+                    provides C scripting everywhere and claims to be the \
+                    smallest ANSI C compiler.
+
+homepage            http://bellard.org/${name}/
+master_sites        http://download.savannah.gnu.org/releases/tinycc
+use_bzip2           yes
+
+checksums \
+    md5     5fb28e4abc830c46a7f54c1f637fb25d \
+    sha1    7110354d3637d0e05f43a006364c897248aed5d0 \
+    rmd160  49ad231a827edffe3b28ca530b6c46fa9d502a8b \
+    sha256  521e701ae436c302545c3f973a9c9b7e2694769c71d9be10f70a2460705b6d71 \
+    size    525906
+
+depends_build-append bin:perl:perl5 \
+                     port:texinfo
+
+# It was designed to be built with gcc
+# (not sure which versions specifically though)
+compiler.whitelist-append gcc
+
+variant tests description {Run the test suite} {
+    depends_test-append port:expect
+    test.run             yes
+    test.cmd             make
+    test.target          test
+    test.env-append      CC=${worksrcpath}/tcc \
+                         CPPFLAGS="-I${worksrcpath}/include" \
+                         CPATH="-I${worksrcpath}/include"
+    pre-test {
+        # force use of copy that tcc has, required to pass testsuite:
+        reinplace "s|<stdarg.h>|\"stdarg.h\"|g" ${worksrcpath}/include/tcclib.h
+    }
+}
+
+# regex is broken, FIXME:
+livecheck.type       none

--- a/lang/tcc/Portfile
+++ b/lang/tcc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 name                tcc
-version             0.9.26
+version             0.9.27
 categories          lang devel
 platforms           darwin
 maintainers         {gwmail.gwu.edu:egall @cooljeanius} openmaintainer
@@ -36,11 +36,11 @@ master_sites        http://download.savannah.gnu.org/releases/tinycc
 use_bzip2           yes
 
 checksums \
-    md5     5fb28e4abc830c46a7f54c1f637fb25d \
-    sha1    7110354d3637d0e05f43a006364c897248aed5d0 \
-    rmd160  49ad231a827edffe3b28ca530b6c46fa9d502a8b \
-    sha256  521e701ae436c302545c3f973a9c9b7e2694769c71d9be10f70a2460705b6d71 \
-    size    525906
+    md5     9cdb185555da76db90287db351ca40b8 \
+    sha1    3bab3acd404ea92ba18e0c261d9d8cb2f366a8a5 \
+    rmd160  5a71748f766f40660e4203f68feb38d8b43f7325 \
+    sha256  de23af78fca90ce32dff2dd45b3432b2334740bb9bb7b05bf60fdbfc396ceb9c \
+    size    634999
 
 depends_build-append bin:perl:perl5 \
                      port:texinfo


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/38196 (or at least it ought to, once it works)

#### Description
I've been hoping for a port for `tcc` for about a decade now, so this Portfile is my attempt at creating one. Note that it doesn't actually work yet, so I'm leaving this in draft mode until it does work. Specifically, I need help with the following:
- [ ] The current build failure (see linked ticket)
- [ ] A fixed livecheck regex
- [ ] A more accurate compiler blacklist/whitelist

###### Type(s)
submission

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`? (need to fix build failure first)
- [ ] tried a full install with `sudo port -vst install`? (need to fix build failure first)
- [ ] tested basic functionality of all binary files? (need to fix build failure first)
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
