### PR TITLE
libuv: update to 1.47.0

### DIFF
--- a/devel/libuv/Portfile
+++ b/devel/libuv/Portfile
@@ -6,17 +6,16 @@ PortGroup        clang_dependency 1.0
 PortGroup        legacysupport 1.1
 PortGroup        muniversal 1.0
 
-github.setup     libuv libuv 1.44.2 v
+github.setup     libuv libuv 1.47.0 v
 revision         0
-checksums        rmd160  3802316d7f5dcfe3906ba371d4a738ab60d77339 \
-                 sha256  8ff28f6ac0d6d2a31d2eeca36aff3d7806706c7d3f5971f5ee013ddb0bdd2e9e \
-                 size    3594484
+checksums        rmd160  6510cd246bb2062874a5cb37e92a1c727a7d2655 \
+                 sha256  72a187104662b47f2a2b204da39d2acb05cf22a4fcb13ceaebe3b0ed0c0e2e43 \
+                 size    1654769
 
 master_sites     https://dist.libuv.org/dist/v${version}
 distfiles        ${name}-v${version}-dist${extract.suffix}
 
 categories       devel
-platforms        darwin
 maintainers      {michaelld @michaelld} \
                  openmaintainer
 license          {MIT BSD}

--- a/devel/libuv/files/patch-libuv-legacy.diff
+++ b/devel/libuv/files/patch-libuv-legacy.diff
@@ -14,16 +14,16 @@
  }
 --- src/unix/fs.c.orig
 +++ src/unix/fs.c
-@@ -1061,7 +1061,7 @@
+@@ -960,7 +960,7 @@
  
      return -1;
    }
--#elif defined(__APPLE__)           || \
-+#elif (defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)) || \
-       defined(__DragonFly__)       || \
-       defined(__FreeBSD__)         || \
-       defined(__FreeBSD_kernel__)
-@@ -1441,7 +1441,7 @@
+-#elif defined(__APPLE__) || defined(__DragonFly__) || defined(__FreeBSD__)
++#elif (defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)) || defined(__DragonFly__) || defined(__FreeBSD__)
+   {
+     off_t len;
+     ssize_t r;
+@@ -1307,7 +1307,7 @@
    dst->st_blksize = src->st_blksize;
    dst->st_blocks = src->st_blocks;
  
@@ -44,8 +44,8 @@
  # include <paths.h>
  # include <sys/kauth.h>
  # include <sys/types.h>
-@@ -387,7 +389,7 @@
- #endif
+@@ -407,7 +409,7 @@
+ }
  
  
 -#if defined(__APPLE__)
@@ -53,7 +53,7 @@
  typedef struct uv__posix_spawn_fncs_tag {
    struct {
      int (*addchdir_np)(const posix_spawn_file_actions_t *, const char *);
-@@ -588,9 +590,11 @@
+@@ -608,9 +610,11 @@
        }
      }
  
@@ -65,7 +65,7 @@
          err = posix_spawn_file_actions_adddup2(actions, use_fd, fd);
      assert(err != ENOSYS);
      if (err != 0)
-@@ -839,7 +843,7 @@
+@@ -859,7 +863,7 @@
    int exec_errorno;
    ssize_t r;
  
@@ -87,7 +87,7 @@
    result = ioctl(fd, TIOCPTYGNAME, &dummy) != 0;
 --- src/unix/udp.c.orig
 +++ src/unix/udp.c
-@@ -938,6 +938,7 @@
+@@ -892,6 +892,7 @@
      !defined(__ANDROID__) &&                                        \
      !defined(__DragonFly__) &&                                      \
      !defined(__QNX__) &&                                            \
