### PR TITLE
jaq: new port (version 1.2.0)

### DIFF
--- a/textproc/jaq/Portfile
+++ b/textproc/jaq/Portfile
@@ -1,0 +1,109 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo   1.0
+PortGroup           github  1.0
+
+github.setup        01mf02 jaq 1.2.0 v
+github.tarball_from archive
+revision            0
+
+description         A jq clone focussed on correctness, speed, and simplicity
+
+long_description    \
+    ${name} is a clone of the JSON data processing tool jq. ${name} aims to \
+    support a large subset of jq's syntax and operations. ${name} focuses on \
+    three goals: Correctness, Performance, and Simplicity
+
+categories          textproc sysutils
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  0e8574c2ec49bf7b6ac9a1c158457ea032ea2ddd \
+                    sha256  3895dda6c808d93353bdcf3d265613c2c2fcdbbb20b1177bda8bb95fc0078277 \
+                    size    83012
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+
+    xinstall -d ${destroot}${prefix}/share/${name}
+    copy ${worksrcpath}/examples ${destroot}${prefix}/share/${name}/
+}
+
+cargo.crates \
+    ahash                            0.8.6  91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a \
+    aho-corasick                     1.1.2  b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0 \
+    allocator-api2                  0.2.16  0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5 \
+    ariadne                          0.3.0  72fe02fc62033df9ba41cba57ee19acf5e742511a140c7dbc3a873e19a19a1bd \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    base64                          0.21.5  35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9 \
+    bincode                          1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    cc                              1.0.79  50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    chumsky                          0.9.3  8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9 \
+    clap                            4.0.22  91b9970d7505127a162fdaa9b96428d28a479ba78c9ec7550a63a5d9863db682 \
+    clap_derive                     4.0.21  0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014 \
+    clap_lex                         0.3.2  350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09 \
+    colored_json                     3.0.1  633215cdbb84194508d4c07c08d06e92ee9d489d54e68d17913d8d1bacfcfdeb \
+    dyn-clone                       1.0.11  68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30 \
+    either                           1.8.1  7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91 \
+    env_logger                      0.10.0  85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0 \
+    equivalent                       1.0.0  88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1 \
+    fastrand                         1.9.0  e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be \
+    getrandom                       0.2.10  be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427 \
+    hashbrown                       0.14.2  f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156 \
+    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    hifijson                         0.2.0  85ef6b41c333e6dd2a4aaa59125a19b633cd17e7aaf372b2260809777bcdef4a \
+    indexmap                         2.1.0  d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f \
+    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
+    itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
+    itoa                             1.0.9  af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38 \
+    libc                           0.2.147  b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3 \
+    libm                             0.2.8  4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058 \
+    libmimalloc-sys                 0.1.35  3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664 \
+    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    memchr                           2.6.4  f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167 \
+    memmap2                          0.9.0  deaba38d7abf1d4cca21cc89e932e542ba2b9258664d2a9ef0e61512039c9375 \
+    mimalloc                        0.1.39  fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c \
+    once_cell                       1.18.0  dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d \
+    os_str_bytes                     6.4.1  9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee \
+    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
+    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
+    proc-macro2                     1.0.69  134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da \
+    quote                           1.0.29  573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105 \
+    redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
+    regex                            1.9.4  12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29 \
+    regex-automata                   0.3.7  49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629 \
+    regex-syntax                     0.7.5  dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    ryu                             1.0.14  fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9 \
+    serde                          1.0.190  91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7 \
+    serde_derive                   1.0.190  67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3 \
+    serde_json                     1.0.108  3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+    syn                             2.0.38  e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b \
+    tempfile                         3.3.0  5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4 \
+    termcolor                        1.2.0  be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6 \
+    time                            0.3.20  cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890 \
+    time-core                        0.1.0  2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd \
+    time-macros                      0.2.8  fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36 \
+    unicode-ident                   1.0.10  22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73 \
+    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
+    urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    yansi                            0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec \
+    zerocopy                        0.7.20  dd66a62464e3ffd4e37bd09950c2b9dd6c4f8767380fabba0d523f9a775bc85a \
+    zerocopy-derive                 0.7.20  255c4596d41e6916ced49cfafea18727b24d67878fa180ddfd69b9df34fd1726


### PR DESCRIPTION
New port for `jaq`, a `jq` clone written in Rust prioritizing correctness, performance and simplicity: https://github.com/01mf02/jaq

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
