### PR TITLE
wgshadertoy: new port (version: 0.3.2)

### DIFF
--- a/graphics/wgshadertoy/Portfile
+++ b/graphics/wgshadertoy/Portfile
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem            1.0
+PortGroup             app     1.0
+PortGroup             cargo   1.0
+PortGroup             github  1.0
+
+github.setup          fralonra wgshadertoy 0.3.2 v
+github.tarball_from   archive
+revision              0
+
+description           A WGSL playground inspired by Shadertoy
+long_description      WgShadertoy is a WGSL playground inspired by Shadertoy. \
+                      It uses a binary format 'wgs' to save and load shaders and textures.
+
+categories            graphics
+installs_libs         no
+license               MIT
+maintainers           {gmail.com:zoronlivingston @fralonra} \
+                      openmaintainer
+
+checksums             ${distname}${extract.suffix} \
+                      rmd160  79bd962c2b205505a021ea8940d21ccd4dbc6bb8 \
+                      sha256  5f544699320f82275283e792241f9772c074aae2f459be6bcc5b1751e0ded50e \
+                      size    889235
+
+app.name              WgShadertoy
+app.icon              ${worksrcpath}/extra/logo/wgshadertoy.svg
+app.retina            yes
+
+fetch.type            git
+
+post-extract {
+    build.env-append  GIT_COMMIT_HASH=[exec git -C ${worksrcpath} rev-parse --short HEAD]
+}
+
+build.pre_args-delete --frozen --offline
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

Add new port: [wgshadertoy](https://github.com/fralonra/wgshadertoy). A WGSL playground inspired by Shadertoy.

Some notes:
I once added a `cargo.crates` stanza but it broke the build, due to the non-existence of some older version crates, eg:
```
Error: Failed to checksum wgshadertoy: addr2line-0.19.0.crate does not exist in /opt/local/var/macports/distfiles/cargo-crates
```
So I removed the  `cargo.crates`.
I’m uncertain about its necessity and its purpose, and there are many cargo projects don't have this part.
If a `cargo.crates` is indeed required, I would appreciate assistance with the aforementioned issue.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.5 18F203 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->