### PR TITLE
igraph: update to 0.10.8

### DIFF
--- a/math/igraph/Portfile
+++ b/math/igraph/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           linear_algebra 1.0
 
-github.setup        igraph igraph 0.10.7
+github.setup        igraph igraph 0.10.8
 revision            0
 github.tarball_from releases
 
@@ -23,18 +23,15 @@ depends_lib         port:arpack \
                     port:gmp \
                     port:libxml2
 
-checksums           rmd160  a7ae864ee6d5c9cb7b8ee1d29d854e80d159ac34 \
-                    sha256  b9e2a46b70896a379d784ea227f076b59750cc7411463b1d4accbf9e38b361ad \
-                    size    4308136
+checksums           rmd160  e0ecde131e6073704f57ecce2029e0b441c9e6f5 \
+                    sha256  ac5fa94ae6fd1eace651e4b235e99c056479a5c5d0d641aed30240ac33b19403 \
+                    size    4326926
 
 # Testing notes:
 #
-# There is a bug in macOS 13 Ventura that will cause the safelocale test to fail.
+# There is a bug in macOS 13.x to 14.0 that will cause the safelocale test to fail.
 # See https://stackoverflow.com/q/76133503/695132 and https://github.com/igraph/igraph/issues/2340
-#
-# There is a bug in ARPACK-NG 3.9.0 that may cause eigenvector centrality tests to fail
-# depending on the BLAS implementation thay is being used.
-# See https://github.com/opencollab/arpack-ng/issues/410
+# This _should_ be fixed in macOS 14.1.
 test.run            yes
 test.target         check
 
@@ -63,16 +60,6 @@ configure.args-append   -DUSE_CCACHE=OFF \
                         -DIGRAPH_OPENMP_SUPPORT=OFF \
                         -DIGRAPH_WARNINGS_AS_ERRORS=OFF
 
-# This should be removed for igraph 0.10.8 or later.
-platform darwin {
-    if {${os.major} >= 11 && ${os.major} <= 12} {
-        # On OS X 10.7 and 0.18, including <iostream> triggers
-        # an error without this.
-        # https://trac.macports.org/ticket/60885
-        configure.cxxflags-append -D_DARWIN_C_SOURCE
-    }
-}
-
 pre-configure {
     # Link to chosen BLAS/LAPACK
     configure.args-append   ${cmake_linalglib}
@@ -83,6 +70,9 @@ variant tls description {Build thread-safe version} {
     configure.args-append           -DIGRAPH_ENABLE_TLS=ON
 }
 
+# The openmp variant is not enabled by default because in MacPorts,
+# the compilers that support OpenMP won't support LTO (without workarounds).
+# Overall, igraph performance benefits more from LTO than OpenMP.
 variant openmp description {Enable OpenMP support} {
     # This compiler gives an invalid warning about uninitialized variables.
     # It is unclear if it also miscompiles the code.


### PR DESCRIPTION
 - update to 0.10.8
 - remove workarounds for OS X 10.7-10.8
 - update comments for current situation

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6 22G120 arm64
Xcode 15.0.1 15A507


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
