### PR TITLE
gcc7+: enforce using system `as`

### DIFF
--- a/lang/gcc-devel/Portfile
+++ b/lang/gcc-devel/Portfile
@@ -28,7 +28,7 @@ set libgccname      lib${name}
 set libcxxname      ${name}-libcxx
 
 version         14-20231001
-revision        0
+revision        1
 subport         ${libgccname} { revision [ expr ${revision} + 0 ] }
 
 checksums       rmd160  d0310cc59e3eab891a7a68abfa780a331a82c207 \
@@ -157,6 +157,26 @@ if { ${subport} ne ${libcxxname} && ${os.platform} eq "darwin" } {
         }
     }
 }
+
+# Since GCC 7.4.0, during configure, it detects features supported by target-as.
+# On the other hand, MacPorts cctools contain a proxy for 'as' that runs system
+# 'as' or one of the supported MacPorts clang's 'as' if it is installed. Here,
+# we may encounter a misconfiguration when GCC builds on a system with some
+# MacPorts clang, and 'as' is using it. However, on a clean system, it uses
+# system 'as' if no MacPorts clang is installed, which may behave differently.
+# This can make GCC broken until MacPorts clang is installed. To avoid a stealth
+# dependency on the used clang, I enforce building with system 'as'.
+# See:
+#  - https://trac.macports.org/ticket/68683
+#  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
+patchfiles-append   patch-gcc10-disable-macports-cctools-as-changes.diff
+
+configure.env-append \
+                    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
+
+build.env-append    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
 
 configure.env-append \
                     AR_FOR_TARGET=${prefix}/bin/ar \

--- a/lang/gcc-devel/files/patch-gcc10-disable-macports-cctools-as-changes.diff
+++ b/lang/gcc-devel/files/patch-gcc10-disable-macports-cctools-as-changes.diff
@@ -1,0 +1,15 @@
+--- Makefile.in.orig	2022-06-29 13:59:25.000000000 +0100
++++ Makefile.in	2022-06-29 13:59:58.000000000 +0100
+@@ -653,6 +653,12 @@
+ @host_makefile_frag@
+ ###
+ 
++# override MacPorts cctools modifications to allow standard gas assembler to be used
++HOST_EXPORTS            += export DISABLE_MACPORTS_AS_CLANG_SEARCH=1;
++HOST_EXPORTS            += export DISABLE_XCODE_AS_CLANG_SEARCH=1;
++POSTSTAGE1_HOST_EXPORTS += export DISABLE_MACPORTS_AS_CLANG_SEARCH=1;
++POSTSTAGE1_HOST_EXPORTS += export DISABLE_XCODE_AS_CLANG_SEARCH=1;
++
+ # This is the list of directories that may be needed in RPATH_ENVVAR
+ # so that programs built for the target machine work.
+ TARGET_LIB_PATH = $(TARGET_LIB_PATH_libstdc++-v3)$(TARGET_LIB_PATH_libsanitizer)$(TARGET_LIB_PATH_libvtv)$(TARGET_LIB_PATH_liboffloadmic)$(TARGET_LIB_PATH_libssp)$(TARGET_LIB_PATH_libphobos)$(TARGET_LIB_PATH_libgomp)$(TARGET_LIB_PATH_libitm)$(TARGET_LIB_PATH_libatomic)$(HOST_LIB_PATH_gcc)

--- a/lang/gcc10/Portfile
+++ b/lang/gcc10/Portfile
@@ -10,7 +10,7 @@ epoch               7
 
 name                gcc10
 version             10.4.0
-revision            4
+revision            5
 
 platforms           {darwin >= 10 < 22}
 categories          lang
@@ -56,22 +56,25 @@ if { ${os.platform} eq "darwin" } {
     patchfiles-append  patch-genconditions.diff
 }
 
