### PR TITLE
libaec: update to 1.1.2, use gitlab PG

### DIFF
--- a/archivers/libaec/Portfile
+++ b/archivers/libaec/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           gitlab 1.0
 
-name                libaec
-version             1.0.4
-platforms           darwin
+gitlab.instance     https://gitlab.dkrz.de
+gitlab.setup        k202009 libaec 1.1.2 v
+revision            0
+
 maintainers         {takeshi @tenomoto} openmaintainer
 license             BSD
 categories          archivers science
@@ -18,11 +20,11 @@ long_description \
     supported, they can also be efficiently coded by grouping exponents\
     and mantissa.
 
-homepage            https://gitlab.dkrz.de/k202009/libaec
-master_sites        ${homepage}/uploads/ea0b7d197a950b0c110da8dfdecbb71f
+checksums           rmd160  8d11b683ee59a31d3fe140f3ee0071f961b346ff \
+                    sha256  8dd74eea399a810433686a2321efcef2149fa6734c8121996aa496621cafd19e \
+                    size    2315289
 
-checksums           rmd160  e41987d68a1bd5325c9016bb161b51a2b845f81a \
-                    sha256  f2b1b232083bd8beaf8a54a024225de3dd72a673a9bcdf8c3ba96c39483f4309 \
-                    size    3120061
+use_autoreconf      yes
+autoreconf.args     -fvi
 
 configure.args      --prefix=${prefix}/lib/${name}


### PR DESCRIPTION
#### Description

- use `gitlab` PG (also fixes the `livecheck`)
- update to latest upstream version

There is a possibility to build the package with CMake, but that messes up the library version numbering (or something along those lines) as doing so will mark all dependents as broken. Using the "old fashioned" build systems appears to be working fine.


###### Tested on
macOS 14.1.1 23B81 x86_64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
