### PR TITLE
fish: update to 3.6.3

### DIFF
--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -5,11 +5,11 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               legacysupport 1.0
 
-github.setup            fish-shell fish-shell 3.6.1
-revision                1
-checksums               rmd160  c69c3d1bd6db6a9b3d9d614d35c0a712d7fc0ac9 \
-                        sha256  55402bb47ca6739d8aba25e41780905b5ce1bce0a5e0dd17dca908b5bc0b49b2 \
-                        size    2866100
+github.setup            fish-shell fish-shell 3.6.3
+revision                0
+checksums               rmd160  af3bfb5bc5ac3cef028ccc0aba7073ecd53fbba0 \
+                        sha256  55520128c8ef515908a3821423b430db9258527a6c6acb61c7cb95626b5a48d5 \
+                        size    2911068
 
 name                    fish
 license                 GPL-2
@@ -58,7 +58,7 @@ platform darwin 8 {
     test.env-append     SHELL=${prefix}/bin/bash
 }
 
-depends_test-append     port:py39-pexpect
+depends_test-append     port:py311-pexpect
 # other possible options are ansi, dtterm, rxvt, vt52, vt100, vt102, xterm
 test.env-append         TERM=nsterm
 test.run                yes


### PR DESCRIPTION
#### Description

fish: update to 3.6.3

fixes [CVE-2023-49284](https://github.com/fish-shell/fish-shell/security/advisories/GHSA-2j9r-pm96-wp4f)

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?