### PR TITLE
py-numexpr: update to 2.8.7; py-numpy: update to 1.26.2, revbump old versions, unbreak < 10.8 

### DIFF
--- a/python/py-numexpr/Portfile
+++ b/python/py-numexpr/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-numexpr
-version             2.8.5
+version             2.8.7
 revision            0
 categories-append   math
 license             MIT
@@ -25,9 +25,9 @@ long_description    The numexpr package evaluates multiple-operator array \
 
 homepage            https://github.com/pydata/numexpr
 
-checksums           rmd160  d4f205f3b8f1a44900b87ebfbf5229994de10a1e \
-                    sha256  45ed41e55a0abcecf3d711481e12a5fb7a904fe99d42bc282a17cc5f8ea510be \
-                    size    101666
+checksums           rmd160  f8947b6bf090e26b029fa0d5d3fc348d2a41e0f5 \
+                    sha256  596eeb3bbfebc912f4b6eaaf842b61ba722cebdb8bc42dfefa657d3a74953849 \
+                    size    103410
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-numpy

--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -13,12 +13,12 @@ maintainers             {michaelld @michaelld} openmaintainer
 description             The core utilities for the scientific library scipy for Python
 long_description        {*}${description}
 
-github.setup            numpy numpy 1.26.1 v
-revision                1
+github.setup            numpy numpy 1.26.2 v
+revision                0
 
-checksums               rmd160  78a71e4c218294e7daa73e61dec8c85849e16f41 \
-                        sha256  c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe \
-                        size    15651806
+checksums               rmd160  637c49bcd078536865dd7f720a85bd1f7bbd2de2 \
+                        sha256  f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea \
+                        size    15664248
 
 if {${name} ne ${subport}} {
     # the python PortGroup puts compiler names in build.env and destroot.env
@@ -54,7 +54,7 @@ if {${name} ne ${subport}} {
         checksums           rmd160  cbb34cf0981ea142ff45722d05a9daad20a134ea \
                             sha256  2dce87065d5de1a83485cfb3de5e4e793787890f5c1dcc3536a9cabf2e1620af \
                             size    4691852
-        revision            3
+        revision            4
         set PATCH_PY_EXT    ".27"
         patchfiles-append   patch-cpu-detection.py.27.patch
         livecheck.url       https://numpy.org/doc/stable/release.html
@@ -64,7 +64,7 @@ if {${name} ne ${subport}} {
         checksums           rmd160  c14f2725afe0f7420d69a6f9ed5744639a2d2b31 \
                             sha256  4a421fdf82dbb3dce7e62400f69c43722b530db109c3321c6c95452f166560d9 \
                             size    5167349
-        revision            2
+        revision            3
         patchfiles-append   patch-cpu-detection.py.35.patch
         set PATCH_PY_EXT    ".35"
         livecheck.url       https://numpy.org/doc/stable/release.html
@@ -74,7 +74,7 @@ if {${name} ne ${subport}} {
         checksums           rmd160 66861032bbd7c1f7e7741d913c9edf6c0b8be68a \
                             sha256 40e0a919cb8741556f8402cb7ec862b3b27903725ba59af44fd5b88620c5a7e1 \
                             size   7037758
-        revision            1
+        revision            2
         # because I pushed 1.20 and it requires Py37+ and so reverting back to 1.19
         epoch               1
         set PATCH_PY_EXT    ".36"
@@ -85,7 +85,7 @@ if {${name} ne ${subport}} {
         checksums           rmd160  e8824bb384025421d8c637f1671b7010c9a79471 \
                             sha256  d4efc6491a1cdc00f9eca9bf2c1aa13671776f6941c7321ddf75b45c862f0c2c \
                             size    9445717
-        revision            0
+        revision            1
         github.tarball_from releases
         set PATCH_PY_EXT    ".37"
         livecheck.regex     {(1\.21(?:\.\d+)+)}
@@ -95,7 +95,7 @@ if {${name} ne ${subport}} {
         checksums           rmd160  dd2df59cb48926eb460143f617a552b8009af11d \
                             sha256  2386da9a471cc00a1f47845e27d916d5ec5346ae9696e01a8a34760858fe9dd2 \
                             size    10903184
-        revision            0
+        revision            1
         github.tarball_from releases
         set PATCH_PY_EXT    ".38"
         livecheck.regex     {(1\.24(?:\.\d+)+)}
@@ -104,7 +104,15 @@ if {${name} ne ${subport}} {
         }
     } else {
         github.tarball_from releases
-        depends_build-append    port:ninja
+        # This is a temporary fix due to:
+        # https://github.com/numpy/numpy/issues/25406
+        # https://github.com/mesonbuild/meson-python/pull/553
+        if {${os.platform} eq "darwin" && ${os.major} < 12} {
+            python.pep517   no
+        } else {
+            depends_build-append \
+                            port:ninja
+        }
         depends_lib-append  port:py${python.version}-pyproject_metadata
         patchfiles-append   patch-build_cython_path.diff
         build.env-append    CYTHON=${prefix}/bin/cython-${python.branch}


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1
Xcode 15.0.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
