### PR TITLE
qt6-qtbase: Fix finding qt6 with cmake find_package

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -1173,6 +1173,19 @@ subport ${name}-qtbase {
                                     ${destroot}${qt6.dir}/bin/qt-cmake
         reinplace                   "s|${prefix}/bin/cmake|/Applications/CMake.app/Contents/bin/cmake|g" \
                                     ${destroot}${qt6.dir}/bin/qt-cmake-private
+
+        if { "${qt6.dir}" ne "${prefix}" } {
+            # Add dummy cmake find modules that forward to the real ones
+            file mkdir "${destroot}${prefix}/lib/cmake/Qt6"
+            foreach configfile [list "Qt6Config.cmake" "Qt6ConfigVersion.cmake"] {
+                set fd [open "${destroot}${prefix}/lib/cmake/Qt6/${configfile}" "w"]
+                puts $fd "set(_PREFIX_PATH_BAK \${CMAKE_PREFIX_PATH})"
+                puts $fd "list(APPEND CMAKE_PREFIX_PATH \"${qt6.dir}\")"
+                puts $fd "include(\"${qt6.dir}/lib/cmake/Qt6/${configfile}\")"
+                puts $fd "set(CMAKE_PREFIX_PATH \${_PREFIX_PATH_BAK})"
+                close $fd
+            }
+        }
     }
 
     # Qt builds part of the system using environment provided by MacPorts.


### PR DESCRIPTION
#### Description

I guess my comment on #17071 never got implemented in the PR that closed it

Fixes building of cmake-based qt applications like Dolphin and PCSX2

The two added files should provide support for all qt6 components as long as applications search for qt6 with `find_package(qt6 COMPONENTS <components>)`, which is the method recommended by qt6 documentation.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.1.1 23B81 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
  - `-t` seems to be broken on Sonoma (untar gets SIGKILL'd), but I did a `sudo port -vs install`
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
