### PR TITLE
R: switch to clang-16 and gcc13

### DIFF
--- a/_resources/port1.0/group/R-1.0.tcl
+++ b/_resources/port1.0/group/R-1.0.tcl
@@ -96,22 +96,22 @@ compiler.cxx_standard       2011
 
 # Avoid Apple clangs:
 compiler.blacklist-append   {clang}
-# Blacklist macports-clang-16+. See discussion: https://trac.macports.org/ticket/67144
+# Blacklist macports-clang-17+. See discussion: https://trac.macports.org/ticket/67144
 # for rationale. The decision when to migrate to a new compiler
 # is then in the hands of the R maintainers and will not change
 # from the current defaults when these get bumped centrally.
-# NOTE : Keep this setting in sync with the one in the R port.
-compiler.blacklist-append   {macports-clang-1[6-9]}
-# Similarly, for gcc select the gcc12 variant of the compilers PG.
-# This setting should also be kept in sync with that in the R Port.
+# NOTE: Keep this setting in sync with the one in the R port.
+compiler.blacklist-append   {macports-clang-1[7-9]}
+# Similarly, for gcc select the gcc13 variant of the compilers PG.
+# This setting should also be kept in sync with that in the R port.
 # Updates should be coordinated with the R maintainers.
-# NOTE: upon the update to gcc13, please add a blacklist of newer gccs,
-# like it is done for clangs. We would prefer using the same version of gcc and gfortran.
+compiler.blacklist-append   {macports-gcc-1[4-9]}
+
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     # Until old platforms are switched to the new libgcc.
     default_variants-append +gcc7
 } else {
-    default_variants-append +gcc12
+    default_variants-append +gcc13
 }
 
 port::register_callback R.add_dependencies

--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -9,7 +9,7 @@ name                        R
 # Remember to set revision to 0 when bumping version
 # And also to update Rversion in R PortGroup
 version                     4.3.2
-revision                    0
+revision                    1
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  math science
@@ -38,22 +38,22 @@ checksums                   rmd160  423dd09d81606f7a4ab8b14fb04bc90114dab6f0 \
 
 # Avoid Apple clangs:
 compiler.blacklist-append   {clang}
-# Blacklist macports-clang-16+. See discussion: https://trac.macports.org/ticket/67144
+# Blacklist macports-clang-17+. See discussion: https://trac.macports.org/ticket/67144
 # for rationale. The decision when to migrate to a new compiler
 # is then in the hands of the R maintainers and will not change
 # from the current defaults when these get bumped centrally.
-# NOTE : Keep this setting in sync with the one in the R portgroup.
-compiler.blacklist-append   {macports-clang-1[6-9]}
-# Similarly, for gcc select the gcc12 variant of the compilers PG.
-# This setting should also be kept in sync with that in the R Portgroup.
+# NOTE: Keep this setting in sync with the one in the R portgroup.
+compiler.blacklist-append   {macports-clang-1[7-9]}
+# Similarly, for gcc select the gcc13 variant of the compilers PG.
+# This setting should also be kept in sync with that in the R portgroup.
 # Updates should be coordinated with the R maintainers.
-# NOTE: upon the update to gcc13, please add a blacklist of newer gccs,
-# like it is done for clangs. We would prefer using the same version of gcc and gfortran.
+compiler.blacklist-append   {macports-gcc-1[4-9]}
+
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     # Until old platforms are switched to the new libgcc.
     default_variants-append +gcc7
 } else {
-    default_variants-append +gcc12
+    default_variants-append +gcc13
 }
 
 compilers.choose            fc f77


### PR DESCRIPTION
#### Description

Let us finally move everything to using new clangs and gcc. This is desirable for better support of C++17 (more R packages explicitly ask for it) and to avoid a need to build an extra gcc.

I did verify rebuilding quite a number of R packages locally now (using C, C++ and Fortran) on Sonoma; I have also been using gcc13 with R stuff for quite a while on my PPC systems.
So yes, this is reasonably tested.

P. S. Since even if clang-17 is allowed, clang-16 is what is actually picked, I use the latter. (We want to retain control over exact compiler from R side.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1
Xcode 15.0.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
