### PR TITLE
libgrapheme: unbreak build on < 10.7, use correct archflags

### DIFF
--- a/textproc/libgrapheme/Portfile
+++ b/textproc/libgrapheme/Portfile
@@ -1,7 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
+
+# _getline
+legacysupport.newest_darwin_requires_legacy 10
 
 name                libgrapheme
 version             2.0.2
@@ -22,6 +26,13 @@ master_sites        https://dl.${domain}/libgrapheme/
 checksums           rmd160  8cf9cddda9f0647e003669d801984a461976ee1c \
                     sha256  a68bbddde76bd55ba5d64116ce5e42a13df045c81c0852de9ab60896aa143125 \
                     size    846990
+
 patchfiles          config.diff
-use_configure       no
+
+post-patch {
+    reinplace "s|@CPPFLAGS@|${configure.cppflags}|" ${worksrcpath}/config.mk
+    reinplace "s|@ARCHFLAGS@|[get_canonical_archflags cc]|" ${worksrcpath}/config.mk
+    reinplace "s|@LDFLAGS@|${configure.ldflags} [get_canonical_archflags ld]|" ${worksrcpath}/config.mk
+}
+
 test.run            yes

--- a/textproc/libgrapheme/files/config.diff
+++ b/textproc/libgrapheme/files/config.diff
@@ -1,6 +1,6 @@
 --- config.mk.orig	2023-10-23 10:47:34
 +++ config.mk	2023-10-23 10:48:26
-@@ -2,7 +2,6 @@
+@@ -2,16 +2,15 @@
  
  # paths (unset $PCPREFIX to not install a pkg-config-file)
  DESTDIR   =
@@ -8,6 +8,18 @@
  INCPREFIX = $(PREFIX)/include
  LIBPREFIX = $(PREFIX)/lib
  MANPREFIX = $(PREFIX)/share/man
+ PCPREFIX  = $(LIBPREFIX)/pkgconfig
+ 
+ # flags
+-CPPFLAGS = -D_DEFAULT_SOURCE
+-CFLAGS   = -std=c99 -Os -Wall -Wextra -Wpedantic
+-LDFLAGS  = -s
++CPPFLAGS = @CPPFLAGS@ -D_DEFAULT_SOURCE
++CFLAGS   = @ARCHFLAGS@ -std=c99 -Os -Wall -Wextra
++LDFLAGS  = @LDFLAGS@ -s
+ 
+ BUILD_CPPFLAGS = $(CPPFLAGS)
+ BUILD_CFLAGS   = $(CFLAGS)
 @@ -19,14 +18,14 @@
  
  SHFLAGS   = -fPIC -ffreestanding


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68677

#### Description

Fix the build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
