### PR TITLE
py-zstd: add py312 subport

### DIFF
--- a/python/py-zstd/Portfile
+++ b/python/py-zstd/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  6b54c29daadff331d3bc2d7eeb5337be38d76f5d \
                     sha256  4f44f00c8abb5faf051c900576816bec6612bb975fcbccf383b72087e78f30d0 \
                     size    712241
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description


###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

---

Tested:
```py
>>> import zstandard
>>> c = zstandard.ZstdCompressor()
>>> d = zstandard.ZstdDecompressor()
>>> d.decompress(c.compress(b'Millom Bakkar og Berg ut med Havet heve Nordmannen fenget sin Heim.'))
b'Millom Bakkar og Berg ut med Havet heve Nordmannen fenget sin Heim.'
>>>
```