### PR TITLE
dotnet-8: new set of ports

### DIFF
--- a/dotnet/aspnetcore-runtime-8/Portfile
+++ b/dotnet/aspnetcore-runtime-8/Portfile
@@ -1,0 +1,70 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                aspnetcore-runtime-8
+version             8.0.0
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} \
+                    {@judaew judaew} openmaintainer
+
+description         ASP.NET Core is a cross-platform .NET framework for building modern \
+                    cloud-based web applications on Windows, Mac, or Linux.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64 arm64
+
+switch ${build_arch} {
+    x86_64 {
+        distname            aspnetcore-runtime-${version}-osx-x64
+        checksums           rmd160  5f0ed5e239d65fa0844174020287bbe675844128 \
+                            sha256  5690e6dc2c014b42b8173743405872fa3b72f97e20cae1f5a7e10439f11e8c99 \
+                            size    41458744
+    }
+    arm64 {
+        distname            aspnetcore-runtime-${version}-osx-arm64
+        checksums           rmd160  1865efc93685b84e4a3145a6b410074b2a07a709 \
+                            sha256  328bbe124c078cce5e1700dee8e2d1b108351b22d18c566ba316ebb380d357de \
+                            size    39527321
+    }
+    default {
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} @ ${version} only supported for architectures ${supported_archs}"
+            return -code error "Unsupported architecture: ${build_arch}"
+        }
+    }
+}
+
+master_sites        https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/${version}/
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli \
+                    port:dotnet-runtime-8
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set runtime_dir /shared/Microsoft.AspNetCore.App
+    xinstall -d ${destroot}${dotnet_home}${runtime_dir}
+
+    move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
+}
+
+livecheck.type      regex
+livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/8.0
+livecheck.regex     "ASP.NET Core Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/aspnetcore-runtime-devel/Portfile
+++ b/dotnet/aspnetcore-runtime-devel/Portfile
@@ -67,6 +67,9 @@ destroot {
     move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
 }
 
+notes ".NET 8 has become a steady version so please use `aspnetcore-runtime-8` port instead.
+The maintenance of this port will be suspended until a new preview version is released."
+
 livecheck.version   [join [lrange [split ${patch_version} .] 0 0] .]
 livecheck.type      regex
 livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/8.0

--- a/dotnet/dotnet-cli/Portfile
+++ b/dotnet/dotnet-cli/Portfile
@@ -24,7 +24,7 @@
 PortSystem          1.0
 
 name                dotnet-cli
-version             7.0.14
+version             8.0.0
 revision            0
 categories          dotnet
 license             MIT
