### PR TITLE
sbt: use default java.fallback

### DIFF
--- a/devel/sbt/Portfile
+++ b/devel/sbt/Portfile
@@ -5,7 +5,7 @@ PortGroup       github 1.0
 PortGroup       java 1.0
 
 github.setup    sbt sbt 1.9.7 v
-revision        0
+revision        1
 categories      devel java
 license         Apache-2
 maintainers     {@catap korins.ky:kirill} openmaintainer
@@ -26,7 +26,6 @@ checksums       rmd160  ad8577e799e6913fdc45847fd13008475b0377c4 \
                 size    47262108
 
 java.version    1.8+
-java.fallback   openjdk8
 
 extract.suffix  .tgz
 extract.rename  yes


### PR DESCRIPTION
#### Description

Should fix install sbt on clean macOS 14

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->