### PR TITLE
mochiweb: update to 3.2.1

### DIFF
--- a/erlang/mochiweb/Portfile
+++ b/erlang/mochiweb/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       github 1.0
 
 epoch           20111014
-github.setup    mochi mochiweb 3.2.0 v
+github.setup    mochi mochiweb 3.2.1 v
 categories      erlang www
 license         MIT
 maintainers     nomaintainer
@@ -19,9 +19,9 @@ depends_lib     port:erlang
 depends_build-append \
                 port:rebar3
 
-checksums       rmd160  2ad1591858cfa33d3d641119d92783cb81301d72 \
-                sha256  8725c8ea3b6d27f959f4905cf37e6e0c6ea1aff7e87fe758a948ec78ef705657 \
-                size    139060
+checksums       rmd160  cdfc2f9e9f4d14a7f1bbbc335e4d7631d7901aca \
+                sha256  747a342b5cba4210b37a51a1baf41eb5574b9dcd9d31025ae93b9f4141ad0b15 \
+                size    139114
 github.tarball_from archive
 
 use_configure   no


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