@@ -52,15 +52,15 @@ master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
 switch ${build_arch} {
     x86_64 {
         distname            dotnet-runtime-${version}-osx-x64
-        checksums           rmd160  dc0a0ca8ab01aa6e254d7608afa642f4b3bcbf09 \
-                            sha256  49fc6e252514290b22b639c8612c6ef06faffedc808113beb1c806be484b4863 \
-                            size    30845624
+        checksums           rmd160  7808f1b8264dd809f3356e3c4416710dbab507f4 \
+                            sha256  ac54851b166c1df0a8726ff1649c0c118ea9c38d4c8b26268215c2282a6fbf0c \
+                            size    30890194
     }
     arm64 {
         distname            dotnet-runtime-${version}-osx-arm64
-        checksums           rmd160  b098d6ee6a57a58534d8d8e91e927b22b3698360 \
-                            sha256  506235647bcd154ca058c181362e527c18f9ca0ae6edf06f4a7b01793d824968 \
-                            size    29180006
+        checksums           rmd160  ee0df181fefd87d08a15e20ec2f0349645361ec8 \
+                            sha256  60d6cb60ae1aab439188f1a7b0b6d62f3f7c25ca71de29e6cef62769a16b2daa \
+                            size    29224894
     }
     default {
         known_fail yes

--- a/dotnet/dotnet-runtime-8/Portfile
+++ b/dotnet/dotnet-runtime-8/Portfile
@@ -1,0 +1,71 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-runtime-8
+version             8.0.0
+revision            0
+categories          dotnet
+license             MIT
+maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} \
+                    {@judaew judaew} openmaintainer
+
+description         .NET is a cross-platform runtime for cloud, mobile, desktop, and IoT apps.
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64 arm64
+
+switch ${build_arch} {
+    x86_64 {
+        distname            dotnet-runtime-${version}-osx-x64
+        checksums           rmd160  7808f1b8264dd809f3356e3c4416710dbab507f4 \
+                            sha256  ac54851b166c1df0a8726ff1649c0c118ea9c38d4c8b26268215c2282a6fbf0c \
+                            size    30890194
+    }
+    arm64 {
+        distname            dotnet-runtime-${version}-osx-arm64
+        checksums           rmd160  ee0df181fefd87d08a15e20ec2f0349645361ec8 \
+                            sha256  60d6cb60ae1aab439188f1a7b0b6d62f3f7c25ca71de29e6cef62769a16b2daa \
+                            size    29224894
+    }
+    default {
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} @ ${version} only supported for architectures ${supported_archs}"
+            return -code error "Unsupported architecture: ${build_arch}"
+        }
+    }
+}
+
+master_sites        https://dotnetcli.azureedge.net/dotnet/Runtime/${version}/
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set hostfxr_dir /host/fxr
+    set runtime_dir /shared/Microsoft.NETCore.App
+    xinstall -d ${destroot}${dotnet_home}${hostfxr_dir}
+    xinstall -d ${destroot}${dotnet_home}${runtime_dir}
+
+    move ${worksrcpath}${hostfxr_dir}/${version} ${destroot}${dotnet_home}${hostfxr_dir}
+    move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
+}
+
+livecheck.type      regex
+livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/8.0
+livecheck.regex     ".NET Runtime (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-runtime-devel/Portfile
+++ b/dotnet/dotnet-runtime-devel/Portfile
@@ -66,6 +66,9 @@ destroot {
     move ${worksrcpath}${runtime_dir}/${version} ${destroot}${dotnet_home}${runtime_dir}
 }
 
+notes ".NET 8 has become a steady version so please use `dotnet-runtime-8` port instead.
+The maintenance of this port will be suspended until a new preview version is released."
+
 livecheck.version   [join [lrange [split ${patch_version} .] 0 0] .]
 livecheck.type      regex
 livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/8.0

