### PR TITLE
unxip: Correctly support macOS 12 targets

### DIFF
--- a/archivers/unxip/Portfile
+++ b/archivers/unxip/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           muniversal 1.1
 
 github.setup        saagarjha unxip 3.0 v
-revision            0
+revision            1
 github.tarball_from archive
 
 categories          archivers sysutils
@@ -31,8 +31,12 @@ if {${os.platform} eq "darwin" && ${os.major} < 21} {
 }
 
 use_configure       no
-use_xcode           yes
 universal_variant   yes
+
+# Use MacOSX13.sdk to compile on macOS 12 Monterey
+if {${os.platform} eq "darwin" && ${os.major} < 22} {
+    configure.sdk_version   13
+}
 
 build.cmd           swiftc
 build.target        unxip.swift


### PR DESCRIPTION
#### Description

`unxip` contains support for macOS 12, but it requires using the 13.0 SDK in order to build. In addition, a full Xcode installation is no longer required.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
