### PR TITLE
py-cryptography: update to 41.0.5

### DIFF
--- a/python/py-cpuinfo/Portfile
+++ b/python/py-cpuinfo/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  70ee76ca118f099879d834bb52ff9557e7077570 \
                     sha256  3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690 \
                     size    104716
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-cryptography/Portfile
+++ b/python/py-cryptography/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        pyca cryptography 41.0.1
+github.setup        pyca cryptography 41.0.5
 name                py-${github.project}
 revision            0
 categories-append   devel
 license             BSD
 
-python.versions     27 36 37 38 39 310 311
+python.versions     27 36 37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer
@@ -21,9 +21,9 @@ description         cryptography is a package designed to expose \
 long_description    {*}${description}
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  949e750d6a5746527fa17d83d92db9c90185b143 \
-                    sha256  2fb033048d93921eb1a6d9bfabe569fd955760bd3e94b2a4214374c7040ed3a9 \
-                    size    35943314
+                    rmd160  cab5815616789fa61d97fb6765fd42704bebdb20 \
+                    sha256  2ce803648ad47efeb1531eed6e026bd518f004aace1b21c1e16fce958a9a7e7b \
+                    size    35947970
 
 # See:
 # * https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst
@@ -159,12 +159,8 @@ if {${name} ne ${subport}
                     port:py${python.version}-pytest \
                     port:py${python.version}-pytest-benchmark \
                     port:py${python.version}-pytest-cov \
-                    port:py${python.version}-pytest-subtests \
                     port:py${python.version}-pytest-xdist \
-                    port:py${python.version}-pretend \
-                    port:py${python.version}-iso8601 \
-                    port:py${python.version}-tz \
-                    port:py${python.version}-hypothesis
+                    port:py${python.version}-pretend
 
         # cd ${worksrcpath}/src/rust
         # sudo cargo update
@@ -197,7 +193,7 @@ if {${name} ne ${subport}
                     pkg-config 0.3.27 26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964 \
                     proc-macro-error 1.0.4 da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
                     proc-macro-error-attr 1.0.4 a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
-                    proc-macro2 1.0.59 6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b \
+                    proc-macro2 1.0.64 78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da \
                     pyo3 0.18.3 e3b1ac5b3731ba34fdaa9785f8d74d17448cd18f30cf19e0c7e7b1fdb5272109 \
                     pyo3-build-config 0.18.3 9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3 \
                     pyo3-ffi 0.18.3 fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c \

--- a/python/py-execnet/Portfile
+++ b/python/py-execnet/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  de3fae0a9a4c7731a11333af8a17f65c17136933 \
                     sha256  8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
                     size    173884
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pytest-benchmark/Portfile
+++ b/python/py-pytest-benchmark/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  a9381f469658dacb7453d5ae634c350bedec471a \
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_run-append \

--- a/python/py-pytest-cov/Portfile
+++ b/python/py-pytest-cov/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  0fb7002356bbee43dae368a6f742be28d014f7e9 \
                     sha256  3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6 \
                     size    63245
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     if {${python.version} in "27 35"} {

--- a/python/py-pytest-forked/Portfile
+++ b/python/py-pytest-forked/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  98a3298258979cc2ec39134b7ba74e0cda9cc205 \
                     sha256  6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca \
                     size    9850
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     if {${python.pep517}} {

--- a/python/py-pytest-subtests/Portfile
+++ b/python/py-pytest-subtests/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
+PortGroup           deprecated 1.0
 
 name                py-pytest-subtests
 version             0.4.0

--- a/python/py-pytest-xdist/Portfile
+++ b/python/py-pytest-xdist/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  b720976b2924ac7e660cb342e4b59545f6d44bb3 \
                     sha256  718887296892f92683f6a51f25a3ae584993b06f7076ce1e1fd482e59a8220a2 \
                     size    64956
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

The unit test suite passes on python 3.12. I bumped all the random dependencies that are needed to run the tests and dropped some obsolete ones.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.1 22G313 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
