### PR TITLE
emacs: revbump for new GCC, update to gcc13

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -103,7 +103,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         29.1
-    revision        2
+    revision        3
 
     checksums       rmd160  c306a0554d77ee472600ed28af4751211dc1ec70 \
                     sha256  5b80e0475b0e619d2ad395ef5bc481b7cb9f13894ed23c301210572040e4b5b1 \
@@ -116,7 +116,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     github.setup    emacs-mirror emacs e32c57ed4d36c5c0302eeb409f96ce9155b545ea
     epoch           5
     version         20231119
-    revision        0
+    revision        1
 
     master_sites    ${github.master_sites}
 
@@ -269,7 +269,7 @@ if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
 }
 
 variant nativecomp description {Builds emacs with native compilation support} {
-    set gcc_v                      12
+    set gcc_v                      13
     depends_lib-append             port:gcc${gcc_v}
     configure.args-append          --with-native-compilation=aot
     compiler.cpath-prepend         ${prefix}/include/gcc${gcc_v}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->