### PR TITLE
py-pythran: fix xsimd_scalar header for macOS <10.9

### DIFF
--- a/python/py-pythran/Portfile
+++ b/python/py-pythran/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-pythran
 version             0.14.0
-revision            0
+revision            1
 
 categories-append   devel
 platforms           {darwin any}
@@ -38,6 +38,10 @@ if {${name} ne ${subport}} {
         depends_lib-append \
                     port:py${python.version}-importlib-metadata
     }
+
+    # https://github.com/serge-sans-paille/pythran/pull/2165
+    patchfiles-append \
+                    patch-xsimd_scalar.hpp-fix-for-missing-__exp10-on-macOS.diff
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-pythran/files/patch-xsimd_scalar.hpp-fix-for-missing-__exp10-on-macOS.diff
+++ b/python/py-pythran/files/patch-xsimd_scalar.hpp-fix-for-missing-__exp10-on-macOS.diff
@@ -1,0 +1,90 @@
+From b98a22802ed75e42c7692fd2ef9264a3174b8491 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Wed, 20 Dec 2023 18:10:41 +0800
+Subject: [PATCH] xsimd_scalar.hpp: fix for missing __exp10 on macOS < 10.9
+
+Fixes: https://github.com/serge-sans-paille/pythran/issues/2164
+See also: https://github.com/xtensor-stack/xsimd/pull/993
+---
+ pythran/xsimd/arch/xsimd_scalar.hpp | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git pythran/xsimd/arch/xsimd_scalar.hpp pythran/xsimd/arch/xsimd_scalar.hpp
+index fc227db84..ed1342815 100644
+--- pythran/xsimd/arch/xsimd_scalar.hpp
++++ pythran/xsimd/arch/xsimd_scalar.hpp
+@@ -24,6 +24,10 @@
+ #include "xtl/xcomplex.hpp"
+ #endif
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ namespace xsimd
+ {
+     template <class T, class A>
+@@ -468,7 +472,7 @@ namespace xsimd
+         return !(x0 == x1);
+     }
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED > 1080)
+     inline float exp10(const float& x) noexcept
+     {
+         return __exp10f(x);
+@@ -486,6 +490,15 @@ namespace xsimd
+     {
+         return ::exp10(x);
+     }
++#elif !defined(__clang__) && defined(__GNUC__) && (__GNUC__ >= 5)
++    inline float exp10(const float& x) noexcept
++    {
++        return __builtin_exp10f(x);
++    }
++    inline double exp10(const double& x) noexcept
++    {
++        return __builtin_exp10(x);
++    }
+ #elif defined(_WIN32)
+     template <class T, class = typename std::enable_if<std::is_scalar<T>::value>::type>
+     inline T exp10(const T& x) noexcept
+
+--- third_party/xsimd/arch/xsimd_scalar.hpp
++++ third_party/xsimd/arch/xsimd_scalar.hpp
+@@ -24,6 +24,10 @@
+ #include "xtl/xcomplex.hpp"
+ #endif
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ namespace xsimd
+ {
+     template <class T, class A>
+@@ -468,7 +472,7 @@ namespace xsimd
+         return !(x0 == x1);
+     }
+ 
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED > 1080)
+     inline float exp10(const float& x) noexcept
+     {
+         return __exp10f(x);
+@@ -486,6 +490,15 @@ namespace xsimd
+     {
+         return ::exp10(x);
+     }
++#elif !defined(__clang__) && defined(__GNUC__) && (__GNUC__ >= 5)
++    inline float exp10(const float& x) noexcept
++    {
++        return __builtin_exp10f(x);
++    }
++    inline double exp10(const double& x) noexcept
++    {
++        return __builtin_exp10(x);
++    }
+ #elif defined(_WIN32)
+     template <class T, class = typename std::enable_if<std::is_scalar<T>::value>::type>
+     inline T exp10(const T& x) noexcept


### PR DESCRIPTION
#### Description

Current headers break the build of `scipy`: https://github.com/serge-sans-paille/pythran/issues/2164
Fix that.

PR to upstream: https://github.com/xtensor-stack/xsimd/pull/993

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
