### PR TITLE
poppler: fix library paths in generated typelib file

### DIFF
--- a/graphics/poppler-devel/Portfile
+++ b/graphics/poppler-devel/Portfile
@@ -9,7 +9,7 @@ name                poppler-devel
 conflicts           poppler xpdf-tools
 set my_name         poppler
 version             24.01.0
-revision            0
+revision            1
 
 categories          graphics
 license             GPL-2+
@@ -75,6 +75,9 @@ patchfiles-append   patch-cmake_modules_PopplerMacros.cmake.diff
 # fix header include path ordering for gobject-introspection call to
 # be source / build first, then system, as best can be determined
 patchfiles-append   patch-glib_CMakeFiles.txt-fix-include-ordering.diff
+
+# fix library paths in generated typelib file
+patchfiles-append   patch-glib_CMakeFiles.txt-fix-lib-location.diff
 
 if {${configure.compiler} eq "macports-gcc-7"} {
     patchfiles-append \

--- a/graphics/poppler-devel/files/patch-glib_CMakeFiles.txt-fix-lib-location.diff
+++ b/graphics/poppler-devel/files/patch-glib_CMakeFiles.txt-fix-lib-location.diff
@@ -1,0 +1,11 @@
+--- glib/CMakeLists.txt.orig	2023-11-04 19:56:34
++++ glib/CMakeLists.txt	2023-11-04 19:58:09
+@@ -123,6 +123,8 @@
+   set(INTROSPECTION_SCANNER_ARGS "--add-include-path=${CMAKE_CURRENT_SOURCE_DIR}" "--warn-all")
+   list(APPEND INTROSPECTION_SCANNER_ARGS "--library-path=${CMAKE_CURRENT_BINARY_DIR}")
+   set(INTROSPECTION_COMPILER_ARGS ${INTROSPECTION_COMPILER_ARGS} "--includedir=${CMAKE_CURRENT_SOURCE_DIR}")
++  get_target_property(POPPLER_GLIB_SOVERSION poppler-glib SOVERSION)
++  list(APPEND INTROSPECTION_COMPILER_ARGS "--shared-library=${CMAKE_INSTALL_NAME_DIR}/libpoppler-glib.${POPPLER_GLIB_SOVERSION}" "--shared-library=${CMAKE_INSTALL_NAME_DIR}/libpoppler.${POPPLER_SOVERSION_NUMBER}")
+ 
+   # Poppler: Assign package to gir & export keys
+   set(Poppler_0_18_gir "poppler-glib")


### PR DESCRIPTION
#### Description
This PR adds a patch that explicitly specifies the paths to the dynamic libraries in the install prefix, as otherwise a path relative to the working directory during buildtime of the port is used.

Before the fix `strings /opt/local/lib/girepository-1.0/Poppler-0.18.typelib | grep lib` gives
```
/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_graphics_poppler/poppler/work/build/libpoppler-glib.8.dylib,/opt/local/var/macports/build/_opt_bblocal_var_buildworker_ports_build_ports_graphics_poppler/poppler/work/build/libpoppler.133.dylib
```

and with the patch we get the correct:
```
/opt/local/lib/libpoppler-glib.8,/opt/local/lib/libpoppler.133
```

Note that I excluded the `dylib` extension intentionally, following the documentation of the `--shared-library` which says
```
The name of the library should not contain the ending shared library suffix.
```

Corresponding Trac ticket: [#68656](https://trac.macports.org/ticket/68656)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.1 22G313 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