@@ -95,7 +95,7 @@
      !defined(__GNU__)
  static int uv__udp_set_source_membership4(uv_udp_t* handle,
                                            const struct sockaddr_in* multicast_addr,
-@@ -1131,6 +1132,7 @@
+@@ -1083,6 +1084,7 @@
      !defined(__ANDROID__) &&                                        \
      !defined(__DragonFly__) &&                                      \
      !defined(__QNX__) &&                                            \
@@ -105,21 +105,21 @@
    union uv__sockaddr mcast_addr;
 --- test/test-fs.c.orig
 +++ test/test-fs.c
-@@ -1410,7 +1410,7 @@
-   ASSERT(0 == uv_fs_fstat(NULL, &req, file, NULL));
-   ASSERT(req.result == 0);
+@@ -1423,7 +1423,7 @@
+   ASSERT_OK(uv_fs_fstat(NULL, &req, file, NULL));
+   ASSERT_OK(req.result);
    s = req.ptr;
 -# if defined(__APPLE__)
 +# if defined(__APPLE__) && (__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050)
-   ASSERT(s->st_birthtim.tv_sec == t.st_birthtimespec.tv_sec);
-   ASSERT(s->st_birthtim.tv_nsec == t.st_birthtimespec.tv_nsec);
+   ASSERT_EQ(s->st_birthtim.tv_sec, t.st_birthtimespec.tv_sec);
+   ASSERT_EQ(s->st_birthtim.tv_nsec, t.st_birthtimespec.tv_nsec);
  # elif defined(__linux__)
-@@ -1451,7 +1451,7 @@
-   ASSERT(s->st_size == (uint64_t) t.st_size);
-   ASSERT(s->st_blksize == (uint64_t) t.st_blksize);
-   ASSERT(s->st_blocks == (uint64_t) t.st_blocks);
+@@ -1464,7 +1464,7 @@
+   ASSERT_EQ(s->st_size, (uint64_t) t.st_size);
+   ASSERT_EQ(s->st_blksize, (uint64_t) t.st_blksize);
+   ASSERT_EQ(s->st_blocks, (uint64_t) t.st_blocks);
 -#if defined(__APPLE__)
 +#if defined(__APPLE__) && (__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050)
-   ASSERT(s->st_atim.tv_sec == t.st_atimespec.tv_sec);
-   ASSERT(s->st_atim.tv_nsec == t.st_atimespec.tv_nsec);
-   ASSERT(s->st_mtim.tv_sec == t.st_mtimespec.tv_sec);
+   ASSERT_EQ(s->st_atim.tv_sec, t.st_atimespec.tv_sec);
+   ASSERT_EQ(s->st_atim.tv_nsec, t.st_atimespec.tv_nsec);
+   ASSERT_EQ(s->st_mtim.tv_sec, t.st_mtimespec.tv_sec);

--- a/devel/libuv/files/patch-libuv-unix-core-close-nocancel.diff
+++ b/devel/libuv/files/patch-libuv-unix-core-close-nocancel.diff
@@ -1,41 +1,41 @@
 --- src/unix/core.c.orig
 +++ src/unix/core.c
-@@ -533,18 +533,31 @@
-  * will unwind the thread when it's in the cancel state. Work around that
-  * by making the system call directly. Musl libc is unaffected.
-  */
-+
+@@ -575,6 +575,14 @@
+   return peerfd;
+ }
+ 
 +#if defined(__GNUC__)
