### PR TITLE
ecl: fix build on i386 on clean system

### DIFF
--- a/lang/ecl/Portfile
+++ b/lang/ecl/Portfile
@@ -78,6 +78,11 @@ if {${build_arch} eq "i386"} {
     compiler.blacklist-append   *clang*
     # I must ban libc++ because it will dismiss gcc
     configure.cxx_stdlib        libstdc++
+    # anyway, gcc may picks modern ld when was configured and build,
+    # via stealth dependency which means that it useless on system
+    # without clang-5.0+; to stay on safe side I should add some clang.
+    # See: https://trac.macports.org/ticket/68683
+    depends_build-append        port:clang-7.0
 }
 
 patchfiles-append   patch-macports-xdg-data-dir.diff


### PR DESCRIPTION
#### Description

See: https://trac.macports.org/ticket/68683

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->