### PR TITLE
bash: update to patchlevel 21

### DIFF
--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                bash
 set bash_version    5.2
-set bash_patchlevel 15
+set bash_patchlevel 21
 subport bash50 {
     # used by bashdb port
     set bash_version    5.0
@@ -107,7 +107,31 @@ if {${subport} eq ${name}} {
                         bash52-015 \
                         rmd160  4b96fdd43e1fea45fb69c3418d40199a581e7dfb \
                         sha256  ef73905169db67399a728e238a9413e0d689462cb9b72ab17a05dba51221358a \
-                        size    8088
+                        size    8088 \
+                        bash52-016 \
+                        rmd160  04013fbe5d21a8c583395c0c6b1efe960a44526b \
+                        sha256  155853bc5bd10e40a9bea369fb6f50a203a7d0358e9e32321be0d9fa21585915 \
+                        size    1225 \
+                        bash52-017 \
+                        rmd160  6438d9ab91b46e9d2949c595162eb5007b5e9f9c \
+                        sha256  1c48cecbc9b7b4217990580203b7e1de19c4979d0bd2c0e310167df748df2c89 \
+                        size    1396 \
+                        bash52-018 \
+                        rmd160  6569790215d8c1d140a5f3a9082980f194bd6f18 \
+                        sha256  4641dd49dd923b454dd0a346277907090410f5d60a29a2de3b82c98e49aaaa80 \
+                        size    151467 \
+                        bash52-019 \
+                        rmd160  51be97047a006d15b14c81a25b2d65f10f6f0b3f \
+                        sha256  325c26860ad4bba8558356c4ab914ac57e7b415dac6f5aae86b9b05ccb7ed282 \
+                        size    2548 \
+                        bash52-020 \
+                        rmd160  b1de66a2edf18a5a0070986f119b3e191199cf39 \
+                        sha256  b6fc252aeb95ce67c9b017d29d81e8a5e285db4bf20d4ec8cdca35892be5c01d \
+                        size    1459 \
+                        bash52-021 \
+                        rmd160  afa6fea5edd7d253a49b5cfca67293d37e064adb \
+                        sha256  8334b88117ad047598f23581aeb0c66c0248cdd77abc3b4e259133aa307650cd \
+                        size    1890
 } elseif {${subport} eq "bash50"} {
    checksums           ${distname}${extract.suffix} \
                        rmd160  a081428a896d617855499376b670eca3433a27c1 \


### PR DESCRIPTION
#### Description

* update to patchlevel 21

###### Tested on
macOS 14.1.1 23B81 x86_64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
