### PR TITLE
py-{mpmath,sympy}: add py312 subport

### DIFF
--- a/python/py-mpmath/Portfile
+++ b/python/py-mpmath/Portfile
@@ -11,7 +11,7 @@ platforms           {darwin any}
 license             BSD
 supported_archs     noarch
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-sympy/Portfile
+++ b/python/py-sympy/Portfile
@@ -12,7 +12,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-sympy/files/py312-sympy
+++ b/python/py-sympy/files/py312-sympy
@@ -1,0 +1,2 @@
+${frameworks_dir}/Python.framework/Versions/3.12/bin/isympy
+${frameworks_dir}/Python.framework/Versions/3.12/share/man/man1/isympy.1


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
