### PR TITLE
papilo: update to 2.1.3; add support sicp and soplex

### DIFF
--- a/math/papilo/Portfile
+++ b/math/papilo/Portfile
@@ -7,9 +7,9 @@ PortGroup               github 1.0
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               compilers 1.0
 
-# NOTE: PaPILO can be used as a header-based library, please bump all dependent ports
-github.setup            scipopt papilo 2.1.3 v
-revision                1
+# NOTE: PaPILO is a header-based library, please bump all dependent ports on update
+github.setup            scipopt papilo 2.1.4 v
+revision                0
 categories              math
 license                 {LGPL-3 GPL-3}
 
@@ -18,9 +18,9 @@ maintainers             {@catap korins.ky:kirill} openmaintainer
 description             Parallel Presolve for Integer and Linear Optimization
 long_description        {*}${description}
 
-checksums               rmd160  56cde21b5f67a8013df4dafdf29038e3416d00ef \
-                        sha256  7c391d74225588707bd810ed238f26d39724d40d7abbd4eeb0b79994e3ff956d \
-                        size    1085222
+checksums               rmd160  a59a3332c24dcc343a07826e8247fc4019f0c653 \
+                        sha256  ac6e4fb2ca491c402cd3368ca5dca1639ea1fdecde71c1f75894915ed9621470 \
+                        size    1086233
 
 compilers.setup         require_fortran
 compiler.cxx_standard   2014
@@ -31,14 +31,28 @@ depends_lib-append      path:lib/libopenblas.dylib:OpenBLAS \
                         port:gmp \
                         port:onetbb
 
-# PAPILO might be frontend for SCIP and/or SOPLEX
-# anyway, SCIP is also required PAPILO,
-# to break the dependency loop and make build clean
-# disable SCIP, SOPLEX and HIGHS at PAPILO
-# See: https://github.com/scipopt/papilo/issues/21
-configure.args-append   -DSCIP=OFF \
+configure.args-append   -DBUILD_SHARED_LIBS=ON
+
+subport libpapilo {
+    # PaPILO as a library doesn't need any solver nor binaries
+    configure.args-append \
+                        -DSCIP=OFF \
                         -DSOPLEX=OFF \
-                        -DHIGHS=OFF
+                        -DHIGHS=OFF \
+                        -DPAPILO_NO_BINARIES=ON
+}
+
+if {${name} eq ${subport}} {
+    # and main port installs binaries, which is linked against soplex and scipt
+    depends_lib-append  port:scip \
+                        port:soplex
+
+    # but it shouldn't install libraries and headers
+    post-destroot {
+        system "rm -rf ${destroot}${prefix}/lib"
+        system "rm -rf ${destroot}${prefix}/include"
+    }
+}
 
 # PAPILO may be linked against libquadmath, prevent that by using GMP.
 configure.args-append   -DGMP=ON \

--- a/math/scip/Portfile
+++ b/math/scip/Portfile
@@ -7,7 +7,7 @@ PortGroup           compilers 1.0
 
 name                scip
 version             8.0.4
-revision            2
+revision            3
 categories          math
 license             Apache-2
 
@@ -33,7 +33,7 @@ compiler.cxx_standard 2014
 depends_lib-append  port:gmp \
                     port:ipopt \
                     port:onetbb \
-                    port:papilo \
+                    port:libpapilo \
                     port:readline \
                     port:soplex
 


### PR DESCRIPTION
#### Description


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->