-if { ${configure.build_arch} eq "i386" } {
+# Since GCC 7.4.0, during configure, it detects features supported by target-as.
+# On the other hand, MacPorts cctools contain a proxy for 'as' that runs system
+# 'as' or one of the supported MacPorts clang's 'as' if it is installed. Here,
+# we may encounter a misconfiguration when GCC builds on a system with some
+# MacPorts clang, and 'as' is using it. However, on a clean system, it uses
+# system 'as' if no MacPorts clang is installed, which may behave differently.
+# This can make GCC broken until MacPorts clang is installed. To avoid a stealth
+# dependency on the used clang, I enforce building with system 'as'.
+# See:
+#  - https://trac.macports.org/ticket/68683
+#  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
+patchfiles-append   patch-gcc10-disable-macports-cctools-as-changes.diff
 
-    # build with traditional "gas" assembler in all cases
-    # upstream does not typically test gcc with clang as assembler on i386 systems
-    # gcc configuration changes with assembler features
-    # also innumerable warnings about text section naming suppressed
-    patchfiles-append  patch-gcc10-disable-macports-cctools-as-changes.diff
+configure.env-append \
+                    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
 
-    configure.env-append \
-      "DISABLE_MACPORTS_AS_CLANG_SEARCH=1" \
-      "DISABLE_XCODE_AS_CLANG_SEARCH=1"
-
-    build.env-append \
-      "DISABLE_MACPORTS_AS_CLANG_SEARCH=1" \
-      "DISABLE_XCODE_AS_CLANG_SEARCH=1"
-}
+build.env-append    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
 
 depends_build-append \
                     port:texinfo

--- a/lang/gcc11/Portfile
+++ b/lang/gcc11/Portfile
@@ -11,7 +11,7 @@ epoch               2
 name                gcc11
 
 version             11.4.0
-revision            0
+revision            1
 
 platforms           {darwin >= 10 < 22}
 categories          lang
@@ -79,6 +79,26 @@ if { ${os.platform} eq "darwin" && ${os.major} >= 17 } {
     # See also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84257
     patchfiles-append patch-disable-dyld_library_path.diff
 }
+
+# Since GCC 7.4.0, during configure, it detects features supported by target-as.
+# On the other hand, MacPorts cctools contain a proxy for 'as' that runs system
+# 'as' or one of the supported MacPorts clang's 'as' if it is installed. Here,
+# we may encounter a misconfiguration when GCC builds on a system with some
+# MacPorts clang, and 'as' is using it. However, on a clean system, it uses
+# system 'as' if no MacPorts clang is installed, which may behave differently.
+# This can make GCC broken until MacPorts clang is installed. To avoid a stealth
+# dependency on the used clang, I enforce building with system 'as'.
+# See:
+#  - https://trac.macports.org/ticket/68683
+#  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
+patchfiles-append   patch-gcc10-disable-macports-cctools-as-changes.diff
+
+configure.env-append \
+                    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
+
+build.env-append    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
 
 depends_build-append \
                     port:texinfo

--- a/lang/gcc11/files/patch-gcc10-disable-macports-cctools-as-changes.diff
+++ b/lang/gcc11/files/patch-gcc10-disable-macports-cctools-as-changes.diff
@@ -1,0 +1,15 @@
+--- Makefile.in.orig	2022-06-29 13:59:25.000000000 +0100
++++ Makefile.in	2022-06-29 13:59:58.000000000 +0100
+@@ -653,6 +653,12 @@
+ @host_makefile_frag@
+ ###
+ 
++# override MacPorts cctools modifications to allow standard gas assembler to be used
++HOST_EXPORTS            += export DISABLE_MACPORTS_AS_CLANG_SEARCH=1;
++HOST_EXPORTS            += export DISABLE_XCODE_AS_CLANG_SEARCH=1;
++POSTSTAGE1_HOST_EXPORTS += export DISABLE_MACPORTS_AS_CLANG_SEARCH=1;
++POSTSTAGE1_HOST_EXPORTS += export DISABLE_XCODE_AS_CLANG_SEARCH=1;
++
+ # This is the list of directories that may be needed in RPATH_ENVVAR
+ # so that programs built for the target machine work.
+ TARGET_LIB_PATH = $(TARGET_LIB_PATH_libstdc++-v3)$(TARGET_LIB_PATH_libsanitizer)$(TARGET_LIB_PATH_libvtv)$(TARGET_LIB_PATH_liboffloadmic)$(TARGET_LIB_PATH_libssp)$(TARGET_LIB_PATH_libphobos)$(TARGET_LIB_PATH_libgomp)$(TARGET_LIB_PATH_libitm)$(TARGET_LIB_PATH_libatomic)$(HOST_LIB_PATH_gcc)

