### PR TITLE
qgis3, mapserver: remove obsolete Python 3.6-3.7 variants

### DIFF
--- a/gis/mapserver/Portfile
+++ b/gis/mapserver/Portfile
@@ -98,7 +98,7 @@ variant fastcgi description {FastCGI support} {
 
 
 # Set Python variants
-set python_suffixes {36 37 38 39 310 311}
+set python_suffixes {38 39 310 311}
 set python_variants {}
 
 foreach pyver ${python_suffixes} {

--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -284,7 +284,7 @@ set projdf "${projdf}} { default_variants +proj${pv} }"
 eval ${projdf}
 
 # Python variants
-set python_suffixes {37 38 39 310 311}
+set python_suffixes {38 39 310 311}
 set python_variants {}
 set plugin_variants {}
 foreach pyver ${python_suffixes} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- Remove `qgis3`, `qgis3-ltr` python37 variant.
- Remove `mapserver` python36 and python37 variants

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
