### PR TITLE
py-py{qt5,qt5-sip,qt-builder}: add py312 subport

### DIFF
--- a/python/py-pyqt-builder/Portfile
+++ b/python/py-pyqt-builder/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  b5532f4991a0863692ab78ed1546c721a7d7eb9e \
                     sha256  5b33e99edcb77d4a63a38605f4457a04cff4e254c771ed529ebc9589906ccdb1 \
                     size    3909851
 
-python.versions     35 36 37 38 39 310 311
+python.versions     35 36 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     if {${python.version} < 37} {

--- a/python/py-pyqt5-sip/Portfile
+++ b/python/py-pyqt5-sip/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  7abb7adc89e2c010c962f04d7cf3e436509015e6 \
                     sha256  7f321daf84b9c9dbca61b80e1ef37bdaffc0e93312edae2cd7da25b953971d91 \
                     size    123225
 
-python.versions     35 36 37 38 39 310 311
+python.versions     35 36 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     if {${python.version} < 37} {

--- a/python/py-pyqt5/Portfile
+++ b/python/py-pyqt5/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  1e6f42643739e99bc47c4431aa045634e358f2b1 \
                     sha256  d46b7804b1b10a4ff91753f8113e5b5580d2b4462f3226288e2d84497334898a \
                     size    3242654
 
-python.versions     35 36 37 38 39 310 311
+python.versions     35 36 37 38 39 310 311 312
 
 supported_archs     arm64 x86_64
 


### PR DESCRIPTION
#### Description

~~Depends on #21482 for CI to pass.~~ I took dbus-python312 out of this one and created a separate PR since the version also had to be updated (except for py27, which must be pinned to the old version).

Edit: should be ready to merge, even though it does not pass CI. See below

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
