### PR TITLE
maven3: update to 3.9.6

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -5,7 +5,7 @@ PortGroup select 1.0
 PortGroup java 1.0
 
 name            maven3
-version         3.9.5
+version         3.9.6
 revision        0
 
 categories      java devel
@@ -35,12 +35,12 @@ master_sites    apache:maven/maven-3/${version}/binaries
 distname        apache-maven-${version}-bin
 worksrcdir      apache-maven-${version}
 
-checksums       rmd160  f6f73dc201f34aba53a291e4d7aef71d031554cf \
-                sha256  5fd272b105041fe81e2e42f6399765e015fc4938ef3753ba4af9f0119d84ef7c \
-                size    9359994
+checksums       rmd160  1d827a23bce84df3923aff622fdb1038db57bd63 \
+                sha256  6eedd2cae3626d6ad3a5c9ee324bd265853d64297f07f033430755bd0e0c3a4b \
+                size    9410508
 
 java.version    1.8+
-java.fallback   openjdk17
+java.fallback   openjdk21
 
 depends_run     port:maven_select
 


### PR DESCRIPTION
#### Description

Update to Maven 3.9.6, update Java fallback version to latest Long Term Support version.

###### Tested on

macOS 14.1.2 23B92 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?