### PR TITLE
Update Colima to 0.6, fix Lima version in build

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.5.6 v
+go.setup            github.com/abiosoft/colima 0.6.0 v
 github.tarball_from archive
 revision            0
 
@@ -17,9 +17,9 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  21a14801a7fd24b1190fc2740695d502456783ce \
-                    sha256  76e53fb9fa003ba328b191c289049aeb9829b1c933384eee58e90f92636767b9 \
-                    size    614617
+checksums           rmd160  15ced93b3fb5741858c0e12d3178a3d2ea8e55a5 \
+                    sha256  5b949119a3fdf9e25ae877bdcbdc7dd3703e6986442442e41a2cb4d441c7a5b5 \
+                    size    604879
 
 depends_run         port:lima
 
@@ -35,4 +35,9 @@ build.args          ./cmd/${name}
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}
+
+notes {
+    If upgrading from Colima 0.5.6 or earlier, both colima instances and
+    profiles must be deleted and recreated.
 }

--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/lima-vm/lima 0.18.0 v
 go.offline_build    no
 github.tarball_from archive
-revision            0
+revision            1
 
 homepage            https://lima-vm.io
 
@@ -27,6 +27,12 @@ checksums           rmd160  6393c44f06b62993abf0f9c742d4f2bce1b6371f \
                     size    6094310
 
 build.cmd           make
+
+patchfiles          patch-Makefile.diff
+
+post-patch {
+    reinplace "s|@@VERSION@@|${version}|g" ${worksrcpath}/Makefile
+}
 
 destroot {
     xinstall -m 0755 \

--- a/sysutils/lima/files/patch-Makefile.diff
+++ b/sysutils/lima/files/patch-Makefile.diff
@@ -1,0 +1,11 @@
+--- Makefile.orig	2023-11-12 11:56:29
++++ Makefile	2023-11-12 11:56:33
+@@ -40,7 +40,7 @@
+ 
+ PACKAGE := github.com/lima-vm/lima
+ 
+-VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
++VERSION=@@VERSION@@
+ VERSION_TRIMMED := $(VERSION:v%=%)
+ 
+ GO_BUILD := $(GO) build -ldflags="-s -w -X $(PACKAGE)/pkg/version.Version=$(VERSION)" -tags "$(GO_BUILDTAGS)"


### PR DESCRIPTION
#### Description

- lima: fix missing version from limactl info

  The newest release of colima now checks for the version of lima, but the lima
  Makefile expects to build from a checked out git file, not a tarball. It sets
  `VERSION` from the latest git tag. This patches the Makefile to replace the
  `git` version check and replaces it with the version determined from the
  Portfile.

- colima: Update to 0.6.0

  This version of colima changes the underlying VM to implement cgroupsv2 and
  various configuration options have changed. Both the instances and profiles
  must be deleted and recreated.

###### Type(s)

- [x] bugfix
- [x] update

###### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
