### PR TITLE
yabai: update to 6.0.1

### DIFF
--- a/sysutils/yabai/Portfile
+++ b/sysutils/yabai/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               makefile 1.0
 PortGroup               xcodeversion 1.0
 
-github.setup            koekeishiya yabai 6.0.0 v
+github.setup            koekeishiya yabai 6.0.1 v
 github.tarball_from     archive
 
 categories              sysutils
@@ -15,9 +15,9 @@ license                 MIT
 description             A tiling window manager for macOS based on binary space partitioning
 long_description        yabai is a window management utility that is designed to work as an extension to the built-in window manager of macOS.
 
-checksums               rmd160  9fd44fefb9bfbdebf4aa97aceb61012f1410f973 \
-                        sha256  9bc2bf11cb6e06c809467c634ef475f3d487510ebfa8db4842f8d3b89bd16c14 \
-                        size    1536323
+checksums               rmd160 9d912a10acd4fe5e0aec08ad8c538aea143f1a9c \
+                        sha256 70420b8ea50d13aeffaa2c96345850ffd3d98e3025d93be8dc7097363f87e58d \
+                        size   1537515
 
 use_parallel_build      no
 


### PR DESCRIPTION
This release fixes Space switching for macOS Sonoma.

###### Type(s)
- [x] bugfix

###### Tested on
macOS 14.1.1 23B81 arm64
Xcode 15.0 15A240d

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
