### PR TITLE
moar, MoarVM: resolve mutual conflicts

### DIFF
--- a/lang/MoarVM/Portfile
+++ b/lang/MoarVM/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.1
+PortGroup           active_variants 1.1
 
 # strnlen, arc4random_buf
 legacysupport.newest_darwin_requires_legacy 10
@@ -23,6 +24,12 @@ homepage            https://moarvm.org/
 master_sites        https://moarvm.org/releases/
 
 conflicts           moar
+
+if {![catch {set result [active_variants moar "pager"]}]} {
+    if {$result} {
+        conflicts-delete moar
+    }
+}
 
 checksums           rmd160  c22c09c79b656d5156e8d74f35569b0b2e211d39 \
                     sha256  143f92510eaa3452c712e4aae9f44d84cd078f16517b40252bab7dd5e224ecdb \

--- a/textproc/moar/Portfile
+++ b/textproc/moar/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/walles/moar 1.18.5 v
 go.offline_build    no
 github.tarball_from archive
-revision            0
+revision            1
 
 conflicts           MoarVM
 
@@ -29,13 +29,26 @@ maintainers         {gmail.com:j.lopez.r @jlopezr} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
+set install_name ${name}
+
+variant pager description {Install as moar-pager} {
+    set install_name ${name}-pager
+
+    conflicts-delete MoarVM
+    patchfiles       patch-moar-1.diff
+}
+
 build.pre_args-append \
     -ldflags \"-X main.versionString=${version}\"
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${install_name}
 
     xinstall -d ${destroot}${prefix}/share/man/man1
     xinstall -m 0644 \
-        ${worksrcpath}/${name}.1 ${destroot}${prefix}/share/man/man1/
+        ${worksrcpath}/${name}.1 ${destroot}${prefix}/share/man/man1/${install_name}.1
+}
+
+notes {
+    The pager variant is compatible with MoarVM for raku and nqp development.
 }

--- a/textproc/moar/files/patch-moar-1.diff
+++ b/textproc/moar/files/patch-moar-1.diff
@@ -1,0 +1,70 @@
+--- moar.1.orig	2023-11-29 23:08:16
++++ moar.1	2023-11-29 23:09:21
+@@ -1,23 +1,23 @@
+-.TH MOAR 1 2022-07-21
++.TH MOAR-PAGER 1 2022-07-21
+ .SH NAME
+-moar \- the nice pager
++moar-pager \- the nice pager
+ .SH SYNOPSIS
+-.B moar
++.B moar-pager
+ [options]
+ .IR file
+ .br
+-.B "moar \-\-help"
++.B "moar-pager \-\-help"
+ .br
+-.B "moar \-\-version"
++.B "moar-pager \-\-version"
+ .SH DESCRIPTION
+-.B moar
++.B moar-pager
+ is a pager much like
+ .I less
+ (1), but with generally nicer out-of-the-box behavior.
+ .PP
+ More information and screenshots: https://github.com/walles/moar#readme
+ .PP
+-Inside of \fBmoar\fR, press
++Inside of \fBmoar-pager\fR, press
+ .B ?
+ to access the built-in help.
+ .PP
+@@ -31,7 +31,7 @@
+ environment variable for persistent configuration.
+ .PP
+ Doing
+-.B moar --help
++.B moar-pager --help
+ will also list these options.
+ .TP
+ \fB\-\-colors\fR={\fBauto\fR | \fB8\fR | \fB16\fR | \fB256\fR | \fB16M\fR}
+@@ -46,7 +46,7 @@
+ .B tail \-f
+ .TP
+ \fB\-\-no\-clear\-on\-exit\fR
+-Retain screen contents when exiting moar
++Retain screen contents when exiting moar-pager  
+ .TP
+ \fB\-\-no\-linenumbers\fR
+ Hide line numbers on startup, press left arrow key to show
+@@ -101,15 +101,15 @@
+ .B 1234
+ .SH ENVIRONMENT
+ Having
+-.B PAGER=moar
++.B PAGER=moar-pager
+ in your environment will make lots of different programs use
+-.B moar
++.B moar-pager
+ as their pager.
+ .PP
+ Additional options are read from the
+ .B MOAR
+ environment variable if set, just as if those same options had been manually added to each
+-.B moar
++.B moar-pager
+ invocation.
+ .SH BUGS
+ Kindly report any bugs here: https://github.com/walles/moar/issues

