### PR TITLE
py-h5py: use py-cython-compat

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -17,7 +17,6 @@ checksums \
     sha256  3a2cbcffab0bc40e391c62a93d5c6964aab308f82a0901e2b015432e4b5d830d \
     size    421866
 
-platforms               darwin
 license                 BSD
 maintainers             {eborisch @eborisch} openmaintainer
 
@@ -41,14 +40,18 @@ python.versions         38 39 310 311
 github.livecheck.regex      {([0-9.]+)}
 
 if {${name} ne ${subport}} {
-    depends_build-append    path:bin/cython-${python.branch}:py${python.version}-cython \
-                            port:py${python.version}-pythran
+    depends_build-append    port:py${python.version}-pythran
 
     depends_lib-append      port:py${python.version}-cached-property \
                             port:py${python.version}-numpy \
                             port:py${python.version}-six \
                             port:py${python.version}-pkgconfig \
                             port:hdf5
+
+    # Not compatible with Cython 3 as of 3.10.0
+    depends_build-append    port:py${python.version}-cython-compat
+    set compat_path [string replace ${python.pkgd} 0 [string length ${python.prefix}]-1 ${prefix}/lib/py${python.version}-cython-compat]
+    build.env-append        PYTHONPATH=${compat_path}
 
     build.env-append        HDF5_DIR=${prefix}
     destroot.env-append     HDF5_DIR=${prefix}


### PR DESCRIPTION
This helps clear the way for py-cython to be updated to 3.x.

See: https://trac.macports.org/ticket/68929
