### PR TITLE
py-numpy: build older versions with py-cython-compat

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -114,6 +114,13 @@ if {${name} ne ${subport}} {
         }
     }
 
+    if {${python.version} <= 38} {
+        # Versions prior to 1.26 don't build with Cython 3
+        depends_build-append  port:py${python.version}-cython-compat
+        set compat_path [string replace ${python.pkgd} 0 [string length ${python.prefix}]-1 ${prefix}/lib/py${python.version}-cython-compat]
+        build.env-append    PYTHONPATH=${compat_path}
+    }
+
     patchfiles-append       patch-numpy_core_setup.py${PATCH_PY_EXT}.diff \
                             patch-numpy_tests_test_scripts.py${PATCH_PY_EXT}.diff \
                             patch-fcompiler_g95${PATCH_PY_EXT}.diff \


### PR DESCRIPTION
This helps clear the way for py-cython to be updated to 3.x.

See: https://trac.macports.org/ticket/68929
