### PR TITLE
bsd-games: fix scores not persistent

### DIFF
--- a/games/bsd-games/Portfile
+++ b/games/bsd-games/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                bsd-games
 version             3.3
-revision            0
+revision            1
 categories          games
 license             BSD
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
@@ -29,8 +29,19 @@ post-patch {
     reinplace \
         "s|snprintf\[\[:space:]]*(ArrayBlock\[\[:space:]]*(\\(\[^)]*\\))|snprintf(\\1, ArraySize(\\1)|g" \
         {*}[glob ${worksrcpath}/*/*.c]
+    reinplace "s|/var/|${prefix}/var/|g" {*}[glob ${worksrcpath}/*/*.6]
 }
 
-configure.args      --localstatedir=${prefix}/var
+configure.args      --localstatedir=${prefix}/var/lib
 
-destroot.args       INSTALL_SCORE='\${INSTALL} -m 664 -g everyone /dev/null'
+destroot.args       INSTALL_SCORE=:
+destroot.keepdirs   ${destroot}${prefix}/var/lib/bsdgames
+
+post-activate {
+    foreach {game} {adventure atc battlestar drop4 robots snake spirhunt} {
+        set scores ${prefix}/var/lib/bsdgames/${game}.scores
+        if {![file exists ${scores}]} {
+            xinstall -m 664 -g everyone /dev/null ${scores}
+        }
+    }
+}


### PR DESCRIPTION
###### Type(s)

- [x] bugfix

###### Tested on
macOS 14.1.1 23B81 x86_64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?