### PR TITLE
py-sphinxcontrib-bibtex: add py311 and py312 subports

### DIFF
--- a/python/py-sphinxcontrib-bibtex/Portfile
+++ b/python/py-sphinxcontrib-bibtex/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  a6421deebac3fb19cfde65fbe86ad083b488af79 \
                     sha256  046b49f070ae5276af34c1b8ddb9bc9562ef6de2f7a52d37a91cb8e53f54b863 \
                     size    117150
 
-python.versions     38 39 310
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append \


### PR DESCRIPTION
#### Description


###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
