### PR TITLE
py-cython: update to 3.0.7, replacing py-cython-devel

### DIFF
--- a/python/py-astropy/Portfile
+++ b/python/py-astropy/Portfile
@@ -30,7 +30,7 @@ compiler.blacklist  {*llvm-gcc42}
 if {${name} ne ${subport}} {
     depends_build-append \
                     port:pkgconfig \
-                    port:py${python.version}-cython-devel \
+                    port:py${python.version}-cython \
                     port:py${python.version}-extension-helpers \
                     port:py${python.version}-jinja2 \
                     port:py${python.version}-setuptools_scm \
@@ -93,9 +93,6 @@ if {${name} ne ${subport}} {
         checksums   rmd160  4dcc891fdfd66aa7233970dab9f76d80242302e4 \
                     sha256  e6a9e34716bda5945788353c63f0644721ee7e5447d16b1cdcb58c48a96b0d9c \
                     size    8288550
-
-        depends_build-replace \
-                    port:py${python.version}-cython-devel port:py${python.version}-cython
 
         patchfiles  patch-pyproject.toml.5.2.diff
     }

--- a/python/py-cython-devel/Portfile
+++ b/python/py-cython-devel/Portfile
@@ -1,59 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
-PortGroup           python 1.0
-PortGroup           select 1.0
-PortGroup           compiler_blacklist_versions 1.0
+PortGroup           obsolete 1.0
 
 name                py-cython-devel
-python.rootname     Cython
+replaced_by         py-cython
 version             3.0.7
-revision            0
-github.setup        cython cython ${version}
+revision            1
 
-conflicts           py-cython
-
-categories-append   devel
+categories          python devel
 license             Apache-2
 
-python.versions     38 39 310 311 312
-python.pep517       yes
-
-maintainers         {mps @Schamschula} openmaintainer
-
-description         A language for writing C extension modules for Python.
-
-long_description    Cython is a language that makes writing C extensions for \
-                    the Python language as easy as Python itself. Cython is  \
-                    based on the well-known Pyrex, but supports more cutting \
-                    edge functionality and optimizations
-
-homepage            http://www.cython.org/
-
-checksums           rmd160  7f1367ae8f06d15446af1c5c639a76c255f9b03c \
-                    sha256  9efcea3c4504c118d2f8d516f6952fffc524f1f1ddf04ad5163bdf362627d174 \
-                    size    2762565
-
-if {${name} ne ${subport}} {
-    conflicts       py${python.version}-cython
-
-    depends_lib-append \
-                        port:py${python.version}-setuptools
-
-    # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
-    compiler.blacklist-append *gcc-3.* *gcc-4.*
-
-    depends_run         port:cython_select
-    test.run            no
-
-    select.group        cython
-    select.file         ${filespath}/cython${python.version}
-
-    notes "
-To make the Python ${python.branch} version of Cython the one that is run\
-when you execute the commands without a version suffix, e.g. 'cython', run:
-
-sudo port select --set ${select.group} [file tail ${select.file}]
-"
+foreach python.version {38 39 310 311 312} {
+    subport py${python.version}-cython-devel {
+        replaced_by py${python.version}-cython
+    }
 }
+
+# Can be removed after 2024-12-??

--- a/python/py-cython-devel/files/cython310
+++ b/python/py-cython-devel/files/cython310
@@ -1,3 +1,0 @@
-${frameworks_dir}/Python.framework/Versions/3.10/bin/cygdb
-${frameworks_dir}/Python.framework/Versions/3.10/bin/cython
-${frameworks_dir}/Python.framework/Versions/3.10/bin/cythonize

--- a/python/py-cython-devel/files/cython311
+++ b/python/py-cython-devel/files/cython311
@@ -1,3 +1,0 @@
-${frameworks_dir}/Python.framework/Versions/3.11/bin/cygdb
-${frameworks_dir}/Python.framework/Versions/3.11/bin/cython
-${frameworks_dir}/Python.framework/Versions/3.11/bin/cythonize

--- a/python/py-cython-devel/files/cython312
+++ b/python/py-cython-devel/files/cython312
@@ -1,3 +1,0 @@
-${frameworks_dir}/Python.framework/Versions/3.12/bin/cygdb
-${frameworks_dir}/Python.framework/Versions/3.12/bin/cython
-${frameworks_dir}/Python.framework/Versions/3.12/bin/cythonize

--- a/python/py-cython-devel/files/cython37
+++ b/python/py-cython-devel/files/cython37
@@ -1,3 +1,0 @@
-${frameworks_dir}/Python.framework/Versions/3.7/bin/cygdb
-${frameworks_dir}/Python.framework/Versions/3.7/bin/cython
-${frameworks_dir}/Python.framework/Versions/3.7/bin/cythonize

--- a/python/py-cython-devel/files/cython38
+++ b/python/py-cython-devel/files/cython38
@@ -1,3 +1,0 @@
-${frameworks_dir}/Python.framework/Versions/3.8/bin/cygdb
-${frameworks_dir}/Python.framework/Versions/3.8/bin/cython
-${frameworks_dir}/Python.framework/Versions/3.8/bin/cythonize

--- a/python/py-cython-devel/files/cython39
+++ b/python/py-cython-devel/files/cython39
@@ -1,3 +1,0 @@
-${frameworks_dir}/Python.framework/Versions/3.9/bin/cygdb
-${frameworks_dir}/Python.framework/Versions/3.9/bin/cython
-${frameworks_dir}/Python.framework/Versions/3.9/bin/cythonize

--- a/python/py-cython/Portfile
+++ b/python/py-cython/Portfile
@@ -7,12 +7,10 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                py-cython
 python.rootname     Cython
-version             0.29.36
+version             3.0.7
 revision            0
 categories-append   devel
 license             Apache-2
-
-conflicts           ${name}-devel
 
 python.versions     27 35 36 37 38 39 310 311 312
 
@@ -27,19 +25,14 @@ long_description    Cython is a language that makes writing C extensions for \
 
 homepage            http://www.cython.org/
 
-checksums           rmd160  746062161d57d0bc93bc8988ed5b36d038a64352 \
-                    sha256  41c0cfd2d754e383c9eeb95effc9aa4ab847d0c9747077ddd7c0dcb68c3bc01f \
-                    size    2097760
+checksums           md5 94ab8466d9350a31cfef3a0853c2fea5 \
+                    rmd160 b3f0c73112a30d8e983e1959e97c1cc3ebfe7aa0 \
+                    sha256 fb299acf3a578573c190c858d49e0cf9d75f4bc49c3f24c5a63804997ef09213 \
+                    size   2741910
 
 if {${name} ne ${subport}} {
     depends_lib-append \
                         port:py${python.version}-setuptools
-
-    if {${python.version} >= 37} {
-        conflicts   py${python.version}-cython-devel
-    } else {
-        conflicts
-    }
 
     # https://github.com/macports/macports-ports/commit/760996927a0a2b5c0d9871670155d64f840dff8e#commitcomment-74373855
     compiler.blacklist-append *gcc-3.* *gcc-4.*

--- a/python/py-vispy/Portfile
+++ b/python/py-vispy/Portfile
@@ -6,7 +6,6 @@ PortGroup           python 1.0
 name                py-vispy
 version             0.14.1
 revision            0
-categories          python
 license             BSD
 maintainers         {mps @Schamschula} openmaintainer
 description         VisPy is a high-performance interactive 2D/3D data visualization \
@@ -24,7 +23,7 @@ checksums           rmd160  006b552469767709da24585e1c0285c5cb2fb58a \
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-cython-devel \
+                    port:py${python.version}-cython \
                     port:py${python.version}-pythran \
                     port:py${python.version}-setuptools_scm \
                     port:py${python.version}-setuptools_scm_git_archive


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68929
