### PR TITLE
symfony-cli: update to 5.7.6

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.7.5
+version             5.7.6
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  321b1ff77980dbae5aa4dca2ebebee5fe23b710d \
-                        sha256  5b4bf3625357776c636c50b5cf2945c2e4251711426c4293790a1354f9c00eff \
-                        size    258243
+    checksums           rmd160  e4f63698393e817dd2198ac183a83b0af77f8c56 \
+                        sha256  351971c0a9dce67c27bf5469a1662a54d4e2a533197c69e7599dbe964c0101e5 \
+                        size    259468
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  02ef5517db82746ebcc0d8e2b52dc982b55a43cf \
-                        sha256  86f40aa06a612ed1057317a8bf1823fe63a943515336b8808ce9aa77b742357d \
-                        size    11144021
+    checksums           rmd160  7cae4bd72749ca965d96cbfeef71dad27c793bf0 \
+                        sha256  c228c3b19290a919afee7540aa32706819a5c37914d0278eb55b08219fd93d53 \
+                        size    11150160
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.7.6

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
