### PR TITLE
GPXSee: update to 13.10, QtPBFImagePlugin: update to 2.6

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.9
+github.setup        tumic0 GPXSee 13.10
 revision            0
 
-checksums           rmd160  437fee0be128036f29a11b300924a78b885658e6 \
-                    sha256  b4fc2c7a13879fef88244ae4f43b66d942a6a4d634ecd8dc3a8e7233d430e627 \
-                    size    5632895
+checksums           rmd160  85fd162bf2b822edea1c90935581bf3796dd2048 \
+                    sha256  a531ee041c14e00e8d637ade4d29a766628e3b75b4472b08edb6d72d3ff506cf \
+                    size    5541000
 
 categories          gis graphics
 license             GPL-3

--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 QtPBFImagePlugin 2.4
-revision            2
+github.setup        tumic0 QtPBFImagePlugin 2.6
+revision            0
 categories          graphics
 license             LGPL-3
 maintainers         {@sikmir disroot.org:sikmir} openmaintainer
@@ -13,9 +13,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         PBF image plugin for Qt5
 long_description    Qt image plugin for displaying Mapbox vector tiles.
 
-checksums           rmd160  562169c9e5b1ccfa33905311c69f69be4990f0cc \
-                    sha256  aada6fe94e6bee06a2f12e19c260aa082315c695c15ea8c793e04af816e87f85 \
-                    size    196556
+checksums           rmd160  fd4c6a4e539a4a60b33ae67e1f2f5299afc4a0a5 \
+                    sha256  cabf91bdfe3d1cf8577ec2e0d4459cbe9c98b582bff706c5687248db25a8104a \
+                    size    197462
 
 # Upstream links to static 'libprotobuf-lite', but needs to be dylib
 patchfiles-append   patch-protobuf-dylib.diff


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
