### PR TITLE
spring-boot-cli: update to 3.2.1

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.2.0
+version         3.2.1
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  1be5df6e2a8f4af8b79ee8733ccfd2e27fb67ddf \
-                sha256  a959fcea5b7ef29b71a133cd26632bd1663b48067cf54238c28bad57483e7fc8 \
-                size    5399270
+checksums       rmd160  19c7a779651d82d6c23f6df8b7beac5e144f934d \
+                sha256  5fca60814830f314f5a2fc9a15a8be2ea5449fcd728f26fe7989115eee37838c \
+                size    5421749
 
 worksrcdir      spring-${version}
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.2.1.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?