### PR TITLE
clang-17: fix OpenMP linkage

### DIFF
--- a/lang/llvm-17/Portfile
+++ b/lang/llvm-17/Portfile
@@ -29,7 +29,7 @@ version                 ${llvm_version}.0.5
 name                    llvm-${llvm_version}
 revision                0
 subport                 mlir-${llvm_version}  { revision [ expr ${revision} + 0 ] }
-subport                 clang-${llvm_version} { revision [ expr ${revision} + 0 ] }
+subport                 clang-${llvm_version} { revision [ expr ${revision} + 1 ] }
 subport                 lldb-${llvm_version}  { revision [ expr ${revision} + 0 ] }
 subport                 flang-${llvm_version} { revision [ expr ${revision} + 0 ] }
 
@@ -145,6 +145,7 @@ patchfiles-append \
     0019-10.6-and-less-use-emulated-TLS-before-10.7.patch \
     0025-lldb-add-defines-needed-for-older-SDKs.patch \
     0026-llvm-set-memrchr-unavailable.patch \
+    0043-Avoid-extra-rpath-with-openmp.patch \
     0999-i386-fix.diff \
     add-missed-i386-host.diff
 

--- a/lang/llvm-17/files/0043-Avoid-extra-rpath-with-openmp.patch
+++ b/lang/llvm-17/files/0043-Avoid-extra-rpath-with-openmp.patch
@@ -1,0 +1,14 @@
+--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp	2023-11-17 15:53:57
++++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp	2023-11-17 15:55:32
+@@ -933,8 +933,9 @@
+   if (IsOffloadingHost && !Args.hasArg(options::OPT_nogpulib))
+     CmdArgs.push_back("-lomptarget.devicertl");
+ 
+-  addArchSpecificRPath(TC, Args, CmdArgs);
+-  addOpenMPRuntimeLibraryPath(TC, Args, CmdArgs);
++  // Handled above to find library provided by MacPorts' libomp package.
++  //addArchSpecificRPath(TC, Args, CmdArgs);
++  //addOpenMPRuntimeLibraryPath(TC, Args, CmdArgs);
+ 
+   return true;
+ }


### PR DESCRIPTION
Upstream has been modifying linking for OpenMP, and the change in https://github.com/llvm/llvm-project/commit/fceea4e1 ended up breaking things for MacPorts. We already explicitly add our custom ($prefix/lib/libomp/) path to the link line; disable the new upstream code.

#### Description

With clang-17, compiling a _c++_ program with OpenMP leads to a broken executable:

```
$ clang++-mp-17 -fopenmp -o main main.cpp
$ ./main
dyld[70650]: Symbol not found: __ZNKSt3__16locale9use_facetERNS0_2idE
  Referenced from: <39A458D0-80A3-3DCC-8D09-710A914EDC28> /Users/M028373/src/external/openmp-test/main
  Expected in:     <no uuid> unknown
Abort trap: 6
$ ldd main
main:
	/opt/local/lib/libomp/libomp.dylib (compatibility version 5.0.0, current version 5.0.0)
	@rpath/libc++.1.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.0.0)
```

The link line for this compilation (with -fopenmp) ends up as (without this patch; I've added line breaks to make it easier to look at):
```
 "/opt/local/libexec/llvm-17/bin/ld" -demangle -lto_library /opt/local/libexec/llvm-17/lib/libLTO.dylib
-no_deduplicate -dynamic -arch x86_64 -platform_version macos 13.0.0 14.0 -syslibroot
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-o main -L/usr/local/lib /var/folders/2q/42jkj0ld5cx0vzhn2d9q14b40000gr/T/main-61f7f0.o
-L/opt/local/lib/libomp -lomp -L/opt/local/libexec/llvm-17/lib -lc++
-lSystem /opt/local/libexec/llvm-17/lib/clang/17/lib/darwin/libclang_rt.osx.a
```

Here is what clang-16 was doing:
```
 "/opt/local/libexec/llvm-16/bin/ld" -demangle -lto_library /opt/local/libexec/llvm-16/lib/libLTO.dylib
-no_deduplicate -dynamic -arch x86_64 -platform_version macos 13.0.0 14.0 -syslibroot
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-o main -L/usr/local/lib /var/folders/2q/42jkj0ld5cx0vzhn2d9q14b40000gr/T/main-4dbf84.o
-L/opt/local/lib/libomp -lomp -rpath /opt/local/libexec/llvm-16/lib -L/opt/local/libexec/llvm-16/lib -lc++
-lSystem /opt/local/libexec/llvm-16/lib/clang/16/lib/darwin/libclang_rt.osx.a
```

With this patch, clang-17 runs:
```
 "/opt/local/libexec/llvm-17/bin/ld" -demangle -lto_library /opt/local/libexec/llvm-17/lib/libLTO.dylib 
-no_deduplicate -dynamic -arch x86_64 -platform_version macos 13.0.0 14.0 -syslibroot 
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-o main -L/usr/local/lib /var/folders/2q/42jkj0ld5cx0vzhn2d9q14b40000gr/T/main-5144e3.o
-L/opt/local/lib/libomp -lomp -lc++
-lSystem /opt/local/libexec/llvm-17/lib/clang/17/lib/darwin/libclang_rt.osx.a
```

N.B. references to `/opt/local/libexec/llvm-17/lib` are removed. We may want to patch up 16 to not throw those in, as well, but it at least still generates a functioning executable thanks to the included `-rpath`.

```
$ otool -L main-16
main-16:
	/opt/local/lib/libomp/libomp.dylib (compatibility version 5.0.0, current version 5.0.0)
	@rpath/libc++.1.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.0.0)
$ otool -L  main-17-broken
main-17-broken:
	/opt/local/lib/libomp/libomp.dylib (compatibility version 5.0.0, current version 5.0.0)
	@rpath/libc++.1.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.0.0)
$ otool -L  main-17-patched
main-17-patched:
	/opt/local/lib/libomp/libomp.dylib (compatibility version 5.0.0, current version 5.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1600.151.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.0.0)
```

I'm open to suggestion for other routes to resolve this, but this appeared (to me) the most direct. In general, we're not trying to have clang link against `/opt/local/libexec/llvm-XX/lib`, but rather /usr/lib/libc++, correct? (I'm not sure how correct that statement is on older OSes.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.1 22G313 x86_64
Xcode 15.0.1 15A507
