### PR TITLE
ginkgo: update to 1.7.0

### DIFF
--- a/math/ginkgo/Portfile
+++ b/math/ginkgo/Portfile
@@ -5,17 +5,17 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 PortGroup           mpi 1.0
 
-github.setup        ginkgo-project ginkgo 1.6.0 v
-revision            1
+github.setup        ginkgo-project ginkgo 1.7.0 v
+revision            0
 categories          math parallel
 license             BSD
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Numerical linear algebra software package
 long_description    A numerical linear algebra library targeting many-core architectures.
 homepage            https://ginkgo-project.github.io
-checksums           rmd160  8e51a402d2ef0df5bfc78b61ab67d1d0f31758ae \
-                    sha256  c59f574090eac212d272c57f0858db0c13ef41ce5547e38331a74c85ef7fba99 \
-                    size    12788830
+checksums           rmd160  f36e609f28bd2f756325aec7a5dc751b4d39b53c \
+                    sha256  f4b362bcb046bc53fbe2e578662b939222d0c44b96449101829e73ecce02bcb3 \
+                    size    13080034
 github.tarball_from archive
 
 cmake.build_type    Release
@@ -88,9 +88,12 @@ variant openmp description "Use OpenMP" {
 }
 
 # FIXME: Upstream has broken this in 1.6.0 for Clang.
+# Issue: https://github.com/ginkgo-project/ginkgo/issues/1482
 # default_variants    +openmp
 
 variant tests description "Enable testing" {
+    # Test failures on PowerPC: https://github.com/ginkgo-project/ginkgo/issues/1260
+    # Test failures on aarch64: https://github.com/ginkgo-project/ginkgo/issues/1481
     depends_test-append port:gtest
 
     configure.pre_args-replace \


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.2
Xcode 15.0.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

At least on Sonoma / aarch64 some tests are not being run and report as failed:
```
94% tests passed, 13 tests failed out of 205

Total Test time (real) = 104.95 sec

The following tests FAILED:
	121 - core/test/mpi/base/communicator (Not Run)
	122 - core/test/mpi/base/exception_helpers (Not Run)
	123 - core/test/mpi/base/bindings (Not Run)
	124 - core/test/mpi/base/polymorphic_object (Not Run)
	125 - core/test/mpi/base/rank_mapping (Not Run)
	126 - core/test/mpi/distributed/helpers (Not Run)
	127 - core/test/mpi/distributed/matrix (Not Run)
	128 - core/test/mpi/distributed/preconditioner/schwarz (Not Run)
	201 - test/mpi/matrix_reference (Not Run)
	202 - test/mpi/partition_helpers_reference (Not Run)
	203 - test/mpi/vector_reference (Not Run)
	204 - test/mpi/preconditioner/schwarz_reference (Not Run)
	205 - test/mpi/solver/solver_reference (Not Run)
Errors while running CTest
```
Issue: https://github.com/ginkgo-project/ginkgo/issues/1481