### PR TITLE
grads @2.2.1: fix HDF5 API compatibility

### DIFF
--- a/science/grads/Portfile
+++ b/science/grads/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                grads
 version             2.2.1
-revision            16
+revision            17
 set branch          [join [lrange [split ${version} .] 0 1] .]
 platforms           darwin
 maintainers         {takeshi @tenomoto}
@@ -67,6 +67,9 @@ configure.args          --without-gui   \
                         --with-netcdf=${prefix} \
                         --libdir=${prefix}/lib/${name} \
                         --with-x
+
+configure.cflags-append \
+                    -DH5_USE_110_API
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68727

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS versions 11, 12, 13., x86 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
