### PR TITLE
OpenBLAS: fix build on 10.6 x86_64

### DIFF
--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -41,6 +41,7 @@ if {[string first "-devel" $subport] > 0} {
                     patch-openblas.pc-fixed-version-and-url.diff \
                     patch-enable-overstep-of-too-long-args-without-DYNAMIC_ARCH.diff \
                     patch-weak-linking-old-macos.diff \
+                    patch-OpenBLAS-old-macos.diff \
                     patch-OpenBLAS-i386-Apple.diff
 
     github.livecheck.branch develop
@@ -64,6 +65,7 @@ if {[string first "-devel" $subport] > 0} {
                     patch-openblas.pc-fixed-version-and-url.diff \
                     patch-enable-overstep-of-too-long-args-without-DYNAMIC_ARCH.diff \
                     patch-weak-linking-old-macos.diff \
+                    patch-OpenBLAS-old-macos.diff \
                     patch-OpenBLAS-i386-Apple.diff
 
     if {![variant_isset native]} {

--- a/math/OpenBLAS/files/patch-OpenBLAS-old-macos.diff
+++ b/math/OpenBLAS/files/patch-OpenBLAS-old-macos.diff
@@ -1,0 +1,15 @@
+https://github.com/OpenMathLib/OpenBLAS/pull/4351
+
+diff --git cmake/system_check.cmake cmake/system_check.cmake
+index 49b9863e3..c9671b379 100644
+--- cmake/system_check.cmake
++++ cmake/system_check.cmake
+@@ -46,7 +46,7 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "loongarch64.*")
+   set(LOONGARCH64 1)
+ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64.*")
+   set(RISCV64 1)
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
++elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*" OR (CMAKE_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_SYSTEM_PROCESSOR MATCHES "i686.*|i386.*|x86.*"))
+   if (NOT BINARY)
+     if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+       set(X86_64 1)


### PR DESCRIPTION
#### Description

`CMAKE_SYSTEM_PROCESSOR` is output of `uname -m` which might not be the desired userland architecture. On macOS, it's the kernel architecture, and on some x86_64 machines running Mac OS X 10.6 the kernel is 32-bit, which is of course not a problem at all for running 64-bit userland programs.

Anyway, on that case the build will turn to 32bit on that machine and fail.

A PR to upstream: https://github.com/OpenMathLib/OpenBLAS/pull/4351

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->