### PR TITLE
doxyqml: new port (0.5.3)

### DIFF
--- a/python/doxyqml/Portfile
+++ b/python/doxyqml/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+name                    doxyqml
+version                 0.5.3
+revision                0
+categories-append       textproc
+platforms               {darwin any}
+supported_archs         noarch
+license                 BSD
+maintainers             nomaintainer
+
+description             A filler for Doxygen to document QML files
+long_description        ${name} is an input filler for Doxygen, a documentation \
+                        system for C++ and a few other languages. ${name} makes \
+                        it possible to use Doxygen to document QML code.
+
+homepage                https://invent.kde.org/sdk/doxyqml
+
+checksums               rmd160  1500c20f8f54221ebfc71ba5fbe4f9e83c72bc9c \
+                        sha256  debfb621a3151c225f6fb4e9a8c6b86b2516e237e6f0fe60dcffee5b62d1796a \
+                        size    27578
+
+depends_run-append      port:doxygen


### PR DESCRIPTION
#### Description

Add `doxyqml` to MacPorts, from a request made 8 years ago.

Closes: https://trac.macports.org/ticket/49811

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
