### PR TITLE
py-greenlet: update to 3.0.1, fix on 10.7–10.11

### DIFF
--- a/python/py-greenlet/Portfile
+++ b/python/py-greenlet/Portfile
@@ -1,10 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           python 1.0
 
 name                py-greenlet
-version             3.0.0
+version             3.0.1
 categories-append   devel
 license             MIT PSF
 
@@ -43,9 +44,9 @@ long_description    The \"greenlet\" package is a spin-off of \
 
 homepage            https://github.com/python-greenlet/greenlet
 
-checksums           rmd160  4e4372dc541515f65c5bbc023a74d0eb5a7d5ad2 \
-                    sha256  19834e3f91f485442adc1ee440171ec5d9a4840a1f7bd5ed97833544719ce10b \
-                    size    174704
+checksums           rmd160  0da390d05dc081472cd99a17a079c86714c056d6 \
+                    sha256  816bd9488a94cba78d93e1abb58000e8266fa9cc2aa9ccdd6eb0696acb24005b \
+                    size    174825
 
 if {${name} ne ${subport}} {
     if {${python.version} < 37} {
@@ -60,6 +61,8 @@ if {${name} ne ${subport}} {
 
     # cc1plus: error: unrecognized command line option "-std=gnu++11"
     compiler.cxx_standard 2011
+    # Fails to build with Xcode compilers of 10.11 and earlier.
+    compiler.blacklist-append {clang < 900}
 
     pre-test {
         test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]


### PR DESCRIPTION
#### Description

Update and a fix for systems where it is broken atm.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
