### PR TITLE
py-libxml2: add py312 subport

### DIFF
--- a/python/py-libxml2/Portfile
+++ b/python/py-libxml2/Portfile
@@ -27,11 +27,15 @@ distname            libxml2-${version}
 dist_subdir         libxml2
 use_xz yes
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
 
+    # Build in PEP517 mode fails with Python 3.11
     python.pep517   no
+
+    depends_build-append \
+                    port:py${python.version}-setuptools
 
     depends_lib-append  \
                     port:libxml2
@@ -50,9 +54,6 @@ if {${name} ne ${subport}} {
     post-patch {
         reinplace "s|@LIBXML_VERSION@|${version}|g;s|@prefix@|${prefix}|g" ${worksrcpath}/setup.py
     }
-
-    # Build in PEP517 mode fails with Python 3.11
-    python.pep517 no
 
     post-destroot {
       set docdir ${prefix}/share/doc/${subport}


### PR DESCRIPTION
###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.1.2 23B92 x86_64
Xcode 15.1 15C65

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?