### PR TITLE
py-poppler-qt5: unbreak installation for python 3.7 and later

### DIFF
--- a/python/py-poppler-qt5/Portfile
+++ b/python/py-poppler-qt5/Portfile
@@ -6,6 +6,7 @@ PortGroup           python 1.0
 name                py-poppler-qt5
 python.rootname     python-poppler-qt5
 version             21.3.0
+revision            1
 
 platforms           darwin
 license             LGPL-2.1+
@@ -36,6 +37,9 @@ if {${name} ne ${subport}} {
     }
 
     PortGroup       qmake5 1.0
+
+    # see https://trac.macports.org/ticket/68764
+    python.pep517   no
 
     # see https://trac.macports.org/ticket/68287
     patchfiles-append force-cxx17.diff


### PR DESCRIPTION
* set python.pep517 to no so that install is done properly

Closes: https://trac.macports.org/ticket/68764

#### Description

Unbreak py3*-poppler-qt5 installations by setting python.pep517 to no so that make in destroot is called with install.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
