### PR TITLE
symfony-cli: update to 5.7.5

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.7.4
+version             5.7.5
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  10609ebc480dae900cf8f7f959b91533381c3d51 \
-                        sha256  a431c59eebb8756255511a422fe21bd963dacd8c09d1da3a30289eaf7d3f0d0b \
-                        size    258196
+    checksums           rmd160  321b1ff77980dbae5aa4dca2ebebee5fe23b710d \
+                        sha256  5b4bf3625357776c636c50b5cf2945c2e4251711426c4293790a1354f9c00eff \
+                        size    258243
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  9bc434c97ea597e0a7dd187253e98dd4d0978295 \
-                        sha256  4843a6597bf03d12a853259d29693569ba4ddba7b8f4aead01abef1aaff8d2b5 \
-                        size    11144185
+    checksums           rmd160  02ef5517db82746ebcc0d8e2b52dc982b55a43cf \
+                        sha256  86f40aa06a612ed1057317a8bf1823fe63a943515336b8808ce9aa77b742357d \
+                        size    11144021
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.7.5

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
