### PR TITLE
py-pybtex{,-docutils}: add py311 and py312 subports

### DIFF
--- a/python/py-pybtex-docutils/Portfile
+++ b/python/py-pybtex-docutils/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  895e12df114e3a87eed4570d85ec7dc778f7dea0 \
                     sha256  d53aa0c31dc94d61fd30ea3f06c749e6f510f9ff0e78cb2765a9300f173d8626 \
                     size    14234
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-pybtex/Portfile
+++ b/python/py-pybtex/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  a735bc1a36c3e229a686d0a9c648620b954fbccc \
                     sha256  818eae35b61733e5c007c3fcd2cfb75ed1bc8b4173c1f70b56cc4c0802d34755 \
                     size    402879
 
-python.versions     27 37 38 39 310
+python.versions     27 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-latexcodec \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Tests:
* py-pybtex-docutils has no tests
* py-pybtex: eight tests fail in the py311 subport, but they the same tests fail in both the py310 and the py37 subport as well (3.6 is the minimum supported version, but we do not provide a subport for that version). I therefore do not think that I broke anything. The tests require py-nose, which is incompatible with Python 3.12 because of the removal of `imp`.