### PR TITLE
postgresql: fix openssl 3.2 support

### DIFF
--- a/databases/postgresql12-doc/Portfile
+++ b/databases/postgresql12-doc/Portfile
@@ -6,6 +6,7 @@ name                postgresql12-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc \
     postgresql13-doc postgresql14-doc
 version             12.16
+revision            1
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -35,6 +36,7 @@ configure.args      --mandir=${prefix}/share/man \
                     --without-readline \
                     --without-zlib
 
+depends_build       port:docbook-xml-4.5 port:docbook-xsl-nons
 build.dir           ${worksrcpath}/doc
 build.type          gnu
 build.target

--- a/databases/postgresql12/Portfile
+++ b/databases/postgresql12/Portfile
@@ -9,7 +9,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql12
 version             12.17
-revision            0
+revision            1
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -35,7 +35,8 @@ checksums           rmd160  ddb48d89e9d4e27529b42bb9c826cf94ed841928 \
 use_bzip2           yes
 
 # do not build man or html files (use postgresqlXY-doc instead)
-patchfiles-append   patch-no_doc.diff
+patchfiles-append   patch-no_doc.diff \
+                    patch-openssl32.diff
 
 depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib port:libxml2 port:libxslt path:lib/pkgconfig/icu-uc.pc:icu path:lib/libgssapi_krb5.dylib:kerberos5
 depends_build       port:bison port:pkgconfig

