### PR TITLE
remove obsolete python 3.7 variants

### DIFF
--- a/aqua/LyX/Portfile
+++ b/aqua/LyX/Portfile
@@ -63,26 +63,21 @@ if {![variant_isset qt4]} {
 }
 
 # Make the default match boost's default.
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39]} {
+if {![variant_isset python38] && ![variant_isset python39]} {
     default_variants-append +python310
 }
 
-variant python37 conflicts python38 python39 python310 description {Use python37} {
-    depends_build-append    port:python37
-    configure.python        ${prefix}/bin/python3.7
-}
-
-variant python38 conflicts python37 python39 python310 description {Use python38} {
+variant python38 conflicts python39 python310 description {Use python38} {
     depends_build-append    port:python38
     configure.python        ${prefix}/bin/python3.8
 }
 
-variant python39 conflicts python37 python38 python310 description {Use python39} {
+variant python39 conflicts python38 python310 description {Use python39} {
     depends_build-append    port:python39
     configure.python        ${prefix}/bin/python3.9
 }
 
-variant python310 conflicts python37 python38 python39 description {Use python310} {
+variant python310 conflicts python38 python39 description {Use python310} {
     depends_build-append    port:python310
     configure.python        ${prefix}/bin/python3.10
 }

--- a/databases/litecli/Portfile
+++ b/databases/litecli/Portfile
@@ -22,15 +22,12 @@ checksums           rmd160  c446258ef99de07b93a3f030255d12239fa2aa07 \
                     size    885382
 github.tarball_from archive
 
-variant python37 conflicts python38 python39 python310 python311 description "Use Python 3.7" {}
-variant python38 conflicts python37 python39 python310 python311 description "Use Python 3.8" {}
-variant python39 conflicts python37 python38 python310 python311 description "Use Python 3.9" {}
-variant python310 conflicts python37 python38 python39 python311 description "Use Python 3.10" {}
-variant python311 conflicts python37 python38 python39 python310 description "Use Python 3.11" {}
+variant python38 conflicts python39 python310 python311 description "Use Python 3.8" {}
+variant python39 conflicts python38 python310 python311 description "Use Python 3.9" {}
+variant python310 conflicts python38 python39 python311 description "Use Python 3.10" {}
+variant python311 conflicts python38 python39 python310 description "Use Python 3.11" {}
 
-if {[variant_isset python37]} {
-    python.default_version 37
-} elseif {[variant_isset python38]} {
+if {[variant_isset python38]} {
     python.default_version 38
 } elseif {[variant_isset python39]} {
     python.default_version 39

--- a/databases/mycli/Portfile
+++ b/databases/mycli/Portfile
@@ -22,14 +22,11 @@ checksums           rmd160  45e5df60b9d1c5f4ce9040732c38700701738992 \
                     sha256  1e5a195120880edb919252dcf05d0948cc0dbc7db3d6ddecf72c202c31329662 \
                     size    276324
 
-variant python37 conflicts python38 python39 python310 description "Use Python 3.7" {}
-variant python38 conflicts python37 python39 python310 description "Use Python 3.8" {}
-variant python39 conflicts python37 python38 python310 description "Use Python 3.9" {}
-variant python310 conflicts python37 python38 python39 description "Use Python 3.10" {}
+variant python38 conflicts python39 python310 description "Use Python 3.8" {}
+variant python39 conflicts python38 python310 description "Use Python 3.9" {}
+variant python310 conflicts python38 python39 description "Use Python 3.10" {}
 
-if {[variant_isset python37]} {
-    python.default_version 37
-} elseif {[variant_isset python38]} {
+if {[variant_isset python38]} {
     python.default_version 38
 } elseif {[variant_isset python39]} {
     python.default_version 39

--- a/databases/pgcli/Portfile
+++ b/databases/pgcli/Portfile
@@ -21,14 +21,11 @@ checksums           rmd160  0df7f981395f69e47b277d52336b117ecead12a4 \
                     sha256  65669f869766bb3416dc26ea719c65bd3297ba692207aa9e0f2164d26315ca8d \
                     size    444871
 
-variant python37 conflicts python38 python39 python310 description "Use Python 3.7" {}
-variant python38 conflicts python37 python39 python310 description "Use Python 3.8" {}
-variant python39 conflicts python37 python38 python310 description "Use Python 3.9" {}
-variant python310 conflicts python37 python38 python39 description "Use Python 3.10" {}
+variant python38 conflicts python39 python310 description "Use Python 3.8" {}
+variant python39 conflicts python38 python310 description "Use Python 3.9" {}
+variant python310 conflicts python38 python39 description "Use Python 3.10" {}
 
-if {[variant_isset python37]} {
-    python.default_version 37
-} elseif {[variant_isset python38]} {
+if {[variant_isset python38]} {
     python.default_version 38
 } elseif {[variant_isset python39]} {
     python.default_version 39

--- a/databases/xeus-sqlite/Portfile
+++ b/databases/xeus-sqlite/Portfile
@@ -21,16 +21,15 @@ compiler.cxx_standard   2017
 
 depends_build-append    port:pkgconfig
 
-variant python37 conflicts python38 python39 python310 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 description {Use Python 3.10} {}
+variant python38 conflicts python39 python310 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 description {Use Python 3.10} {}
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39]} {
+if {![variant_isset python38] && ![variant_isset python39]} {
     default_variants +python310
 }
 
-foreach pv {310 39 38 37} {
+foreach pv {310 39 38} {
     if {[variant_isset python${pv}]} {
         set python.version ${pv}
         break

--- a/devel/omniORB/Portfile
+++ b/devel/omniORB/Portfile
@@ -45,16 +45,7 @@ if {${build_arch} eq "x86_64" && ${os.platform} eq "darwin"} {
 # force a global variable
 set python_framework []
 
-variant python37 conflicts python38 python39 description {Build Python 3.7 IDL support} {
-    configure.python            ${prefix}/bin/python3.7
-    set python_framework        ${frameworks_dir}/Python.framework/Versions/3.7/lib
-    depends_lib-append          port:python37
-    configure.pkg_config_path   ${python_framework}/lib/pkgconfig
-
-    notes "Install py37-omniORBpy for omniORBpy."
-}
-
-variant python38 conflicts python37 python39 description {Build Python 3.8 IDL support} {
+variant python38 conflicts python39 description {Build Python 3.8 IDL support} {
     configure.python            ${prefix}/bin/python3.8
     set python_framework        ${frameworks_dir}/Python.framework/Versions/3.8/lib
     depends_lib-append          port:python38
@@ -63,7 +54,7 @@ variant python38 conflicts python37 python39 description {Build Python 3.8 IDL s
     notes "Install py38-omniORBpy for omniORBpy."
 }
 
-variant python39 conflicts python37 python38 description {Build Python 3.9 IDL support} {
+variant python39 conflicts python38 description {Build Python 3.9 IDL support} {
     configure.python            ${prefix}/bin/python3.9
     set python_framework        ${frameworks_dir}/Python.framework/Versions/3.9/lib
     depends_lib-append          port:python39
@@ -72,7 +63,7 @@ variant python39 conflicts python37 python38 description {Build Python 3.9 IDL s
     notes "Install py39-omniORBpy for omniORBpy."
 }
 
-if {![variant_isset python37] && ![variant_isset python38]} {
+if {![variant_isset python38]} {
     default_variants +python39
 }
 

--- a/gnome/gpodder/Portfile
+++ b/gnome/gpodder/Portfile
@@ -38,21 +38,15 @@ destroot.cmd           make
 destroot.destdir       DESTDIR=${destroot}
 
 
-variant python36 conflicts python27 python35 python37 python38 python39 python310 description {Use Python 3.6} {}
-variant python37 conflicts python27 python35 python36 python38 python39 python310 description {Use Python 3.7} {}
-variant python38 conflicts python27 python35 python36 python37 python39 python310 description {Use Python 3.8} {}
-variant python39 conflicts python27 python35 python36 python37 python38 python310 description {Use Python 3.9} {}
-variant python310 conflicts python27 python35 python36 python37 python38 python39 description {Use Python 3.10} {}
+variant python38 conflicts python39 python310 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 description {Use Python 3.10} {}
 
-if {![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
     default_variants +python310
 }
 
-if {[variant_isset python36]} {
-    python.default_version  36
-} elseif {[variant_isset python37]} {
-    python.default_version  37
-} elseif {[variant_isset python38]} {
+if {[variant_isset python38]} {
     python.default_version  38
 } elseif {[variant_isset python39]} {
     python.default_version  39

--- a/gnome/gtk-doc/Portfile
+++ b/gnome/gtk-doc/Portfile
@@ -49,19 +49,7 @@ configure.env-append XSLTPROC=${prefix}/bin/xsltproc
 configure.args      --with-xml-catalog=${prefix}/etc/xml/catalog \
                     --disable-silent-rules
 
-variant python37 conflicts python38 python39 python310 python311 description {Build using Python 3.7} {
-    depends_lib-append \
-        port:python37 \
-        port:py37-anytree \
-        port:py37-lxml \
-        port:py37-pygments
-
-    depends_test        port:py37-mock
-
-    configure.python    ${prefix}/bin/python3.7
-}
-
-variant python38 conflicts python37 python39 python310 python311 description {Build using Python 3.8} {
+variant python38 conflicts python39 python310 python311 description {Build using Python 3.8} {
     depends_lib-append \
         port:python38 \
         port:py38-anytree \
@@ -73,7 +61,7 @@ variant python38 conflicts python37 python39 python310 python311 description {Bu
     configure.python    ${prefix}/bin/python3.8
 }
 
-variant python39 conflicts python37 python38 python310 python311 description {Build using Python 3.9} {
+variant python39 conflicts python38 python310 python311 description {Build using Python 3.9} {
     depends_lib-append \
         port:python39 \
         port:py39-anytree \
@@ -85,7 +73,7 @@ variant python39 conflicts python37 python38 python310 python311 description {Bu
     configure.python    ${prefix}/bin/python3.9
 }
 
-variant python310 conflicts python37 python38 python39 python311 description {Build using Python 3.10} {
+variant python310 conflicts python38 python39 python311 description {Build using Python 3.10} {
     depends_lib-append \
         port:python310 \
         port:py310-anytree \
@@ -97,7 +85,7 @@ variant python310 conflicts python37 python38 python39 python311 description {Bu
     configure.python    ${prefix}/bin/python3.10
 }
 
-variant python311 conflicts python37 python38 python39 python310 description {Build using Python 3.11} {
+variant python311 conflicts python38 python39 python310 description {Build using Python 3.11} {
     depends_lib-append \
         port:python311 \
         port:py311-anytree \
@@ -109,8 +97,7 @@ variant python311 conflicts python37 python38 python39 python310 description {Bu
     configure.python    ${prefix}/bin/python3.11
 }
 
-if {![variant_isset python37] &&
-    ![variant_isset python38] &&
+if {![variant_isset python38] &&
     ![variant_isset python39] &&
     ![variant_isset python310] &&
     ![variant_isset python311] } {

--- a/graphics/fontforge/Portfile
+++ b/graphics/fontforge/Portfile
@@ -69,19 +69,7 @@ configure.args-append -DENABLE_GUI=False \
                       -DENABLE_WRITE_PFM=False \
                       -DENABLE_X11=False
 
-variant python37 conflicts python38 python39 python310 python311 description {Enable Python support (Python 3.7)} {
-    depends_lib-append      port:python37
-    configure.args-replace  -DENABLE_PYTHON_EXTENSION=False \
-                            -DENABLE_PYTHON_EXTENSION=True
-    configure.args-replace  -DENABLE_PYTHON_SCRIPTING=False \
-                            -DENABLE_PYTHON_SCRIPTING=True
-    configure.args-append   -DPython3_EXECUTABLE="${prefix}/bin/python3.7" \
-                            -DPYHOOK_INSTALL_DIR="${frameworks_dir}/Python.framework/Versions/3.7/lib/python3.7/site-packages"
-    configure.pkg_config_path \
-                            "${frameworks_dir}/Python.framework/Versions/3.7/lib/pkgconfig"
-}
-
-variant python38 conflicts python37 python39 python310 python311 description {Enable Python support (Python 3.8)} {
+variant python38 conflicts python39 python310 python311 description {Enable Python support (Python 3.8)} {
     depends_lib-append      port:python38
     configure.args-replace  -DENABLE_PYTHON_EXTENSION=False \
                             -DENABLE_PYTHON_EXTENSION=True
@@ -93,7 +81,7 @@ variant python38 conflicts python37 python39 python310 python311 description {En
                             "${frameworks_dir}/Python.framework/Versions/3.8/lib/pkgconfig"
 }
 
-variant python39 conflicts python37 python38 python310 python311 description {Enable Python support (Python 3.9)} {
+variant python39 conflicts python38 python310 python311 description {Enable Python support (Python 3.9)} {
     depends_lib-append      port:python39
     configure.args-replace  -DENABLE_PYTHON_EXTENSION=False \
                             -DENABLE_PYTHON_EXTENSION=True
@@ -105,7 +93,7 @@ variant python39 conflicts python37 python38 python310 python311 description {En
                             "${frameworks_dir}/Python.framework/Versions/3.9/lib/pkgconfig"
 }
 
-variant python310 conflicts python37 python38 python39 python311 description {Enable Python support (Python 3.10)} {
+variant python310 conflicts python38 python39 python311 description {Enable Python support (Python 3.10)} {
     depends_lib-append      port:python310
     configure.args-replace  -DENABLE_PYTHON_EXTENSION=False \
                             -DENABLE_PYTHON_EXTENSION=True
@@ -117,7 +105,7 @@ variant python310 conflicts python37 python38 python39 python311 description {En
                             "${frameworks_dir}/Python.framework/Versions/3.10/lib/pkgconfig"
 }
 
-variant python311 conflicts python37 python38 python39 python310 description {Enable Python support (Python 3.11)} {
+variant python311 conflicts python38 python39 python310 description {Enable Python support (Python 3.11)} {
     depends_lib-append      port:python311
     configure.args-replace  -DENABLE_PYTHON_EXTENSION=False \
                             -DENABLE_PYTHON_EXTENSION=True
@@ -139,6 +127,6 @@ variant gui description {Enable GUI support} {
 }
 
 default_variants    +gui
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
     default_variants-append +python311
 }

--- a/graphics/gimp3-devel/Portfile
+++ b/graphics/gimp3-devel/Portfile
@@ -149,26 +149,6 @@ destroot.keepdirs   ${destroot}${prefix}/share/gimp/2.99/fonts
 
 # requires python >= 3.6.0
 
-variant python36 description {Build with python plugin support using python 3.6} {
-    configure.args-delete     --disable-python
-    configure.python          ${prefix}/bin/python3.6
-    depends_lib-append        port:py36-cairo \
-                              port:py36-gobject3
-    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.6
-    configure.pkg_config_path ${python_framework}/lib/pkgconfig
-    configure.env-append      PATH=${python_framework}/bin:$env(PATH)
-}
-
-variant python37 description {Build with python plugin support using python 3.7} {
-    configure.args-delete     --disable-python
-    configure.python          ${prefix}/bin/python3.7
-    depends_lib-append        port:py37-cairo \
-                              port:py37-gobject3
-    set python_framework      ${frameworks_dir}/Python.framework/Versions/3.7
-    configure.pkg_config_path ${python_framework}/lib/pkgconfig
-    configure.env-append      PATH=${python_framework}/bin:$env(PATH)
-}
-
 variant python38 description {Build with python plugin support using python 3.8} {
     configure.args-delete     --disable-python
     configure.python          ${prefix}/bin/python3.8
@@ -179,10 +159,8 @@ variant python38 description {Build with python plugin support using python 3.8}
     configure.env-append      PATH=${python_framework}/bin:$env(PATH)
 }
 
-if {![variant_isset python36] && \
-    ![variant_isset python37] && \
-    ![variant_isset python38]} {
-    default_variants +python37
+if {![variant_isset python38]} {
+    default_variants +python38
 }
 
 variant remote description {Enable building of obsolete gimp-remote helper app} {

--- a/graphics/img2pdf/Portfile
+++ b/graphics/img2pdf/Portfile
@@ -15,17 +15,16 @@ supported_archs     noarch
 platforms           {darwin any}
 homepage            https://gitlab.mister-muffin.de/josch/img2pdf
 
-variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 python311 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10} {}
-variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11} {}
+variant python38 conflicts python39 python310 python311 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 python311 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 python311 description {Use Python 3.10} {}
+variant python311 conflicts python38 python39 python310 description {Use Python 3.11} {}
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
     default_variants +python311
 }
 
-foreach pv {311 310 39 38 37} {
+foreach pv {311 310 39 38} {
     if {[variant_isset python${pv}]} {
         python.default_version ${pv}
         break

--- a/graphics/opencolorio/Portfile
+++ b/graphics/opencolorio/Portfile
@@ -106,7 +106,7 @@ if {${configure.build_arch} in [list ppc ppc64]} {
 # OpenColorIO intentially installs Python module in lib
 # see https://github.com/imageworks/OpenColorIO/blob/15e96c1f579d3640947a5fcb5ec831383cc3956e/src/pyglue/CMakeLists.txt#L85
 
-variant python27 description {Build the Python 2.7 bindings} conflicts python36 python37 python38 python39 python310 python311 {
+variant python27 description {Build the Python 2.7 bindings} conflicts python38 python39 python310 python311 {
     depends_lib-append port:python27
     configure.args-append \
         -DPYTHON=${prefix}/bin/python2.7
@@ -119,33 +119,7 @@ variant python27 description {Build the Python 2.7 bindings} conflicts python36 
     }
 }
 
-variant python36 description {Build the Python 3.6 bindings} conflicts python27 python37 python38 python39 python310 python311 {
-    depends_lib-append port:python36
-    configure.args-append \
-        -DPYTHON=${prefix}/bin/python3.6
-    post-destroot {
-        xinstall -d -m 0755 \
-            ${destroot}${frameworks_dir}/Python.framework/Versions/3.6/lib/python3.6/site-packages
-        ln -s \
-            ${prefix}/lib/python3.6/site-packages/PyOpenColorIO.so \
-            ${destroot}${frameworks_dir}/Python.framework/Versions/3.6/lib/python3.6/site-packages/
-    }
-}
-
-variant python37 description {Build the Python 3.7 bindings} conflicts python27 python36 python38 python39 python310 python311 {
-    depends_lib-append port:python37
-    configure.args-append \
-        -DPYTHON=${prefix}/bin/python3.7
-    post-destroot {
-        xinstall -d -m 0755 \
-            ${destroot}${frameworks_dir}/Python.framework/Versions/3.7/lib/python3.7/site-packages
-        ln -s \
-            ${prefix}/lib/python3.7/site-packages/PyOpenColorIO.so \
-            ${destroot}${frameworks_dir}/Python.framework/Versions/3.7/lib/python3.7/site-packages/
-    }
-}
-
-variant python38 description {Build the Python 3.8 bindings} conflicts python27 python36 python37 python39 python310 python311 {
+variant python38 description {Build the Python 3.8 bindings} conflicts python27 python39 python310 python311 {
     depends_lib-append port:python38
     configure.args-append \
         -DPYTHON=${prefix}/bin/python3.8
@@ -158,7 +132,7 @@ variant python38 description {Build the Python 3.8 bindings} conflicts python27 
     }
 }
 
-variant python39 description {Build the Python 3.9 bindings} conflicts python27 python36 python37 python38 python310 python311 {
+variant python39 description {Build the Python 3.9 bindings} conflicts python27 python38 python310 python311 {
     depends_lib-append port:python39
     configure.args-append \
         -DPYTHON=${prefix}/bin/python3.9
@@ -171,7 +145,7 @@ variant python39 description {Build the Python 3.9 bindings} conflicts python27 
     }
 }
 
-variant python310 description {Build the Python 3.10 bindings} conflicts python27 python36 python37 python38 python39 python311 {
+variant python310 description {Build the Python 3.10 bindings} conflicts python27 python38 python39 python311 {
     depends_lib-append port:python310
     configure.args-append \
         -DPYTHON=${prefix}/bin/python3.10
@@ -185,7 +159,7 @@ variant python310 description {Build the Python 3.10 bindings} conflicts python2
 }
 
 
-variant python311 description {Build the Python 3.11 bindings} conflicts python27 python36 python37 python38 python39 python310 {
+variant python311 description {Build the Python 3.11 bindings} conflicts python27 python38 python39 python310 {
     depends_lib-append port:python311
     configure.args-append \
         -DPYTHON=${prefix}/bin/python3.11
@@ -198,11 +172,11 @@ variant python311 description {Build the Python 3.11 bindings} conflicts python2
     }
 }
 
-if {![variant_isset python27] && ![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
+if {![variant_isset python27] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
     default_variants +python311
 }
 
-if {![variant_isset python27] && ![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
+if {![variant_isset python27] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
     configure.args-append \
         -DOCIO_BUILD_PYGLUE=OFF
 }

--- a/lang/qore-python-module/Portfile
+++ b/lang/qore-python-module/Portfile
@@ -23,19 +23,16 @@ checksums           rmd160 2b5ca8d4245af0be54555fb40e416ff69e6758e5 \
                     sha256 429a2358004b72f8cebfb3dc2b8a24e481bb5bd44dd78ed8702f163d667b9ff7 \
                     size 66810
 
-variant python37 conflicts python38 python39 python310 python311 description {Enable Python 3.7} {}
-variant python38 conflicts python37 python39 python310 python311 description {Enable Python 3.8} {}
-variant python39 conflicts python37 python38 python310 python311 description {Enable Python 3.9} {}
-variant python310 conflicts python37 python38 python39 python311 description {Enable Python 3.10} {}
-variant python311 conflicts python37 python38 python39 python310 description {Enable Python 3.11} {}
+variant python38 conflicts python39 python310 python311 description {Enable Python 3.8} {}
+variant python39 conflicts python38 python310 python311 description {Enable Python 3.9} {}
+variant python310 conflicts python38 python39 python311 description {Enable Python 3.10} {}
+variant python311 conflicts python38 python39 python310 description {Enable Python 3.11} {}
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
     default_variants +python311
 }
 
-if {[variant_isset python37]} {
-    set python_version "37"
-} elseif {[variant_isset python38]} {
+if {[variant_isset python38]} {
     set python_version "38"
 } elseif {[variant_isset python39]} {
     set python_version "39"

--- a/net/httpie/Portfile
+++ b/net/httpie/Portfile
@@ -22,16 +22,12 @@ long_description    HTTPie (pronounced aych-tee-tee-pie) is a command line HTTP 
 license             BSD
 homepage            https://httpie.io/
 
-variant python37 conflicts python38 python39 python310 python311 description "Use Python 3.7" {}
-variant python38 conflicts python37 python39 python310 python311 description "Use Python 3.8" {}
-variant python39 conflicts python37 python38 python310 python311 description "Use Python 3.9" {}
-variant python310 conflicts python37 python38 python39 python311 description "Use Python 3.10" {}
-variant python311 conflicts python37 python38 python39 python310 description "Use Python 3.11" {}
+variant python38 conflicts python39 python310 python311 description "Use Python 3.8" {}
+variant python39 conflicts python38 python310 python311 description "Use Python 3.9" {}
+variant python310 conflicts python38 python39 python311 description "Use Python 3.10" {}
+variant python311 conflicts python38 python39 python310 description "Use Python 3.11" {}
 
-if {[variant_isset python37]} {
-    python.default_version 37
-    depends_lib-append port:py${python.version}-typing_extensions
-} elseif {[variant_isset python38]} {
+if {[variant_isset python38]} {
     python.default_version 38
     depends_lib-append port:py${python.version}-typing_extensions
 } elseif {[variant_isset python39]} {

--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -99,19 +99,16 @@ variant ffmpeg description {Add ffmpeg dependency, used to extract audio} {
 
 default_variants    +ffmpeg
 
-variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 python311 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10} {}
-variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11} {}
+variant python38 conflicts python39 python310 python311 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 python311 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 python311 description {Use Python 3.10} {}
+variant python311 conflicts python38 python39 python310 description {Use Python 3.11} {}
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
     default_variants +python311
 }
 
-if {[variant_isset python37]} {
-    python.default_version  37
-} elseif {[variant_isset python38]} {
+if {[variant_isset python38]} {
     python.default_version  38
 } elseif {[variant_isset python39]} {
     python.default_version  39

--- a/octave/octave-symbolic/Portfile
+++ b/octave/octave-symbolic/Portfile
@@ -19,17 +19,16 @@ checksums           rmd160  7a35a7d5a3b69325d9e92d389424fe72d618acf2 \
 supported_archs     noarch
 platforms           {darwin any}
 
-variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7 SymPy} {}
-variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8 SymPy} {}
-variant python39 conflicts python37 python38 python310 python311 description {Use Python 3.9 SymPy} {}
-variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10 SymPy} {}
-variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11 SymPy} {}
+variant python38 conflicts python39 python310 python311 description {Use Python 3.8 SymPy} {}
+variant python39 conflicts python38 python310 python311 description {Use Python 3.9 SymPy} {}
+variant python310 conflicts python38 python39 python311 description {Use Python 3.10 SymPy} {}
+variant python311 conflicts python38 python39 python310 description {Use Python 3.11 SymPy} {}
 
-if {![variant_isset python37] &&![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
     default_variants +python311
 }
 
-foreach pv {311 310 39 38 37} {
+foreach pv {311 310 39 38} {
     if {[variant_isset python${pv}]} {
         set python.branch [string index ${pv} 0].[string range ${pv} 1 end]
 

--- a/python/pipx/Portfile
+++ b/python/pipx/Portfile
@@ -23,7 +23,6 @@ github.tarball_from archive
 github.livecheck.regex  {([\d.]+)}
 
 if {
-    ![variant_isset python37] &&
     ![variant_isset python38] &&
     ![variant_isset python39] &&
     ![variant_isset python310] &&
@@ -32,11 +31,10 @@ if {
     default_variants +python311
 }
 
-variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 python311 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10} {}
-variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11} {}
+variant python38 conflicts python39 python310 python311 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 python311 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 python311 description {Use Python 3.10} {}
+variant python311 conflicts python38 python39 python310 description {Use Python 3.11} {}
 
 if {[variant_isset python311]} {
     python.default_version 311
@@ -46,8 +44,6 @@ if {[variant_isset python311]} {
     python.default_version 39
 } elseif {[variant_isset python38]} {
     python.default_version 38
-} elseif {[variant_isset python37]} {
-    python.default_version 37
 }
 
 python.pep517       yes
@@ -60,8 +56,3 @@ depends_lib-append  port:py${python.version}-argcomplete \
                     port:py${python.version}-packaging \
                     port:py${python.version}-pip \
                     port:py${python.version}-userpath
-
-if {${python.version} < 38} {
-    depends_run-append \
-                    port:py${python.version}-importlib-metadata
-}

--- a/python/rdiff-backup/Portfile
+++ b/python/rdiff-backup/Portfile
@@ -21,17 +21,16 @@ long_description    {*}${description}
 
 homepage            https://rdiff-backup.net/
 
-variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 python311 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10} {}
-variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11} {}
+variant python38 conflicts python39 python310 python311 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 python311 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 python311 description {Use Python 3.10} {}
+variant python311 conflicts python38 python39 python310 description {Use Python 3.11} {}
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
         default_variants +python311
 }
 
-foreach pv {311 310 39 38 37} {
+foreach pv {311 310 39 38} {
     if {[variant_isset python${pv}]} {
         python.default_version ${pv}
         break
@@ -44,8 +43,7 @@ depends_build-append \
                     port:py${python.version}-wheel
 
 depends_lib-append  port:librsync \
-                    port:py${python.version}-xattr \
-                    port:librsync
+                    port:py${python.version}-xattr
 
 build.env           "LIBRSYNC_DIR=${prefix}"
 

--- a/science/PothosLiquidDSP/Portfile
+++ b/science/PothosLiquidDSP/Portfile
@@ -26,29 +26,24 @@ compiler.cxx_standard 2011
 # set Python version and variants
 set PythonVersionNoDot ""
 
-variant python37 conflicts python38 python39 python310 description {Build using Python 3.7} {}
-variant python38 conflicts python37 python39 python310 description {Build using Python 3.8} {}
-variant python39 conflicts python37 python38 python310  description {Build using Python 3.9} {}
-variant python310 conflicts python37 python38 python39 description {Build using Python 3.10} {}
+variant python38 conflicts python39 python310 description {Build using Python 3.8} {}
+variant python39 conflicts python38 python310  description {Build using Python 3.9} {}
+variant python310 conflicts python38 python39 description {Build using Python 3.10} {}
 
-if {![variant_isset python37] &&
-    ![variant_isset python38] &&
+if {![variant_isset python38] &&
     ![variant_isset python39] &&
     ![variant_isset python310]} {
     default_variants +python39
 }
 
-if {![variant_isset python37] &&
-    ![variant_isset python38] &&
+if {![variant_isset python38] &&
     ![variant_isset python39] &&
     ![variant_isset python310]} {
-    ui_error "\n\nYou must select one of the variants +python37, +python38, +python39, or +python310.\n"
+    ui_error "\n\nYou must select one of the variants +python38, +python39, or +python310.\n"
     return -code error "Invalid variant selection"
 }
 
-if {[variant_isset python37]} {
-    set PythonVersionNoDot "37"
-} elseif {[variant_isset python38]} {
+if {[variant_isset python38]} {
     set PythonVersionNoDot "38"
 } elseif {[variant_isset python310]} {
     set PythonVersionNoDot "310"

--- a/science/ViennaRNA/Portfile
+++ b/science/ViennaRNA/Portfile
@@ -41,21 +41,14 @@ depends_lib-append port:gsl \
 test.run           yes
 test.target        check
 
-variant python37 conflicts python38 python39 description {Enable python3.7 wrappers} {
-    depends_lib-append     port:python37
-    configure.args-replace --without-python3 PYTHON3=${prefix}/bin/python3.7
-    configure.args-append  PYTHON3_DIR=${frameworks_dir}/Python.framework/Versions/3.7/lib/python3.7/site-packages
-    configure.args-append  PYTHON3_EXECDIR=${frameworks_dir}/Python.framework/Versions/3.7/lib/python3.7/site-packages
-}
-
-variant python38 conflicts python37 python39 description {Enable python3.8 wrappers} {
+variant python38 conflicts python39 description {Enable python3.8 wrappers} {
     depends_lib-append     port:python38
     configure.args-replace --without-python3 PYTHON3=${prefix}/bin/python3.8
     configure.args-append  PYTHON3_DIR=${frameworks_dir}/Python.framework/Versions/3.8/lib/python3.8/site-packages
     configure.args-append  PYTHON3_EXECDIR=${frameworks_dir}/Python.framework/Versions/3.8/lib/python3.8/site-packages
 }
 
-variant python39 conflicts python37 python38 description {Enable python3.9 wrappers} {
+variant python39 conflicts python38 description {Enable python3.9 wrappers} {
     depends_lib-append     port:python39
     configure.args-replace --without-python3 PYTHON3=${prefix}/bin/python3.9
     configure.args-append  PYTHON3_DIR=${frameworks_dir}/Python.framework/Versions/3.9/lib/python3.9/site-packages

--- a/science/getdp/Portfile
+++ b/science/getdp/Portfile
@@ -17,8 +17,8 @@ description             a general environment for the treatment of discrete prob
 long_description        \
     GetDP is a free finite element solver using mixed elements to discretize de Rham-type complexes in one, two and three dimensions.
 
-homepage                http://getdp.info
-master_sites            http://getdp.info/src
+homepage                https://getdp.info
+master_sites            https://getdp.info/src
 
 extract.suffix          .tgz
 distname                ${name}-${version}-source
@@ -86,40 +86,26 @@ variant petsc description {Use PETSc linear solver} {
     }
 }
 
-variant python27 description {Build the Python 2.7 bindings} conflicts python36 python37 python38 {
+variant python27 description {Build the Python 2.7 bindings} conflicts python38 {
     depends_lib-append port:python27
     post-patch {
         reinplace "s|__MACPORTS_PYTHON_VERSION__|2.7|g" ${worksrcpath}/CMakeLists.txt
     }
 }
 
-variant python36 description {Build the Python 3.6 bindings} conflicts python27 python37 python38 {
-    depends_lib-append port:python36
-    post-patch {
-        reinplace "s|__MACPORTS_PYTHON_VERSION__|3.6|g" ${worksrcpath}/CMakeLists.txt
-    }
-}
-
-variant python37 description {Build the Python 3.7 bindings} conflicts python27 python36 python38 {
-    depends_lib-append port:python37
-    post-patch {
-        reinplace "s|__MACPORTS_PYTHON_VERSION__|3.7|g" ${worksrcpath}/CMakeLists.txt
-    }
-}
-
-variant python38 description {Build the Python 3.8 bindings} conflicts python27 python36 python37 {
+variant python38 description {Build the Python 3.8 bindings} conflicts python27 {
     depends_lib-append port:python38
     post-patch {
         reinplace "s|__MACPORTS_PYTHON_VERSION__|3.8|g" ${worksrcpath}/CMakeLists.txt
     }
 }
 
-if {![variant_isset python27] && ![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38]} {
+if {![variant_isset python27] && ![variant_isset python38]} {
     configure.args-append \
         -DENABLE_PYTHON=OFF
 }
 
-if {![variant_isset python27] && ![variant_isset python36] && ![variant_isset python37] && ![variant_isset python38]} {
+if {![variant_isset python27] && ![variant_isset python38]} {
     # keep in sync with python PG
     default_variants +python38
 }

--- a/science/htcondor/Portfile
+++ b/science/htcondor/Portfile
@@ -39,9 +39,9 @@ variant personal \
     startupitem.stop    "${prefix}/sbin/condor_off -all -master"
 }
 
-set pythons_suffixes {27 35 36 37 38 39}
+set pythons_suffixes {27 38 39}
 
-if { !([variant_isset python27] || [variant_isset python35] || [variant_isset python36] || [variant_isset python37] || [variant_isset python38] || [variant_isset python39]) } {
+if { !([variant_isset python27] || [variant_isset python38] || [variant_isset python39]) } {
     default_variants +python39
 }
 

--- a/science/libsbml/Portfile
+++ b/science/libsbml/Portfile
@@ -95,37 +95,19 @@ variant multi description {Enable libSBML support for the SBML Level 3 Multistat
     configure.args-append   -DENABLE_MULTI:BOOL=ON
 }
 
-variant python27 conflicts python35 python36 python37 python38 python39 description {Configure to use Python version 2.7} {
+variant python27 conflicts python38 python39 description {Configure to use Python version 2.7} {
     depends_build-append  port:swig-python
     depends_lib-append      port:python27
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
 }
 
-variant python35 conflicts python27 python36 python37 python38 python39 description {Configure to use Python version 3.5} {
-    depends_build-append  port:swig-python
-    depends_lib-append      port:python35
-    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.5 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
-}
-
-variant python36 conflicts python27 python35 python37 python38 python39 description {Configure to use Python version 3.6} {
-    depends_build-append  port:swig-python
-    depends_lib-append      port:python36
-    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.6 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
-}
-
-variant python37 conflicts python27 python35 python36 python38 python39 description {Configure to use Python version 3.7} {
-    depends_build-append  port:swig-python
-    depends_lib-append      port:python37
-    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.7 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
-}
-
-variant python38 conflicts python27 python35 python36 python37 python39 description {Configure to use Python version 3.8} {
+variant python38 conflicts python27 python39 description {Configure to use Python version 3.8} {
     depends_build-append  port:swig-python
     depends_lib-append      port:python38
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.8 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON
 }
 
-variant python39 conflicts python27 python35 python36 python37 python38 description {Configure to use Python version 3.9} {
+variant python39 conflicts python27 python38 description {Configure to use Python version 3.9} {
     depends_build-append  port:swig-python
     depends_lib-append      port:python39
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.9 -DPYTHON_USE_DYNAMIC_LOOKUP:BOOL=ON

--- a/science/libsbmlsim/Portfile
+++ b/science/libsbmlsim/Portfile
@@ -37,31 +37,19 @@ variant java description {Generate Java language bindings.} {
     configure.args-append  -DWITH_JAVA:BOOL=ON
 }
 
-variant python27 conflicts python36 python37 python38 python39 description {Generate Python version 2.7 language bindings.} {
+variant python27 conflicts python38 python39 description {Generate Python version 2.7 language bindings.} {
     depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python27
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python2.7
 }
 
-variant python36 conflicts python27 python37 python38 python39 description {Generate Python version 3.6 language bindings.} {
-    depends_build-append  port:swig port:swig-python
-    depends_lib-append      port:python36
-    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.6
-}
-
-variant python37 conflicts python27 python36 python38 python39 description {Generate Python version 3.7 language bindings.} {
-    depends_build-append  port:swig port:swig-python
-    depends_lib-append      port:python37
-    configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.7
-}
-
-variant python38 conflicts python27 python36 python37 python39 description {Generate Python version 3.8 language bindings.} {
+variant python38 conflicts python27 python39 description {Generate Python version 3.8 language bindings.} {
     depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python38
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.8
 }
 
-variant python39 conflicts python27 python36 python37 python38 description {Generate Python version 3.9 language bindings.} {
+variant python39 conflicts python27 python38 description {Generate Python version 3.9 language bindings.} {
     depends_build-append  port:swig port:swig-python
     depends_lib-append      port:python39
     configure.args-append   -DWITH_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${prefix}/bin/python3.9

--- a/science/ompl/Portfile
+++ b/science/ompl/Portfile
@@ -33,7 +33,7 @@ configure.args-append   -DOMPL_BUILD_DEMOS=OFF \
 # somewhat dependent on compiler and/or boost version, so we can't
 # pre-generate them and make them available as an extra download.
 post-configure {
-    if {[variant_isset python35] || [variant_isset python36] || [variant_isset python37] || [variant_isset python38] || [variant_isset python39] || [variant_isset python310] || [variant_isset python311]} {
+    if {[variant_isset python38] || [variant_isset python39] || [variant_isset python310] || [variant_isset python311]} {
         # enable parallel build on at most 2 cores. Generating the bindings
         # uses large amounts of memory, so don't use more cores.
         if { ${use_parallel_build} } { set cj "-j 2" } else { set cj "" }
@@ -81,7 +81,7 @@ variant spot description {Include support for automaton generation from LTL spec
     depends_lib-append    port:spot
 }
 
-set pythons_versions {3.5 3.6 3.7 3.8 3.9 3.10 3.11}
+set pythons_versions {3.8 3.9 3.10 3.11}
 
 set pythons_ports {}
 foreach v ${pythons_versions} {

--- a/science/pymol/Portfile
+++ b/science/pymol/Portfile
@@ -38,17 +38,16 @@ subport pymol-devel {
                     size    10494860
 }
 
-variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 python311 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10} {}
-variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11} {}
+variant python38 conflicts python39 python310 python311 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 python311 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 python311 description {Use Python 3.10} {}
+variant python311 conflicts python38 python39 python310 description {Use Python 3.11} {}
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
     default_variants +python311
 }
 
-foreach pv {311 310 39 38 37} {
+foreach pv {311 310 39 38} {
     if {[variant_isset python${pv}]} {
         python.default_version ${pv}
         break

--- a/science/xraylib/Portfile
+++ b/science/xraylib/Portfile
@@ -63,35 +63,28 @@ if {[variant_isset perl5_28] || [variant_isset perl5_30] || [variant_isset perl5
     depends_build-append port:swig-perl
 }
 
-variant python27 description {Python 2.7 bindings} conflicts python37 python38 python39 python310 {
+variant python27 description {Python 2.7 bindings} conflicts python38 python39 python310 {
     configure.args-append --enable-python --enable-python-integration --enable-python-numpy PYTHON=${prefix}/bin/python2.7
     configure.args-delete --disable-python --disable-python-numpy
     depends_build-append port:swig-python port:py27-cython
     depends_lib-append port:python27 port:py27-numpy
 }
 
-variant python37 description {Python 3.7 bindings} conflicts python27 python38 python39 python310 {
-    configure.args-append --enable-python --enable-python-integration --enable-python-numpy PYTHON=${prefix}/bin/python3.7
-    configure.args-delete --disable-python --disable-python-numpy
-    depends_build-append port:swig-python port:py37-cython
-    depends_lib-append port:python37 port:py37-numpy
-}
-
-variant python38 description {Python 3.8 bindings} conflicts python27 python37 python39 python310 {
+variant python38 description {Python 3.8 bindings} conflicts python27 python39 python310 {
     configure.args-append --enable-python --enable-python-integration --enable-python-numpy PYTHON=${prefix}/bin/python3.8
     configure.args-delete --disable-python --disable-python-numpy
     depends_build-append port:swig-python port:py38-cython
     depends_lib-append port:python38 port:py38-numpy
 }
 
-variant python39 description {Python 3.9 bindings} conflicts python27 python37 python38 python310 {
+variant python39 description {Python 3.9 bindings} conflicts python27 python38 python310 {
     configure.args-append --enable-python --enable-python-integration --enable-python-numpy PYTHON=${prefix}/bin/python3.9
     configure.args-delete --disable-python --disable-python-numpy
     depends_build-append port:swig-python port:py39-cython
     depends_lib-append port:python39 port:py39-numpy
 }
 
-variant python310 description {Python 3.10 bindings} conflicts python27 python37 python38 python39 {
+variant python310 description {Python 3.10 bindings} conflicts python27 python38 python39 {
     configure.args-append --enable-python --enable-python-integration --enable-python-numpy PYTHON=${prefix}/bin/python3.10
     configure.args-delete --disable-python --disable-python-numpy
     depends_build-append port:swig-python port:py310-cython
@@ -134,7 +127,7 @@ if {[fortran_variant_isset]} {
     configure.args-replace --disable-fortran2003 --enable-fortran2003
 }
 
-if {![variant_isset python27] && ![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39]} {
+if {![variant_isset python27] && ![variant_isset python38] && ![variant_isset python39]} {
     default_variants    +python310
 }
 

--- a/security/certbot-dns-namecheap/Portfile
+++ b/security/certbot-dns-namecheap/Portfile
@@ -15,18 +15,18 @@ long_description    The namecheap.com plugin automates the process of completing
                     dns-01 challenge (DNS01) by creating, and subsequently removing, \
                     TXT records using the (XML-RPC-based) namecheap.com API.
 platforms           darwin
+homepage            https://github.com/knoxell/certbot-dns-namecheap
 
-variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 python311 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10} {}
-variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11} {}
+variant python38 conflicts python39 python310 python311 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 python311 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 python311 description {Use Python 3.10} {}
+variant python311 conflicts python38 python39 python310 description {Use Python 3.11} {}
 
-if { ![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
+if { ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
     default_variants +python311
 }
 
-foreach pv {311 310 39 38 37} {
+foreach pv {311 310 39 38} {
     if {[variant_isset python${pv}]} {
         python.default_version  ${pv}
         set python_variant      python${pv}

--- a/security/certbot/Portfile
+++ b/security/certbot/Portfile
@@ -20,13 +20,12 @@ checksums           rmd160  a7a068426664dcb9499df3ac075584638637f699 \
                     sha256  9622082c0b1361fec379d1497783a4d9725724ce61381c414ab7632367ba30fc \
                     size    1345347
 
-variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 python311 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10} {}
-variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11} {}
+variant python38 conflicts python39 python310 python311 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 python311 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 python311 description {Use Python 3.10} {}
+variant python311 conflicts python38 python39 python310 description {Use Python 3.11} {}
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
     default_variants +python311
 }
 

--- a/security/sqlmap/Portfile
+++ b/security/sqlmap/Portfile
@@ -40,32 +40,27 @@ post-patch {
     }
 }
 
-variant python27 conflicts python37 python38 python39 python310 python311 \
+variant python27 conflicts python38 python39 python310 python311 \
     description {Build for Python 2.7} {
     python.default_version 27
 }
 
-variant python37 conflicts python27 python38 python39 python310 python311 \
-    description {Build for Python 3.7} {
-    python.default_version 37
-}
-
-variant python38 conflicts python27 python37 python39 python310 python311 \
+variant python38 conflicts python27 python39 python310 python311 \
     description {Build for Python 3.8} {
     python.default_version 38
 }
 
-variant python39 conflicts python27 python37 python38 python310 python311 \
+variant python39 conflicts python27 python38 python310 python311 \
     description {Build for Python 3.9} {
     python.default_version 39
 }
 
-variant python310 conflicts python27 python37 python38 python39 python311 \
+variant python310 conflicts python27 python38 python39 python311 \
     description {Build for Python 3.10} {
     python.default_version 310
 }
 
-variant python311 conflicts python27 python37 python38 python39 python310 \
+variant python311 conflicts python27 python38 python39 python310 \
     description {Build for Python 3.11} {
     python.default_version 311
 }
@@ -73,7 +68,7 @@ variant python311 conflicts python27 python37 python38 python39 python310 \
 depends_build-append \
                     port:py${python.version}-setuptools
 
-if {![variant_isset python27] && ![variant_isset python37] && \
+if {![variant_isset python27] && \
     ![variant_isset python38] && ![variant_isset python39] && \
     ![variant_isset python310] && ![variant_isset python311]} {
     default_variants +python311

--- a/shells/xonsh/Portfile
+++ b/shells/xonsh/Portfile
@@ -26,17 +26,16 @@ checksums           rmd160  cb1b8bd4bd633582e6c373daae9e5b848474a61a \
                     sha256  0481e57164134c3401a61411ed381397a054f1d2f9eeda05d71dbb0ee105bdcc \
                     size    12730040
 
-variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 python311 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10} {}
-variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11} {}
+variant python38 conflicts python39 python310 python311 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 python311 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 python311 description {Use Python 3.10} {}
+variant python311 conflicts python38 python39 python310 description {Use Python 3.11} {}
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
         default_variants +python311
 }
 
-foreach pv {311 310 39 38 37} {
+foreach pv {311 310 39 38} {
     if {[variant_isset python${pv}]} {
         python.default_version ${pv}
         break

--- a/sysutils/littleutils/Portfile
+++ b/sysutils/littleutils/Portfile
@@ -61,17 +61,16 @@ configure.args      PROGPERL=${perl5.bin}
 
 destroot.target     "install install-extra"
 
-variant python37 conflicts python38 python39 python310 python311 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 python311 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 python311 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 python311 description {Use Python 3.10} {}
-variant python311 conflicts python37 python38 python39 python310 description {Use Python 3.11} {}
+variant python38 conflicts python39 python310 python311 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 python311 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 python311 description {Use Python 3.10} {}
+variant python311 conflicts python38 python39 python310 description {Use Python 3.11} {}
 
-if {![variant_isset python37] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
     default_variants +python311
 }
 
-foreach pv {311 310 39 38 37} {
+foreach pv {311 310 39 38} {
     if {[variant_isset python${pv}]} {
         depends_lib-append \
                     port:python${pv}

--- a/sysutils/salt/Portfile
+++ b/sysutils/salt/Portfile
@@ -22,38 +22,11 @@ long_description  SaltStack is fast, scalable and flexible software for data \
                   to the entire application stack.
 homepage          https://saltstack.com/
 
-    if {![variant_isset python37]} {
+    if {![variant_isset python38]} {
         default_variants +python38
     }
 
-    variant python37 conflicts python38 description {python-3.7 support} {
-        python.default_version 37
-        depends_build       port:py${python.version}-setuptools
-
-        depends_lib-append  port:py${python.version}-asn1 \
-                            port:py${python.version}-cffi \
-                            port:py${python.version}-cherrypy \
-                            port:py${python.version}-cryptography \
-                            port:py${python.version}-dateutil \
-                            port:py${python.version}-distro \
-                            port:py${python.version}-gitpython \
-                            port:py${python.version}-gnupg \
-                            port:py${python.version}-idna \
-                            port:py${python.version}-jinja2 \
-                            port:py${python.version}-mako \
-                            port:py${python.version}-msgpack \
-                            port:py${python.version}-psutil \
-                            port:py${python.version}-pycryptodome \
-                            port:py${python.version}-pyobjc \
-                            port:py${python.version}-setproctitle \
-                            port:py${python.version}-tornado \
-                            port:py${python.version}-yaml \
-                            port:py${python.version}-zmq
-
-        destroot.cmd-append --with-salt-version=${version}
-    }
-
-    variant python38 conflicts python37 description {python-3.8 support} {
+    variant python38 description {python-3.8 support} {
         python.default_version 38
         depends_build       port:py${python.version}-setuptools
 

--- a/www/mod_wsgi/Portfile
+++ b/www/mod_wsgi/Portfile
@@ -33,16 +33,15 @@ depends_lib         port:apache2
 configure.args      --disable-framework \
                     --with-apxs=${apxs}
 
-variant python37 conflicts python38 python39 python310 description {Use Python 3.7} {}
-variant python38 conflicts python37 python39 python310 description {Use Python 3.8} {}
-variant python39 conflicts python37 python38 python310 description {Use Python 3.9} {}
-variant python310 conflicts python37 python38 python39 description {Use Python 3.10} {}
+variant python38 conflicts python39 python310 description {Use Python 3.8} {}
+variant python39 conflicts python38 python310 description {Use Python 3.9} {}
+variant python310 conflicts python38 python39 description {Use Python 3.10} {}
 
-if {![variant_isset python37] && ![variant_isset python38]} {
+if {![variant_isset python38]} {
     default_variants +python310
 }
 
-foreach pv {310 39 38 37} {
+foreach pv {310 39 38} {
     if {[variant_isset python${pv}]} {
         depends_lib-append \
                     port:python${pv}


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.1 22G313 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
