### PR TITLE
google-cloud-sdk: update to 457.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             456.0.0
+version             457.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  e7410d9631d098793a74fc8d01305f4667702581 \
-                    sha256  e30ae8c974bdd0ee1dc7d00a5f474bf6a235f5dfd33c64f18e4265ead340bc74 \
-                    size    122169307
+    checksums       rmd160  85b0d23f11bb3e1fc9bead5cb3c102027578a198 \
+                    sha256  5e1d9cb87e5f800d03e49f54ba3942089e98ed57b984911b81bd6bc9939f9539 \
+                    size    122329437
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  dbfc77e5bb7cecb5fff72adf6e1469ee23b8fb3f \
-                    sha256  2961471b9d81092443456de15509f46fea685dfaf401f1b6c444eab63b45ccb7 \
-                    size    123456047
+    checksums       rmd160  ef7be5a98851edc8779c3922a47a36de7b733dbf \
+                    sha256  8f9f022a59473b5a2b830cb6e9e5026054dd519682acd2a43800a8544bb82572 \
+                    size    123615309
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  0b4097d471ab0c9c2da4db307fc62978a37c404c \
-                    sha256  80c31937d3a3dce98d730844ff028715a46cd9fd5d5d44096b16e85fa54e6df1 \
-                    size    120519828
+    checksums       rmd160  1de855170b2d41c52ddd7b14becad1549331144a \
+                    sha256  287d0976e64fc181aeeb7b800537357804749008223ceaa6689d2309b6a89d0e \
+                    size    120679088
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 457.0.0.

###### Tested on

macOS 14.2 23C64 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?