### PR TITLE
offlineimap: update to 8.0.0-20231218

### DIFF
--- a/mail/offlineimap/Portfile
+++ b/mail/offlineimap/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        OfflineIMAP offlineimap3 77e70ed4747313552f6df75b68a43c70af7267e1
+github.setup        OfflineIMAP offlineimap3 d29a4dc459401f8a78e347cb0f8ae7670add0975
 name                offlineimap
-version             8.0.0-20231201
+version             8.0.0-20231218
 revision            0
 categories          mail python
 platforms           {darwin any}
@@ -39,11 +39,11 @@ long_description    OfflineIMAP is a tool to simplify your e-mail reading. \
 
 homepage            http://offlineimap.org/
 
-checksums           rmd160  e5db296a7c102f6ec9190d3f711a3e0c07c15120 \
-                    sha256  05d59a01f3d8fcde482185e67e145e62946fc74223f4b4e923e9136c091878a0 \
-                    size    704587
+checksums           rmd160  83ead6118d5fb4277890981af0338e48c8284779 \
+                    sha256  2a6dde6d07b7cb8ca15cf45979513159380887d00650f761c7d5f5bdb6f13f9e \
+                    size    704621
 
-python.default_version 311
+python.default_version 312
 
 depends_build       port:py${python.version}-docutils \
                     port:py${python.version}-sphinx \

--- a/python/py-gssapi/Portfile
+++ b/python/py-gssapi/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  797a49767ccea7aa0e0799395df7ca8b2208ac1d \
                     sha256  3f250cbc636c7d934e7ae5127af4681fbe4b5daba05568ff109c38c443a76476 \
                     size    113958
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 patchfiles          patch-setup.py.diff
 

--- a/python/py-imaplib2/Portfile
+++ b/python/py-imaplib2/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  2e8e893f8145f9a613c1d36c07007edec470132b \
                     sha256  96cb485b31868a242cb98d5c5dc67b39b22a6359f30316de536060488e581e5b \
                     size    26252
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-rfc6555/Portfile
+++ b/python/py-rfc6555/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  5a2e58cbbdbe6134dcd4f0d86867e236081774ab \
                     sha256  123905b8f68e2bec0c15f321998a262b27e2eaadea29a28bd270021ada411b67 \
                     size    10094
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Update offlineimap, switched to python-3.12 and added a few `py312` subports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->