### PR TITLE
colima: update to 0.6.2

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.6.1 v
+go.setup            github.com/abiosoft/colima 0.6.2 v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  0123c8feb717cc8dc8333f158b13e015516b6973 \
-                    sha256  aa9d1ae29c3f3e417311f836bbb81d64f6211af96f98d9a9ca9a477b3659e06f \
-                    size    604876
+checksums           rmd160  dffa6b6dd539e50de69a9cf8e0e838769d7dc208 \
+                    sha256  8ca2ceca433cc5658a3bdce84394a6c47cd3f02e7e91377b1416bdeaf4dcde4e \
+                    size    605583
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

Update colima to 0.6.2

###### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
