### PR TITLE
libtapi: avoid dependency cycle on old macOS

### DIFF
--- a/devel/libtapi/Portfile
+++ b/devel/libtapi/Portfile
@@ -80,9 +80,9 @@ if {(${os.platform} eq "darwin" && ${os.major} < 11) || [string match macports-g
     build.env               DYLD_LIBRARY_PATH=${prefix}/libexec/llvm-$clangversion/lib/
 }
 
-# on macOS before 10.13 use clang-11-bootstrap
-if {${os.platform} eq "darwin" && ${os.major} < 17 && ${configure.build_arch} ni [list ppc ppc64]} {
-
+# libtapi might be used as part of bootstrap process for clang, avoid dependency cycle
+# when MacPorts decided to use MacPorts clang by replacing compiler to clang-11-bootstrap.
+if {[string match macports-clang-* ${configure.compiler}]} {
     configure.compiler.add_deps no
 
     depends_build-append   port:clang-11-bootstrap


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/68736

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->