### PR TITLE
py-setuptools_scm_git_archive: add py312 subport

### DIFF
--- a/python/py-setuptools_scm_git_archive/Portfile
+++ b/python/py-setuptools_scm_git_archive/Portfile
@@ -13,7 +13,7 @@ supported_archs     noarch
 master_sites        pypi:s/setuptools_scm_git_archive
 distname            setuptools_scm_git_archive-${version}
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 maintainers         {gmail.com:giovanni.bussi @GiovanniBussi} openmaintainer
 


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

(variants: none)