### PR TITLE
py-{shiboken,pyside}: add py312 subport

### DIFF
--- a/python/py-pyside/Portfile
+++ b/python/py-pyside/Portfile
@@ -8,7 +8,7 @@ github.setup        pyside PySide 1.2.4
 name                py-pyside
 revision            0
 set                 qt.ver 4.8
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 categories-append   devel
 maintainers         nomaintainer
 license             LGPL
@@ -33,6 +33,10 @@ if {${name} ne ${subport}} {
     if {${python.version} >= 311} {
         patchfiles-append \
                     patch-py311-compatibility.diff
+    }
+    if {${python.version} >= 312} {
+        patchfiles-append \
+                    patch-py312-compatibility.diff
     }
     depends_lib-append port:py${python.version}-shiboken
     use_configure   yes

--- a/python/py-pyside/files/patch-py312-compatibility.diff
+++ b/python/py-pyside/files/patch-py312-compatibility.diff
@@ -1,0 +1,17 @@
+--- PySide/QtCore/typesystem_core_common.xml
++++ PySide/QtCore/typesystem_core_common.xml
+@@ -201,12 +201,11 @@
+         </native-to-target>
+         <target-to-native>
+             <add-conversion type="PyUnicode">
+-            Py_UNICODE* unicode = PyUnicode_AS_UNICODE(%in);
+             #if defined(Py_UNICODE_WIDE)
+             // cast as Py_UNICODE can be a different type
+-            %out = QString::fromUcs4((const uint*)unicode);
++            %out = QString::fromUcs4((const uint*)PyUnicode_4BYTE_DATA(%in));
+             #else
+-            %out = QString::fromUtf16((const ushort*)unicode, PyUnicode_GET_SIZE(%in));
++            %out = QString::fromUtf16((const ushort*)PyUnicode_2BYTE_DATA(%in), PyUnicode_GET_SIZE(%in));
+             #endif
+             </add-conversion>
+             <add-conversion type="PyString" check="py2kStrCheck(%in)">

--- a/python/py-shiboken/Portfile
+++ b/python/py-shiboken/Portfile
@@ -7,7 +7,7 @@ PortGroup github 1.0
 github.setup        pyside Shiboken 1.2.4
 name                py-shiboken
 revision            2
-python.versions     27 35 36 37 38 39 310 311
+python.versions     27 35 36 37 38 39 310 311 312
 categories-append   devel
 maintainers         nomaintainer
 license             LGPL
@@ -38,6 +38,10 @@ if {${name} ne ${subport}} {
     if {${python.version} >= 311} {
         patchfiles-append \
                         patch-py311-compatibility.diff
+    }
+    if {${python.version} >= 312} {
+        patchfiles-append \
+                        patch-py312-compatibility.diff
     }
 
     depends_lib-append  port:python${python.version} \

--- a/python/py-shiboken/files/patch-py312-compatibility.diff
+++ b/python/py-shiboken/files/patch-py312-compatibility.diff
@@ -1,0 +1,11 @@
+--- libshiboken/sbkstring.cpp
++++ libshiboken/sbkstring.cpp
+@@ -173,7 +173,7 @@ Py_ssize_t len(PyObject* str)
+         return 0;
+
+     if (PyUnicode_Check(str))
+-        return PyUnicode_GET_SIZE(str);
++        return PyUnicode_GetLength(str);
+
+     if (PyBytes_Check(str))
+         return PyBytes_GET_SIZE(str);


### PR DESCRIPTION
#### Description

Patching py-shiboken and py-pyside with Python 3.12 support. Note that these are obsolete versions of tools that are still being maintained, but have been moved away from GitHub. I do not use them directly, I am only doing this because of matplotlib, which for some reason has a variant that depends on these ancient versions instead of more recent ones. Given that these versions are obsolete, I have not submitted the patch that I wrote to the master repo ([apparently I did after patching py-shiboken for Python 3.9](https://github.com/pyside/Shiboken/pull/90), but I closed it now after three years of inactivity).

The Shiboken patch is straightforward; in shiboken2 they simply replaced `PyUnicode_GET_SIZE` with `PyUnicode_GetLength`, so I did that.

The PySide code in question has been completely rewritten, so I had to improvise. The patch itself should be pretty straightforward, but since I wrote it myself I feel it is best that I explain it: The removed function was `PyUnicode_AS_UNICODE`, which converts a string from non-Unicode to Unicode - or simply returns the Unicode buffer if the internal representation is “Unicode” (which used to mean `wchar_t*`). Of course the internal representation has been Unicode for a very long time now, so conversion is no longer needed. However, the buffer type is no longer `wchar_t*`, but either `uint16_t*` (UCS-2) or, if `Py_UNICODE_WIDE` is defined, `uint32_t*` (UCS-4). Inline comments in the Python 3.11 source code on `PyUnicode_AS_UNICODE` recommend using the `PyUnicode_*BYTE_DATA` functions, depending on the kind of Unicode used. This translates to replacing `PyUnicode_AS_UNICODE` with `PyUnicode_4BYTE_DATA` if `Py_UNICODE_WIDE` is defined and with `PyUnicode_2BYTE_DATA` if it is not. Luckily, the PySide code already has an `#if defined(Py_Unicode_WIDE)` in there, so we can feed the result of `PyUnicode_2BYTE_DATA` and `PyUnicode_4BYTE_DATA` directly into `QString::fromUtf16` and `QString::fromUcs4`, eliminating the variable that used to hold the return value of `PyUnicode_AS_UNICODE`.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Binary files: Shiboken has an executable. Tested by checking out the Shiboken repo, navigating to `tests/test_generator` and running `shiboken-3.12 test_global.h test_typesystem.xml`, which reports `Done, 0 warnings (0 known issues)`.