### PR TITLE
hdf5: Revert to normal linker

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -72,16 +72,6 @@ configure.args \
                     --with-szlib=${prefix}/lib/libaec \
                     --with-zlib=yes
 
-if { [vercmp ${xcodeversion} >= 15.0] || [vercmp ${xcodecltversion} >= 15.0] } {
-    # On macOS13 and newer ensure the 'legacy' linker is used as GCC currently has problems
-    # with the new default linker in Xcode 15. See e.g.
-    # https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking
-    # https://discussions.apple.com/thread/255137447
-    # https://developer.apple.com/forums/thread/737707
-    # https://github.com/Homebrew/homebrew-core/issues/145991
-    configure.env   LDFLAGS=-ld_classic
-}
-
 # Actively checks how to get clang to warn on implicit functions with this.
 configure.checks.implicit_function_declaration.whitelist-append strchr
 


### PR DESCRIPTION
#### Description

Revert workaround for Sonoma/Xcode 15.0.
`ld_classic` is no longer needed with HDF5 1.14.3. 

https://github.com/HDFGroup/hdf5/issues/3571
https://github.com/HDFGroup/hdf5/pull/3581
'Removed "-commons" linking option on Darwin'
https://github.com/HDFGroup/hdf5/blob/hdf5_1_14_3/release_docs/RELEASE.txt

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 11, 12, 13 only.  X86 only.
Not yet tested on Sonoma, Xcode 15, or ARM.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
