### PR TITLE
google-cloud-sdk: update to 458.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             458.0.0
+version             458.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4e208d3b0bc6aadfebb203974f17eca33925e78b \
-                    sha256  3bd787cc0ef8360414a3dca48131ada77234e08e9740ed2d6aac76ecbdf5c45b \
-                    size    122371471
+    checksums       rmd160  7fb40c2e82157af6be7a9fb5805b7d8fae332606 \
+                    sha256  fa1919776b16bb694a40e8e807d1c3d9589918d4ccffa2bff3f95fed4abf51fa \
+                    size    122371622
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  9b5ed2fc41ffb510abc6b9413af4a31fff27fc85 \
-                    sha256  e6d4129d911706717fd9c63ad7500930ff7cb255314b64e79f86216807d4d7a1 \
-                    size    123657750
+    checksums       rmd160  ca4f0d31772c8cee1490da8da60d381aea7b24ce \
+                    sha256  a8027789a9b52f43718c269914a57670e60b6e05550d5dc01770823d4eace19c \
+                    size    123657786
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  c2c9a0be56df3d6e7e842f2913e5a3acf2610a1e \
-                    sha256  611d9fb6109985c178cb834b46ec014d0ece6eb899e418c3c99a280b7a264c23 \
-                    size    120725725
+    checksums       rmd160  788d3c053781743a4ce3846921692e2654c9d80f \
+                    sha256  c88a5edad240ee4eb1708f6bdaaffce77a9ff94166944c61f92023ef2a896f64 \
+                    size    120725443
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 458.0.1.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?