### PR TITLE
py-{networkx,tifffile,pywavelets}: add py312 subport

### DIFF
--- a/python/py-imagecodecs/Portfile
+++ b/python/py-imagecodecs/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  099b215d8055512f216d8288e6d5c2bd42099805 \
                     sha256  bf4b4be4759fc3b27b5022228aada83e735744e4b7c204bcdccaa961c3f79d4d \
                     size    9444699
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 platforms {darwin >= 17}
 

--- a/python/py-networkx/Portfile
+++ b/python/py-networkx/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-pywavelets/Portfile
+++ b/python/py-pywavelets/Portfile
@@ -10,7 +10,7 @@ revision            1
 categories-append   science math
 license             MIT
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-tifffile/Portfile
+++ b/python/py-tifffile/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  6fc79c3a31ab898fb167db2c35f899362e775fc6 \
                     sha256  9dd1da91180a6453018a241ff219e1905f169384355cd89c9ef4034c1b46cdb8 \
                     size    353467
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
#### Description

Dependencies of scikit-image.

One py-tifffile variant depends on imagecodecs, so I added a py312 subport for that as well.

All four packages tested by importing them and testing basic functionality.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Tests: none have tests enabled.

Binary files: I ran a couple of the py-tifffile binaries to verify that there were no linker errors etc. The output of tifffile and tiffinfo looks as it should. It explicitly supports 3.12 (according to PyPI), so I believe that is enough. None of the others I could install install binaries.