### PR TITLE
hdf5: Update to 1.14.3; no revbumps required.

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 name                hdf5
-version             1.14.2
+version             1.14.3
 set mainversion     [lrange [split ${version} -] 0 0]
 revision            0
 set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
@@ -24,16 +24,16 @@ long_description    HDF5 is a data model, library, and file format for storing\
                     of HDF5. The HDF5 Technology suite includes tools and\
                     applications for managing, manipulating, viewing, and\
                     analyzing data in the HDF5 format.
-homepage            https://portal.hdfgroup.org/display/HDF5
+homepage            https://www.hdfgroup.org/solutions/hdf5/
 platforms           darwin
 
 distfiles           ${name}-${version}.tar.bz2
 master_sites \
     https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${shortversion}/hdf5-${mainversion}/src
 checksums \
-    rmd160  32d411636a449ef7b03c1ac3eb61b4787d703dcf \
-    sha256  ea3c5e257ef322af5e77fc1e52ead3ad6bf3bb4ac06480dd17ee3900d7a24cfb \
-    size    16070491
+    rmd160  4038e67868ffa4d5bde3ed02a5cd03f24056b072 \
+    sha256  9425f224ed75d1280bb46d6f26923dd938f9040e7eaebf57e66ec7357c08f917 \
+    size    16320137
 mpi.setup           -gcc44 -gcc45
 
 use_bzip2           yes


### PR DESCRIPTION
Maintainer update.

Upstream [notes](https://github.com/HDFGroup/hdf5/blob/8b5cac6bc498546efa5639f99bb7dbbc1a2d5d90/release_docs/RELEASE.txt#L204) this fixes (removes) -commons flag, but retaining the fix from 3d830f34 for clang/gcc issues until linker issues are known to be resolved.