### PR TITLE
catch2: update to 3.5.0

### DIFF
--- a/devel/catch2/Portfile
+++ b/devel/catch2/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        catchorg Catch2 3.4.0 v
+github.setup        catchorg Catch2 3.5.0 v
 name                catch2
 revision            0
 
@@ -14,14 +14,14 @@ license             Boost-1
 maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
 
 description         Catch 2: a modern, C++-native, header-only, test framework for unit-tests
-long_description    ${description}, TDD and BDD - using C++11, C++14, C++17 and later.
+long_description    ${description}, TDD and BDD - using C++14, C++17 and later.
 
-checksums           rmd160  e77e3a7a8fcfe647d83436c8a3a72ab0d5c32757 \
-                    sha256  122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb \
-                    size    1112790
+checksums           rmd160  b802c77384a464265740b5aed33f6e62b390bf4d \
+                    sha256  f6d4f8d78a9b59ec72a81d49f58d18eb317372ac07f8d9432710a079e69fd66a \
+                    size    1155736
 github.tarball_from archive
 
-compiler.cxx_standard 2011
+compiler.cxx_standard 2014
 
 # Old clangs apparently have trouble with std::is_constructible.
 # https://github.com/catchorg/Catch2/issues/1935


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1
Xcode 15.1

macOS 10A190
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
