### PR TITLE
py-frozendict: New port, version 2.3.10

### DIFF
--- a/python/py-frozendict/Portfile
+++ b/python/py-frozendict/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-frozendict
+version             2.3.10
+revision            0
+
+categories-append   devel
+license             LGPL-3
+maintainers         nomaintainer
+
+description         frozendict is a simple immutable dictionary
+long_description    {*}${description}. It's fast as dict, and \
+                    sometimes faster! Unlike other similar \
+                    implementations, immutability is guaranteed: \
+                    you can't change the internal variables of \
+                    the class, and they are all immutable objects.
+
+homepage            https://github.com/Marco-Sulla/python-frozendict
+
+checksums           rmd160  458b02b34360e7b74b09b7b20b89d7cb5dc6f29d \
+                    sha256  aadc83510ce82751a0bb3575231f778bc37cbb373f5f05a52b888e26cbb92f79 \
+                    size    312896
+
+python.versions     38 39 310 311 312
+
+if {${name} ne ${subport}} {
+    # C extension is only available for earlier Python versions
+    if {${python.version} >= 311} {
+        supported_archs noarch
+        platforms       {darwin any}
+    }
+}


### PR DESCRIPTION
#### Description

This PR adds a new port for the python frozendict module (https://github.com/Marco-Sulla/python-frozendict).

I have tried the API examples shown in the README and they work as expected. I have just tried the python 3.11 port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] submission

###### Tested on
macOS 13.3.1 22E261 arm64

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
