### PR TITLE
python 3.12 variants for several ports

### DIFF
--- a/python/py-crashtest/Portfile
+++ b/python/py-crashtest/Portfile
@@ -21,6 +21,6 @@ checksums           rmd160  7ed7e18f113900997801c79a602a08577ae45ffd \
                     sha256  80d7b1f316ebfbd429f648076d6275c877ba30ba48979de4191714a75266f0ce \
                     size    4708
 
-python.versions         38 39 310 311
+python.versions         38 39 310 311 312
 python.pep517           yes
 python.pep517_backend   poetry

--- a/python/py-requests-toolbelt/Portfile
+++ b/python/py-requests-toolbelt/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  bc8306044dbad82b948fbbe47f763f61173a8412 \
                     sha256  5743439930e6072034f441eabf2bef93a21961aee8ab8f6291a860fa04d530b4 \
                     size    199298
 
-python.versions     27 36 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

These are eventual dependencies of poetry. I have not tested them out but poetry is working on 3.12 with them.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.1 22G313 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
