### PR TITLE
yabai: clarify post-install notes

### DIFF
--- a/sysutils/yabai/Portfile
+++ b/sysutils/yabai/Portfile
@@ -45,7 +45,7 @@ if {${os.major} < 20} {
 } elseif {${os.major} == 20} {
     supported_archs x86_64
     patchfiles-append patch-makefile-macos11.diff
-    patchfiles-append  patch-workspace.m.diff
+    patchfiles-append patch-workspace.m.diff
 } else {
     patchfiles-append patch-makefile.diff
 }
@@ -58,11 +58,13 @@ notes "
     * ~/.config/${name}/yabairc
     and adjust it to your needs.
 
-    Some common post-install steps are to run:
+    If this is your first time installing yabai, you'll need to create a new
+    keychain to codesign the installed binary. See the official instructions:
+    https://github.com/koekeishiya/yabai/wiki/Installing-yabai-(from-HEAD)
+
+    Some common post-install or post-upgrade steps are to run:
+    * sudo codesign -fs 'yabai-cert' ${prefix}/bin/yabai
     * sudo yabai --load-sa
     * yabai --start-service
     See `man yabai` for more details.
-
-    You may also need to codesign the installed binary. See the official wiki:
-    https://github.com/koekeishiya/yabai/wiki/Installing-yabai-(from-HEAD)
 "


### PR DESCRIPTION
#### Description

Clarify which steps are on-first-install-only and which steps are generally run after each upgrade.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
N/A, just a notes change

###### Verification <!-- (delete not applicable items) -->
N/A, just a notes change

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
