### PR TITLE
mmtf-cpp: update to 1.1.0

### DIFF
--- a/science/mmtf-cpp/Portfile
+++ b/science/mmtf-cpp/Portfile
@@ -4,18 +4,19 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        rcsb mmtf-cpp 1.0.0 v
-revision            1
+github.setup        rcsb mmtf-cpp 1.1.0 v
+github.tarball_from archive
+revision            0
+
 categories          science
-platforms           darwin
 maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
 license             MIT
 
 description         MMTF in C++
 long_description    The macromolecular transmission format (MMTF) is a binary encoding of biological structures.
 
-checksums           rmd160  ddee6c5f449254bd58f1a919bfe7e8818e77a026 \
-                    sha256  276e19f1019b080969d40b85094ff604dc2f1762707be0fa4c59bf67b8cff2e5 \
-                    size    59370
+checksums           rmd160  132692f916e05be4149ca89d4502317d6be254ea \
+                    sha256  021173bdc1814b1d0541c4426277d39df2b629af53151999b137e015418f76c0 \
+                    size    106527
 
-depends_lib-append port:msgpack
+depends_lib-append  port:msgpack


### PR DESCRIPTION
#### Description

- update to latest upstream version


###### Tested on
macOS 14.1.1 23B81 x86_64
Xcode 15.0.1 15A507


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
