### PR TITLE
py-pandas: use py-cython-compat

### DIFF
--- a/python/py-pandas/Portfile
+++ b/python/py-pandas/Portfile
@@ -17,7 +17,7 @@ maintainers         {stromnov @stromnov} openmaintainer
 
 description         Powerful data structures for data analysis and statistics
 
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://pandas.pydata.org
 
@@ -67,8 +67,12 @@ if {${name} ne ${subport}} {
         }
     }
 
+    # Not yet compatible with Cython 3.
+    set compat_path [string replace ${python.pkgd} 0 [string length ${python.prefix}]-1 ${prefix}/lib/py${python.version}-cython-compat]
+    build.env-append    PYTHONPATH=${compat_path}
+
     depends_build-append \
-                        port:py${python.version}-cython
+                        port:py${python.version}-cython-compat
 
     depends_lib-append  port:py${python.version}-dateutil \
                         port:py${python.version}-tz \


### PR DESCRIPTION
This helps clear the way for py-cython to be updated to 3.x.

See: https://trac.macports.org/ticket/68929
