### PR TITLE
groovy: update to 4.0.16

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         4.0.15
+version         4.0.16
 revision        0
 
 categories      lang java
@@ -41,16 +41,16 @@ master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zi
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  efe927010c6fe07db8956a01d30c19a16ff0c290 \
-                sha256  31d96c1e1cf75c7e8173cdcef9bed1e3edd4e87e6400400584220e0bb42892e5 \
-                size    29698122
+checksums       rmd160  d2cba0ba34ac6ddc5c7995df0c59453062cb7eeb \
+                sha256  b8c3bec88a3f5a62235d9429a97e371032bf7216f3e28724823a9169dd10befc \
+                size    29793704
 
 worksrcdir      ${name}-${version}
 
 use_configure   no
 
 java.version    1.8+
-java.fallback   openjdk17
+java.fallback   openjdk21
 
 build {}
 


### PR DESCRIPTION
#### Description

Update to Groovy 4.0.16, update Java fallback version to latest Long Term Support release.

###### Tested on

macOS 14.1.2 23B92 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?