-+# define GCC_VERSION \
++#define GCC_VERSION \
 +	(__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 +#endif
 +#if defined(__clang__) || (defined(GCC_VERSION) && (GCC_VERSION >= 40500))
 +/* gcc diagnostic pragmas available */
-+# define GCC_DIAGNOSTIC_AVAILABLE
++#define GCC_DIAGNOSTIC_AVAILABLE
 +#endif
+ 
+ /* close() on macos has the "interesting" quirk that it fails with EINTR
+  * without closing the file descriptor when a thread is in the cancel state.
+@@ -585,17 +593,21 @@
+  * by making the system call directly. Musl libc is unaffected.
+  */
  int uv__close_nocancel(int fd) {
 -#if defined(__APPLE__)
--#pragma GCC diagnostic push
--#pragma GCC diagnostic ignored "-Wdollar-in-identifier-extension"
--#if defined(__LP64__) || TARGET_OS_IPHONE
 +#if defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)
-+# if defined(GCC_DIAGNOSTIC_AVAILABLE)
-+#  pragma GCC diagnostic push
-+#  pragma GCC diagnostic ignored "-Wdollar-in-identifier-extension"
-+# endif
-+# if defined(__LP64__) || __LP64__ || (defined(TARGET_OS_IPHONE) && (TARGET_OS_IPHONE > 0))
++#if defined(GCC_DIAGNOSTIC_AVAILABLE)
+ #pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wdollar-in-identifier-extension"
+-#if defined(__LP64__) || TARGET_OS_IPHONE
++#endif
++#if defined(__LP64__) || __LP64__ || (defined(TARGET_OS_IPHONE) && (TARGET_OS_IPHONE > 0))
    extern int close$NOCANCEL(int);
    return close$NOCANCEL(fd);
--#else
-+# else
+ #else
    extern int close$NOCANCEL$UNIX2003(int);
    return close$NOCANCEL$UNIX2003(fd);
--#endif
--#pragma GCC diagnostic pop
-+# endif
-+# if defined(GCC_DIAGNOSTIC_AVAILABLE)
-+#  pragma GCC diagnostic pop
-+# endif
+ #endif
++#if defined(GCC_DIAGNOSTIC_AVAILABLE)
+ #pragma GCC diagnostic pop
++#endif
  #elif defined(__linux__) && defined(__SANITIZE_THREAD__) && defined(__clang__)
    long rc;
    __sanitizer_syscall_pre_close(fd);

--- a/devel/libuv/files/patch-no-libutil-on-Tiger.diff
+++ b/devel/libuv/files/patch-no-libutil-on-Tiger.diff
@@ -1,56 +1,11 @@
---- Makefile.in.orig
-+++ Makefile.in
-@@ -255,7 +255,7 @@
- @DARWIN_TRUE@                    src/unix/proctitle.c \
- @DARWIN_TRUE@                    src/unix/random-getentropy.c
+--- Makefile.am.orig
++++ Makefile.am
+@@ -425,7 +425,7 @@
+                     src/unix/kqueue.c \
+                     src/unix/proctitle.c \
+                     src/unix/random-getentropy.c
+-test_run_tests_LDFLAGS += -lutil
++# test_run_tests_LDFLAGS += -lutil
+ endif
  
--@DARWIN_TRUE@am__append_31 = -lutil
-+# @DARWIN_TRUE@am__append_31 = -lutil
- @DRAGONFLY_TRUE@am__append_32 = include/uv/bsd.h
- @DRAGONFLY_TRUE@am__append_33 = src/unix/bsd-ifaddrs.c \
- @DRAGONFLY_TRUE@                    src/unix/bsd-proctitle.c \
-@@ -263,7 +263,7 @@
- @DRAGONFLY_TRUE@                    src/unix/kqueue.c \
- @DRAGONFLY_TRUE@                    src/unix/posix-hrtime.c
- 
--@DRAGONFLY_TRUE@am__append_34 = -lutil
-+# @DRAGONFLY_TRUE@am__append_34 = -lutil
- @FREEBSD_TRUE@am__append_35 = include/uv/bsd.h
- @FREEBSD_TRUE@am__append_36 = src/unix/bsd-ifaddrs.c \
- @FREEBSD_TRUE@                    src/unix/bsd-proctitle.c \
-@@ -272,7 +272,7 @@
- @FREEBSD_TRUE@                    src/unix/posix-hrtime.c \
- @FREEBSD_TRUE@                    src/unix/random-getrandom.c
- 
--@FREEBSD_TRUE@am__append_37 = -lutil
-+# @FREEBSD_TRUE@am__append_37 = -lutil
- @HAIKU_TRUE@am__append_38 = include/uv/posix.h
- @HAIKU_TRUE@am__append_39 = -D_BSD_SOURCE
- @HAIKU_TRUE@am__append_40 = src/unix/bsd-ifaddrs.c \
-@@ -303,7 +303,7 @@
- @LINUX_TRUE@                    src/unix/random-sysctl-linux.c \
- @LINUX_TRUE@                    src/unix/epoll.c
- 
--@LINUX_TRUE@am__append_47 = -lutil
-+# @LINUX_TRUE@am__append_47 = -lutil
- @MSYS_TRUE@am__append_48 = -D_GNU_SOURCE
- @MSYS_TRUE@am__append_49 = src/unix/cygwin.c \
- @MSYS_TRUE@                    src/unix/bsd-ifaddrs.c \
-@@ -322,7 +322,7 @@
- @NETBSD_TRUE@                    src/unix/netbsd.c \
- @NETBSD_TRUE@                    src/unix/posix-hrtime.c
- 
--@NETBSD_TRUE@am__append_52 = -lutil
-+# @NETBSD_TRUE@am__append_52 = -lutil
- @OPENBSD_TRUE@am__append_53 = include/uv/bsd.h
- @OPENBSD_TRUE@am__append_54 = src/unix/bsd-ifaddrs.c \
- @OPENBSD_TRUE@                    src/unix/bsd-proctitle.c \
-@@ -331,7 +331,7 @@
- @OPENBSD_TRUE@                    src/unix/posix-hrtime.c \
- @OPENBSD_TRUE@                    src/unix/random-getentropy.c
- 
--@OPENBSD_TRUE@am__append_55 = -lutil
-+# @OPENBSD_TRUE@am__append_55 = -lutil
- @SUNOS_TRUE@am__append_56 = include/uv/sunos.h
- @SUNOS_TRUE@am__append_57 = -D__EXTENSIONS__ \
- @SUNOS_TRUE@                   -D_XOPEN_SOURCE=500 \
+ if DRAGONFLY


### PR DESCRIPTION
#### Description

> Ah... noticed that #20421 already started this work! I'll raise it up anyway @herbygillot , @barracuda156 but please feel free to close this if it's noise. Maybe the patches are useful?

I took care to apply the patches cleanly to 1.47.0. The Tiger specific patch didn't work against 1.44.2, and presumably no one has noticed (?), so I would challenge if it is worth keeping around at this point (extra maintenance burden).

Similarly, are the other patches still worth keeping around as guards for pre-Leopard/Lion versions of macOS? Is there a general deprecation policy for old OS versions?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.6.7 21G651 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] (my bad!) checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

<details>

<summary>Test output</summary>

```
/Library/Developer/CommandLineTools/usr/bin/make  check-TESTS
1..432
ok 1 - platform_output
# Output from process `platform_output`:
# uv_get_process_title: /opt/local/var/macports/build/_private_tmp_macports_devel_libuv/libuv/work/libuv-1.47.0/test/.libs/run-tests
# uv_cwd: /opt/local/var/macports/build/_private_tmp_macports_devel_libuv/libuv/work/libuv-1.47.0
# uv_resident_set_memory: 1769472
# uv_uptime: 10811051.000000
# uv_getrusage:
#   user: 0 sec 1329 microsec
#   system: 0 sec 576 microsec
#   page faults: 0
#   maximum resident set size: 1728
# uv_available_parallelism: 10
# uv_cpu_info:
#   model: Apple M1 Max
#   speed: 2400
#   times.sys: 244362540
#   times.user: 301459140
#   times.idle: 1499833440
#   times.irq: 0
#   times.nice: 0
#   model: Apple M1 Max
#   speed: 2400
#   times.sys: 226184370
#   times.user: 299773530
#   times.idle: 1519626720
#   times.irq: 0
#   times.nice: 0
#   model: Apple M1 Max
#   speed: 2400
#   times.sys: 83604000
#   times.user: 115724060
#   times.idle: 1846256730
#   times.irq: 0
#   times.nice: 0
#   model: Apple M1 Max
#   speed: 2400
#   times.sys: 45732310
#   times.user: 69241280
#   times.idle: 1930611550
#   times.irq: 0
#   times.nice: 0
#   model: Apple M1 Max
#
#   speed: 2400
#   times.sys: 20849390
#   times.user: 34187670
#   times.idle: 1990548240
#   times.irq: 0
#   times.nice: 0
#   model: Apple M1 Max
#   speed: 2400
#   times.sys: 15082170
#   times.user: 21296060
#   times.idle: 2009207390
#   times.irq: 0
#   times.nice: 0
#   model: Apple M1 Max
#   speed: 2400
#   times.sys: 8970990
#   times.user: 19819030
#   times.idle: 2016795800
#   times.irq: 0
#   times.nice: 0
#   model: Apple M1 Max
#   speed: 2400
#   times.sys: 4124640
#   times.user: 6946970
#   times.idle: 2034514540
#   times.irq: 0
#   times.nice: 0
#   model: Apple M1 Max
#   speed: 2400
#   times.sys: 3049630
#   times.user: 4524950
#   times.idle: 2038011720
#   times.irq: 0
#   times.nice: 0
#   model: Apple M1 Max
#   speed: 2400
#   times.sys: 2604110
#   times.user: 3641880
#   times.idle: 2039340830
#   times.irq: 0
#   times.nice: 0
# uv_interface_addresses:
#   name: lo0
#   internal: 1
#   physical address: 00:00:00:00:00:00
#   address: 127.0.0.1
#   netmask: 255.0.0.0
#   name: lo0
#   internal: 1
#   physical address: 00:00:00:00:00:00
#   address: ::1
#   netmask: ffff:ffff:
# ffff:ffff:ffff:ffff:ffff:ffff
#   name: lo0
#   internal: 1
#   physical address: 00:00:00:00:00:00
#   address: fe80::1
#   netmask: ffff:ffff:ffff:ffff::
#   name: anpi2
#   internal: 0
#   physical address: 46:64:04:22:bf:e0
#   address: fe80::4464:4ff:fe22:bfe0
#   netmask: ffff:ffff:ffff:ffff::
#   name: anpi1
#   internal: 0
#   physical address: 46:64:04:22:bf:df
#   address: fe80::4464:4ff:fe22:bfdf
#   netmask: ffff:ffff:ffff:ffff::
#   name: anpi0
#   internal: 0
#   physical address: 46:64:04:22:bf:de
#   address: fe80::4464:4ff:fe22:bfde
#   netmask: ffff:ffff:ffff:ffff::
#   name: en0
#   internal: 0
#   physical address: f0:2f:4b:00:dd:d2
#   address: fe80::1ca0:2590:b026:2c5a
#   netmask: ffff:ffff:ffff:ffff::
#   name: en0
#   internal: 0
#   physical address: f0:2f:4b:00:dd:d2
#   address: 192.168.1.221
#   netmask: 255.255.255.0
#   name: awdl0
#   internal: 0
#   physical address: 86:91:79:b1:fe:7c
#   address: fe80::8491:79ff:feb1:fe7c
#   netmask: ffff:ffff:ffff:ffff::
#   name: llw0
#   internal: 0
#   physical address: 86:91:79:b1:fe:7c
#   address: fe80::8491:79
# ff:feb1:fe7c
#   netmask: ffff:ffff:ffff:ffff::
#   name: utun0
#   internal: 0
#   physical address: 00:00:00:00:00:00
#   address: fe80::b02:1bab:a29f:89af
#   netmask: ffff:ffff:ffff:ffff::
#   name: utun1
#   internal: 0
#   physical address: 00:00:00:00:00:00
#   address: fe80::26d2:2afd:be46:aef4
#   netmask: ffff:ffff:ffff:ffff::
#   name: utun2
#   internal: 0
#   physical address: 00:00:00:00:00:00
#   address: fe80::ce81:b1c:bd2c:69e
#   netmask: ffff:ffff:ffff:ffff::
#   name: utun3
#   internal: 0
#   physical address: 00:00:00:00:00:00
#   address: fe80::e8bc:9b65:f5a5:7a00
#   netmask: ffff:ffff:ffff:ffff::
#   name: utun4
#   internal: 0
#   physical address: 00:00:00:00:00:00
#   address: fe80::f7c3:e3d8:1191:bfca
#   netmask: ffff:ffff:ffff:ffff::
#   name: utun5
#   internal: 0
#   physical address: 00:00:00:00:00:00
#   address: fe80::9eb0:1218:e60:539d
#   netmask: ffff:ffff:ffff:ffff::
#   name: utun6
#   internal: 0
#   physical address: 00:00:00:00:00:00
#   address: fe80::e6:c6d0:bb1a:43f3
#   netmask: ffff:ffff:ffff:ffff::
# uv_os_get_passwd:
#   euid: 502
#
# gid: 501 (macports)
#     members: [ ]
#   username: macports
#   shell: /usr/bin/false
#   home directory: /opt/local/var/macports/home
# uv_os_getpid: 2658
# uv_os_getppid: 2644
# uv_os_uname:
#   sysname: Darwin
#   release: 21.6.0
#   version: Darwin Kernel Version 21.6.0: Thu Jun  8 23:56:13 PDT 2023; root:xnu-8020.240.18.701.6~1/RELEASE_ARM64_T6000
#   machine: arm64
ok 2 - active
ok 3 - async
ok 4 - async_null_cb
ok 5 - async_ref
ok 6 - barrier_1
ok 7 - barrier_2
ok 8 - barrier_3
ok 9 - barrier_serial_thread
ok 10 - barrier_serial_thread_single
ok 11 - callback_stack
ok 12 - check_ref
ok 13 - clock_gettime
ok 14 - close_fd
ok 15 - close_order
ok 16 - closed_fd_events
ok 17 - condvar_1
ok 18 - condvar_2
ok 19 - condvar_3
ok 20 - condvar_4
ok 21 - condvar_5
ok 22 - connect_unspecified
ok 23 - connection_fail
ok 24 - connection_fail_doesnt_auto_close
ok 25 - cwd_and_chdir
ok 26 - default_loop_close
ok 27 - delayed_accept
ok 28 - dlerror
ok 29 - eintr_handling
ok 30 - embed
ok 31 - emfile
ok 32 - env_vars
ok 33 - error_message
ok 34 - fork_close_signal_in_child
ok 35 - fork_signal_to_child
ok 36 - fork_signal_to_child_closed
ok 37 - fork_socketpair
ok 38 - fork_socketpair_started
ok 39 - fork_threadpool_queue_work_simple
ok 40 - fork_timer
ok 41 - fs_access
ok 42 - fs_async_dir
ok 43 - fs_async_sendfile
ok 44 - fs_async_sendfile_nodata
ok 45 - fs_chmod
ok 46 - fs_chown
ok 47 - fs_copyfile
ok 48 - fs_event_close_in_callback
ok 49 - fs_event_close_with_pending_delete_event
ok 50 - fs_event_close_with_pending_event
ok 51 - fs_event_error_reporting
ok 52 - fs_event_getpath
ok 53 - fs_event_immediate_close
ok 54 - fs_event_no_callback_after_close
ok 55 - fs_event_no_callback_on_close
ok 56 - fs_event_ref
ok 57 - fs_event_start_and_close
ok 58 - fs_event_stop_in_cb
ok 59 - fs_event_watch_dir
ok 60 - fs_event_watch_dir_recursive
ok 61 - fs_event_watch_file
ok 62 - fs_event_watch_file_current_dir
ok 63 - fs_event_watch_file_exact_path
ok 64 - fs_event_watch_file_twice
ok 65 - fs_event_watch_invalid_path
ok 66 - fs_file_async
ok 67 - fs_file_loop
ok 68 - fs_file_nametoolong
ok 69 - fs_file_noent
ok 70 - fs_file_open_append
ok 71 - fs_file_pos_after_op_with_offset
ok 72 - fs_file_sync
ok 73 - fs_file_write_null_buffer
ok 74 - fs_fstat
ok 75 - fs_fstat_stdio
ok 76 - fs_futime
ok 77 - fs_get_system_error
ok 78 - fs_link
ok 79 - fs_lutime
ok 80 - fs_mkdtemp
ok 81 - fs_mkstemp
ok 82 - fs_null_req
ok 83 - fs_open_dir
ok 84 - fs_partial_read
ok 85 - fs_partial_write
ok 86 - fs_poll
ok 87 - fs_poll_close_request
ok 88 - fs_poll_close_request_multi_start_stop
ok 89 - fs_poll_close_request_multi_stop_start
ok 90 - fs_poll_close_request_stop_when_active
ok 91 - fs_poll_getpath
ok 92 - fs_poll_ref
ok 93 - fs_read_bufs
ok 94 - fs_read_dir
ok 95 - fs_read_file_eof
ok 96 - fs_read_write_null_arguments
ok 97 - fs_readdir_empty_dir
ok 98 - fs_readdir_file
ok 99 - fs_readdir_non_empty_dir
ok 100 - fs_readdir_non_existing_dir
ok 101 - fs_readlink
ok 102 - fs_realpath
ok 103 - fs_rename_to_existing_file
ok 104 - fs_scandir_early_exit
ok 105 - fs_scandir_empty_dir
ok 106 - fs_scandir_file
ok 107 - fs_scandir_non_existent_dir
ok 108 - fs_stat_batch_multiple
ok 109 - fs_stat_missing_path
ok 110 - fs_statfs
ok 111 - fs_symlink
ok 112 - fs_symlink_dir
ok 113 - fs_unlink_readonly
ok 114 - fs_utime
ok 115 - fs_utime_round
ok 116 - fs_write_alotof_bufs
ok 117 - fs_write_alotof_bufs_with_offset
ok 118 - fs_write_multiple_bufs
ok 119 - get_currentexe
ok 120 - get_group
ok 121 - get_loadavg
ok 122 - get_memory
ok 123 - get_osfhandle_valid_handle
ok 124 - get_passwd
ok 125 - get_passwd2
ok 126 - getaddrinfo_basic
ok 127 - getaddrinfo_basic_sync
ok 128 - getaddrinfo_concurrent
ok 129 - getaddrinfo_fail
ok 130 - getaddrinfo_fail_sync
ok 131 - gethostname
ok 132 - getnameinfo_basic_ip4
ok 133 - getnameinfo_basic_ip4_sync
ok 134 - getnameinfo_basic_ip6
ok 135 - getsockname_tcp
ok 136 - getsockname_udp
ok 137 - getters_setters
ok 138 - gettimeofday
ok 139 - handle_fileno
ok 140 - handle_type_name
ok 141 - has_ref
ok 142 - homedir
ok 143 - hrtime
ok 144 - idle_check
ok 145 - idle_ref
ok 146 - idle_starvation
ok 147 - idna_toascii
ok 148 - ip4_addr
ok 149 - ip6_addr_link_local
ok 150 - ip6_pton
ok 151 - ip6_sin6_len
ok 152 - ip_name
ok 153 - ipc_heavy_traffic_deadlock_bug
ok 154 - ipc_listen_after_write
ok 155 - ipc_listen_before_write
ok 156 - ipc_send_recv_pipe
ok 157 - ipc_send_recv_pipe_inprocess
ok 158 - ipc_send_recv_tcp
ok 159 - ipc_send_recv_tcp_inprocess
ok 160 - ipc_send_zero
ok 161 - ipc_tcp_connection
ok 162 - kill
ok 163 - kill_invalid_signum
ok 164 - loop_alive
ok 165 - loop_backend_timeout
ok 166 - loop_close
ok 167 - loop_configure
ok 168 - loop_handles
ok 169 - loop_instant_close
ok 170 - loop_stop
ok 171 - loop_stop_before_run
ok 172 - loop_update_time
ok 173 - metrics_idle_time
ok 174 - metrics_idle_time_thread
ok 175 - metrics_idle_time_zero
ok 176 - metrics_info_check
ok 177 - metrics_pool_events
ok 178 - multiple_listen
ok 179 - not_readable_nor_writable_on_read_error
ok 180 - not_writable_after_shutdown
ok 181 - open_osfhandle_valid_handle
got some input
with a couple of lines
feel pretty happy
ok 182 - osx_select
got some input
with a couple of lines
feel pretty happy
ok 183 - osx_select_many_fds
ok 184 - pipe_bind_error_addrinuse
ok 185 - pipe_bind_error_addrnotavail
ok 186 - pipe_bind_error_inval
ok 187 - pipe_bind_or_listen_error_after_close
ok 188 - pipe_close_stdout_read_stdin
ok 189 - pipe_connect_bad_name
ok 190 - pipe_connect_close_multiple
ok 191 - pipe_connect_multiple
ok 192 - pipe_connect_on_prepare
ok 193 - pipe_connect_to_file
ok 194 - pipe_getsockname
ok 195 - pipe_getsockname_abstract
ok 196 - pipe_getsockname_blocking
ok 197 - pipe_listen_without_bind
ok 198 - pipe_overlong_path
ok 199 - pipe_pending_instances
ok 200 - pipe_ping_pong
ok 201 - pipe_ping_pong_vec
ok 202 - pipe_ref
ok 203 - pipe_ref2
ok 204 - pipe_ref3
ok 205 - pipe_ref4
ok 206 - pipe_sendmsg
ok 207 - pipe_server_close
ok 208 - pipe_set_chmod
ok 209 - pipe_set_non_blocking
ok 210 - poll_bad_fdtype
ok 211 - poll_close
ok 212 - poll_close_doesnt_corrupt_stack # SKIP Test only relevant on Windows
ok 213 - poll_closesocket # SKIP Test only relevant on Windows
ok 214 - poll_duplex
ok 215 - poll_multiple_handles
ok 216 - poll_nested_kqueue
ok 217 - poll_oob
ok 218 - poll_unidirectional
ok 219 - prepare_ref
ok 220 - process_priority
ok 221 - process_ref
ok 222 - process_title
ok 223 - process_title_big_argv
ok 224 - process_title_threadsafe
ok 225 - queue_foreach_delete
ok 226 - random_async
ok 227 - random_sync
ok 228 - readable_on_eof
ok 229 - ref
ok 230 - req_type_name
ok 231 - run_nowait
ok 232 - run_once
ok 233 - semaphore_1
ok 234 - semaphore_2
ok 235 - semaphore_3
ok 236 - shutdown_close_pipe
ok 237 - shutdown_close_tcp
ok 238 - shutdown_eof
ok 239 - shutdown_simultaneous
ok 240 - shutdown_twice
ok 241 - signal_close_loop_alive
ok 242 - signal_multiple_loops
ok 243 - signal_pending_on_close
ok 244 - socket_buffer_size
ok 245 - spawn_and_kill
ok 246 - spawn_and_kill_with_std
ok 247 - spawn_and_ping
ok 248 - spawn_auto_unref
ok 249 - spawn_closed_process_io
ok 250 - spawn_detached
ok 251 - spawn_empty_env # SKIP doesn't work with DYLD_LIBRARY_PATH/LD_LIBRARY_PATH/LIBPATH
ok 252 - spawn_exercise_sigchld_issue
ok 253 - spawn_exit_code
ok 254 - spawn_fails
ok 255 - spawn_fails_check_for_waitpid_cleanup
ok 256 - spawn_fs_open
ok 257 - spawn_ignored_stdio
ok 258 - spawn_inherit_streams
ok 259 - spawn_preserve_env
ok 260 - spawn_quoted_path # SKIP Test for Windows
ok 261 - spawn_reads_child_path
ok 262 - spawn_relative_path
ok 263 - spawn_same_stdout_stderr
ok 264 - spawn_setgid_fails
ok 265 - spawn_setuid_fails
ok 266 - spawn_setuid_setgid # SKIP It should be run as root user
ok 267 - spawn_stdin
ok 268 - spawn_stdio_greater_than_3
ok 269 - spawn_stdout
ok 270 - spawn_stdout_and_stderr_to_file
ok 271 - spawn_stdout_and_stderr_to_file2
ok 272 - spawn_stdout_and_stderr_to_file_swap
ok 273 - spawn_stdout_to_file
ok 274 - spawn_tcp_server
ok 275 - stdio_emulate_iocp
ok 276 - stdio_over_pipes
ok 277 - strscpy
ok 278 - strtok
ok 279 - sys_error
ok 280 - tcp6_local_connect_timeout
ok 281 - tcp6_ping_pong
ok 282 - tcp6_ping_pong_vec
ok 283 - tcp_alloc_cb_fail
ok 284 - tcp_bind6_error_addrinuse
ok 285 - tcp_bind6_error_addrnotavail
ok 286 - tcp_bind6_error_fault
ok 287 - tcp_bind6_error_inval
ok 288 - tcp_bind6_localhost_ok
ok 289 - tcp_bind_error_addrinuse_connect
ok 290 - tcp_bind_error_addrinuse_listen
ok 291 - tcp_bind_error_addrnotavail_1
ok 292 - tcp_bind_error_addrnotavail_2
ok 293 - tcp_bind_error_fault
ok 294 - tcp_bind_error_inval
ok 295 - tcp_bind_invalid_flags
ok 296 - tcp_bind_localhost_ok
ok 297 - tcp_bind_or_listen_error_after_close
ok 298 - tcp_bind_writable_flags
ok 299 - tcp_close
ok 300 - tcp_close_accept
ok 301 - tcp_close_after_read_timeout
ok 302 - tcp_close_reset_accepted
ok 303 - tcp_close_reset_accepted_after_shutdown
ok 304 - tcp_close_reset_accepted_after_socket_shutdown
ok 305 - tcp_close_reset_client
ok 306 - tcp_close_reset_client_after_shutdown
ok 307 - tcp_close_while_connecting
ok 308 - tcp_connect6_error_fault
ok 309 - tcp_connect6_link_local
ok 310 - tcp_connect_error_after_write
ok 311 - tcp_connect_error_fault
ok 312 - tcp_connect_timeout
ok 313 - tcp_create_early
ok 314 - tcp_create_early_accept
ok 315 - tcp_create_early_bad_bind
ok 316 - tcp_create_early_bad_domain
ok 317 - tcp_flags
ok 318 - tcp_listen_without_bind
ok 319 - tcp_local_connect_timeout
ok 320 - tcp_oob
ok 321 - tcp_open
ok 322 - tcp_open_bound
ok 323 - tcp_open_connected
ok 324 - tcp_open_twice
ok 325 - tcp_ping_pong
ok 326 - tcp_ping_pong_vec
ok 327 - tcp_read_stop
ok 328 - tcp_read_stop_start
ok 329 - tcp_ref
ok 330 - tcp_ref2
ok 331 - tcp_ref2b
ok 332 - tcp_ref3
ok 333 - tcp_ref4
ok 334 - tcp_rst
ok 335 - tcp_shutdown_after_write
ok 336 - tcp_try_write
ok 337 - tcp_try_write_error
ok 338 - tcp_unexpected_read
ok 339 - tcp_write_after_connect
ok 340 - tcp_write_fail
ok 341 - tcp_write_in_a_row
ok 342 - tcp_write_queue_order
ok 343 - tcp_write_ready
ok 344 - tcp_write_to_half_open_connection
ok 345 - tcp_writealot
ok 346 - test_macros
ok 347 - thread_affinity
ok 348 - thread_create
ok 349 - thread_equal
ok 350 - thread_local_storage
ok 351 - thread_mutex
ok 352 - thread_mutex_recursive
ok 353 - thread_rwlock
ok 354 - thread_rwlock_trylock
ok 355 - thread_stack_size
ok 356 - thread_stack_size_explicit
ok 357 - threadpool_cancel_fs
ok 358 - threadpool_cancel_getaddrinfo
ok 359 - threadpool_cancel_getnameinfo
ok 360 - threadpool_cancel_random
ok 361 - threadpool_cancel_single
ok 362 - threadpool_cancel_when_busy
ok 363 - threadpool_cancel_work
ok 364 - threadpool_multiple_event_loops
ok 365 - threadpool_queue_work_einval
ok 366 - threadpool_queue_work_simple
ok 367 - timer
ok 368 - timer_again
ok 369 - timer_early_check
ok 370 - timer_from_check
ok 371 - timer_huge_repeat
ok 372 - timer_huge_timeout
ok 373 - timer_init
ok 374 - timer_is_closing
ok 375 - timer_no_double_call_nowait
ok 376 - timer_no_double_call_once
ok 377 - timer_no_run_on_unref
ok 378 - timer_null_callback
ok 379 - timer_order
ok 380 - timer_ref
ok 381 - timer_ref2
ok 382 - timer_run_once
ok 383 - timer_start_twice
ok 384 - tmpdir
ok 385 - tty
ok 386 - tty_file
ok 387 - tty_pty
ok 388 - udp_alloc_cb_fail
ok 389 - udp_bind
ok 390 - udp_bind_reuseaddr
ok 391 - udp_connect
ok 392 - udp_connect6
ok 393 - udp_create_early
ok 394 - udp_create_early_bad_bind
ok 395 - udp_create_early_bad_domain
ok 396 - udp_dgram_too_big
ok 397 - udp_dual_stack
ok 398 - udp_ipv6_only
ok 399 - udp_mmsg
ok 400 - udp_multicast_interface
ok 401 - udp_multicast_interface6
ok 402 - udp_multicast_join
ok 403 - udp_multicast_join6
ok 404 - udp_multicast_ttl
ok 405 - udp_no_autobind
ok 406 - udp_open
ok 407 - udp_open_bound
ok 408 - udp_open_connect
ok 409 - udp_open_twice
ok 410 - udp_options
ok 411 - udp_options6
ok 412 - udp_recv_in_a_row
ok 413 - udp_ref
ok 414 - udp_ref2
ok 415 - udp_ref3
ok 416 - udp_send_and_recv
ok 417 - udp_send_hang_loop
ok 418 - udp_send_immediate
ok 419 - udp_send_unix
ok 420 - udp_send_unreachable
ok 421 - udp_sendmmsg_error
ok 422 - udp_try_send
ok 423 - uname
ok 424 - unref_in_prepare_cb
ok 425 - utf8_decode1
ok 426 - utf8_decode1_overrun
ok 427 - walk_handles
ok 428 - watcher_cross_stop
ok 429 - we_get_signal
ok 430 - we_get_signal_one_shot
ok 431 - we_get_signals
ok 432 - we_get_signals_mixed
PASS: test/run-tests
=============
1 test passed
=============

```

</details>