### PR TITLE
openjkd17-openj9: update to 17.0.9

### DIFF
--- a/java/openjdk17-openj9/Portfile
+++ b/java/openjdk17-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      17.0.8.1
+version      17.0.9
 revision     0
 
-set build    1
-set openj9_version 0.40.0
+set build    9
+set openj9_version 0.41.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 17
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru17-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  80fe1c6c98339a2f63582a241e1f83450dd28dd3 \
-                 sha256  5e5ef3e21c7d0e6a4e4a9f4c848bf6fb91c9f5e7ee85fa356ec886d6f72ecfef \
-                 size    210318265
+    checksums    rmd160  bb7f934cfcc3b2973ee4fa39bb78d7c36a5d827a \
+                 sha256  585f48be83935a44ef980249aaab024119d4ea6ef0937a2cd2d97d0c77cda1c2 \
+                 size    211702338
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  a153d4d3bc8c5882174f4a0cdb42ada1d6c5e568 \
-                 sha256  69ec0904b3ea0c79d5c82f594a7efc5acf5ec9c296989526a9f195adc95adc70 \
-                 size    203483278
+    checksums    rmd160  0eaead70fc3ef93f27a2e42a69b508eaad7aea39 \
+                 sha256  5fed15250cb613a4024f2b2e75ccb54e6526ffa5ff78d955a6e2a11ae330f003 \
+                 size    204941296
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 17.0.9.

###### Tested on

macOS 14.2 23C64 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?