### PR TITLE
py-geojson: update to 3.1.0 and add Python 3.12 support

### DIFF
--- a/python/py-geojson/Portfile
+++ b/python/py-geojson/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-geojson
-version             3.0.1
+version             3.1.0
 revision            0
 
 categories-append   gis
@@ -20,13 +20,13 @@ long_description    \
     formatted data and is an implementation of the Python __geo_interface__ \
     Specification.
 
-homepage            https://github.com/frewsxcv/python-geojson
+homepage            https://github.com/jazzband/geojson
 
-checksums           rmd160  b3fb2b2931e77a294bb6792a9b99739bf03a3196 \
-                    sha256  ff3d75acab60b1e66504a11f7ea12c104bad32ff3c410a807788663b966dee4a \
-                    size    24258
+checksums           rmd160  1b7c2e910bd1900ab405a9dd5c6a6061aafe6110 \
+                    sha256  58a7fa40727ea058efc28b0e9ff0099eadf6d0965e04690830208d3ef571adac \
+                    size    24492
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Update `py-geojson` to version 3.1.0 and add Python 3.12 support. 
In addition, update homepage url.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.1 22G313 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
