### PR TITLE
libvterm,neovim*: update to latest

### DIFF
--- a/devel/libvterm/Portfile
+++ b/devel/libvterm/Portfile
@@ -3,15 +3,14 @@
 PortSystem          1.0
 
 name                libvterm
-version             0.3.1
+version             0.3.3
 categories          devel
-platforms           darwin
 maintainers         {raimue @raimue} \
                     openmaintainer
 license             MIT
 
 description         A library for a VT220/xterm/ECMA-48 terminal emulator
-  
+
 long_description \
     An abstract C99 library which implements a VT220 or xterm-like terminal \
     emulator. It doesn't use any particular graphics toolkit or output system, \
@@ -21,11 +20,11 @@ long_description \
 
 homepage            http://www.leonerd.org.uk/code/libvterm/
 
-master_sites        ${homepage}
+master_sites        https://launchpad.net/${name}/trunk/v0.3/+download/
 
-checksums           rmd160  dc8d243beea22bdb77b02f713a6d90a9efdf9fed \
-                    sha256  25a8ad9c15485368dfd0a8a9dca1aec8fea5c27da3fa74ec518d5d3787f0c397 \
-                    size    79344
+checksums           rmd160  757be59cf6b79f92bd8f45c95eb47276c04b4394 \
+                    sha256  09156f43dd2128bd347cbeebe50d9a571d32c64e0cf18d211197946aff7226e0 \
+                    size    80024
 
 compiler.c_standard 1999
 
@@ -44,4 +43,6 @@ build.env-append    CC=${configure.cc} \
 
 destroot.args       ${build.args}
 
-livecheck.regex     ${name}-(\[0-9.\]+)\\.tar
+livecheck.type      regex
+livecheck.url       http://launchpad.net/${name}/+download
+livecheck.regex     ${name}-(\[0-9.\]+)\\.tar\\.gz

--- a/editors/neovim-devel/Portfile
+++ b/editors/neovim-devel/Portfile
@@ -4,9 +4,9 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            neovim neovim a03e00a3539ea995c69196aeb35d84912ead8c3f
+github.setup            neovim neovim 324fad1e88ba38c87db446418a96fd3170b7f392
 name                    neovim-devel
-version                 20231010
+version                 20231106
 revision                0
 categories              editors
 maintainers             {l2dy @l2dy} {judaew @judaew} \
@@ -23,9 +23,10 @@ long_description \
 
 homepage                https://neovim.io
 
-checksums               rmd160  5b9caf46eff6004522be00d70243405fe5b2745e \
-                        sha256  b7a7e75189122ceef8435ce0fe87799cb3968705eb46a248d54daf14117a30a6 \
-                        size    12337511
+github.tarball_from     archive
+checksums               rmd160  e303bbfa2cac86ef059646a940edf3565d7d1665 \
+                        sha256  9c338cb768ad494d57f54a68b392e7ee543799487d8ff15f9de295a89cd36c66 \
+                        size    12451059
 
 depends_build-append    port:pkgconfig
 

--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -1,15 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup github 1.0
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               cmake 1.1
 
-# use cmake 1.0 for CMAKE_BUILD_TYPE=Release
-PortGroup cmake 1.0
-
-github.setup            neovim neovim 0.9.2 v
+github.setup            neovim neovim 0.9.4 v
 revision                0
 categories              editors
-platforms               darwin
 maintainers             {raimue @raimue} \
                         {l2dy @l2dy} \
                         {judaew @judaew} \
@@ -26,9 +23,10 @@ long_description \
 
 homepage                https://neovim.io
 
-checksums               rmd160  9674646fc85da256174fb241268cc65cfc83922c \
-                        sha256  2355bfe785ac17436dd9bc6e1d20af71b99ffd283621f0c10fd27035e59f97db \
-                        size    11582244
+github.tarball_from     archive
+checksums               rmd160  aa68674d5744e89fd5a5258414f420f839852e64 \
+                        sha256  148356027ee8d586adebb6513a94d76accc79da9597109ace5c445b09d383093 \
+                        size    11585425
 
 depends_build-append    port:pkgconfig
 
@@ -45,7 +43,7 @@ depends_lib             port:gettext \
                         port:libiconv \
                         port:tree-sitter
 
-cmake.out_of_source     yes
+cmake.build_type        Release
 
 configure.args-append   -DUSE_BUNDLED=OFF \
                         -DLUA_PRG=${prefix}/bin/luajit


### PR DESCRIPTION
#### Description

- update libvterm to 0.3.3
- update neovim to v0.9.4
- update neovim-devel to 20231106

> Note: a recent update to neovim-devel set the [minimum version of libvterm to 0.3.3](https://github.com/neovim/neovim/commit/8405649f92a8a8eb254944eca15e8b0169cbb6fb)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.7 21G651 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->