### PR TITLE
qt5-qtwebengine-gn: maintain

### DIFF
--- a/devel/gn-devel/Portfile
+++ b/devel/gn-devel/Portfile
@@ -17,6 +17,7 @@ subport qt5-qtwebengine-gn {
     set hyphen_version 2022-12-09
     version         [string map {"-" ""} ${hyphen_version}]
     revision        0
+    maintainers     {gmx.us:chrischavez @chrstphrchvz} openmaintainer
     description     {*}${description} (for building qtwebengine)
     long_description {*}${long_description} This port is for building qt5-qtwebengine \
                     as it contains Qt-specific additions to GN.


### PR DESCRIPTION
#### Description
I created this subport and did most of its updates.

(gn-devel has never been used by anything else in MacPorts and has never been updated, so I am not interested in listing myself as its maintainer if must then update it.)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
