### PR TITLE
fnc: fix tickets #64175 and #67290

### DIFF
--- a/devel/fnc/Portfile
+++ b/devel/fnc/Portfile
@@ -5,7 +5,7 @@ PortGroup       makefile 1.0
 
 name            fnc
 version         0.15
-revision        0
+revision        1
 categories      devel
 license         ISC
 maintainers     {bsdbox.org:mark @mcjsk} \
@@ -27,7 +27,10 @@ checksums       rmd160  ecf53aed0c22284710c5bcd2cbcb58641f804295 \
 
 build.type      bsd
 
-depends_lib-append      port:zlib
+patchfiles      libf-Werror-include-ncursesw.diff
+
+depends_lib-append      port:zlib \
+                        port:ncurses
 
 destroot {
     xinstall -m 755 ${worksrcpath}/src/${name} ${destroot}${prefix}/bin/${name}

--- a/devel/fnc/files/libf-Werror-include-ncursesw.diff
+++ b/devel/fnc/files/libf-Werror-include-ncursesw.diff
@@ -1,0 +1,22 @@
+Index: fnc.bld.mk
+=======================================================================
+hash - d5125d91b651e4115400e52857e80fd35cd8fb25ccf50e3828db32c27f119b63
+hash + 0461726b7bef3caa495e6e17283581bc33b1f0d439da29c2ef477439a27d6d45
+--- fnc.bld.mk
++++ fnc.bld.mk
+@@ -37,13 +37,13 @@ FOSSIL_CFLAGS =	${CFLAGS} -Wall -Werror -Wsign-compare 
+ 		-DSQLITE_TRUSTED_SCHEMA=0
+ 
+ # FLAGS NEEDED TO BUILD LIBFOSSIL
+-FOSSIL_CFLAGS =	${CFLAGS} -Wall -Werror -Wsign-compare -pedantic -std=c99
++FOSSIL_CFLAGS =	${CFLAGS} -Wall -Wsign-compare -pedantic -std=c99
+ 
+ # On SOME Linux (e.g., Ubuntu 18.04.6), we have to include wchar curses from
+ # I/.../ncursesw, but linking to -lncursesw (w/ no special -L path) works fine.
+ # FLAGS NEEDED TO BUILD FNC
+ FNC_CFLAGS =	${CFLAGS} -Wall -Werror -Wsign-compare -pedantic -std=c99 \
+-		-I./lib -I./include -I/usr/include/ncursesw \
++		-I./lib -I./include \
+ 		-D_XOPEN_SOURCE_EXTENDED -DVERSION=${VERSION} -DHASH=${HASH} \
+ 		-DDATE="${DATE}"
+ 


### PR DESCRIPTION
#### Description

The first (#64175) changes the Portfile to add a missing depends (`ncurses`), and patches out an unwanted include (i.e,`-I/usr/include/ncursesw`) from upstream's makefile.
The second fix (#67290) patches out `-Werror` from the upstream's libfossil build to silence warnings due to missing fallthrough attribute on older compilers.

#64175: https://trac.macports.org/ticket/64175
#67290: https://trac.macports.org/ticket/67290

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6.1 22G313 x86_64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
