### PR TITLE
xa: update to 2.4.0

### DIFF
--- a/devel/xa/Portfile
+++ b/devel/xa/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                xa
-version             2.3.13
+version             2.4.0
 revision            0
 categories          devel
 maintainers         {breun.nl:nils @breun} openmaintainer
@@ -19,9 +19,9 @@ license             GPL-2+
 
 master_sites        https://www.floodgap.com/retrotech/xa/dists/
 
-checksums           rmd160  1e6462692b9f79f7c57dc3954a2ce2daafddadca \
-                    sha256  a9477af150b6c8a91cd3d41e1cf8c9df552d383326495576830271ca4467bd86 \
-                    size    155606
+checksums           rmd160  1b47b24e250f96d153e3a1bfea66e68d0c794b38 \
+                    sha256  9e587a0ca8ff791009880bfa331f6ed36935e08ef9c123822ca175285f8c030c \
+                    size    197862
 
 use_configure       no
 variant universal {}


### PR DESCRIPTION
#### Description

Update to xa 2.4.0.

###### Tested on

macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?