### PR TITLE
helix: fix broken URL for 'gemini' grammar

### DIFF
--- a/editors/helix/Portfile
+++ b/editors/helix/Portfile
@@ -5,7 +5,8 @@ PortGroup           cargo   1.0
 PortGroup           github  1.0
 
 github.setup        helix-editor helix 23.10
-revision            0
+github.tarball_from archive
+revision            1
 
 homepage            https://helix-editor.com
 
@@ -23,12 +24,12 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 variant devel description {Include grammar source and debugging symbols} {}
 
-# Helix's build process requires git
-fetch.type          git
+checksums           ${distname}${extract.suffix} \
+                    rmd160  09897c961fa8cbe698d302eb3859f0270a2521a6 \
+                    sha256  a1a98b24692ba8fc648245bebc3511b27eb4edf9eb97d97d8aed7157316d01e8 \
+                    size    2083647
 
-# Helix does not build well using frozen deps
-build.pre_args-delete \
-                    --frozen
+patchfiles-append   patch-languages.toml.diff
 
 set hx_bin_path     ${prefix}/bin/hx-bin
 set hx_share_path   ${prefix}/share/${name}
@@ -36,7 +37,6 @@ set hx_runtime_path ${hx_share_path}/runtime
 set hx_grammar_path ${hx_runtime_path}/grammars
 
 post-extract {
-    system -W ${worksrcpath} "git submodule update --init"
     copy ${filespath}/wrapper.sh ${workpath}/
 }
 
@@ -58,3 +58,257 @@ destroot {
         file delete -force ${destroot}${hx_grammar_path}/sources
     }
 }
