### PR TITLE
ruby-build: Update to 20231114

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20231107 v
+github.setup        rbenv ruby-build 20231114 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  6c59e13dcf2769dbac7d8a40555cbb49c0b9b468 \
-                    sha256  97b5a2d23416033ded5c422f947c1188da7e635d82481f60c7b055a5cc64be88 \
-                    size    85433
+checksums           rmd160  99553d9af74b39199bd68756b7874b10d585b347 \
+                    sha256  0ecb3c870ec260b6b80a462bdba423768dee3247e4422e4be92ad5790ac41104 \
+                    size    86295
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Update ruby-build to 20231114

###### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0 15A240d

###### Verificatio

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
