### PR TITLE
fgsl: update to 1.5.0

### DIFF
--- a/math/fgsl/Portfile
+++ b/math/fgsl/Portfile
@@ -4,19 +4,26 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        reinh-bader fgsl 1.4.0 v
+github.setup        reinh-bader fgsl 1.5.0
+github.tarball_from archive
 revision            0
 categories          math science
-maintainers         {takeshi @tenomoto} openmaintainer
+maintainers         {takeshi @tenomoto} \
+                    {@Dave-Allured noaa.gov:dave.allured} \
+                    openmaintainer
 license             GPL-2
+
 description         Fortran interface to the GNU scientific library
-long_description \
-    A portable, object-based Fortran interface to the GNU scientific library, \
-    a collection of numerical routines for scientific computing.
-homepage            https://doku.lrz.de/display/PUBLIC/FGSL+-+A+Fortran+interface+to+the+GNU+Scientific+Library
-checksums           rmd160  580a519dc98ab1a774e5b50b347de1bfe0222171 \
-                    sha256  7b1b33d7165b756279c26ecd4b27edb19ee0c11165e13bf518cd7f91019d1b39 \
-                    size    2880105
+long_description    A portable, object-based Fortran interface to the GNU scientific library \
+                    (GSL), a collection of numerical routines for scientific computing. \
+                    Version 1.5.x is for use with GSL versions >= 2.6.
+
+homepage            https://doku.lrz.de/fgsl-a-fortran-interface-to-the-gnu-scientific-library-10746505.html \
+                    https://github.com/reinh-bader/fgsl/
+
+checksums           rmd160  fec0e747a13906fdf0a9abdc43a4204769ef4a5d \
+                    sha256  5013b4e000e556daac8b3c83192adfe8f36ffdc91d1d4baf0b1cb3100260e664 \
+                    size    2945012
 
 depends_build       port:pkgconfig
 depends_lib         port:gsl

--- a/math/fgsl/Portfile
+++ b/math/fgsl/Portfile
@@ -16,10 +16,10 @@ license             GPL-2
 description         Fortran interface to the GNU scientific library
 long_description    A portable, object-based Fortran interface to the GNU scientific library \
                     (GSL), a collection of numerical routines for scientific computing. \
-                    Version 1.5.x is for use with GSL versions >= 2.6.
+                    Version 1.5.x is for use with GSL versions >= 2.6. \
+                    Source: https://github.com/reinh-bader/fgsl
 
-homepage            https://doku.lrz.de/fgsl-a-fortran-interface-to-the-gnu-scientific-library-10746505.html \
-                    https://github.com/reinh-bader/fgsl/
+homepage            https://doku.lrz.de/fgsl-a-fortran-interface-to-the-gnu-scientific-library-10746505.html
 
 checksums           rmd160  fec0e747a13906fdf0a9abdc43a4204769ef4a5d \
                     sha256  5013b4e000e556daac8b3c83192adfe8f36ffdc91d1d4baf0b1cb3100260e664 \


### PR DESCRIPTION
#### Description

* Update FGSL 1.4.0 --> 1.5.0.
* Fix Github download.
* Fix livecheck.
* Add to description: Version 1.5.x is for use with GSL versions >= 2.6.
* Add direct link to upstream github repo.
* Add myself as co-maintainer.

Fiixes: https://trac.macports.org/ticket/68851

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `sudo port -v install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
