### PR TITLE
sbcl: update to 2.3.10

### DIFF
--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                ecl
 version             23.9.9
-revision            1
+revision            2
 categories          lang
 license             GPL-2+
 maintainers         {easieste @easye} {@catap korins.ky:kirill} openmaintainer
@@ -41,7 +41,7 @@ subport ecl-devel {
 
     gitlab.setup    embeddable-common-lisp ecl d1fdd797a84da8b30cfc88bbbca9bad6241c79d8
     version         20230925
-    revision        0
+    revision        1
 
     conflicts       ecl
 
@@ -60,7 +60,8 @@ use_parallel_build  no
 universal_variant   no
 
 depends_lib-append  port:boehmgc \
-                    port:gmp
+                    port:gmp \
+                    port:libatomic_ops
 
 configure.args-append \
                     --enable-boehm=system \

--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -11,7 +11,7 @@ name            sbcl
 #
 # Please bump the revision of math/maxima (and when it exists
 # math/maxima-devel) and fricas when this port changes.
-version         2.3.9
+version         2.3.10
 revision        0
 epoch           1
 
@@ -36,9 +36,9 @@ homepage        http://www.sbcl.org
 patchfiles      0001-fix-building-when-root-directory-contain-non-ASCII-c.patch \
                 0002-add-MacPorts-XDG_DATA_DIRS.patch
 
-checksums       rmd160  99f0a5533c60887890775c4df4a6331a4359b432 \
-                sha256  7d289a91232022028bf0128900c32bf00e4c5430c32f28af0594c8a592a98654 \
-                size    7574665
+checksums       rmd160  621122aba4ae1599f3f4f1b85b7fee82b60e2cb7 \
+                sha256  358033315d07e4c5a6c838ee7f22cfc4d49e94848eb71ec1389d494bc32dd2ab \
+                size    7600039
 
 if {${name} eq ${subport}} {
     master_sites \

--- a/math/fricas/Portfile
+++ b/math/fricas/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fricas
 version             1.3.9
-revision            4
+revision            5
 categories          math
 maintainers         {@pietvo vanoostrum.org:pieter} openmaintainer
 platforms           darwin

--- a/math/maxima/Portfile
+++ b/math/maxima/Portfile
@@ -38,7 +38,7 @@ subport maxima-devel {
     # Date:  Sun Jul 30 06:55:16 2023 -0700
     # commit 65e393d796fedd34162d2a510af37c2448f07d74
     version     5.47-dev-20230730
-    revision    2
+    revision    3
     fetch.type  git
     git.url     https://git.code.sf.net/p/maxima/code
     git.branch  65e393d796fedd34162d2a510af37c2448f07d74
@@ -58,7 +58,7 @@ if {${subport} eq ${name}} {
     conflicts   maxima-devel
 
     version     5.47.0
-    revision    2
+    revision    3
     # get the source tarball from sourceforge.
     master_sites    sourceforge:project/maxima/Maxima-source/${version}-source
 


### PR DESCRIPTION
#### Description

Here I've updated sbcl to 2.3.10, added forgonnet dependency to ECL which leads to https://trac.macports.org/ticket/68344 that prevents SBCL to be used on macOS 14.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->