### PR TITLE
libretroshare: fix installation broken with recent update

### DIFF
--- a/net/libretroshare/Portfile
+++ b/net/libretroshare/Portfile
@@ -8,7 +8,7 @@ PortGroup               openssl 1.0
 
 github.setup            RetroShare libretroshare 78739f1eb504503b12f107109356624da49e75ef
 version                 2023.11.26
-revision                0
+revision                1
 categories              net devel security
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
 license                 {AGPL-3 Apache-2 GPL-3 LGPL-3 MIT}
@@ -53,9 +53,10 @@ post-patch {
 compiler.cxx_standard   2017
 
 configure.args-append   -DPython_EXECUTABLE=${prefix}/bin/python${py_ver} \
-                        -DRS_MINIUPNPC=ON \
-                        -DRS_JSON_API=ON \
                         -DRS_EXPORT_JNI_ONLOAD=OFF \
+                        -DRS_JSON_API=ON \
+                        -DRS_LIBRETROSHARE_STANDALONE_INSTALL=ON \
+                        -DRS_MINIUPNPC=ON \
                         -DRS_SQLCIPHER=ON \
                         -DRS_WARN_DEPRECATED=OFF
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68913

#### Description

My fault, upstream recently added an option to actually install the thing, and I missed that. In result it built, but nothing installed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
