### PR TITLE
avidemux: disable AddressSanitizer

### DIFF
--- a/multimedia/avidemux/Portfile
+++ b/multimedia/avidemux/Portfile
@@ -20,7 +20,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
 
 name                        avidemux
 version                     2.8.1
-revision                    1
+revision                    2
 
 categories                  multimedia
 platforms                   macosx
@@ -100,6 +100,7 @@ configure.args-append       -DGTK=OFF \
 # disable most options, enable them in variants
 configure.args-append       -DAFTEN=OFF \
                             -DARTS=OFF \
+                            -DASAN=OFF \
                             -DDCAENC=OFF -DLIBDCA=OFF \
                             -DESD=OFF \
                             -DFAAC=OFF -DFAAD=OFF \
@@ -127,10 +128,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
 }
 
 if {${configure.build_arch} in [list ppc ppc64]} {
-    configure.args-append   -DASAN=OFF \
-                            -DADM_CPU_ALTIVEC=ON
-} else {
-    configure.args-append   -DASAN=ON
+    configure.args-append   -DADM_CPU_ALTIVEC=ON
 }
 
 # make bundled copy of ffmpeg build verbosely


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68336

#### Description
ASan (AddressSanitizer) is mainly intended for use by developers, and ports should not use it by default because it requires linking to compiler-rt libraries from a specific version of Xcode, command line tools, or MacPorts LLVM. I am not aware why it was originally enabled in this port.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 Intel
Xcode 14.2

Not tested beyond verifying that configure phase emits `Address Sanitizer not activated`.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
