### PR TITLE
php_igbinary: update to 3.2.15 and add php83 port

### DIFF
--- a/php/php-igbinary/Portfile
+++ b/php/php-igbinary/Portfile
@@ -9,15 +9,15 @@ license             BSD PHP-3.01
 platforms           darwin freebsd openbsd
 maintainers         {ryandesign @ryandesign} openmaintainer
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3
 php.pecl            yes
 
 if {[vercmp ${php.branch} 7.0] >= 0} {
-    version         3.2.14
+    version         3.2.15
     revision        0
-    checksums       rmd160  c19b2ba9d5b10a3c9e0a34594ca22bb59bc2c279 \
-                    sha256  6337147a4fb888072566674837bda9928ee06ee7f0114b4338b86c816232925d \
-                    size    102824
+    checksums       rmd160  7bd0b12e2d702cd9aba594c78b842d308a24daaa \
+                    sha256  eff099b0343b45fbe9765d4b3d441064ddefbbf9cfb7198487de9bda6b8f4907 \
+                    size    103238
 } elseif {[vercmp ${php.branch} 5.2] >= 0} {
     version         2.0.8
     revision        0


### PR DESCRIPTION
#### Description

Update to 3.2.15 and add php83 port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.2 22G91 x86_64
Xcode 15.0.1 15A507
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
