### PR TITLE
gsoap: update to 2.8.131, fix build on new macOS

### DIFF
--- a/devel/gsoap/Portfile
+++ b/devel/gsoap/Portfile
@@ -1,12 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           openssl 1.0
 
 name                gsoap
-version             2.8.66
-revision            2
+version             2.8.131
+revision            0
 set branch          [join [lrange [split ${version} .] 0 1] .]
-platforms           darwin
 categories          devel
 maintainers         nomaintainer
 license             {GPL-2+ OpenSSLException}
@@ -21,19 +21,23 @@ long_description    The gSOAP toolkit is a cross-platform development \
                     HTTP Web server, and much more.
 
 homepage            https://www.genivia.com/dev.html
-master_sites        sourceforge:project/gsoap2/${name}-${branch}
+master_sites        sourceforge:project/gsoap2/
 
 use_zip             yes
 distname            ${name}_${version}
 worksrcdir          ${name}-${branch}
 
-checksums           rmd160  382b7e3f511a1a40af7fc1ece7a2cac27e0409b3 \
-                    sha256  ef7a7ebf3963922ebc97424a6b2371b3761581f3fd07ecfdbaf8a36a8df63d59 \
-                    size    33002504
-
-depends_lib         path:lib/libssl.dylib:openssl
+checksums           rmd160  9758243fd63b7c3e03c7b41a3225085c4f4325c5 \
+                    sha256  e5e1a4ea25fea56ebd62d7b94a089c29e9394b6394ad362762297b7cb31622df \
+                    size    35233649
 
 patchfiles          patch-configure.diff
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool \
+                    port:pkgconfig
 
 use_parallel_build  no
 


### PR DESCRIPTION
#### Description

Update, fix build on new macOS where it currently fails: https://ports.macports.org/port/gsoap/details

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.1.2
Xcode 15.0.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
