### PR TITLE
py-fonttools: add py312 subport

### DIFF
--- a/python/py-fonttools/Portfile
+++ b/python/py-fonttools/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  c4af4fd3771d3466cd87ae58c17653a0325d9257 \
                     sha256  6e441286d55fe7ec7c4fb36812bf914924813776ff514b744b510680fc2733f2 \
                     size    3396173
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     if {${python.version} == 37} {

--- a/python/py-fonttools/files/fonttools-312
+++ b/python/py-fonttools/files/fonttools-312
@@ -1,0 +1,5 @@
+bin/fonttools-3.12
+bin/pyftmerge-3.12
+bin/pyftsubset-3.12
+bin/ttx-3.12
+${frameworks_dir}/Python.framework/Versions/3.12/share/man/man1/ttx.1


### PR DESCRIPTION
#### Description

Note: variant `+qt` depends on PR #21553

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? *
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken? **

\* Ran the binary files with `--help` to verify that there were no linking issues, but no more than that.
\** Non-default variant `+qt` will not work until #21553 is merged