### PR TITLE
py-pyobjc + dependencies: add py312 subport

### DIFF
--- a/python/py-babel/Portfile
+++ b/python/py-babel/Portfile
@@ -12,7 +12,7 @@ platforms           {darwin any}
 license             BSD
 supported_archs     noarch
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-blockdiag/Portfile
+++ b/python/py-blockdiag/Portfile
@@ -11,7 +11,7 @@ license             Apache-2
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-docutils/Portfile
+++ b/python/py-docutils/Portfile
@@ -24,7 +24,7 @@ checksums           md5 93bcfe0065cf1d0b6a0bcabeca7a2335 \
                     rmd160 4e03b8fdc202abdb5bd5811a40bdea8647db25d2 \
                     sha256 f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 if {$subport ne $name} {
     depends_build       port:py${python.version}-setuptools

--- a/python/py-funcparserlib/Portfile
+++ b/python/py-funcparserlib/Portfile
@@ -11,7 +11,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 python.pep517       yes
 python.pep517_backend poetry
 

--- a/python/py-pygments/Portfile
+++ b/python/py-pygments/Portfile
@@ -13,7 +13,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-pygments/files/py312-pygments
+++ b/python/py-pygments/files/py312-pygments
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.12/bin/pygmentize

--- a/python/py-pyobjc/Portfile
+++ b/python/py-pyobjc/Portfile
@@ -28,7 +28,7 @@ long_description    The PyObjC project aims to provide a bridge between \
                     Python based functionality.
 homepage            https://pyobjc.readthedocs.io
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-roman/Portfile
+++ b/python/py-roman/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  ebfa4afbfd864715ba59d5caf3d179442183cf49 \
                     sha256  4da8a200529a730822a27f1704b3ac70bc907141d3bc558115fb8e36af13b412 \
                     size    7005
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-sphinx/Portfile
+++ b/python/py-sphinx/Portfile
@@ -26,7 +26,7 @@ checksums           md5 18971ebdd6ec1b7788ff0898682fe0da \
                     rmd160 3d0745a7da0c8240d3cd52930dd5c66be4357f8c \
                     sha256 9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5
 
-python.versions     27 36 37 38 39 310 311
+python.versions     27 36 37 38 39 310 311 312
 
 if {$subport ne $name} {
     depends_lib     port:py${python.version}-docutils

--- a/python/py-sphinx/files/py312-sphinx
+++ b/python/py-sphinx/files/py312-sphinx
@@ -1,0 +1,4 @@
+${frameworks_dir}/Python.framework/Versions/3.12/bin/sphinx-apidoc
+${frameworks_dir}/Python.framework/Versions/3.12/bin/sphinx-quickstart
+${frameworks_dir}/Python.framework/Versions/3.12/bin/sphinx-autogen
+${frameworks_dir}/Python.framework/Versions/3.12/bin/sphinx-build

--- a/python/py-sphinxcontrib-applehelp/Portfile
+++ b/python/py-sphinxcontrib-applehelp/Portfile
@@ -20,7 +20,7 @@ checksums           md5 660ede87eb89408a9989a740faab1675 \
                     rmd160 dd23b33bbb45195c09d4ef4c29f1eccba26d2208 \
                     sha256 39fdc8d762d33b01a7d8f026a3b7d71563ea3b72787d5f00ad8465bd9d6dfbfa
 
-python.versions     36 37 38 39 310 311
+python.versions     36 37 38 39 310 311 312
 python.pep517       yes
 python.pep517_backend   flit
 

--- a/python/py-sphinxcontrib-blockdiag/Portfile
+++ b/python/py-sphinxcontrib-blockdiag/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  1fbe5f0cd13d0ac1aab70f28ea05e8297be00647 \
                     sha256  aa49bf924516f5de8a479994c7be81e077df5599c9da2a082003d5b388e1d450 \
                     size    6070
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-devhelp/Portfile
+++ b/python/py-sphinxcontrib-devhelp/Portfile
@@ -22,7 +22,7 @@ checksums           md5 0fd9d587ece0a8fe9f515d497c183fce \
                     sha256 63b41e0d38207ca40ebbeabcf4d8e51f76c03e78cd61abe118cf4435c73d4212 \
                     size 12343
 
-python.versions     36 37 38 39 310 311
+python.versions     36 37 38 39 310 311 312
 python.pep517       yes
 
 if {${name} ne ${subport}} {

--- a/python/py-sphinxcontrib-htmlhelp/Portfile
+++ b/python/py-sphinxcontrib-htmlhelp/Portfile
@@ -21,7 +21,7 @@ checksums           md5 cbc0df02c4716f995a0410d455837b3b \
                     rmd160 0a3451660d84a248d4f18c4ad3fe376d8b139d5a \
                     sha256 6c26a118a05b76000738429b724a0568dbde5b72391a688577da08f11891092a
 
-python.versions     36 37 38 39 310 311
+python.versions     36 37 38 39 310 311 312
 python.pep517       yes
 python.pep517_backend   flit
 

--- a/python/py-sphinxcontrib-jsmath/Portfile
+++ b/python/py-sphinxcontrib-jsmath/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  9ff064c88f8f121bd7876ae3f79b4c31f5a9264f \
                     sha256  a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8 \
                     size    5787
 
-python.versions     36 37 38 39 310 311
+python.versions     36 37 38 39 310 311 312
 python.pep517       yes
 
 if {${name} ne ${subport}} {

--- a/python/py-sphinxcontrib-qthelp/Portfile
+++ b/python/py-sphinxcontrib-qthelp/Portfile
@@ -22,7 +22,7 @@ checksums           md5 7a945ad3b0c47e9e2777a146e38e34af \
                     sha256 62b9d1a186ab7f5ee3356d906f648cacb7a6bdb94d201ee7adf26db55092982d \
                     size 16555
 
-python.versions     36 37 38 39 310 311
+python.versions     36 37 38 39 310 311 312
 python.pep517       yes
 
 if {${name} ne ${subport}} {

--- a/python/py-sphinxcontrib-serializinghtml/Portfile
+++ b/python/py-sphinxcontrib-serializinghtml/Portfile
@@ -23,7 +23,7 @@ checksums           md5 84957dfa6d85d2e509181281082c11ee \
                     sha256 0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54 \
                     size 15446
 
-python.versions     36 37 38 39 310 311
+python.versions     36 37 38 39 310 311 312
 python.pep517       yes
 
 if {$subport ne $name} {

--- a/python/py-webcolors/Portfile
+++ b/python/py-webcolors/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer


### PR DESCRIPTION
#### Description

py312-babel py312-blockdiag py312-docutils py312-funcparserlib py312-pygments py312-pyobjc py312-roman py312-sphinx py312-sphinxcontrib-applehelp py312-webcolors py312-sphinxcontrib-blockdiag py312-sphinxcontrib-devhelp py312-sphinxcontrib-htmlhelp py312-sphinxcontrib-jsmath py312-sphinxcontrib-qthelp py312-sphinxcontrib-serializinghtml

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

lint: missing `size` for a couple of them, not related to this PR

installation: tested all except py312-pyobjc, which is not installable on my system (10.9). The reason for adding these are that they are dependencies of variants of other Python ports that I am going to add

tested binaries: ran all binaries (files in `/.../bin/`) reported by `port contents` without arguments to verify that the output made sense.