### PR TITLE
hyfetch: Add appropriate run dependencies

### DIFF
--- a/python/hyfetch/Portfile
+++ b/python/hyfetch/Portfile
@@ -6,7 +6,7 @@ PortGroup               python 1.0
 python.rootname         HyFetch
 name                    [string tolower ${python.rootname}]
 version                 1.4.11
-revision                0
+revision                1
 categories-append       sysutils
 platforms               {darwin any}
 supported_archs         noarch
@@ -25,4 +25,5 @@ checksums               rmd160  2239681635a7608f2f99d466247f852756d74607 \
 # This should stay consistent with the python PG default
 python.default_version  311
 
-depends_build-append    port:py${python.version}-typing_extensions
+depends_run-append      port:py${python.version}-setuptools \
+                        port:py${python.version}-typing_extensions


### PR DESCRIPTION
#### Description

Add appropriate run dependencies so that `hyfetch` functions as intended when installing.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
