### PR TITLE
libomp: reduce build dependencies on old systems

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -86,8 +86,14 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
         worksrcdir      openmp-${version}/final/runtime
         version         3.8.1
         checksums       rmd160  a41054068a127ef84610afef8090109078cb6c46 \
-                        sha256  4c46b5946fe9b2a701661746d11c7c85c51a7f18673194a7ebd2a43470948a34
+                        sha256  4c46b5946fe9b2a701661746d11c7c85c51a7f18673194a7ebd2a43470948a34 \
+                        size    5587986
         set rtpath      "./"
+
+        # use cmake-bootstrap to minimize dependencies.
+        depends_build-replace  \
+                        path:bin/cmake:cmake port:cmake-bootstrap
+        configure.cmd   ${prefix}/libexec/cmake-bootstrap/bin/cmake
     }
     livecheck.type      none
 }
@@ -101,7 +107,7 @@ compiler.blacklist-append {clang < 500} *gcc*
 # https://trac.macports.org/ticket/68490#
 # Use clang-11-bootstrap on OSX10.11 and older
 if {${os.major} <= 15} {
-    compiler.blacklist-append clang *gcc*
+    configure.compiler.add_deps no
     depends_build-append port:clang-11-bootstrap
     depends_skip_archcheck-append clang-11-bootstrap
     pre-configure {


### PR DESCRIPTION
#### Description

Here I've replaced cmake to `cmake-bootstrap` for `libomp-3.8.1` which is pin on system which uses `cxx_stdlib=libstdc++`.

I also avoid dependency to `clang-3.7` when it uses `clang-11-bootstrap`, and added size to checksum.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->