### PR TITLE
zsh-syntax-highlighting: Update to 0.8.0

### DIFF
--- a/sysutils/zsh-syntax-highlighting/Portfile
+++ b/sysutils/zsh-syntax-highlighting/Portfile
@@ -2,8 +2,9 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
 
-github.setup        zsh-users zsh-syntax-highlighting 0.7.1
+github.setup        zsh-users zsh-syntax-highlighting 0.8.0
 
 categories          sysutils shells
 
@@ -15,9 +16,7 @@ long_description    This package provides syntax highlighing for the shell zsh. 
                     It enables highlighing of commands whilst they are typed at \
                     a zsh prompt into an interactive terminal. This helps in \
                     reviewing commands before running them, particularly in \
-                    catching syntax errors. \
-                    \
-                    Please note that you must load zsh-syntax-highlighting \
+                    catching syntax errors. Please note that you must load ${name} \
                     after all other custom widgets, at the end of your .zshrc \
                     file.
 
@@ -26,16 +25,14 @@ license             BSD
 platforms           any
 supported_archs     noarch
 
-checksums           sha256  5abb9814ed5fcfc9d393be4932adb86b39de3b324eee8ade2debe44530acd840 \
-                    rmd160  9df8771fb309f44f62a41fb0af65ddc34296d506 \
-                    size    133551
+checksums           rmd160  a05ac72e372c4012e5be7cb5d62031eebad2ad64 \
+                    sha256  0e329871928620b6f521bf366dfe8f8ddf4b03d97f8fa3eb6af25a26a6ed9b21 \
+                    size    155949
 
-depends_run         path:bin/zsh:zsh
+depends_run-append  path:bin/zsh:zsh
 
-use_configure       no
+test.run            yes
+test.args-append    ZSH="${prefix}/bin/zsh"
+test.target         test
 
-build { }
-
-destroot.args-append ZSH=${prefix}/bin/zsh PREFIX=$prefix
-
-github.livecheck.regex {([^"-]+)}
+github.livecheck.regex {([^\"-]+)}


### PR DESCRIPTION
#### Description

Update `zsh-syntax-higlighting` to its latest released version, 0.8.0, while appropriately testing the package with `test.run`.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
