### PR TITLE
Updates proguard version to 7.4.1

### DIFF
--- a/java/proguard/Portfile
+++ b/java/proguard/Portfile
@@ -28,7 +28,7 @@ github.tarball_from \
 
 checksums       rmd160  adf7c7295a04bddf8e79f066381165d8755f7055 \
                 sha256  d3a83be58eb2a4a9baf8c462d8c2774a9b473a4afc66c3aa0da83811ef5db889 \
-                size    32076938 
+                size    32076938
 
 depends_lib     bin:java:kaffe
 

--- a/java/proguard/Portfile
+++ b/java/proguard/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    Guardsquare proguard 7.0.1 v
+github.setup    Guardsquare proguard 7.4.1 v
 revision        0
 
 categories      java
@@ -26,9 +26,9 @@ homepage        https://www.guardsquare.com/en/products/proguard
 github.tarball_from \
                 releases
 
-checksums       rmd160  17afce2755e0be8139c9d0cec63f255988a08065 \
-                sha256  b7fd1ee6da650b392ab9fe619f0bfd01f1fe8272620d9471fcfc7908b5216d71 \
-                size    13246555
+checksums       rmd160  adf7c7295a04bddf8e79f066381165d8755f7055 \
+                sha256  d3a83be58eb2a4a9baf8c462d8c2774a9b473a4afc66c3aa0da83811ef5db889 \
+                size    32076938 
 
 depends_lib     bin:java:kaffe
 


### PR DESCRIPTION
#### Description

Updates proguard version to 7.4.1

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 12.5 12E262

###### Verification
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

