### PR TITLE
py-tkinter: fix compilation on Mavericks

### DIFF
--- a/python/py-tkinter/Portfile
+++ b/python/py-tkinter/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem 1.0
 PortGroup python 1.0
+PortGroup compiler_blacklist_versions 1.0
 
 name            py-tkinter
 version         2.4.6
@@ -143,6 +144,8 @@ subport py312-tkinter {
 
 master_sites    https://www.python.org/ftp/python/${version}/
 distname        Python-${version}
+
+compiler.blacklist-append { clang < 700 }
 
 if {${name} ne ${subport}} {
     use_xz      yes


### PR DESCRIPTION
#### Description

`py-tkinter` now requires a C11 capable compiler. The default C standard in Clang 3.7 (upon which Yosemite’s AppleClang is based) is C11, while the default standard in 3.5 (upon which Maverick’s version is based) is C99. The change of default version happened in Clang 3.6. Thus compilation fails on some `static_assert` statement. Injecting `-std=c11` in setup.py works, but I found no easy way of doing that in the Portfile (let me know if there is!). Setting `configure.cflags` did not work. The simplest solution was to blacklist `clang < 700`.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

`lint --nitpick` warns about "missing recommended checksum type: size", but that is not related to my changes.
