### PR TITLE
lchat: new Portfile

### DIFF
--- a/irc/lchat/Portfile
+++ b/irc/lchat/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           makefile 1.0
+
+name                lchat
+version             1.0
+categories          irc
+maintainers         @wwalexander openmaintainer
+license             MIT
+description         line oriented front end for ii-like chat programs
+long_description    lchat (line chat) is a line oriented front end for ii-like chat programs. It handles the input from keyboard and output file in parallel. Thus, you are able to type messages while new chat lines are arriving. Its main focus is on usability and simplicity.
+set domain          suckless.org
+homepage            https://tools.${domain}/${name}/
+master_sites        https://dl.${domain}/tools/
+checksums           rmd160  ddbbb2027ccc295ed3f6fd9d04fdc6619a8d21f7 \
+                    sha256  89247b5c8e853bbfc2f97909b1926fadf44d637543767e77e9e42e72242f375f \
+                    size    24455
+patchfiles          config.diff
+depends_lib         port:libgrapheme
+depends_run         bin:tail:coreutils bin:grep:grep
+test.run            yes

--- a/irc/lchat/files/config.diff
+++ b/irc/lchat/files/config.diff
@@ -1,0 +1,18 @@
+--- config.mk.orig	2023-11-10 14:49:30
++++ config.mk	2023-11-10 15:11:58
+@@ -1,12 +1,11 @@
+ VERSION = 1.0
+ 
+ # paths
+-PREFIX	= /usr/local
+ BINDIR	= $(PREFIX)/bin
+-MANDIR	= $(PREFIX)/man
++MANDIR	= $(PREFIX)/share/man
+ MAN1DIR	= $(MANDIR)/man1
+ 
+-CFLAGS = -std=c99 -pedantic -Wall -Wextra -I/usr/local/include
++CFLAGS = -std=c99 -pedantic -Wall -Wextra -I$(PREFIX)/include
+ 
+ # grapheme.h
+-LIBS = -L/usr/local/lib -lgrapheme
++LIBS = -L$(PREFIX)/lib -lgrapheme


### PR DESCRIPTION
#### Description
lchat is "a line oriented front end for ii-like chat programs" from suckless.org. It is a simple frontend for their file-based ii IRC client.

As with many suckless.org projects, build settings are configured via config.mk. config.diff applies the appropriate settings to config.mk.

lchat has runtime dependencies on tail(1) and grep(1). Since sufficient binaries are included with macOS, I have specified these as bin dependencies.

References: https://github.com/macports/macports-ports/pull/21266

###### Type(s)
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.1 23B74 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?