### PR TITLE
dotnet-{6, 7}: Version bump

### DIFF
--- a/dotnet/aspnetcore-runtime-6/Portfile
+++ b/dotnet/aspnetcore-runtime-6/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                aspnetcore-runtime-6
-version             6.0.24
+version             6.0.25
 revision            0
 categories          dotnet
 license             MIT
@@ -26,15 +26,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            aspnetcore-runtime-${version}-osx-x64
-        checksums           rmd160  2b49a910a36d2b50c8b88d5c5dfb1475a4dd88e5 \
-                            sha256  4057474503a5a79b6d2e7f19fa28a8772919e090e430d9384c4c4ed57565ad39 \
-                            size    39200541
+        checksums           rmd160  29485b30073dc41ed88e3f8a1584e57006f7c469 \
+                            sha256  a58e0b087f0df833d97659b66d7e952e98451b748cde101b58e2b2327020ba74 \
+                            size    39201726
     }
     arm64 {
         distname            aspnetcore-runtime-${version}-osx-arm64
-        checksums           rmd160  92e3bcfca144f2b13c05d0956594b98fe6b90c2e \
-                            sha256  88ac3c2c8ef6bf17e4a5f4f480a62658998a34183cb9d4e9292e38a49f3e7a7e \
-                            size    36945197
+        checksums           rmd160  38c2fe0d1e14c2887a68f2102b736460241745b8 \
+                            sha256  b919852fa8461f1dfdf1044043b65a47eccfac5f7a9f5106ab4b51cd91698a6d \
+                            size    36948042
     }
     default {
         known_fail yes

--- a/dotnet/aspnetcore-runtime-7/Portfile
+++ b/dotnet/aspnetcore-runtime-7/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                aspnetcore-runtime-7
-version             7.0.13
+version             7.0.14
 revision            0
 categories          dotnet
 license             MIT
@@ -26,15 +26,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            aspnetcore-runtime-${version}-osx-x64
-        checksums           rmd160  90a6c10cb32f4997696409c5bf94185d79c44481 \
-                            sha256  57bbc50410abbf7410d256490b7e5fb73400ba1273a977d1504db75492146048 \
-                            size    40581403
+        checksums           rmd160  ff438b3f7d8e592f5a11b059a367c5aafd009f37 \
+                            sha256  f1dc9db8d8a0558481aef9407c4232496eff0841a4bbcfe1c3b743cc00c843ab \
+                            size    40581944
     }
     arm64 {
         distname            aspnetcore-runtime-${version}-osx-arm64
-        checksums           rmd160  c37b43bf82b9f65222f50a2b7cc82a79abc15fb2 \
-                            sha256  05ac90128eb39a25f6e4dba0ccea97a19b819c095d158eea46ae5ee2d94c6636 \
-                            size    38653000
+        checksums           rmd160  da1d11ff52e9ccc81a56f3dc321c8e5b6041b716 \
+                            sha256  86f71a2463014d5667b0bc2061d75b3d4c016247002f6323de5df5fee82f990e \
+                            size    38654154
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-cli/Portfile
+++ b/dotnet/dotnet-cli/Portfile
@@ -24,7 +24,7 @@
 PortSystem          1.0
 
 name                dotnet-cli
-version             7.0.13
+version             7.0.14
 revision            0
 categories          dotnet
 license             MIT
@@ -52,15 +52,15 @@ master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  7a49a3fe40a18b71f043bcb50a6c070cc747620e \
-                            sha256  6eae5723e5a4a63eb29c279b210ffb5fc8c3011d0b1a9f09bcfabe777675deea \
-                            size    30844773
+        checksums           rmd160  dc0a0ca8ab01aa6e254d7608afa642f4b3bcbf09 \
+                            sha256  49fc6e252514290b22b639c8612c6ef06faffedc808113beb1c806be484b4863 \
+                            size    30845624
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  50f8e9c908b78888c28106ad816be31e2c2b1d79 \
-                            sha256  5118d80ced9d34a1d940321f966d578521e7ab0e1d8451dc02b6f4043be0214f \
-                            size    29178298
+        checksums           rmd160  b098d6ee6a57a58534d8d8e91e927b22b3698360 \
+                            sha256  506235647bcd154ca058c181362e527c18f9ca0ae6edf06f4a7b01793d824968 \
+                            size    29180006
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-6/Portfile
+++ b/dotnet/dotnet-runtime-6/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-runtime-6
-version             6.0.24
+version             6.0.25
 revision            0
 categories          dotnet
 license             MIT
@@ -25,15 +25,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  cdce41af33fd88db1468e374cf538506fec9ef71 \
-                            sha256  94213d2b89e5234bd4210ad07b50dade5b4a5737e0d901b56f57f0458a7a4f6c \
-                            size    30083412
+        checksums           rmd160  3ae92c290b1651f7d31e3c69f8d84b40e6192a4d \
+                            sha256  8c6e9b4d28b46d1e1cd3e075c4d8d8179ae7f01a80d1c9a816d4a0839b646c29 \
+                            size    30086752
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  101d92eb03a44e99db347e5d4ed7c390434f4e2c \
-                            sha256  712c0f81315116654de5bcbfb57a716b0dcfc29c90cdc3e03a493fdaf01d956e \
-                            size    28191808
+        checksums           rmd160  b7839938cd475456223b83be8e5efc04ed01dcca \
+                            sha256  fe942164005f9d18d8d6e426e34eb6f40c71e5aeaddcebad4d87336286b9a666 \
+                            size    28190614
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-7/Portfile
+++ b/dotnet/dotnet-runtime-7/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-runtime-7
-version             7.0.13
+version             7.0.14
 revision            0
 categories          dotnet
 license             MIT
@@ -25,15 +25,15 @@ supported_archs     x86_64 arm64
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  7a49a3fe40a18b71f043bcb50a6c070cc747620e \
-                            sha256  6eae5723e5a4a63eb29c279b210ffb5fc8c3011d0b1a9f09bcfabe777675deea \
-                            size    30844773
+        checksums           rmd160  dc0a0ca8ab01aa6e254d7608afa642f4b3bcbf09 \
+                            sha256  49fc6e252514290b22b639c8612c6ef06faffedc808113beb1c806be484b4863 \
+                            size    30845624
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  50f8e9c908b78888c28106ad816be31e2c2b1d79 \
-                            sha256  5118d80ced9d34a1d940321f966d578521e7ab0e1d8451dc02b6f4043be0214f \
-                            size    29178298
+        checksums           rmd160  b098d6ee6a57a58534d8d8e91e927b22b3698360 \
+                            sha256  506235647bcd154ca058c181362e527c18f9ca0ae6edf06f4a7b01793d824968 \
+                            size    29180006
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-sdk-6/Portfile
+++ b/dotnet/dotnet-sdk-6/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-sdk-6
-version             6.0.416
+version             6.0.417
 revision            0
 categories          dotnet devel
 license             MIT
@@ -27,16 +27,16 @@ switch ${build_arch} {
     x86_64 {
         set dotnet_rid osx-x64
         distname            dotnet-sdk-${version}-osx-x64
-        checksums           rmd160  59bbddb5520a343a7e5369ef8ad48a872c8d612a \
-                            sha256  5287ae730c96fe404cd1fff1d5f76d68104b4b22fadc7fe621a5f5d01f855b9c \
-                            size    184245838
+        checksums           rmd160  5a39bae0840699bb250edc911d639bc3aa0cdd26 \
+                            sha256  70354789a3e52146ed47a8b378afd3ccb2b50b2540ddcef1183512fd286a420a \
+                            size    184246873
     }
     arm64 {
         set dotnet_rid osx-arm64
         distname            dotnet-sdk-${version}-osx-arm64
-        checksums           rmd160  78428f02af23345444035b1d30d1414e17928e85 \
-                            sha256  ce7aac2cde05dde2bf6c3876f2f68499aac9fe923d719f396a31537cf9d2be9e \
-                            size    178432888
+        checksums           rmd160  282cd206f8023cbfe4d595251a4dd7a92db5957a \
+                            sha256  e7cc57bf645c444661528bc56c893e8612224e1e8ed2124298d15eb93351c4be \
+                            size    178439602
     }
     default {
         known_fail yes
@@ -62,7 +62,7 @@ build {}
 
 destroot {
     set dotnet_home ${prefix}/share/dotnet
-    set dotnet_runtime_version 6.0.24
+    set dotnet_runtime_version 6.0.25
 
     # ASP.NET Core Targeting Pack
     set aspnet_target_dir /packs/Microsoft.AspNetCore.App.Ref

--- a/dotnet/dotnet-sdk-7/Portfile
+++ b/dotnet/dotnet-sdk-7/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dotnet-sdk-7
-version             7.0.403
+version             7.0.404
 revision            0
 categories          dotnet devel
 license             MIT
@@ -27,16 +27,16 @@ switch ${build_arch} {
     x86_64 {
         set dotnet_rid osx-x64
         distname            dotnet-sdk-${version}-osx-x64
-        checksums           rmd160  d27ed4686ba134a5f9db3516072c79544bc4c32a \
-                            sha256  3e1a003243960847fd976f5e155173bbd345f6c9f1c2f6c3d72fd1f1828fb9bb \
-                            size    217007906
+        checksums           rmd160  b7b4382263f1e77837d76d93c06d833997e1f385 \
+                            sha256  a7603bb0d3e9aa695edb7fd0663cad0e924fe0ee3ab836c5bf42198588a700fe \
+                            size    217007732
     }
     arm64 {
         set dotnet_rid osx-arm64
         distname            dotnet-sdk-${version}-osx-arm64
-        checksums           rmd160  3fb492d21f877b0b571fc6260045c823009b2ad6 \
-                            sha256  94521e4d619f39b4c5ae85c4c9694957e979f7d952ad962a52f1a2d3d075ad55 \
-                            size    211888227
+        checksums           rmd160  65961bcac03a9b1b093d054bb331f2c5ba238536 \
+                            sha256  88e75c15f78d72f57038db6f49dc7274de507aea5f239de64a082bfb86131e03 \
+                            size    211867877
     }
     default {
         known_fail yes
@@ -62,7 +62,7 @@ build {}
 
 destroot {
     set dotnet_home ${prefix}/share/dotnet
-    set dotnet_runtime_version 7.0.13
+    set dotnet_runtime_version 7.0.14
 
     # ASP.NET Core Targeting Pack
     set aspnet_target_dir /packs/Microsoft.AspNetCore.App.Ref


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

dotnet-6: runtime update to 6.0.25; sdk update to 6.0.417
dotnet-7: runtime update to 7.0.14; sdk update to 7.0.404

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1 23B81 arm64
Command Line Tools 15.0.0.0.1.1694021235


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
