### PR TITLE
lagrange: update to 1.17.5

### DIFF
--- a/net/lagrange/Portfile
+++ b/net/lagrange/Portfile
@@ -6,7 +6,7 @@ PortGroup           gitea 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 gitea.domain        git.skyjake.fi
-gitea.setup         gemini lagrange 1.17.4 v
+gitea.setup         gemini lagrange 1.17.5 v
 revision            0
 categories          net gemini
 license             BSD
@@ -15,9 +15,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         A Beautiful Gemini Client
 long_description    {*}${description}
 
-checksums           rmd160  3cc0cb9c520ab9f0ad7c8c84dcd5bf786671e5fc \
-                    sha256  866807765f94bb9eabf8208738f931706ddd883f7795edb12c5afd840f281354 \
-                    size    7732879
+checksums           rmd160  e07c9c839a7f2fee65a046eccc851cf242172ba5 \
+                    sha256  96c8bb810cabd6f2d3964be5a92cb41a51a0ae1d663c10c54e047a18b2e67181 \
+                    size    7733889
 
 worksrcdir          ${name}
 


### PR DESCRIPTION
#### Description
Changelog: https://github.com/skyjake/lagrange/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
