### PR TITLE
ffmpeg6: Update ffmpeg6 to version to 6.1

### DIFF
--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -16,8 +16,8 @@ PortGroup           xcode_workaround 1.0
 name                ffmpeg6
 set my_name         ffmpeg
 
-version             6.0
-revision            4
+version             6.1
+revision            0
 epoch               0
 
 license             LGPL-2.1+
@@ -60,9 +60,9 @@ distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 use_xz              yes
 
-checksums           rmd160  591511f1b96534dcd007875394913ba63e82a4a4 \
-                    sha256  57be87c22d9b49c112b6d24bc67d42508660e6b718b3db89c44e47e289137082 \
-                    size    10234012
+checksums           rmd160  5b9e3ee087e41aa61094530d01e29903f6048ed7 \
+                    sha256  488c76e57dd9b3bee901f71d5c95eaf1db4a5a31fe46a28654e837144207c270 \
+                    size    10455956
 
 depends_build-append \
                     port:cctools \

--- a/multimedia/ffmpeg6/files/patch-libavcodec-audiotoolboxenc.c.diff
+++ b/multimedia/ffmpeg6/files/patch-libavcodec-audiotoolboxenc.c.diff
@@ -1,13 +1,11 @@
---- libavcodec/audiotoolboxenc.c.orig	2016-05-18 05:07:43.000000000 -0700
-+++ libavcodec/audiotoolboxenc.c	2016-05-18 05:09:16.000000000 -0700
-@@ -66,8 +66,10 @@
+--- libavcodec/audiotoolboxenc.c.orig	2023-11-11 01:25:17
++++ libavcodec/audiotoolboxenc.c	2023-11-13 09:49:29
+@@ -69,7 +69,7 @@
              return kAudioFormatMPEG4AAC_HE_V2;
-         case FF_PROFILE_AAC_LD:
+         case AV_PROFILE_AAC_LD:
              return kAudioFormatMPEG4AAC_LD;
+-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
 +#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-         case FF_PROFILE_AAC_ELD:
+         case AV_PROFILE_AAC_ELD:
              return kAudioFormatMPEG4AAC_ELD;
-+#endif
-         }
-     case AV_CODEC_ID_ADPCM_IMA_QT:
-         return kAudioFormatAppleIMA4;
+ #endif


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Version 6.1 of ffmpeg introduces a fix for building on macOS 10.5 which breaks our audiotoolboxenc.c patch. As the macOS version check is different and our Portfile specifically mentions that AudioToolbox requires 10.7+, I have updated the patch to the new upstream source file.

Upstream commit:
https://github.com/FFmpeg/FFmpeg/commit/35342dc390781f310daa53e6c850285863ab5829

Trac Ticket regarding ffmpeg 6.x:
https://trac.macports.org/ticket/65623

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [-] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
