### PR TITLE
ffmpeg{,-devel}: fix build with texinfo >= 7

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -119,6 +119,12 @@ patchfiles-append   patch-issue-9439-non-b-frame-encoding.diff
 # Fixed via upstream commit: 031f1561cd286596cdb374da32f8aa816ce3b135
 patchfiles-append   patch-libavcodec-libsvtav1-ten_bit_format.diff
 
+# Patch for building docs with texinfo >= 7
+# https://trac.macports.org/ticket/68747
+# https://trac.ffmpeg.org/ticket/10636
+# Fixed via upstream commit: f01fdedb69e4accb1d1555106d8f682ff1f1ddc7
+patchfiles-append   patch-texinfo-7.diff
+
 # enable auto configure of asm optimizations
 # requires Xcode 3.1 or better on Leopard
 minimum_xcodeversions {9 3.1}

--- a/multimedia/ffmpeg-devel/files/patch-texinfo-7.diff
+++ b/multimedia/ffmpeg-devel/files/patch-texinfo-7.diff
@@ -1,0 +1,207 @@
+Backported from the below upstream commit.
+
+From f01fdedb69e4accb1d1555106d8f682ff1f1ddc7 Mon Sep 17 00:00:00 2001
+From: Frank Plowman <post@frankplowman.com>
+Date: Wed, 8 Nov 2023 07:55:18 +0000
+Subject: [PATCH 1/1] doc/html: support texinfo 7.0
+
+Resolves trac ticket #10636 (http://trac.ffmpeg.org/ticket/10636).
+
+Texinfo 7.0, released in November 2022, changed the names of various
+functions. Compiling docs with Texinfo 7.0 resulted in warnings and
+improperly formatted documentation. More old names appear to have
+been removed in Texinfo 7.1, released October 2023, which causes docs
+compilation to fail.
+
+This commit addresses the issue by adding logic to switch between the old
+and new function names depending on the Texinfo version. Texinfo 6.8
+produces identical documentation before and after the patch.
+
+CC
+https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1938238.html
+https://bugs.gentoo.org/916104
+
+Signed-off-by: Frank Plowman <post@frankplowman.com>
+---
+ doc/t2h.pm | 106 ++++++++++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 85 insertions(+), 21 deletions(-)
+
+diff --git a/doc/t2h.pm b/doc/t2h.pm
+index d07d974286..b7485e1f1e 100644
+--- doc/t2h.pm	2023-04-12 14:01:50
++++ doc/t2h.pm	2023-11-21 13:32:35
+@@ -20,8 +20,45 @@
+ # License along with FFmpeg; if not, write to the Free Software
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ 
++# Texinfo 7.0 changed the syntax of various functions.
++# Provide a shim for older versions.
++sub ff_set_from_init_file($$) {
++    my $key = shift;
++    my $value = shift;
++    if (exists &{'texinfo_set_from_init_file'}) {
++        texinfo_set_from_init_file($key, $value);
++    } else {
++        set_from_init_file($key, $value);
++    }
++}
++
++sub ff_get_conf($) {
++    my $key = shift;
++    if (exists &{'texinfo_get_conf'}) {
++        texinfo_get_conf($key);
++    } else {
++        get_conf($key);
++    }
++}
++
++sub get_formatting_function($$) {
++    my $obj = shift;
++    my $func = shift;
++
++    my $sub = $obj->can('formatting_function');
++    if ($sub) {
++        return $obj->formatting_function($func);
++    } else {
++        return $obj->{$func};
++    }
++}
++
++# determine texinfo version
++my $program_version_num = version->declare(ff_get_conf('PACKAGE_VERSION'))->numify;
++my $program_version_6_8 = $program_version_num >= 6.008000;
++
+ # no navigation elements
+-set_from_init_file('HEADERS', 0);
++ff_set_from_init_file('HEADERS', 0);
+ 
+ sub ffmpeg_heading_command($$$$$)
+ {
+@@ -55,7 +92,7 @@ sub ffmpeg_heading_command($$$$$)
+         $element = $command->{'parent'};
+     }
+     if ($element) {
+-        $result .= &{$self->{'format_element_header'}}($self, $cmdname,
++        $result .= &{get_formatting_function($self, 'format_element_header')}($self, $cmdname,
+                                                        $command, $element);
+     }
+ 
+@@ -112,7 +149,11 @@ sub ffmpeg_heading_command($$$$$)
+                 $cmdname
+                     = $Texinfo::Common::level_to_structuring_command{$cmdname}->[$heading_level];
+             }
+-            $result .= &{$self->{'format_heading_text'}}(
++            # format_heading_text expects an array of headings for texinfo >= 7.0
++            if ($program_version_num >= 7.000000) {
++                $heading = [$heading];
++            }
++            $result .= &{get_formatting_function($self,'format_heading_text')}(
+                         $self, $cmdname, $heading,
+                         $heading_level +
+                         $self->get_conf('CHAPTER_HEADER_LEVEL') - 1, $command);
+@@ -127,14 +168,14 @@ foreach my $command (keys(%Texinfo::Common::sectioning
+ }
+ 
+ # print the TOC where @contents is used
+-set_from_init_file('INLINE_CONTENTS', 1);
++ff_set_from_init_file('INLINE_CONTENTS', 1);
+ 
+ # make chapters <h2>
+-set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
++ff_set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
+ 
+ # Do not add <hr>
+-set_from_init_file('DEFAULT_RULE', '');
+-set_from_init_file('BIG_RULE', '');
++ff_set_from_init_file('DEFAULT_RULE', '');
++ff_set_from_init_file('BIG_RULE', '');
+ 
+ # Customized file beginning
+ sub ffmpeg_begin_file($$$)
+@@ -151,7 +192,18 @@ sub ffmpeg_begin_file($$$)
+     my ($title, $description, $encoding, $date, $css_lines,
+         $doctype, $bodytext, $copying_comment, $after_body_open,
+         $extra_head, $program_and_version, $program_homepage,
+-        $program, $generator) = $self->_file_header_informations($command);
++        $program, $generator);
++    if ($program_version_num >= 7.000000) {
++        ($title, $description, $encoding, $date, $css_lines,
++         $doctype, $bodytext, $copying_comment, $after_body_open,
++         $extra_head, $program_and_version, $program_homepage,
++         $program, $generator) = $self->_file_header_information($command);
++    } else {
++        ($title, $description, $encoding, $date, $css_lines,
++         $doctype, $bodytext, $copying_comment, $after_body_open,
++         $extra_head, $program_and_version, $program_homepage,
++         $program, $generator) = $self->_file_header_informations($command);
++    }
+ 
+     my $links = $self->_get_links ($filename, $element);
+ 
+@@ -207,7 +259,7 @@ sub ffmpeg_end_file($)
+ sub ffmpeg_end_file($)
+ {
+     my $self = shift;
+-    my $program_string = &{$self->{'format_program_string'}}($self);
++    my $program_string = &{get_formatting_function($self,'format_program_string')}($self);
+     my $program_text = <<EOT;
+       <p style="font-size: small;">
+         $program_string
+@@ -224,7 +276,7 @@ texinfo_register_formatting_function('end_file', \&ffm
+ 
+ # Dummy title command
+ # Ignore title. Title is handled through ffmpeg_begin_file().
+-set_from_init_file('USE_TITLEPAGE_FOR_TITLE', 1);
++ff_set_from_init_file('USE_TITLEPAGE_FOR_TITLE', 1);
+ sub ffmpeg_title($$$$)
+ {
+     return '';
+@@ -242,8 +294,14 @@ sub ffmpeg_float($$$$$)
+     my $args = shift;
+     my $content = shift;
+ 
+-    my ($caption, $prepended) = Texinfo::Common::float_name_caption($self,
+-                                                                $command);
++    my ($caption, $prepended);
++    if ($program_version_num >= 7.000000) {
++        ($caption, $prepended) = Texinfo::Convert::Converter::float_name_caption($self,
++                                                                                 $command);
++    } else {
++        ($caption, $prepended) = Texinfo::Common::float_name_caption($self,
++                                                                     $command);
++    }
+     my $caption_text = '';
+     my $prepended_text;
+     my $prepended_save = '';
+@@ -315,8 +373,13 @@ sub ffmpeg_float($$$$$)
+             $caption->{'args'}->[0], 'float caption');
+     }
+     if ($prepended_text.$caption_text ne '') {
+-        $prepended_text = $self->_attribute_class('div','float-caption'). '>'
+-                . $prepended_text;
++        if ($program_version_num >= 7.000000) {
++            $prepended_text = $self->html_attribute_class('div',['float-caption']). '>'
++                    . $prepended_text;
++        } else {
++            $prepended_text = $self->_attribute_class('div','float-caption'). '>'
++                    . $prepended_text;
++        }
+         $caption_text .= '</div>';
+     }
+     my $html_class = '';
+@@ -329,8 +392,13 @@ sub ffmpeg_float($$$$$)
+         $prepended_text = '';
+         $caption_text   = '';
+     }
+-    return $self->_attribute_class('div', $html_class). '>' . "\n" .
+-        $prepended_text . $caption_text . $content . '</div>';
++    if ($program_version_num >= 7.000000) {
++        return $self->html_attribute_class('div', [$html_class]). '>' . "\n" .
++            $prepended_text . $caption_text . $content . '</div>';
++    } else {
++        return $self->_attribute_class('div', $html_class). '>' . "\n" .
++            $prepended_text . $caption_text . $content . '</div>';
++    }
+ }
+ 
+ texinfo_register_command_formatting('float',

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -119,6 +119,12 @@ patchfiles-append   patch-issue-9439-non-b-frame-encoding.diff
 # Fixed via upstream commit: 031f1561cd286596cdb374da32f8aa816ce3b135
 patchfiles-append   patch-libavcodec-libsvtav1-ten_bit_format.diff
 
+# Patch for building docs with texinfo >= 7
+# https://trac.macports.org/ticket/68747
+# https://trac.ffmpeg.org/ticket/10636
+# Fixed via upstream commit: f01fdedb69e4accb1d1555106d8f682ff1f1ddc7
+patchfiles-append   patch-texinfo-7.diff
+
 # enable auto configure of asm optimizations
 # requires Xcode 3.1 or better on Leopard
 minimum_xcodeversions {9 3.1}

--- a/multimedia/ffmpeg/files/patch-texinfo-7.diff
+++ b/multimedia/ffmpeg/files/patch-texinfo-7.diff
@@ -1,0 +1,207 @@
+Backported from the below upstream commit.
+
+From f01fdedb69e4accb1d1555106d8f682ff1f1ddc7 Mon Sep 17 00:00:00 2001
+From: Frank Plowman <post@frankplowman.com>
+Date: Wed, 8 Nov 2023 07:55:18 +0000
+Subject: [PATCH 1/1] doc/html: support texinfo 7.0
+
+Resolves trac ticket #10636 (http://trac.ffmpeg.org/ticket/10636).
+
+Texinfo 7.0, released in November 2022, changed the names of various
+functions. Compiling docs with Texinfo 7.0 resulted in warnings and
+improperly formatted documentation. More old names appear to have
+been removed in Texinfo 7.1, released October 2023, which causes docs
+compilation to fail.
+
+This commit addresses the issue by adding logic to switch between the old
+and new function names depending on the Texinfo version. Texinfo 6.8
+produces identical documentation before and after the patch.
+
+CC
+https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1938238.html
+https://bugs.gentoo.org/916104
+
+Signed-off-by: Frank Plowman <post@frankplowman.com>
+---
+ doc/t2h.pm | 106 ++++++++++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 85 insertions(+), 21 deletions(-)
+
+diff --git a/doc/t2h.pm b/doc/t2h.pm
+index d07d974286..b7485e1f1e 100644
+--- doc/t2h.pm	2023-04-12 14:01:50
++++ doc/t2h.pm	2023-11-21 13:32:35
+@@ -20,8 +20,45 @@
+ # License along with FFmpeg; if not, write to the Free Software
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ 
++# Texinfo 7.0 changed the syntax of various functions.
++# Provide a shim for older versions.
++sub ff_set_from_init_file($$) {
++    my $key = shift;
++    my $value = shift;
++    if (exists &{'texinfo_set_from_init_file'}) {
++        texinfo_set_from_init_file($key, $value);
++    } else {
++        set_from_init_file($key, $value);
++    }
++}
++
++sub ff_get_conf($) {
++    my $key = shift;
++    if (exists &{'texinfo_get_conf'}) {
++        texinfo_get_conf($key);
++    } else {
++        get_conf($key);
++    }
++}
++
++sub get_formatting_function($$) {
++    my $obj = shift;
++    my $func = shift;
++
++    my $sub = $obj->can('formatting_function');
++    if ($sub) {
++        return $obj->formatting_function($func);
++    } else {
++        return $obj->{$func};
++    }
++}
++
++# determine texinfo version
++my $program_version_num = version->declare(ff_get_conf('PACKAGE_VERSION'))->numify;
++my $program_version_6_8 = $program_version_num >= 6.008000;
++
+ # no navigation elements
+-set_from_init_file('HEADERS', 0);
++ff_set_from_init_file('HEADERS', 0);
+ 
+ sub ffmpeg_heading_command($$$$$)
+ {
+@@ -55,7 +92,7 @@ sub ffmpeg_heading_command($$$$$)
+         $element = $command->{'parent'};
+     }
+     if ($element) {
+-        $result .= &{$self->{'format_element_header'}}($self, $cmdname,
++        $result .= &{get_formatting_function($self, 'format_element_header')}($self, $cmdname,
+                                                        $command, $element);
+     }
+ 
+@@ -112,7 +149,11 @@ sub ffmpeg_heading_command($$$$$)
+                 $cmdname
+                     = $Texinfo::Common::level_to_structuring_command{$cmdname}->[$heading_level];
+             }
+-            $result .= &{$self->{'format_heading_text'}}(
++            # format_heading_text expects an array of headings for texinfo >= 7.0
++            if ($program_version_num >= 7.000000) {
++                $heading = [$heading];
++            }
++            $result .= &{get_formatting_function($self,'format_heading_text')}(
+                         $self, $cmdname, $heading,
+                         $heading_level +
+                         $self->get_conf('CHAPTER_HEADER_LEVEL') - 1, $command);
+@@ -127,14 +168,14 @@ foreach my $command (keys(%Texinfo::Common::sectioning
+ }
+ 
+ # print the TOC where @contents is used
+-set_from_init_file('INLINE_CONTENTS', 1);
++ff_set_from_init_file('INLINE_CONTENTS', 1);
+ 
+ # make chapters <h2>
+-set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
++ff_set_from_init_file('CHAPTER_HEADER_LEVEL', 2);
+ 
+ # Do not add <hr>
+-set_from_init_file('DEFAULT_RULE', '');
+-set_from_init_file('BIG_RULE', '');
++ff_set_from_init_file('DEFAULT_RULE', '');
++ff_set_from_init_file('BIG_RULE', '');
+ 
+ # Customized file beginning
+ sub ffmpeg_begin_file($$$)
+@@ -151,7 +192,18 @@ sub ffmpeg_begin_file($$$)
+     my ($title, $description, $encoding, $date, $css_lines,
+         $doctype, $bodytext, $copying_comment, $after_body_open,
+         $extra_head, $program_and_version, $program_homepage,
+-        $program, $generator) = $self->_file_header_informations($command);
++        $program, $generator);
++    if ($program_version_num >= 7.000000) {
++        ($title, $description, $encoding, $date, $css_lines,
++         $doctype, $bodytext, $copying_comment, $after_body_open,
++         $extra_head, $program_and_version, $program_homepage,
++         $program, $generator) = $self->_file_header_information($command);
++    } else {
++        ($title, $description, $encoding, $date, $css_lines,
++         $doctype, $bodytext, $copying_comment, $after_body_open,
++         $extra_head, $program_and_version, $program_homepage,
++         $program, $generator) = $self->_file_header_informations($command);
++    }
+ 
+     my $links = $self->_get_links ($filename, $element);
+ 
+@@ -207,7 +259,7 @@ sub ffmpeg_end_file($)
+ sub ffmpeg_end_file($)
+ {
+     my $self = shift;
+-    my $program_string = &{$self->{'format_program_string'}}($self);
++    my $program_string = &{get_formatting_function($self,'format_program_string')}($self);
+     my $program_text = <<EOT;
+       <p style="font-size: small;">
+         $program_string
+@@ -224,7 +276,7 @@ texinfo_register_formatting_function('end_file', \&ffm
+ 
+ # Dummy title command
+ # Ignore title. Title is handled through ffmpeg_begin_file().
+-set_from_init_file('USE_TITLEPAGE_FOR_TITLE', 1);
++ff_set_from_init_file('USE_TITLEPAGE_FOR_TITLE', 1);
+ sub ffmpeg_title($$$$)
+ {
+     return '';
+@@ -242,8 +294,14 @@ sub ffmpeg_float($$$$$)
+     my $args = shift;
+     my $content = shift;
+ 
+-    my ($caption, $prepended) = Texinfo::Common::float_name_caption($self,
+-                                                                $command);
++    my ($caption, $prepended);
++    if ($program_version_num >= 7.000000) {
++        ($caption, $prepended) = Texinfo::Convert::Converter::float_name_caption($self,
++                                                                                 $command);
++    } else {
++        ($caption, $prepended) = Texinfo::Common::float_name_caption($self,
++                                                                     $command);
++    }
+     my $caption_text = '';
+     my $prepended_text;
+     my $prepended_save = '';
+@@ -315,8 +373,13 @@ sub ffmpeg_float($$$$$)
+             $caption->{'args'}->[0], 'float caption');
+     }
+     if ($prepended_text.$caption_text ne '') {
+-        $prepended_text = $self->_attribute_class('div','float-caption'). '>'
+-                . $prepended_text;
++        if ($program_version_num >= 7.000000) {
++            $prepended_text = $self->html_attribute_class('div',['float-caption']). '>'
++                    . $prepended_text;
++        } else {
++            $prepended_text = $self->_attribute_class('div','float-caption'). '>'
++                    . $prepended_text;
++        }
+         $caption_text .= '</div>';
+     }
+     my $html_class = '';
+@@ -329,8 +392,13 @@ sub ffmpeg_float($$$$$)
+         $prepended_text = '';
+         $caption_text   = '';
+     }
+-    return $self->_attribute_class('div', $html_class). '>' . "\n" .
+-        $prepended_text . $caption_text . $content . '</div>';
++    if ($program_version_num >= 7.000000) {
++        return $self->html_attribute_class('div', [$html_class]). '>' . "\n" .
++            $prepended_text . $caption_text . $content . '</div>';
++    } else {
++        return $self->_attribute_class('div', $html_class). '>' . "\n" .
++            $prepended_text . $caption_text . $content . '</div>';
++    }
+ }
+ 
+ texinfo_register_command_formatting('float',


### PR DESCRIPTION
#### Description

Backport upstream ffmpeg commit to prevent a build failure in doc generation. The recent upgrade of texinfo to 7.1 in 3c51e9bb4c77fcbc2232330af3621c99194bee33 caused deprecated function name usage in the ffmpeg docs to turn into failures now that the old function names have been removed.

Fixes: https://trac.macports.org/ticket/68747
Upstream bug: https://trac.ffmpeg.org/ticket/10636
Upstream commit: https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/f01fdedb69e4accb1d1555106d8f682ff1f1ddc7

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1
Xcode 15.0.1 / Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
