### PR TITLE
openjdk11-openj9: update to 11.0.21

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      11.0.20.1
+version      11.0.21
 revision     0
 
-set build    1
-set openj9_version 0.40.0
+set build    9
+set openj9_version 0.41.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 11
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  b23f739dec3b0e361d2ad6af7b845609cf95243e \
-                 sha256  253042ac9f6146006a5deb3742e8d14ad41f44f092ed86248e02dc11a7e2fb2f \
-                 size    205331513
+    checksums    rmd160  ce894f346f5a531da39a78511684ebf5f5d4837e \
+                 sha256  195800cd1783626659c5b70355ecf19072f849eeabcf1f652d45d76e22ec31af \
+                 size    206685231
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  cffb86a9216ae8dca2880bfe15507d166687321e \
-                 sha256  249706cfaaa82f07ca57c1e23eedfb38956e2a006bee81dd4d06268d798e6866 \
-                 size    199485594
+    checksums    rmd160  6fa276d4b7adc68778055c5c1e6b92249c99342b \
+                 sha256  108e8ac9e738ca0c19ca3c5ba3e89ee807e4c4d78ffd5692ce04abe1bb5a07c4 \
+                 size    200954634
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.21.

###### Tested on

macOS 14.2 23C64 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?