### PR TITLE
gcc{7,8,9}: fix build before 10.6 i386

### DIFF
--- a/lang/gcc7/Portfile
+++ b/lang/gcc7/Portfile
@@ -43,7 +43,7 @@ checksums           rmd160  91d46ec088badec75f41a2ad2a0ba228a6715107 \
 # NOTE : The logic here must match that in the libgcc port.
 set isLastSupported [ expr ${os.major} < 10 ]
 
-if { ${configure.build_arch} eq "i386"} {
+if { ${configure.build_arch} eq "i386" && ${os.major} >= 10 } {
 
     # fix no-pie clang bug bootstrapping gcc on i386
     # https://trac.macports.org/ticket/63161

--- a/lang/gcc8/Portfile
+++ b/lang/gcc8/Portfile
@@ -60,7 +60,7 @@ if { ${os.major} > 19 } {
     patchfiles-append         fix-sanitisers-darwin20.diff
 }
 
-if { ${configure.build_arch} eq "i386"} {
+if { ${configure.build_arch} eq "i386" && ${os.major} >= 10 } {
 
     # fix no-pie clang bug bootstrapping gcc on i386
     # https://trac.macports.org/ticket/63161

--- a/lang/gcc9/Portfile
+++ b/lang/gcc9/Portfile
@@ -47,7 +47,7 @@ if { ${os.platform} eq "darwin" && ${os.major} > 19 } {
     patchfiles-append patch-genconditions.diff
 }
 
-if { ${configure.build_arch} eq "i386" } {
+if { ${configure.build_arch} eq "i386" && ${os.major} >= 10 } {
 
     # fix no-pie clang bug bootstrapping gcc on i386
     # https://trac.macports.org/ticket/63161


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8 9L34 i386
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->