### PR TITLE
py311-meson: fix g-ir-scanner calls

### DIFF
--- a/python/py-meson/Portfile
+++ b/python/py-meson/Portfile
@@ -8,7 +8,7 @@ name                py-meson
 # update version and revision also in the meson port
 github.setup        mesonbuild meson 1.3.0
 github.tarball_from releases
-revision            0
+revision            1
 
 checksums           rmd160  ab5b0514c9046df363a1de4159937ceb6a47c929 \
                     sha256  4ba253ef60e454e23234696119cbafa082a0aead0bd3bbf6991295054795f5dc \
@@ -58,6 +58,9 @@ if {${subport} ne ${name}} {
 
     # Compiled typelib files need their dylibs' full install path
     patchfiles-append   patch-meson-gnome.diff
+
+    # don't set CC for g-ir-scanner. MacPorts does that, often with modifications
+    patchfiles-append   patch-meson-gnome-dont-set-cc-for-gir-scanner.diff
 
     # disable warning not accepted by older clang versions
     # this manifests currently on systems up to 10.9

--- a/python/py-meson/files/patch-meson-gnome-dont-set-cc-for-gir-scanner.diff
+++ b/python/py-meson/files/patch-meson-gnome-dont-set-cc-for-gir-scanner.diff
@@ -1,0 +1,12 @@
+--- ./mesonbuild/modules/gnome.py2	2023-12-21 20:03:04
++++ ./mesonbuild/modules/gnome.py	2023-12-21 20:04:34
+@@ -983,7 +983,8 @@
+         run_env = PkgConfigInterface.get_env(state.environment, MachineChoice.HOST, uninstalled=True)
+         # g-ir-scanner uses Python's distutils to find the compiler, which uses 'CC'
+         cc_exelist = state.environment.coredata.compilers.host['c'].get_exelist()
+-        run_env.set('CC', [quote_arg(x) for x in cc_exelist], ' ')
++         # MACPORTS MOD -- do not set CC here. MacPorts sets it directly, with modifications
++         # run_env.set('CC', [quote_arg(x) for x in cc_exelist], ' ')
+         run_env.merge(kwargs['env'])
+ 
+         return GirTarget(


### PR DESCRIPTION
meson added a commit to set CC in the environement https://github.com/mesonbuild/meson/commit/bf44120a4f272652f98c607bd05065e8a0492d3a

however, this interfers with MacPorts setting CC in the environment, often with modifications (added arch flags, for example) and so universal building was broken

revert the essence of the meson commit, which leaves CC pristine in the environment, for MacPorts to modify

closes: https://trac.macports.org/ticket/68945

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
