### PR TITLE
qt5pas: fix build

### DIFF
--- a/devel/qt5pas/Portfile
+++ b/devel/qt5pas/Portfile
@@ -27,6 +27,9 @@ checksums           rmd160  878d64c1e5a7c0842d51d3f37d2644a00d32fdb5 \
 
 worksrcdir          lazarus/lcl/interfaces/qt5/cbindings
 
+# Workaround xcrun: error: SDK "macosx12" cannot be located
+configure.sdk_version
+
 use_xcode           yes
 
 post-destroot {


### PR DESCRIPTION
#### Description
Fix build:
```sh
:info:configure Executing:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_devel_qt5pas/qt5pas/work/lazarus/lcl/interfaces/qt5/cbindings" && /opt/local/libexec/qt5/bin/qmake PREFIX=/opt/local -spec macx-clang
:debug:configure system:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_devel_qt5pas/qt5pas/work/lazarus/lcl/interfaces/qt5/cbindings" && /opt/local/libexec/qt5/bin/qmake PREFIX=/opt/local -spec macx-clang
:info:configure Project ERROR: Could not resolve SDK Path for 'macosx12.3' using --show-sdk-path
:info:configure Command failed:  cd "/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_devel_qt5pas/qt5pas/work/lazarus/lcl/interfaces/qt5/cbindings" && /opt/local/libexec/qt5/bin/qmake PREFIX=/opt/local -spec macx-clang
:info:configure Exit code: 3
:error:configure Failed to configure qt5pas: configure failure: command execution failed
```

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.1 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
