### PR TITLE
bearssl: fix dylib install name

### DIFF
--- a/devel/bearssl/Portfile
+++ b/devel/bearssl/Portfile
@@ -5,7 +5,7 @@ PortGroup           makefile 1.0
 
 name                bearssl
 version             0.6
-revision            0
+revision            1
 categories          devel crypto
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -44,6 +44,7 @@ destroot {
     copy ${builddir}/brssl ${destroot}${prefix}/bin
     copy ${builddir}/libbearssl.a ${destroot}${prefix}/lib
     copy ${builddir}/libbearssl.dylib ${destroot}${prefix}/lib
+    system "install_name_tool -id ${prefix}/lib/libbearssl.dylib ${destroot}${prefix}/lib/libbearssl.dylib"
     # The following is intended: the main header is placed into include directly:
     move ${worksrcpath}/${name}/bearssl.h ${destroot}${prefix}/include/bearssl.h
     copy ${worksrcpath}/${name} ${destroot}${prefix}/include


### PR DESCRIPTION
#### Description

Fix install name (otherwise it installed with `build/libbearssl.dylib`).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
