### PR TITLE
retry: new port (1.0.5)

### DIFF
--- a/sysutils/retry/Portfile
+++ b/sysutils/retry/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+github.setup            minfrin retry 1.0.5 retry-
+github.tarball_from     releases
+revision                0
+categories              sysutils
+license                 Apache-2
+maintainers             {@therealketo gmail.com:therealketo} openmaintainer
+
+description             Repeat a command until a command succeeds
+long_description        {*}${description}. Retry captures stdin into memory as the data is passed to \
+                        the repeated command, and this captured stdin is then replayed should the command \
+                        be repeated. This makes it possible to embed the retry tool into shell pipelines.
+
+checksums               rmd160  8fafffee444a9d1345dcb041b1c26ebbd1519676 \
+                        sha256  68e241d10f0e2d784a165634bb2eb12b7baf0a9fd9d27c4d54315382597d892e \
+                        size    260264
+
+use_bzip2               yes
+
+configure.args-append   --disable-silent-rules
+
+post-destroot {
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} COPYING ${destroot}${prefix}/share/doc/${name}
+}


### PR DESCRIPTION
#### Description

Add `retry`, a utility that allows users to repeat commands until they succeed and more.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
