### PR TITLE
beets-devel: update to 20231217; beets-summarize: update to 20231219

### DIFF
--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -39,13 +39,13 @@ if {$subport eq $name} {
 subport ${name}-devel {
     conflicts       $name
 
-    github.setup    beetbox beets 708a04d4a88eb955f261a21f0b1146c9e2ae0a55
-    version         20230823
+    github.setup    beetbox beets bcf180d14dd14604e1d82414fac28d41c275e1c9
+    version         20231217
     revision        0
 
-    checksums       rmd160  4f1b58c3fe04b994e279e1dacfc86ef5711ad6df \
-                    sha256  2769b782cd483468b40811b8522fdd72eb98561cf9864531ef087c3e93601e75 \
-                    size    2235693
+    checksums       rmd160  a28f33f2da8521e7f2c854019ce1deeed3e3a990 \
+                    sha256  6d38be22f6be03edf8fd9feb97d77b0dab78dd179f1af762bb669dafac7cf77a \
+                    size    2239737
 
     depends_build-append \
                     port:py${python.version}-sphinx

--- a/audio/beets/Portfile
+++ b/audio/beets/Portfile
@@ -530,8 +530,8 @@ subport ${name}-originquery {
 }
 
 subport ${name}-summarize {
-    github.setup    steven-murray beet-summarize 10870ac3a978b14a5dd27211eac4a406d00f97bf
-    version         20231101
+    github.setup    steven-murray beet-summarize 0d7890097fecf0be4202c972cee8ce9e0b1b8dfb
+    version         20231219
     revision        0
 
     license         LGPL-3
@@ -540,11 +540,9 @@ subport ${name}-summarize {
     long_description \
                     {*}${description}
 
-    checksums       rmd160  eaaff5f88478f11edb49e9f88574b00ffecc15a2 \
-                    sha256  6c548e0c9daacc039c98687bc5bb5f8f96c512f4c4255a87074699735b501379 \
-                    size    13320
-
-    python.pep517   yes
+    checksums       rmd160  e1d28adcf278b5754ebec6b06e31710697926365 \
+                    sha256  35a5199821d7708c5bba325731a63dbd5223ab8922881659814298de643c838b \
+                    size    13330
 
     depends_build-append \
                     port:py${python.version}-setuptools_scm


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->