### PR TITLE
py-matplotlib: add py312 subport

### DIFF
--- a/python/py-matplotlib/Portfile
+++ b/python/py-matplotlib/Portfile
@@ -31,7 +31,7 @@ checksums           rmd160  73ef7c18b4c71e9a0fce1171223abfec6f3f8b83 \
 
 use_parallel_build  no
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 python.pep517       no
 
 if {${name} ne ${subport}} {


### PR DESCRIPTION
#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Variants:
* Variant `pyside` is broken because `py-shiboken` (a dependency of `py-pyside`) cannot be compiled for Python 3.12 because it uses removed APIs (it has not been updated in ten years)
* Variant `qt5` is broken until PR #21468 is merged (it is ready for review, even though it does not pass CI)

Neither variant is enabled by default.