### PR TITLE
libutf8proc: update to 2.9.0

### DIFF
--- a/textproc/libutf8proc/Portfile
+++ b/textproc/libutf8proc/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           makefile 1.0
 
-github.setup        JuliaStrings utf8proc 2.8.0 v
-revision            1
+github.setup        JuliaStrings utf8proc 2.9.0 v
+revision            0
 name                libutf8proc
 categories          textproc
 license             MIT
@@ -15,9 +15,9 @@ long_description    ${description}
 
 homepage            https://julialang.org/utf8proc/
 
-checksums           rmd160  77a542977efcb5d8eab04497a24cda7b14d0fc39 \
-                    sha256  573f552e95f00612fe801ea77bc8a1e08c597975386b19e24d975174de1f0455 \
-                    size    190342
+checksums           rmd160  88f747bdd16720dfb1eb53e063f50848fc89c621 \
+                    sha256  38ed5036583222c275866b067914be6ccf9eae86d0d1c5559c2fbb597b0231a1 \
+                    size    193513
 
 patchfiles          remove-Wsign-conversion.diff
 


### PR DESCRIPTION
#### Description

Simple update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
