### PR TITLE
icu-devel: update to 74.2

### DIFF
--- a/devel/icu-devel/Portfile
+++ b/devel/icu-devel/Portfile
@@ -23,7 +23,7 @@ set my_name         icu
 # Please confirm that all ports and its subport can be build. To find the list, use:
 #  port file all | sort -u | xargs grep -El ':icu( |$)' | rev | cut -d / -f 2 | rev | xargs port info --name --subport | cut -d : -f 2 | tr ',' ' ' | grep -v '\-\-' | tr ' ' '\n' | sort -u
 
-version             74.1
+version             74.2
 revision            0
 epoch               1
 subport             ${name}-docs         { revision 0 }
@@ -66,10 +66,19 @@ if {${subport} eq ${name} || ${subport} eq "${name}-lx"} {
     extract.suffix      .tgz
     worksrcdir          icu/source
 
+    # tar.gz from 74.2 is broken and contains symlink into ../LICENSE instead of LICENSE
+    # create a file which cintains link to license
+    # See: https://unicode-org.atlassian.net/browse/ICU-22601
+    pre-extract {
+        set license_file [open ${workpath}/LICENSE w]
+        puts ${license_file} "https://raw.githubusercontent.com/unicode-org/icu/main/LICENSE"
+        close ${license_file}
+    }
+
     # please also update the icu-docs checksums at the bottom of the Portfile
-    checksums           rmd160  81a6bf20b28e00c869425547a8f1dd2d11cac566 \
-                        sha256  86ce8e60681972e60e4dcb2490c697463fcec60dd400a5f9bffba26d0b52b8d0 \
-                        size    26625850
+    checksums           rmd160  df2b06b3556ff21176858c27fc46f2d1e2bbe0ec \
+                        sha256  5e4fb11d6a3e6b85afb55de8da8a71538f1d8fd64fce893986b37d60e5bb0091 \
+                        size    26618071
 
     # use full pathnames to libraries in tools
     patchfiles-append   patch-i18n-formatted_string_builder.h.diff
@@ -184,9 +193,9 @@ if {${subport} eq "${name}-docs"} {
 
     use_zip                 yes
     distname                icu4c-[string map {. _} [string map {.rc rc} ${version}]]-docs
-    checksums               rmd160  b1640eec3f6d9bd55698d57a075bbddfe3e72611 \
-                            sha256  9df27f55f956c7594d5bff8de42e05e3a4137ad023812e5a409a7d7634b607e2 \
-                            size    8532358
+    checksums               rmd160  1baf0c68241757b24f73ce6784185dc1887efd60 \
+                            sha256  5b8acafb087fce1c607d9719161ab305ce1350858cb3cf40e7cb1d2e457aeb84 \
+                            size    8532437
 
     extract.dir             ${worksrcpath}/doc/html
     use_configure           no


### PR DESCRIPTION
#### Description

This is minor upgrade of ICU for devel subport.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->