### PR TITLE
kotlin: update to 1.9.21

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.9.20 v
+github.setup        JetBrains kotlin 1.9.21 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,12 +24,12 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  2102516b54db610d94ecffddf2f56fc71f3bf5ab \
-                    sha256  15a8a2825b74ccf6c44e04e97672db802d2df75ce2fbb63ef0539bf3ae5006f0 \
-                    size    90988771
+checksums           rmd160  e1a48e8be875f82fc3710610cc8d9217b684a3fc \
+                    sha256  cf17e0272bc065d49e64a86953b73af06065370629f090d5b7c2fe353ccf9c1a \
+                    size    91026093
 
 java.version        1.8+
-java.fallback       openjdk17
+java.fallback       openjdk21
 
 worksrcdir          kotlinc
 


### PR DESCRIPTION
#### Description

Update to Kotlin 1.9.21. Updated fallback Java version to latest LTS version.

###### Tested on

macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?