### PR TITLE
libplist{,-devel}: Correctly download tarballs

### DIFF
--- a/textproc/libplist/Portfile
+++ b/textproc/libplist/Portfile
@@ -5,10 +5,8 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        libimobiledevice libplist 2.3.0
-revision            0
+revision            1
 categories          textproc multimedia
-platforms           darwin
-
 license             LGPL-2.1
 maintainers         {ijackson @JacksonIsaac} {i0ntempest @i0ntempest} openmaintainer
 
@@ -17,44 +15,48 @@ long_description    ${description}
 
 homepage            https://www.libimobiledevice.org/
 
-checksums           rmd160  e80704e4645842d35ad063e1026503a0470d929d \
-                    sha256  9be5dbe3985b0b5f2ebff8583c21df30f5e825f9245a803b5ad7560528e0153c \
-                    size    218819
+checksums           rmd160  400481d585f895058218f8abbbbf29db02202fe6 \
+                    sha256  4e8580d3f39d3dfa13cefab1a13f39ea85c4b0202e9305c5c8f63818182cac61 \
+                    size    487721
 
 depends_build-append \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool \
                     port:pkgconfig
-
-# See https://github.com/libimobiledevice/libimobiledevice-glue/commit/0e7b8b42ce4cbeb32eb3103b0ff97916cb273d78
-# remove after next release
-pre-configure {
-    system -W ${worksrcpath} "echo ${version} > .tarball-version"
-}
 
 # https://trac.macports.org/ticket/68238
 compiler.blacklist-append \
                     *gcc-4.0 *gcc-4.2 {clang < 421}
 
-configure.cmd       ./autogen.sh
-
 configure.args      --disable-silent-rules \
                     --without-cython
 
 subport libplist-devel {
-    github.setup    libimobiledevice libplist d45396aad911d496494a587bd2d3ef20c2e8a8d0
-    version         20230829
+    github.setup    libimobiledevice libplist 2cd858c679d25633077ca78b67182a9b77653816
+    version         20231003
     revision        0
 
     github.tarball_from \
                     archive
 
-    checksums       rmd160  e80704e4645842d35ad063e1026503a0470d929d \
-                    sha256  9be5dbe3985b0b5f2ebff8583c21df30f5e825f9245a803b5ad7560528e0153c \
-                    size    218819
+    checksums       rmd160  7767978d612aecc5fe7cb8ad9cfd19f5648c39e4 \
+                    sha256  7bc3aae8a451c83569e21a2d3c2b13e9496d20808559e9cde02cee7f4b846460 \
+                    size    219091
 
     conflicts       libplist
+
+    depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
+
+    # Adhere devel port to libimobiledevice's versioning system
+    # This is handled in the stable port with a release tarball
+    #
+    # See https://github.com/libimobiledevice/libimobiledevice-glue/commit/0e7b8b42ce4cbeb32eb3103b0ff97916cb273d78
+    pre-configure {
+        system -W ${worksrcpath} "echo ${version} > .tarball-version"
+    }
+
+    configure.cmd   ./autogen.sh
 
     livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
 }

--- a/textproc/libplist/Portfile
+++ b/textproc/libplist/Portfile
@@ -6,8 +6,6 @@ PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        libimobiledevice libplist 2.3.0
 revision            0
-github.tarball_from archive
-
 categories          textproc multimedia
 platforms           darwin
 
@@ -49,6 +47,9 @@ subport libplist-devel {
     version         20230829
     revision        0
 
+    github.tarball_from \
+                    archive
+
     checksums       rmd160  e80704e4645842d35ad063e1026503a0470d929d \
                     sha256  9be5dbe3985b0b5f2ebff8583c21df30f5e825f9245a803b5ad7560528e0153c \
                     size    218819
@@ -59,5 +60,8 @@ subport libplist-devel {
 }
 
 if {${subport} eq ${name}} {
+    github.tarball_from \
+                    releases
+    use_bzip2       yes
     conflicts       libplist-devel
 }


### PR DESCRIPTION
#### Description

Previously, the Portfile was set up in a way in which both the stable port and the devel port used the same tarball, which can create build failures when updating devel ports, such as `idevicerestore-devel`.

To further prove this, the latest stable tarball and the lastest devel tarball, when looking at their checksums, reveal that they're the same tarball

```
9be5dbe3985b0b5f2ebff8583c21df30f5e825f9245a803b5ad7560528e0153c  libplist-2.3.0.tar.gz
9be5dbe3985b0b5f2ebff8583c21df30f5e825f9245a803b5ad7560528e0153c  libplist-d45396aad911d496494a587bd2d3ef20c2e8a8d0.tar.gz
```

For that reason, `libplist-devel` required updating to its latest commit, fixing any issues regarding the `libplist` port and its subports.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
