### PR TITLE
ruby-devel: update to 2023.11.17

### DIFF
--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -15,13 +15,13 @@ legacysupport.newest_darwin_requires_legacy 14
 # ruby/openssl since ruby-3.2 supports openssl-3
 openssl.branch      3
 
-github.setup        ruby ruby e7d845b1d0154651962f34eefb37ffb0ac0c4e0a
+github.setup        ruby ruby e5d6b4099e9f4027dbaaeb8b825ada572279b066
 
 set ruby_ver        3.3
 set ruby_patch      0
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby-devel
-version             2023.10.23
+version             2023.11.17
 revision            0
 
 categories          lang ruby
@@ -37,9 +37,9 @@ long_description    Ruby is the interpreted scripting language \
 homepage            https://www.ruby-lang.org
 license             {Ruby BSD}
 
-checksums           rmd160  209df6cb3672a5c772de0e89bc6ed7035933db4e \
-                    sha256  3348a9a7fc33720ebfa30dceba3b35e6e2787bc09e156213edc46b053ab1ba80 \
-                    size    16229301
+checksums           rmd160  ae7fdf245064e2bc8bae5c0606b61ccbbc310f2c \
+                    sha256  1a361676e013dbe7e052f9982611ad14c40f9c104c31458fc961c384ea88cabe \
+                    size    16329958
 github.tarball_from archive
 
 universal_variant   no

--- a/lang/ruby-devel/files/0001-Use-numerical-macOS-versions.patch
+++ b/lang/ruby-devel/files/0001-Use-numerical-macOS-versions.patch
@@ -1,7 +1,7 @@
 From d3a6597049a2e6e752dee3f8deea667296cd7b2c Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <vital.had@gmail.com>
 Date: Fri, 21 Oct 2022 00:26:52 +0800
-Subject: [PATCH 1/3] Use numerical macOS versions
+Subject: [PATCH] Use numerical macOS versions
 
 ---
  configure.ac     | 6 +++---
@@ -104,12 +104,12 @@ diff --git a/thread_pthread.c b/thread_pthread.c
 index aa5435aa99..006f0c2fc0 100644
 --- a/thread_pthread.c
 +++ b/thread_pthread.c
-@@ -2732,11 +2732,11 @@
-     return INT2FIX(tid);
+@@ -1862,11 +1862,11 @@ native_thread_native_thread_id(rb_thread_t *target_th)
  #elif defined(__APPLE__)
      uint64_t tid;
--# if ((MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6) || \
-+# if ((MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || \
+ # if (!defined(MAC_OS_X_VERSION_10_6) || \
+-      (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6) || \
++      (MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || \
        defined(__POWERPC__) /* never defined for PowerPC platforms */)
      const bool no_pthread_threadid_np = true;
  #   define NO_PTHREAD_MACH_THREAD_NP 1
@@ -118,3 +118,4 @@ index aa5435aa99..006f0c2fc0 100644
      const bool no_pthread_threadid_np = false;
  # else
  #   if !(defined(__has_attribute) && __has_attribute(availability))
+ 


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