+
+cargo.crates \
+    addr2line                       0.20.0  f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3 \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    ahash                            0.8.5  cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d \
+    aho-corasick                    0.7.20  cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac \
+    aho-corasick                     1.0.2  43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41 \
+    allocator-api2                  0.2.14  c4f263788a35611fba42eb41ff811c5d0360c58b97402570312a350736e2542e \
+    android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
+    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    anyhow                          1.0.75  a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6 \
+    arc-swap                         1.6.0  bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    backtrace                       0.3.68  4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12 \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                         2.4.1  327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07 \
+    bstr                             1.6.0  6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05 \
+    btoi                             0.4.3  9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad \
+    bumpalo                         3.12.0  0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535 \
+    bytecount                        0.6.3  2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c \
+    bytes                            1.4.0  89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be \
+    cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
+    cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    chardetng                       0.1.17  14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea \
+    chrono                          0.4.31  7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38 \
+    clipboard-win                    4.5.0  7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362 \
+    clru                             0.6.1  b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807 \
+    codespan-reporting              0.11.1  3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e \
+    content_inspector                0.2.4  b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38 \
+    core-foundation-sys              0.8.4  e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa \
+    cov-mark                         1.1.0  9ffa3d3e0138386cd4361f63537765cac7ee40698028844635a54495a92f67f3 \
+    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
+    crossbeam-channel                0.5.8  a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200 \
+    crossbeam-deque                  0.8.3  ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef \
+    crossbeam-epoch                 0.9.15  ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7 \
+    crossbeam-utils                 0.8.16  5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294 \
+    crossterm                       0.27.0  f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df \
+    crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
+    cxx                             1.0.94  f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93 \
+    cxx-build                       1.0.94  12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b \
+    cxxbridge-flags                 1.0.94  7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb \
+    cxxbridge-macro                 1.0.94  2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5 \
+    dirs                             5.0.1  44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225 \
+    dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
+    dunce                            1.0.4  56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b \
+    either                           1.8.1  7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91 \
+    encoding_rs                     0.8.33  7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1 \
+    encoding_rs_io                   0.1.7  1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83 \
+    equivalent                       1.0.0  88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1 \
+    errno                            0.3.1  4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a \
+    errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
+    error-code                       2.3.1  64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21 \
+    etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
+    faster-hex                       0.8.1  239f7bfb930f820ab16a9cd95afc26f88264cf6905c960b340a615384aa3338a \
+    fastrand                         2.0.0  6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764 \
+    fern                             0.6.2  d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee \
+    filedescriptor                   0.8.2  7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e \
+    flate2                          1.0.27  c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    form_urlencoded                  1.2.0  a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652 \
+    futures-core                    0.3.28  4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c \
+    futures-executor                0.3.28  ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0 \
+    futures-task                    0.3.28  76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65 \
+    futures-util                    0.3.28  26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533 \
+    getrandom                        0.2.9  c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4 \
+    gimli                           0.27.3  b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e \
+    gix                             0.55.2  002667cd1ebb789313d0d0afe3d23b2821cf3b0e91605095f0e6d8751f0ceeea \
+    gix-actor                       0.28.0  948a5f9e43559d16faf583694f1c742eb401ce24ce8e6f2238caedea7486433c \
+    gix-chunk                        0.4.4  5b42ea64420f7994000130328f3c7a2038f639120518870436d31b8bde704493 \
+    gix-commitgraph                 0.22.0  7e8bc78b1a6328fa6d8b3a53b6c73997af37fd6bfc1d6c49f149e63bda5cbb36 \
+    gix-config                      0.31.0  5cae98c6b4c66c09379bc35274b172587d6b0ac369a416c39128ad8c6454f9bb \
+    gix-config-value                0.14.0  ea7505b97f4d8e7933e29735a568ba2f86d8de466669d9f0e8321384f9972f47 \
+    gix-date                         0.8.0  fc7df669639582dc7c02737642f76890b03b5544e141caba68a7d6b4eb551e0d \
+    gix-diff                        0.37.0  931394f69fb8c9ed6afc0aae3487bd869e936339bcc13ed8884472af072e0554 \
+    gix-discover                    0.26.0  a45d5cf0321178883e38705ab2b098f625d609a7d4c391b33ac952eff2c490f2 \
+    gix-features                    0.36.0  51f4365ba17c4f218d7fd9ec102b8d2d3cb0ca200a835e81151ace7778aec827 \
+    gix-fs                           0.8.0  8cd171c0cae97cd0dc57e7b4601cb1ebf596450e263ef3c02be9107272c877bd \
+    gix-glob                        0.14.0  8fac08925dbc14d414bd02eb45ffb4cecd912d1fce3883f867bd0103c192d3e4 \
+    gix-hash                        0.13.1  1884c7b41ea0875217c1be9ce91322f90bde433e91d374d0e1276073a51ccc60 \
+    gix-hashtable                    0.4.0  409268480841ad008e81c17ca5a293393fbf9f2b6c2f85b8ab9de1f0c5176a16 \
+    gix-lock                        11.0.0  f4feb1dcd304fe384ddc22edba9dd56a42b0800032de6537728cea2f033a4f37 \
+    gix-macros                       0.1.0  9d8acb5ee668d55f0f2d19a320a3f9ef67a6999ad483e11135abcc2464ed18b6 \
+    gix-object                      0.38.0  740f2a44267f58770a1cb3a3d01d14e67b089c7136c48d4bddbb3cfd2bf86a51 \
+    gix-odb                         0.54.0  8630b56cb80d8fa684d383dad006a66401ee8314e12fbf0e566ddad8c115143b \
+    gix-pack                        0.44.0  1431ba2e30deff1405920693d54ab231c88d7c240dd6ccc936ee223d8f8697c3 \
+    gix-path                        0.10.0  6a1d370115171e3ae03c5c6d4f7d096f2981a40ddccb98dfd704c773530ba73b \
+    gix-quote                        0.4.7  475c86a97dd0127ba4465fbb239abac9ea10e68301470c9791a6dd5351cdc905 \
+    gix-ref                         0.38.0  0ec2f6d07ac88d2fb8007ee3fa3e801856fb9d82e7366ec0ca332eb2c9d74a52 \
+    gix-refspec                     0.19.0  ccb0974cc41dbdb43a180c7f67aa481e1c1e160fcfa8f4a55291fd1126c1a6e7 \
+    gix-revision                    0.23.0  2ca97ac73459a7f3766aa4a5638a6e37d56d4c7962bc1986fbaf4883d0772588 \
+    gix-revwalk                      0.9.0  a16d8c892e4cd676d86f0265bf9d40cefd73d8d94f86b213b8b77d50e77efae0 \
+    gix-sec                         0.10.0  92b9542ac025a8c02ed5d17b3fc031a111a384e859d0be3532ec4d58c40a0f28 \
+    gix-tempfile                    11.0.0  05cc2205cf10d99f70b96e04e16c55d4c7cf33efc151df1f793e29fd12a931f8 \
+    gix-trace                        0.1.3  96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836 \
+    gix-traverse                    0.34.0  14d050ec7d4e1bb76abf0636cf4104fb915b70e54e3ced9a4427c999100ff38a \
+    gix-url                         0.25.1  b1b9ac8ed32ad45f9fc6c5f8c0be2ed911e544a5a19afd62d95d524ebaa95671 \
+    gix-utils                        0.1.5  b85d89dc728613e26e0ed952a19583744e7f5240fcd4aa30d6c824ffd8b52f0f \
+    gix-validate                     0.8.0  e05cab2b03a45b866156e052aa38619f4ece4adcb2f79978bfc249bc3b21b8c5 \
+    globset                         0.4.13  759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d \
+    grep-matcher                     0.1.6  3902ca28f26945fe35cad349d776f163981d777fee382ccd6ef451126f51b319 \
+    grep-regex                      0.1.11  997598b41d53a37a2e3fc5300d5c11d825368c054420a9c65125b8fe1078463f \
+    grep-searcher                   0.1.11  5601c4b9f480f0c9ebb40b1f6cbf447b8a50c5369223937a6c5214368c58779f \
+    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+    hashbrown                       0.14.2  f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156 \
+    hermit-abi                       0.2.6  ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7 \
+    home                             0.5.4  747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408 \
+    iana-time-zone                  0.1.56  0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c \
+    iana-time-zone-haiku             0.1.1  0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca \
+    idna                             0.4.0  7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c \
+    ignore                          0.4.20  dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492 \
+    imara-diff                       0.1.5  e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8 \
+    indexmap                         2.0.0  d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d \
+    indoc                            2.0.4  1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8 \
+    itoa                             1.0.6  453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6 \
+    js-sys                          0.3.61  445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                           0.2.149  a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b \
+    libloading                       0.8.1  c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161 \
+    link-cplusplus                   1.0.8  ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5 \
+    linux-raw-sys                   0.4.10  da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f \
+    lock_api                         0.4.9  435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df \
+    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    lsp-types                       0.94.1  c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1 \
+    memchr                           2.6.3  8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c \
+    memmap2                         0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
+    memmap2                          0.7.1  f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6 \
+    memoffset                        0.9.0  5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
+    miniz_oxide                      0.7.1  e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7 \
+    mio                              0.8.6  5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9 \
+    nucleo                           0.2.1  ae5331f4bcce475cf28cb29c95366c3091af4b0aa7703f1a6bc858f29718fdf3 \
+    nucleo-matcher                   0.2.0  1b702b402fe286162d1f00b552a046ce74365d2ac473a2607ff36ba650f9bd57 \
+    num-traits                      0.2.15  578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd \
+    num_cpus                        1.15.0  0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b \
+    num_threads                      0.1.6  2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44 \
+    object                          0.31.1  8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1 \
+    once_cell                       1.18.0  dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d \
+    option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
+    parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
+    parking_lot_core                 0.9.7  9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521 \
+    percent-encoding                 2.3.0  9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94 \
+    pin-project-lite                0.2.12  12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05 \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    proc-macro2                     1.0.69  134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da \
+    prodash                         26.2.2  794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf \
+    pulldown-cmark                   0.9.3  77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998 \
+    quickcheck                       1.0.3  588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6 \
+    quote                           1.0.29  573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105 \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+    rayon                            1.7.0  1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b \
+    rayon-core                      1.11.0  4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d \
+    redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
+    redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
+    redox_users                      0.4.3  b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b \
+    regex                           1.10.2  380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343 \
+    regex-automata                   0.3.9  59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9 \
+    regex-automata                   0.4.3  5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f \
+    regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
+    regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+    ropey                            1.6.1  93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5 \
+    rustc-demangle                  0.1.23  d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76 \
+    rustix                         0.38.20  67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0 \
+    ryu                             1.0.13  f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    scratch                          1.0.5  1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1 \
+    serde                          1.0.189  8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537 \
+    serde_derive                   1.0.189  1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5 \
+    serde_json                     1.0.107  6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65 \
+    serde_repr                      0.1.12  bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab \
+    serde_spanned                    0.6.3  96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186 \
+    sha1_smol                        1.0.0  ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012 \
+    signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
+    signal-hook-mio                  0.2.3  29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af \
+    signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
+    signal-hook-tokio                0.3.1  213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e \
+    slab                             0.4.8  6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d \
+    slotmap                          1.0.6  e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342 \
+    smallvec                        1.11.1  942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a \
+    smartstring                      1.0.1  3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29 \
+    smawk                            0.3.1  f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043 \
+    socket2                          0.5.3  2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877 \
+    static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
+    str-buf                          1.0.6  9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0 \
+    str_indices                      0.4.1  5f026164926842ec52deb1938fae44f83dfdb82d0a5b0270c5bd5935ab74d6dd \
+    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+    syn                             2.0.38  e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b \
+    tempfile                         3.8.0  cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef \
+    termcolor                        1.2.0  be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6 \
+    termini                          1.0.0  2ad441d87dd98bc5eeb31cf2fb7e4839968763006b478efb38668a3bf9da0d59 \
+    textwrap                        0.16.0  222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d \
+    thiserror                       1.0.50  f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2 \
+    thiserror-impl                  1.0.50  266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8 \
+    thread_local                     1.1.7  3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152 \
+    threadpool                       1.8.1  d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa \
+    time                            0.3.23  59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446 \
+    time-core                        0.1.1  7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb \
+    time-macros                     0.2.10  96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4 \
+    tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+    tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
+    tokio                           1.33.0  4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653 \
+    tokio-macros                     2.1.0  630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e \
+    tokio-stream                    0.1.14  397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842 \
+    toml                             0.7.6  c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542 \
+    toml_datetime                    0.6.3  7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b \
+    toml_edit                      0.19.12  c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78 \
+    tree-sitter                    0.20.10  e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d \
+    unicase                          2.6.0  50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6 \
+    unicode-bidi                    0.3.13  92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460 \
+    unicode-bom                      2.0.2  98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552 \
+    unicode-general-category         0.6.0  2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7 \
+    unicode-ident                    1.0.8  e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4 \
+    unicode-linebreak                0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
+    unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
+    unicode-segmentation            1.10.1  1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36 \
+    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
+    url                              2.4.1  143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5 \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    walkdir                          2.3.3  36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698 \
+    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasm-bindgen                    0.2.84  31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b \
+    wasm-bindgen-backend            0.2.84  95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9 \
+    wasm-bindgen-macro              0.2.84  4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5 \
+    wasm-bindgen-macro-support      0.2.84  2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6 \
+    wasm-bindgen-shared             0.2.84  0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d \
+    which                            4.4.1  8ad25fe5717e59ada8ea33511bbbf7420b11031730a24c65e82428766c307006 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows                         0.48.0  e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f \
+    windows-sys                     0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-targets                 0.42.2  8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
+    windows-targets                 0.48.0  7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5 \
+    windows_aarch64_gnullvm         0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
+    windows_aarch64_gnullvm         0.48.0  91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc \
+    windows_aarch64_msvc            0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
+    windows_aarch64_msvc            0.48.0  b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3 \
+    windows_i686_gnu                0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
+    windows_i686_gnu                0.48.0  622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241 \
+    windows_i686_msvc               0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
+    windows_i686_msvc               0.48.0  4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00 \
+    windows_x86_64_gnu              0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
+    windows_x86_64_gnu              0.48.0  ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1 \
+    windows_x86_64_gnullvm          0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
+    windows_x86_64_gnullvm          0.48.0  7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953 \
+    windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
+    windows_x86_64_msvc             0.48.0  1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a \
+    winnow                           0.4.6  61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699 \
+    winnow                          0.5.17  a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c \
+    zerocopy                        0.7.11  4c19fae0c8a9efc6a8281f2e623db8af1db9e57852e04cde3e754dd2dc29340f \
+    zerocopy-derive                 0.7.11  fc56589e9ddd1f1c28d4b4b5c773ce232910a6bb67a70133d61c9e347585efe9

--- a/editors/helix/files/patch-languages.toml.diff
+++ b/editors/helix/files/patch-languages.toml.diff
@@ -1,0 +1,13 @@
+# https://github.com/helix-editor/helix/pull/8932
+
+--- ./languages.toml	2023-12-05 01:38:58
++++ ./languages.toml	2023-12-05 01:39:07
+@@ -2998,7 +2998,7 @@
+ 
+ [[grammar]]
+ name = "gemini"
+-source = { git = "https://git.sr.ht/~sfr/tree-sitter-gemini", rev = "3cc5e4bdf572d5df4277fc2e54d6299bd59a54b3" }
++source = { git = "https://git.sr.ht/~nbsp/tree-sitter-gemini", rev = "3cc5e4bdf572d5df4277fc2e54d6299bd59a54b3" }
+ 
+ [[language]]
+ name = "templ"


### PR DESCRIPTION
- build from source archive, no longer fetch source using git

Closes: https://trac.macports.org/ticket/68812

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
