### PR TITLE
py-igraph: re-enable testing on Python 3.12

### DIFF
--- a/python/py-igraph/Portfile
+++ b/python/py-igraph/Portfile
@@ -75,22 +75,18 @@ if {${name} ne ${subport}} {
         build.env-append        IGRAPH_CMAKE_EXTRA_ARGS=[join $extra_cmake_args]
     }
 
-    # Testing py312-igraph disabled until all test dependencies get py312 subports.
+    # Some test dependencies are disabled for Python 3.12 until they become available.
     if {${subport} ne "py312-${python.rootname}"} {
         # python-igraph optionally makes use of these, and some tests depend on them.
-        # If they are not installed, the corresponding tests will simply be skipped..
+        # If they are not installed, the corresponding tests will simply be skipped.
         depends_test-append     port:py${python.version}-matplotlib \
                                 port:py${python.version}-networkx \
                                 port:py${python.version}-numpy \
                                 port:py${python.version}-pandas \
                                 port:py${python.version}-scipy
-
-        pre-test {
-            test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
-        }
-
-        test.run yes
+    } else {
+        depends_test-append     port:py${python.version}-numpy
     }
 
-    livecheck.type          none
+    test.run yes
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
