### PR TITLE
mpich, openmpi: add gcc13 and clang17 variants

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -73,10 +73,14 @@ dict set clist gcc7    {macports-gcc-7}
 dict set clist gcc10   {macports-gcc-10}
 dict set clist gcc11   {macports-gcc-11}
 dict set clist gcc12   {macports-gcc-12}
+dict set clist gcc13   {macports-gcc-13}
 dict set clist clang11 {macports-clang-11}
 dict set clist clang12 {macports-clang-12}
 dict set clist clang13 {macports-clang-13}
 dict set clist clang14 {macports-clang-14}
+dict set clist clang15 {macports-clang-15}
+dict set clist clang16 {macports-clang-16}
+dict set clist clang17 {macports-clang-17}
 
 # Only enable default (gcc), and Xcode clang, for MacOS 10.7 and later
 if { ${os.major} >= 11 } {
@@ -102,15 +106,6 @@ if { ${os.major} >= 10 && ${os.major} <= 14 } {
 } else {
     lappend clist_unsupported \
         gcc9
-}
-
-# Clang 15 and 16 only available on 10.7 and later
-if {${os.major} >= 11} {
-    dict set clist clang15 {macports-clang-15}
-    dict set clist clang16 {macports-clang-16}
-} else {
-    lappend clist_unsupported \
-        clang15 clang16
 }
 
 #-------------------------------------------------------------------------------
@@ -288,7 +283,8 @@ if {${subport_enabled}} {
 
         if {${cname} eq "gcc10" ||
             ${cname} eq "gcc11" ||
-            ${cname} eq "gcc12"} {
+            ${cname} eq "gcc12" ||
+            ${cname} eq "gcc13"} {
             # see https://lists.mpich.org/pipermail/discuss/2020-January/005862.html
             # see https://github.com/pmodels/mpich/issues/4300
             # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91556

--- a/science/mpich/files/portselect/mpich-clang17
+++ b/science/mpich/files/portselect/mpich-clang17
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-clang16
+bin/mpichversion-mpich-clang17
+bin/mpicxx-mpich-clang17
+bin/mpiexec-mpich-clang17
+bin/mpirun-mpich-clang17
+-
+-
+bin/parkill-mpich-clang17
+lib/mpich-clang17/pkgconfig/mpich.pc
+-
+-

--- a/science/mpich/files/portselect/mpich-clang17-fortran
+++ b/science/mpich/files/portselect/mpich-clang17-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-clang17
+bin/mpichversion-mpich-clang17
+bin/mpicxx-mpich-clang17
+bin/mpiexec-mpich-clang17
+bin/mpirun-mpich-clang17
+bin/mpif77-mpich-clang17
+bin/mpif90-mpich-clang17
+bin/parkill-mpich-clang17
+lib/mpich-clang17/pkgconfig/mpich.pc
+-
+bin/mpifort-mpich-clang17

--- a/science/mpich/files/portselect/mpich-gcc13-fortran
+++ b/science/mpich/files/portselect/mpich-gcc13-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-mpich-gcc13
+bin/mpichversion-mpich-gcc13
+bin/mpicxx-mpich-gcc13
+bin/mpiexec-mpich-gcc13
+bin/mpirun-mpich-gcc13
+bin/mpif77-mpich-gcc13
+bin/mpif90-mpich-gcc13
+bin/parkill-mpich-gcc13
+lib/mpich-gcc13/pkgconfig/mpich.pc
+-
+bin/mpifort-mpich-gcc13

--- a/science/openmpi/Portfile
+++ b/science/openmpi/Portfile
@@ -71,10 +71,14 @@ dict set clist gcc7    {macports-gcc-7}
 dict set clist gcc10   {macports-gcc-10}
 dict set clist gcc11   {macports-gcc-11}
 dict set clist gcc12   {macports-gcc-12}
+dict set clist gcc13   {macports-gcc-13}
 dict set clist clang11 {macports-clang-11}
 dict set clist clang12 {macports-clang-12}
 dict set clist clang13 {macports-clang-13}
 dict set clist clang14 {macports-clang-14}
+dict set clist clang15 {macports-clang-15}
+dict set clist clang16 {macports-clang-16}
+dict set clist clang17 {macports-clang-17}
 
 # Only enable Xcode clang builds for MacOS 10.7 and later
 if { ${os.major} >= 11 } {
@@ -99,15 +103,6 @@ if { ${os.major} >= 10 && ${os.major} <= 14 } {
 } else {
     lappend clist_unsupported \
         gcc9
-}
-
-# Clang 15 and 16 only available on 10.7 and later
-if {${os.major} >= 11} {
-    dict set clist clang15 {macports-clang-15}
-    dict set clist clang16 {macports-clang-16}
-} else {
-    lappend clist_unsupported \
-        clang15 clang16
 }
 
 #-------------------------------------------------------------------------------

--- a/science/openmpi/files/portselect/openmpi-clang17
+++ b/science/openmpi/files/portselect/openmpi-clang17
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang17
+-
+bin/mpicxx-openmpi-clang17
+bin/mpiexec-openmpi-clang17
+bin/mpirun-openmpi-clang17
+-
+-
+-
+lib/openmpi-clang17/pkgconfig/ompi.pc
+lib/openmpi-clang17/pkgconfig/orte.pc
+-

--- a/science/openmpi/files/portselect/openmpi-clang17-fortran
+++ b/science/openmpi/files/portselect/openmpi-clang17-fortran
@@ -1,0 +1,11 @@
+bin/mpicc-openmpi-clang17
+-
+bin/mpicxx-openmpi-clang17
+bin/mpiexec-openmpi-clang17
+bin/mpirun-openmpi-clang17
+bin/mpif77-openmpi-clang17
+bin/mpif90-openmpi-clang17
+-
+lib/openmpi-clang17/pkgconfig/ompi.pc
+lib/openmpi-clang17/pkgconfig/orte.pc
+bin/mpifort-openmpi-clang17

--- a/science/openmpi/files/portselect/openmpi-gcc13-fortran
+++ b/science/openmpi/files/portselect/openmpi-gcc13-fortran
@@ -1,0 +1,12 @@
+bin/mpicc-openmpi-gcc13
+-
+bin/mpicxx-openmpi-gcc13
+bin/mpiexec-openmpi-gcc13
+bin/mpirun-openmpi-gcc13
+bin/mpif77-openmpi-gcc13
+bin/mpif90-openmpi-gcc13
+-
+-
+lib/openmpi-gcc13/pkgconfig/ompi.pc
+lib/openmpi-gcc13/pkgconfig/orte.pc
+bin/mpifort-openmpi-gcc13


### PR DESCRIPTION
#### Description

I also globally allows clang15+ since it was fixed on 10.5+

Closes: https://trac.macports.org/ticket/68653

I've also skip CI because it will fail by timeout anyway

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->