### PR TITLE
py-brotli, py-zopfli: add Python 3.12 support

### DIFF
--- a/python/py-brotli/Portfile
+++ b/python/py-brotli/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  3e2402d137fd75f898007d3730773b32025a4857 \
                     sha256  b56a4371636e063ad3695f7c53aed5c18fc2303034564534981e7d6a11b75138 \
                     size    487046
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {$subport ne $name} {
     depends_build-append port:py${python.version}-setuptools

--- a/python/py-zopfli/Portfile
+++ b/python/py-zopfli/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  28121b90d485ca5518c3c44cb0fc0cda1efecca5 \
                     sha256  2d49db7540d9991976af464ebc1b9ed12988c04d90691bcb51dc4a373a9e2afc \
                     size    205320
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 python.pep517       yes
 


### PR DESCRIPTION
#### Description

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
