### PR TITLE
lilypond: update to 2.24.3

### DIFF
--- a/textproc/lilypond/Portfile
+++ b/textproc/lilypond/Portfile
@@ -44,12 +44,12 @@ notes-append "\
 compiler.cxx_standard 2014
 
 if {${subport} eq ${name}} {
-    version         2.24.2
+    version         2.24.3
     revision        0
     conflicts       lilypond-devel
-    checksums       rmd160  cf2b0c327142cce424161cf95c3990417ff5166d \
-                    sha256  7944e610d7b4f1de4c71ccfe1fbdd3201f54fac54561bdcd048914f8dbb60a48 \
-                    size    19439984
+    checksums       rmd160  c37651f49ac60517056ddc7c281954d1b7e1cd84 \
+                    sha256  df005f76ef7af5a4cd74a10f8e7115278b7fa79f14018937b65c109498ec44be \
+                    size    19441299
 
     set livecheck_url "source.html"
 } else {


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.24.3.
This fixes an incompatibility with ghostscript 10.02.1.

Closes: https://trac.macports.org/ticket/68737

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.1.1 23B81 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
