### PR TITLE
netcdf-fortran: avoid duplicate LC_RPATH

### DIFF
--- a/science/netcdf-fortran/Portfile
+++ b/science/netcdf-fortran/Portfile
@@ -21,8 +21,10 @@ PortGroup                   github 1.0
 mpi.enforce_variant         netcdf
 
 github.setup                Unidata netcdf-fortran 4.6.1 v
-revision                    2
-maintainers                 {takeshi @tenomoto} openmaintainer
+revision                    3
+maintainers                 {takeshi @tenomoto} \
+                            {@Dave-Allured noaa.gov:dave.allured} \
+                            openmaintainer
 categories                  science
 license                     Permissive
 
@@ -45,11 +47,8 @@ patchfiles          patch-nf03_test4-Makefile.in.diff \
                     patch-nf-config.diff
 
 compilers.choose    f77 f90 fc
+compilers.add_gcc_rpath_support no
 mpi.setup           require_fortran
-
-# see https://trac.macports.org/ticket/60561
-compilers.allow_arguments_mismatch \
-                    yes
 
 depends_lib         port:netcdf
 


### PR DESCRIPTION
#### Description

* Avoid duplicate LC_RPATH in libnetcdf-fortran.dylib, coming from compiler PG.
* Remove allow_arguments_mismatch.  Seems to be fixed upstream.
* Add myself as co-maintainer.

This PR fixes builds for dependent ports on Ventura and Sonoma, with Xcode 15.  The Xcode 15 linker has a new rule against duplicate LC_RPATH's.  Previous successful dependant builds are fine, so no dependant rev bumps are needed.

LC_RPATH fix was copied from recent OpenBLAS fix for the same thing:
https://github.com/macports/macports-ports/pull/21765

###### Type(s)

- [x] bugfix

###### Tested on

macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `port -v install`?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
