### PR TITLE
FAudio: update to 23.11

### DIFF
--- a/audio/FAudio/Portfile
+++ b/audio/FAudio/Portfile
@@ -1,26 +1,26 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               compiler_blacklist_versions 1.0
+PortGroup               github 1.0
 
-github.setup            FNA-XNA FAudio 23.10
+github.setup            FNA-XNA FAudio 23.11
 revision                0
 
 license                 zlib
 categories              audio
 maintainers             nomaintainer
 description             XAudio reimplementation
-long_description        an XAudio reimplementation that focuses solely on developing \
-                        fully accurate DirectX Audio runtime libraries for the FNA project,\
+long_description        An XAudio reimplementation that focuses solely on developing \
+                        fully accurate DirectX Audio runtime libraries for the FNA project, \
                         including XAudio2, X3DAudio, XAPO, and XACT3.
 
 depends_lib-append      port:libsdl2
 
-checksums               rmd160  968ade802634345ed1a55d51d58505047ed849f2 \
-                        sha256  5e451d0e41404efb38ee6445aeb9106bd6ab80d9b717d098e95284313c3fed9b \
-                        size    1120429
+checksums               rmd160  ceb1a1fb08c27362175838f00ba80fe586e38a14 \
+                        sha256  7b734a1af950000d9176945df735f1974babb3a98ddde583b79ba76dcfa162ed \
+                        size    1120328
 
 # remove set deployment target and hard-coded RPATH setting
 patchfiles              patch-faudio-remove-deployment-target.diff


### PR DESCRIPTION
#### Description

Simple update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
