### PR TITLE
py-rapidfuzz: update to 3.5.2

### DIFF
--- a/python/py-distro/Portfile
+++ b/python/py-distro/Portfile
@@ -15,7 +15,7 @@ supported_archs     noarch
 platforms           {darwin any}
 homepage            https://github.com/nir0s/distro
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 checksums           rmd160  10d88223f966f61231dab605d2b2c32c5fa2616a \
                     sha256  02e111d1dc6a50abb8eed6bf31c3e48ed8b0830d1ea2a1b78c61765c2513fdd8 \

--- a/python/py-rapidfuzz/Portfile
+++ b/python/py-rapidfuzz/Portfile
@@ -5,12 +5,12 @@ PortGroup           python 1.0
 PortGroup           compiler_wrapper 1.0
 
 name                py-rapidfuzz
-version             3.1.2
+version             3.5.2
 revision            0
 categories-append   textproc
 license             MIT
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer
@@ -20,9 +20,9 @@ long_description    ${description}
 
 homepage            https://github.com/maxbachmann/RapidFuzz
 
-checksums           rmd160  8c4c9b5045752ea72115b801f045b9c304548eb7 \
-                    sha256  1b1b2eab728efc239c8aab97b4821f8e10dcd5a1b066365d0e38023e3b2289e8 \
-                    size    1280133
+checksums           rmd160  b0d87692ae90b1950deef50ce3b2db04b6e2090c \
+                    sha256  9e9b395743e12c36a3167a3a9fd1b4e11d92fb0aa21ec98017ee6df639ed385e \
+                    size    1524315
 
 if {${name} ne ${subport}} {
     compiler.cxx_standard 2017

--- a/python/py-scikit-build/Portfile
+++ b/python/py-scikit-build/Portfile
@@ -9,7 +9,7 @@ revision            0
 categories-append   devel
 license             BSD
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 python.pep517       yes
 python.pep517_backend hatch
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.1 22G313 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
