### PR TITLE
tmux: restrict default terminal to before Sonoma

### DIFF
--- a/sysutils/tmux/Portfile
+++ b/sysutils/tmux/Portfile
@@ -9,13 +9,13 @@ legacysupport.newest_darwin_requires_legacy 8
 
 github.setup    tmux tmux 3.3a
 if {${subport} eq ${name}} {
-    revision        1
+    revision        2
     conflicts       tmux-devel
 }
 subport tmux-devel {
     github.setup    tmux tmux 96ad8280b28283eb01e7789f5bafd2e1f6cde139
     version         20210610-[string range ${github.version} 0 6]
-    revision        1
+    revision        2
     conflicts       tmux
 }
 categories      sysutils
@@ -31,9 +31,6 @@ platforms       darwin
 license         BSD
 
 depends_lib     port:libevent port:ncurses
-
-# Use screen by default to display tmux correctly when backspacing
-configure.args-append   --with-TERM=screen
 
 if {${subport} eq ${name}} {
     github.tarball_from     releases
@@ -59,6 +56,15 @@ subport tmux-devel {
     post-extract {
         set reinplace_cmd [subst -nobackslashes -nocommands {s/AC_INIT\(\[tmux\], (next-[0-9]+\.[0-9]+)\)/AC_INIT([tmux], \1 (${version}))/g}]
         reinplace -E $reinplace_cmd ${worksrcpath}/configure.ac
+    }
+}
+
+platform darwin {
+    if {${os.major} < 23} {
+        # Before Sonoma, macOS lacked terminal descriptions for tmux,
+        # tmux-256color. Fallback on a terminal definition that is available on
+        # these older versions
+        configure.args-append   --with-TERM=screen-256color
     }
 }
 


### PR DESCRIPTION
#### Description

A tweak on #20765 that restricts the terminal override to happen just for versions of macOS before Sonoma. Sonoma includes a newer version of ncurses which means that `tmux` and `tmux-256color` is now available to stock programmes.

**/cc** @TheRealKeto

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.7 21G651 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