--- a/textproc/riff/Portfile
+++ b/textproc/riff/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        walles riff 2.27.1
 github.tarball_from archive
-revision            0
+revision            1
 
 description         A diff filter highlighting which line parts have changed
 
@@ -24,15 +24,17 @@ checksums           ${distname}${extract.suffix} \
                     sha256  ba52c76c103f7e88301a61227b648d63115e52c7b14ff966073a8d0264f42bde \
                     size    495762
 
+patchfiles          patch-src-main-rs-moar-pager.diff
+
 destroot {
     xinstall -m 0755 \
         ${worksrcpath}/target/[cargo.rust_platform]/release/${name} \
         ${destroot}${prefix}/bin/
 }
 
-notes "
-    You can also install and use `moar` with `${name}`
-"
+notes {
+    You can also install and use `moar` with `${name}`.
+}
 
 cargo.crates \
     addr2line                       0.14.0  7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423 \

--- a/textproc/riff/files/patch-src-main-rs-moar-pager.diff
+++ b/textproc/riff/files/patch-src-main-rs-moar-pager.diff
@@ -1,0 +1,13 @@
+--- src/main.rs.orig	2023-11-29 23:16:30
++++ src/main.rs	2023-11-29 23:16:56
+@@ -240,6 +240,10 @@
+ 
+         // FIXME: Print warning at the end if $PAGER was set to something that
+         // doesn't exist.
++    }
++
++    if try_pager(input, "moar-pager") {
++        return;
+     }
+ 
+     if try_pager(input, "moar") {

--- a/textproc/ugrep/Portfile
+++ b/textproc/ugrep/Portfile
@@ -7,7 +7,7 @@ PortGroup           legacysupport 1.1
 
 github.setup        Genivia ugrep 4.3.4 v
 github.tarball_from archive
-revision            0
+revision            1
 
 categories          textproc sysutils
 license             BSD
@@ -31,6 +31,8 @@ compiler.blacklist-append {clang < 700}
 
 legacysupport.newest_darwin_requires_legacy 10
 # needed for strnlen
+
+patchfiles          patch-moar-pager-query-cpp.diff
 
 depends_lib-append  port:pcre2 \
                     port:zlib \

--- a/textproc/ugrep/files/patch-moar-pager-query-cpp.diff
+++ b/textproc/ugrep/files/patch-moar-pager-query-cpp.diff
@@ -1,0 +1,10 @@
+--- src/query.cpp.orig	2023-11-29 22:58:32
++++ src/query.cpp	2023-11-29 22:59:23
+@@ -2330,6 +2330,7 @@ void Query::view()
+       !flag_with_hex &&
+       (command == "less"  ||
++       command == "moar-pager"  ||
+        command == "moar"  ||
+        command == "more"  ||
+        command == "most"  ||
+        command == "w3m"   ||


### PR DESCRIPTION
#### Description

Add a `+pager` variant to `textproc/moar` that removes the mutual conflict with `lang/MoarVM` and update `riff` and `ugrep` to recognize the `+pager` variant of `moar`.

Closes: https://trac.macports.org/ticket/68491

###### Type(s)

- [x] enhancement

###### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`? (See below for details)
- [x] tested basic functionality of all binary files?

Regarding installations, I have installed and tested each of `moar` (with and without `+pager`), `riff`, and `ugrep`. `riff` and `ugrep` appear to recognize `PAGER=moar-pager` the same way that they recognize `PAGER=moar`. I have also tested `man moar-pager` with `moar +pager` installed.

For `MoarVM` (as I am not currently doing any work with rakudo ornqp), I tested that the conflict shows up with `port info` and either `moar` is _not_ installed or `moar` is installed with no variant. `sudo port install` is blocked. When `moar +pager` is installed, `port info` no longer shows the conflict and `sudo port install` prompts to install dependencies.
