### PR TITLE
toot: update to v0.39.0

### DIFF
--- a/net/toot/Portfile
+++ b/net/toot/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        ihabunek toot 0.36.0
+github.setup        ihabunek toot 0.39.0
 github.tarball_from archive
 revision            0
 
@@ -17,11 +17,10 @@ categories          net python
 license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
-platforms           darwin
 
-checksums           rmd160  2dfb0fb86bfb0e3ef53e641703d4c4aef45e62ff \
-                    sha256  0aa554154d3a784e5e2345a8a2df9a90b877de6d888419194968807c942c7d73 \
-                    size    893951
+checksums           rmd160  7bf4458c2a3c5dd35f66548094156a03cffba846 \
+                    sha256  8c5626e5586b73d1b940e9edea9276595ee85df5a67c69932a88b001f3e9ca77 \
+                    size    909649
 
 python.default_version 311
 
@@ -34,5 +33,6 @@ test.args
 depends_lib-append  port:py${python.version}-beautifulsoup4 \
                     port:py${python.version}-requests       \
                     port:py${python.version}-setuptools     \
+                    port:py${python.version}-tomlkit        \
                     port:py${python.version}-urwid          \
                     port:py${python.version}-wcwidth


### PR DESCRIPTION
#### Description

toot: update to v0.39.0

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement


###### Tested on

macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
