### PR TITLE
gdal: fix std::shared_mutex build failure; enable build with libxml2 2.12

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -47,6 +47,8 @@ compiler.thread_local_storage yes
 patchfiles-append   0001-sqlite_rtree_bulk_load.c-define-__STDC_FORMAT_MACROS.patch
 # for GDAL 3.8.0 with libxml2 2.12
 patchfiles-append   patch-build-for-libxml2-12.diff
+# https://trac.macports.org/ticket/68716
+patchfiles-append   patch-have_shared_mutex.diff
 
 configure.optflags  -DGDAL_COMPILATION
 

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -45,6 +45,8 @@ compiler.thread_local_storage yes
 # https://github.com/OSGeo/gdal/pull/8748
 # https://trac.macports.org/ticket/68734
 patchfiles-append   0001-sqlite_rtree_bulk_load.c-define-__STDC_FORMAT_MACROS.patch
+# for GDAL 3.8.0 with libxml2 2.12
+patchfiles-append   patch-build-for-libxml2-12.diff
 
 configure.optflags  -DGDAL_COMPILATION
 

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -36,7 +36,13 @@ use_xz              yes
 # error: call to 'abs' is ambiguous
 compiler.blacklist-append {clang < 900}
 
-compiler.cxx_standard 2014
+# Enable use of std::shared_mutex on systems that support it (macOS 10.12+),
+# next major GDAL version (>3.8) will require C++17.
+if {${os.platform} eq "darwin" && ${os.major} < 16} {
+    compiler.cxx_standard 2014
+} else {
+    compiler.cxx_standard 2017
+}
 cmake.set_cxx_standard yes
 
 # See https://trac.macports.org/ticket/56908

--- a/gis/gdal/files/patch-build-for-libxml2-12.diff
+++ b/gis/gdal/files/patch-build-for-libxml2-12.diff
@@ -1,0 +1,32 @@
+Patch to enable GDAL 3.8.0 build with libxml2 2.12, as noted in
+https://lists.osgeo.org/pipermail/gdal-dev/2023-November/057965.html
+
+--- gcore/gdaljp2metadatagenerator.cpp.orig
++++ gcore/gdaljp2metadatagenerator.cpp
+@@ -357,7 +357,12 @@
+ /************************************************************************/
+ 
+ static void GDALGMLJP2XPathErrorHandler(void * /* userData */,
+-                                        xmlErrorPtr error)
++#if LIBXML_VERSION >= 21200
++                                        const xmlError *error
++#else
++                                        xmlErrorPtr error
++#endif
++)
+ {
+     if (error->domain == XML_FROM_XPATH && error->str1 != nullptr &&
+         error->int1 < static_cast<int>(strlen(error->str1)))
+
+
+--- port/cpl_xml_validate.cpp.orig
++++ port/cpl_xml_validate.cpp
+@@ -914,7 +914,7 @@
+ 
+     if (strstr(pszStr, "since this namespace was already imported") == nullptr)
+     {
+-        xmlErrorPtr pErrorPtr = xmlGetLastError();
++        const xmlError *pErrorPtr = xmlGetLastError();
+         const char *pszFilename = static_cast<char *>(ctx);
+         char *pszStrDup = CPLStrdup(pszStr);
+         int nLen = static_cast<int>(strlen(pszStrDup));

--- a/gis/gdal/files/patch-have_shared_mutex.diff
+++ b/gis/gdal/files/patch-have_shared_mutex.diff
@@ -1,0 +1,51 @@
+Addresses https://trac.macports.org/ticket/68716,
+committed upstream https://github.com/OSGeo/gdal/commit/994e40dbbf3dfd58ad66de02d87070afafd8da88
+
+--- cmake/template/cpl_config.h.in.orig
++++ cmake/template/cpl_config.h.in
+@@ -175,6 +175,9 @@
+ /* Define to 1 if you have the `sched_getaffinity' function. */
+ #cmakedefine HAVE_SCHED_GETAFFINITY 1
+ 
++/* Define to 1 if you have the `std::shared_mutex' function. */
++#cmakedefine HAVE_SHARED_MUTEX 1
++
+ /* Define to 1 if you have the `uselocale' function. */
+ #cmakedefine HAVE_USELOCALE 1
+ 
+
+
+--- cmake/helpers/configure.cmake.orig
++++ cmake/helpers/configure.cmake
+@@ -359,6 +359,19 @@
+     add_definitions(-DDONT_DEPRECATE_SPRINTF)
+   endif ()
+ 
++  check_cxx_source_compiles(
++    "
++    #include <shared_mutex>
++    int main(int argc, const char * argv[]) {
++        std::shared_mutex smtx;
++        smtx.lock_shared();
++        smtx.unlock_shared();
++        return 0;
++    }
++    "
++    HAVE_SHARED_MUTEX
++  )
++
+   check_include_file("linux/userfaultfd.h" HAVE_USERFAULTFD_H)
+ endif ()
+
+
+--- port/cpl_vsi_mem.cpp.orig
++++ port/cpl_vsi_mem.cpp
+@@ -50,7 +50,7 @@
+ 
+ #include <mutex>
+ // c++17 or VS2017
+-#if __cplusplus >= 201703L || _MSC_VER >= 1910
++#if defined(HAVE_SHARED_MUTEX) || _MSC_VER >= 1910
+ #include <shared_mutex>
+ #define CPL_SHARED_MUTEX_TYPE std::shared_mutex
+ #define CPL_SHARED_LOCK std::shared_lock<std::shared_mutex>


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- fix build failure on missing std::shared_mutex
   Closes https://trac.macports.org/ticket/68716
- enable build with libxml2 version 2.12
   (suggested in https://lists.osgeo.org/pipermail/gdal-dev/2023-November/057965.html)
-  set CXX standard to 2017 for macOS 10.12+
   enables the use of std::shared_mutex, which was introduced with version 3.8.0,
for systems that support it.



###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.2 22G320 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
