### PR TITLE
codegroup: fix livecheck

### DIFF
--- a/comms/codegroup/Portfile
+++ b/comms/codegroup/Portfile
@@ -60,7 +60,7 @@ checksums           rmd160  d00f22c278df6bcf25dfc123da026dee8d31da4e \
 
 extract.mkdir       yes
 
-patchfiles          Makefile.patch
+patchfiles-append   Makefile.patch
 
 test.run            yes
 test.target         check
@@ -72,3 +72,5 @@ destroot {
     xinstall -m 644 ${worksrcpath}/codegroup.html ${destroot}${prefix}/share/doc/${name}
     xinstall -m 644 ${worksrcpath}/codegroup.jpg ${destroot}${prefix}/share/doc/${name}
 }
+
+livecheck.type      none


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

* disable livecheck
* Change "patchfiles" to "patchfiles-append"

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7.5 11G63 i386
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
