### PR TITLE
colima: update to 0.6.1

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.6.0 v
+go.setup            github.com/abiosoft/colima 0.6.1 v
 github.tarball_from archive
 revision            0
 
@@ -15,11 +15,12 @@ categories          sysutils
 installs_libs       no
 license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  15ced93b3fb5741858c0e12d3178a3d2ea8e55a5 \
-                    sha256  5b949119a3fdf9e25ae877bdcbdc7dd3703e6986442442e41a2cb4d441c7a5b5 \
-                    size    604879
+checksums           rmd160  0123c8feb717cc8dc8333f158b13e015516b6973 \
+                    sha256  aa9d1ae29c3f3e417311f836bbb81d64f6211af96f98d9a9ca9a477b3659e06f \
+                    size    604876
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

> This is a quickfix release to handle regression with regards to hostname for
> virtual machines.

###### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
