### PR TITLE
colima: Update to 0.6.6

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.6.5 v
+go.setup            github.com/abiosoft/colima 0.6.6 v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  05197e2459c48089c1f4da49f5b50f2519995597 \
-                    sha256  ac99615c8364c4f9e2d776a9104cc7c65f91ab9b60ade577a3f4bb63ef83abd8 \
-                    size    607189
+checksums           rmd160  f0b0caadf8f2a38dc87754bd7d47cdb79a3d79f5 \
+                    sha256  254d2fd00addf8e5ceefc39a726a55537fb71ca03476c1f58263a1603a3afac6 \
+                    size    608435
 
 depends_run         port:lima
 


### PR DESCRIPTION
#### Description

colima: Update to 0.6.6

##### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0 15A240d

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
