### PR TITLE
py-cairo: add py312 subport

### DIFF
--- a/python/py-cairo/Portfile
+++ b/python/py-cairo/Portfile
@@ -22,7 +22,7 @@ checksums               rmd160  eed7451eca845fcd980d7de18079d913631a795b \
                         sha256  9b61ac818723adc04367301317eb2e814a83522f07bbd1f409af0dada463c44c \
                         size    344623
 
-python.versions         27 35 36 37 38 39 310 311
+python.versions         27 35 36 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     if {${python.version} == 27} {


### PR DESCRIPTION
#### Description


###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Test: called `import cairo`. X11 variant untested because I use XQuartz