### PR TITLE
ntpstat: fix livecheck

### DIFF
--- a/sysutils/ntpstat/Portfile
+++ b/sysutils/ntpstat/Portfile
@@ -25,7 +25,7 @@ homepage            https://web.archive.org/web/20121207230716/http://people.red
 checksums           rmd160  d82756f5f5a9a7a6d947303147e19a0a7664497b \
                     sha256  d6e3cb1a95ea975a2f8703b3676b1ca6df1752747c172f90e474f11323feeb9c \
                     size    3952
-
+                    
 patchfiles          1001-Makefile.patch \
                     1002-Header-includes.patch
 
@@ -37,3 +37,5 @@ destroot {
     xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${name}
     xinstall -m 0644 ${worksrcpath}/COPYING ${destroot}${prefix}/share/doc/${name}
 }
+
+livecheck.type      none


### PR DESCRIPTION

#### Description

ntpstat: fix livecheck

* Add "livecheck.type none" statement

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
