### PR TITLE
py-libpysal: update to version 4.9.2

### DIFF
--- a/python/py-libpysal/Portfile
+++ b/python/py-libpysal/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-libpysal
-version             4.8.0
+version             4.9.2
 platforms           {darwin any}
 supported_archs     noarch
 license             BSD
@@ -17,17 +17,15 @@ long_description    {*}${description}, a library of spatial analysis functions.
 
 homepage            https://pysal.org
 
-checksums           rmd160  708befd535364f894449455e085f3407f03777ee \
-                    sha256  af6904f11cf63d4d111beab0fd63bdecedf07c11184e26ffa6601a036fba27e2 \
-                    size    5598608
+checksums           rmd160  9d9558ff213f3338773df8c613cb4afb46b4c037 \
+                    sha256  621f9fbbd1394193adfc590f1096ab959cee83bade388987c075e44326b5a3f1 \
+                    size    5602779
 
 python.versions     39 310 311
 python.pep517       yes
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-pytest-runner \
-                    port:py${python.version}-setuptools \
                     port:py${python.version}-setuptools_scm
 
     depends_run-append \
@@ -41,4 +39,12 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-scipy \
                     port:py${python.version}-shapely \
                     port:py${python.version}-packaging
+
+    if {${python.version} == 39} {
+        version         4.8.0
+        revision        0
+        checksums       rmd160  708befd535364f894449455e085f3407f03777ee \
+                        sha256  af6904f11cf63d4d111beab0fd63bdecedf07c11184e26ffa6601a036fba27e2 \
+                        size    5598608
+    }
 }


### PR DESCRIPTION
#### Description

Update `py-libpysal` to version 4.9.2, which supports Python 3.10+, thus version 4.8.0 is pinned for `py39-libpysal`.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.1 22G313 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
