### PR TITLE
libpaper: attempt to fix 10.6 build

### DIFF
--- a/print/libpaper/Portfile
+++ b/print/libpaper/Portfile
@@ -2,6 +2,10 @@
 
 PortSystem      1.0
 PortGroup       github 1.0
+PortGroup       legacysupport 1.1
+
+# Need getline(), strndup()
+legacysupport.newest_darwin_requires_legacy 10
 
 github.setup    rrthomas libpaper 2.1.2 v
 revision        0


### PR DESCRIPTION
#### Description

https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/178263/steps/install-port/logs/stdio

```
libpaper.c:116:12: warning: implicitly declaring library function 'strndup' with type 'char *(const char *, unsigned long)' [-Wimplicit-function-declaration]
    return strndup(p, i);
           ^
libpaper.c:116:12: note: include the header <string.h> or explicitly provide a declaration for 'strndup'
libpaper.c:184:37: warning: implicit declaration of function 'getline' is invalid in C99 [-Wimplicit-function-declaration]
        for (*lineno = 1, l = NULL; getline(&l, &n, ps) > 0; prev = p, (*lineno)++) {
                                    ^
libpaper.c:296:9: warning: implicit declaration of function 'getline' is invalid in C99 [-Wimplicit-function-declaration]
    if (getline(&l, &n, fp) > 0) {
        ^
3 warnings generated.
```

```
Undefined symbols for architecture x86_64:
  "_strndup", referenced from:
      _gettok in libpaper.o
  "_getline", referenced from:
      _papernamefile in libpaper.o
      _readspecs in libpaper.o
ld: symbol(s) not found for architecture x86_64
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
