### PR TITLE
libb64: update to 1.2.1

### DIFF
--- a/mail/libb64/Portfile
+++ b/mail/libb64/Portfile
@@ -1,11 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
+PortGroup       makefile 1.0
 
 name            libb64
-version         1.1
+version         1.2.1
 categories      mail net
 license         Permissive
+
+conflicts       base64
+
 maintainers     nomaintainer
 description     C library for fast encoding/decoding into and from base64
 long_description \
@@ -15,17 +19,18 @@ long_description \
 
 homepage        https://libb64.sourceforge.net
 master_sites    sourceforge
-distname        ${distname}.src
-checksums       md5 bd4e95e62f2dd8a220503e0bf5a2dfad
+checksums       rmd160  4d830ddfce762c3ca6f441c5c2dca5326d072bd7 \
+                sha256  20106f0ba95cfd9c35a13c71206643e3fb3e46512df3e2efb2fdbf87116314b2 \
+                size    23316
 
-worksrcdir      ${name}
+use_zip         yes
 
-use_configure   no
+patchfiles      patch-no-examples.diff
+
+use_parallel_build  no
 
 destroot {
-    xinstall -m 755 -W ${worksrcpath}/src b64dec b64enc decoder encoder \
-        ${destroot}${prefix}/bin
-    xinstall -m 644 ${worksrcpath}/src/libb64.a \
-        ${destroot}${prefix}/lib
+    xinstall -m 755 ${worksrcpath}/base64/base64 ${destroot}${prefix}/bin
+    xinstall -m 644 ${worksrcpath}/src/libb64.a ${destroot}${prefix}/lib
     file copy ${worksrcpath}/include/b64 ${destroot}${prefix}/include
 }

--- a/mail/libb64/Portfile
+++ b/mail/libb64/Portfile
@@ -1,31 +1,31 @@
-PortSystem 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
-name			libb64
-version			1.1
-categories		mail
-platforms		darwin
-license			Permissive
-maintainers		nomaintainer
-description		C library for fast encoding/decoding into and from base64
-long_description	\
-libb64 is a library of ANSI C routines for fast encoding/decoding data into \
-and from a base64-encoded format. C++ wrappers are included, as well as the \
-source code for standalone encoding and decoding executables.
+PortSystem      1.0
 
-homepage		http://libb64.sourceforge.net/
-master_sites	sourceforge
-distname		${distname}.src
-checksums		md5 bd4e95e62f2dd8a220503e0bf5a2dfad
+name            libb64
+version         1.1
+categories      mail net
+license         Permissive
+maintainers     nomaintainer
+description     C library for fast encoding/decoding into and from base64
+long_description \
+                libb64 is a library of ANSI C routines for fast encoding/decoding data \
+                into and from a base64-encoded format. C++ wrappers are included, \
+                as well as the source code for standalone encoding and decoding executables.
 
-worksrcdir		${name}
+homepage        https://libb64.sourceforge.net
+master_sites    sourceforge
+distname        ${distname}.src
+checksums       md5 bd4e95e62f2dd8a220503e0bf5a2dfad
 
-use_configure	no
+worksrcdir      ${name}
+
+use_configure   no
 
 destroot {
-	xinstall -m 755 -W ${worksrcpath}/src b64dec b64enc decoder encoder \
-		${destroot}${prefix}/bin
-	xinstall -m 644 ${worksrcpath}/src/libb64.a \
-		${destroot}${prefix}/lib
-	file copy ${worksrcpath}/include/b64 ${destroot}${prefix}/include
+    xinstall -m 755 -W ${worksrcpath}/src b64dec b64enc decoder encoder \
+        ${destroot}${prefix}/bin
+    xinstall -m 644 ${worksrcpath}/src/libb64.a \
+        ${destroot}${prefix}/lib
+    file copy ${worksrcpath}/include/b64 ${destroot}${prefix}/include
 }
-

--- a/mail/libb64/files/patch-no-examples.diff
+++ b/mail/libb64/files/patch-no-examples.diff
@@ -1,0 +1,8 @@
+--- Makefile	2013-06-18 20:49:36
++++ Makefile	2023-12-23 19:37:13
+@@ -1,4 +1,4 @@
+-all: all_src all_base64 all_examples
++all: all_src all_base64
+ 
+ all_src:
+ 	$(MAKE) -C src


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
