### PR TITLE
py-jsonschema: update to version 4.20.0

### DIFF
--- a/python/py-jsonschema/Portfile
+++ b/python/py-jsonschema/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-jsonschema
-version             4.17.3
+version             4.20.0
 revision            0
 categories-append   devel
 license             MIT
@@ -22,47 +22,54 @@ long_description    {*}${description}
 
 homepage            https://github.com/python-jsonschema/jsonschema
 
-checksums           rmd160  86637e335ef60176700311eb93e0d5dbbcb8d457 \
-                    sha256  0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d \
-                    size    297785
+checksums           rmd160  d3809a9d155cf5842885e9b5615911097edf39b6 \
+                    sha256  4f614fd46d8d61258610998997743ec5492a648b33cf478c1ddc23ed4598a5fa \
+                    size    320243
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools_scm \
-                        port:py${python.version}-hatch-vcs \
-                        port:py${python.version}-hatch-fancy-pypi-readme
-
     # CLI depends on pkg_resources.py from setuptools
     depends_lib-append  port:py${python.version}-attrs \
-                        port:py${python.version}-pyrsistent \
                         port:py${python.version}-setuptools
 
     if {${python.version} < 37} {
         version             3.2.0
-        revision            0
         distname            ${python.rootname}-${version}
         checksums           rmd160  fb79174fba8955cf5433fa0e79d3ad3a48c590fb \
                             sha256  c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a \
                             size    167226
         python.pep517       no
-        depends_build-delete \
-                        port:py${python.version}-hatch-vcs \
-                        port:py${python.version}-hatch-fancy-pypi-readme
-        depends_lib-append  port:py${python.version}-six
+
+        depends_build-append \
+                            port:py${python.version}-setuptools_scm
+
+        depends_lib-append  port:py${python.version}-importlib-metadata \
+                            port:py${python.version}-pyrsistent \
+                            port:py${python.version}-six
     } else {
         patchfiles-append   patch-setup.py.diff
+
+        depends_build-append \
+                            port:py${python.version}-hatch-vcs \
+                            port:py${python.version}-hatch-fancy-pypi-readme
+
         if {${python.version} < 38} {
-            depends_lib-append  port:py${python.version}-typing_extensions
+            version             4.17.3
+            checksums           rmd160  86637e335ef60176700311eb93e0d5dbbcb8d457 \
+                                sha256  0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d \
+                                size    297785
+
+            depends_lib-append  port:py${python.version}-typing_extensions \
+                                port:py${python.version}-importlib-metadata \
+                                port:py${python.version}-pyrsistent
+        } else {
+            depends_lib-append  port:py${python.version}-jsonschema-specifications \
+                                port:py${python.version}-referencing \
+                                port:py${python.version}-rpds-py
         }
+
         if {${python.version} < 39} {
             depends_lib-append  port:py${python.version}-importlib-resources \
                                 port:py${python.version}-pkgutil_resolve_name
         }
     }
-
-    if {${python.version} < 38} {
-        depends_lib-append  port:py${python.version}-importlib-metadata
-    }
-
-    livecheck.type      none
 }


### PR DESCRIPTION
#### Description

Updated to 4.20.0 and restructured the portfile

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.2 22G320 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] ~~squashed and [minimized your commits](https://guide.macports.org/#project.github)?~~
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] ~~referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?~~ <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] ~~tried existing tests with `sudo port test`?~~
- [x] tried a full install with `sudo port -vst install`? Without "-t" and not py35 and py36.
- [ ] ~~tested basic functionality of all binary files?~~
- [ ] ~~checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?~~

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
