### PR TITLE
py-mypy: fix build on 32-bit platforms

### DIFF
--- a/python/py-mypy/Portfile
+++ b/python/py-mypy/Portfile
@@ -8,7 +8,6 @@ name                py-mypy
 version             1.7.1
 revision            0
 license             MIT
-platforms           darwin
 maintainers         {toby @tobypeterson} openmaintainer
 description         Optional static typing for Python
 long_description    Add type annotations to your Python programs, and use mypy to \
@@ -18,7 +17,7 @@ long_description    Add type annotations to your Python programs, and use mypy t
                     type system with features such as type inference, gradual typing, \
                     generics and union types.
 
-homepage            http://www.mypy-lang.org
+homepage            https://www.mypy-lang.org
 
 checksums           rmd160  040fbdefd0f24f1dba0f345eac79e81836acfc9e \
                     sha256  fcb6d9afb1b6208b4c712af0dafdc650f518836065df0d4fb1d800f5d6773db2 \
@@ -50,7 +49,18 @@ if {${name} ne ${subport}} {
         depends_lib-append  port:py${python.version}-typed-ast
     }
 
+    compiler.blacklist-append \
+                            *gcc-4.0 *gcc-4.2
+
     build.env-append        MYPY_USE_MYPYC=1
+
+    # https://trac.macports.org/ticket/68943
+    # https://github.com/python/mypy/issues/16684
+    # https://github.com/python/mypy/issues/11507
+    if {${configure.build_arch} in [list arm i386 ppc]} {
+        build.env-append    MYPYC_DEBUG_LEVEL=0 \
+                            MYPYC_MULTI_FILE=1
+    }
 
     select.group            mypy
     select.file             ${filespath}/mypy${python.version}


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68943
See also: https://github.com/python/mypy/issues/16684

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
