### PR TITLE
jdk20: obsolete

### DIFF
--- a/java/jdk20/Portfile
+++ b/java/jdk20/Portfile
@@ -1,95 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+# Remove after 2024-05-26
+PortSystem  1.0
+PortGroup   obsolete 1.0
 
-name             jdk20
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        darwin
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          NFTC NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
-
-supported_archs  x86_64 arm64
-
-# https://www.oracle.com/java/technologies/downloads/#jdk20-mac
-version      20.0.2
-revision     1
-
-description  Oracle Java SE Development Kit 20
-long_description Java Platform, Standard Edition Development Kit (JDK). \
-    The JDK is a development environment for building applications and components using the Java programming language. \
-    This software is provided under the Oracle No-Fee Terms and Conditions (NFTC) license (https://java.com/freeuselicense).
-
-master_sites https://download.oracle.com/java/20/archive/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  0a41878ec9fb8553d0576437cd4231f197cb3c69 \
-                 sha256  8a0484e95b40a95f65c0a498a5b299e80757343f0ff1cc1ec43fc5249468bedb \
-                 size    188263345
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  8589c25243754e8117a47f39153f19d0202717f5 \
-                 sha256  e8718838c2011bab3ab00eb8097ddb20aa3b8fe0a8bb0b9e3c9d801c973477bc \
-                 size    185819340
-}
-
-worksrcdir   jdk-${version}.jdk
-
-homepage     https://www.oracle.com/java/
-
-livecheck.type      regex
-livecheck.url       https://www.oracle.com/java/technologies/downloads/
-livecheck.regex     Java SE Development Kit (20\.\[0-9\.\]+)
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-20-oracle-java-se.jdk
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}${jdk}
-    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
-    xinstall -m 755 -d ${destroot}${jvms}
-    ln -s ${prefix}${jdk} ${destroot}${jdk}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${jdk}/Contents/Home
-"
+name        jdk20
+categories  java devel
+version     20.0.2
+revision    2
+replaced_by jdk21


### PR DESCRIPTION
#### Description

Obsolete `jdk20`, mark as replaced by `jdk21`.

###### Tested on

macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?