### PR TITLE
yubikey-manager4: Add missing py-poetry-core dep

### DIFF
--- a/security/yubikey-manager4/Portfile
+++ b/security/yubikey-manager4/Portfile
@@ -29,6 +29,9 @@ python.rootname     yubikey-manager
 # runtime.
 python.default_version 310
 
+depends_build-append \
+    port:py${python.version}-poetry-core
+
 depends_lib-append \
     port:py${python.version}-setuptools
 


### PR DESCRIPTION
#### Description

`pyproject.toml` contains:

```
[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
```

This means that the build requires the py-poetry-core package to be installed and will fail otherwise because it cannot import poetry.core.masonry.api.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
