### PR TITLE
iperf3-devel: obsolete port

### DIFF
--- a/net/iperf3/Portfile
+++ b/net/iperf3/Portfile
@@ -35,19 +35,14 @@ if {${subport} eq ${name}} {
                         sha256  9b03a51623d2098eddbd04f8802d1d03def5571a0fcd97b3ce5b51b52b07d84d \
                         size    652099
 
-    conflicts           ${name}-devel
-
     github.livecheck.regex {([0-9.]+)}
 }
 
 subport ${name}-devel {
-    github.setup        esnet iperf 40a663b2871dce1da4cee571a62e43d3557e6816
-    version             20230719
+    PortGroup           obsolete 1.0
+    version             20231123
     revision            0
 
-    checksums           rmd160  97b1a842b052557063d1456c84b8e9e189acaf30 \
-                        sha256  bcd79dcbe3dd4fc0987aa34e5ee99a80b0025cd012ab268491e4bfd842c871b5 \
-                        size    650883
-
-    conflicts           ${name}
+    # remove this subport after November 24, 2024
+    replaced_by         ${name}
 }


### PR DESCRIPTION
#### Description
Moving port to obsolete status.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1 23B81 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
