### PR TITLE
edid-decode: update to version 20231103

### DIFF
--- a/sysutils/edid-decode/Portfile
+++ b/sysutils/edid-decode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                edid-decode
-version             20231031
+version             20231103
 categories          sysutils
 maintainers         @wwalexander openmaintainer
 license             MIT
@@ -14,7 +14,7 @@ set domain          linuxtv.org
 homepage            https://git.${domain}/${name}.git
 fetch.type          git
 git.url             git://${domain}/${name}.git
-git.branch          100437c
+git.branch          385c6cb
 
 patchfiles          cxxflags-fix.diff
 


### PR DESCRIPTION
#### Description

* update to version 20231103

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [X] security fix

Question: Am I using this checkbox correctly, i.e. to indicate what sort of change was made to the upstream software with this update? The upstream commit message states
> We are using string functions for the EDID format parsing that depend on 0-terminated sequences, so to be safe add a '\0' after reading the EDID file.

###### Tested on
macOS 14.1 23B74 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?