### PR TITLE
openexr_viewers: fix build; openexr2: backport fix for missing libdispatch from 3.x

### DIFF
--- a/graphics/openexr2/Portfile
+++ b/graphics/openexr2/Portfile
@@ -29,6 +29,9 @@ checksums                       rmd160  5b623bebf0a456db656f8e9fc91d6109386fa61b
                                 sha256  38443be87db1b0eaa53747104246943120c3812cc54cfbbec1846c8917e74884 \
                                 size    27540352
 
+# backport of https://github.com/AcademySoftwareFoundation/openexr/commit/155f1bf174e2b87a4de721e936f8b6ab141079fb
+patchfiles-append               patch-macOS-use-libdispatch-only-where-available.diff
+
 subport ${name} {
     cmake.source_dir            ${worksrcpath}/OpenEXR
     cmake.install_prefix        ${prefix}/libexec/${name}

--- a/graphics/openexr2/Portfile
+++ b/graphics/openexr2/Portfile
@@ -44,6 +44,8 @@ subport ilmbase {
 
 subport openexr_viewers {
     cmake.source_dir            ${worksrcpath}/OpenEXR_Viewers
+
+    cmake.module_path-append    ${prefix}/libexec/openexr2/lib/cmake
 }
 
 compiler.cxx_standard           2014

--- a/graphics/openexr2/files/patch-macOS-use-libdispatch-only-where-available.diff
+++ b/graphics/openexr2/files/patch-macOS-use-libdispatch-only-where-available.diff
@@ -1,0 +1,83 @@
+From d13d644f0a062e6992db5f30a2551703a6a7badf Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Sat, 16 Dec 2023 11:39:36 +0800
+Subject: [PATCH] macOS: use libdispatch only where available
+
+---
+ IlmBase/IlmThread/IlmThreadSemaphore.h              | 8 ++++++--
+ IlmBase/IlmThread/IlmThreadSemaphoreOSX.cpp         | 6 ++++++
+ IlmBase/IlmThread/IlmThreadSemaphorePosixCompat.cpp | 7 ++++++-
+ 3 files changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/IlmBase/IlmThread/IlmThreadSemaphore.h b/IlmBase/IlmThread/IlmThreadSemaphore.h
+index 0810af22..c89e5c9a 100644
+--- IlmBase/IlmThread/IlmThreadSemaphore.h
++++ IlmBase/IlmThread/IlmThreadSemaphore.h
+@@ -46,6 +46,10 @@
+ #include "IlmThreadExport.h"
+ #include "IlmThreadNamespace.h"
+ 
++#if defined(__APPLE__)
++#   include <AvailabilityMacros.h>
++#endif
++
+ #if defined _WIN32 || defined _WIN64
+ #   ifdef NOMINMAX
+ #      undef NOMINMAX
+@@ -56,7 +60,7 @@
+ 
+ #ifdef HAVE_POSIX_SEMAPHORES
+ #   include <semaphore.h>
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
+ #   include <dispatch/dispatch.h>
+ #else
+ #   ifdef ILMBASE_FORCE_CXX03
+@@ -94,7 +98,7 @@ class ILMTHREAD_EXPORT Semaphore
+ 
+ 	mutable sem_t _semaphore;
+ 
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
+ 	mutable dispatch_semaphore_t _semaphore;
+ 
+ #else
+diff --git a/IlmBase/IlmThread/IlmThreadSemaphoreOSX.cpp b/IlmBase/IlmThread/IlmThreadSemaphoreOSX.cpp
+index 3ad88f28..305d0727 100644
+--- IlmBase/IlmThread/IlmThreadSemaphoreOSX.cpp
++++ IlmBase/IlmThread/IlmThreadSemaphoreOSX.cpp
+@@ -41,6 +41,10 @@
+ 
+ #if defined(__APPLE__)
+ 
++#include <AvailabilityMacros.h>
++
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
++
+ #include "IlmThreadSemaphore.h"
+ #include "Iex.h"
+ 
+@@ -96,3 +100,5 @@ Semaphore::value () const
+ ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
+ 
+ #endif
++
++#endif
+diff --git a/IlmBase/IlmThread/IlmThreadSemaphorePosixCompat.cpp b/IlmBase/IlmThread/IlmThreadSemaphorePosixCompat.cpp
+index f46ba618..bb55e261 100644
+--- IlmBase/IlmThread/IlmThreadSemaphorePosixCompat.cpp
++++ IlmBase/IlmThread/IlmThreadSemaphorePosixCompat.cpp
+@@ -42,7 +42,12 @@
+ #include "IlmBaseConfig.h"
+ #include "IlmThreadSemaphore.h"
+ 
+-#if !defined (HAVE_POSIX_SEMAPHORES) && !defined (__APPLE__)
++#if defined(__APPLE__)
++#    include <AvailabilityMacros.h>
++#endif
++
++#if !defined (HAVE_POSIX_SEMAPHORES) && \
++    (!defined(__APPLE__) || (defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || defined(__ppc__))))
+ #if (!defined (_WIN32) && !defined (_WIN64)) || defined (__MINGW64_VERSION_MAJOR)
+ 
+ #include "Iex.h"


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/67655

#### Description

UPD. Turned out, `openexr_viewers` was broken, at least on newer macOS. Fixed that too.

Fix build on 10.5 and powerpc.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