--- a/lang/gcc12/Portfile
+++ b/lang/gcc12/Portfile
@@ -23,7 +23,7 @@ long_description    {*}${description}, including front ends for \
 
 # Remember to reset all revision increments below to 0 on new versions
 version             12.3.0
-revision            3
+revision            4
 
 set libgccname      lib${name}
 subport             ${libgccname} { revision [ expr ${revision} + 0 ] }
@@ -164,6 +164,26 @@ if { ${os.platform} eq "darwin" } {
     # git diff --no-prefix releases/gcc-12.2.0 gcc-12.2-darwin-r0
     patchfiles-append  patch-darwin-gcc-${version}.diff
 }
+
+# Since GCC 7.4.0, during configure, it detects features supported by target-as.
+# On the other hand, MacPorts cctools contain a proxy for 'as' that runs system
+# 'as' or one of the supported MacPorts clang's 'as' if it is installed. Here,
+# we may encounter a misconfiguration when GCC builds on a system with some
+# MacPorts clang, and 'as' is using it. However, on a clean system, it uses
+# system 'as' if no MacPorts clang is installed, which may behave differently.
+# This can make GCC broken until MacPorts clang is installed. To avoid a stealth
+# dependency on the used clang, I enforce building with system 'as'.
+# See:
+#  - https://trac.macports.org/ticket/68683
+#  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
+patchfiles-append   patch-gcc10-disable-macports-cctools-as-changes.diff
+
+configure.env-append \
+                    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
+
+build.env-append    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
 
 if {${os.platform} eq "darwin" && ${os.major} >= 22} {
     if { [vercmp ${xcodeversion} >= 15.0] || [vercmp ${xcodecltversion} >= 15.0] } {

--- a/lang/gcc12/files/patch-gcc10-disable-macports-cctools-as-changes.diff
+++ b/lang/gcc12/files/patch-gcc10-disable-macports-cctools-as-changes.diff
@@ -1,0 +1,15 @@
+--- Makefile.in.orig	2022-06-29 13:59:25.000000000 +0100
++++ Makefile.in	2022-06-29 13:59:58.000000000 +0100
+@@ -653,6 +653,12 @@
+ @host_makefile_frag@
+ ###
+ 
++# override MacPorts cctools modifications to allow standard gas assembler to be used
++HOST_EXPORTS            += export DISABLE_MACPORTS_AS_CLANG_SEARCH=1;
++HOST_EXPORTS            += export DISABLE_XCODE_AS_CLANG_SEARCH=1;
++POSTSTAGE1_HOST_EXPORTS += export DISABLE_MACPORTS_AS_CLANG_SEARCH=1;
++POSTSTAGE1_HOST_EXPORTS += export DISABLE_XCODE_AS_CLANG_SEARCH=1;
++
+ # This is the list of directories that may be needed in RPATH_ENVVAR
+ # so that programs built for the target machine work.
+ TARGET_LIB_PATH = $(TARGET_LIB_PATH_libstdc++-v3)$(TARGET_LIB_PATH_libsanitizer)$(TARGET_LIB_PATH_libvtv)$(TARGET_LIB_PATH_liboffloadmic)$(TARGET_LIB_PATH_libssp)$(TARGET_LIB_PATH_libphobos)$(TARGET_LIB_PATH_libgomp)$(TARGET_LIB_PATH_libitm)$(TARGET_LIB_PATH_libatomic)$(HOST_LIB_PATH_gcc)

--- a/lang/gcc13/Portfile
+++ b/lang/gcc13/Portfile
@@ -23,7 +23,7 @@ long_description    {*}${description}, including front ends for \
 
 # Remember to reset all revision increments below to 0 on new versions
 version             13.2.0
-revision            3
+revision            4
 
 set libgccname      lib${name}
 subport             ${libgccname} { revision [ expr ${revision} + 0 ] }
@@ -170,6 +170,26 @@ if { ${os.platform} eq "darwin" } {
         patchfiles-append  patch-OSX10.14-ucred-atomic-define.diff
     }
 }
+
+# Since GCC 7.4.0, during configure, it detects features supported by target-as.
+# On the other hand, MacPorts cctools contain a proxy for 'as' that runs system
+# 'as' or one of the supported MacPorts clang's 'as' if it is installed. Here,
+# we may encounter a misconfiguration when GCC builds on a system with some
+# MacPorts clang, and 'as' is using it. However, on a clean system, it uses
+# system 'as' if no MacPorts clang is installed, which may behave differently.
+# This can make GCC broken until MacPorts clang is installed. To avoid a stealth
+# dependency on the used clang, I enforce building with system 'as'.
+# See:
+#  - https://trac.macports.org/ticket/68683
+#  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
+patchfiles-append   patch-gcc10-disable-macports-cctools-as-changes.diff
+
+configure.env-append \
+                    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
+
+build.env-append    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
 
 if {${os.platform} eq "darwin" && ${os.major} >= 22} {
     if { [vercmp ${xcodeversion} >= 15.0] || [vercmp ${xcodecltversion} >= 15.0] } {

--- a/lang/gcc13/files/patch-gcc10-disable-macports-cctools-as-changes.diff
+++ b/lang/gcc13/files/patch-gcc10-disable-macports-cctools-as-changes.diff
@@ -1,0 +1,15 @@
+--- Makefile.in.orig	2022-06-29 13:59:25.000000000 +0100
++++ Makefile.in	2022-06-29 13:59:58.000000000 +0100
+@@ -653,6 +653,12 @@
+ @host_makefile_frag@
+ ###
+ 
++# override MacPorts cctools modifications to allow standard gas assembler to be used
++HOST_EXPORTS            += export DISABLE_MACPORTS_AS_CLANG_SEARCH=1;
++HOST_EXPORTS            += export DISABLE_XCODE_AS_CLANG_SEARCH=1;
++POSTSTAGE1_HOST_EXPORTS += export DISABLE_MACPORTS_AS_CLANG_SEARCH=1;
++POSTSTAGE1_HOST_EXPORTS += export DISABLE_XCODE_AS_CLANG_SEARCH=1;
++
+ # This is the list of directories that may be needed in RPATH_ENVVAR
+ # so that programs built for the target machine work.
+ TARGET_LIB_PATH = $(TARGET_LIB_PATH_libstdc++-v3)$(TARGET_LIB_PATH_libsanitizer)$(TARGET_LIB_PATH_libvtv)$(TARGET_LIB_PATH_liboffloadmic)$(TARGET_LIB_PATH_libssp)$(TARGET_LIB_PATH_libphobos)$(TARGET_LIB_PATH_libgomp)$(TARGET_LIB_PATH_libitm)$(TARGET_LIB_PATH_libatomic)$(HOST_LIB_PATH_gcc)

--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -10,7 +10,7 @@ PortGroup xcode_workaround             1.0
 name                gcc7
 epoch               3
 version             7.5.0
-revision            3
+revision            4
 subport             libgcc7 { revision 1 }
 platforms           {darwin < 15}
 categories          lang
@@ -43,26 +43,32 @@ checksums           rmd160  91d46ec088badec75f41a2ad2a0ba228a6715107 \
 # NOTE : The logic here must match that in the libgcc port.
 set isLastSupported [ expr ${os.major} < 10 ]
 
-if { ${configure.build_arch} eq "i386" && ${os.major} >= 10 } {
+if { ${configure.build_arch} eq "i386"} {
 
     # fix no-pie clang bug bootstrapping gcc on i386
     # https://trac.macports.org/ticket/63161
     patchfiles-append  patch-gcc7-i686-clang-bootstrap-fix.diff
-
-    # build with traditional "gas" assembler in all cases
-    # upstream does not typically test gcc with clang as assembler on i386 systems
-    # gcc configuration changes with assembler features
-    # also innumerable warnings about text section naming suppressed
-    patchfiles-append  patch-gcc7-disable-macports-cctools-as-changes.diff
-
-    configure.env-append \
-      "DISABLE_MACPORTS_AS_CLANG_SEARCH=1" \
-      "DISABLE_XCODE_AS_CLANG_SEARCH=1"
-
-    build.env-append \
-      "DISABLE_MACPORTS_AS_CLANG_SEARCH=1" \
-      "DISABLE_XCODE_AS_CLANG_SEARCH=1"
 }
+
+# Since GCC 7.4.0, during configure, it detects features supported by target-as.
+# On the other hand, MacPorts cctools contain a proxy for 'as' that runs system
+# 'as' or one of the supported MacPorts clang's 'as' if it is installed. Here,
+# we may encounter a misconfiguration when GCC builds on a system with some
+# MacPorts clang, and 'as' is using it. However, on a clean system, it uses
+# system 'as' if no MacPorts clang is installed, which may behave differently.
+# This can make GCC broken until MacPorts clang is installed. To avoid a stealth
+# dependency on the used clang, I enforce building with system 'as'.
+# See:
+#  - https://trac.macports.org/ticket/68683
+#  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
+patchfiles-append   patch-gcc7-disable-macports-cctools-as-changes.diff
+
+configure.env-append \
+                    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
+
+build.env-append    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
 
 depends_lib         port:cctools \
                     port:gmp \

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -10,7 +10,7 @@ PortGroup xcode_workaround             1.0
 epoch               5
 name                gcc8
 version             8.5.0
-revision            1
+revision            2
 subport             libgcc8 { revision 1 }
 platforms           {darwin >= 10 < 15}
 categories          lang
@@ -60,26 +60,32 @@ if { ${os.major} > 19 } {
     patchfiles-append         fix-sanitisers-darwin20.diff
 }
 
-if { ${configure.build_arch} eq "i386" } {
+if { ${configure.build_arch} eq "i386"} {
 
     # fix no-pie clang bug bootstrapping gcc on i386
     # https://trac.macports.org/ticket/63161
     patchfiles-append  patch-gcc10-i686-clang-bootstrap-fix.diff
-
-    # build with traditional "gas" assembler in all cases
-    # upstream does not typically test gcc with clang as assembler on i386 systems
-    # gcc configuration changes with assembler features
-    # also innumerable warnings about text section naming suppressed
-    patchfiles-append  patch-gcc10-disable-macports-cctools-as-changes.diff
-
-    configure.env-append \
-      "DISABLE_MACPORTS_AS_CLANG_SEARCH=1" \
-      "DISABLE_XCODE_AS_CLANG_SEARCH=1"
-
-    build.env-append \
-      "DISABLE_MACPORTS_AS_CLANG_SEARCH=1" \
-      "DISABLE_XCODE_AS_CLANG_SEARCH=1"
 }
+
+# Since GCC 7.4.0, during configure, it detects features supported by target-as.
+# On the other hand, MacPorts cctools contain a proxy for 'as' that runs system
+# 'as' or one of the supported MacPorts clang's 'as' if it is installed. Here,
+# we may encounter a misconfiguration when GCC builds on a system with some
+# MacPorts clang, and 'as' is using it. However, on a clean system, it uses
+# system 'as' if no MacPorts clang is installed, which may behave differently.
+# This can make GCC broken until MacPorts clang is installed. To avoid a stealth
+# dependency on the used clang, I enforce building with system 'as'.
+# See:
+#  - https://trac.macports.org/ticket/68683
+#  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
+patchfiles-append   patch-gcc10-disable-macports-cctools-as-changes.diff
+
+configure.env-append \
+                    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
+
+build.env-append    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
 
 depends_lib         port:cctools \
                     port:gmp \
@@ -168,6 +174,16 @@ if { ${os.platform} eq "darwin" } {
         configure.args-append  --without-build-config
     }
 }
+
+# cctools' as may pick MacPorts clang when it's instaled on the system,
+# which leads to configure GCC for as from modern clang, and not system one.
+# When it had happened it makes a stealth dependency for any new enough clang on old system.
+# See:
+#  - https://trac.macports.org/ticket/68683
+#  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
+configure.env-append \
+                    DISABLE_MACPORTS_AS_CLANG_SEARCH=1
+build.env-append    DISABLE_MACPORTS_AS_CLANG_SEARCH=1
 
 configure.env-append \
                     AR_FOR_TARGET=${prefix}/bin/ar \

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -10,7 +10,7 @@ PortGroup           xcode_workaround             1.0
 epoch               3
 name                gcc9
 version             9.5.0
-revision            0
+revision            1
 subport             libgcc9 { revision 2 }
 platforms           {darwin >= 10 < 15}
 categories          lang
@@ -52,21 +52,27 @@ if { ${configure.build_arch} eq "i386" } {
     # fix no-pie clang bug bootstrapping gcc on i386
     # https://trac.macports.org/ticket/63161
     patchfiles-append  patch-gcc10-i686-clang-bootstrap-fix.diff
-
-    # build with traditional "gas" assembler in all cases
-    # upstream does not typically test gcc with clang as assembler on i386 systems
-    # gcc configuration changes with assembler features
-    # also innumerable warnings about text section naming suppressed
-    patchfiles-append  patch-gcc10-disable-macports-cctools-as-changes.diff
-
-    configure.env-append \
-      "DISABLE_MACPORTS_AS_CLANG_SEARCH=1" \
-      "DISABLE_XCODE_AS_CLANG_SEARCH=1"
-
-    build.env-append \
-      "DISABLE_MACPORTS_AS_CLANG_SEARCH=1" \
-      "DISABLE_XCODE_AS_CLANG_SEARCH=1"
 }
+
+# Since GCC 7.4.0, during configure, it detects features supported by target-as.
+# On the other hand, MacPorts cctools contain a proxy for 'as' that runs system
+# 'as' or one of the supported MacPorts clang's 'as' if it is installed. Here,
+# we may encounter a misconfiguration when GCC builds on a system with some
+# MacPorts clang, and 'as' is using it. However, on a clean system, it uses
+# system 'as' if no MacPorts clang is installed, which may behave differently.
+# This can make GCC broken until MacPorts clang is installed. To avoid a stealth
+# dependency on the used clang, I enforce building with system 'as'.
+# See:
+#  - https://trac.macports.org/ticket/68683
+#  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
+patchfiles-append   patch-gcc10-disable-macports-cctools-as-changes.diff
+
+configure.env-append \
+                    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
+
+build.env-append    DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
+                    DISABLE_XCODE_AS_CLANG_SEARCH=1
 
 depends_lib         port:cctools \
                     port:gmp \


### PR DESCRIPTION
#### Description

Since GCC 7.4.0, during configure, it detects features supported by target-as. On the other hand, MacPorts cctools contain a proxy for `as` that runs system `as` or one of the supported MacPorts clang's `as` if it is installed. Here, we may encounter a misconfiguration when GCC builds on a system with some MacPorts clang, and `as` is using it. However, on a clean system, it uses system `as` if no MacPorts clang is installed, which may behave differently. This can make GCC broken until MacPorts clang is installed. To avoid a stealth dependency on the used clang, I enforce building with system `as`.

See: https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
Closes: https://trac.macports.org/ticket/68683

P.S. I skip CI because it had no chance to build it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

as rebuild gcc with installed clang-11, try to compile hello world with and without clang-11.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->