### PR TITLE
gtk-gnutella: update to 2023.10.25

### DIFF
--- a/net/gtk-gnutella/Portfile
+++ b/net/gtk-gnutella/Portfile
@@ -4,8 +4,8 @@ PortSystem      1.0
 PortGroup       conflicts_build 1.0
 PortGroup       github 1.0
 
-github.setup    gtk-gnutella gtk-gnutella d5eef26211bbbd664a1be928155c36538060e0c0
-version         2023.08.28
+github.setup    gtk-gnutella gtk-gnutella a028284d5367bec414afdf238c108bb557356b2f
+version         2023.10.25
 revision        0
 categories      net p2p www
 license         GPL-2+
@@ -17,9 +17,9 @@ long_description \
                 and some basic statistics.
 homepage        https://gtk-gnutella.sourceforge.net
 
-checksums       rmd160  f61bc0bf66bd5917ec929cd60dd2b18111377398 \
-                sha256  c0250a19b98400fb4dc28148a2d8f20c04dff0105dd37d3c5939cfff3149066a \
-                size    26719865
+checksums       rmd160  9395d1fbc9791d0e1e3c16a5fcb96129377bb9c3 \
+                sha256  c34784ffc6715b1c761f726851e820121f86bf1fb7e07f899a7011f95bbf20ef \
+                size    26721323
 github.tarball_from archive
 
 depends_lib-append \


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
