### PR TITLE
madness: update to 2023.12.03, move gperftools support into a variant

### DIFF
--- a/science/madness/Portfile
+++ b/science/madness/Portfile
@@ -9,9 +9,9 @@ PortGroup           legacysupport 1.1
 
 boost.version       1.81
 
-github.setup        m-a-d-n-e-s-s madness 69ace5826625506fc04f5021d806942b21959d36
-version             2023.11.02
-revision            1
+github.setup        m-a-d-n-e-s-s madness d108709161b5ee55ba238065e5e7ba62f888bcb8
+version             2023.12.03
+revision            0
 categories          science math
 license             GPL-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -20,9 +20,9 @@ long_description    MADNESS provides a high-level environment for the solution \
                     of integral and differential equations in many dimensions \
                     using adaptive, fast methods with guaranteed precision \
                     based on multi-resolution analysis and novel separated representations.
-checksums           rmd160  d7d7933f42608c4af5bafb9f08a6c3a0de9b8506 \
-                    sha256  db8caaad87a5de0b93e150770c9e9f5708d1625feefb0969841e853d483d6749 \
-                    size    36734000
+checksums           rmd160  88ca6a5dffdf8801e3c6cc26c28930836632ee61 \
+                    sha256  aca84aaa43affa39f7b3a204ac0a920890905dd20426194ec122251fbc691215 \
+                    size    36734418
 github.tarball_from archive
 
 set py_ver          3.11
@@ -45,8 +45,6 @@ if {(${os.platform} eq "darwin" && ${os.major} < 20) || ${os.platform} ne "darwi
     configure.pre_args-append \
                     -DLAPACK_LIBRARIES=OpenBLAS
 }
-
-depends_lib-append  port:gperftools
 
 patch.pre_args      -p1
 # Temporarily avoid building chemistry part:
@@ -81,7 +79,7 @@ configure.args-append \
                     -DENABLE_BOOST=ON \
                     -DENABLE_ELEMENTAL=OFF \
                     -DENABLE_GENTENSOR=OFF \
-                    -DENABLE_GPERFTOOLS=ON \
+                    -DENABLE_GPERFTOOLS=OFF \
                     -DENABLE_LIBUNWIND=OFF \
                     -DENABLE_LIBXC=OFF \
                     -DENABLE_MKL=OFF \
@@ -123,6 +121,14 @@ if {![option configure.ccache]} {
     configure.env-append   CCACHE_DIR=${workpath}/.ccache
     build.env-append       CCACHE_DIR=${workpath}/.ccache
     destroot.env-append    CCACHE_DIR=${workpath}/.ccache
+}
+
+# Make this a variant due to: https://trac.macports.org/ticket/68775
+variant gperftools description "Build with gperftools support" {
+    depends_lib-append \
+                    port:gperftools
+    configure.args-replace \
+                    -DENABLE_GPERFTOOLS=OFF -DENABLE_GPERFTOOLS=ON
 }
 
 variant tests description "Build and run tests" {


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
