### PR TITLE
py-parsing: add py312 subport

### DIFF
--- a/python/py-parsing/Portfile
+++ b/python/py-parsing/Portfile
@@ -29,7 +29,7 @@ checksums           rmd160  e940832a430965c7026176ee0316345be43b3bb3 \
                     sha256  ede28a1a32462f5a9705e07aea48001a08f7cf81a021585011deba701581a0db \
                     size    884814
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     if {${python.version} <= 35} {


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

`port test`: fails because of missing dependencies, some of which are not on MacPorts (e.g. `railroad`).