### PR TITLE
google-cloud-sdk: update to 454.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             453.0.0
+version             454.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  e9fcb573c702c32890b86c21f25f126ec7f0a84d \
-                    sha256  774f8aa095b0f0d971863d376c8898feedb4356240b9f14c4c032a905042805d \
-                    size    121350020
+    checksums       rmd160  a8d6490637b392438ffcb8a1bc50f1076e5030b9 \
+                    sha256  1e1b8f0cebbe91a4df3c61bc4a2c02a374e50af80ce9e50dab92e6cdc7bd2909 \
+                    size    121482435
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  7600bd87e3412fc466176ba89dd4bde1daec1eb3 \
-                    sha256  fa5c102e4199f9b98cf634e72cefdb8b1c3f9ef5744ef98cac354ff2b8059478 \
-                    size    122635582
+    checksums       rmd160  1c695a5600501fd18de232644331c7d20ed5d901 \
+                    sha256  0496ab72467b514d0f83fae7443f6cb8cc2cf7188d47a8afba1cc723e91f3362 \
+                    size    122768998
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  9bb1a7bf0d15e2a39e2a08d9265f1ec08fd37370 \
-                    sha256  c065f7a8ff7f6ed625fe56ec22addf8163ba8c553ad58acef1c570f5a1321b38 \
-                    size    119715659
+    checksums       rmd160  22cd88de146629cd32e31aa9653fa413994112b5 \
+                    sha256  4393bb922c11ced61284a51d8ac6b781a93e5f9646c045384ac638758eb3a3e2 \
+                    size    119847243
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 454.0.0.

###### Tested on

macOS 14.1 23B74 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?