### PR TITLE
py-gnureadline: add py312 subport

### DIFF
--- a/python/py-gnureadline/Portfile
+++ b/python/py-gnureadline/Portfile
@@ -7,7 +7,7 @@ name                py-gnureadline
 version             8.1.2
 license             GPL-3+ PSF
 
-python.versions     27 36 37 38 39 310 311
+python.versions     27 36 37 38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
