### PR TITLE
ast-grep: new port (version 0.14.2)

### DIFF
--- a/devel/ast-grep/Portfile
+++ b/devel/ast-grep/Portfile
@@ -1,0 +1,294 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo   1.0
+PortGroup           github  1.0
+
+github.setup        ast-grep ast-grep 0.14.2
+github.tarball_from archive
+revision            0
+
+homepage            https://ast-grep.github.io/
+
+description         A CLI tool for code structural search, lint and rewriting.
+
+long_description    \
+    ${name} is a AST-based tool to search code by pattern code. Think it as \
+    your old-friend grep but it matches AST nodes instead of text. You can \
+    write patterns as if you are writing ordinary code. It will match all \
+    code that has the same syntactical structure. You can use \$ sign \+ \
+    upper case letters as wildcard, e.g. \$MATCH, to match any single AST \
+    node. Think it as REGEX dot ., except it is not textual.
+
+categories          devel textproc
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  ff4c29ab3d8ba7f254d529c645abb8851dfc74ec \
+                    sha256  c219ac5cbd6802f87a76b098164430af9fccb71714426363b1359d631440fc08 \
+                    size    797096
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/target/[cargo.rust_platform]/release/sg      \
+        ${destroot}${prefix}/bin/
+}
+
+cargo.crates \
+    aho-corasick                     1.1.2  b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0 \
+    anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    anstream                         0.6.4  2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44 \
+    anstyle                          1.0.0  41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d \
+    anstyle-parse                    0.2.0  e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee \
+    anstyle-query                    1.0.0  5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b \
+    anstyle-wincon                   3.0.1  f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628 \
+    anyhow                          1.0.75  a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6 \
+    assert_cmd                      2.0.12  88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6 \
+    ast-grep-tree-sitter-c-sharp    0.20.0  69bb67af006de48085e828eb70bdf65adfd148d6cee34aad192ffaec0bc04538 \
+    async-trait                     0.1.57  76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    auto_impl                        1.0.1  8a8c1df849285fbacd587de7818cc7d13be6cd2cbcd47a04fb1801b0e2706e33 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    bit-set                          0.5.3  0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1 \
+    bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                         2.3.3  630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42 \
+    bstr                             1.8.0  542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c \
+    bumpalo                         3.10.0  37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3 \
+    bytes                            1.2.1  ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db \
+    cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
+    cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    ciborium                         0.2.0  b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f \
+    ciborium-io                      0.2.0  346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369 \
+    ciborium-ll                      0.2.0  213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b \
+    clap                            4.4.10  41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272 \
+    clap_builder                     4.4.9  63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1 \
+    clap_complete                    4.4.4  bffe91f06a11b4b9420f62103854e90867812cd5d01557f853c5ee8e791b12ae \
+    clap_derive                      4.4.7  cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442 \
+    clap_lex                         0.6.0  702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1 \
+    codespan-reporting              0.11.1  3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e \
+    colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
+    convert_case                     0.6.0  ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca \
+    criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
+    criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
+    crossbeam-channel                0.5.7  cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c \
+    crossbeam-deque                  0.8.3  ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef \
+    crossbeam-epoch                 0.9.14  46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695 \
+    crossbeam-utils                 0.8.15  3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b \
+    crossterm                       0.25.0  e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67 \
+    crossterm                       0.27.0  f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df \
+    crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
+    ctor                             0.2.0  dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b \
+    dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
+    difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
+    doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
+    dyn-clone                       1.0.11  68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30 \
+    either                           1.8.1  7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91 \
+    equivalent                       1.0.0  88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1 \
+    errno                            0.3.0  50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0 \
+    errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
+    float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
+    form_urlencoded                  1.0.1  5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191 \
+    fuchsia-cprng                    0.1.1  a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba \
+    futures                         0.3.23  ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa \
+    futures-channel                 0.3.23  2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1 \
+    futures-core                    0.3.23  d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115 \
+    futures-io                      0.3.23  93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5 \
+    futures-macro                   0.3.23  0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d \
+    futures-sink                    0.3.23  ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765 \
+    futures-task                    0.3.23  842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306 \
+    futures-util                    0.3.23  f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577 \
+    globset                         0.4.14  57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1 \
+    half                             1.8.2  eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7 \
+    hashbrown                       0.14.0  2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a \
+    heck                             0.4.0  2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9 \
+    hermit-abi                      0.1.19  62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33 \
+    hermit-abi                       0.3.1  fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286 \
+    httparse                         1.8.0  d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904 \
+    idna                             0.2.3  418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8 \
+    ignore                          0.4.21  747ad1b4ae841a78e8aba0d63adbfbeaea26b517b63705d47856b73015d27060 \
+    indexmap                         2.0.0  d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d \
+    indoc                            2.0.4  1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8 \
+    inquire                          0.6.2  c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b \
+    io-lifetimes                     1.0.3  46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c \
+    is-terminal                      0.4.6  256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8 \
+    itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
+    itertools                       0.11.0  b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57 \
+    itoa                             1.0.3  6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754 \
+    js-sys                          0.3.58  c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27 \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                           0.2.140  99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c \
+    libloading                       0.8.0  d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb \
+    linux-raw-sys                    0.3.1  d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f \
+    lock_api                        0.4.10  c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16 \
+    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    lsp-types                       0.94.1  c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1 \
+    matches                          0.1.9  a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f \
+    memchr                           2.6.3  8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c \
+    memoffset                        0.8.0  d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1 \
+    memoffset                        0.9.0  5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
+    mio                              0.8.4  57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf \
+    napi                            2.14.1  1133249c46e92da921bafc8aba4912bf84d6c475f7625183772ed2d0844dc3a7 \
+    napi-build                       2.0.1  882a73d9ef23e8dc2ebbffb6a6ae2ef467c0f18ac10711e4cc59c5485d41df0e \
+    napi-derive                     2.14.2  a0cca5738c6e81eb5ffd2c8ff2b4f05ece9c4c60c7e2b36cec6524492cf7f330 \
+    napi-derive-backend             1.0.55  35960e5f33228192a9b661447d0dfe8f5a3790ff5b4058c4d67680ded4f65b91 \
+    napi-sys                         2.3.0  2503fa6af34dc83fb74888df8b22afe933b58d37daf7d80424b1c60c68196b8b \
+    newline-converter                0.2.2  1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f \
+    normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
+    num-traits                      0.2.15  578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd \
+    num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
+    once_cell                       1.18.0  dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d \
+    oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
+    parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
+    parking_lot_core                 0.9.8  93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447 \
+    percent-encoding                 2.1.0  d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e \
+    pin-project                     1.0.12  ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc \
+    pin-project-internal            1.0.12  069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55 \
+    pin-project-lite                 0.2.9  e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116 \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    plotters                         0.3.4  2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97 \
+    plotters-backend                 0.3.4  193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142 \
+    plotters-svg                     0.3.3  f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f \
+    predicates                       3.0.4  6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0 \
+    predicates-core                  1.0.6  b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174 \
+    predicates-tree                  1.0.7  54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d \
+    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
+    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
+    proc-macro2                     1.0.63  7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb \
+    pyo3                            0.20.0  04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b \
+    pyo3-build-config               0.20.0  a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5 \
+    pyo3-ffi                        0.20.0  214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b \
+    pyo3-macros                     0.20.0  dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b \
+    pyo3-macros-backend             0.20.0  7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424 \
+    pythonize                       0.20.0  ffd1c3ef39c725d63db5f9bc455461bafd80540cb7824c61afb823501921a850 \
+    quote                           1.0.29  573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105 \
+    rand                             0.4.6  552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293 \
+    rand_core                        0.3.1  7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b \
+    rand_core                        0.4.2  9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc \
+    rayon                            1.7.0  1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b \
+    rayon-core                      1.11.0  4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d \
+    rdrand                           0.4.0  678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2 \
+    redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
+    regex                           1.10.2  380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343 \
+    regex-automata                   0.4.3  5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f \
+    regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    rustix                          0.37.6  d097081ed288dfe45699b72f5b5d648e5f15d64d900c7080273baa20c16a6849 \
+    ryu                             1.0.10  f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    schemars                        0.8.16  45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29 \
+    schemars_derive                 0.8.16  c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967 \
+    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+    semver                          1.0.17  bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed \
+    serde                          1.0.190  91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7 \
+    serde_derive                   1.0.190  67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3 \
+    serde_derive_internals          0.26.0  85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c \
+    serde_json                     1.0.108  3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b \
+    serde_repr                       0.1.9  1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca \
+    serde_yaml                      0.9.27  3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c \
+    signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
+    signal-hook-mio                  0.2.3  29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af \
+    signal-hook-registry             1.4.0  e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0 \
+    similar                          2.3.0  2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597 \
+    slab                             0.4.7  4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef \
+    smallvec                         1.9.0  2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1 \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    syn                             1.0.98  c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd \
+    syn                             2.0.32  239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2 \
+    target-lexicon                 0.12.11  9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a \
+    tempdir                          0.3.7  15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8 \
+    termcolor                        1.1.3  bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755 \
+    termtree                         0.4.0  95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8 \
+    thiserror                       1.0.50  f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2 \
+    thiserror-impl                  1.0.50  266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8 \
+    tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
+    tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+    tinyvec_macros                   0.1.0  cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c \
+    tokio                           1.20.1  7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581 \
+    tokio-util                       0.7.3  cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45 \
+    toml_datetime                    0.6.5  3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1 \
+    toml_edit                       0.21.0  d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03 \
+    tower                           0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
+    tower-layer                      0.3.1  343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62 \
+    tower-lsp                       0.20.0  d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508 \
+    tower-lsp-macros                 0.9.0  84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa \
+    tower-service                    0.3.2  b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52 \
+    tracing                         0.1.36  2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307 \
+    tracing-attributes              0.1.23  4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a \
+    tracing-core                    0.1.29  5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7 \
+    tree-sitter                    0.20.10  e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d \
+    tree-sitter-c                   0.20.6  30b03bdf218020057abee831581a74bff8c298323d6c6cd1a70556430ded9f4b \
+    tree-sitter-cpp                 0.20.3  23b4b625f46a7370544b9cf0545532c26712ae49bfc02eb09825db358b9f79e1 \
+    tree-sitter-css                 0.20.0  c3306ddefa1d2681adda2613d11974ffabfbeb215e23235da6c862f3493a04fd \
+    tree-sitter-dart                 0.0.3  2fb6a2192689dd0554c558cfb81d96e446c41d101d701521fd1b452774d132ba \
+    tree-sitter-facade-sg            0.9.2  bf5a4036a699b30bb1360c9883502d8473c5fe5a7f10d4cb0fefb0fbfd97228b \
+    tree-sitter-go                  0.19.1  71967701c8214be4aa77e0260e98361e6fd71ceec1d9d03abb37a22c9f60d0ff \
+    tree-sitter-html                0.19.0  184e6b77953a354303dc87bf5fe36558c83569ce92606e7b382a0dc1b7443443 \
+    tree-sitter-java                0.20.2  2adc5696bf5abf761081d7457d2bb82d0e3b28964f4214f63fd7e720ef462653 \
+    tree-sitter-javascript          0.20.1  edbc663376bdd294bd1f0a6daf859aedb9aa5bdb72217d7ad8ba2d5314102cf7 \
+    tree-sitter-json                0.20.1  50d82d2e33ee675dc71289e2ace4f8f9cf96d36d81400e9dae5ea61edaf5dea6 \
+    tree-sitter-kotlin               0.3.1  1b5f367466210220a194a2d8831fc12d15aa13305e7bcdf2dba47714aa328e86 \
+    tree-sitter-lua                 0.0.19  0968cf4962ead1d26da28921dde1fd97407e7bbcf2f959cd20cf04ba2daa9421 \
+    tree-sitter-python              0.20.3  f47ebd9cac632764b2f4389b08517bf2ef895431dd163eb562e3d2062cc23a14 \
+    tree-sitter-ruby                0.20.0  0ac30cbb1560363ae76e1ccde543d6d99087421e228cc47afcec004b86bb711a \
+    tree-sitter-rust                0.20.4  b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594 \
+    tree-sitter-scala               0.20.2  93df43ab4f2b3299fe97e73eb9b946bbca453b402bea8debf1fa69ab4e28412b \
+    tree-sitter-swift                0.3.6  eee2dbeb101a88a1d9e4883e3fbda6c799cf676f6a1cf59e4fc3862e67e70118 \
+    tree-sitter-thrift               0.5.0  10546b134d045fa8d8787d58faf5851d2b8c2d5eaad9699203c4e7197cd8bea5 \
+    tree-sitter-typescript          0.20.3  a75049f0aafabb2aac205d7bb24da162b53dcd0cfb326785f25a2f32efa8071a \
+    unicode-bidi                     0.3.8  099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992 \
+    unicode-ident                    1.0.1  5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c \
+    unicode-normalization           0.1.21  854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6 \
+    unicode-segmentation            1.10.0  0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a \
+    unicode-width                    0.1.9  3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973 \
+    unindent                         0.2.3  c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce \
+    unsafe-libyaml                   0.2.7  ad2024452afd3874bf539695e04af6732ba06517424dbf958fdb16a01f3bef6c \
+    url                              2.2.2  a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c \
+    utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
+    walkdir                          2.4.0  d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee \
+    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasm-bindgen                    0.2.83  eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268 \
+    wasm-bindgen-backend            0.2.83  4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142 \
+    wasm-bindgen-futures            0.4.31  de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f \
+    wasm-bindgen-macro              0.2.83  052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810 \
+    wasm-bindgen-macro-support      0.2.83  07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c \
+    wasm-bindgen-shared             0.2.83  1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f \
+    web-sys                         0.3.58  2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90 \
+    web-tree-sitter-sg               1.3.4  b9a450701853b465dddfd9edb45b5ab2ff191cd666d9f54382fad24fe6c5503a \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows-sys                     0.36.1  ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2 \
+    windows-sys                     0.42.0  5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7 \
+    windows-sys                     0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-targets                 0.42.2  8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
+    windows-targets                 0.48.0  7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5 \
+    windows_aarch64_gnullvm         0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
+    windows_aarch64_gnullvm         0.48.0  91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc \
+    windows_aarch64_msvc            0.36.1  9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47 \
+    windows_aarch64_msvc            0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
+    windows_aarch64_msvc            0.48.0  b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3 \
+    windows_i686_gnu                0.36.1  180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6 \
+    windows_i686_gnu                0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
+    windows_i686_gnu                0.48.0  622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241 \
+    windows_i686_msvc               0.36.1  e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024 \
+    windows_i686_msvc               0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
+    windows_i686_msvc               0.48.0  4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00 \
+    windows_x86_64_gnu              0.36.1  4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1 \
+    windows_x86_64_gnu              0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
+    windows_x86_64_gnu              0.48.0  ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1 \
+    windows_x86_64_gnullvm          0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
+    windows_x86_64_gnullvm          0.48.0  7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953 \
+    windows_x86_64_msvc             0.36.1  c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680 \
+    windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
+    windows_x86_64_msvc             0.48.0  1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a \
+    winnow                           0.5.0  81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7 \


### PR DESCRIPTION
New port for `ast-grep`: https://ast-grep.github.io/

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
