### PR TITLE
py-watchdog: provide version for < 10.7

### DIFF
--- a/python/py-watchdog/Portfile
+++ b/python/py-watchdog/Portfile
@@ -8,7 +8,6 @@ version             3.0.0
 revision            0
 
 categories-append   sysutils
-platforms           darwin
 license             Apache-2
 maintainers         {petr @petrrr} {@catap korins.ky:kirill} openmaintainer
 
@@ -24,7 +23,21 @@ checksums           sha256  4d98a320595da7a7c5a18fc48cb633c2e73cda78f93cac2ef42d
 python.versions     27 37 38 39 310 311
 
 if {${name} ne ${subport}} {
-    if {${python.version} < 37} {
+    if {${os.platform} eq "darwin" && ${os.major} <= 10} {
+        # support for 10.7 and below was dropped in version 0.10.4
+        # https://trac.macports.org/ticket/64584
+        # https://github.com/gorakhargosh/watchdog/issues/1021
+        # TODO: see if we can use a newer version, borrowing fallback code from 0.10.3.
+        version     0.10.3
+        revision    0
+        checksums   sha256  4214e1379d128b0588021880ccaf40317ee156d4603ac388b9adcf29165e0c04 \
+                    rmd160  cd117cd0cd0f54264eb6ebfd855f58dbeeb616f9 \
+                    size    94086
+        patchfiles  patch.osx-10.6.setup.py
+        depends_lib-append  port:py${python.version}-pathtools
+        compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
+    } elseif {${python.version} < 37} {
         version     0.10.7
         revision    0
         checksums   sha256  50cb861700b99edcb4b7af330d28ce34ba5551a74b51c0a283ed221e936435f4 \
@@ -43,10 +56,6 @@ if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-argh \
                             port:py${python.version}-setuptools \
                             port:py${python.version}-yaml
-
-    if {${os.major} <= 10} {
-        patchfiles  patch.osx-10.6.setup.py
-    }
 
     depends_test-append \
                     port:py${python.version}-flaky


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/64584

#### Description

Offer a version working on older systems.

P. S. Once this is merged, we can have `maestral`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
