### PR TITLE
mrustc: update to 20231219

### DIFF
--- a/lang/mrustc/Portfile
+++ b/lang/mrustc/Portfile
@@ -5,14 +5,14 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        thepowersgang mrustc 417f29394bd8948af407eb48be31750a5a62a7f5
+github.setup        thepowersgang mrustc 967eea07a3f6651ee617472a247512ef82a3304d
 
 set rust_version    1.54.0
 set rust_version_major [join [lrange [split ${rust_version} .-] 0 1] .]
 set rust_version_major_underscore [join [lrange [split ${rust_version} .-] 0 1] _]
 
 # subport mrustc-rust has its own versioning
-version             ${rust_version_major}-20230925
+version             ${rust_version_major}-20231219
 revision            0
 epoch               1
 
@@ -34,9 +34,9 @@ master_sites-append https://static.rust-lang.org/dist/:rust
 distfiles-append    rustc-${rust_version}-src.tar.gz:rust
 
 checksums           mrustc-${github.version}.tar.gz \
-                    rmd160  ef1e4beaf9a9265eef35be63bdcada24101955de \
-                    sha256  ccd3d81443a077409dffc3fb4e4c70ec97d289ef2bbaca69f0b78da5de4cf4a2 \
-                    size    1277627 \
+                    rmd160  f1cec542c40a14e72ffbf41310a79a1f21c086b0 \
+                    sha256  6be42ee0b274d4a4c2cc86d479ab2e30929fe1072fe0f9c267fdd378ff003c08 \
+                    size    1274527 \
                     rustc-${rust_version}-src.tar.gz \
                     rmd160  be2de16e2deaf91aee723e631a36f6de52636ddd \
                     sha256  ac8511633e9b5a65ad030a1a2e5bdaa841fdfe3132f2baaa52cc04e71c6c6976 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->