### PR TITLE
py{27,35}-cython: update to 0.29.36

### DIFF
--- a/python/py-cython/Portfile
+++ b/python/py-cython/Portfile
@@ -15,7 +15,6 @@ license             Apache-2
 conflicts           ${name}-devel
 
 python.versions     27 35 36 37 38 39 310 311 312
-python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -42,26 +41,8 @@ if {${name} ne ${subport}} {
         conflicts
     }
 
-    if {${python.version} eq 27} {
-        version             0.29.13
-        revision            0
-        checksums           rmd160  40caf2eb2ebcc6cec9ca782fb6dad70fda0f9dfa \
-                            sha256  c29d069a4a30f472482343c866f7486731ad638ef9af92bfe5fca9c7323d638e \
-                            size    2051189
-    } elseif {${python.version} eq 35} {
-        version             0.29.17
-        revision            0
-        checksums           rmd160  130804bc375318396f2bd47073bd1d514acbdcdb \
-                            sha256  6361588cb1d82875bcfbad83d7dd66c442099759f895cf547995f00601f9caf2 \
-                            size    2060265
-    } else {
-        # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
-        compiler.blacklist-append *gcc-3.* *gcc-4.*
-    }
-
-    if {${python.version} < 37} {
-        python.pep517       no
-    }
+    # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
+    compiler.blacklist-append *gcc-3.* *gcc-4.*
 
     depends_run         port:cython_select
     test.run            no


### PR DESCRIPTION
The newer version appears to build fine, and there's no indication upstream that support has been dropped.
