### PR TITLE
mpich{,-doc}: 4.1.2. Use ch3 for now.

### DIFF
--- a/_resources/port1.0/group/mpi-1.0.tcl
+++ b/_resources/port1.0/group/mpi-1.0.tcl
@@ -341,7 +341,7 @@ proc mpi.setup {args} {
         # Clang 15 and 16 only available on 10.7 and later
         if {${os.major} < 11} {
             lappend ::mpi.disabled_compilers \
-                -clang15 -clang16
+                -clang15 -clang16 -clang17
         }
 
         if {${os.arch} eq "arm"} {

--- a/science/mpi-doc/Portfile
+++ b/science/mpi-doc/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 # make sure to keep in sync with mpich
 name                mpi-doc
-version             4.1.1
+version             4.1.2
 revision            0
 
 license             BSD
@@ -22,9 +22,9 @@ master_sites        ${homepage}static/downloads/${version}/
 distname            mpich-${version}
 
 checksums \
-    rmd160  87cab1d40759846cb7ca3d008522c66965c7aae8 \
-    sha256  ee30471b35ef87f4c88f871a5e2ad3811cd9c4df32fd4f138443072ff4284ca2 \
-    size    38537070
+    rmd160  b4bc2115f5080ef93595597afc6d3f9f1665e051 \
+    sha256  3492e98adab62b597ef0d292fb2459b6123bc80070a8aa0a30be6962075a12f0 \
+    size    39250122
 
 dist_subdir         mpich
 

--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -173,7 +173,6 @@ if {${subport_enabled}} {
                     --with-thread-package=posix      \
                     --with-hwloc-prefix=${prefix}    \
                     --disable-collalgo-tests         \
-                    "F90FLAGS='' F90=''"             \
                     --with-device=ch3:nemesis        \
                     --enable-nemesis-shm-collectives
 

--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -20,7 +20,7 @@ PortGroup           mpiutil 1.0
 
 # make sure to keep in sync with mpi-doc
 name                mpich
-version             4.1.1
+version             4.1.2
 revision            0
 
 license             BSD
@@ -47,9 +47,9 @@ long_description    MPICH is a high-performance and widely portable\
 homepage            https://www.mpich.org/
 master_sites        ${homepage}static/downloads/${version}
 
-checksums           rmd160  87cab1d40759846cb7ca3d008522c66965c7aae8 \
-                    sha256  ee30471b35ef87f4c88f871a5e2ad3811cd9c4df32fd4f138443072ff4284ca2 \
-                    size    38537070
+checksums           rmd160  b4bc2115f5080ef93595597afc6d3f9f1665e051 \
+                    sha256  3492e98adab62b597ef0d292fb2459b6123bc80070a8aa0a30be6962075a12f0 \
+                    size    39250122
 
 # Disable livecheck for all subports; only enabled for main port, at end of portfile
 livecheck.type      none
@@ -156,6 +156,9 @@ if {${subport_enabled}} {
         }
     }
 
+    # ch4 is hanging in finalize https://github.com/pmodels/mpich/issues/6584
+    # always use ch3 for now.
+
     configure.args  --disable-dependency-tracking    \
                     --disable-fortran                \
                     --disable-silent-rules           \
@@ -170,8 +173,10 @@ if {${subport_enabled}} {
                     --with-thread-package=posix      \
                     --with-hwloc-prefix=${prefix}    \
                     --disable-collalgo-tests         \
-                    --disable-f08                    \
-                    "F90FLAGS='' F90=''"
+                    "F90FLAGS='' F90=''"             \
+                    --with-device=ch3:nemesis        \
+                    --enable-nemesis-shm-collectives
+
 
     if {${os.major} < 12} {
         # MPICH requires OpenCL version 1.2, which was not introduced until OS X Mountain Lion
@@ -182,9 +187,7 @@ if {${subport_enabled}} {
     patchfiles-append \
                     patch-no_qmkshrobj.diff \
                     patch-ch4-ipv6.diff \
-                    patch-mpich-darwin-powerpc.diff \
-                    patch-pingpong.diff \
-                    patch-spinlocks.diff
+                    patch-mpich-darwin-powerpc.diff
 
     platform darwin powerpc {
         # libfabric calls for atomicops, on PPC at least


### PR DESCRIPTION
Maintainer update. Use ch3 for hanging finalize with ch4 (https://github.com/pmodels/mpich/issues/6584).