### PR TITLE
OpenBLAS: avoid double RPATH on macOS 13 as well

### DIFF
--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -50,6 +50,7 @@
 #   ensure Fortran code accepts "calls to external procedures with mismatches between the calls and the procedure definition"
 #   the use of this option is "strongly discouraged" as the code should be made to be "standard-conforming"
 #   see https://gcc.gnu.org/onlinedocs/gfortran/Fortran-Dialect-Options.html
+# compilers.add_gcc_rpath_support: enforce adding -rpath,${prefix}/lib/libgcc
 #
 # The compilers.gcc_default variable may be useful for setting a default compiler variant
 # even in ports that do not use this PortGroup's automatic creation of variants.
@@ -75,6 +76,9 @@ default compilers.clear_archflags no
 
 options compilers.allow_arguments_mismatch
 default compilers.allow_arguments_mismatch no
+
+options compilers.add_gcc_rpath_support
+default compilers.add_gcc_rpath_support yes
 
 # Set a default gcc version
 if {${os.major} < 10 && ${os.platform} eq "darwin" } {
@@ -802,6 +806,9 @@ pre-configure {
     compilers.action_enforce_c ${compilers.required_c}
     compilers.action_enforce_f ${compilers.required_f}
     compilers.action_enforce_some_f ${compilers.required_some_f}
+    if {${compilers.add_gcc_rpath_support}} {
+        compilers::add_gcc_rpath_support
+    }
 }
 
 namespace eval compilers {
@@ -849,8 +856,6 @@ proc compilers::add_gcc_rpath_support {} {
         }
     }
 }
-
-port::register_callback compilers::add_gcc_rpath_support
 
 proc compilers::fortran_legacy_support_proc {option action args} {
     if {$action ne  "set"} return

--- a/math/OpenBLAS/Portfile
+++ b/math/OpenBLAS/Portfile
@@ -33,7 +33,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums       rmd160  30577718a2f6880b2c9a799fa0dcf8830ef91c47 \
                     sha256  7be7acf6cc22c55a36980953942e1f6fecadf993bd6e02b793b70e15fbd25e9e \
                     size    24307835
-    revision        2
+    revision        3
 
     conflicts       OpenBLAS
 
@@ -56,7 +56,7 @@ if {[string first "-devel" $subport] > 0} {
     checksums       rmd160  eea6fe2c33762df4c47c7241808dabbdb085eed3 \
                     sha256  4c25cb30c4bb23eddca05d7d0a85997b8db6144f5464ba7f8c09ce91e2f35543 \
                     size    24073168
-    revision        4
+    revision        5
 
     conflicts       OpenBLAS-devel
 
@@ -200,12 +200,7 @@ configure.pre_args-replace  -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
                             -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
 cmake.install_rpath
-
-if {${os.platform} eq "darwin" && ${os.major} >= 23} {
-    pre-configure {
-        configure.ldflags-delete  -Wl,-rpath,${prefix}/lib/libgcc
-    }
-}
+compilers.add_gcc_rpath_support no
 
 post-destroot {
     # For compatibility, put header files in ${prefix}/include


### PR DESCRIPTION
#### Description

The new linker in Xcode 15 is buggy, causing build failures for many (but not all) ports that link to OpenBLAS. OpenBLAS detects this and includes `-Wl,-ld_classic` in the generated cmake, For compatibility reasons, buildbot uses Xcode 14, and OpenBLAS built on Xcode 14 is broken. on machines with Xcode 14. Here we have only one configuration which has two possible Xcode: MacOS 13. Prevent precompiled binaries on this system.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.1 22G313 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
