### PR TITLE
py-pythran: add py312 subport

### DIFF
--- a/python/py-pythran/Portfile
+++ b/python/py-pythran/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pythran
+# Please delete Python 3.12 compatibility patch below when updating
 version             0.14.0
 revision            1
 
@@ -22,7 +23,7 @@ checksums           rmd160  e15b91c1a315cd6d18d2741db4fe98675f8de977 \
                     sha256  42f3473946205964844eff7f750e2541afb2006d53475d708f5ff2d048db89bd \
                     size    4015360
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -42,6 +43,10 @@ if {${name} ne ${subport}} {
     # https://github.com/serge-sans-paille/pythran/pull/2165
     patchfiles-append \
                     patch-xsimd_scalar.hpp-fix-for-missing-__exp10-on-macOS.diff
+
+    # Python 3.12 compatibility backported from master
+    # Please delete when updating past 0.14.0
+    patchfiles-append patch-py312-compatibility.diff
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/python/py-pythran/files/patch-py312-compatibility.diff
+++ b/python/py-pythran/files/patch-py312-compatibility.diff
@@ -1,0 +1,96 @@
+--- pythran/config.py
++++ pythran/config.py
+@@ -246,26 +246,20 @@ def make_extension(python, **extra):
+         extension['define_macros'].append('PYTHRAN_BLAS_NONE')
+ 
+     if user_blas not in reserved_blas_entries:
+-        if sys.version_info < (3, 12):
+-            # `numpy.distutils` not present for Python >= 3.12
+-            try:
+-                import numpy.distutils.system_info as numpy_sys
+-                 # Numpy can pollute stdout with checks
+-                with silent():
+-                    numpy_blas = numpy_sys.get_info(user_blas)
+-                    # required to cope with atlas missing extern "C"
+-                    extension['define_macros'].append('PYTHRAN_BLAS_{}'
+-                                                      .format(user_blas.upper()))
+-                    extension['libraries'].extend(numpy_blas.get('libraries', []))
+-                    extension['library_dirs'].extend(
+-                        numpy_blas.get('library_dirs', []))
+-                    extension['include_dirs'].extend(
+-                        numpy_blas.get('include_dirs', []))
+-            except Exception as exc:
+-                raise RuntimeError(
+-                    "The likely cause of this failure is an incompatibility "
+-                    "between `setuptools` and `numpy.distutils. "
+-                ) from exc
++        try:
++            import numpy.distutils.system_info as numpy_sys
++             # Numpy can pollute stdout with checks
++            with silent():
++                numpy_blas = numpy_sys.get_info(user_blas)
++                extension['libraries'].extend(numpy_blas.get('libraries', []))
++                extension['library_dirs'].extend(
++                    numpy_blas.get('library_dirs', []))
++        # `numpy.distutils` not present for Python >= 3.12
++        except ImportError:
++            blas = numpy.show_config('dicts')["Build Dependencies"]["blas"]
++            libblas = {'openblas64': 'openblas'}.get(blas['name'], blas['name'])
++            extension["libraries"].append(libblas)
++
+ 
+     # final macro normalization
+     extension["define_macros"] = [
+--- pythran/dist.py
++++ pythran/dist.py
+@@ -13,14 +13,17 @@ except ImportError:
+ import os.path
+ import os
+ 
+-from distutils.command.build_ext import build_ext as LegacyBuildExt
++try:
++    from distutils.command.build_ext import build_ext as LegacyBuildExt
++except ImportError:
++    from setuptools.command.build_ext import build_ext as LegacyBuildExt
+ 
+ try:
+     # `numpy.distutils` is deprecated, and won't be present on Python >=3.12
+     # If it is installed, we need to use it though, so try-import it:
+     from numpy.distutils.extension import Extension
+ except ImportError:
+-    from distutils.extension import Extension
++    from setuptools.extension import Extension
+ 
+ 
+ 
+--- requirements.txt
++++ requirements.txt
+@@ -1,4 +1,5 @@
+ ply>=3.4
++setuptools
+ gast~=0.5.0
+ numpy
+ beniget~=0.4.0
+--- pythran/toolchain.py
++++ pythran/toolchain.py
+@@ -22,13 +22,17 @@ from pythran.version import __version__
+ from pythran.utils import cxxid
+ import pythran.frontend as frontend
+ 
+-from distutils.errors import CompileError
+-from distutils import sysconfig
++try:
++    from distutils.errors import CompileError
++    from distutils import sysconfig
++except ImportError:
++    from setuptools.errors import CompileError
++    from setuptools._distutils import sysconfig
+ try:
+     # `numpy.distutils is deprecated, may not be present, or broken
+     from numpy.distutils.core import setup
+ except Exception:
+-    from distutils.core import setup
++    from setuptools import setup
+ 
+ from tempfile import mkdtemp, NamedTemporaryFile
+ import gast as ast


### PR DESCRIPTION
#### Description

Backporting [#258ab9a](https://github.com/serge-sans-paille/pythran/commit/258ab9aaf26172f669eab1bf2a346b5f65db3ac0) from master (I skipped the test files, since they are not run by MacPorts). MacPorts will install the py312 subport successfully without this patch, but one quickly runs into runtime exceptions. It should be removed the next time the port version is updated.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Testing the binaries: I tested the binary indirectly by successfully building SciPy with it.
