### PR TITLE
py-libusb1: new port (3.1.0)

### DIFF
--- a/python/py-libusb1/Portfile
+++ b/python/py-libusb1/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+name                    py-libusb1
+version                 3.1.0
+categories              python devel
+platforms               {darwin any}
+supported_archs         noarch
+license                 LGPL-2.1+
+maintainers             nomaintainer
+description             Pure Python wrapper for libusb-1.0
+long_description        {*}${description}. Supports all transfer types, \
+                        both in synchronous and asynchronous mode.
+
+homepage                https://github.com/vpelletier/python-libusb1
+
+checksums               rmd160  a1757aa095e386ef6ec416940e6ebb83ca6a5ded \
+                        sha256  4ee9b0a55f8bd0b3ea7017ae919a6c1f439af742c4a4b04543c5fd7af89b828c \
+                        size    83013
+
+python.versions         38 39 310 311 312
+python.default_version  311
+
+if {${name} ne ${subport}} {
+    depends_lib-append      lib:libusb-1.0:libusb
+    depends_build-append    port:py${python.version}-setuptools
+
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/examples/${name}
+        xinstall -m 0644 \
+            {*}[glob -directory ${worksrcpath}/examples *] \
+            ${destroot}${prefix}/share/examples/${name}
+    }
+}


### PR DESCRIPTION
#### Description

Add `py-libusb1` to MacPorts, from a request made 7 years ago.

Closes: https://trac.macports.org/ticket/51702

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
