### PR TITLE
libvmaf: fix build on macOS <10.12

### DIFF
--- a/multimedia/libvmaf/Portfile
+++ b/multimedia/libvmaf/Portfile
@@ -3,10 +3,15 @@
 PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               meson 1.0
+PortGroup               legacysupport 1.1
+PortGroup               compiler_blacklist_versions 1.0
+
+# strnlen
+legacysupport.newest_darwin_requires_legacy 10
 
 github.setup            Netflix vmaf 3.0.0 v
 name                    libvmaf
-revision                0
+revision                1
 categories              multimedia
 license                 BSD
 maintainers             {i0ntempest @i0ntempest} openmaintainer
@@ -26,10 +31,20 @@ configure.dir           ${configure.dir}/libvmaf
 depends_build-append    port:nasm \
                         port:vim
 
+# needed for stdatomic and uses newer assembly features
+compiler.blacklist-append \
+                        {*gcc-[3-4].*} {clang < 900}
+
 configure.args-append   --buildtype release \
                         -Denable_asm=true \
+                        -Denable_avx512=false \
                         -Dbuilt_in_models=true \
                         -Denable_tests=false
+
+# incorrect strsep detection on <10.7
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    configure.cflags-append -DHAVE_STRSEP
+}
 
 variant float description {Compile floating-point feature extractors into the library} {
     configure.args-append \
@@ -37,6 +52,8 @@ variant float description {Compile floating-point feature extractors into the li
 }
 
 variant avx512 description {Build AVX-512 asm files} {
+    configure.args-delete \
+                        -Denable_avx512=false
     configure.args-append \
                         -Denable_avx512=true
 }


### PR DESCRIPTION
* fix +avx512 variant

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
