### PR TITLE
py-m2crypto: fix build error

### DIFF
--- a/python/py-m2crypto/Portfile
+++ b/python/py-m2crypto/Portfile
@@ -40,10 +40,14 @@ if {${name} ne ${subport}} {
         openssl.branch      3
     }
     set openssl_nodot       [string map {. {}} openssl${openssl.branch}]
+    set openssl_path        ${prefix}/libexec/${openssl_nodot}
 
     if {${python.version} > 36} {
         depends_lib-append  port:py${python.version}-importlib-metadata
         depends_test-append port:py${python.version}-parameterized
+        build.cmd-append    --config-setting openssl=${openssl_path}
+    } else {
+        build.cmd-append    build_ext --openssl=${openssl_path}
     }
 
     patchfiles              patch-setup.py.diff
@@ -57,7 +61,6 @@ if {${name} ne ${subport}} {
         build.env-append    "SWIG_FEATURES=\
             -I${prefix}/libexec/${openssl_nodot}/include"
     }
-    build.cmd-append        build_ext --openssl=${prefix}/libexec/${openssl_nodot}
 
     test.run                yes
 


### PR DESCRIPTION
Errors due to change from setup.py to build module on python37 and later. Build checks were successful on the original PR (#20551) before merge.

closes: https://trac.macports.org/ticket/68752
closes: https://trac.macports.org/ticket/66337

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1 23B81 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
