### PR TITLE
feq-parse: update to 2023.12.06

### DIFF
--- a/fortran/feq-parse/Portfile
+++ b/fortran/feq-parse/Portfile
@@ -3,17 +3,18 @@
 PortSystem          1.0
 PortGroup           fortran 1.0
 
-github.setup        FluidNumerics feq-parse cb1f51874f85d197f1e49bd3bb53282b37c1520b
-version             2023.09.27
+github.setup        FluidNumerics feq-parse 91f35dd71821c7a1e7e72be1d5825a795afb9eda
+version             2023.12.06
 revision            0
 categories-append   math
 license             Apache-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         An equation parser class for modern Fortran
 long_description    {*}${description}
-checksums           rmd160  a47111acdbd61a5e804ab6d581a5e81a85fe3556 \
-                    sha256  39f2bdcfdfa6d2e71fdb6e00ededf8a0894ea9fbe55817d8abd17ce12e994bc5 \
-                    size    9821
+checksums           rmd160  1f7ddd4be76836a3675bff4c3948f4312293f9d1 \
+                    sha256  01adda8382b30f1c978173f13a53b3c2a79a56ee3da86dfee1d874a2b72d4941 \
+                    size    27661
+github.tarball_from archive
 
 post-destroot {
     set docdir ${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
