### PR TITLE
ne: Update to 3.3.3

### DIFF
--- a/editors/ne/Portfile
+++ b/editors/ne/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 
-github.setup        vigna ne 3.3.1
+github.setup        vigna ne 3.3.3
 github.tarball_from archive
 revision            0
 
@@ -21,18 +21,21 @@ long_description    ne is a free text editor that runs on (hopefully almost) any
 
 homepage            https://ne.di.unimi.it/
 
-checksums           rmd160  e1ce65bbe14f0085054fa7b7a95560bc5df21574 \
-                    sha256  931f01380b48e539b06d65d80ddf313cce67aab6d7b62462a548253ab9b3e10a \
-                    size    542857
+checksums           rmd160  c6c9efad0a7fb5e0abd2f68cd94092e133858702 \
+                    sha256  4f7509bb552e10348f9599f39856c8b7a2a74ea54c980dd2c9e15be212a1a6f0 \
+                    size    551030
 
 use_parallel_build  no
 
 depends_build-append \
-                    port:texinfo
+                    port:texinfo \
+                    port:perl5
 
 depends_lib-append  port:ncurses
 
+patch.pre_args      -p1
 patchfiles          patch-makefile.diff \
                     patch-src-makefile.diff
 
-build.target
+build.target        build
+build.args-append   PERL=${prefix}/bin/perl5

--- a/editors/ne/files/patch-makefile.diff
+++ b/editors/ne/files/patch-makefile.diff
@@ -1,11 +1,22 @@
---- makefile.orig	2021-05-27 10:41:44.000000000 -0400
-+++ makefile	2021-05-27 10:41:59.000000000 -0400
-@@ -36,7 +36,7 @@
- 	( cd doc; make pdf )
+diff -urN a/makefile b/makefile
+--- a/makefile	2023-11-04 19:35:24.000000000 -0400
++++ b/makefile	2023-11-04 20:02:11.000000000 -0400
+@@ -27,7 +27,8 @@
+ 
+ 
+ build: docs
+-	( cd src; $(MAKE) clean; $(MAKE) NE_GLOBAL_DIR=$(PREFIX)/share/ne; $(STRIP) ne )
++	( cd src; $(MAKE) clean; $(MAKE) NE_GLOBAL_DIR=$(PREFIX)/share/ne )
++	$(STRIP) src/ne
+ 
+ docs:
+ 	( cd doc; $(MAKE) )
+@@ -36,7 +37,7 @@
+ 	( cd doc; $(MAKE) pdf )
  
  version:
 -	./version.pl VERSION=$(VERSION)
-+	perl version.pl VERSION=$(VERSION)
++	$(PERL) version.pl VERSION=$(VERSION)
  
  source: version alldocs
- 	( cd src; make clean; make )
+ 	( cd src; $(MAKE) clean; $(MAKE) )

--- a/editors/ne/files/patch-src-makefile.diff
+++ b/editors/ne/files/patch-src-makefile.diff
@@ -1,7 +1,8 @@
---- src/makefile.orig	2021-05-27 08:06:56.000000000 -0400
-+++ src/makefile	2021-05-27 08:07:20.000000000 -0400
-@@ -100,11 +100,11 @@
- LDFLAGS=-flto=auto
+diff -urN a/src/makefile b/src/makefile
+--- a/src/makefile	2023-11-04 19:35:24.000000000 -0400
++++ b/src/makefile	2023-11-04 20:11:21.000000000 -0400
+@@ -107,11 +107,11 @@
+ 
  endif
  
 -CFLAGS=$(GCCFLAGS) \
@@ -9,8 +10,8 @@
  	-D_REGEX_LARGE_OFFSETS -D_GNU_SOURCE -DSTDC_HEADERS -DHAVE_SNPRINTF \
  	$(if $(NE_NOWCHAR), -DNOWCHAR,) \
  	$(if $(NE_TEST),    -DNE_TEST -coverage,) \
--	$(if $(NE_DEBUG),   -g -fsanitize=address -fsanitize=undefined,-O3 -DNDEBUG) \
-+	$(if $(NE_DEBUG),   -g -fsanitize=address -fsanitize=undefined, -DNDEBUG) \
+-	$(if $(NE_DEBUG),   -g -O -fsanitize=address -fsanitize=undefined,-O3 -DNDEBUG) \
++	$(if $(NE_DEBUG),   -g -O -fsanitize=address -fsanitize=undefined, -DNDEBUG) \
  	$(if $(NE_TERMCAP), -DNE_TERMCAP,) \
  	$(if $(NE_ANSI),    -DNE_TERMCAP -DNE_ANSI,) \
  	$(OPTS)


### PR DESCRIPTION
#### Description

Update `ne` to its latest release, while fixing building.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
