### PR TITLE
py-scipy: update to 1.11.4 and add py312 subport

### DIFF
--- a/python/py-pythran/Portfile
+++ b/python/py-pythran/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pythran
+# Please delete Python 3.12 compatibility patch below when updating
 version             0.14.0
 revision            1
 
@@ -22,7 +23,7 @@ checksums           rmd160  e15b91c1a315cd6d18d2741db4fe98675f8de977 \
                     sha256  42f3473946205964844eff7f750e2541afb2006d53475d708f5ff2d048db89bd \
                     size    4015360
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -42,6 +43,10 @@ if {${name} ne ${subport}} {
     # https://github.com/serge-sans-paille/pythran/pull/2165
     patchfiles-append \
                     patch-xsimd_scalar.hpp-fix-for-missing-__exp10-on-macOS.diff
+
+    # Python 3.12 compatibility backported from master
+    # Please delete when updating past 0.14.0
+    patchfiles-append patch-py312-compatibility.diff
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-pythran/files/patch-py312-compatibility.diff
+++ b/python/py-pythran/files/patch-py312-compatibility.diff
@@ -1,0 +1,96 @@
+--- pythran/config.py
++++ pythran/config.py
+@@ -246,26 +246,20 @@ def make_extension(python, **extra):
+         extension['define_macros'].append('PYTHRAN_BLAS_NONE')
+ 
+     if user_blas not in reserved_blas_entries:
+-        if sys.version_info < (3, 12):
+-            # `numpy.distutils` not present for Python >= 3.12
+-            try:
+-                import numpy.distutils.system_info as numpy_sys
+-                 # Numpy can pollute stdout with checks
+-                with silent():
+-                    numpy_blas = numpy_sys.get_info(user_blas)
+-                    # required to cope with atlas missing extern "C"
+-                    extension['define_macros'].append('PYTHRAN_BLAS_{}'
+-                                                      .format(user_blas.upper()))
+-                    extension['libraries'].extend(numpy_blas.get('libraries', []))
+-                    extension['library_dirs'].extend(
+-                        numpy_blas.get('library_dirs', []))
+-                    extension['include_dirs'].extend(
+-                        numpy_blas.get('include_dirs', []))
+-            except Exception as exc:
+-                raise RuntimeError(
+-                    "The likely cause of this failure is an incompatibility "
+-                    "between `setuptools` and `numpy.distutils. "
+-                ) from exc
++        try:
++            import numpy.distutils.system_info as numpy_sys
++             # Numpy can pollute stdout with checks
++            with silent():
++                numpy_blas = numpy_sys.get_info(user_blas)
++                extension['libraries'].extend(numpy_blas.get('libraries', []))
++                extension['library_dirs'].extend(
++                    numpy_blas.get('library_dirs', []))
++        # `numpy.distutils` not present for Python >= 3.12
++        except ImportError:
++            blas = numpy.show_config('dicts')["Build Dependencies"]["blas"]
++            libblas = {'openblas64': 'openblas'}.get(blas['name'], blas['name'])
++            extension["libraries"].append(libblas)
++
+ 
+     # final macro normalization
+     extension["define_macros"] = [
+--- pythran/dist.py
++++ pythran/dist.py
+@@ -13,14 +13,17 @@ except ImportError:
+ import os.path
+ import os
+ 
+-from distutils.command.build_ext import build_ext as LegacyBuildExt
++try:
++    from distutils.command.build_ext import build_ext as LegacyBuildExt
++except ImportError:
++    from setuptools.command.build_ext import build_ext as LegacyBuildExt
+ 
+ try:
+     # `numpy.distutils` is deprecated, and won't be present on Python >=3.12
+     # If it is installed, we need to use it though, so try-import it:
+     from numpy.distutils.extension import Extension
+ except ImportError:
+-    from distutils.extension import Extension
++    from setuptools.extension import Extension
+ 
+ 
+ 
+--- requirements.txt
++++ requirements.txt
+@@ -1,4 +1,5 @@
+ ply>=3.4
++setuptools
+ gast~=0.5.0
+ numpy
+ beniget~=0.4.0
+--- pythran/toolchain.py
++++ pythran/toolchain.py
+@@ -22,13 +22,17 @@ from pythran.version import __version__
+ from pythran.utils import cxxid
+ import pythran.frontend as frontend
+ 
+-from distutils.errors import CompileError
+-from distutils import sysconfig
++try:
++    from distutils.errors import CompileError
++    from distutils import sysconfig
++except ImportError:
++    from setuptools.errors import CompileError
++    from setuptools._distutils import sysconfig
+ try:
+     # `numpy.distutils is deprecated, may not be present, or broken
+     from numpy.distutils.core import setup
+ except Exception:
+-    from distutils.core import setup
++    from setuptools import setup
+ 
+ from tempfile import mkdtemp, NamedTemporaryFile
+ import gast as ast

--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -12,13 +12,13 @@ PortGroup               legacysupport 1.1
 # __sincos https://trac.macports.org/ticket/63233
 legacysupport.newest_darwin_requires_legacy 12
 
-github.setup            scipy   scipy 1.10.1 v
+github.setup            scipy   scipy 1.11.4 v
 github.tarball_from     releases
 revision                1
 
-checksums               rmd160  a97f16d6acefbc7e52b81499d250226e0cce114d \
-                        sha256  2cf9dfb80a7b4589ba4c40ce7588986d6d5cebc5457cad2c2880f6bc2d42f3a5 \
-                        size    42407997
+checksums               rmd160  8120272e76e1065f8f6b5aaf3fa7fd450d56e4c3 \
+                        sha256  90a2b78e7f5733b9de748f589f09225013685f9b218275257f8a8168ededaeaa \
+                        size    56336202
 
 name                    py-scipy
 license                 BSD
@@ -28,8 +28,7 @@ long_description        {*}${description}
 
 homepage                https://www.scipy.org/
 
-python.versions         38 39 310 311
-python.pep517           no
+python.versions         38 39 310 311 312
 
 python.add_archflags    no
 universal_variant       no
@@ -45,6 +44,7 @@ if {${name} ne ${subport}} {
                     port:swig-python
 
     depends_lib-append \
+                    port:py${python.version}-meson-python \
                     port:py${python.version}-numpy \
                     port:py${python.version}-pybind11 \
                     port:py${python.version}-mypy
@@ -57,7 +57,7 @@ if {${name} ne ${subport}} {
     compiler.blacklist-append {clang < 900}
 
     boost.version       1.76
-    patchfiles-append   patch-allow-MP-boost.diff
+    patchfiles-append   patch-allow-MP-boost.diff patch-pyproject.toml.diff
 
     # force disable STDC THREADS from <threads.h> and instead just use __thread
     # https://trac.macports.org/ticket/62488
@@ -68,25 +68,26 @@ if {${name} ne ${subport}} {
     destroot.env-append     "CCFLAGS=-I${prefix}/include -L${prefix}/lib"
     configure.fflags-append -fno-second-underscore
 
-    build.env-append        SETUPTOOLS_USE_DISTUTILS=stdlib
-    destroot.env-append     SETUPTOOLS_USE_DISTUTILS=stdlib
-
     pre-configure {
-        set fc_options      "config_fc --fcompiler gnu95 --f77exec ${configure.f77} --f77flags='${configure.f77_archflags} ${configure.fflags}' --f90exec ${configure.f90} --f90flags='${configure.f90_archflags} ${configure.fflags}'"
-        set config_options  "config --cc ${configure.cc} --include-dirs ${prefix}/include --library-dirs ${prefix}/lib"
-        build.cmd-append    ${fc_options} ${config_options}
-        destroot.cmd-append ${fc_options} ${config_options}
-
         build.env-append    CC=${configure.cc} \
                             CXX=${configure.cxx} \
                             CFLAGS=${configure.cc_archflags} \
                             CXXFLAGS=${configure.cxx_archflags} \
-                            CPPFLAGS=${configure.cppflags}
+                            CPPFLAGS=${configure.cppflags} \
+                            FC=${configure.fc} \
+                            F77=${configure.f77} \
+                            F90=${configure.f90} \
+                            FFLAGS=${configure.f77_archflags} ${configure.fflags} \
+                            F90FLAGS=${configure.f90_archflags} ${configure.fflags} \
+                            PKG_CONFIG_PATH=${python.pkgd}/pybind11/share/pkgconfig
         destroot.env-append CC=${configure.cc} \
                             CXX=${configure.cxx} \
                             CFLAGS=${configure.cc_archflags} \
                             CXXFLAGS=${configure.cxx_archflags} \
                             CPPFLAGS=${configure.cppflags}
+
+        reinplace "s|'pythran', native: true|'pythran', native: true, dirs: \['${python.prefix}/bin'\]|g" ${worksrcpath}/meson.build
+        reinplace "s|numpy==|numpy>=|g" ${worksrcpath}/pyproject.toml
     }
 
     post-destroot {

--- a/python/py-scipy/files/patch-allow-MP-boost.diff
+++ b/python/py-scipy/files/patch-allow-MP-boost.diff
@@ -4,10 +4,10 @@
  def check_boost_submodule():
      from scipy._lib._boost_utils import _boost_dir
  
--    if not os.path.exists(_boost_dir(ret_path=True) / 'README.rst'):
+-    if not os.path.exists(_boost_dir(ret_path=True).parent / 'README.md'):
 -        raise RuntimeError("Missing the `boost` submodule! Run `git submodule "
 -                           "update --init` to fix this.")
-+    #if not os.path.exists(_boost_dir(ret_path=True) / 'README.rst'):
++    #if not os.path.exists(_boost_dir(ret_path=True).parent / 'README.md'):
 +    #    raise RuntimeError("Missing the `boost` submodule! Run `git submodule "
 +    #                       "update --init` to fix this.")
  

--- a/python/py-scipy/files/patch-pyproject.toml.diff
+++ b/python/py-scipy/files/patch-pyproject.toml.diff
@@ -1,0 +1,15 @@
+--- pyproject.toml
++++ pyproject.toml
+@@ -11,11 +11,11 @@
+ build-backend = 'mesonpy'
+ requires = [
+     # Reason for `<`: future-proofing (0.14.0 released and known to work)
+-    "meson-python>=0.12.1,<0.15.0",
++    "meson-python>=0.12.1",
+     # Reason for `<`: we want to build the 1.11.x releases with 0.29.x (too many changes in 3.0)
+     "Cython>=0.29.35,<3.0",   # when updating version, also update check in meson.build
+     # Reason for `<`: future-proofing (2.11.1 is the most recent version)
+-    "pybind11>=2.10.4,<2.11.1",
++    "pybind11>=2.10.4",
+     # Reason for `<`: future-proofing (0.14.0 released and known to work)
+     "pythran>=0.12.0,<0.15.0",


### PR DESCRIPTION
#### Description

Scipy: update to 1.11.4 and add py312 subport. The new version no longer has a setup.py, so I had to enable PEP517. A few changes were necessary because of that:
* Meson is required to build
* I had to replace the `config_fc` thing passed to setup.py with Fortran environment variables.
* The old fallback solution for finding pybind11 (import it and print the path using `python -c`) has been removed, so pkg-config must be able to find it. The `pybind11.pc` file is not found by pkg-config by default, so I had to set `PKG_CONFIG_PATH`. It is not the prettiest solution, I must admit that, but it is the only one I could come up with.
* Since py-pythran does not install the `pythran` binary on `PATH` (only `pythran-3.12`), I also had to patch `meson.build` so that Meson looks in the `bin` folder where `pythran` resides.
* The environment variable `SETUPTOOLS_USE_DISTUTILS=stdlib` only made the build fail (by making something try to import `distutils`), so I removed it. I double checked that py311 still builds.
* pyproject.toml has very strict requirements. I had to patch out the max allowed version of a couple of packages (seems to have been done on master) and also replace `numpy==` with `numpy>=` to avoid breaking all non-3.12 subports.

For this to work I also had to add a py312 subport to its depdencency Pythran, which in turn required backporting [#258ab9a](https://github.com/serge-sans-paille/pythran/commit/258ab9aaf26172f669eab1bf2a346b5f65db3ac0) from master (I skipped the test files, since they are not run by MacPorts). I believe this is uncontroversial, so I did not create a separate PR for that. This patch should be removed the next time this port is updated.
(MacPorts will install it successfully without the patch, but one quickly runs into runtime exceptions.)

Edit: I found out after submitting the PR that there is a Trac ticket that I did not see earlier (I must have misspelt the port name): https://trac.macports.org/ticket/68380

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Binaries: only Pythran has binaries. Tested indirectly by successfully building SciPy.

Variants: only SciPy has variants – a bunch of them. I only tested the default ones. I think it is overkill to compile it with ten different compilers and three different BLAS libraries that literally take hours to build from source.