### PR TITLE
py-reportlab: update to 4.0.7 and add py312 subport

### DIFF
--- a/python/py-reportlab/Portfile
+++ b/python/py-reportlab/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-reportlab
-version             3.6.12
+version             4.0.7
 revision            0
 categories-append   textproc
 platforms           darwin
 license             BSD
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer
@@ -22,9 +22,9 @@ long_description    The ReportLab Toolkit is a library for programatically \
 
 homepage            https://www.reportlab.com/software/opensource/rl-toolkit/
 
-checksums           rmd160  aeb3c36688d4c6f3c9b58ffdf2b9b06be4e7d151 \
-                    sha256  b13cebf4e397bba14542bcd023338b6ff2c151a3a12aabca89eecbf972cb361a \
-                    size    4519536
+checksums           rmd160  ac6be4baad92f50cf84c09371a3e5faa983da55c \
+                    sha256  967c77f00efd918cc231cf8b6d8f4e477dc973b5c16557e3bd18dfaeb5a70234 \
+                    size    3683030
 
 if {${name} ne ${subport}} {
     if {${python.version} eq 27} {
@@ -44,7 +44,7 @@ if {${name} ne ${subport}} {
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
-        xinstall -m 0644 -W ${worksrcpath} README.txt CHANGES.md LICENSE.txt \
+        xinstall -m 0644 -W ${worksrcpath} README.txt CHANGES.md \
             ${destroot}${docdir}
     }
 


### PR DESCRIPTION
#### Description

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
