### PR TITLE
quadpack: fix build with new fpm

### DIFF
--- a/fortran/quadpack/Portfile
+++ b/fortran/quadpack/Portfile
@@ -20,6 +20,9 @@ checksums           rmd160  ae8adb4aad4e32e6f686fcd5d28532e2e602942f \
                     sha256  465c3350d7c88d6725e857a507669136c2f545735b70f8e05e340866e0bf7a96 \
                     size    116421
 
+# https://github.com/jacobwilliams/quadpack/issues/26
+patchfiles          patch-fpm.diff
+
 post-destroot {
     set docdir ${prefix}/share/doc/${name}
     xinstall -d ${destroot}${docdir}

--- a/fortran/quadpack/files/patch-fpm.diff
+++ b/fortran/quadpack/files/patch-fpm.diff
@@ -1,0 +1,23 @@
+--- fpm.toml	2022-12-16 23:56:52
++++ fpm.toml	2023-12-01 11:25:02
+@@ -18,17 +18,17 @@
+ [install]
+ library = true
+ 
+-[[ test ]]
++[[test]]
+ name = "single"
+ source-dir = "test"
+ main = "quadpack_tests_single.F90"
+ 
+-[[ test ]]
++[[test]]
+ name = "double"
+ source-dir = "test"
+ main = "quadpack_tests_double.F90"
+ 
+-[[ test ]]
++[[test]]
+ name = "quad"
+ source-dir = "test"
+ main = "quadpack_tests_quad.F90"


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68799

#### Description

Fix the build, as suggested in https://github.com/jacobwilliams/quadpack/issues/26

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.1
Xcode 15.0.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
