### PR TITLE
Gildas: fixed compilation under Sonoma and Xcode 15

### DIFF
--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           active_variants 1.1
 
 name                gildas
-version             202311b
+version             202311c
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 supported_archs     arm64 x86_64
 set my_machine      [if {[string match *arm* ${os.arch}]} {list arm64} {list x86_64}]
@@ -32,9 +32,9 @@ master_sites        https://www.iram.fr/~gildas/dist/ \
 distname            ${name}-src-${my_version}
 use_xz              yes
 
-checksums           rmd160  fb4fc67e00c07c3b0740cf8290dc9dda2fd4681e \
-                    sha256  a397c47a175ae4c75b0af2997a0a1bfeb9989bd975283f814aef5952c786072c \
-                    size    46220420
+checksums           rmd160  0a9935d5973a009f35d49de496e885c80d5828f2 \
+                    sha256  ea2c790999bcad5022240939e3bf457171c10c7d5eccc644b2556af73ec0e904 \
+                    size    46204380
 
 patch.pre_args      -p1
 patchfiles          patch-admin-Makefile.def.diff \
@@ -83,7 +83,6 @@ configure {
     reinplace -W ${worksrcpath}/admin "s|@CXX@|${configure.cxx}|g" define-system.sh
     reinplace -W ${worksrcpath}/admin "s|@CPP@|${configure.cpp}|g" Makefile.def define-system.sh
     reinplace -W ${worksrcpath}/admin "s|@CPPFLAGS@|${configure.cppflags}|g" Makefile.def
-    reinplace -W ${worksrcpath}/admin "s|@LDFLAGS@|${configure.ldflags}|g" Makefile.def
     reinplace -W ${worksrcpath}/admin "s|@PYTHON@|${configure.python}|g" Makefile.build Makefile.def Makefile.python gildas-env.sh python-config-ldflags.py
 }
 

--- a/science/gildas/files/patch-admin-Makefile.def.diff
+++ b/science/gildas/files/patch-admin-Makefile.def.diff
@@ -1,25 +1,22 @@
---- gildas-src-dec15a/admin/Makefile.def.orig	2015-11-30 13:25:52.000000000 +0100
-+++ gildas-src-dec15a/admin/Makefile.def	2015-12-04 16:19:05.000000000 +0100
-@@ -72,12 +72,12 @@
+--- gildas-src-nov23b/admin/Makefile.def.orig	2023-11-27 17:55:20
++++ gildas-src-nov23b/admin/Makefile.def	2023-11-27 17:53:56
+@@ -70,12 +70,12 @@
  # The following variables are provided to the user so that he can override
  # the preprocessing, compilation and linking options defined by default
  # later in this file. User can modify them here.
 -CPPFLAGS = $(GAG_CPPFLAGS)
--SLDFLAGS = $(GAG_SLDFLAGS)
--FLDFLAGS = $(GAG_FLDFLAGS)
--CLDFLAGS = $(GAG_CLDFLAGS)
++CPPFLAGS = @CPPFLAGS@ $(GAG_CPPFLAGS)
+ SLDFLAGS = $(GAG_SLDFLAGS)
+ FLDFLAGS = $(GAG_FLDFLAGS)
+ CLDFLAGS = $(GAG_CLDFLAGS)
 -FFLAGS = $(GAG_FFLAGS)
 -CFLAGS = $(GAG_CFLAGS)
-+CPPFLAGS = @CPPFLAGS@ $(GAG_CPPFLAGS)
-+SLDFLAGS = @LDFLAGS@ $(GAG_SLDFLAGS)
-+FLDFLAGS = @LDFLAGS@ $(GAG_FLDFLAGS)
-+CLDFLAGS = @LDFLAGS@ $(GAG_CLDFLAGS)
 +FFLAGS = @FCFLAGS@ $(GAG_FFLAGS)
 +CFLAGS = @CCFLAGS@ $(GAG_CFLAGS)
  
  # The following variables are for mandatory GLOBAL definitions.
  # They should be modified only in this file.
-@@ -219,7 +219,7 @@
+@@ -228,7 +228,7 @@
  # Fortran preprocessing
  
  # Preprocessor command
@@ -27,8 +24,8 @@
 +CPP = @CPP@
  
  # Preprocessor generic flags
- GLOBAL_CPPFLAGS += -P -traditional -C 
-@@ -551,7 +551,7 @@
+ GLOBAL_CPPFLAGS += -P -traditional -C
+@@ -547,7 +547,7 @@
  SIC_SYS_LIBS =
  SIC_LIB_DEPENDS += $(_GAG_LIBS) $(LEGACY_LIBS)
  ifeq ($(PYTHON_PRESENT),yes)
@@ -36,4 +33,4 @@
 +  SIC_SYS_LIBS += $(shell @PYTHON@ $(gagadmdir)/python-config-ldflags.py)
  endif
  ifeq ($(CFITSIO_PRESENT),yes)
-   SIC_LIB_DEPENDS += -lcfitsio
+   SIC_SYS_LIBS += $(shell pkg-config --libs cfitsio)


### PR DESCRIPTION
###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
