### PR TITLE
jql: new port (version 7.0.7)

### DIFF
--- a/textproc/jql/Portfile
+++ b/textproc/jql/Portfile
@@ -1,0 +1,146 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo   1.0
+PortGroup           github  1.0
+
+github.setup        yamafaktory jql 7.0.7 jql-v
+github.tarball_from archive
+revision            0
+
+homepage            https://crates.io/crates/jql
+
+description         A JSON Query Language CLI tool
+
+long_description    \
+    jql is a JSON Query Language tool built with Rust. Pronounce it as \
+    \"jackal\".
+
+categories          textproc
+installs_libs       no
+license             {Apache-2 MIT}
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  f4597b79482555d35ac6e452c3b520df5e566184 \
+                    sha256  b7f89239ac566ee6ea23216a3896d3ff5ce85b12d7dc57a44a088396813c142c \
+                    size    447211
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
+        ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    addr2line                       0.21.0  8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    aho-corasick                     1.1.2  b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0 \
+    anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
+    anstream                         0.6.4  2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44 \
+    anstyle                          1.0.4  7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87 \
+    anstyle-parse                    0.2.2  317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140 \
+    anstyle-query                    1.0.0  5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b \
+    anstyle-wincon                   3.0.1  f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628 \
+    anyhow                          1.0.75  a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    backtrace                       0.3.69  2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837 \
+    bitflags                         2.4.1  327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07 \
+    bumpalo                         3.14.0  7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec \
+    bytes                            1.5.0  a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223 \
+    cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
+    cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    ciborium                         0.2.1  effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926 \
+    ciborium-io                      0.2.1  cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656 \
+    ciborium-ll                      0.2.1  defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b \
+    clap                             4.4.8  2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64 \
+    clap_builder                     4.4.8  07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc \
+    clap_derive                      4.4.7  cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442 \
+    clap_lex                         0.6.0  702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1 \
+    colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
+    colored_json                     4.1.0  79cff32df5cfea75e6484eeff0b4e48ad3977fb6582676a7862b3590dddc7a87 \
+    criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
+    criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
+    crossbeam-deque                  0.8.3  ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef \
+    crossbeam-epoch                 0.9.15  ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7 \
+    crossbeam-utils                 0.8.16  5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294 \
+    either                           1.9.0  a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07 \
+    equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
+    errno                            0.3.5  ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860 \
+    gimli                           0.28.0  6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0 \
+    half                             1.8.2  eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7 \
+    hashbrown                       0.14.2  f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156 \
+    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    hermit-abi                       0.3.3  d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7 \
+    indexmap                         2.1.0  d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f \
+    is-terminal                      0.4.9  cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b \
+    itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
+    itoa                             1.0.9  af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38 \
+    js-sys                          0.3.65  54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8 \
+    libc                           0.2.149  a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b \
+    linux-raw-sys                   0.4.10  da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f \
+    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    memchr                           2.6.4  f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167 \
+    memoffset                        0.9.0  5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
+    minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
+    miniz_oxide                      0.7.1  e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7 \
+    nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
+    num-traits                      0.2.17  39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c \
+    num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
+    object                          0.32.1  9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0 \
+    once_cell                       1.18.0  dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d \
+    oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
+    pin-project-lite                0.2.13  8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58 \
+    plotters                         0.3.5  d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45 \
+    plotters-backend                 0.3.5  9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609 \
+    plotters-svg                     0.3.5  38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab \
+    proc-macro2                     1.0.69  134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da \
+    psm                             0.1.21  5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874 \
+    quote                           1.0.33  5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae \
+    rayon                            1.8.0  9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1 \
+    rayon-core                      1.12.0  5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed \
+    regex                           1.10.2  380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343 \
+    regex-automata                   0.4.3  5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f \
+    regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+    rustc-demangle                  0.1.23  d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76 \
+    rustix                         0.38.21  2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3 \
+    ryu                             1.0.15  1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    serde                          1.0.193  25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89 \
+    serde_derive                   1.0.193  43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3 \
+    serde_json                     1.0.108  3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b \
+    serde_stacker                   0.1.10  7f5321e680f77e7b5cfccc78708ff86a814d39aba030610aee67bd5eaf8a1c30 \
+    stacker                         0.1.15  c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    syn                             2.0.38  e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b \
+    thiserror                       1.0.50  f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2 \
+    thiserror-impl                  1.0.50  266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8 \
+    tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
+    tokio                           1.34.0  d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9 \
+    tokio-macros                     2.2.0  5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b \
+    unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
+    utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
+    walkdir                          2.4.0  d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee \
+    wasm-bindgen                    0.2.88  7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce \
+    wasm-bindgen-backend            0.2.88  e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217 \
+    wasm-bindgen-macro              0.2.88  5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2 \
+    wasm-bindgen-macro-support      0.2.88  c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907 \
+    wasm-bindgen-shared             0.2.88  0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b \
+    web-sys                         0.3.65  5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.6  f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
+    yansi                            0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec


### PR DESCRIPTION
`jql` is a JSON Query Language CLI: https://github.com/yamafaktory/jql

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
