### PR TITLE
thrift: fix lisp support

### DIFF
--- a/devel/thrift/Portfile
+++ b/devel/thrift/Portfile
@@ -13,7 +13,7 @@ version         0.19.0
 checksums       rmd160  6a9560b841762a260bb8e6cc7f9d69d663c5e99c \
                 sha256  d49c896c2724a78701e05cfccf6cf70b5db312d82a17efe951b441d300ccf275 \
                 size    4335656
-revision        0
+revision        1
 
 categories      devel
 license         Apache-2
@@ -155,11 +155,10 @@ variant swift description "enable the Swift library" {
     use_xcode yes
 }
 
-# Fails on PowerPC at the moment: https://trac.macports.org/ticket/68477
+# NOTE: Lisp support was removed at 0.17, and recovered as proxy to cl-thrift at 0.19
+# this mean that `--with-cl=yes` is useless.
 variant lisp description "enable the CL library" {
-    configure.args-delete   --with-cl=no
-    configure.args-append   --with-cl=yes
-    depends_lib-append      port:sbcl
+    depends_run-append      port:cl-thrift
 }
 
 test.run        yes

--- a/lisp/cl-thrift/Portfile
+++ b/lisp/cl-thrift/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           common_lisp 1.0
+
+github.setup        TurtleWarePL de.setf.thrift a6be204851d564f05c983e77f9624ed85c79beef
+name                cl-thrift
+version             20171121
+revision            0
+
+checksums           rmd160  21c031cec2628e77df14cb3a4aee68ddd9e16c9d \
+                    sha256  031397ca87564718ac0f0f7b172a7ed552b6ba633ef75fed119dac45c77afec9 \
+                    size    63225
+
+categories-append   devel
+maintainers         {@catap korins.ky:kirill} openmaintainer
+license             Apache-2
+
+description         A Common Lisp binding for the Apache Thrift framework
+
+long_description    {*}${description}
+
+depends_lib-append  port:cl-alexandria \
+                    port:cl-closer-mop \
+                    port:cl-ieee-floats \
+                    port:cl-puri \
+                    port:cl-trivial-gray-streams \
+                    port:cl-trivial-utf-8 \
+                    port:cl-usocket
+
+common_lisp.threads yes
+
+common_lisp.ecl     yes
+
+# See: https://github.com/usocket/usocket/issues/113
+common_lisp.abcl    no
+
+github.livecheck.branch backport-update


### PR DESCRIPTION
#### Description

Support of Lisp were was removed at 0.17, and recovered as proxy to `cl-thrift` at 0.19, this mean that variant should add only run depedency, nothing more.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->