### PR TITLE
mapnik: fix location of python binary

### DIFF
--- a/gis/mapnik/Portfile
+++ b/gis/mapnik/Portfile
@@ -6,7 +6,7 @@ PortGroup           boost 1.0
 
 name                mapnik
 version             3.1.0
-revision            5
+revision            6
 categories          gis devel
 platforms           darwin
 license             LGPL-2.1
@@ -42,8 +42,16 @@ checksums           rmd160  ddd58a419aa6f7cf537e40ae10d369be423f18b2 \
 # `mod_tile` `revision` attribute.
 boost.version       1.76
 
+set python_branch       3.11
+set python_version      [string map {. {}} ${python_branch}]
+
+patchfiles          patch-scons-action.py.diff \
+                    patch-scons-tool-javac.py.diff \
+                    patch-scons-util.py.diff
+
 depends_build-append \
-                    port:pkgconfig
+                    port:pkgconfig \
+                    port:python${python_version}
 
 depends_lib-append  path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     path:lib/pkgconfig/icu-uc.pc:icu \
@@ -98,7 +106,7 @@ universal_variant   no
 
 configure.pkg_config ${prefix}/bin/pkg-config
 
-configure.python    /usr/bin/python
+configure.python        ${prefix}/bin/python${python_branch}
 
 build.cmd           ${configure.python} scons/scons.py
 build.pre_args

--- a/gis/mapnik/files/patch-scons-action.py.diff
+++ b/gis/mapnik/files/patch-scons-action.py.diff
@@ -1,0 +1,19 @@
+--- scons/scons-local-3.0.1/SCons/Action.py.orig	2023-11-15 16:08:13.000000000 +0000
++++ scons/scons-local-3.0.1/SCons/Action.py	2023-11-15 16:09:58.000000000 +0000
+@@ -107,6 +107,7 @@
+ import subprocess
+ import itertools
+ import inspect
++from collections import OrderedDict
+ 
+ import SCons.Debug
+ from SCons.Debug import logInstanceCreation
+@@ -1289,7 +1290,7 @@
+         return result
+ 
+     def get_varlist(self, target, source, env, executor=None):
+-        result = SCons.Util.OrderedDict()
++        result = OrderedDict()
+         for act in self.list:
+             for var in act.get_varlist(target, source, env, executor):
+                 result[var] = True

--- a/gis/mapnik/files/patch-scons-tool-javac.py.diff
+++ b/gis/mapnik/files/patch-scons-tool-javac.py.diff
@@ -1,0 +1,19 @@
+--- scons/scons-local-3.0.1/SCons/Tool/javac.py.orig	2023-11-15 16:08:31.000000000 +0000
++++ scons/scons-local-3.0.1/SCons/Tool/javac.py	2023-11-15 16:10:14.000000000 +0000
+@@ -34,6 +34,7 @@
+ 
+ import os
+ import os.path
++from collections import OrderedDict
+ 
+ import SCons.Action
+ import SCons.Builder
+@@ -70,7 +71,7 @@
+         if isinstance(entry, SCons.Node.FS.File):
+             slist.append(entry)
+         elif isinstance(entry, SCons.Node.FS.Dir):
+-            result = SCons.Util.OrderedDict()
++            result = OrderedDict()
+             dirnode = entry.rdir()
+             def find_java_files(arg, dirpath, filenames):
+                 java_files = sorted([n for n in filenames

--- a/gis/mapnik/files/patch-scons-util.py.diff
+++ b/gis/mapnik/files/patch-scons-util.py.diff
@@ -1,0 +1,102 @@
+--- scons/scons-local-3.0.1/SCons/Util.py.orig	2023-11-15 16:08:41.000000000 +0000
++++ scons/scons-local-3.0.1/SCons/Util.py	2023-11-15 16:10:05.000000000 +0000
+@@ -37,21 +37,18 @@
+ PY3 = sys.version_info[0] == 3
+ 
+ try:
++    from collections import UserDict, UserList, UserString
++except ImportError:
+     from UserDict import UserDict
+-except ImportError as e:
+-    from collections import UserDict
+-
+-try:
+     from UserList import UserList
+-except ImportError as e:
+-    from collections import UserList
+-
+-from collections import Iterable
++    from UserString import UserString
+ 
+ try:
+-    from UserString import UserString
+-except ImportError as e:
+-    from collections import UserString
++    from collections.abc import Iterable
++except ImportError:
++    from collections import Iterable
++
++from collections import OrderedDict
+ 
+ # Don't "from types import ..." these because we need to get at the
+ # types module later to look for UnicodeType.
+@@ -63,7 +60,7 @@
+ FunctionType    = types.FunctionType
+ 
+ try:
+-    unicode
++    _ = type(unicode)
+ except NameError:
+     UnicodeType = str
+ else:
+@@ -1034,60 +1031,6 @@
+     def __str__(self):
+         return ' '.join(self.data)
+ 
+-# A dictionary that preserves the order in which items are added.
+-# Submitted by David Benjamin to ActiveState's Python Cookbook web site:
+-#     http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/107747
+-# Including fixes/enhancements from the follow-on discussions.
+-class OrderedDict(UserDict):
+-    def __init__(self, dict = None):
+-        self._keys = []
+-        UserDict.__init__(self, dict)
+-
+-    def __delitem__(self, key):
+-        UserDict.__delitem__(self, key)
+-        self._keys.remove(key)
+-
+-    def __setitem__(self, key, item):
+-        UserDict.__setitem__(self, key, item)
+-        if key not in self._keys: self._keys.append(key)
+-
+-    def clear(self):
+-        UserDict.clear(self)
+-        self._keys = []
+-
+-    def copy(self):
+-        dict = OrderedDict()
+-        dict.update(self)
+-        return dict
+-
+-    def items(self):
+-        return list(zip(self._keys, list(self.values())))
+-
+-    def keys(self):
+-        return self._keys[:]
+-
+-    def popitem(self):
+-        try:
+-            key = self._keys[-1]
+-        except IndexError:
+-            raise KeyError('dictionary is empty')
+-
+-        val = self[key]
+-        del self[key]
+-
+-        return (key, val)
+-
+-    def setdefault(self, key, failobj = None):
+-        UserDict.setdefault(self, key, failobj)
+-        if key not in self._keys: self._keys.append(key)
+-
+-    def update(self, dict):
+-        for (key, val) in dict.items():
+-            self.__setitem__(key, val)
+-
+-    def values(self):
+-        return list(map(self.get, self._keys))
+-
+ class Selector(OrderedDict):
+     """A callable ordered dictionary that maps file suffixes to
+     dictionary values.  We preserve the order in which items are added


### PR DESCRIPTION

#### Description

The `mapnik` port was failing to build as it depended on `/usr/bin/python` which no longer exists on newer versions of macOS.

Additionally, the latest release of `mapnik` (v3.1.0 - Jan 8, 2021) still uses Python 2 to build, so applied the https://github.com/mapnik/mapnik/commit/7da9009e7ffffb0b9429890f6f13fee837ac320f patch from upstream to build with Python 3, pending their next release.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
