### PR TITLE
SuiteSparse_GraphBLAS: enable OpenMP

### DIFF
--- a/math/SuiteSparse/Portfile
+++ b/math/SuiteSparse/Portfile
@@ -44,10 +44,11 @@ subport SuiteSparse_config {
 
 subport SuiteSparse_GraphBLAS {
     version                 7.2.0
-    revision                0
+    revision                1
     license                 Apache-2
     long_description-append ${subport}: graph algorithms in the language of linear algebra.
     compiler.c_standard     2011
+    compiler.openmp_version 4.0
 }
 
 subport SuiteSparse_Mongoose {


### PR DESCRIPTION
#### Description

Using OpenMP is essential for GraphBLAS performance. See here:

https://github.com/DrTimothyAldenDavis/GraphBLAS#for-distro-maintainers-linux-homebrew-spack-r-octave-trilinos-

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0.1 15A507


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
