### PR TITLE
colima: update to 0.6.3

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.6.2 v
+go.setup            github.com/abiosoft/colima 0.6.3 v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  dffa6b6dd539e50de69a9cf8e0e838769d7dc208 \
-                    sha256  8ca2ceca433cc5658a3bdce84394a6c47cd3f02e7e91377b1416bdeaf4dcde4e \
-                    size    605583
+checksums           rmd160  7329542e9fd16cbd68f0fa6c87ba558234284e38 \
+                    sha256  74da3504d6ec40eb095c8d2d7ed2be13959c677984a1ab49677ed031b09b7bfa \
+                    size    605934
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

Update colima to 0.6.3

###### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0 15A240d

###### Verificatio

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
