### PR TITLE
py-cvxopt:  update to version 1.3.2

### DIFF
--- a/python/py-cvxopt/Portfile
+++ b/python/py-cvxopt/Portfile
@@ -2,14 +2,14 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           github 1.0
 PortGroup           linear_algebra  1.0
 
 linalg.setup        noveclibfort
 
-github.setup        cvxopt cvxopt 1.2.7
-revision            0
 name                py-cvxopt
+python.rootname     cvxopt
+version             1.3.2
+revision            0
 categories-append   math
 license             GPL-3+
 maintainers         {gmail.com:jjstickel @jjstickel} openmaintainer
@@ -28,11 +28,12 @@ long_description    CVXOPT is a free software package for convex \
                     programming language.
 homepage            https://cvxopt.org/
 
-checksums           rmd160  4af2fec6a886aa076206de428e5b7ead9447e1d4 \
-                    sha256  e03d8cdd2c952672fa45fd365338857f2d30fbd913df5708747a0535558a51ea \
-                    size    4115655
 
-python.versions     27 37 38 39 310
+checksums           rmd160  e181f9ef9224136835a34f6142c9974335d95ebf \
+                    sha256  3461fa42c1b2240ba4da1d985ca73503914157fc4c77417327ed6d7d85acdbe6 \
+                    size    4108454
+
+python.versions     27 37 38 39 310 311
 
 if {${subport} ne ${name}} {
     # ignore empty BLAS and LAPACK inputs
@@ -42,6 +43,10 @@ if {${subport} ne ${name}} {
         CVXOPT_BLAS_LIB_DIR=${prefix}/lib \
         CVXOPT_LAPACK_LIB=
 
+    pre-destroot {
+        system -W ${worksrcpath} "chown -R $env(USER) ."
+    }
+    
     pre-build {
         set blas_lib {}
         set blas_extra_link_args {}
@@ -94,7 +99,7 @@ if {${subport} ne ${name}} {
             CVXOPT_DSDP_INC_DIR=${prefix}/include
     }
 
-    depends_build-append    port:py${python.version}-setuptools
+    depends_build-append    port:py${python.version}-setuptools_scm
 
     # link against MacPorts SuiteSparse
     depends_lib-append  port:SuiteSparse_config \


### PR DESCRIPTION
* update to version 1.3.2
* switch to pypi for download due to error "setuptools-scm was unable to detect version"

#### Description

Update requested in https://github.com/macports/macports-ports/pull/21451#issuecomment-1817830243

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.2 22G320 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
