### PR TITLE
ceres-solver: update to 2.2.0

### DIFF
--- a/math/ceres-solver/Portfile
+++ b/math/ceres-solver/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 name                ceres-solver
-version             2.1.0
+version             2.2.0
 revision            0
 categories          math
 license             BSD
@@ -18,13 +18,11 @@ long_description    Ceres Solver is an open source C++ library for modeling \
 homepage            http://ceres-solver.org
 master_sites        ${homepage}
 
-checksums           rmd160  ce24b67679ff25c0adfe3a9cb9a72898ab57d4d5 \
-                    sha256  f7d74eecde0aed75bfc51ec48c91d01fe16a6bf16bce1987a7073286701e2fc6 \
-                    size    3802187
+checksums           rmd160  8cf4b7e69089429a0e78d3f594bda85cb398f585 \
+                    sha256  48b2302a7986ece172898477c3bcd6deb8fb5cf19b3327bc49969aad4cede82d \
+                    size    7635532
 
-# Version 2.1.x requires a Cxx 2014 compiler
-# Future version 2.2.x, will require a Cxx 2017 compiler
-compiler.cxx_standard 2014
+compiler.cxx_standard 2017
 
 # Avoid Xcode Clang 7/8: error: no viable conversion between unique_ptr types
 compiler.blacklist-append \
@@ -40,8 +38,7 @@ depends_lib         path:share/pkgconfig/eigen3.pc:eigen3 \
                     port:SuiteSparse_COLAMD \
                     port:SuiteSparse_CCOLAMD \
                     port:SuiteSparse_CHOLMOD \
-                    port:SuiteSparse_SPQR \
-                    port:SuiteSparse_CXSparse
+                    port:SuiteSparse_SPQR
 
 configure.args-append -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
 


### PR DESCRIPTION
#### Description

This update is necessary before merging #21451.

I ran the tests manually, _with_ the changes in #21451. Testing is not enabled in this PR as it would increase build times.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.2 22G320 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
