### PR TITLE
beets-devel: update to 20230823; beets-summarize: update to 20231101

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -530,8 +530,8 @@ subport ${name}-originquery {
 }
 
 subport ${name}-summarize {
-    github.setup    steven-murray beet-summarize 0aa0a8fe37786f82707ee9c965ac5bc0443820c3
-    version         20230801
+    github.setup    steven-murray beet-summarize 10870ac3a978b14a5dd27211eac4a406d00f97bf
+    version         20231101
     revision        0
 
     license         LGPL-3
@@ -540,9 +540,9 @@ subport ${name}-summarize {
     long_description \
                     {*}${description}
 
-    checksums       rmd160  0b1b7acbb4fe498bedb419d4bc50f7769248740b \
-                    sha256  408eab04eb4a299f80460698c1b9ad25bd42794365a63ed802116f4a349fbb46 \
-                    size    13328
+    checksums       rmd160  eaaff5f88478f11edb49e9f88574b00ffecc15a2 \
+                    sha256  6c548e0c9daacc039c98687bc5bb5f8f96c512f4c4255a87074699735b501379 \
+                    size    13320
 
     python.pep517   yes
 

--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -39,13 +39,13 @@ if {$subport eq $name} {
 subport ${name}-devel {
     conflicts       $name
 
-    github.setup    beetbox beets 62859f4389715d87af36827b6042d21a82e91fdc
+    github.setup    beetbox beets 708a04d4a88eb955f261a21f0b1146c9e2ae0a55
     version         20230823
-    revision        1
+    revision        0
 
-    checksums       rmd160  607d024f8cc8d111d418f265e18e0cc16dd6e814 \
-                    sha256  367552c32126ab026d73e9dde5ffe9dcec7178a402eb68f3f84c1d7fba751d83 \
-                    size    2200692
+    checksums       rmd160  4f1b58c3fe04b994e279e1dacfc86ef5711ad6df \
+                    sha256  2769b782cd483468b40811b8522fdd72eb98561cf9864531ef087c3e93601e75 \
+                    size    2235693
 
     depends_build-append \
                     port:py${python.version}-sphinx


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->