### PR TITLE
py-yaml: use py-cython-compat

### DIFF
--- a/python/py-yaml/Portfile
+++ b/python/py-yaml/Portfile
@@ -8,7 +8,6 @@ python.rootname     PyYAML
 version             6.0.1
 revision            0
 categories-append   devel
-platforms           darwin
 license             MIT
 
 python.versions     27 35 36 37 38 39 310 311 312
@@ -28,8 +27,12 @@ checksums           rmd160  d7d944c9be55413d0a7431669a274cd1e579dd13 \
                     size    125201
 
 if {${name} ne ${subport}} {
+    # Not compatible with Cython 3 as of 6.0.1
     depends_build-append \
-                        port:py${python.version}-cython
+                        port:py${python.version}-cython-compat
+    set compat_path [string replace ${python.pkgd} 0 [string length ${python.prefix}]-1 ${prefix}/lib/py${python.version}-cython-compat]
+    build.env-append    PYTHONPATH=${compat_path}
+
     depends_lib-append  port:libyaml
 
     if {${python.version} < 37} {


### PR DESCRIPTION
This helps clear the way for py-cython to be updated to 3.x.

See: https://trac.macports.org/ticket/68929
