### PR TITLE
cmake-{devel}: remove variants for EOL Python versions

### DIFF
--- a/devel/cmake-devel/Portfile
+++ b/devel/cmake-devel/Portfile
@@ -269,7 +269,7 @@ subport ${subport_docs} {
     }
 
     # Supported pythons
-    set python_versions {35 36 37 38 39 310 311}
+    set python_versions {38 39 310 311}
 
     # declare all +python* variants, with conflicts
     foreach pyver ${python_versions} {

--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -211,7 +211,7 @@ post-destroot {
 # due to the default compiler needing cmake to build.
 if {[info exists cmake_bootstrapping]} {
     set some_variant_disabled 0
-    foreach vname { qt5 docs python35 python36 python37 python38 python39 python310 python311 } {
+    foreach vname { qt5 docs python38 python39 python310 python311} {
         if {[variant_isset $vname]} {
             unset ::variations($vname)
             set some_variant_disabled 1
@@ -236,7 +236,7 @@ if {![variant_isset qt5]} {
 }
 
 # Supported pythons
-set python_versions {35 36 37 38 39 310 311}
+set python_versions {38 39 310 311}
 
 # declare all +python* variants, with conflicts
 foreach pyver ${python_versions} {
@@ -287,7 +287,7 @@ if {[variant_isset docs]} {
     }
 
     if {!${python_isset}} {
-        ui_error "\n\nYou must select exactly one of the +python35, +python36, +python37, +python38, +python39, +python310, or +python311 variants when using variant +docs.\n"
+        ui_error "\n\nYou must select exactly one of the +python38, +python39, +python310, or +python311 variants when using variant +docs.\n"
         return -code error "Invalid variant selection"
     }
 }


### PR DESCRIPTION
#### Description
Frankly, I think there shouldn't be any variants and the documentation should just be build with MacPorts' defaul Python versions. But at least, there shouldn't be variants for EOL Python versions anymore.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.1.1 23B81 x86_64
Xcode 15.0.1 15A507


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
