### PR TITLE
libunwind: reduce build dependencies on old systems

### DIFF
--- a/devel/libunwind/Portfile
+++ b/devel/libunwind/Portfile
@@ -17,11 +17,19 @@ homepage                http://blog.llvm.org/2013/10/new-libunwind-implementatio
 master_sites            https://releases.llvm.org/${version}/
 dist_subdir             llvm
  
-use_xz                  yes
 distname                ${name}-${version}.src
 
+# use xz-bootstrap to minimize dependency tree
+depends_extract         port:xz-bootstrap
+depends_skip_archcheck-append \
+                        xz-bootstrap
+
+extract.suffix          .tar.xz
+extract.cmd             ${prefix}/libexec/xz-bootstrap/bin/xz
+
 checksums               rmd160  26d3dac149e2fd355e1b8b367a9bf61e01c38fbf \
-                        sha256  6bbfbf6679435b858bd74bdf080386d084a76dfbf233fb6e47b2c28e0872d0fe
+                        sha256  6bbfbf6679435b858bd74bdf080386d084a76dfbf233fb6e47b2c28e0872d0fe \
+                        size    72180
 
 use_configure           no
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->