### PR TITLE
py-dateutil + dependencies: add Python 3.12 support

### DIFF
--- a/python/py-dateutil/Portfile
+++ b/python/py-dateutil/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  b61a18d5135f4bb241831d7c7b3295999f6cb27e \
                     sha256  0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
                     size    357324
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-freezegun/Portfile
+++ b/python/py-freezegun/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  fe7a03df9a03ed58f602150d6a9fd0a89fad02fb \
                     sha256  3bd449003f847ec97b3ebcae8e3439c56f3faf75ebf29c11e886c30aead5ed29 \
                     size    25977
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-funcsigs/Portfile
+++ b/python/py-funcsigs/Portfile
@@ -12,7 +12,7 @@ license             Apache-2
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-mock/Portfile
+++ b/python/py-mock/Portfile
@@ -22,7 +22,7 @@ checksums           sha256  5e96aad5ccda4718e0a229ed94b2024df75cc2d55575ba5762d3
                     rmd160  acf0cdfd1f3627d0c022ddf5f8c7281414510cdd \
                     size    80232
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Add py312-dateutil, py312-freezegun, py312-funcsigs, py312-mock

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

py-dateutil: some tests fail with `DeprecationWarning`.