### PR TITLE
fish: update to 3.6.4

### DIFF
--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -5,11 +5,11 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               legacysupport 1.0
 
-github.setup            fish-shell fish-shell 3.6.3
+github.setup            fish-shell fish-shell 3.6.4
 revision                0
-checksums               rmd160  af3bfb5bc5ac3cef028ccc0aba7073ecd53fbba0 \
-                        sha256  55520128c8ef515908a3821423b430db9258527a6c6acb61c7cb95626b5a48d5 \
-                        size    2911068
+checksums               rmd160  de7189d46546a655b04bf702316153d0c5c620a5 \
+                        sha256  0f3f610e580de092fbe882c8aa76623ecf91bb16fdf0543241e6e90d5d4bc393 \
+                        size    2911364
 
 name                    fish
 license                 GPL-2


### PR DESCRIPTION
#### Description

fish: update to 3.6.4

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.1.2 23B92 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
