### PR TITLE
skaffold: update to 2.9.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.8.0 v
+github.setup        GoogleContainerTools skaffold 2.9.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  a2d99c3dc7966c50004852174f7dbf35f4c084b2 \
-                    sha256  36c107dd7736e8ce4f652937b09bbfec8a7c8edb816b3b70b68dcbce54c7c43a \
-                    size    60513049
+checksums           rmd160  531db148dcc47278cccbf4d76ca83c060f6caf4a \
+                    sha256  92a0e0181ecd3b73a2fd816048c817a19de096a4fb10c2adcb6f74c599f6d9b6 \
+                    size    60514939
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.9.0.

###### Tested on

macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?