### PR TITLE
ofc: update to 2023.11.29

### DIFF
--- a/lang/ofc/Portfile
+++ b/lang/ofc/Portfile
@@ -9,8 +9,8 @@ PortGroup           makefile 1.0
 # strndup
 legacysupport.newest_darwin_requires_legacy 10
 
-github.setup        CodethinkLabs ofc b69ad37be62d580eabeb081e64b43afe3c0b3384
-version             2023.02.06
+github.setup        CodethinkLabs ofc f6cd87db13f13187c3be0df9d26951c4ec053874
+version             2023.11.29
 revision            0
 categories          lang fortran
 license             Apache-2
@@ -19,9 +19,9 @@ description         Open Fortran Compiler
 long_description    Currently OFC is a Fortran front-end capable of parsing and performing semantic analysis \
                     on Fortran. We’re targeting legacy Fortran first, and can currently parse and semantically analyse \
                     most F77 and earlier, providing syntax and semantic warnings and errors.
-checksums           rmd160  64d56a24c41295fd0f29aac144b790531e15db41 \
-                    sha256  55a66c5d9cf51843bde6fc0442a9cbc66e6c5ff700bfe52cfb840ef998803767 \
-                    size    199538
+checksums           rmd160  7e312e124366eea3cc75d48545d01941b6d88d55 \
+                    sha256  ad1fc4ccfb749cb3e4be4e369de60b8630dc54bbe96792ce7f07e87d08660d22 \
+                    size    199336
 github.tarball_from archive
 installs_libs       no
 
@@ -29,10 +29,6 @@ compiler.blacklist  *gcc-4.* {clang < 421}
 
 post-patch {
     reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/Makefile
-
-    # https://github.com/CodethinkLabs/ofc/issues/46
-    # https://github.com/CodethinkLabs/ofc/issues/49
-    reinplace "s|-Werror||g" ${worksrcpath}/Makefile
 
     if {${os.platform} eq "darwin" && ${os.major} < 11} {
         reinplace "s|LDFLAGS = -lm|LDFLAGS = -lm -lMacportsLegacySupport|" ${worksrcpath}/Makefile


### PR DESCRIPTION
See:
https://github.com/CodethinkLabs/ofc/issues/46
https://github.com/CodethinkLabs/ofc/issues/49

#### Description

@reneeotten @pmetzger A follow-up update. We do not to patch out `-Werror` anymore, upstream removed it.
However, this updates also includes an upstream fix for mismatching types.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1
Xcode 15.0.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
