### PR TITLE
hyfetch: new port (1.4.10)

### DIFF
--- a/python/hyfetch/Portfile
+++ b/python/hyfetch/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+python.rootname         HyFetch
+name                    [string tolower ${python.rootname}]
+version                 1.4.10
+revision                0
+categories-append       sysutils
+platforms               {darwin any}
+supported_archs         noarch
+license                 MIT
+maintainers             {@therealketo gmail.com:therealketo} openmaintainer
+
+description             Fast, highly customisable system info script with LGBTQ+ pride flags
+long_description        {*}${description}.
+
+homepage                https://github.com/hykilpikonna/hyfetch
+
+checksums               rmd160  ec18dd2d3f5603f59aac2d57921f27dcae080e76 \
+                        sha256  023733fa358380fd41589cd80e9b008d376eeef16b489fba8ee8610e71e42057 \
+                        size    399570
+
+# This should stay consistent with the python PG default
+python.default_version  311
+
+depends_build-append    port:py${python.version}-typing_extensions


### PR DESCRIPTION
#### Description

Add `hyfetch`, a Neofetch alternative with support for LGBTQ+ pride flags.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?