### PR TITLE
smake: update to version 1.7-2023-09-28; speedup +universal variant

### DIFF
--- a/devel/smake/Portfile
+++ b/devel/smake/Portfile
@@ -5,10 +5,9 @@ PortGroup               makefile 1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               conflicts_build 1.0
 PortGroup               codeberg 1.0
-PortGroup               muniversal 1.1
 
 name                    smake
-codeberg.setup          schilytools schilytools 2023-04-19
+codeberg.setup          schilytools schilytools 2023-09-28
 version                 1.7-${codeberg.version}
 revision                0
 categories              devel
@@ -20,38 +19,39 @@ long_description        Smake is a highly portable make program with automake \
                         features. It is currently mainly targeted to be used \
                         with the Schily SING makefile system.
 
-checksums               rmd160  e154278ecbe7d778bc1d6766ed163c9963b1cc82 \
-                        sha256  a4270cdcca5dd69c0114079277b06e5efad260b0a099c9c09d31e16e99a23ff5 \
-                        size    5896292
+homepage                https://codeberg.org/schilytools/schilytools
+master_sites            ${homepage}/archive/
+checksums               rmd160  c9d662b84c1a013cd68d38050020e112a9a0b2a7 \
+                        sha256  c813cc19a320f8d3b5d82f5b1ca6a93ab1bb5f4c50f86fdac58101fe472d2143 \
+                        size    5891733
 
 post-extract {
-                        copy ${filespath}/Gmake.smake ${worksrcpath}
+    copy ${filespath}/Gmake.smake ${worksrcpath}
 }
 
 patchfiles-append       001-Makefile-Patch.diff
 
 post-patch {
-                        reinplace -locale C "s|/opt/schily|${prefix}|g" \
-                        ${worksrcpath}/DEFAULTS/Defaults.darwin \
-                        ${worksrcpath}/DEFAULTS/Defaults.mac-os10 \
-                        ${worksrcpath}/DEFAULTS_ENG/Defaults.darwin \
-                        ${worksrcpath}/DEFAULTS_ENG/Defaults.mac-os10 \
-                        ${worksrcpath}/libfind/find.c \
-                        ${worksrcpath}/libfind/find_main.c \
-                        ${worksrcpath}/librscg/scsi-remote.c \
-                        ${worksrcpath}/patch/tests/random/cmptest.sh \
-                        ${worksrcpath}/patch/tests/random/gentest.sh \
-                        ${worksrcpath}/smake/job.c \
-                        ${worksrcpath}/smake/make.c \
-                        ${worksrcpath}/smake/smake.1 \
-                        ${worksrcpath}/TEMPLATES/Defaults.gcc \
-                        ${worksrcpath}/TEMPLATES/Defaults.clang \
-                        ${worksrcpath}/TEMPLATES/Defaults.xcc
+    reinplace -locale C "s|/opt/schily|${prefix}|g" \
+    ${worksrcpath}/DEFAULTS/Defaults.darwin \
+    ${worksrcpath}/DEFAULTS/Defaults.mac-os10 \
+    ${worksrcpath}/DEFAULTS_ENG/Defaults.darwin \
+    ${worksrcpath}/DEFAULTS_ENG/Defaults.mac-os10 \
+    ${worksrcpath}/libfind/find.c \
+    ${worksrcpath}/libfind/find_main.c \
+    ${worksrcpath}/librscg/scsi-remote.c \
+    ${worksrcpath}/patch/tests/random/cmptest.sh \
+    ${worksrcpath}/patch/tests/random/gentest.sh \
+    ${worksrcpath}/smake/job.c \
+    ${worksrcpath}/smake/make.c \
+    ${worksrcpath}/smake/smake.1 \
+    ${worksrcpath}/TEMPLATES/Defaults.gcc \
+    ${worksrcpath}/TEMPLATES/Defaults.clang \
+    ${worksrcpath}/TEMPLATES/Defaults.xcc
 }
 
 proc port_conflict_check {p_port_name p_conflict_ver_min p_conflict_ver_max} {
     ui_info "Checking for conflict against port: ${p_port_name}"
-
     if { ![catch {set port_conflict_ver_info [lindex [registry_active ${p_port_name}] 0]}] } {
         set port_conflict_ver [lindex ${port_conflict_ver_info} 1]_[lindex ${port_conflict_ver_info} 2]
         ui_info "${p_port_name} active version: ${port_conflict_ver}"
@@ -73,6 +73,65 @@ compiler.blacklist-append\
                         llvm-gcc-4.2 macports-llvm-gcc-4.2 {clang < 300}
 
 configure.ldflags-append -lintl
+
+pre-build {
+    if { $universal_possible && [variant_isset universal] } {
+#       Big Sur and Later
+        if { ${os.platform} eq "darwin" && ${os.major} >= 20 } {
+            platform i386 {
+                build.args-append   COPTX="-arch x86_64 -arch arm64" \
+                                    C++OPTX="-arch x86_64 -arch arm64" \
+                                    LDOPTX="-arch x86_64 -arch arm64"
+            }
+            platform arm {
+                build.args-append   COPTX="-arch x86_64 -arch arm64" \
+                                    C++OPTX="-arch x86_64 -arch arm64" \
+                                    LDOPTX="-arch x86_64 -arch arm64"
+            }
+#       Lion to Catalina
+        } elseif { ${os.platform} eq "darwin" && ${os.major} >=11 } {
+            platform i386 {
+                build.args-append   COPTX="-arch x86_64 -arch i386" \
+                                    C++OPTX="-arch x86_64 -arch i386" \
+                                    LDOPTX="-arch x86_64 -arch i386"
+            }
+#       Snow Leopard
+        } elseif { ${os.platform} eq "darwin" && ${os.major} ==10 } {
+            platform i386 {
+                build.args-append   COPTX="-arch x86_64 -arch i386" \
+                                    C++OPTX="-arch x86_64 -arch i386" \
+                                    LDOPTX="-arch x86_64 -arch i386"
+            }
+#           Note: Snow Leopard can only run 32bit ppc apps via Rosetta
+            platform powerpc {
+                build.args-append   COPTX="-arch ppc -arch i386" \
+                                    C++OPTX="-arch ppc -arch i386" \
+                                    LDOPTX="-arch ppc -arch i386"
+            }
+#       Tiger and Leopard
+        } elseif { ${os.platform} eq "darwin" && ${os.major} >= 8 } {
+#           Note: One could change ppc to ppc64 if so desired
+            platform i386 {
+                build.args-append   COPTX="-arch ppc -arch i386" \
+                                    C++OPTX="-arch ppc -arch i386" \
+                                    LDOPTX="-arch ppc -arch i386"
+            }
+#           Note: One could change ppc to ppc64 if so desired
+            platform powerpc {
+                build.args-append   COPTX="-arch ppc -arch i386" \
+                                    C++OPTX="-arch ppc -arch i386" \
+                                    LDOPTX="-arch ppc -arch i386"
+            }
+#       Panther and earlier
+        } else {
+            platform powerpc {
+                build.args-append   COPTX="-arch ppc -arch ppc64" \
+                                    C++OPTX="-arch ppc -arch ppc64" \
+                                    LDOPTX="-arch ppc -arch ppc64"
+            }
+        }
+    }
+}
 
 depends_build-append    port:gmake \
                         port:gettext
@@ -100,15 +159,13 @@ destroot.destdir        INS_BASE="${destroot}${prefix}" \
 use_parallel_build      no
 
 destroot {
-                        xinstall -m 0755    {*}[glob ${worksrcpath}/smake/OBJ/*/smake] \
+    xinstall -m 0755    {*}[glob ${worksrcpath}/smake/OBJ/*/smake] \
                         ${destroot}${prefix}/bin
-                        
-                        xinstall -m 0644    {*}[glob ${worksrcpath}/smake/OBJ/*/*/smake.1] \
+
+    xinstall -m 0644    {*}[glob ${worksrcpath}/smake/OBJ/*/*/smake.1] \
                         ${destroot}${prefix}/share/man/man1
-                        
-                        xinstall -m 0644    {*}[glob ${worksrcpath}/man/man5/OBJ/*/*/makefiles.5] \
-                        ${destroot}${prefix}/share/man/man5
-                        
-                        xinstall -m 0644    {*}[glob ${worksrcpath}/man/man5/OBJ/*/*/makerules.5] \
+
+    xinstall -m 0644    {*}[glob ${worksrcpath}/man/man5/OBJ/*/*/makefiles.5] \
+                        {*}[glob ${worksrcpath}/man/man5/OBJ/*/*/makerules.5] \
                         ${destroot}${prefix}/share/man/man5
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

smake: update to version 1.7-2023-09-28; speedup +universal variant

* Remove "muniversal 1.1" PortGroup from Portfile
* Add pre-build {} code block needed for +universal variant
* Clean up destroot {} code block code
* Add "-r" flag to the smake commands in the Gmake.smake script
* Fix formatting in Portfile

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
