### PR TITLE
micronaut: update to 4.2.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.2.0 v
+github.setup    micronaut-projects micronaut-starter 4.2.1 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  297615c6e44bb2f645b64024667b466b39c0ebf1 \
-                sha256  1f7142d3b9483d3aaab547ec98b63228701e1c57e378d4f46827101d96723161 \
-                size    20329324
+checksums       rmd160  16fa82366e55c2b1c475e4ba3a34198ee5b74a96 \
+                sha256  78676a61e3d6b50888e6d42b1aa6348f7fe972e8da910b282ef97c6b697bc1c6 \
+                size    20349405
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.2.1.

###### Tested on

macOS 14.1.2 23B92 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?