### PR TITLE
dbus-python: update to 1.3.2 and add py312 subport

### DIFF
--- a/devel/dbus-python/Portfile
+++ b/devel/dbus-python/Portfile
@@ -3,13 +3,13 @@
 PortSystem      1.0
 
 name            dbus-python
-version         1.2.18
+version         1.3.2
 
-set python_versions {27 35 36 37 38 39 310 311}
+set python_versions {27 35 36 37 38 39 310 311 312}
 
 # this default version should stay synchronized with python_get_default_version
 #    in the python PortGroup
-set python_default_version 310
+set python_default_version 311
 
 maintainers     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 license         MIT
@@ -39,9 +39,20 @@ foreach python_version ${python_versions} {
 
         master_sites    https://dbus.freedesktop.org/releases/dbus-python/
 
-        checksums           rmd160  5552b124fb35d5271b8a4813e8635cbf1bdb5836 \
-                            sha256  92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260 \
-                            size    578204
+        if {${python_version} == 27} {
+            version             1.2.18
+
+            checksums           rmd160  5552b124fb35d5271b8a4813e8635cbf1bdb5836 \
+                                sha256  92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260 \
+                                size    578204
+
+            patchfiles-append dynamic_lookup-11.patch
+        } else {
+
+            checksums           rmd160  344f6d035fc8ca806585b6d566221d4769794fab \
+                                sha256  ad67819308618b5069537be237f8e68ca1c7fcc95ee4a121fe6845b1418248f8 \
+                                size    605495
+        }
 
         distname        ${name}-${version}
 
@@ -54,8 +65,6 @@ foreach python_version ${python_versions} {
             path:lib/pkgconfig/glib-2.0.pc:glib2  \
             port:libiconv \
             port:python${python_version}
-
-        patchfiles-append dynamic_lookup-11.patch
 
         set python_prefix ${frameworks_dir}/Python.framework/Versions/${python_branch}
 


### PR DESCRIPTION
#### Description

Add py312 subport. Update to 1.3.2, so that `install -t` passes. Patch has been merged to master and is no longer required.

Originally part of another PR (that I set to “draft” status after CI failed), but I decided to do this one separately when I realised that I had to update the version in addition to adding the py312 subport.

Version 1.3.0 axed Python 2.x support, so I pinned the subport py27 to the old version (1.2.18).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Notes:
* Other PRs: a draft by me (#21468), which I will update later.
* Port has no tests or binaries
* Variant `doc` requires sphinx, for which I have an open PR (#21470). I do not know if it qualifies as an “important variant”, but docs are not built in the default configuration
* `install` completes successfully without updating to 1.3.2, but `install -vst` fails because `configure` does not find `distutils`. With 1.3.2 `-vst` works too