### PR TITLE
doxygen-devel: fix build on < 10.7

### DIFF
--- a/textproc/doxygen-devel/Portfile
+++ b/textproc/doxygen-devel/Portfile
@@ -66,6 +66,9 @@ patchfiles-append       patch-src-portable_c.c.diff
 patchfiles-append       patch-CMakeLists.txt.diff
 patchfiles-append       patch-longtabu.diff
 
+# https://trac.macports.org/ticket/68581
+patchfiles-append       patch-pthread_threadid_np.diff
+
 depends_build-append \
                         port:bison \
                         port:flex \

--- a/textproc/doxygen-devel/files/patch-pthread_threadid_np.diff
+++ b/textproc/doxygen-devel/files/patch-pthread_threadid_np.diff
@@ -1,0 +1,34 @@
+# https://github.com/gabime/spdlog/commit/c65aa4e4889939c1afa82001db349cac237a13f8
+
+--- deps/spdlog/include/spdlog/details/os-inl.h	2023-01-15 03:29:53.000000000 +0800
++++ deps/spdlog/include/spdlog/details/os-inl.h	2023-11-19 11:37:02.000000000 +0800
+@@ -58,6 +58,10 @@
+ #        include <thread.h> // for thr_self
+ #    endif
+ 
++#if defined __APPLE__
++#    include <AvailabilityMacros.h>
++#endif
++
+ #endif // unix
+ 
+ #ifndef __has_feature          // Clang - feature checking macros.
+@@ -353,7 +357,17 @@
+     return static_cast<size_t>(::thr_self());
+ #elif __APPLE__
+     uint64_t tid;
+-    pthread_threadid_np(nullptr, &tid);
++#    if (MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || defined(__POWERPC__)
++        tid = pthread_mach_thread_np(pthread_self());
++#    elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++        if (&pthread_threadid_np) {
++            pthread_threadid_np(nullptr, &tid);
++        } else {
++            tid = pthread_mach_thread_np(pthread_self());
++        }
++#    else
++        pthread_threadid_np(nullptr, &tid);
++#    endif
+     return static_cast<size_t>(tid);
+ #else // Default to standard C++11 (other Unix)
+     return static_cast<size_t>(std::hash<std::thread::id>()(std::this_thread::get_id()));


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68581
See also: https://github.com/macports/macports-ports/commit/0379c87280faa1a14758cb61a52fb4e6d5922a97

#### Description

Fix the build on older OSs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
