### PR TITLE
collectd: Disable -Werror

### DIFF
--- a/sysutils/collectd/Portfile
+++ b/sysutils/collectd/Portfile
@@ -31,19 +31,6 @@ checksums           rmd160  9f21d334bbf6a791d3553c16cc533532056cd87f \
 
 depends_build       port:pkgconfig
 
-# collectd uses -Werror in their CFLAGS, which turns warnings into errors.
-# Some of these are not fixable and thus need to be suppressed when clang
-# is used.
-if {[string match *clang* ${configure.compiler}]} {
-    # Do not error out on unused command-line arguments
-    configure.cflags-append -Qunused-arguments
-    # Do not error out on use of IN6_IS_ADDR_MULTICAST()
-    # that adds an extra pair of parentheses
-    configure.cflags-append -Wno-parentheses-equality
-    # Do not error out on depreciation warnings
-    configure.cflags-append -Wno-deprecated-declarations
-}
-
 livecheck.type  regex
 livecheck.regex ${name}-(\\d+(\\.\\d+)+)\\.tar
 
@@ -51,7 +38,8 @@ use_autoreconf yes
 autoreconf.args --install --verbose --force
 
 configure.args \
-    --disable-silent-rules
+    --disable-silent-rules \
+    --disable-werror
 
 post-destroot {
     fs-traverse f ${destroot}${prefix}/lib/perl5 {


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/68896

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2 23C64 arm64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
