### PR TITLE
john-jumbo-devel: update to 20231003; john-jumbo: fix build by clang-16

### DIFF
--- a/sysutils/john/Portfile
+++ b/sysutils/john/Portfile
@@ -92,7 +92,8 @@ subport john-jumbo {
     conflicts                   john john-jumbo-devel
 
     patchfiles-append           patch-apple-m1.diff \
-                                patch-fix-ld-multiple-definition-errors.diff
+                                patch-fix-ld-multiple-definition-errors.diff \
+                                patch-fix-alignment-compile-error.diff
 }
 
 subport john-jumbo-devel {

--- a/sysutils/john/Portfile
+++ b/sysutils/john/Portfile
@@ -99,13 +99,13 @@ subport john-jumbo {
 subport john-jumbo-devel {
     PortGroup                   github 1.0
 
-    github.setup                openwall john d2f7bb0579bb1bd8a01689c50dfed1e0f712466a
-    version                     20230922
+    github.setup                openwall john b8b5d164d0b3bb15401d837cd4577905b6214ad0
+    version                     20231003
     revision                    0
 
-    checksums                   rmd160  f610c88d9150da0d55c905d7e7836f44118d6d99 \
-                                sha256  a9a402292c15b2ef6d5f54f2e2e3810190208ca99419fa70f764ad1627d42c70 \
-                                size    56767377
+    checksums                   rmd160  7f4f902d7d52bf741a7d31f75dd8ca5a0b4e3e18 \
+                                sha256  cafed027ac6a2edc204db8df07def7d768f5a0fcd8b8244b916fc40b2f9dee15 \
+                                size    56795470
 
     conflicts                   john john-jumbo
 

--- a/sysutils/john/files/patch-fix-alignment-compile-error.diff
+++ b/sysutils/john/files/patch-fix-alignment-compile-error.diff
@@ -1,0 +1,42 @@
+https://github.com/openwall/john/pull/4611
+
+diff --git src/blake2.h src/blake2.h
+index b05208117e..b4398f9e13 100644
+--- src/blake2.h
++++ src/blake2.h
+@@ -57,7 +57,7 @@ extern "C" {
+     uint8_t  personal[BLAKE2S_PERSONALBYTES];  // 32
+   } blake2s_param;
+ 
+-  JTR_ALIGN( 64 ) typedef struct __blake2s_state
++  typedef struct JTR_ALIGN( 64 ) __blake2s_state
+   {
+     uint32_t h[8];
+     uint32_t t[2];
+@@ -82,7 +82,7 @@ extern "C" {
+     uint8_t  personal[BLAKE2B_PERSONALBYTES];  // 64
+   } blake2b_param;
+ 
+-  JTR_ALIGN( 64 ) typedef struct __blake2b_state
++  typedef struct JTR_ALIGN( 64 ) __blake2b_state
+   {
+     uint64_t h[8];
+     uint64_t t[2];
+@@ -94,7 +94,7 @@ extern "C" {
+ #if defined(JOHN_NO_SIMD) || (!defined(__SSE2__) && !defined(__SSE4_1__) && !defined(__XOP__))
+   typedef struct __blake2sp_state
+ #else
+-  JTR_ALIGN( 64 ) typedef struct __blake2sp_state
++  typedef struct JTR_ALIGN( 64 ) __blake2sp_state
+ #endif
+   {
+     blake2s_state S[8][1];
+@@ -106,7 +106,7 @@ extern "C" {
+ #if defined(JOHN_NO_SIMD) || (!defined(__SSE2__) && !defined(__SSE4_1__) && !defined(__XOP__))
+   typedef struct __blake2bp_state
+ #else
+-  JTR_ALIGN( 64 ) typedef struct __blake2bp_state
++  typedef struct JTR_ALIGN( 64 ) __blake2bp_state
+ #endif
+   {
+     blake2b_state S[4][1];


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->