### PR TITLE
ruby-devel: update to 2023.12.09

### DIFF
--- a/lang/ruby-devel/Portfile
+++ b/lang/ruby-devel/Portfile
@@ -15,13 +15,13 @@ legacysupport.newest_darwin_requires_legacy 14
 # ruby/openssl since ruby-3.2 supports openssl-3
 openssl.branch      3
 
-github.setup        ruby ruby e5d6b4099e9f4027dbaaeb8b825ada572279b066
+github.setup        ruby ruby 88d9a4d58af5c41a3258761dd6d0ea405fe47c07
 
 set ruby_ver        3.3
 set ruby_patch      0
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby-devel
-version             2023.11.17
+version             2023.12.09
 revision            0
 
 categories          lang ruby
@@ -37,9 +37,9 @@ long_description    Ruby is the interpreted scripting language \
 homepage            https://www.ruby-lang.org
 license             {Ruby BSD}
 
-checksums           rmd160  ae7fdf245064e2bc8bae5c0606b61ccbbc310f2c \
-                    sha256  1a361676e013dbe7e052f9982611ad14c40f9c104c31458fc961c384ea88cabe \
-                    size    16329958
+checksums           rmd160  0b78c4f9925682c30722f6c41fa537bfcbe0ebd5 \
+                    sha256  34311f93f4584ab0109cd21f51d4e9e3c9d107e0e2a06fa4eab56e28842b5e8b \
+                    size    16383004
 github.tarball_from archive
 
 universal_variant   no


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
