### PR TITLE
libuninameslist: update to 20230916

### DIFF
--- a/devel/libuninameslist/Portfile
+++ b/devel/libuninameslist/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 epoch               1
-github.setup        fontforge libuninameslist 20221022
+github.setup        fontforge libuninameslist 20230916
 categories          devel textproc
 maintainers         nomaintainer
 license             Permissive
@@ -16,9 +16,10 @@ long_description    The Unicode consortium provides a file containing \
                     contains a compiled version of this file so that programs \
                     can access these data easily.
 
-checksums           rmd160  c70b52d85e19595e0a05a8e1f546a36e833e3345 \
-                    sha256  bffc86f6e5090721f8520dbbdc14138afd801a9f3b9eb9b233e672602513b9b9 \
-                    size    940390
+checksums           rmd160  8148f604be30926198b81165de106be7054e4065 \
+                    sha256  da3614f596d018753ed609e4c2c2e79cd2325586b1d5bc2fe92a3e26e45902f2 \
+                    size    952278
+github.tarball_from archive
 
 use_autoreconf      yes
 


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1
Xcode 15

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
