### PR TITLE
py-sip: add Python 3.12, fix toml/tomli deps requirements

### DIFF
--- a/python/py-sip/Portfile
+++ b/python/py-sip/Portfile
@@ -25,9 +25,9 @@ checksums           rmd160  23db5d5e6b57763143bcccbeeb2449aa764cb0af \
                     sha256  08e66f742592eb818ac8fda4173e2ed64c9f2d40b70bee11db1c499127d98450 \
                     size    1169656
 
-python.versions     35 36 37 38 39 310 311
+python.versions     35 36 37 38 39 310 311 312
 
-foreach pver {37 38 39 310 311} {
+foreach pver {37 38 39 310 311 312} {
     subport py${pver}-sip-devel {
         version         6.6.2.dev2206062241
         master_sites    https://www.riverbankcomputing.com/pypi/packages/sip/

--- a/python/py-sip/Portfile
+++ b/python/py-sip/Portfile
@@ -67,13 +67,26 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-packaging \
-                    port:py${python.version}-setuptools \
-                    port:py${python.version}-toml \
-                    port:py${python.version}-tomli
+                    port:py${python.version}-setuptools
 
     if {${python.version} < 38} {
         depends_lib-append \
                     port:py${python.version}-importlib-metadata
+    }
+
+    if {${python.version} <= 36} {
+        depends_lib-append \
+                    port:py${python.version}-toml
+    } elseif {${python.version} < 311} {
+        depends_lib-append \
+                    port:py${python.version}-tomli
+    }
+
+    if {[string match "*-sip-devel" ${subport}]} {
+        depends_lib-append \
+                    port:py${python.version}-toml
+        depends_lib-delete \
+                    port:py${python.version}-tomli
     }
 
     post-destroot {


### PR DESCRIPTION
#### Description

- Add Python 3.12 support for `py-sip`

- Add dependencies `toml` and `tomli` as upstream specifies:
  - SIP  <=6.7.7 requires 'toml'
    (https://www.riverbankcomputing.com/hg/sip/file/2d5cad50e879/setup.py)
  - SIP >=6.7.8  requires 'tomli' for Python <3.11
    (https://www.riverbankcomputing.com/hg/sip/file/2c0f7dee9327/setup.py)


<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.2 22G320 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
