### PR TITLE
py-pyfatfs: new port (1.0.5)

### DIFF
--- a/python/py-appdirs/Portfile
+++ b/python/py-appdirs/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  9cb319eaad2555f163855a2d14bc8104f741496e \
                     size    13470
 
 # keep version for PY27 and PY34, these are (indirect) dependencies of py-virtualenv
-python.versions     27 34 35 36 37 38 39 310 311
+python.versions     27 34 35 36 37 38 39 310 311 312
 
 if {${subport} ne ${name}} {
     if {${python.version} != 34} {

--- a/python/py-fs/Portfile
+++ b/python/py-fs/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-fs
-version             2.4.15
+version             2.4.16
 revision            0
 
 license             MIT
@@ -15,11 +15,11 @@ long_description    ${description}
 
 homepage            https://github.com/PyFilesystem/pyfilesystem2
 
-checksums           rmd160  05a8f5204a089cf10607cab278944b741f12c292 \
-                    sha256  b09d02c311f4add1e6e2b75724c450eafcfeecc917579224ca8ad21dacd0a182 \
-                    size    184933
+checksums           rmd160  8f6ef82ac6c3e24901bfd64603bcbf1628d024dc \
+                    sha256  ae97c7d51213f4b70b6a958292530289090de3a7e15841e108fbe144f069d313 \
+                    size    187441
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pyfatfs/Portfile
+++ b/python/py-pyfatfs/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pyfatfs
+version             1.0.5
+revision            0
+
+maintainers         nomaintainer
+platforms           {darwin any}
+supported_archs     noarch
+license             MIT
+
+description         A filesystem module to access or modify FAT filesystems
+long_description    ${description}
+
+homepage            https://github.com/nathanhi/pyfatfs
+
+checksums           rmd160  2b632da58d4bbea4535b23ec1f35bce3df8f5d77 \
+                    sha256  e49ea062119fdf6198c7bbbcfe08589d8919e34ac21f5f604d0ed8b5c444972d \
+                    size    50114
+
+python.versions     38 39 310 311 312
+python.pep517       yes
+
+if {${name} ne ${subport}} {
+    patchfiles-append       patch-py312_tests.diff
+    depends_build-append    port:py${python.version}-pip
+    depends_lib-append      port:py${python.version}-fs
+    build.args              --skip-dependency-check
+    test.run                yes
+}

--- a/python/py-pyfatfs/files/patch-py312_tests.diff
+++ b/python/py-pyfatfs/files/patch-py312_tests.diff
@@ -1,0 +1,94 @@
+https://github.com/nathanhi/pyfatfs/commit/a4ec954fc12ff212740bc06ca962d539111e0f60.patch
+
+From a4ec954fc12ff212740bc06ca962d539111e0f60 Mon Sep 17 00:00:00 2001
+From: "Nathan-J. Hirschauer" <nathanhi@deepserve.info>
+Date: Sun, 15 Oct 2023 11:27:55 +0200
+Subject: [PATCH] Add workaround for PyFilesystem/pyfilesystem2#568 (Python
+ 3.12)
+
+---
+ pyfatfs/EightDotThree.py |  4 ++--
+ pyfatfs/FatIO.py         |  8 ++++----
+ tests/test_PyFatFS.py    | 16 +++++++++++++---
+ 3 files changed, 19 insertions(+), 9 deletions(-)
+
+diff --git pyfatfs/EightDotThree.py pyfatfs/EightDotThree.py
+index 57d0ac3..0791228 100644
+--- pyfatfs/EightDotThree.py
++++ pyfatfs/EightDotThree.py
+@@ -75,7 +75,7 @@ def set_byte_name(self, name: bytes):
+         :param name: `bytes`: Padded (must be 11 bytes) 8dot3 name
+         """
+         if not isinstance(name, bytes):
+-            raise TypeError(f"Given parameter must be of type bytes,"
++            raise TypeError(f"Given parameter must be of type bytes, "
+                             f"but got {type(name)} instead.")
+ 
+         name = bytearray(name)
+@@ -94,7 +94,7 @@ def set_byte_name(self, name: bytes):
+     def set_str_name(self, name: str):
+         """Set the name as string from user input (i.e. folder creation)."""
+         if not isinstance(name, str):
+-            raise TypeError(f"Given parameter must be of type str,"
++            raise TypeError(f"Given parameter must be of type str, "
+                             f"but got {type(name)} instead.")
+ 
+         if not self.is_8dot3_conform(name, self.encoding):
+diff --git pyfatfs/FatIO.py pyfatfs/FatIO.py
+index 5947bd0..67c316e 100644
+--- pyfatfs/FatIO.py
++++ pyfatfs/FatIO.py
+@@ -57,10 +57,10 @@ def __repr__(self) -> str:
+ 
+         ex: <FatFile fs=<PyFat object> path="/README.txt" mode="r">
+         """
+-        return f'<{self.__class__.__name__} ' \
+-               f'fs={self.fs} ' \
+-               f'path="{self.name}" ' \
+-               f'mode="{self.mode}"'
++        return str(f'<{self.__class__.__name__} '
++                   f'fs={self.fs} '
++                   f'path="{self.name}" '
++                   f'mode="{self.mode}"')
+ 
+     def seek(self, offset: int, whence: int = 0) -> int:
+         """Seek to a given offset in the file.
+diff --git tests/test_PyFatFS.py tests/test_PyFatFS.py
+index a62d307..c5771e4 100644
+--- tests/test_PyFatFS.py
++++ tests/test_PyFatFS.py
+@@ -36,7 +36,17 @@ def _make_fs(fat_type: int, **kwargs) -> (PyFatBytesIOFS, BytesIO):
+             in_memory_fs)
+ 
+ 
+-class TestPyFatFS16(FSTestCases, TestCase):
++class PyFsCompatLayer:
++    """PyFilesystem2 Python 3.12 compatibility layer.
++
++    Adds a workaround for PyFilesystem2#568:
++    https://github.com/PyFilesystem/pyfilesystem2/issues/568
++    """
++
++    assertRaisesRegexp = TestCase.assertRaisesRegex
++
++
++class TestPyFatFS16(FSTestCases, TestCase, PyFsCompatLayer):
+     """Integration tests with PyFilesystem2 for FAT16."""
+ 
+     FAT_TYPE = PyFat.FAT_TYPE_FAT16
+@@ -107,13 +117,13 @@ def test_writetest_truncates(self):
+         assert self.fs.readtext(fname) == '1' * 16
+ 
+ 
+-class TestPyFatFS32(TestPyFatFS16, FSTestCases, TestCase):
++class TestPyFatFS32(TestPyFatFS16, FSTestCases, TestCase, PyFsCompatLayer):
+     """Integration tests with PyFilesystem2 for FAT32."""
+ 
+     FAT_TYPE = PyFat.FAT_TYPE_FAT32
+ 
+ 
+-class TestPyFatFS12(TestPyFatFS16, FSTestCases, TestCase):
++class TestPyFatFS12(TestPyFatFS16, FSTestCases, TestCase, PyFsCompatLayer):
+     """Test specifics of FAT12 filesystem."""
+ 
+     FAT_TYPE = PyFat.FAT_TYPE_FAT12


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This also adds py312 subports to dependency py-fs, and its dependency py-appdirs. py-fs is updated to 2.4.16 in the process.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1 23B74 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
