### PR TITLE
abcl: always use FFI

### DIFF
--- a/lang/abcl/Portfile
+++ b/lang/abcl/Portfile
@@ -5,7 +5,7 @@ PortGroup           java 1.0
 
 name                abcl
 version             1.9.2
-revision            3
+revision            4
 categories          lang java
 license             GPL-2
 supported_archs     noarch
@@ -36,22 +36,32 @@ checksums           rmd160  63702c969e4093065ce038ad7c82c7295ae15419 \
                     sha256  4e2f4b8f85e2d95d95e5bdbcd9fa17ad6131a17e2fcf12bc19ffb97b48bc1d38 \
                     size    2477992
 
-depends_build       port:apache-ant
+depends_build-append \
+                    port:apache-ant
+# It needed for implementation of FFI, not build
+depends_run-append  port:maven3
 
 # It may work on openjdk6 and openjdk7, but officially it is 1.8+
 java.version        1.8+
 java.fallback       openjdk11
 use_configure       no
 
-patchfiles-append   patch-macports-xdg-data-dir.diff
+patchfiles-append   patch-macports-xdg-data-dir.diff \
+                    patch-macports-maven.diff
 
 post-patch {
-    reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/src/org/armedbear/lisp/asdf.lisp
+    reinplace -W ${worksrcpath} "s|@@PREFIX@@|${prefix}|g" \
+        src/org/armedbear/lisp/asdf.lisp \
+        contrib/abcl-asdf/maven.lisp
 }
 
 build.cmd           ant
 build.target        abcl
-build.args          -Djava.path=/usr/bin/java
+pre-configure {
+    # This must be called to set ${java.home}
+    java::java_set_env
+    build.args      -Djava.path=${java.home}/bin/java
+}
 
 post-build {
     reinplace "s|${worksrcpath}/dist/abcl.jar|${prefix}/share/java/abcl/abcl.jar|g" \
@@ -71,8 +81,4 @@ destroot {
         ${destroot}${prefix}/share/java/abcl
     system "ln -fs ${prefix}/share/java/abcl/abcl \
         ${destroot}${prefix}/bin/abcl"
-}
-
-variant ffi description "Include MacPorts Maven as runtime dependency for resolving artifacts from the network." {
-    depends_run-append port:maven3
 }

--- a/lang/abcl/files/patch-macports-maven.diff
+++ b/lang/abcl/files/patch-macports-maven.diff
@@ -1,0 +1,19 @@
+diff --git contrib/abcl-asdf/maven.lisp contrib/abcl-asdf/maven.lisp
+index b6541d8b..fac6084a 100644
+--- contrib/abcl-asdf/maven.lisp
++++ contrib/abcl-asdf/maven.lisp
+@@ -55,12 +55,8 @@ Test:
+ 
+ |#
+ 
+-(defparameter *mavens* 
+-  (if (find :windows *features*)
+-      '("mvn" "mvn.bat" "mvn.cmd" "mvn3.bat")
+-      '("mvn" "mvn3"
+-        ;; MacPorts
+-        "/opt/local/bin/mvn" "/opt/local/bin/mvn3"))
++(defparameter *mavens*
++  '("@@PREFIX@@/bin/mvn3")
+   "Locations to search for the Maven executable.")
+ 
+ (defun find-mvn () 


### PR DESCRIPTION
Thus, I've also fixed which maven is used, and if user had installed maven2, and selected it as default one, it will broke FFI at ABCL.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->