### PR TITLE
osxphotos: update to 0.65.0

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.64.3
+version                 0.65.0
 revision                0
 
 categories              graphics python
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  75fc6f66f8f4602edaa1a0a69951cf0fcc502e84 \
-                        sha256  bc3d11355b497acd2c106b762d7ab07c5e7b57fc87706a4a1a048dba86d8a75a \
-                        size    2059706
+checksums               rmd160  ab0304563735edd50fcddf04882d0d853d332ca9 \
+                        sha256  07e81c2af5de20a73fe898834a56fe5fda5ba6870b9a5037bd4562cbc32a16c2 \
+                        size    2046061
 
 python.default_version  311
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.65.0.

###### Tested on

macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?