### PR TITLE
qt6-qtbase: Patch for building on MacOS 10.14, Xcode 11.3

### DIFF
--- a/aqua/qt6/files/patch-qtbase-macos_10.14_sdk.diff
+++ b/aqua/qt6/files/patch-qtbase-macos_10.14_sdk.diff
@@ -17,7 +17,7 @@ Upstream-Status: Inappropriate [violates DRY]
                  if (charactersWithModifiers.length > 0)
 --- src/gui/rhi/qrhimetal.mm.orig
 +++ src/gui/rhi/qrhimetal.mm
-@@ -382,15 +382,15 @@
+@@ -369,15 +369,15 @@
      driverInfoStruct.deviceType = QRhiDriverInfo::IntegratedDevice;
  #else
      if (@available(macOS 10.15, *)) {
@@ -37,3 +37,61 @@ Upstream-Status: Inappropriate [violates DRY]
              driverInfoStruct.deviceType = QRhiDriverInfo::ExternalDevice;
              break;
          default:
+@@ -403,7 +403,7 @@
+     caps.maxTextureSize = 16384;
+     caps.baseVertexAndInstance = true;
+     if (@available(macOS 10.15, *))
+-        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamilyApple7];
++        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamily(1007)]; // MTLGPUFamilyApple7
+     caps.maxThreadGroupSize = 1024;
+ #elif defined(Q_OS_TVOS)
+     if ([d->dev supportsFeatureSet: MTLFeatureSet(30003)]) // MTLFeatureSet_tvOS_GPUFamily2_v1
+@@ -2543,6 +2543,26 @@
+         return srgb ? MTLPixelFormatASTC_12x10_sRGB : MTLPixelFormatASTC_12x10_LDR;
+     case QRhiTexture::ASTC_12x12:
+         return srgb ? MTLPixelFormatASTC_12x12_sRGB : MTLPixelFormatASTC_12x12_LDR;
++#elif MAC_OS_X_VERSION_MAX_ALLOWED < 110000
++    case QRhiTexture::ETC2_RGB8:
++    case QRhiTexture::ETC2_RGB8A1:
++    case QRhiTexture::ETC2_RGBA8:
++    case QRhiTexture::ASTC_4x4:
++    case QRhiTexture::ASTC_5x4:
++    case QRhiTexture::ASTC_5x5:
++    case QRhiTexture::ASTC_6x5:
++    case QRhiTexture::ASTC_6x6:
++    case QRhiTexture::ASTC_8x5:
++    case QRhiTexture::ASTC_8x6:
++    case QRhiTexture::ASTC_8x8:
++    case QRhiTexture::ASTC_10x5:
++    case QRhiTexture::ASTC_10x6:
++    case QRhiTexture::ASTC_10x8:
++    case QRhiTexture::ASTC_10x10:
++    case QRhiTexture::ASTC_12x10:
++    case QRhiTexture::ASTC_12x12:
++        qWarning("QRhiMetal: ETC2 compression not supported on this platform");
++        return MTLPixelFormatInvalid;
+ #else
+     case QRhiTexture::ETC2_RGB8:
+         if (d->caps.isAppleGPU) {
+@@ -2727,6 +2747,7 @@
+     switch (m_type) {
+     case DepthStencil:
+ #ifdef Q_OS_MACOS
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         if (rhiD->caps.isAppleGPU) {
+             if (@available(macOS 11.0, *)) {
+                 desc.storageMode = MTLStorageModeMemoryless;
+@@ -2735,10 +2756,13 @@
+                 Q_UNREACHABLE();
+             }
+         } else {
++#endif
+             desc.storageMode = MTLStorageModePrivate;
+             d->format = rhiD->d->dev.depth24Stencil8PixelFormatSupported
+                     ? MTLPixelFormatDepth24Unorm_Stencil8 : MTLPixelFormatDepth32Float_Stencil8;
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
+         }
++#endif
+ #else
+         desc.storageMode = MTLStorageModeMemoryless;
+         d->format = MTLPixelFormatDepth32Float_Stencil8;


### PR DESCRIPTION
#### Description

This PR is the result of rebasing #19407 and keeping only the qt6-qtbase patch, in the hope that it may be easier to accept.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
