### PR TITLE
faad2: update to 2.11.0

### DIFF
--- a/audio/faad2/Portfile
+++ b/audio/faad2/Portfile
@@ -2,8 +2,9 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           cmake 1.1
 
-github.setup        knik0 faad2 2.10.1
+github.setup        knik0 faad2 2.11.0
 github.tarball_from archive
 revision            0
 
@@ -17,8 +18,8 @@ long_description \
     Efficiency), LTP (Long Term Prediction), LD (Low Delay) and ER (Error \
     Resiliency) object type AAC files.
 
-checksums           rmd160  5fa611d1383d6d6885dbcdb335b313cdc3ac8de4 \
-                    sha256  4c16c71295ca0cbf7c3dfe98eb11d8fa8d0ac3042e41604cfd6cc11a408cf264 \
-                    size    803488
+checksums           rmd160  1a7b27c0e152cc6c7d1cde184744338ae4d4e19d \
+                    sha256  720c1dc404439e0a9117aa144dc7ead56f1658adf4badbb39f959d6ad8eed489 \
+                    size    656610
 
-use_autoreconf      yes
+patchfiles-append   patch-build-shared-libraries.diff

--- a/audio/faad2/files/patch-build-shared-libraries.diff
+++ b/audio/faad2/files/patch-build-shared-libraries.diff
@@ -1,0 +1,26 @@
+From 92ce281311f629faa99c9e06baaf41977f431f1b Mon Sep 17 00:00:00 2001
+From: Fabian Greffrath <fabian@greffrath.com>
+Date: Tue, 7 Nov 2023 11:19:42 +0100
+Subject: [PATCH] build shared libraries by default and hide symbols
+
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -15,12 +15,18 @@ if(NOT DEFINED FAAD_BUNDLED_MODE)
+   # depending on whether or not we are the top-level project.
+   if(FAAD_PARENT_DIRECTORY)
+     set(FAAD_BUNDLED_MODE ON)
++    set(BUILD_SHARED_LIBS OFF)
+   else()
+     set(FAAD_BUNDLED_MODE OFF)
++    set(BUILD_SHARED_LIBS ON)
+   endif()
+ endif()
+ mark_as_advanced(FAAD_BUNDLED_MODE)
+ 
++if(BUILD_SHARED_LIBS)
++  set(CMAKE_C_VISIBILITY_PRESET hidden)
++endif()
++
+ find_library(MATH_LIBRARY m)
+ 
+ include(GNUInstallDirs)


### PR DESCRIPTION
* switch to cmake 1.1 portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
