### PR TITLE
Update php apcu, redis, xhprof, zip and zstd extensions to build for php83

### DIFF
--- a/php/php-APCu/Portfile
+++ b/php/php-APCu/Portfile
@@ -8,7 +8,7 @@ categories          php devel
 maintainers         {ryandesign @ryandesign}
 license             PHP-3.01
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3
 php.pecl            yes
 
 if {[vercmp ${php.branch} >= 7.0]} {

--- a/php/php-redis/Portfile
+++ b/php/php-redis/Portfile
@@ -8,7 +8,7 @@ categories-append       databases
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 PHP-3.01
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3
 php.pecl                yes
 
 if {[vercmp ${php.branch} >= 7.2]} {

--- a/php/php-xhprof/Portfile
+++ b/php/php-xhprof/Portfile
@@ -8,7 +8,7 @@ categories-append       devel
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 Apache-2
 
-php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2
+php.branches            5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3
 php.pecl                yes
 
 if {[vercmp ${php.branch} >= 7.0]} {

--- a/php/php-zip/Portfile
+++ b/php/php-zip/Portfile
@@ -9,7 +9,7 @@ maintainers         {ryandesign @ryandesign} openmaintainer
 license             PHP-3.01
 
 # Compatible with PHP 8.3 as of 1.22.0.
-php.branches        5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2
+php.branches        5.2 5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3
 php.pecl            yes
 
 if {[vercmp ${php.branch} >= 5.4]} {

--- a/php/php-zstd/Portfile
+++ b/php/php-zstd/Portfile
@@ -9,7 +9,7 @@ categories-append   devel
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             MIT
 
-php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2
+php.branches        5.3 5.4 5.5 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3
 
 description         Zstandard compression
 


### PR DESCRIPTION
#### Description

Update php apcu, redis, xhprof, zip and zstd extensions to build for php83.

All current versions seem to be working ok with php83, no need to update any. Just adding the 8.3 builds.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.5.2 22G91 x86_64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

One detail worth noting is that I've been able to test all the extensions standalone (we have unit tests using them), and xhprof manually.

But one thing that seems impossible to install right now is the php-redis extension with support for both igbinary and zstd. Unless I'm wrong, the php-redis port is missing any variant, so those opt-in features cannot be enabled.

When installing from PECL or configuring it, there are the `--enable-redis-igbinary` and the `--enable-redis-zstd` options (among others) that, maybe, could become "variants" here.

Anyway, that's apart from this PR that just updates those 5 extensions to build for php83.

Ciao :-)
