### PR TITLE
sysutils/stressdrive: update to 1.4

### DIFF
--- a/sysutils/stressdrive/Portfile
+++ b/sysutils/stressdrive/Portfile
@@ -5,8 +5,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           xcode 1.0
 
-github.setup        rentzsch stressdrive 1.3.2
-revision            1
+github.setup        rentzsch stressdrive 1.4
+revision            0
 categories          sysutils
 platforms           darwin
 maintainers         {@toy yandex.com:bstj} openmaintainer
@@ -24,9 +24,9 @@ long_description    ${description} by filling a drive up with random data \
 
 notes               "${danger}"
 
-checksums           rmd160  abab2499c1fe405b8df447b2a9b8aa3b7e5775f3 \
-                    sha256  ecb51c26fa299464bf7627242ef4047a56061d706b8552fbc30b2ab3fa44ee55 \
-                    size    7298
+checksums           rmd160  7dd1ffe2a44c7451d25b1c11f43db28b4b68b6d0 \
+                    sha256  3e43f5b7f418695fe2e12aaa024fc7ce5d6d8d480fbdbaa298093460d3b2a162 \
+                    size    8260
 
 depends_lib         port:openssl
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.1
Xcode 14.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