--- a/dotnet/dotnet-sdk-8/Portfile
+++ b/dotnet/dotnet-sdk-8/Portfile
@@ -1,0 +1,104 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                dotnet-sdk-8
+version             8.0.100
+revision            0
+categories          dotnet devel
+license             MIT
+maintainers         {@tsabirgaliev gmail.com:tair.sabirgaliev} \
+                    {@judaew judaew} openmaintainer
+
+description         Core functionality needed to create .NET Core projects, that is \
+                    shared between Visual Studio and CLI
+
+long_description    .NET is a free, cross-platform, open source developer platform \
+                    for building many different types of applications. \
+                    \
+                    With .NET, you can use multiple languages, editors, and libraries \
+                    to build for web, mobile, desktop, games, and IoT.
+
+homepage            https://dotnet.microsoft.com/
+platforms           darwin
+supported_archs     x86_64 arm64
+
+switch ${build_arch} {
+    x86_64 {
+        set dotnet_rid osx-x64
+        distname            dotnet-sdk-${version}-osx-x64
+        checksums           rmd160  89af8cfb083b79f7f4b6e5881bf4349ed28a0332 \
+                            sha256  cfbde9f7ef322332bcd0749fc5da843c09cf78e1cc4d10d3358d3ae4dc655c24 \
+                            size    212677343
+    }
+    arm64 {
+        set dotnet_rid osx-arm64
+        distname            dotnet-sdk-${version}-osx-arm64
+        checksums           rmd160  a492a04d9fd3e74cefeba16e89113d20641d45d6 \
+                            sha256  e6ba41f9340fe71875bb569df92fa8e400f0cf71abf3cf19e5f1f8bd5e3e7bf5 \
+                            size    207464431
+    }
+    default {
+        known_fail yes
+        pre-fetch {
+            ui_error "${subport} @ ${version} only supported for architectures ${supported_archs}"
+            return -code error "Unsupported architecture: ${build_arch}"
+        }
+    }
+}
+
+master_sites        https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/
+
+worksrcdir          ${name}-${version}
+extract.mkdir       yes
+
+use_configure       no
+
+depends_run         port:dotnet-cli \
+                    port:dotnet-runtime-8 \
+                    port:aspnetcore-runtime-8
+
+build {}
+
+destroot {
+    set dotnet_home ${prefix}/share/dotnet
+    set dotnet_runtime_version 8.0.0
+
+    # ASP.NET Core Targeting Pack
+    set aspnet_target_dir /packs/Microsoft.AspNetCore.App.Ref
+    set aspnet_target_version ${dotnet_runtime_version}
+    xinstall -d ${destroot}${dotnet_home}${aspnet_target_dir}
+    move ${worksrcpath}${aspnet_target_dir}/${aspnet_target_version} ${destroot}${dotnet_home}${aspnet_target_dir}
+
+    # .NET AppHost Pack
+    set dotnet_apphost_dir /packs/Microsoft.NETCore.App.Host.${dotnet_rid}
+    set dotnet_apphost_version ${dotnet_runtime_version}
+    xinstall -d ${destroot}${dotnet_home}${dotnet_apphost_dir}
+    move ${worksrcpath}${dotnet_apphost_dir}/${dotnet_apphost_version} ${destroot}${dotnet_home}${dotnet_apphost_dir}
+
+    # .NET Targeting Pack
+    set dotnet_target_dir /packs/Microsoft.NETCore.App.Ref
+    set dotnet_target_version ${dotnet_runtime_version}
+    xinstall -d ${destroot}${dotnet_home}${dotnet_target_dir}
+    move ${worksrcpath}${dotnet_target_dir}/${dotnet_target_version} ${destroot}${dotnet_home}${dotnet_target_dir}
+
+    # SDK
+    xinstall -d ${destroot}${dotnet_home}/sdk
+    move ${worksrcpath}/sdk/${version} ${destroot}${dotnet_home}/sdk
+
+    # SDK-Manifests
+    set dotnet_manifest_version 8.0.100
+    xinstall -d ${destroot}${dotnet_home}/sdk-manifests
+    move ${worksrcpath}/sdk-manifests/${dotnet_manifest_version} ${destroot}${dotnet_home}/sdk-manifests
+    # remove this once all sdk-manifests are out of rc
+    move ${worksrcpath}/sdk-manifests/8.0.100-rc.2 ${destroot}${dotnet_home}/sdk-manifests
+
+    # Templates
+    set dotnet_templates_version ${dotnet_runtime_version}
+    xinstall -d ${destroot}${dotnet_home}/templates
+    move ${worksrcpath}/templates/${dotnet_templates_version} ${destroot}${dotnet_home}/templates
+}
+
+livecheck.type      regex
+livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/8.0
+livecheck.regex     "SDK (\\d+(?:\\.\\d+)*)"

--- a/dotnet/dotnet-sdk-devel/Portfile
+++ b/dotnet/dotnet-sdk-devel/Portfile
@@ -80,6 +80,9 @@ destroot {
     move ${worksrcpath}/sdk-manifests/${dotnet_manifest_version} ${destroot}${dotnet_home}/sdk-manifests
 }
 
+notes ".NET 8 has become a steady version so please use `dotnet-sdk-8` port instead.
+The maintenance of this port will be suspended until a new preview version is released."
+
 livecheck.version   [join [lrange [split ${patch_version} .] 0 0] .]
 livecheck.type      regex
 livecheck.url       https://dotnet.microsoft.com/en-us/download/dotnet/8.0


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

dotnet-8: runtime verison 8.0.0; sdk version 8.0.100

`port lint --nitpick` is known to fail because `${dotnet_manifest_version}` is the same as `${version}`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1 23B81 arm64
Command Line Tools 15.0.0.0.1.1694021235


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
