### PR TITLE
editorconfig-core-c: Update to 0.12.6

### DIFF
--- a/devel/editorconfig-core-c/Portfile
+++ b/devel/editorconfig-core-c/Portfile
@@ -4,25 +4,23 @@ PortSystem              1.0
 PortGroup               cmake  1.1
 PortGroup               github 1.0
 
-github.setup            editorconfig editorconfig-core-c 0.12.2 v
-license                 BSD
+github.setup            editorconfig editorconfig-core-c 0.12.6 v
+github.tarball_from     archive
+revision                0
 categories              devel
-maintainers             nomaintainer
+license                 BSD
+maintainers             {@therealketo gmail.com:therealketo} openmaintainer
+
 description             EditorConfig makes it easy to maintain the correct coding style
 long_description        This code produces a program that accepts a filename as input and will \
                         look for .editorconfig files with sections applicable to the given file, \
                         outputting any properties found.
 
-platforms               darwin
+checksums               rmd160  c837d7f7f58fc3f7661f8e8ec99f86e71ce2de1f \
+                        sha256  36052a5371731d915b53d9c7a24a11c4032585ccacb392ec9d58656eef4c0edf \
+                        size    76525
 
-depends_lib             port:pcre
-
-checksums               rmd160  14a1e30f0db589c7c37592855aad432c705cef68 \
-                        sha256  ad16136ab410aebf1abbf7f6d457412e7b3cab27a903abc952224e1d4102fd20 \
-                        size    66999
-
-pre-build {
-    file mkdir "${worksrcpath}/doc/man"
-}
+depends_build-append    port:doxygen
+depends_lib-append      port:pcre2
 
 github.livecheck.regex  {([^"-]+)}

--- a/devel/editorconfig-core-c/Portfile
+++ b/devel/editorconfig-core-c/Portfile
@@ -1,26 +1,25 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           cmake 1.1
-PortGroup           github 1.0
+PortSystem              1.0
+PortGroup               cmake  1.1
+PortGroup               github 1.0
 
-github.setup        editorconfig editorconfig-core-c 0.12.2 v
-license             BSD
-categories          devel
-maintainers         nomaintainer
-description         EditorConfig makes it easy to maintain the correct coding style
-long_description \
-   This code produces a program that accepts a filename as input and will \
-   look for .editorconfig files with sections applicable to the given file, \
-   outputting any properties found.
+github.setup            editorconfig editorconfig-core-c 0.12.2 v
+license                 BSD
+categories              devel
+maintainers             nomaintainer
+description             EditorConfig makes it easy to maintain the correct coding style
+long_description        This code produces a program that accepts a filename as input and will \
+                        look for .editorconfig files with sections applicable to the given file, \
+                        outputting any properties found.
 
-platforms           darwin
+platforms               darwin
 
-depends_lib         port:pcre
+depends_lib             port:pcre
 
-checksums           rmd160  14a1e30f0db589c7c37592855aad432c705cef68 \
-                    sha256  ad16136ab410aebf1abbf7f6d457412e7b3cab27a903abc952224e1d4102fd20 \
-                    size    66999
+checksums               rmd160  14a1e30f0db589c7c37592855aad432c705cef68 \
+                        sha256  ad16136ab410aebf1abbf7f6d457412e7b3cab27a903abc952224e1d4102fd20 \
+                        size    66999
 
 pre-build {
     file mkdir "${worksrcpath}/doc/man"


### PR DESCRIPTION
#### Description

Update `editorconfig-core-c` to its latest released version, 0.12.6, and claim maintainer role. 

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
