### PR TITLE
py-sphinxcontrib-*: add py312 subport for three ports

### DIFF
--- a/python/py-sphinxcontrib-httpdomain/Portfile
+++ b/python/py-sphinxcontrib-httpdomain/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  3293cda9351acf22631bf01a7d12bf82d7ae828c \
                     sha256  6c2dfe6ca282d75f66df333869bb0ce7331c01b475db6809ff9d107b7cdfe04b \
                     size    19266
 
-python.versions     39 310 311
+python.versions     39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-sphinxcontrib-svg2pdfconverter/Portfile
+++ b/python/py-sphinxcontrib-svg2pdfconverter/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  5e09fc441c8745f524b3d39d10bf09de00062df6 \
                     sha256  80a55ca61f70eae93efc65f3814f2f177c86ba55934a9f6c5022f1778b62146b \
                     size    5516
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     # can use inkscape, librsvg, or cairosvg to do the image conversion

--- a/python/py-sphinxcontrib-websupport/Portfile
+++ b/python/py-sphinxcontrib-websupport/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  360dec014f96f95fd2c9c2f07787ae021549abff \
                     sha256  4edf0223a0685a7c485ae5a156b6f529ba1ee481a1417817935b20bde1956232 \
                     size    602360
 
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 
 if {${subport} ne ${name}} {
     if {${python.version} == 27} {


### PR DESCRIPTION
#### Description

Add py312 subport for py-sphinxcontrib-httpdomain, py-sphinxcontrib-svg2pdfconverter and py-sphinxcontrib-websupport

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
