### PR TITLE
paho.mqtt.cpp: update to 1.3.0

### DIFF
--- a/net/paho.mqtt.cpp/Portfile
+++ b/net/paho.mqtt.cpp/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           openssl 1.0
 
-github.setup        eclipse paho.mqtt.cpp 1.2.0 v
+github.setup        eclipse paho.mqtt.cpp 1.3.0 v
 revision            0
 categories          net
 maintainers         nomaintainer
@@ -27,6 +27,6 @@ depends_lib-append \
 configure.args-append \
                     -DPAHO_WITH_SSL=ON
 
-checksums           rmd160  435b0a3366dd68811c372e76b02ddd868c55d43a \
-                    sha256  2640f780b1cab2baab0d85dd74a0298c4ff2976d8174cfe63a63d01233fee3ee \
-                    size    216127
+checksums           rmd160  a771074c3ac147c4f7193020bda476f185a5a776 \
+                    sha256  9c96d48f145f370108a010fd8f0cb083ffb784fa239a1539b8599fbe77e098e6 \
+                    size    230491


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/eclipse/paho.mqtt.cpp/releases/tag/v1.3.0)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
