### PR TITLE
postgresql: security updates

### DIFF
--- a/databases/postgresql12/Portfile
+++ b/databases/postgresql12/Portfile
@@ -8,8 +8,8 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql12
-version             12.16
-revision            1
+version             12.17
+revision            0
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -28,9 +28,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  580fdd1b873699e5ebdfea635e2c13064d73093a \
-                    sha256  c5f1fff7a0f93e1ec3746417b0594290ece617b4995ed95b8d527af0ba0e38f3 \
-                    size    21140532
+checksums           rmd160  ddb48d89e9d4e27529b42bb9c826cf94ed841928 \
+                    sha256  93e8e1b23981d5f03c6c5763f77b28184c1ce4db7194fa466e2edb65d9c1c5f6 \
+                    size    21181616
 
 use_bzip2           yes
 
@@ -71,7 +71,7 @@ configure.universal_args-delete --disable-dependency-tracking
 # building psql with clang from Xcode prior to 4.4 causes segfault on query; see #31717
 compiler.blacklist-append {clang < 421}
 compilers.choose          cc cxx
-compilers.setup           -gcc -fortran -clang33 -clang34 -clang37 -clang16 -clang17
+compilers.setup           -gcc -fortran -clang33 -clang34 -clang37
 notes "To use the postgresql server as a startup item install the ${name}-server port."
 
 if {${universal_possible} && [variant_isset universal]} {

--- a/databases/postgresql13/Portfile
+++ b/databases/postgresql13/Portfile
@@ -8,8 +8,8 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql13
-version             13.12
-revision            1
+version             13.13
+revision            0
 
 categories          databases
 platforms           darwin
@@ -29,9 +29,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  5897c58612677738e2e61533e20a05b6dbaae218 \
-                    sha256  0da1edcee3514b7bc7ba6dbaf0c00499e8ac1590668e8789c50253a6249f218b \
-                    size    21542293
+checksums           rmd160  23e88ae4d558fefd3b5a43777965fdce6f23a273 \
+                    sha256  8af69c2599047a2ad246567d68ec4131aef116954d8c3e469e9789080b37a474 \
+                    size    21563452
 
 use_bzip2           yes
 
@@ -79,7 +79,7 @@ configure.universal_args-delete --disable-dependency-tracking
 # building psql with clang from Xcode prior to 4.4 causes segfault on query; see #31717
 compiler.blacklist-append {clang < 421}
 compilers.choose          cc cxx
-compilers.setup           -gcc -fortran -clang33 -clang34 -clang37 -clang16 -clang17
+compilers.setup           -gcc -fortran -clang33 -clang34 -clang37
 notes "To use the postgresql server as a startup item install the ${name}-server port."
 
 if {${universal_possible} && [variant_isset universal]} {

--- a/databases/postgresql14/Portfile
+++ b/databases/postgresql14/Portfile
@@ -8,8 +8,8 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql14
-version             14.9
-revision            2
+version             14.10
+revision            0
 
 categories          databases
 platforms           darwin
@@ -29,9 +29,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  50e3ad6799dff9aef7c7c05245d03ef2374e01cb \
-                    sha256  b1fe3ba9b1a7f3a9637dd1656dfdad2889016073fd4d35f13b50143cbbb6a8ef \
-                    size    22207374
+checksums           rmd160  b2e001d5c5115df81627e6625b2a4549f4fd9ad5 \
+                    sha256  c99431c48e9d470b0d0ab946eb2141a3cd19130c2fb4dc4b3284a7774ecc8399 \
+                    size    22298652
 
 use_bzip2           yes
 
@@ -79,7 +79,7 @@ configure.universal_args-delete --disable-dependency-tracking
 # building psql with clang from Xcode prior to 4.4 causes segfault on query; see #31717
 compiler.blacklist-append {clang < 421}
 compilers.choose          cc cxx
-compilers.setup           -gcc -fortran -clang33 -clang34 -clang37 -clang16 -clang17
+compilers.setup           -gcc -fortran -clang33 -clang34 -clang37
 notes "To use the postgresql server as a startup item install the ${name}-server port."
 
 if {${universal_possible} && [variant_isset universal]} {

--- a/databases/postgresql15/Portfile
+++ b/databases/postgresql15/Portfile
@@ -8,8 +8,8 @@ PortGroup muniversal 1.0
 
 #remember to update the -doc and -server as well
 name                postgresql15
-version             15.4
-revision            2
+version             15.5
+revision            0
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -28,9 +28,9 @@ master_sites        http://ftp3.de.postgresql.org/pub/Mirrors/ftp.postgresql.org
             postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  5e69828ea995447d39f5990f6a18f110519df233 \
-                    sha256  baec5a4bdc4437336653b6cb5d9ed89be5bd5c0c58b94e0becee0a999e63c8f9 \
-                    size    22850355
+checksums           rmd160  3b5202b1a3d1e481f3861b77c1b8bcca8806a39b \
+                    sha256  8f53aa95d78eb8e82536ea46b68187793b42bba3b4f65aa342f540b23c9b10a6 \
+                    size    23091780
 
 use_bzip2           yes
 
@@ -80,7 +80,7 @@ configure.universal_args-delete --disable-dependency-tracking
 # building psql with clang from Xcode prior to 4.4 causes segfault on query; see #31717
 compiler.blacklist-append {clang < 421}
 compilers.choose          cc cxx
-compilers.setup           -gcc -fortran -clang33 -clang34 -clang37 -clang16 -clang17
+compilers.setup           -gcc -fortran -clang33 -clang34 -clang37
 notes "To use the postgresql server as a startup item install the ${name}-server port."
 
 if {${universal_possible} && [variant_isset universal]} {

--- a/databases/postgresql16/Portfile
+++ b/databases/postgresql16/Portfile
@@ -8,8 +8,8 @@ PortGroup muniversal 1.0
 PortGroup legacysupport 1.1
 
 name                postgresql16
-version             16.0
-revision            1
+version             16.1
+revision            0
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -29,9 +29,9 @@ homepage            https://www.postgresql.org/
 master_sites        postgresql:source/v${version}/
 distname            postgresql-${version}
 
-checksums           rmd160  859a3fd84167542a12262ea6422a19d1575827a9 \
-                    sha256  df9e823eb22330444e1d48e52cc65135a652a6fdb3ce325e3f08549339f51b99 \
-                    size    24528207
+checksums           rmd160  7d5c28b9e6c987cb11932fced9b4534309635711 \
+                    sha256  ce3c4d85d19b0121fe0d3f8ef1fa601f71989e86f8a66f7dc3ad546dd5564fec \
+                    size    24605482
 
 use_bzip2           yes
 
@@ -88,7 +88,7 @@ configure.universal_args-delete --disable-dependency-tracking
 # building psql with clang from Xcode prior to 4.4 causes segfault on query; see #31717
 compiler.blacklist-append {clang < 421}
 compilers.choose          cc cxx
-compilers.setup           -gcc -fortran -clang33 -clang34 -clang37 -clang16 -clang17
+compilers.setup           -gcc -fortran -clang33 -clang34 -clang37
 notes "To use the postgresql server as a startup item install the ${name}-server port."
 
 if {${universal_possible} && [variant_isset universal]} {
@@ -162,7 +162,7 @@ variant tcl description {add Tcl support} {
 }
 
 variant llvm description {add support for JIT compilation} {
-    set llvm_ver 15
+    set llvm_ver 17
 
     foreach clang ${compilers.clang_variants} {
         if { [variant_exists ${clang}] && [variant_isset ${clang}] } {


### PR DESCRIPTION
#### Description

They backported fixes for recent LLVM to all supported branches so new LLVM can be unblocked

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.1 22G313 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
