### PR TITLE
kdiff3: switch to Qt5 for newer OS, fixes aarch64

### DIFF
--- a/devel/kdiff3/Portfile
+++ b/devel/kdiff3/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                kdiff3
 version             0.9.98
-revision            4
+revision            5
 categories          devel
 maintainers         nomaintainer
 license             GPL-2
@@ -26,22 +26,29 @@ checksums           rmd160  17fc05df3fd8f052e2010834ba8efe2481e4f434 \
 variant kde description {Build the KDE version} {}
 
 if {[variant_isset kde]} {
-    PortGroup kde4 1.1
+    PortGroup               kde4 1.1
 
-    depends_lib-append  port:kdelibs4
+    depends_lib-append      port:kdelibs4
     post-destroot {
         ln -s ${applications_dir}/KDE4/${name}.app/Contents/MacOS/kdiff3 ${destroot}${prefix}/bin
     }
 } else {
-    PortGroup           xcodeversion 1.0
-    PortGroup           qmake 1.0
+    if {${os.platform} eq "darwin" && ${os.major} < 12} {
+        PortGroup           qmake 1.0
+        PortGroup           xcodeversion 1.0
 
-    qt4.debug_variant   no
-    set worksrcpath     ${worksrcpath}/src-QT4
+        qt4.debug_variant   no
+        minimum_xcodeversions {9 3.1}
+    } else {
+        PortGroup           qmake5 1.0
 
-    minimum_xcodeversions {9 3.1}
+        qt5.debug_variant   no
+    }
 
-    patchfiles-append   patch-src-QT4-kdiff3.pro.diff
+    # Naming here is inconsequential:
+    set worksrcpath         ${worksrcpath}/src-QT4
+
+    patchfiles-append       patch-src-QT4-kdiff3.pro.diff
 
     post-patch {
         reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/kdiff3.pro

--- a/devel/kdiff3/Portfile
+++ b/devel/kdiff3/Portfile
@@ -6,28 +6,28 @@ name                kdiff3
 version             0.9.98
 revision            4
 categories          devel
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-2
-description         kdiff3 is a file comparing and merging tool.
-long_description    kdiff3 compares two or three input files and shows the \
-                    differences line by line and character by character. It \
-                    provides an automatic merge facility and an integrated \
+description         ${name} is a file comparing and merging tool.
+long_description    ${name} compares two or three input files and shows \
+                    the differences line by line and character by character. \
+                    It provides an automatic merge facility and an integrated \
                     editor for comfortable solving of merge conflicts. \
-                    kdiff3 allows recursive directory comparison and merging \
+                    ${name} allows recursive directory comparison and merging \
                     as well.
 
-homepage            http://kdiff3.sourceforge.net/
+homepage            https://kdiff3.sourceforge.net
 master_sites        sourceforge:project/kdiff3/kdiff3/${version}
 
-checksums           rmd160 17fc05df3fd8f052e2010834ba8efe2481e4f434 \
-                    sha256 802c1ababa02b403a5dca15955c01592997116a24909745016931537210fd668
-
+checksums           rmd160  17fc05df3fd8f052e2010834ba8efe2481e4f434 \
+                    sha256  802c1ababa02b403a5dca15955c01592997116a24909745016931537210fd668 \
+                    size    1762715
 
 variant kde description {Build the KDE version} {}
 
 if {[variant_isset kde]} {
     PortGroup kde4 1.1
+
     depends_lib-append  port:kdelibs4
     post-destroot {
         ln -s ${applications_dir}/KDE4/${name}.app/Contents/MacOS/kdiff3 ${destroot}${prefix}/bin
@@ -35,10 +35,14 @@ if {[variant_isset kde]} {
 } else {
     PortGroup           xcodeversion 1.0
     PortGroup           qmake 1.0
+
     qt4.debug_variant   no
     set worksrcpath     ${worksrcpath}/src-QT4
+
     minimum_xcodeversions {9 3.1}
-    patchfiles patch-src-QT4-kdiff3.pro.diff
+
+    patchfiles-append   patch-src-QT4-kdiff3.pro.diff
+
     post-patch {
         reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/kdiff3.pro
     }


### PR DESCRIPTION
#### Description

Also fix lint.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14
Xcode 15

macOS 10.6
Xcode 3.2
(No change in effect for old systems, but I verified it still builds for `ppc` and launches normally.)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
