### PR TITLE
osxbom: new port

### DIFF
--- a/sysutils/osxbom/Portfile
+++ b/sysutils/osxbom/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+# My repo is ahead of the main one in terms of versions:
+github.setup        cooljeanius osxbom 0.0.6
+github.tarball_from archive
+categories          sysutils
+maintainers         {gwmail.gwu.edu:egall @cooljeanius}
+license             public-domain
+
+description         A free re-implementation of the NextSTEP/OSX lsbom \
+                    utility
+long_description    ${description}. Used by the PureDarwin project \
+                    to work with MacPorts binary packages.
+
+checksums           rmd160  3c3bd7e35c831c4056462f074cfb54a26c37bc1d \
+                    sha256  5c9a879c5261407bda861c09b5843c6e911317b054efea1214ae86a7d73cc371 \
+                    size    159429
+
+# mostly just things picked up by trace mode:
+depends_build-append \
+                    port:gawk \
+                    port:grep \
+                    bin:nroff:groff \
+                    bin:gmkdir:coreutils \
+                    port:libmacho-headers
+depends_lib-append  port:libunwind
+
+test.run            yes
+test.target         check
+test.target-append  distcheck
+depends_test-append bin:gzip:gzip \
+                    bin:zip:zip
+
+destroot {
+    xinstall ${worksrcpath}/lsbom ${destroot}${prefix}/bin/${name}
+    xinstall -d ${destroot}${prefix}/include/${name}
+    xinstall ${worksrcpath}/bom.h ${destroot}${prefix}/include/${name}
+}
+
+variant lsbom description \
+{Allow osxbom to be called as lsbom, even if that shadows the system lsbom} {
+    post-destroot {
+        ln -s ${name} ${destroot}${prefix}/bin/lsbom
+    }
+}


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/38306

#### Description
`osxbom` is a free reimplementation of the NextSTEP/OSX `lsbom` utility. It is used by the PureDarwin project to deal with MacPorts binary packages.

###### Type(s)
submission

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
