### PR TITLE
libmaxminddb: add test phase lib

### DIFF
--- a/devel/libmaxminddb/Portfile
+++ b/devel/libmaxminddb/Portfile
@@ -38,6 +38,9 @@ build.env-append    CC=${configure.cc} \
                     "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
                     "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]"
 
+depends_test-append \
+                    port:p5-ipc-run3
+
 test.run            yes
 test.target         check
 


### PR DESCRIPTION
#### Description
This PR adds a test phase dependency to fix the errors below. No other change so no revbump needed.

```
1..0 # skip all tests skipped - these tests need the Test::More 0.88, File::Temp, and IPC::Run3 modules:
Can't locate IPC/Run3.pm in @INC (you may need to install the IPC::Run3 module) (@INC contains: /opt/local/lib/perl5/site_perl/5.34/darwin-thread-multi-2level /opt/local/lib/perl5/site_perl/5.34 /opt/local/lib/perl5/vendor_perl/5.34/darwin-thread-multi-2level /opt/local/lib/perl5/vendor_perl/5.34 /opt/local/lib/perl5/5.34/darwin-thread-multi-2level /opt/local/lib/perl5/5.34) at (eval 5) line 3.
BEGIN failed--compilation aborted at (eval 5) line 3.

1..0 # skip all tests skipped - these tests need the Test::More 0.88, IPC::Run3 and Test::Output modules:
Can't locate IPC/Run3.pm in @INC (you may need to install the IPC::Run3 module) (@INC contains: /opt/local/lib/perl5/site_perl/5.34/darwin-thread-multi-2level /opt/local/lib/perl5/site_perl/5.34 /opt/local/lib/perl5/vendor_perl/5.34/darwin-thread-multi-2level /opt/local/lib/perl5/vendor_perl/5.34 /opt/local/lib/perl5/5.34/darwin-thread-multi-2level /opt/local/lib/perl5/5.34) at (eval 5) line 2.
BEGIN failed--compilation aborted at (eval 5) line 2.
```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1 23B81 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
