### PR TITLE
libretroshare: update to 2023.11.26

### DIFF
--- a/net/libretroshare/Portfile
+++ b/net/libretroshare/Portfile
@@ -6,8 +6,8 @@ PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 PortGroup               openssl 1.0
 
-github.setup            RetroShare libretroshare e22b48790d143b5718879d3d72d55e1a3c337304
-version                 2023.11.07
+github.setup            RetroShare libretroshare 78739f1eb504503b12f107109356624da49e75ef
+version                 2023.11.26
 revision                0
 categories              net devel security
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -17,9 +17,9 @@ long_description        {*}${description} RetroShare functionalities (file shari
                         are implemented under the hood by libretroshare which offer a documented C++ and JSON API. \
                         While RetroShare is an application on its own, libretroshare is meant to be used as part of other programs.
 homepage                https://retroshare.cc
-checksums               rmd160  f0ccfe041d2110a1db3f545d785dd8f9df210cc4 \
-                        sha256  1488dd29840e9246e0d53b22b39aa628d76e8daf70454745f4e7c109fade1213 \
-                        size    1928270
+checksums               rmd160  243ca1fe218b0991112acdd17767aef8fbb3a1d4 \
+                        sha256  75107d398b5b45a0a93e3913750163c0207d5d260c30de06b215638a04ccc43f \
+                        size    1929414
 github.tarball_from     archive
 
 # getline, strnlen

--- a/net/libretroshare/files/0001-Fix-CMakeLists-for-MacPorts.patch
+++ b/net/libretroshare/files/0001-Fix-CMakeLists-for-MacPorts.patch
@@ -1,20 +1,32 @@
 From ded16fbe8d5c146ed413c8682fc67a8b8e40a3ce Mon Sep 17 00:00:00 2001
 From: Sergey Fedorov <vital.had@gmail.com>
 Date: Tue, 31 Jan 2023 04:55:12 +0800
-Subject: [PATCH 2/2] Fix CMakeLists for MacPorts
-
----
- CMakeLists.txt | 19 +++----------------
- 1 file changed, 3 insertions(+), 16 deletions(-)
+Subject: [PATCH] Fix CMakeLists for MacPorts
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 7cb4f6dc..9198c575 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -405,24 +405,11 @@ if(RS_JSON_API)
- 	if(RS_ANDROID)
+@@ -438,37 +438,10 @@
+ 		## should be sent upstream.
+ 		## Restbed is therefore compiled by Android toolchain preparation script
  		target_link_libraries(${PROJECT_NAME} PRIVATE restbed)
+-	elseif(EXISTS "${RESTBED_DEVEL_DIR}/CMakeLists.txt")
+-		message( STATUS
+-		         "Restbed submodule found at ${RESTBED_DEVEL_DIR} using it" )
+-		add_subdirectory(
+-			${RESTBED_DEVEL_DIR}
+-			${CMAKE_BINARY_DIR}/restbed
+-			EXCLUDE_FROM_ALL )
+-		# EXCLUDE_FROM_ALL prevent executing install directives from included
+-		# dependencies see https://stackoverflow.com/a/64900982
+-
+-		target_include_directories(
+-			${PROJECT_NAME} PRIVATE "${RESTBED_DEVEL_DIR}/source/" )
+-		target_link_libraries(${PROJECT_NAME} PRIVATE restbed)
  	else()
+-		message( WARNING
+-		         "FetchContent restbed, will be installed if you run make install")
 -		FetchContent_Declare(
 -			restbed
 -			GIT_REPOSITORY "https://github.com/Corvusoft/restbed.git"
@@ -23,19 +35,15 @@ index 7cb4f6dc..9198c575 100644
 -			GIT_SHALLOW TRUE
 -			GIT_PROGRESS TRUE
 -			TIMEOUT 10
+-#			EXCLUDE_FROM_ALL # Available only in CMake >= 3.28
 -		)
 -		FetchContent_MakeAvailable(restbed)
 -
--		## TODO: Temporary work around target_include_directories PUBLIC should
--		## be added upstream
  		target_include_directories(
 -			${PROJECT_NAME} PRIVATE ${restbed_SOURCE_DIR}/source/ )
-+			${PROJECT_NAME} PUBLIC @PREFIX@/include/restbed/ )
- 
 -		target_link_libraries(${PROJECT_NAME} PRIVATE restbed-static)
--	endif(RS_ANDROID)
++			${PROJECT_NAME} PUBLIC @PREFIX@/include/restbed/ )
 +		target_link_libraries(${PROJECT_NAME} PUBLIC restbed)
-+	endif()
+ 	endif()
  
- 	target_compile_definitions(${PROJECT_NAME} PUBLIC RS_JSONAPI)
- endif(RS_JSON_API)
+ 


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x]  checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
