### PR TITLE
groovy: update to 4.0.17

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         4.0.16
+version         4.0.17
 revision        0
 
 categories      lang java
@@ -41,9 +41,9 @@ master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zi
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  d2cba0ba34ac6ddc5c7995df0c59453062cb7eeb \
-                sha256  b8c3bec88a3f5a62235d9429a97e371032bf7216f3e28724823a9169dd10befc \
-                size    29793704
+checksums       rmd160  e1259f6ea48c9df27c3321163124f165e30c8752 \
+                sha256  05d8fc8f3c3c583850fc7f46c235ca4c8b58024ec8d9d7c16f72548a2b2b5430 \
+                size    32712516
 
 worksrcdir      ${name}-${version}
 


### PR DESCRIPTION
#### Description

Update to Groovy 4.0.17.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?