### PR TITLE
py-gobject3: add py312 subport

### DIFF
--- a/python/py-gobject3/Portfile
+++ b/python/py-gobject3/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  ab889fe19d883dbe9ce693cfe6d4af048a353014 \
                     sha256  426008b2dad548c9af1c7b03b59df0440fde5c33f38fb5406b103a43d653cafc \
                     size    561552
 
-python.versions     36 37 38 39 310 311
+python.versions     36 37 38 39 310 311 312
 python.pep517       no
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.1.2 23B92 x86_64
Xcode 15.0.1 15A507

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?