### PR TITLE
edid-decode: update to version 20231207

### DIFF
--- a/sysutils/edid-decode/Portfile
+++ b/sysutils/edid-decode/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                edid-decode
-version             20231127
+version             20231207
 categories          sysutils
 maintainers         @wwalexander openmaintainer
 license             MIT
@@ -14,7 +14,7 @@ set domain          linuxtv.org
 homepage            https://git.${domain}/${name}.git
 fetch.type          git
 git.url             git://${domain}/${name}.git
-git.branch          08b5ddb
+git.branch          1e99fe8
 
 patchfiles          cxxflags-fix.diff
 


### PR DESCRIPTION
#### Description
* update to version 20231207

> check for more dummy serial numbers
>
> Also check if the Display Product Serial Number is one of a known
set of dummy values.

###### Type(s)
- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 14.1.2 23B92 arm64
Xcode 15.0.1 15A507

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?