### PR TITLE
google-cloud-sdk: update to 455.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             454.0.0
+version             455.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  a8d6490637b392438ffcb8a1bc50f1076e5030b9 \
-                    sha256  1e1b8f0cebbe91a4df3c61bc4a2c02a374e50af80ce9e50dab92e6cdc7bd2909 \
-                    size    121482435
+    checksums       rmd160  30bea7212c55f75d51fa29342c3b931b564d1562 \
+                    sha256  1c1fa949f7b8a74e6be74b60a57febab6f16adf5fa720391ba4373994cdc9f0d \
+                    size    121519956
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  1c695a5600501fd18de232644331c7d20ed5d901 \
-                    sha256  0496ab72467b514d0f83fae7443f6cb8cc2cf7188d47a8afba1cc723e91f3362 \
-                    size    122768998
+    checksums       rmd160  ca9239c092350e4c10b128ea7c3a9174c850a21c \
+                    sha256  bd4213d15f7e9173e1420567d5d73f3439219294e863d6fe475f1e261cb57093 \
+                    size    122806645
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  22cd88de146629cd32e31aa9653fa413994112b5 \
-                    sha256  4393bb922c11ced61284a51d8ac6b781a93e5f9646c045384ac638758eb3a3e2 \
-                    size    119847243
+    checksums       rmd160  51095eb190a08f7734bd8318eccbecb53f409771 \
+                    sha256  07b01cebf47b162612d6589d427dc868fe69666dc91ba2221210d2050676ab43 \
+                    size    119890163
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -42,7 +42,7 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 worksrcdir          ${name}
 
 # Most recent supported Python version according to https://cloud.google.com/sdk/docs/install#mac
-python.default_version 310
+python.default_version 311
 
 post-patch {
     # Default to the MacPorts Python binary


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 455.0.0.

###### Tested on

macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
