### PR TITLE
The second update of some lisp ports

### DIFF
--- a/lisp/cl-3bz/Portfile
+++ b/lisp/cl-3bz/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        3b 3bz 4f8a90ec5dc8376145a390094061163ee583a700
+name                cl-3bz
+version             20230321
+revision            0
+
+checksums           rmd160  3fca9355b7e7cc6c1e0b25ae6f680fc04b885529 \
+                    sha256  f072501e4d6e7ab22caba1eec2b29bad3e962371960407b32fbd4ce6d94cc1cc \
+                    size    34061
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         yet another CL deflate decompressor
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-babel \
+                    port:cl-cffi \
+                    port:cl-mmap \
+                    port:cl-nibbles \
+                    port:cl-trivial-features
+
+common_lisp.ffi     yes

--- a/lisp/cl-com.gigamonkeys.binary-data/Portfile
+++ b/lisp/cl-com.gigamonkeys.binary-data/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        gigamonkey monkeylib-binary-data 22e908976d7f3e2318b7168909f911b4a00963ee
+name                cl-com.gigamonkeys.binary-data
+version             20111201
+revision            0
+
+checksums           rmd160  36fc878603d5ce2c2cafbd662000ebe53b7fc1db \
+                    sha256  63bd78ce5afa6e6ee08bcff746d5370d97e862fbad5c3e8787c1b0fc9e1d2ec6 \
+                    size    4969
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Binary data library based on code from chapter 24 of Practical Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria

--- a/lisp/cl-deflate/Portfile
+++ b/lisp/cl-deflate/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        pmai Deflate 7a3f243d4928d3d2d967dbbc46b2ec10ae96ad61
+name                cl-deflate
+version             20231106
+revision            0
+
+checksums           rmd160  84e464e1477d5af200336e4c8a086e9a0156ab97 \
+                    sha256  5223d16c8c46d9556712866cc635a2b363e71cf936de6f9b0c5eb3783bf5c59e \
+                    size    13816
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         Native Deflate Decompression for Common Lisp
+
+long_description    {*}${description}
+
+# See: https://github.com/pmai/Deflate/issues/5
+common_lisp.ecl     no
+common_lisp.abcl    no

--- a/lisp/cl-in-nomine/Portfile
+++ b/lisp/cl-in-nomine/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        phoe in-nomine 03524bab99309848d8a18de0673f055192058f0a
+name                cl-in-nomine
+version             20231126
+revision            0
+
+checksums           rmd160  d793dffbc245b7cba93ef6af61a28287d6ccfd44 \
+                    sha256  d175fcc29b59395d3c2c427dfe1b25fab75525a06114f4f8cd1c5a05be7bd54b \
+                    size    16860
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             LLGPL
+
+description         Utilities for extensible namespaces in Common Lisp.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-closer-mop \
+                    port:cl-fiveam \
+                    port:cl-introspect-environment \
+                    port:cl-lisp-namespace \
+                    port:cl-trivial-arguments
+
+# See: https://github.com/Bike/introspect-environment/issues/5
+common_lisp.clisp   no

--- a/lisp/cl-jpeg-turbo/Portfile
+++ b/lisp/cl-jpeg-turbo/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        shamazmazum jpeg-turbo f79c646cc266c107bdace53572a31664754c6e0c
+name                cl-jpeg-turbo
+version             20201121
+revision            0
+
+checksums           rmd160  7b19bb8bff1e79ef123d7625c3d2e6c002bcda5e \
+                    sha256  42b0e770c30ca9365261e8eea5742dc781630ce426c520101f7fbc62cfd9af6a \
+                    size    10021
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Common Lisp wrapper for libjpeg-turbo
+
+long_description    {*}${description}
+
+patchfiles-append   macports-integration.diff
+
+post-patch {
+    reinplace -W ${worksrcpath} "s|@@MACPORTS_PREFIX@@|${prefix}|" \
+        src/grovel.lisp
+}
+
+depends_lib-append  path:include/turbojpeg.h:libjpeg-turbo \
+                    port:cl-cffi
+
+common_lisp.ffi     yes

