### PR TITLE
colima: Update to 0.6.5

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.6.4 v
+go.setup            github.com/abiosoft/colima 0.6.5 v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  feda1ca6d286d357afc7147d9323a63cdb7a0229 \
-                    sha256  a726a91cf3a7e8fe6b5648bcf9b1e2c9a2486bd207f224c37c6b1e861ac0fc54 \
-                    size    607343
+checksums           rmd160  05197e2459c48089c1f4da49f5b50f2519995597 \
+                    sha256  ac99615c8364c4f9e2d776a9104cc7c65f91ab9b60ade577a3f4bb63ef83abd8 \
+                    size    607189
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

colima: Update to 0.6.5

##### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0 15A240d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
