### PR TITLE
cdrtools:  update to version 3.02-2023-09-28

### DIFF
--- a/sysutils/cdrtools/Portfile
+++ b/sysutils/cdrtools/Portfile
@@ -7,7 +7,7 @@ PortGroup               conflicts_build 1.0
 PortGroup               codeberg 1.0
 
 name                    cdrtools
-codeberg.setup          schilytools schilytools 2023-04-19
+codeberg.setup          schilytools schilytools 2023-09-28
 version                 3.02-${codeberg.version}
 revision                0
 categories              sysutils audio
@@ -22,9 +22,9 @@ long_description        The cdrtools software includes programs to create \
                         integrity, and write them to a disc.\nAlso included \
                         is a cd audio disc ripper.
 
-checksums               rmd160  e154278ecbe7d778bc1d6766ed163c9963b1cc82 \
-                        sha256  a4270cdcca5dd69c0114079277b06e5efad260b0a099c9c09d31e16e99a23ff5 \
-                        size    5896292
+checksums               rmd160  c9d662b84c1a013cd68d38050020e112a9a0b2a7 \
+                        sha256  c813cc19a320f8d3b5d82f5b1ca6a93ab1bb5f4c50f86fdac58101fe472d2143 \
+                        size    5891733
 
 post-patch {
                         reinplace -locale C "s|-noclobber| |g" \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

cdrtools:  update to version 3.02-2023-09-28

* Update version number in codeberg.setup to 2023-09-28
* Update checksums in the Portfile

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
