### PR TITLE
Update argyll 3.1.0

### DIFF
--- a/graphics/argyll/Portfile
+++ b/graphics/argyll/Portfile
@@ -80,11 +80,11 @@ post-destroot {
         ${destroot}${prefix}/share/${name}/ref
     # xinstall does not remove 'quarantine' attribute;
     # do that manually.
-    #fs-traverse fixfile ${destroot} {
-    #    if {[exec xattr -l ${fixfile}] != ""} {
-    #        system "xattr -d com.apple.quarantine ${fixfile}"
-    #    }
-    #}
+    fs-traverse fixfile ${destroot} {
+        if {[string match "*com.apple.quarantine*" [exec xattr -l ${fixfile}]]} {
+            system "xattr -d com.apple.quarantine ${fixfile}"
+        }
+    }
 }
 
 # conflicts with num-utils on ${prefix}/bin/average

--- a/graphics/argyll/Portfile
+++ b/graphics/argyll/Portfile
@@ -64,7 +64,7 @@ post-destroot {
     # Install documentation.
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
     xinstall -m 644 -W ${worksrcpath} \
-         Readme.txt \
+        Readme.txt \
         ${destroot}${prefix}/share/doc/${name}
     system "cp -r ${worksrcpath}/doc/* \
         ${destroot}${prefix}/share/doc/${name} && \

--- a/graphics/argyll/Portfile
+++ b/graphics/argyll/Portfile
@@ -3,11 +3,11 @@
 PortSystem              1.0
 
 name                    argyll
-version                 2.3.1
+version                 3.1.0
 revision                0
-checksums               rmd160  08a703814507e6c4b6821d97ddd5506540ab3106 \
-                        sha256  bd0bcf58cec284824b79ff55baa242903ed361e12b1b37e12228679f9754961c \
-                        size    14098636
+checksums               rmd160  33d3ca28d2aa3cbce292f25a6c472c6a6a6ffa9c \
+                        sha256  4fdd5a1d7bc6dde79a54e350ec9374f6ef00b53903ee0d184cdfa4a11f0ecdcb \
+                        size    14671869
 
 categories              graphics
 maintainers             nomaintainer
@@ -64,7 +64,7 @@ post-destroot {
     # Install documentation.
     xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
     xinstall -m 644 -W ${worksrcpath} \
-        notes.txt Readme.txt ttbd.txt \
+         Readme.txt \
         ${destroot}${prefix}/share/doc/${name}
     system "cp -r ${worksrcpath}/doc/* \
         ${destroot}${prefix}/share/doc/${name} && \
@@ -80,11 +80,11 @@ post-destroot {
         ${destroot}${prefix}/share/${name}/ref
     # xinstall does not remove 'quarantine' attribute;
     # do that manually.
-    fs-traverse fixfile ${destroot} {
-        if {[exec xattr -l ${fixfile}] != ""} {
-            system "xattr -d com.apple.quarantine ${fixfile}"
-        }
-    }
+    #fs-traverse fixfile ${destroot} {
+    #    if {[exec xattr -l ${fixfile}] != ""} {
+    #        system "xattr -d com.apple.quarantine ${fixfile}"
+    #    }
+    #}
 }
 
 # conflicts with num-utils on ${prefix}/bin/average


### PR DESCRIPTION
#### Description
argyll: update to version 3.1.0

* update to version 3.1.0
* removed *.txt no longer available in source package 
* removed xattr -d... since that's not necessary for self built stuff and breaks installation on my M1

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.2 23B92 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

check done by perfoming a display calibration via displaycal

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
