### PR TITLE
google-cloud-sdk: update to 456.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             455.0.0
+version             456.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  30bea7212c55f75d51fa29342c3b931b564d1562 \
-                    sha256  1c1fa949f7b8a74e6be74b60a57febab6f16adf5fa720391ba4373994cdc9f0d \
-                    size    121519956
+    checksums       rmd160  e7410d9631d098793a74fc8d01305f4667702581 \
+                    sha256  e30ae8c974bdd0ee1dc7d00a5f474bf6a235f5dfd33c64f18e4265ead340bc74 \
+                    size    122169307
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  ca9239c092350e4c10b128ea7c3a9174c850a21c \
-                    sha256  bd4213d15f7e9173e1420567d5d73f3439219294e863d6fe475f1e261cb57093 \
-                    size    122806645
+    checksums       rmd160  dbfc77e5bb7cecb5fff72adf6e1469ee23b8fb3f \
+                    sha256  2961471b9d81092443456de15509f46fea685dfaf401f1b6c444eab63b45ccb7 \
+                    size    123456047
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  51095eb190a08f7734bd8318eccbecb53f409771 \
-                    sha256  07b01cebf47b162612d6589d427dc868fe69666dc91ba2221210d2050676ab43 \
-                    size    119890163
+    checksums       rmd160  0b4097d471ab0c9c2da4db307fc62978a37c404c \
+                    sha256  80c31937d3a3dce98d730844ff028715a46cd9fd5d5d44096b16e85fa54e6df1 \
+                    size    120519828
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 456.0.0.

###### Tested on

macOS 14.1.2 23B92 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?