### PR TITLE
arm-none-eabi-gcc: fix builds in macOS 13+

### DIFF
--- a/cross/arm-none-eabi-gcc/Portfile
+++ b/cross/arm-none-eabi-gcc/Portfile
@@ -11,6 +11,8 @@ revision            0
 
 maintainers         {judaew @judaew} openmaintainer
 
+depends_build       bin:makeinfo:texinfo
+
 # specific to ARM
 configure.args-append \
                     --enable-interwork \


### PR DESCRIPTION
#### Description

This PR adds `makeinfo` binary from `texinfo` port as a build dependency by implementing the comment made by @ryandesign in https://trac.macports.org/ticket/67737#comment:4

By doing this change, macOS 13+ builders will be able to compile the package properly; see https://github.com/linuxgemini/macports-ports-custom/actions/runs/7273135615 for an example.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2 23C64 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
