### PR TITLE
spring-boot-cli: update to 3.2.0

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.1.6
+version         3.2.0
 revision        0
 
 categories      java
@@ -30,16 +30,16 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  7361f9a0971fa08ef4f6f7c96a531e63f6eb7629 \
-                sha256  0737a9143c2de6e09cd50c1ff8cea2c83ac7687c97eeca941bc0549b06ee870d \
-                size    5150883
+checksums       rmd160  1be5df6e2a8f4af8b79ee8733ccfd2e27fb67ddf \
+                sha256  a959fcea5b7ef29b71a133cd26632bd1663b48067cf54238c28bad57483e7fc8 \
+                size    5399270
 
 worksrcdir      spring-${version}
 
 use_configure   no
 
 java.version    17+
-java.fallback   openjdk17
+java.fallback   openjdk21
 
 build {}
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.2.0, update Java fallback version to latest Long Term Support version.

###### Tested on

macOS 14.1.2 23B92 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?