### PR TITLE
m1ddc: new port

### DIFF
--- a/sysutils/m1ddc/Portfile
+++ b/sysutils/m1ddc/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github      1.0
+PortGroup           makefile    1.0
+
+github.setup        waydabber m1ddc 1.1.0 v
+github.tarball_from archive
+revision            0
+
+description         Controls external displays using DDC/CI on Apple Silicon Macs
+
+long_description    This little tool controls external displays (connected via USB-C/DisplayPort Alt Mode) using DDC/CI on Apple Silicon Macs.
+
+categories          sysutils
+license             MIT
+maintainers         nomaintainer
+installs_libs       no
+platforms           macosx
+supported_archs     arm64
+
+checksums           rmd160  95589e2f1bbd138d83c485405ed875093f14740a \
+                    sha256  d12bf9e59f9e9a09a0b6fd54bcf752cdc01dd3a8dae3df0bcaa0abf8dcf6d388 \
+                    size    5845
+
+# https://trac.macports.org/ticket/59992
+depends_build       port:macports-module-map
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/${name} \
+        ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

Add m1ddc.  This is like [ddcctl](https://github.com/macports/macports-ports/blob/93de4e9fc1e5e8427bf98f48209e783a5e8fab57/sysutils/ddcctl/Portfile) for Apple Silicon machines.  (ddcctl is sadly inop on said machines.)

```
% m1ddc display list
1 - DELL P2715Q (10ACBD40-0000-0000-121B-0104A53C2278)
2 - DELL P2715Q (10ACBD40-0000-0000-121B-0104A53C2278)
% for d in 1 2; do m1ddc display $d set luminance 50; done
```

@herbygillot, possibly relevant to your interests? :)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] submission

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.1 22G313 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
  no upstream tests
- [ ] tried a full install with `sudo port -vst install`?
  no, trace mode is [inop on Ventura](https://trac.macports.org/ticket/66358)
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
