### PR TITLE
icu-devel: update to 74.1

### DIFF
--- a/devel/icu-devel/Portfile
+++ b/devel/icu-devel/Portfile
@@ -23,7 +23,7 @@ set my_name         icu
 # Please confirm that all ports and its subport can be build. To find the list, use:
 #  port file all | sort -u | xargs grep -El ':icu( |$)' | rev | cut -d / -f 2 | rev | xargs port info --name --subport | cut -d : -f 2 | tr ',' ' ' | grep -v '\-\-' | tr ' ' '\n' | sort -u
 
-version             73.2
+version             74.1
 revision            0
 epoch               1
 subport             ${name}-docs         { revision 0 }
@@ -67,9 +67,9 @@ if {${subport} eq ${name} || ${subport} eq "${name}-lx"} {
     worksrcdir          icu/source
 
     # please also update the icu-docs checksums at the bottom of the Portfile
-    checksums           rmd160  d8ff2467ab4785ca27910050fbac642d3985a3fd \
-                        sha256  818a80712ed3caacd9b652305e01afc7fa167e6f2e94996da44b90c2ab604ce1 \
-                        size    26519906
+    checksums           rmd160  81a6bf20b28e00c869425547a8f1dd2d11cac566 \
+                        sha256  86ce8e60681972e60e4dcb2490c697463fcec60dd400a5f9bffba26d0b52b8d0 \
+                        size    26625850
 
     # use full pathnames to libraries in tools
     patchfiles-append   patch-i18n-formatted_string_builder.h.diff
@@ -184,9 +184,9 @@ if {${subport} eq "${name}-docs"} {
 
     use_zip                 yes
     distname                icu4c-[string map {. _} [string map {.rc rc} ${version}]]-docs
-    checksums               rmd160  bb3829f8c7ede7f6e427a7fd052f1fcf89de77c7 \
-                            sha256  99d74b537961fa7eba2a3db8735e77060fc5ee1e8ce865d3ab53de6425285614 \
-                            size    8517399
+    checksums               rmd160  b1640eec3f6d9bd55698d57a075bbddfe3e72611 \
+                            sha256  9df27f55f956c7594d5bff8de42e05e3a4137ad023812e5a409a7d7634b607e2 \
+                            size    8532358
 
     extract.dir             ${worksrcpath}/doc/html
     use_configure           no


### PR DESCRIPTION
#### Description

As usual the first step to update ICU is update `icu-devel`. In two weeks I'll open a PR to update ICU and revbump all dependencies without testing all of them.

I kindly ask maintainers to install `icu-devel` to catch any future issue before end users.

I've skiped CI because it can't build icu-devel due to conflict with icu port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->