--- a/lisp/cl-jpeg-turbo/files/macports-integration.diff
+++ b/lisp/cl-jpeg-turbo/files/macports-integration.diff
@@ -1,0 +1,13 @@
+diff --git src/grovel.lisp src/grovel.lisp
+index 062045e..cb8b0f7 100644
+--- src/grovel.lisp
++++ src/grovel.lisp
+@@ -1,7 +1,7 @@
+ (in-package :jpeg-turbo)
+ (include "turbojpeg.h")
+ #+(or freebsd OS-MACOSX)
+-(cc-flags "-I/usr/local/include")
++(cc-flags "-I@@MACPORTS_PREFIX@@/include")
+ 
+ ;; Subsampling modes
+ (cenum subsamp

--- a/lisp/cl-mmap/Portfile
+++ b/lisp/cl-mmap/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera mmap b045b6c6f986770f89c57423b26e8b1626eb1033
+name                cl-mmap
+version             20230902
+revision            0
+
+checksums           rmd160  12fdb5e5f54ba0b286117ba3792fd3afbdfebb44 \
+                    sha256  4179ac9b7d51c2e0a97795eb40fd45b5faf644f20a99e634853a87030187c9bf \
+                    size    13624
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         yet another CL deflate decompressor
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-cffi \
+                    port:cl-documentation-utils \
+                    port:cl-parachute \
+                    port:cl-trivial-features
+
+common_lisp.ffi     yes

--- a/lisp/cl-nibbles/Portfile
+++ b/lisp/cl-nibbles/Portfile
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        sharplispers nibbles a46a67736e07b548cdd7485cb36834f7942313f1
+name                cl-nibbles
+version             20230920
+revision            0
+
+checksums           rmd160  ee37b4f50f20eb18611590cd7b0e2a8acc067782 \
+                    sha256  1a73b11b0db580ce35021f928023e622b4d731aad705ecfeb77e79032e21cc57 \
+                    size    19851
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         A Common Lisp library for accessing octet-addressed blocks of data
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-rt
+
+# See: https://github.com/sharplispers/nibbles/issues/13
+common_lisp.clisp   no

--- a/lisp/cl-nodgui/Portfile
+++ b/lisp/cl-nodgui/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           codeberg 1.0
 PortGroup           common_lisp 1.0
 
-codeberg.setup      cage nodgui e45fc7e4e9eb9fc38d3e3cbd9aa24985723b6ff2
+codeberg.setup      cage nodgui d221ff6ddaebdfcf5a8b6f31a1d1f2aee48adcdd
 name                cl-nodgui
-version             20230816
+version             20231125
 revision            0
 
-checksums           rmd160  cb368ba65db1f348a0797bfc126368478e0823e8 \
-                    sha256  fefeb422e44074721ab60dffc00036976cf742d33322cee03ff752e3f9c85a6e \
-                    size    172896
+checksums           rmd160  4cf1e6a33481fd027db1629443e23f271235dcf9 \
+                    sha256  a598e9cb50b090bbed25046ff32157706a72652c6f5473934e4fcb17bc803ccf \
+                    size    198734
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -26,9 +26,11 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-clunit2 \
                     port:cl-colors2 \
                     port:cl-esrap \
-                    port:cl-jpeg \
+                    port:cl-flexi-streams \
+                    port:cl-jpeg-turbo \
                     port:cl-named-readtables \
                     port:cl-parse-number \
+                    port:cl-pngload \
                     port:cl-ppcre \
                     port:cl-ppcre-unicode \
                     port:cl-unicode

--- a/lisp/cl-nodgui/Portfile
+++ b/lisp/cl-nodgui/Portfile
@@ -34,3 +34,6 @@ depends_lib-append  port:cl-alexandria \
                     port:cl-unicode
 
 common_lisp.threads yes
+
+# See: https://codeberg.org/cage/nodgui/issues/4
+common_lisp.abcl    no

--- a/lisp/cl-opticl-core/Portfile
+++ b/lisp/cl-opticl-core/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        slyrus opticl-core b7cd13d26df6b824b216fbc360dc27bfadf04999
+name                cl-opticl-core
+version             20170906
+revision            0
+
+checksums           rmd160  5c64a8b9bb0eb48a02b2fd615c247d76bbddbb70 \
+                    sha256  5d3ca0b919159861f698fc1cb7ffc9cd3de7133423e3eb4d47061d10554d5c20 \
+                    size    4564
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Core classes and pixel access macros from opticl
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria

--- a/lisp/cl-opticl/Portfile
+++ b/lisp/cl-opticl/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        slyrus opticl f6fc4dc5fa61ae3f2527b77e4bda99001ba37dcb
+name                cl-opticl
+version             20220207
+revision            0
+
+checksums           rmd160  9f19989b016a052ffbb9105e9b7098a968d67a6e \
+                    sha256  e4513d4fc8d88b46ad7d5b48c6cc85e590ddbc9161f24cd865eff5c9ea6c3bff \
+                    size    243013
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         An image processing library for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-fiveam \
+                    port:cl-jpeg \
+                    port:cl-markdown \
+                    port:cl-opticl-core \
+                    port:cl-png-read \
+                    port:cl-pngload \
+                    port:cl-retrospectiff \
+                    port:cl-skippy \
+                    port:cl-tga \
+                    port:cl-zpng

--- a/lisp/cl-parse-float/Portfile
+++ b/lisp/cl-parse-float/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        soemraws parse-float 3074765101e41222b6b624a66aaf1e6416379f9c
+name                cl-parse-float
+version             20200109
+revision            0
+
+checksums           rmd160  f853c48e6085d430791e368f50154c01b62849e2 \
+                    sha256  922c46341ce44cbe63fc971628b38fbe2b5724f0032d2421568d8038672e8a87 \
+                    size    4764
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             public-domain
+
+description         Parse a floating point value from a string in Common Lisp.
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria

--- a/lisp/cl-png-read/Portfile
+++ b/lisp/cl-png-read/Portfile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Ramarren png-read ec29f38a689972b9f1373f13bbbcd6b05deada88
+name                cl-png-read
+version             20170815
+revision            0
+
+checksums           rmd160  b6894dcd20396348160dc63eda370d48afa368f1 \
+                    sha256  319d3328f32d6387fe19c807136458b1f3289e32c0f304f209bc0f1078db3694 \
+                    size    8798
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         A PNG decoder for Common Lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-babel \
+                    port:cl-chipz \
+                    port:cl-iterate

--- a/lisp/cl-pngload/Portfile
+++ b/lisp/cl-pngload/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               common_lisp 1.0
+
+github.setup            bufferswap pngload e9ea54f095ac7b4d25ab53a58b4303331f5b8e4b
+name                    cl-pngload
+version                 20220402
+revision                0
+
+checksums               rmd160  48c68173e8dcfc0e8a5716541fb8196f79494341 \
+                        sha256  c45d7c117eb7ace7fafa653f7f46c8f2fb7e8b6dae66fd8210c289a5b62409d9 \
+                        size    91735
+
+categories-append       devel
+maintainers             {@catap korins.ky:kirill} openmaintainer
+license                 MIT
+
+description             A PNG (Portable Network Graphics) image format decoder.
+
+long_description        {*}${description}
+
+if {${name} eq ${subport}} {
+    depends_lib-append  port:cl-3bz \
+                        port:cl-alexandria \
+                        port:cl-cffi \
+                        port:cl-mmap \
+                        port:cl-parse-float \
+                        port:cl-static-vectors \
+                        port:cl-swap-bytes \
+                        port:cl-zpb-exif
+
+    common_lisp.systems pngload.asd
+
+    test.run            no
+}
+
+common_lisp.ffi         yes

--- a/lisp/cl-pngload/Portfile
+++ b/lisp/cl-pngload/Portfile
@@ -36,4 +36,16 @@ if {${name} eq ${subport}} {
     test.run            no
 }
 
+subport cl-pngload-test {
+    depends_lib-append  port:cl-alexandria \
+                        port:cl-local-time \
+                        port:cl-opticl \
+                        port:cl-png-read \
+                        port:cl-pngload
+
+    common_lisp.systems pngload.test.asd
+
+    livecheck.type      none
+}
+
 common_lisp.ffi         yes

--- a/lisp/cl-retrospectiff/Portfile
+++ b/lisp/cl-retrospectiff/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        slyrus retrospectiff 2fbf8c687799487654d988c7036d19d75a7fc67d
+name                cl-retrospectiff
+version             20211121
+revision            0
+
+checksums           rmd160  4447f582e90e4d6683bb15125ec50a25949ac1ff \
+                    sha256  4d78a01a24cc5480710b77e929f564e8efce7657ea863bcb184396bcd41846d0 \
+                    size    1616625
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         A library for reading and writing TIFF image files in common lisp
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-com.gigamonkeys.binary-data \
+                    port:cl-deflate \
+                    port:cl-flexi-streams \
+                    port:cl-ieee-floats \
+                    port:cl-jpeg \
+                    port:cl-opticl-core

--- a/lisp/cl-skippy/Portfile
+++ b/lisp/cl-skippy/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        xach skippy e456210202ca702c792292c5060a264d45e47090
+name                cl-skippy
+version             20171027
+revision            0
+
+checksums           rmd160  660bb6c5afb27647796d85dc6f524f426b2ff445 \
+                    sha256  49c5dbd5e10e23bedd54463ff9124c4c20cf2913eacf4c46d3d6113c3ce74782 \
+                    size    31587
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Common Lisp GIF library
+
+long_description    {*}${description}

--- a/lisp/cl-spinneret/Portfile
+++ b/lisp/cl-spinneret/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           common_lisp 1.0
 
-github.setup        ruricolist spinneret d82aea82b8570800a73aa6b6295735f7f5125a9c
+github.setup        ruricolist spinneret 00ad98b3a1c7ffbbaa8f83c7145f397cf7165d5e
 name                cl-spinneret
-version             20230918
+version             20231123
 revision            0
 
-checksums           rmd160  ce769362796efe5c8b1d1d644e4732b43a0120a2 \
-                    sha256  aca7d90ceb28a36b4b8676078f87ead2d37f9f14f831d112bb45a359feed036d \
-                    size    31472
+checksums           rmd160  778c06a77484a90aeab7b4be91a9ef60ce6c9b42 \
+                    sha256  a05473d702a57632daaccda1cf334b8bbe437763b6ada0ee242d20fd75b1cc51 \
+                    size    31753
 
 categories-append   devel
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -22,14 +22,14 @@ description         Common Lisp HTML5 generator.
 long_description    {*}${description}
 
 depends_lib-append  port:cl-alexandria \
+                    port:cl-fiveam \
                     port:cl-global-vars \
+                    port:cl-in-nomine \
                     port:cl-markdown \
                     port:cl-parenscript \
                     port:cl-ppcre \
                     port:cl-serapeum \
                     port:cl-trivia \
                     port:cl-trivial-gray-streams
-
-depends_test-append port:cl-fiveam
 
 common_lisp.threads yes

--- a/lisp/cl-tga/Portfile
+++ b/lisp/cl-tga/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        fisxoj cl-tga 4dc2f7b8a259b9360862306640a07a23d4afaacc
+version             20160223
+revision            0
+
+checksums           rmd160  2b1306feb4145887511acb92c640b60f7e193e48 \
+                    sha256  251e718c8c1a8e89d739eccd39de551850fbe99ea17c19c823c2a93425adea23 \
+                    size    312493
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             MIT
+
+description         TGA file loader in common lisp
+
+long_description    {*}${description}

--- a/lisp/cl-trivial-arguments/Portfile
+++ b/lisp/cl-trivial-arguments/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        Shinmera trivial-arguments 10d09784cfa0912d43ddfe3edfad6d9fde82298f
+name                cl-trivial-arguments
+version             20230703
+revision            0
+
+checksums           rmd160  b092692b5b4f28d17d8e61184d3ec21f6d472ae7 \
+                    sha256  14d8337d82b8c472b2bfda4d02c432b03e54219156385c8016d67ea54c9e9d5b \
+                    size    3446
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             zlib
+
+description         Tiny CL library to retrieve the arguments list of a function.
+
+long_description    {*}${description}

--- a/lisp/cl-zpb-exif/Portfile
+++ b/lisp/cl-zpb-exif/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        xach zpb-exif ee8a467614072edd0a5ddd256df0f459b1b84d49
+name                cl-zpb-exif
+version             20210117
+revision            0
+
+checksums           rmd160  948791fe59ff596c253992e62977f70b90879007 \
+                    sha256  2402c3de425c93a11a4627ad8b456577ce58be19564837604abdf88bd019e016 \
+                    size    15680
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             BSD
+
+description         Extract EXIF information from image files
+
+long_description    {*}${description}


### PR DESCRIPTION
#### Description

Well, an update of `cl-nodgui` adds support of TIFF and PNG, and switched backend for JPEG which leads to adding a dozen of new lisp ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->