### PR TITLE
luajit: update to 2.1.1699524327

### DIFF
--- a/lang/luajit/Portfile
+++ b/lang/luajit/Portfile
@@ -5,19 +5,22 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           xcode_workaround 1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
+PortGroup           makefile 1.0
 
-# Using the v2.1 branch for Apple Silicon support
-# Revert to master_sites on new release, see https://github.com/LuaJIT/LuaJIT/issues/563
-github.setup        LuaJIT LuaJIT c4fe76d50cda24f3529604448f80ff14754599dd
-version             2.1.0-beta3
-revision            6
-checksums           rmd160  ec1dbe9fb0909d3b45aa9059692f0846254abdef \
-                    sha256  9ff3bea98453e4ac5e1d15c26cbc105287ac7b8f15663f6ecde6a308e4842936 \
-                    size    1071348
+set branch          2.1
+set version_date    2023-11-09T10:05:27Z
+github.setup        LuaJIT LuaJIT 69bbbf77363ceb00ad2653a7729a5c9e8316e61f
+revision            0
+checksums           rmd160  2949a8edb3d43d381c6483d6cf7fa5e49d8930e7 \
+                    sha256  42b3a298d8b8a24a3d484797cf58acda32ab5374e120f0de184c804505ccc1ac \
+                    size    1078553
+
+set version_date_s  [clock scan "${version_date}" -format {%Y-%m-%dT%H:%M:%SZ}]
+version             ${branch}.${version_date_s}
 
 name                luajit
 categories          lang
-license             BSD
+license             MIT
 maintainers         nomaintainer
 
 description         a Just-In-Time Compiler for Lua
@@ -31,31 +34,34 @@ patchfiles          powerpc.patch
 
 post-patch {
     reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/etc/luajit.pc
-}
 
-use_configure       no
+    # Remove -march=i686 from CCOPT_x86
+    reinplace -E {s|-march=[a-z0-9_]+||g} ${worksrcpath}/src/Makefile
+
+    # The build process normally expects git and a .git directory to establish
+    # the version but it includes a fallback for a `.relver` file
+    set relver      [open "${worksrcpath}/.relver" w 0644]
+    puts ${relver}  "${version_date_s}"
+    close ${relver}
+}
 
 compiler.blacklist  {clang < 700} *gcc-4.2 macports-clang-3.3 macports-clang-3.4
 
 # changes to compiler flags must be made before `CFLAGS=...`
 xcode_workaround.type append_to_compiler_flags
 
-build.target        amalg
-build.args-append   CC="${configure.cc}" \
-                    CFLAGS="${configure.cppflags} ${configure.cflags} [get_canonical_archflags] -DLUAJIT_ENABLE_LUA52COMPAT" \
-                    LDFLAGS="${configure.ldflags} [get_canonical_archflags]" \
-                    PREFIX="${prefix}" \
-                    Q=""
+configure.cflags-append -DLUAJIT_ENABLE_LUA52COMPAT
+makefile.override   CC CFLAGS LDFLAGS PREFIX
 
-destroot.args-append \
-                    PREFIX="${prefix}"
+build.target        amalg
+build.args-append   Q=
 
 post-destroot {
-    ln -s ${prefix}/bin/luajit-${version} ${destroot}${prefix}/bin/luajit
     xinstall -m 755 -d ${destroot}${prefix}/share/doc
     copy ${worksrcpath}/doc/ ${destroot}${prefix}/share/doc/${name}
 }
 
 livecheck.type      regex
-livecheck.url       ${master_sites}.html
-livecheck.regex     {LuaJIT-(\d+(?:\.\d+)*(?:-beta\d+)?).tar.gz}
+livecheck.url       ${github.homepage}/commits/v${branch}.atom
+livecheck.version   ${version_date}
+livecheck.regex     {<updated>([:TZ0-9-]+)</updated>}


### PR DESCRIPTION
#### Description

This adopt the rolling release format described in https://luajit.org/status.html#release

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.7 21G651 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
