### PR TITLE
clang_compilers, compilers PG: allow to use the same clang on 10.5 as on 10.6

### DIFF
--- a/_resources/port1.0/compilers/clang_compilers.tcl
+++ b/_resources/port1.0/compilers/clang_compilers.tcl
@@ -34,7 +34,7 @@ if {${os.major} >= 11 || ${os.platform} ne "darwin"} {
 
 if {${os.platform} eq "darwin"} {
 
-    if {${os.major} >= 10} {
+    if {${os.major} >= 9} {
         lappend compilers macports-clang-11
         if {[option build_arch] ne "arm64"} {
             lappend compilers macports-clang-10 macports-clang-9.0

--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -174,14 +174,14 @@ if { ${os.arch} ne "arm" && ${os.platform} eq "darwin" } {
     if { ${os.major} >= 9 && ${os.major} < 20 } {
         lappend clang_versions 5.0 6.0 7.0
     }
-    if { ${os.major} >= 10 } {
+    if { ${os.major} >= 9 } {
         if { ${os.major} < 20 } {
             lappend clang_versions 8.0
         }
         lappend clang_versions 9.0 10
     }
 }
-if { ${os.major} >= 10 || ${os.platform} ne "darwin" } {
+if { ${os.major} >= 9 || ${os.platform} ne "darwin" } {
     lappend clang_versions 11
     if { ${os.major} >= 11 || ${os.platform} ne "darwin"} {
         lappend clang_versions 12 13 14 15 16 17


### PR DESCRIPTION
#### Description

Allow to use the same clang on 10.5 as on 10.6 and 10.7.

Let whitelist it as well globally.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->