### PR TITLE
cargo_fetch: Update reference to cargo2port

### DIFF
--- a/_resources/port1.0/group/cargo_fetch-1.0.tcl
+++ b/_resources/port1.0/group/cargo_fetch-1.0.tcl
@@ -22,11 +22,7 @@
 # the upstream source code. The cargo2port generator can be used to automate
 # updates of this list for new releases.
 #
-# To get a list of these, run in worksrcdir:
-#     cargo update
-#     egrep -e '^(name|version|checksum) = ' Cargo.lock | perl -pe 's/^(?:name|version|checksum) = "(.+)"/$1/'
-#
-# https://github.com/macports/macports-contrib/tree/master/cargo2port/cargo2port.tcl
+# https://ports.macports.org/port/cargo2port/
 #
 # If Cargo.lock references pre-release versions, or in general references
 # crates not published on crates.io, but available from GitHub, also use the


### PR DESCRIPTION
#### Description

Update the reference to the cargo2port port in the ports tree. The old script in macports-contrib is outdated and no longer works with the V2 format of Cargo.lock.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
(not applicable)

###### Verification <!-- (delete not applicable items) -->
(not applicable)

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
