### PR TITLE
lagrange: update to 1.17.3

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.17.1 v
+gitea.setup         gemini lagrange 1.17.3 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  81527c11b5ac570a004122b13860b345fbb5f319 \
-                    sha256  f080c2719fa0cd034a6b0663e065e2ea92b7739b70c59d3fa0e6d9cacc16bce0 \
-                    size    7723891
+checksums           rmd160  85f681b2be154e2a568d324bb947288484a9867d \
+                    sha256  4b97941b57a2c71dba2c17e9a0165c6b6e22396a0b16a375ec7dda6e165f52e7 \
+                    size    7730821
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
Changelog: https://github.com/skyjake/lagrange/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
