### PR TITLE
checkmake: new port (0.2.2)

### DIFF
--- a/devel/checkmake/Portfile
+++ b/devel/checkmake/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/mrtazz/checkmake 0.2.2
+revision            0
+categories          devel
+license             MIT
+maintainers         {@therealketo gmail.com:therealketo} openmaintainer
+
+description         experimental tool for linting and checking Makefiles
+long_description    ${name} is a {*}${description}. It may not do what you \
+                    want it to.
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  13116415355b2353487bd724b8480e43ff19d12f \
+                        sha256  4d93f70268ee33690754dbcdb9744b1481ca027e4ce070043ba27c14aec878b0 \
+                        size    102682
+
+patch.pre_args      -p1
+patchfiles          no-builder-name-email.diff
+
+depends_build-append \
+                    port:pandoc
+
+# Vendored libraries cause failure, fetch them at build time
+go.offline_build    no
+
+build.cmd           make
+build.target        all
+build.args          BUILDER="MacPorts" \
+                    VERSION="${version}"
+
+destroot {
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 0644 \
+        ${worksrcpath}/${name}.1 \
+        ${destroot}${prefix}/share/man/man1/
+}

--- a/devel/checkmake/files/no-builder-name-email.diff
+++ b/devel/checkmake/files/no-builder-name-email.diff
@@ -1,0 +1,20 @@
+diff -urN a/Makefile b/Makefile
+--- a/Makefile	2023-04-11 12:51:08.000000000 +0000
++++ b/Makefile	2023-11-12 00:42:54.000000000 +0000
+@@ -23,16 +23,6 @@
+ $(RELEASE_ARTIFACTS_DIR):
+ 	install -d $@
+ 
+-BUILDER_NAME := $(if $(BUILDER_NAME),$(BUILDER_NAME),$(shell git config user.name))
+-ifndef BUILDER_NAME
+-$(error "You must set environment variable BUILDER_NAME or set a user.name in your git configuration.")
+-endif
+-
+-EMAIL := $(if $(BUILDER_EMAIL),$(BUILDER_EMAIL),$(shell git config user.email))
+-ifndef EMAIL
+-$(error "You must set environment variable BUILDER_EMAIL or set a user.email in your git configuration.")
+-endif
+-
+ BUILDER := $(shell echo "${BUILDER_NAME} <${EMAIL}>")
+ 
+ PKG_RELEASE ?= 1


### PR DESCRIPTION
#### Description

Add `checkmake`, a linter and analyzer for Makefiles.

Closes: https://trac.macports.org/ticket/68571

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