--- a/databases/postgresql12/files/patch-openssl32.diff
+++ b/databases/postgresql12/files/patch-openssl32.diff
@@ -1,0 +1,190 @@
+From 0acbe32e1a24e23aa36a7fbcce3a002ee22b10ed Mon Sep 17 00:00:00 2001
+From: Tom Lane <tgl@sss.pgh.pa.us>
+Date: Tue, 28 Nov 2023 12:34:03 -0500
+Subject: [PATCH] Use BIO_{get,set}_app_data instead of BIO_{get,set}_data.
+
+We should have done it this way all along, but we accidentally got
+away with using the wrong BIO field up until OpenSSL 3.2.  There,
+the library's BIO routines that we rely on use the "data" field
+for their own purposes, and our conflicting use causes assorted
+weird behaviors up to and including core dumps when SSL connections
+are attempted.  Switch to using the approved field for the purpose,
+i.e. app_data.
+
+While at it, remove our configure probes for BIO_get_data as well
+as the fallback implementation.  BIO_{get,set}_app_data have been
+there since long before any OpenSSL version that we still support,
+even in the back branches.
+
+Also, update src/test/ssl/t/001_ssltests.pl to allow for a minor
+change in an error message spelling that evidently came in with 3.2.
+
+Tristan Partin and Bo Andreson.  Back-patch to all supported branches.
+
+Discussion: https://postgr.es/m/CAN55FZ1eDDYsYaL7mv+oSLUij2h_u6hvD4Qmv-7PK7jkji0uyQ@mail.gmail.com
+---
+ configure                                |  2 +-
+ configure.in                             |  2 +-
+ src/backend/libpq/be-secure-openssl.c    | 11 +++--------
+ src/include/pg_config.h.in               |  3 ---
+ src/include/pg_config.h.win32            |  3 ---
+ src/interfaces/libpq/fe-secure-openssl.c | 11 ++++-------
+ src/tools/msvc/Solution.pm               |  1 -
+ 7 files changed, 9 insertions(+), 24 deletions(-)
+
+diff --git configure configure
+index cce104aebb..346ea8e2c1 100755
+--- configure
++++ configure
+@@ -12641,7 +12641,7 @@ done
+   # defines OPENSSL_VERSION_NUMBER to claim version 2.0.0, even though it
+   # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+   # functions.
+-  for ac_func in OPENSSL_init_ssl BIO_get_data BIO_meth_new ASN1_STRING_get0_data
++  for ac_func in OPENSSL_init_ssl BIO_meth_new ASN1_STRING_get0_data
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+diff --git configure.in configure.in
+index 3c93e7a944..2c15b20049 100644
+--- configure.in
++++ configure.in
+@@ -1290,7 +1290,7 @@ if test "$with_openssl" = yes ; then
+   # defines OPENSSL_VERSION_NUMBER to claim version 2.0.0, even though it
+   # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+   # functions.
+-  AC_CHECK_FUNCS([OPENSSL_init_ssl BIO_get_data BIO_meth_new ASN1_STRING_get0_data])
++  AC_CHECK_FUNCS([OPENSSL_init_ssl BIO_meth_new ASN1_STRING_get0_data])
+   # OpenSSL versions before 1.1.0 required setting callback functions, for
+   # thread-safety. In 1.1.0, it's no longer required, and CRYPTO_lock()
+   # function was removed.
+diff --git src/backend/libpq/be-secure-openssl.c src/backend/libpq/be-secure-openssl.c
+index b0a1f7258a..34f8f9e71e 100644
+--- src/backend/libpq/be-secure-openssl.c
++++ src/backend/libpq/be-secure-openssl.c
+@@ -699,11 +699,6 @@ be_tls_write(Port *port, void *ptr, size_t len, int *waitfor)
+  * to retry; do we need to adopt their logic for that?
+  */
+ 
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods = NULL;
+ 
+ static int
+@@ -713,7 +708,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ 
+ 	if (buf != NULL)
+ 	{
+-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
++		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
+ 		BIO_clear_retry_flags(h);
+ 		if (res <= 0)
+ 		{
+@@ -733,7 +728,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res = 0;
+ 
+-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
++	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res <= 0)
+ 	{
+@@ -809,7 +804,7 @@ my_SSL_set_fd(Port *port, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, port);
++	BIO_set_app_data(bio, port);
+ 
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+ 	SSL_set_bio(port->ssl, bio, bio);
+diff --git src/include/pg_config.h.in src/include/pg_config.h.in
+index 457a8713cc..1e9d21c3e4 100644
+--- src/include/pg_config.h.in
++++ src/include/pg_config.h.in
+@@ -96,9 +96,6 @@
+ /* Define to 1 if you have the <atomic.h> header file. */
+ #undef HAVE_ATOMIC_H
+ 
+-/* Define to 1 if you have the `BIO_get_data' function. */
+-#undef HAVE_BIO_GET_DATA
+-
+ /* Define to 1 if you have the `BIO_meth_new' function. */
+ #undef HAVE_BIO_METH_NEW
+ 
+diff --git src/include/pg_config.h.win32 src/include/pg_config.h.win32
+index 42fd7067f1..37accc560b 100644
+--- src/include/pg_config.h.win32
++++ src/include/pg_config.h.win32
+@@ -75,9 +75,6 @@
+ /* Define to 1 if you have the `ASN1_STRING_get0_data' function. */
+ /* #undef HAVE_ASN1_STRING_GET0_DATA */
+ 
+-/* Define to 1 if you have the `BIO_get_data' function. */
+-/* #undef HAVE_BIO_GET_DATA */
+-
+ /* Define to 1 if you have the `BIO_meth_new' function. */
+ /* #undef HAVE_BIO_METH_NEW */
+ 
+diff --git src/interfaces/libpq/fe-secure-openssl.c src/interfaces/libpq/fe-secure-openssl.c
+index 5948a37983..2e91587b7c 100644
+--- src/interfaces/libpq/fe-secure-openssl.c
++++ src/interfaces/libpq/fe-secure-openssl.c
+@@ -1491,11 +1491,8 @@ PQsslAttribute(PGconn *conn, const char *attribute_name)
+  * to retry; do we need to adopt their logic for that?
+  */
+ 
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+ 
++/* protected by ssl_config_mutex */
+ static BIO_METHOD *my_bio_methods;
+ 
+ static int
+@@ -1503,7 +1500,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ {
+ 	int			res;
+ 
+-	res = pqsecure_raw_read((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_read((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1533,7 +1530,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res;
+ 
+-	res = pqsecure_raw_write((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_write((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1624,7 +1621,7 @@ my_SSL_set_fd(PGconn *conn, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, conn);
++	BIO_set_app_data(bio, conn);
+ 
+ 	SSL_set_bio(conn->ssl, bio, bio);
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+diff --git src/tools/msvc/Solution.pm src/tools/msvc/Solution.pm
+index 20ce233af4..a7e5fdbda9 100644
+--- src/tools/msvc/Solution.pm
++++ src/tools/msvc/Solution.pm
+@@ -273,7 +273,6 @@ sub GenerateFiles
+ 				|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0'))
+ 			{
+ 				print $o "#define HAVE_ASN1_STRING_GET0_DATA 1\n";
+-				print $o "#define HAVE_BIO_GET_DATA 1\n";
+ 				print $o "#define HAVE_BIO_METH_NEW 1\n";
+ 				print $o "#define HAVE_OPENSSL_INIT_SSL 1\n";
+ 			}
+-- 
+2.42.1
+

--- a/databases/postgresql13-doc/Portfile
+++ b/databases/postgresql13-doc/Portfile
@@ -6,6 +6,7 @@ name                postgresql13-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc \
     postgresql12-doc postgresql14-doc
 version             13.12
+revision            1
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -35,6 +36,7 @@ configure.args      --mandir=${prefix}/share/man \
                     --without-readline \
                     --without-zlib
 
+depends_build       port:docbook-xml-4.5 port:docbook-xsl-nons
 build.dir           ${worksrcpath}/doc
 build.type          gnu
 build.target

--- a/databases/postgresql13/Portfile
+++ b/databases/postgresql13/Portfile
@@ -9,7 +9,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql13
 version             13.13
-revision            0
+revision            1
 
 categories          databases
 platforms           darwin
@@ -36,7 +36,8 @@ checksums           rmd160  23e88ae4d558fefd3b5a43777965fdce6f23a273 \
 use_bzip2           yes
 
 # do not build man or html files (use postgresqlXY-doc instead)
-patchfiles-append   patch-no_doc.diff
+patchfiles-append   patch-no_doc.diff \
+                    patch-openssl32.diff
 
 # https://trac.macports.org/ticket/66060
 # https://postgrespro.ru/list/thread-id/2551610

--- a/databases/postgresql13/files/patch-openssl32.diff
+++ b/databases/postgresql13/files/patch-openssl32.diff
@@ -1,0 +1,183 @@
+From a94f909f36d886fb2ae174ee1607e3e7e56e3a9b Mon Sep 17 00:00:00 2001
+From: Tom Lane <tgl@sss.pgh.pa.us>
+Date: Tue, 28 Nov 2023 12:34:03 -0500
+Subject: [PATCH] Use BIO_{get,set}_app_data instead of BIO_{get,set}_data.
+
+We should have done it this way all along, but we accidentally got
+away with using the wrong BIO field up until OpenSSL 3.2.  There,
+the library's BIO routines that we rely on use the "data" field
+for their own purposes, and our conflicting use causes assorted
+weird behaviors up to and including core dumps when SSL connections
+are attempted.  Switch to using the approved field for the purpose,
+i.e. app_data.
+
+While at it, remove our configure probes for BIO_get_data as well
+as the fallback implementation.  BIO_{get,set}_app_data have been
+there since long before any OpenSSL version that we still support,
+even in the back branches.
+
+Also, update src/test/ssl/t/001_ssltests.pl to allow for a minor
+change in an error message spelling that evidently came in with 3.2.
+
+Tristan Partin and Bo Andreson.  Back-patch to all supported branches.
+
+Discussion: https://postgr.es/m/CAN55FZ1eDDYsYaL7mv+oSLUij2h_u6hvD4Qmv-7PK7jkji0uyQ@mail.gmail.com
+---
+ configure                                |  2 +-
+ configure.in                             |  2 +-
+ src/backend/libpq/be-secure-openssl.c    | 11 +++--------
+ src/include/pg_config.h.in               |  3 ---
+ src/interfaces/libpq/fe-secure-openssl.c | 11 ++++-------
+ src/tools/msvc/Solution.pm               |  2 --
+ 6 files changed, 9 insertions(+), 22 deletions(-)
+
+diff --git configure configure
+index 2fc7dca504..b7caf88229 100755
+--- configure
++++ configure
+@@ -12713,7 +12713,7 @@ done
+   # defines OPENSSL_VERSION_NUMBER to claim version 2.0.0, even though it
+   # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+   # functions.
+-  for ac_func in OPENSSL_init_ssl BIO_get_data BIO_meth_new ASN1_STRING_get0_data
++  for ac_func in OPENSSL_init_ssl BIO_meth_new ASN1_STRING_get0_data
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+diff --git configure.in configure.in
+index eaca132607..9aec28c8d1 100644
+--- configure.in
++++ configure.in
+@@ -1275,7 +1275,7 @@ if test "$with_openssl" = yes ; then
+   # defines OPENSSL_VERSION_NUMBER to claim version 2.0.0, even though it
+   # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+   # functions.
+-  AC_CHECK_FUNCS([OPENSSL_init_ssl BIO_get_data BIO_meth_new ASN1_STRING_get0_data])
++  AC_CHECK_FUNCS([OPENSSL_init_ssl BIO_meth_new ASN1_STRING_get0_data])
+   # OpenSSL versions before 1.1.0 required setting callback functions, for
+   # thread-safety. In 1.1.0, it's no longer required, and CRYPTO_lock()
+   # function was removed.
+diff --git src/backend/libpq/be-secure-openssl.c src/backend/libpq/be-secure-openssl.c
+index 55fe59276a..9e22911379 100644
+--- src/backend/libpq/be-secure-openssl.c
++++ src/backend/libpq/be-secure-openssl.c
+@@ -748,11 +748,6 @@ be_tls_write(Port *port, void *ptr, size_t len, int *waitfor)
+  * to retry; do we need to adopt their logic for that?
+  */
+ 
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods = NULL;
+ 
+ static int
+@@ -762,7 +757,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ 
+ 	if (buf != NULL)
+ 	{
+-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
++		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
+ 		BIO_clear_retry_flags(h);
+ 		if (res <= 0)
+ 		{
+@@ -782,7 +777,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res = 0;
+ 
+-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
++	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res <= 0)
+ 	{
+@@ -858,7 +853,7 @@ my_SSL_set_fd(Port *port, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, port);
++	BIO_set_app_data(bio, port);
+ 
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+ 	SSL_set_bio(port->ssl, bio, bio);
+diff --git src/include/pg_config.h.in src/include/pg_config.h.in
+index 13fc4e0db6..978e685c70 100644
+--- src/include/pg_config.h.in
++++ src/include/pg_config.h.in
+@@ -86,9 +86,6 @@
+ /* Define to 1 if you have the `backtrace_symbols' function. */
+ #undef HAVE_BACKTRACE_SYMBOLS
+ 
+-/* Define to 1 if you have the `BIO_get_data' function. */
+-#undef HAVE_BIO_GET_DATA
+-
+ /* Define to 1 if you have the `BIO_meth_new' function. */
+ #undef HAVE_BIO_METH_NEW
+ 
+diff --git src/interfaces/libpq/fe-secure-openssl.c src/interfaces/libpq/fe-secure-openssl.c
+index 07d5daf4d9..73728cbdc2 100644
+--- src/interfaces/libpq/fe-secure-openssl.c
++++ src/interfaces/libpq/fe-secure-openssl.c
+@@ -1602,11 +1602,8 @@ PQsslAttribute(PGconn *conn, const char *attribute_name)
+  * to retry; do we need to adopt their logic for that?
+  */
+ 
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+ 
++/* protected by ssl_config_mutex */
+ static BIO_METHOD *my_bio_methods;
+ 
+ static int
+@@ -1614,7 +1611,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ {
+ 	int			res;
+ 
+-	res = pqsecure_raw_read((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_read((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1644,7 +1641,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res;
+ 
+-	res = pqsecure_raw_write((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_write((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1735,7 +1732,7 @@ my_SSL_set_fd(PGconn *conn, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, conn);
++	BIO_set_app_data(bio, conn);
+ 
+ 	SSL_set_bio(conn->ssl, bio, bio);
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+diff --git src/tools/msvc/Solution.pm src/tools/msvc/Solution.pm
+index 78328e1fac..e88e3967cd 100644
+--- src/tools/msvc/Solution.pm
++++ src/tools/msvc/Solution.pm
+@@ -226,7 +226,6 @@ sub GenerateFiles
+ 		HAVE_ATOMICS               => 1,
+ 		HAVE_ATOMIC_H              => undef,
+ 		HAVE_BACKTRACE_SYMBOLS     => undef,
+-		HAVE_BIO_GET_DATA          => undef,
+ 		HAVE_BIO_METH_NEW          => undef,
+ 		HAVE_CLOCK_GETTIME         => undef,
+ 		HAVE_COMPUTED_GOTO         => undef,
+@@ -543,7 +542,6 @@ sub GenerateFiles
+ 			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0'))
+ 		{
+ 			$define{HAVE_ASN1_STRING_GET0_DATA} = 1;
+-			$define{HAVE_BIO_GET_DATA}          = 1;
+ 			$define{HAVE_BIO_METH_NEW}          = 1;
+ 			$define{HAVE_OPENSSL_INIT_SSL}      = 1;
+ 		}
+-- 
+2.42.1
+

--- a/databases/postgresql14-doc/Portfile
+++ b/databases/postgresql14-doc/Portfile
@@ -6,6 +6,7 @@ name                postgresql14-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc postgresql12-doc \
     postgresql13-doc
 version             14.9
+revision            1
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -35,6 +36,7 @@ configure.args      --mandir=${prefix}/share/man \
                     --without-readline \
                     --without-zlib
 
+depends_build       port:docbook-xml-4.5 port:docbook-xsl-nons
 build.dir           ${worksrcpath}/doc
 build.type          gnu
 build.target

--- a/databases/postgresql14/Portfile
+++ b/databases/postgresql14/Portfile
@@ -9,7 +9,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql14
 version             14.10
-revision            0
+revision            1
 
 categories          databases
 platforms           darwin
@@ -36,7 +36,8 @@ checksums           rmd160  b2e001d5c5115df81627e6625b2a4549f4fd9ad5 \
 use_bzip2           yes
 
 # do not build man or html files (use postgresqlXY-doc instead)
-patchfiles-append   patch-no_doc.diff
+patchfiles-append   patch-no_doc.diff \
+                    patch-openssl32.diff
 
 # https://trac.macports.org/ticket/66060
 # https://postgrespro.ru/list/thread-id/2551610

--- a/databases/postgresql14/files/patch-openssl32.diff
+++ b/databases/postgresql14/files/patch-openssl32.diff
@@ -1,0 +1,206 @@
+From 966d74c19719e4fec6c3542ef5e86f82f83f7053 Mon Sep 17 00:00:00 2001
+From: Tom Lane <tgl@sss.pgh.pa.us>
+Date: Tue, 28 Nov 2023 12:34:03 -0500
+Subject: [PATCH] Use BIO_{get,set}_app_data instead of BIO_{get,set}_data.
+
+We should have done it this way all along, but we accidentally got
+away with using the wrong BIO field up until OpenSSL 3.2.  There,
+the library's BIO routines that we rely on use the "data" field
+for their own purposes, and our conflicting use causes assorted
+weird behaviors up to and including core dumps when SSL connections
+are attempted.  Switch to using the approved field for the purpose,
+i.e. app_data.
+
+While at it, remove our configure probes for BIO_get_data as well
+as the fallback implementation.  BIO_{get,set}_app_data have been
+there since long before any OpenSSL version that we still support,
+even in the back branches.
+
+Also, update src/test/ssl/t/001_ssltests.pl to allow for a minor
+change in an error message spelling that evidently came in with 3.2.
+
+Tristan Partin and Bo Andreson.  Back-patch to all supported branches.
+
+Discussion: https://postgr.es/m/CAN55FZ1eDDYsYaL7mv+oSLUij2h_u6hvD4Qmv-7PK7jkji0uyQ@mail.gmail.com
+---
+ configure                                |  2 +-
+ configure.ac                             |  2 +-
+ src/backend/libpq/be-secure-openssl.c    | 11 +++--------
+ src/include/pg_config.h.in               |  3 ---
+ src/interfaces/libpq/fe-secure-openssl.c | 11 ++++-------
+ src/test/ssl/t/001_ssltests.pl           |  4 ++--
+ src/tools/msvc/Solution.pm               |  2 --
+ 7 files changed, 11 insertions(+), 24 deletions(-)
+
+diff --git configure configure
+index 49500d61c2..b74f431046 100755
+--- configure
++++ configure
+@@ -13069,7 +13069,7 @@ done
+   # defines OPENSSL_VERSION_NUMBER to claim version 2.0.0, even though it
+   # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+   # functions.
+-  for ac_func in OPENSSL_init_ssl BIO_get_data BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free
++  for ac_func in OPENSSL_init_ssl BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+diff --git configure.ac configure.ac
+index 159f2a2677..2a92f7d797 100644
+--- configure.ac
++++ configure.ac
+@@ -1311,7 +1311,7 @@ if test "$with_ssl" = openssl ; then
+   # defines OPENSSL_VERSION_NUMBER to claim version 2.0.0, even though it
+   # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+   # functions.
+-  AC_CHECK_FUNCS([OPENSSL_init_ssl BIO_get_data BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free])
++  AC_CHECK_FUNCS([OPENSSL_init_ssl BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free])
+   # OpenSSL versions before 1.1.0 required setting callback functions, for
+   # thread-safety. In 1.1.0, it's no longer required, and CRYPTO_lock()
+   # function was removed.
+diff --git src/backend/libpq/be-secure-openssl.c src/backend/libpq/be-secure-openssl.c
+index 13ac961442..e39952494e 100644
+--- src/backend/libpq/be-secure-openssl.c
++++ src/backend/libpq/be-secure-openssl.c
+@@ -823,11 +823,6 @@ be_tls_write(Port *port, void *ptr, size_t len, int *waitfor)
+  * to retry; do we need to adopt their logic for that?
+  */
+ 
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods = NULL;
+ 
+ static int
+@@ -837,7 +832,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ 
+ 	if (buf != NULL)
+ 	{
+-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
++		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
+ 		BIO_clear_retry_flags(h);
+ 		if (res <= 0)
+ 		{
+@@ -857,7 +852,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res = 0;
+ 
+-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
++	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res <= 0)
+ 	{
+@@ -933,7 +928,7 @@ my_SSL_set_fd(Port *port, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, port);
++	BIO_set_app_data(bio, port);
+ 
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+ 	SSL_set_bio(port->ssl, bio, bio);
+diff --git src/include/pg_config.h.in src/include/pg_config.h.in
+index 40d513c128..51fa911fb6 100644
+--- src/include/pg_config.h.in
++++ src/include/pg_config.h.in
+@@ -86,9 +86,6 @@
+ /* Define to 1 if you have the `backtrace_symbols' function. */
+ #undef HAVE_BACKTRACE_SYMBOLS
+ 
+-/* Define to 1 if you have the `BIO_get_data' function. */
+-#undef HAVE_BIO_GET_DATA
+-
+ /* Define to 1 if you have the `BIO_meth_new' function. */
+ #undef HAVE_BIO_METH_NEW
+ 
+diff --git src/interfaces/libpq/fe-secure-openssl.c src/interfaces/libpq/fe-secure-openssl.c
+index 7f27767da6..8e2f70a31f 100644
+--- src/interfaces/libpq/fe-secure-openssl.c
++++ src/interfaces/libpq/fe-secure-openssl.c
+@@ -1661,11 +1661,8 @@ PQsslAttribute(PGconn *conn, const char *attribute_name)
+  * to retry; do we need to adopt their logic for that?
+  */
+ 
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+ 
++/* protected by ssl_config_mutex */
+ static BIO_METHOD *my_bio_methods;
+ 
+ static int
+@@ -1673,7 +1670,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ {
+ 	int			res;
+ 
+-	res = pqsecure_raw_read((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_read((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1703,7 +1700,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res;
+ 
+-	res = pqsecure_raw_write((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_write((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1794,7 +1791,7 @@ my_SSL_set_fd(PGconn *conn, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, conn);
++	BIO_set_app_data(bio, conn);
+ 
+ 	SSL_set_bio(conn->ssl, bio, bio);
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+diff --git src/test/ssl/t/001_ssltests.pl src/test/ssl/t/001_ssltests.pl
+index 8cdd0d2e68..cc7bd98c83 100644
+--- src/test/ssl/t/001_ssltests.pl
++++ src/test/ssl/t/001_ssltests.pl
+@@ -538,7 +538,7 @@ $node->connect_fails(
+ $node->connect_fails(
+ 	"$common_connstr user=ssltestuser sslcert=ssl/client-revoked.crt sslkey=ssl/client-revoked_tmp.key",
+ 	"certificate authorization fails with revoked client cert",
+-	expected_stderr => qr/SSL error: sslv3 alert certificate revoked/,
++	expected_stderr => qr|SSL error: ssl[a-z0-9/]* alert certificate revoked|,
+ 	# revoked certificates should not authenticate the user
+ 	log_unlike => [qr/connection authenticated:/],);
+ 
+@@ -591,7 +591,7 @@ switch_server_cert($node, 'server-cn-only', undef, undef,
+ $node->connect_fails(
+ 	"$common_connstr user=ssltestuser sslcert=ssl/client-revoked.crt sslkey=ssl/client-revoked_tmp.key",
+ 	"certificate authorization fails with revoked client cert with server-side CRL directory",
+-	expected_stderr => qr/SSL error: sslv3 alert certificate revoked/);
++	expected_stderr => qr|SSL error: ssl[a-z0-9/]* alert certificate revoked|);
+ 
+ # clean up
+ foreach my $key (@keys)
+diff --git src/tools/msvc/Solution.pm src/tools/msvc/Solution.pm
+index 577b5afea7..53d60dbd25 100644
+--- src/tools/msvc/Solution.pm
++++ src/tools/msvc/Solution.pm
+@@ -229,7 +229,6 @@ sub GenerateFiles
+ 		HAVE_ATOMICS               => 1,
+ 		HAVE_ATOMIC_H              => undef,
+ 		HAVE_BACKTRACE_SYMBOLS     => undef,
+-		HAVE_BIO_GET_DATA          => undef,
+ 		HAVE_BIO_METH_NEW          => undef,
+ 		HAVE_CLOCK_GETTIME         => undef,
+ 		HAVE_COMPUTED_GOTO         => undef,
+@@ -562,7 +561,6 @@ sub GenerateFiles
+ 			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0'))
+ 		{
+ 			$define{HAVE_ASN1_STRING_GET0_DATA} = 1;
+-			$define{HAVE_BIO_GET_DATA}          = 1;
+ 			$define{HAVE_BIO_METH_NEW}          = 1;
+ 			$define{HAVE_HMAC_CTX_FREE}         = 1;
+ 			$define{HAVE_HMAC_CTX_NEW}          = 1;
+-- 
+2.42.1
+

--- a/databases/postgresql15-doc/Portfile
+++ b/databases/postgresql15-doc/Portfile
@@ -6,6 +6,7 @@ name                postgresql15-doc
 conflicts           postgresql96-doc postgresql10-doc postgresql11-doc postgresql12-doc \
     postgresql13-doc postgresql14-doc
 version             15.4
+revision            1
 categories          databases
 platforms           darwin
 maintainers         {jwa @jyrkiwahlstedt}
@@ -35,6 +36,7 @@ configure.args      --mandir=${prefix}/share/man \
                     --without-readline \
                     --without-zlib
 
+depends_build       port:docbook-xml-4.5 port:docbook-xsl-nons
 build.dir           ${worksrcpath}/doc
 build.type          gnu
 build.target

--- a/databases/postgresql15/Portfile
+++ b/databases/postgresql15/Portfile
@@ -9,7 +9,7 @@ PortGroup muniversal 1.0
 #remember to update the -doc and -server as well
 name                postgresql15
 version             15.5
-revision            0
+revision            1
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -35,7 +35,8 @@ checksums           rmd160  3b5202b1a3d1e481f3861b77c1b8bcca8806a39b \
 use_bzip2           yes
 
 # do not build man or html files (use postgresqlXY-doc instead)
-patchfiles-append   patch-no_doc.diff
+patchfiles-append   patch-no_doc.diff \
+                    patch-openssl32.diff
 
 # https://trac.macports.org/ticket/66060
 # https://trac.macports.org/ticket/67365

--- a/databases/postgresql15/files/patch-openssl32.diff
+++ b/databases/postgresql15/files/patch-openssl32.diff
@@ -1,0 +1,205 @@
+From 905c907043372b6f1d530ab2076154c64f43fdbf Mon Sep 17 00:00:00 2001
+From: Tom Lane <tgl@sss.pgh.pa.us>
+Date: Tue, 28 Nov 2023 12:34:03 -0500
+Subject: [PATCH] Use BIO_{get,set}_app_data instead of BIO_{get,set}_data.
+
+We should have done it this way all along, but we accidentally got
+away with using the wrong BIO field up until OpenSSL 3.2.  There,
+the library's BIO routines that we rely on use the "data" field
+for their own purposes, and our conflicting use causes assorted
+weird behaviors up to and including core dumps when SSL connections
+are attempted.  Switch to using the approved field for the purpose,
+i.e. app_data.
+
+While at it, remove our configure probes for BIO_get_data as well
+as the fallback implementation.  BIO_{get,set}_app_data have been
+there since long before any OpenSSL version that we still support,
+even in the back branches.
+
+Also, update src/test/ssl/t/001_ssltests.pl to allow for a minor
+change in an error message spelling that evidently came in with 3.2.
+
+Tristan Partin and Bo Andreson.  Back-patch to all supported branches.
+
+Discussion: https://postgr.es/m/CAN55FZ1eDDYsYaL7mv+oSLUij2h_u6hvD4Qmv-7PK7jkji0uyQ@mail.gmail.com
+---
+ configure                                |  2 +-
+ configure.ac                             |  2 +-
+ src/backend/libpq/be-secure-openssl.c    | 11 +++--------
+ src/include/pg_config.h.in               |  3 ---
+ src/interfaces/libpq/fe-secure-openssl.c | 11 ++++-------
+ src/test/ssl/t/001_ssltests.pl           |  4 ++--
+ src/tools/msvc/Solution.pm               |  2 --
+ 7 files changed, 11 insertions(+), 24 deletions(-)
+
+diff --git configure configure
+index d83a402ea1..d55440cd6a 100755
+--- configure
++++ configure
+@@ -13239,7 +13239,7 @@ done
+   # defines OPENSSL_VERSION_NUMBER to claim version 2.0.0, even though it
+   # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+   # functions.
+-  for ac_func in OPENSSL_init_ssl BIO_get_data BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free
++  for ac_func in OPENSSL_init_ssl BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+diff --git configure.ac configure.ac
+index 570daced81..2bc752ca1a 100644
+--- configure.ac
++++ configure.ac
+@@ -1347,7 +1347,7 @@ if test "$with_ssl" = openssl ; then
+   # defines OPENSSL_VERSION_NUMBER to claim version 2.0.0, even though it
+   # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+   # functions.
+-  AC_CHECK_FUNCS([OPENSSL_init_ssl BIO_get_data BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free])
++  AC_CHECK_FUNCS([OPENSSL_init_ssl BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free])
+   # OpenSSL versions before 1.1.0 required setting callback functions, for
+   # thread-safety. In 1.1.0, it's no longer required, and CRYPTO_lock()
+   # function was removed.
+diff --git src/backend/libpq/be-secure-openssl.c src/backend/libpq/be-secure-openssl.c
+index f5c5ed210e..aed8a75345 100644
+--- src/backend/libpq/be-secure-openssl.c
++++ src/backend/libpq/be-secure-openssl.c
+@@ -839,11 +839,6 @@ be_tls_write(Port *port, void *ptr, size_t len, int *waitfor)
+  * to retry; do we need to adopt their logic for that?
+  */
+ 
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods = NULL;
+ 
+ static int
+@@ -853,7 +848,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ 
+ 	if (buf != NULL)
+ 	{
+-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
++		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
+ 		BIO_clear_retry_flags(h);
+ 		if (res <= 0)
+ 		{
+@@ -873,7 +868,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res = 0;
+ 
+-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
++	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res <= 0)
+ 	{
+@@ -949,7 +944,7 @@ my_SSL_set_fd(Port *port, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, port);
++	BIO_set_app_data(bio, port);
+ 
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+ 	SSL_set_bio(port->ssl, bio, bio);
+diff --git src/include/pg_config.h.in src/include/pg_config.h.in
+index d09e9f9a1c..768e3d719c 100644
+--- src/include/pg_config.h.in
++++ src/include/pg_config.h.in
+@@ -77,9 +77,6 @@
+ /* Define to 1 if you have the `backtrace_symbols' function. */
+ #undef HAVE_BACKTRACE_SYMBOLS
+ 
+-/* Define to 1 if you have the `BIO_get_data' function. */
+-#undef HAVE_BIO_GET_DATA
+-
+ /* Define to 1 if you have the `BIO_meth_new' function. */
+ #undef HAVE_BIO_METH_NEW
+ 
+diff --git src/interfaces/libpq/fe-secure-openssl.c src/interfaces/libpq/fe-secure-openssl.c
+index af59ff49f7..d4bf40da21 100644
+--- src/interfaces/libpq/fe-secure-openssl.c
++++ src/interfaces/libpq/fe-secure-openssl.c
+@@ -1800,11 +1800,8 @@ PQsslAttribute(PGconn *conn, const char *attribute_name)
+  * to retry; do we need to adopt their logic for that?
+  */
+ 
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+ 
++/* protected by ssl_config_mutex */
+ static BIO_METHOD *my_bio_methods;
+ 
+ static int
+@@ -1812,7 +1809,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ {
+ 	int			res;
+ 
+-	res = pqsecure_raw_read((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_read((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1842,7 +1839,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res;
+ 
+-	res = pqsecure_raw_write((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_write((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1933,7 +1930,7 @@ my_SSL_set_fd(PGconn *conn, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, conn);
++	BIO_set_app_data(bio, conn);
+ 
+ 	SSL_set_bio(conn->ssl, bio, bio);
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+diff --git src/test/ssl/t/001_ssltests.pl src/test/ssl/t/001_ssltests.pl
+index 707f4005af..c570b48a1b 100644
+--- src/test/ssl/t/001_ssltests.pl
++++ src/test/ssl/t/001_ssltests.pl
+@@ -682,7 +682,7 @@ $node->connect_fails(
+ 	"$common_connstr user=ssltestuser sslcert=ssl/client-revoked.crt "
+ 	  . sslkey('client-revoked.key'),
+ 	"certificate authorization fails with revoked client cert",
+-	expected_stderr => qr/SSL error: sslv3 alert certificate revoked/,
++	expected_stderr => qr|SSL error: ssl[a-z0-9/]* alert certificate revoked|,
+ 	# revoked certificates should not authenticate the user
+ 	log_unlike => [qr/connection authenticated:/],);
+ 
+@@ -743,6 +743,6 @@ $node->connect_fails(
+ 	"$common_connstr user=ssltestuser sslcert=ssl/client-revoked.crt "
+ 	  . sslkey('client-revoked.key'),
+ 	"certificate authorization fails with revoked client cert with server-side CRL directory",
+-	expected_stderr => qr/SSL error: sslv3 alert certificate revoked/);
++	expected_stderr => qr|SSL error: ssl[a-z0-9/]* alert certificate revoked|);
+ 
+ done_testing();
+diff --git src/tools/msvc/Solution.pm src/tools/msvc/Solution.pm
+index 790f03b05e..a53239fa28 100644
+--- src/tools/msvc/Solution.pm
++++ src/tools/msvc/Solution.pm
+@@ -226,7 +226,6 @@ sub GenerateFiles
+ 		HAVE_ATOMICS               => 1,
+ 		HAVE_ATOMIC_H              => undef,
+ 		HAVE_BACKTRACE_SYMBOLS     => undef,
+-		HAVE_BIO_GET_DATA          => undef,
+ 		HAVE_BIO_METH_NEW          => undef,
+ 		HAVE_CLOCK_GETTIME         => undef,
+ 		HAVE_COMPUTED_GOTO         => undef,
+@@ -566,7 +565,6 @@ sub GenerateFiles
+ 			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0'))
+ 		{
+ 			$define{HAVE_ASN1_STRING_GET0_DATA} = 1;
+-			$define{HAVE_BIO_GET_DATA}          = 1;
+ 			$define{HAVE_BIO_METH_NEW}          = 1;
+ 			$define{HAVE_HMAC_CTX_FREE}         = 1;
+ 			$define{HAVE_HMAC_CTX_NEW}          = 1;
+-- 
+2.42.1
+

--- a/databases/postgresql16/Portfile
+++ b/databases/postgresql16/Portfile
@@ -9,7 +9,7 @@ PortGroup legacysupport 1.1
 
 name                postgresql16
 version             16.1
-revision            0
+revision            1
 
 categories          databases
 maintainers         {gmail.com:davidgilman1 @dgilman} \
@@ -43,6 +43,7 @@ platform darwin powerpc {
     patchfiles-append  patch-icu.diff \
                        patch-fix-ppc-asm.diff
 }
+patchfiles-append   patch-openssl32.diff
 
 depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib \
                     port:libxml2 port:libxslt \
@@ -50,7 +51,8 @@ depends_lib         port:readline path:lib/libssl.dylib:openssl port:zlib \
                     path:lib/libgssapi_krb5.dylib:kerberos5 \
                     path:lib/libzstd.dylib:zstd \
                     path:lib/liblz4.dylib:lz4
-depends_build       port:bison port:pkgconfig
+depends_build       port:bison port:pkgconfig \
+                    port:docbook-xml-4.5 port:docbook-xsl-nons
 depends_run         port:postgresql_select
 
 legacysupport.newest_darwin_requires_legacy \

--- a/databases/postgresql16/files/patch-openssl32.diff
+++ b/databases/postgresql16/files/patch-openssl32.diff
@@ -1,0 +1,226 @@
+From d35bb1a3eb324c0d1118ad8cbc6253bf968ff589 Mon Sep 17 00:00:00 2001
+From: Tom Lane <tgl@sss.pgh.pa.us>
+Date: Tue, 28 Nov 2023 12:34:03 -0500
+Subject: [PATCH] Use BIO_{get,set}_app_data instead of BIO_{get,set}_data.
+
+We should have done it this way all along, but we accidentally got
+away with using the wrong BIO field up until OpenSSL 3.2.  There,
+the library's BIO routines that we rely on use the "data" field
+for their own purposes, and our conflicting use causes assorted
+weird behaviors up to and including core dumps when SSL connections
+are attempted.  Switch to using the approved field for the purpose,
+i.e. app_data.
+
+While at it, remove our configure probes for BIO_get_data as well
+as the fallback implementation.  BIO_{get,set}_app_data have been
+there since long before any OpenSSL version that we still support,
+even in the back branches.
+
+Also, update src/test/ssl/t/001_ssltests.pl to allow for a minor
+change in an error message spelling that evidently came in with 3.2.
+
+Tristan Partin and Bo Andreson.  Back-patch to all supported branches.
+
+Discussion: https://postgr.es/m/CAN55FZ1eDDYsYaL7mv+oSLUij2h_u6hvD4Qmv-7PK7jkji0uyQ@mail.gmail.com
+---
+ configure                                |  2 +-
+ configure.ac                             |  2 +-
+ meson.build                              |  1 -
+ src/backend/libpq/be-secure-openssl.c    | 11 +++--------
+ src/include/pg_config.h.in               |  3 ---
+ src/interfaces/libpq/fe-secure-openssl.c | 10 +++-------
+ src/test/ssl/t/001_ssltests.pl           |  6 +++---
+ src/tools/msvc/Solution.pm               |  2 --
+ 8 files changed, 11 insertions(+), 26 deletions(-)
+
+diff --git configure configure
+index 82e45657b2..907c777b9c 100755
+--- configure
++++ configure
+@@ -12982,7 +12982,7 @@ done
+   # defines OPENSSL_VERSION_NUMBER to claim version 2.0.0, even though it
+   # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+   # functions.
+-  for ac_func in OPENSSL_init_ssl BIO_get_data BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free
++  for ac_func in OPENSSL_init_ssl BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+diff --git configure.ac configure.ac
+index fcea0bcab4..ab32bfdd08 100644
+--- configure.ac
++++ configure.ac
+@@ -1385,7 +1385,7 @@ if test "$with_ssl" = openssl ; then
+   # defines OPENSSL_VERSION_NUMBER to claim version 2.0.0, even though it
+   # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+   # functions.
+-  AC_CHECK_FUNCS([OPENSSL_init_ssl BIO_get_data BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free])
++  AC_CHECK_FUNCS([OPENSSL_init_ssl BIO_meth_new ASN1_STRING_get0_data HMAC_CTX_new HMAC_CTX_free])
+   # OpenSSL versions before 1.1.0 required setting callback functions, for
+   # thread-safety. In 1.1.0, it's no longer required, and CRYPTO_lock()
+   # function was removed.
+diff --git meson.build meson.build
+index 51b5285924..96fc2e139a 100644
+--- meson.build
++++ meson.build
+@@ -1278,7 +1278,6 @@ if sslopt in ['auto', 'openssl']
+       # doesn't have these OpenSSL 1.1.0 functions. So check for individual
+       # functions.
+       ['OPENSSL_init_ssl'],
+-      ['BIO_get_data'],
+       ['BIO_meth_new'],
+       ['ASN1_STRING_get0_data'],
+       ['HMAC_CTX_new'],
+diff --git src/backend/libpq/be-secure-openssl.c src/backend/libpq/be-secure-openssl.c
+index e9c86d08df..49dca0cda9 100644
+--- src/backend/libpq/be-secure-openssl.c
++++ src/backend/libpq/be-secure-openssl.c
+@@ -844,11 +844,6 @@ be_tls_write(Port *port, void *ptr, size_t len, int *waitfor)
+  * to retry; do we need to adopt their logic for that?
+  */
+ 
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods = NULL;
+ 
+ static int
+@@ -858,7 +853,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ 
+ 	if (buf != NULL)
+ 	{
+-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
++		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
+ 		BIO_clear_retry_flags(h);
+ 		if (res <= 0)
+ 		{
+@@ -878,7 +873,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res = 0;
+ 
+-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
++	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res <= 0)
+ 	{
+@@ -954,7 +949,7 @@ my_SSL_set_fd(Port *port, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, port);
++	BIO_set_app_data(bio, port);
+ 
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+ 	SSL_set_bio(port->ssl, bio, bio);
+diff --git src/include/pg_config.h.in src/include/pg_config.h.in
+index 6d572c3820..174544630e 100644
+--- src/include/pg_config.h.in
++++ src/include/pg_config.h.in
+@@ -70,9 +70,6 @@
+ /* Define to 1 if you have the `backtrace_symbols' function. */
+ #undef HAVE_BACKTRACE_SYMBOLS
+ 
+-/* Define to 1 if you have the `BIO_get_data' function. */
+-#undef HAVE_BIO_GET_DATA
+-
+ /* Define to 1 if you have the `BIO_meth_new' function. */
+ #undef HAVE_BIO_METH_NEW
+ 
+diff --git src/interfaces/libpq/fe-secure-openssl.c src/interfaces/libpq/fe-secure-openssl.c
+index 390c888c96..694d32754f 100644
+--- src/interfaces/libpq/fe-secure-openssl.c
++++ src/interfaces/libpq/fe-secure-openssl.c
+@@ -1830,10 +1830,6 @@ PQsslAttribute(PGconn *conn, const char *attribute_name)
+  * to retry; do we need to adopt their logic for that?
+  */
+ 
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+ 
+ static BIO_METHOD *my_bio_methods;
+ 
+@@ -1842,7 +1838,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ {
+ 	int			res;
+ 
+-	res = pqsecure_raw_read((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_read((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1872,7 +1868,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res;
+ 
+-	res = pqsecure_raw_write((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_write((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1963,7 +1959,7 @@ my_SSL_set_fd(PGconn *conn, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, conn);
++	BIO_set_app_data(bio, conn);
+ 
+ 	SSL_set_bio(conn->ssl, bio, bio);
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+diff --git src/test/ssl/t/001_ssltests.pl src/test/ssl/t/001_ssltests.pl
+index 76442de063..9bb28fbc83 100644
+--- src/test/ssl/t/001_ssltests.pl
++++ src/test/ssl/t/001_ssltests.pl
+@@ -781,7 +781,7 @@ $node->connect_fails(
+ 	"$common_connstr user=ssltestuser sslcert=ssl/client-revoked.crt "
+ 	  . sslkey('client-revoked.key'),
+ 	"certificate authorization fails with revoked client cert",
+-	expected_stderr => qr/SSL error: sslv3 alert certificate revoked/,
++	expected_stderr => qr|SSL error: ssl[a-z0-9/]* alert certificate revoked|,
+ 	# temporarily(?) skip this check due to timing issue
+ 	#	log_like => [
+ 	#		qr{Client certificate verification failed at depth 0: certificate revoked},
+@@ -886,7 +886,7 @@ $node->connect_fails(
+ 	"$common_connstr user=ssltestuser sslcert=ssl/client-revoked.crt "
+ 	  . sslkey('client-revoked.key'),
+ 	"certificate authorization fails with revoked client cert with server-side CRL directory",
+-	expected_stderr => qr/SSL error: sslv3 alert certificate revoked/,
++	expected_stderr => qr|SSL error: ssl[a-z0-9/]* alert certificate revoked|,
+ 	# temporarily(?) skip this check due to timing issue
+ 	#	log_like => [
+ 	#		qr{Client certificate verification failed at depth 0: certificate revoked},
+@@ -899,7 +899,7 @@ $node->connect_fails(
+ 	"$common_connstr user=ssltestuser sslcert=ssl/client-revoked-utf8.crt "
+ 	  . sslkey('client-revoked-utf8.key'),
+ 	"certificate authorization fails with revoked UTF-8 client cert with server-side CRL directory",
+-	expected_stderr => qr/SSL error: sslv3 alert certificate revoked/,
++	expected_stderr => qr|SSL error: ssl[a-z0-9/]* alert certificate revoked|,
+ 	# temporarily(?) skip this check due to timing issue
+ 	#	log_like => [
+ 	#		qr{Client certificate verification failed at depth 0: certificate revoked},
+diff --git src/tools/msvc/Solution.pm src/tools/msvc/Solution.pm
+index b6d31c3583..711fae853f 100644
+--- src/tools/msvc/Solution.pm
++++ src/tools/msvc/Solution.pm
+@@ -225,7 +225,6 @@ sub GenerateFiles
+ 		HAVE_ATOMICS => 1,
+ 		HAVE_ATOMIC_H => undef,
+ 		HAVE_BACKTRACE_SYMBOLS => undef,
+-		HAVE_BIO_GET_DATA => undef,
+ 		HAVE_BIO_METH_NEW => undef,
+ 		HAVE_COMPUTED_GOTO => undef,
+ 		HAVE_COPYFILE => undef,
+@@ -503,7 +502,6 @@ sub GenerateFiles
+ 			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0'))
+ 		{
+ 			$define{HAVE_ASN1_STRING_GET0_DATA} = 1;
+-			$define{HAVE_BIO_GET_DATA} = 1;
+ 			$define{HAVE_BIO_METH_NEW} = 1;
+ 			$define{HAVE_HMAC_CTX_FREE} = 1;
+ 			$define{HAVE_HMAC_CTX_NEW} = 1;
+-- 
+2.42.1
+


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68777

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.1 22G313 x86_64
Command Line Tools 15.0.0.0.1.1694021235

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
