### PR TITLE
ngtcp2, nghttp3: update to 1.1.0

### DIFF
--- a/net/nghttp3/Portfile
+++ b/net/nghttp3/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            ngtcp2 nghttp3 1.0.0 v
+github.setup            ngtcp2 nghttp3 1.1.0 v
 revision                0
 categories              net
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -11,9 +11,9 @@ license                 MIT
 description             nghttp3 is an implementation of RFC 9114 HTTP/3 mapping over QUIC and RFC 9204 QPACK in C
 long_description        {*}${description}
 homepage                https://nghttp2.org/nghttp3
-checksums               rmd160  114399796fa9f02ad1a4288d31b76d804f1e33bd \
-                        sha256  838def499e368b24d8a4656ad9a1f38bb7ca8b2857a44c5de1c006420cc0bbee \
-                        size    190422
+checksums               rmd160  0f9e648b06786d439c34c7a7c4e55b632174ce09 \
+                        sha256  b3ffb23a90442a0eafe8bfbefbc8b4ffb5179d68a7c0b8a416a34cf04b28d7c5 \
+                        size    191457
 github.tarball_from     archive
 
 depends_lib-append      port:cunit

--- a/net/ngtcp2/Portfile
+++ b/net/ngtcp2/Portfile
@@ -5,7 +5,7 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 PortGroup               openssl 1.0
 
-github.setup            ngtcp2 ngtcp2 1.0.1 v
+github.setup            ngtcp2 ngtcp2 1.1.0 v
 revision                0
 categories              net devel
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -13,9 +13,9 @@ license                 MIT
 description             ngtcp2 project is an effort to implement RFC9000 QUIC protocol
 long_description        {*}${description}
 homepage                https://nghttp2.org/ngtcp2
-checksums               rmd160  c98fa8a4ecd5d1b4db24df83fc8204ee78d3238f \
-                        sha256  9db25678ac5288faf1d4e39b4e28a68b73b49068c5444b542a96a06362f1b778 \
-                        size    596660
+checksums               rmd160  b80f0a17ae394a589e1dba7fa2aa84714f20c54f \
+                        sha256  987d784643edea4f2859c405f7dfbc53871a9f7ae5fcddf5fb12ec5dfce1ef22 \
+                        size    599242
 github.tarball_from     archive
 
 depends_lib-append      path:lib/pkgconfig/gnutls.pc:gnutls \
@@ -35,6 +35,9 @@ configure.args-append   -DENABLE_EXAMPLES:BOOL=OFF \
                         -DENABLE_OPENSSL:BOOL=ON \
                         -DENABLE_SHARED_LIB:BOOL=ON \
                         -DENABLE_WERROR:BOOL=OFF
+
+# Until this is fixed: https://github.com/ngtcp2/ngtcp2/issues/1034
+configure.args-append   -DHAVE_SSL_IS_QUIC:BOOL=OFF
 
 if {${os.platform} eq "darwin" && ${os.major} < 10} {
     # Until jemalloc fixed for 10.5 and below: https://trac.macports.org/ticket/65945


### PR DESCRIPTION
#### Description

Disable QUIC with OpenSSL for now, since it is broken: https://github.com/ngtcp2/ngtcp2/issues/1034

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2
Xcode 15.1

macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
