### PR TITLE
gpgme: update to 1.23.1, enable C++ with libstdc++, fix installation

### DIFF
--- a/devel/gpgme/Portfile
+++ b/devel/gpgme/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 
 name                gpgme
-version             1.22.0
+version             1.23.1
 revision            0
 
-checksums           rmd160  b838515aecd025d4e3914e5bd33fda82c09134a3 \
-                    sha256  9551e37081ad3bde81018a0d24f245c3f8206990549598fb31a97a68380a7b71 \
-                    size    1717836
+checksums           rmd160  57b266764dee2784b30b2668439c40bb2d121ea8 \
+                    sha256  a0c316f7ab7d3bfb01a8753c3370dc906e5b61436021f3b54ff1483b513769bd \
+                    size    1716825
 
 categories          devel security crypto
 license             {LGPL-2.1+ GPL-3+}
@@ -46,7 +46,7 @@ post-patch {
 }
 
 compiler.cxx_standard 2017
-# Build uses c++17 features, but incorrectly configures for c++11 only..
+# Build uses c++17 features, but incorrectly configures for c++11 only.
 configure.cxxflags-append -std=c++17
 
 # We are patching configure.ac.
@@ -62,12 +62,11 @@ configure.checks.implicit_function_declaration.whitelist-append strchr
 
 lappend languages cl
 
-# cpp bindings require libc++
-
+# This has to be enabled, otherwise CMake config files are not installed,
+# which breaks some dependents, like Poppler.
+# Contrary to the earlier situation, it does build now against libstdc++.
 platform darwin {
-    if {${configure.cxx_stdlib} eq "libc++"} {
-        lappend languages cpp
-    }
+    lappend languages cpp
 }
 
 # gpg regression tests run during build repeatedly fail with error


### PR DESCRIPTION
#### Description

No idea why C++ was excluded from builds with `libstdc++`, but it has broken `poppler`. Fixed now.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
