### PR TITLE
google-cloud-sdk: update to 458.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             457.0.0
+version             458.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  85b0d23f11bb3e1fc9bead5cb3c102027578a198 \
-                    sha256  5e1d9cb87e5f800d03e49f54ba3942089e98ed57b984911b81bd6bc9939f9539 \
-                    size    122329437
+    checksums       rmd160  4e208d3b0bc6aadfebb203974f17eca33925e78b \
+                    sha256  3bd787cc0ef8360414a3dca48131ada77234e08e9740ed2d6aac76ecbdf5c45b \
+                    size    122371471
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  ef7be5a98851edc8779c3922a47a36de7b733dbf \
-                    sha256  8f9f022a59473b5a2b830cb6e9e5026054dd519682acd2a43800a8544bb82572 \
-                    size    123615309
+    checksums       rmd160  9b5ed2fc41ffb510abc6b9413af4a31fff27fc85 \
+                    sha256  e6d4129d911706717fd9c63ad7500930ff7cb255314b64e79f86216807d4d7a1 \
+                    size    123657750
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  1de855170b2d41c52ddd7b14becad1549331144a \
-                    sha256  287d0976e64fc181aeeb7b800537357804749008223ceaa6689d2309b6a89d0e \
-                    size    120679088
+    checksums       rmd160  c2c9a0be56df3d6e7e842f2913e5a3acf2610a1e \
+                    sha256  611d9fb6109985c178cb834b46ec014d0ece6eb899e418c3c99a280b7a264c23 \
+                    size    120725725
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 458.0.0.

###### Tested on

macOS 14.2 23C64 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?