### PR TITLE
pgpointcloud: remove icu dependency, fix '--without-cunit' flag

### DIFF
--- a/databases/pgpointcloud/Portfile
+++ b/databases/pgpointcloud/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 
 github.setup        pgpointcloud pointcloud 1.2.5 v
-revision            1
+revision            2
 github.tarball_from archive
 
 name                pgpointcloud
@@ -21,7 +21,8 @@ checksums           rmd160  54e0784994a458e9591ea416caf7ae106c0d7007 \
                     sha256  f3924f283345f2da46a971e65f0c6ce602640ecf88a2057293443ec2a7a56774 \
                     size    348678
 
-patchfiles          patch-config-mk-in.diff
+patchfiles          patch-config-mk-in.diff \
+                    patch-configure-ac.diff
 
 configure.cmd       autoupdate && ./autogen.sh && ./configure
 
@@ -31,9 +32,6 @@ depends_build-append \
                     port:pkgconfig
 
 depends_lib-append  port:libxml2 \
-                    port:lzma \
-                    port:icu \
-                    port:libiconv \
                     port:zlib
 
 configure.args-append \

--- a/databases/pgpointcloud/files/patch-configure-ac.diff
+++ b/databases/pgpointcloud/files/patch-configure-ac.diff
@@ -1,0 +1,24 @@
+Honor '--without-cunit', addressed upstreams with https://github.com/pgpointcloud/pointcloud/pull/349
+
+Only link to libxml2, addresses https://trac.macports.org/ticket/68704
+
+--- configure.ac.orig
++++ configure.ac
+@@ -138,7 +138,7 @@
+   CPPFLAGS="${CPPFLAGS_SAVE}"
+ fi
+ 
+-if test "$FOUND_CUNIT" = "YES"; then
++if test "$FOUND_CUNIT" = "YES" && test x${with_cunit} != "xno"; then
+   AC_DEFINE([HAVE_CUNIT], [1], [Have CUnit])
+   CUNIT_STATUS="enabled"
+   if test $CUNITDIR; then
+@@ -281,7 +281,7 @@
+ 
+ 
+ dnl Extract the linker and include flags
+-XML2_LDFLAGS=`$XML2CONFIG --libs`
++XML2_LDFLAGS=`$XML2CONFIG --libs --dynamic`
+ XML2_CPPFLAGS=`$XML2CONFIG --cflags`
+ 
+ dnl Extract the version


### PR DESCRIPTION
#### Description

Remove icu dependency for `pgpointcloud`. While `pgpointcloud` does indeed links to `icu`, it does so via `xml2-config` (of port `libxml2`). `icu` is not a direct dependency to `pgpointcloud`.

Closes https://trac.macports.org/ticket/68704

Unrelated fix for honoring `--without-cunit` flag is addressed upstreams: https://github.com/pgpointcloud/pointcloud/pull/349

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.2 22G320 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
