### PR TITLE
sbcl-devel: update to 20231125

### DIFF
--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -56,15 +56,15 @@ subport sbcl-devel {
     PortGroup   github  1.0
 
     github.setup \
-                sbcl sbcl 58d78cbdf279ddf71fdf15751723a12aa2807782
-    version     20230928
+                sbcl sbcl 7e5c8161aeb33a11f6e853c40a7eedb6a6c38971
+    version     20231125
     revision    0
 
     conflicts   sbcl
 
-    checksums   rmd160  72c233558a3f0e1cf9f1baf08faad5f87b680d3b \
-                sha256  dd5cc585a7466b21e406614f60a415e4967e589978770ae287d47d9be2562323 \
-                size    9662352
+    checksums   rmd160  69b87a2a2d6e06d239d0dda2aaedd44a9d6ab4b9 \
+                sha256  c312a4094ae1d3ed6bc6afbdbdd84645afe142f65e647fcc886e043b66ecbcfa \
+                size    9721278
 
     pre-build {
         system -W ${worksrcpath} "echo '\"${version}\"' > version.lisp-expr"


### PR DESCRIPTION
#### Description

SBCL had a code freez and I would like to update that port to confirm that the next release works well on all macOS by building and self-bootstrap on build bots.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->