### PR TITLE
libgrapheme: new Portfile

### DIFF
--- a/textproc/libgrapheme/Portfile
+++ b/textproc/libgrapheme/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           makefile 1.0
+
+name                libgrapheme
+version             2.0.2
+categories          textproc
+maintainers         @wwalexander openmaintainer
+license             MIT
+description         extremely simple freestanding C99 library providing utilities for properly handling strings according to the latest Unicode standard
+long_description    libgrapheme is an extremely simple freestanding C99 library providing utilities for properly handling strings according to the latest Unicode standard 15.0.0. It offers fully Unicode compliant grapheme cluster (i.e. user-perceived character) segmentation, word segmentation, sentence segmentation, detection of permissible line break opportunities, case detection (lower-, upper- and title-case), case conversion (to lower-, upper- and title-case) on UTF-8 strings and codepoint arrays, which both can also be null-terminated. \
+                    \
+                    The necessary lookup-tables are automatically generated from the Unicode standard data (contained in the tarball) and heavily compressed. Over 10,000 automatically generated conformance tests and over 150 unit tests ensure conformance and correctness. \
+                    \
+                    There is no complicated build-system involved and it's all done using one POSIX-compliant Makefile. All you need is a C99 compiler, given the lookup-table-generators and compressors that are only run at build-time are also written in C99. The resulting library is freestanding and thus not even dependent on a standard library to be present at runtime, making it a suitable choice for bare metal applications. \
+                    \
+                    It is also way smaller and much faster than the other established Unicode string libraries (ICU, GNU's libunistring, libutf8proc).
+set domain          suckless.org
+homepage            https://libs.${domain}/${name}/
+master_sites        https://dl.${domain}/libgrapheme/
+checksums           rmd160  8cf9cddda9f0647e003669d801984a461976ee1c \
+                    sha256  a68bbddde76bd55ba5d64116ce5e42a13df045c81c0852de9ab60896aa143125 \
+                    size    846990
+patchfiles          config.diff
+use_configure       no
+test.run            yes

--- a/textproc/libgrapheme/files/config.diff
+++ b/textproc/libgrapheme/files/config.diff
@@ -1,0 +1,29 @@
+--- config.mk.orig	2023-10-23 10:47:34
++++ config.mk	2023-10-23 10:48:26
+@@ -2,7 +2,6 @@
+ 
+ # paths (unset $PCPREFIX to not install a pkg-config-file)
+ DESTDIR   =
+-PREFIX    = /usr/local
+ INCPREFIX = $(PREFIX)/include
+ LIBPREFIX = $(PREFIX)/lib
+ MANPREFIX = $(PREFIX)/share/man
+@@ -19,14 +18,14 @@
+ 
+ SHFLAGS   = -fPIC -ffreestanding
+ 
+-SOFLAGS   = -shared -nostdlib -Wl,--soname=libgrapheme.so.$(VERSION_MAJOR).$(VERSION_MINOR)
+-SONAME    = libgrapheme.so.$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
+-SOSYMLINK = true
++SOFLAGS   = -dynamiclib -install_name libgrapheme.$(VERSION_MAJOR).dylib -current_version $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH) -compatibility_version $(VERSION_MAJOR).$(VERSION_MINOR).0
++SONAME    = libgrapheme.$(VERSION_MAJOR).dylib
++SOSYMLINK = false
+ 
+ # tools (unset $LDCONFIG to not call ldconfig(1) after install/uninstall)
+ CC       = cc
+ BUILD_CC = $(CC)
+ AR       = ar
+ RANLIB   = ranlib
+-LDCONFIG = ldconfig
++LDCONFIG = 
+ SH       = sh


### PR DESCRIPTION
#### Description

* new Portfile

libgrapheme is "an extremely simple freestanding C99 library providing utilities for properly handling strings" from suckless.org.

As with many suckless.org projects, build settings are configured via config.mk. There is a configure script, which simply sets values in config.mk based on the OS. config.diff applies the Darwin build settings and removes the hardcoded PREFIX from config.mk.

libgrapheme is a dependency of another suckless.org project, lchat, which is a frontend for their ii IRC client. If this port is approved, I hope to add a port for lchat.

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.1 23B74 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?