### PR TITLE
opensmtpd update to 7.4.0p1 + more recent upstream patches.

### DIFF
--- a/mail/opensmtpd/Portfile
+++ b/mail/opensmtpd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           legacysupport 1.1
 
 name                opensmtpd
-version             7.3.0p2
+version             7.4.0p1
 revision            0
 categories          mail
 license             ISC
@@ -22,9 +22,9 @@ homepage            https://www.opensmtpd.org
 
 master_sites        https://opensmtpd.org/archives/
 
-checksums           rmd160  02956aee2043b27b2bd9b778434c5abc4f308c2e \
-                    sha256  fccdfbc5b98d150012bf9ccdef51752c18a862ed10888b56289826b83a2b5a4e \
-                    size    846999
+checksums           rmd160  e62234e14c5288c8b3e73714224d99d216df9479 \
+                    sha256  9e82a2ec9419e181d4ca27d8e3ebe5d129fded5ba84022ff4d11a73f8edb70b5 \
+                    size    908307
 
 depends_build       port:bison
 
@@ -43,8 +43,10 @@ post-patch {
     reinplace "s|file:/etc/mail/aliases|file:${sysconfdir}/aliases|g" ${worksrcpath}/usr.sbin/smtpd/smtpd.conf
 }
 
-
-
+#temp fix for 7.4.0p1. Already patched upstream, to be included in next release.
+patchfiles          configureac.patch
+patchfiles          configure.patch
+ 
 depends_build-append \
                     port:autoconf \
                     port:automake \

--- a/mail/opensmtpd/files/configure.patch
+++ b/mail/opensmtpd/files/configure.patch
@@ -1,0 +1,11 @@
+--- configure	2023-11-09 09:15:16
++++ configure.modif	2023-11-17 21:32:53
+@@ -19483,7 +19483,7 @@
+ if test ${with_mantype+y}
+ then :
+   withval=$with_mantype;
+-		case "withval" in
++		case "$withval" in
+ 		man|cat|doc)
+ 			MANTYPE=$withval
+ 			;;

--- a/mail/opensmtpd/files/configureac.patch
+++ b/mail/opensmtpd/files/configureac.patch
@@ -1,0 +1,11 @@
+--- configure.ac.orig
++++ configure.ac
+@@ -735,7 +735,7 @@
+ AC_ARG_WITH([mantype],
+ 	[  --with-mantype=man|cat|doc   Set man page type],
+ 	[
+-		case "withval" in
++		case "$withval" in
+ 		man|cat|doc)
+ 			MANTYPE=$withval
+ 			;;


### PR DESCRIPTION
* closes https://trac.macports.org/ticket/68573
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
