### PR TITLE
symfony-cli: update to 5.7.2

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.6.2
+version             5.7.2
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  8871ad7d98656bcb2dfccc9d198bcb1772cc572e \
-                        sha256  923e5dfe19764fd5bca4358ad4e5438aaf4284da6b257cd11dae297b3ea3c068 \
-                        size    256823
+    checksums           rmd160  0afcd1ef85987e0f824d1fb36f7dd05fb119a44a \
+                        sha256  0fe533f27b1c90975915a66f5ea98f5bb81f9e13f26cfc8e4e04975a526adc34 \
+                        size    258077
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  977c0afe47618ff3978d8e601b9712d65e458fd2 \
-                        sha256  75693146f61548f4cf0bfba2ce79b0fb2933c4ce663c63b1610859c42183c14c \
-                        size    11132370
+    checksums           rmd160  49b3e905a58e0c86195499f9e6b1023a7e717810 \
+                        sha256  9b0de331f8c7bf81171d64c24fb210682fc4b2308a7c6afc59af3adb8dc0475d \
+                        size    11154857
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.7.2

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
