### PR TITLE
c-ares: backport fix from upstream to unbreak build on <10.9

### DIFF
--- a/net/c-ares/Portfile
+++ b/net/c-ares/Portfile
@@ -31,6 +31,10 @@ checksums           rmd160  f63d2b4cd1d05c1a90e75d555e86d36e2a55afc0 \
                     sha256  c517de6d5ac9cd55a9b72c1541c3e25b84588421817b5f092850ac09a8df5103 \
                     size    1368749
 
+# https://github.com/c-ares/c-ares/issues/672
+# Drop with next release.
+patchfiles-append   patch-fix-10.8.diff
+
 configure.args-append \
                     -DCARES_SHARED:BOOL=ON
 

--- a/net/c-ares/files/patch-fix-10.8.diff
+++ b/net/c-ares/files/patch-fix-10.8.diff
@@ -1,0 +1,18 @@
+https://github.com/c-ares/c-ares/commit/7e63ac00cfa110d8d4ef18128a14c26e0adc10de
+
+--- CMakeLists.txt	2023-12-17 17:58:48.000000000 +0800
++++ CMakeLists.txt	2023-12-22 17:27:11.000000000 +0800
+@@ -210,7 +210,12 @@
+ CHECK_INCLUDE_FILES (memory.h              HAVE_MEMORY_H)
+ CHECK_INCLUDE_FILES (netdb.h               HAVE_NETDB_H)
+ CHECK_INCLUDE_FILES (netinet/in.h          HAVE_NETINET_IN_H)
+-CHECK_INCLUDE_FILES (net/if.h              HAVE_NET_IF_H)
++# On old MacOS SDK versions, you must include sys/socket.h before net/if.h
++IF (HAVE_SYS_SOCKET_H)
++  CHECK_INCLUDE_FILES ("sys/socket.h;net/if.h"  HAVE_NET_IF_H)
++ELSE ()
++  CHECK_INCLUDE_FILES (net/if.h                 HAVE_NET_IF_H)
++ENDIF ()
+ CHECK_INCLUDE_FILES (signal.h              HAVE_SIGNAL_H)
+ CHECK_INCLUDE_FILES (socket.h              HAVE_SOCKET_H)
+ CHECK_INCLUDE_FILES (stdbool.h             HAVE_STDBOOL_H)


### PR DESCRIPTION
Backport of https://github.com/c-ares/c-ares/commit/7e63ac00cfa110d8d4ef18128a14c26e0adc10de Fixes: https://trac.macports.org/ticket/68947

#### Description

Backport of a fix from upstream.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
