### PR TITLE
desktop-file-utils: unbreak build after update: set correct C standard

### DIFF
--- a/gnome/desktop-file-utils/Portfile
+++ b/gnome/desktop-file-utils/Portfile
@@ -10,7 +10,6 @@ maintainers     nomaintainer
 categories      gnome
 license         GPL-2+
 installs_libs   no
-platforms       darwin
 description     Command line utilities for working with desktop entries.
 
 long_description \
@@ -30,6 +29,9 @@ depends_build   port:pkgconfig \
                 port:automake
 
 depends_lib     path:lib/pkgconfig/glib-2.0.pc:glib2
+
+# cc1: error: unrecognized command line option "-std=gnu11"
+compiler.c_standard 2011
 
 post-activate {
     system "update-desktop-database -q ${prefix}/share/applications; true"


### PR DESCRIPTION
#### Description

It requires C11, which was not set.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
