### PR TITLE
py-scapy*: add py312; py-scapy-devel: update to 20231209

### DIFF
--- a/python/py-pysap/Portfile
+++ b/python/py-pysap/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pysap
 version             0.1.19
-revision            0
+revision            1
 
 license             GPL-2+
 maintainers         {@catap korins.ky:kirill} openmaintainer
@@ -30,5 +30,5 @@ if {${name} ne ${subport}} {
 
     depends_lib-append \
                     port:py${python.version}-cryptography \
-                    port:py${python.version}-scapy
+                    path:bin/scapy-${python.branch}:py${python.version}-scapy
 }

--- a/python/py-scapy/Portfile
+++ b/python/py-scapy/Portfile
@@ -35,20 +35,20 @@ checksums                   rmd160  1c5576ae4282cd17cd9512382f5e4987bf8ef2e3 \
                             size    1279162
 
 # NOTE: 2.5.0 is the last version of scapy which support Python 2
-set devel_python_versions   {38 39 310 311}
+set devel_python_versions   {38 39 310 311 312}
 python.versions             27 {*}${devel_python_versions}
 
 foreach pver [list {*}${devel_python_versions} ""] {
     subport py${pver}-scapy-devel {
         PortGroup           github 1.0
 
-        github.setup        secdev scapy 353b2413f41c01eeacf3516eebc70821c82f70ef
+        github.setup        secdev scapy 0dd08cd064134bcbf7c6bfbdbd356b69cdee05ac
         github.tarball_from archive
-        version             20230907
+        version             20231209
         revision            0
-        checksums           rmd160  a2c1b3345fb280361171a3a34c8dc243361f4102 \
-                            sha256  155ac5bd445472f6b1ead2ec4dba07a479ccbc9324eee80c146c000bfcdaea0b \
-                            size    6075517
+        checksums           rmd160  a0f49d2b5ed36a8be6a17942271767bf35d066c3 \
+                            sha256  30ce2e78a788d9574665640da2bd01f01ae5f5818747dd6dbadf3e8b7599f5ff \
+                            size    6107144
 
         long_description    ${long_description} \
             This port is kept up with the ${name} GIT 'master' branch, is typically updated weekly to monthly.

--- a/python/py-scapy/files/py312-scapy
+++ b/python/py-scapy/files/py312-scapy
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.12/bin/scapy

--- a/python/py-scapy/files/py312-scapy-devel
+++ b/python/py-scapy/files/py312-scapy-devel
@@ -1,0 +1,1 @@
+${frameworks_dir}/Python.framework/Versions/3.12/bin/scapy

--- a/science/gr-pcap/Portfile
+++ b/science/gr-pcap/Portfile
@@ -12,7 +12,7 @@ license             GPL-3
 
 if {${subport} eq ${name}} {
     version         20170402
-    revision        7
+    revision        8
     replaced_by     gr37-pcap
     PortGroup       obsolete 1.0
 }
@@ -23,7 +23,7 @@ subport gr37-pcap {
 
     github.setup    osh gr-pcap f643e518c8d75aa8c9bf474fad51dae235dfddf1
     version         20170402
-    revision        2
+    revision        3
     checksums       rmd160 4426c2e9134bacc98e90f72933a9ed523969830c \
                     sha256 e7cacc7343531865c357288d73248764f9f5273d3eadbb8d57eccff9a22395d5
 
@@ -33,7 +33,7 @@ subport gr37-pcap {
 }
 
 depends_lib-append \
-    port:py${active_python_version_no_dot}-scapy
+    path:bin/scapy-${active_python_version}:py${active_python_version_no_dot}-scapy
 
 # include examples in destroot
 post-destroot {

--- a/sysutils/john/Portfile
+++ b/sysutils/john/Portfile
@@ -77,7 +77,7 @@ if {${subport} eq "john"} {
 
 subport john-jumbo {
     version                     1.9.0
-    revision                    5
+    revision                    6
     set jumbo_patchlvl          1
 
     master_sites                https://www.openwall.com/john/k/
@@ -101,7 +101,7 @@ subport john-jumbo-devel {
 
     github.setup                openwall john 9a941fc8915b905d95fc4a68702267de745a8a71
     version                     20231220
-    revision                    0
+    revision                    1
 
     checksums                   rmd160  f7eda815c49645761f2d0f01557754399743dd7e \
                                 sha256  7356fbfc1b574384bbadf6abd88d2d29fd1308f8dbf2d099b7f958db95181293 \
@@ -162,7 +162,7 @@ if {${subport} in [list "john-jumbo" "john-jumbo-devel"]} {
         depends_run-append      port:py${python2_version}-lxml \
                                 port:py${python2_version}-pycryptodome
 
-        depends_run-append      path:bin/scapy-${python2_branch}:py${python2_version}-scapy
+        depends_run-append      bin:scapy-${python2_branch}:py${python2_version}-scapy
     }
 
     if {${subport} eq "john-jumbo-devel"} {
@@ -172,7 +172,7 @@ if {${subport} in [list "john-jumbo" "john-jumbo-devel"]} {
                                 port:py${python3_version}-lxml \
                                 port:py${python3_version}-pycryptodome
 
-        depends_run-append      path:bin/scapy-${python3_branch}:py${python3_version}-scapy
+        depends_run-append      bin:scapy-${python3_branch}:py${python3_version}-scapy
     }
 
     configure.dir               ${worksrcpath}/src


### PR DESCRIPTION
#### Description

~Is blocked by https://github.com/macports/macports-ports/pull/21843~

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->