### PR TITLE
ipopt: update to 3.14.13

### DIFF
--- a/_resources/port1.0/group/mpi-1.0.tcl
+++ b/_resources/port1.0/group/mpi-1.0.tcl
@@ -232,6 +232,17 @@ pre-configure {
             return -code error "Install ${mpi.name} +$need"
         }
     }
+
+    if {[mpi_variant_isset] && ([mpi_variant_name] eq "mpich" || [mpi_variant_name] eq "mpich-devel")} {
+        # The new linker in Xcode 15 is buggy, causing build failures for many (but not all)
+        # ports that link to mpich. The -Wl,-ld_classic option below reverts to the
+        # classic linker.
+        #
+        # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
+        if { ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+            configure.ldflags-append    -Wl,-ld_classic
+        }
+    }
 }
 
 proc mpi_variant_isset {} {

--- a/math/ipopt/Portfile
+++ b/math/ipopt/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           mpi 1.0
 PortGroup           github 1.0
 
-github.setup        coin-or ipopt 3.14.12 releases/
-revision            2
+github.setup        coin-or ipopt 3.14.13 releases/
+revision            0
 categories          math
 license             Eclipse
 
@@ -15,9 +15,9 @@ homepage            https://coin-or.github.io/Ipopt
 description         COIN-OR Interior Point Optimizer IPOPT
 long_description    {*}${description}
 
-checksums           rmd160  f710f4895e2ebcf8382bc87c8e13f8bb4a281644 \
-                    sha256  f5972bf5b368e3bf83bd3c9f9e6c8b0b5e4a82077e22192dc548574118292cc0 \
-                    size    1851016
+checksums           rmd160  55f584e523f0a192fdec8e50a772b785bf564129 \
+                    sha256  0c61eb253576316e8ca299460b9e98d9aa5bf1e3d310a04d8313834025a89025 \
+                    size    1856539
 
 mpi.setup           require
 

--- a/math/scip/Portfile
+++ b/math/scip/Portfile
@@ -7,7 +7,7 @@ PortGroup           compilers 1.0
 
 name                scip
 version             8.0.4
-revision            1
+revision            2
 categories          math
 license             Apache-2
 
@@ -47,6 +47,15 @@ configure.args      -DCMAKE_BUILD_TYPE=Release \
                     -DCOVERAGE=OFF \
                     -DSHARED=ON \
                     -DAUTOBUILD=OFF
+
+# due to the new linker (which was introduced in Xcode 15: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes),
+# this port requires '-ld_classic' to build successfully with the toolchains from Xcode 15 or Command Line Tools 15.
+#
+# TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
+if { ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
+    configure.ldflags-append \
+                    -Wl,-ld_classic
+}
 
 livecheck.type      regex
 livecheck.regex     SCIP version (\[0-9.\]+)


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.8 21G725 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->