### PR TITLE
py-tinydb: New port, version 4.7.1

### DIFF
--- a/python/py-tinydb/Portfile
+++ b/python/py-tinydb/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-tinydb
+version             4.7.1
+revision            0
+categories-append   devel
+license             MIT
+supported_archs     noarch
+platforms           {darwin any}
+
+maintainers         nomaintainer
+
+description         TinyDB is a tiny, document oriented database
+
+long_description    TinyDB is a lightweight document oriented database \
+                    optimized for your happiness :).
+
+homepage            https://github.com/msiemens/tinydb
+
+checksums           rmd160  b4e50dc8fa5cf39111fcda06f6a4bfbff71e12d3 \
+                    sha256  8955c239a79b8a6c8f637900152e2de38690848199d71d870c33c16405433ca5 \
+                    size    32523
+
+python.versions     38 39 310 311 312
+python.pep517       yes
+python.pep517_backend poetry


### PR DESCRIPTION
#### Description

This PR adds a new port for the python tinydb module (https://tinydb.readthedocs.io/en/latest/index.html).

I have tried a minimal tinydb example as shown in the tinydb documentation and this seems to be working.  I have tested the py310-tinydb package, have not tried with the other python versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] submission

###### Tested on
macOS 13.3.1 22E261 arm64
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

