### PR TITLE
ruby-build: Update to 20231107

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20231025 v
+github.setup        rbenv ruby-build 20231107 v
+github.tarball_from archive
 categories          ruby
 license             MIT
 platforms           any
@@ -16,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  8a5cd21f7ffc30662e856b3a43bb9afdfc8e5edf \
-                    sha256  aaf8f6a6bbccc7bcb7f53bbe459805a451d097d2ff68d11d584f4d77373b3dd6 \
-                    size    81637
+checksums           rmd160  6c59e13dcf2769dbac7d8a40555cbb49c0b9b468 \
+                    sha256  97b5a2d23416033ded5c422f947c1188da7e635d82481f60c7b055a5cc64be88 \
+                    size    85433
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Full changelog:
https://github.com/rbenv/ruby-build/releases/tag/v20231107

> This is the biggest ruby-build update in a long while since it
> includes a large restructuring of how ruby-build works to make it
> a more modern and friendlier command line tool for Ruby beginners and
> experts alike. The most visible change should be that the output of
> ruby-build is now more verbose (even in the default, non-verbose
> mode), but there were many other changes under the hood that should
> help with the overall health of the project.

Also of note:

- Automatically link to Homebrew OpenSSL even if it is keg-only
- Add JRuby 9.4.5.0 and 9.3.13.0
- Add ruby-build(1) man page
- Respect NO_COLOR and CLICOLOR_FORCE
- Remove support for Topaz and Maglev
- Unmark Ruby 2.7 as soon-to-be-EOL since it's already EOL

###### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
