### PR TITLE
py-pysam: update to 0.22.0

### DIFF
--- a/python/py-pysam/Portfile
+++ b/python/py-pysam/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pysam
-version             0.19.0
+version             0.22.0
 revision            0
 
 categories-append   science
@@ -18,18 +18,16 @@ long_description    Pysam is a python module for reading and manipulating \
 
 homepage            https://github.com/pysam-developers/pysam
 
-checksums           rmd160  b01dae25f1e6306788555330e52b02a07ccf0a61 \
-                    sha256  dcc052566f9509fd93b2a2664f094a13f016fd60cdd189e05fb4eafa0c89505b \
-                    size    3843661
+checksums           md5 f5f8abbff6ba5bfdc15336d89c217f5a \
+                    rmd160 3b682310be843f9d72b96e65b82772d29bc5a7f3 \
+                    sha256 ab7a46973cf0ab8c6ac327f4c3fb67698d7ccbeef8631a716898c6ba01ef3e45 \
+                    size   4631254
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-setuptools \
                     port:py${python.version}-cython
-
-    use_parallel_build  no
 
     depends_lib-append  port:htslib
 


### PR DESCRIPTION
Also add py311 and py312 subports. Now compatible with Cython 3.
