### PR TITLE
py-{unicodedata2,cppy,pybind11}: add py312 subport

### DIFF
--- a/python/py-cppy/Portfile
+++ b/python/py-cppy/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  becb55f0adec5640f54a7890a984ef520715f4c8 \
                     sha256  83b43bf17b1085ac15c5debdb42154f138b928234b21447358981f69d0d6fe1b \
                     size    18040
 
-python.versions     36 37 38 39 310 311
+python.versions     36 37 38 39 310 311 312
 python.pep517       yes
 
 if {${name} ne ${subport}} {

--- a/python/py-pybind11/Portfile
+++ b/python/py-pybind11/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-unicodedata2/Portfile
+++ b/python/py-unicodedata2/Portfile
@@ -17,7 +17,7 @@ checksums           rmd160  95403fd8edde714ff40273983e72dc43b32d2a73 \
                     sha256  cb30f189ad66482f8529a45da71b2a8841e9bd2bb376cc2933003a4a55a07648 \
                     size    592892
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Add Python 3.12 support

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
