### PR TITLE
macos-trash: fix builds with ncurses installed

### DIFF
--- a/sysutils/macos-trash/Portfile
+++ b/sysutils/macos-trash/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           xcodeversion 1.0
 
 github.setup        sindresorhus macos-trash 1.2.0 v
-revision            0
+revision            1
 github.tarball_from archive
 
 categories          sysutils
@@ -31,6 +31,10 @@ if {${os.platform} eq "darwin" && ${os.major} < 20} {
         ui_error "${name} requires macOS 11 or later."
         return -code error "incompatible macOS version"
     }
+}
+
+if {![catch {registry_active ncurses}]} {
+    depends_build-append port:macports-module-map
 }
 
 use_configure       no


### PR DESCRIPTION
#### Description

Add macports-module-map as a build-time dependency when ncurses is installed.

Closes: https://trac.macports.org/ticket/68839
See: https://trac.macports.org/ticket/68283

###### Type(s)

- [x] bugfix

###### Tested on

macOS 13.6.2 22G320 arm64
Xcode 15.0 15A240d

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
