### PR TITLE
tesseract: set cxx_standard 2017

### DIFF
--- a/textproc/tesseract/Portfile
+++ b/textproc/tesseract/Portfile
@@ -64,10 +64,7 @@ subport ${name}-training {
 }
 
 if {${subport} in [list tesseract tesseract-training]} {
-    # error: use of undeclared identifier '__cpuid_count'
-    compiler.blacklist-append macports-clang-3.3 {clang < 503}
-    # https://trac.macports.org/ticket/66979
-    compiler.cxx_standard   2011
+    compiler.cxx_standard   2017
     
     use_autoreconf          yes
     autoreconf.cmd          ./autogen.sh


### PR DESCRIPTION
#### Description

Tesseract now requires “a compiler with good C++17 support”.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
