### PR TITLE
libplacebo: provide fallback version for old systems

### DIFF
--- a/devel/libplacebo/Portfile
+++ b/devel/libplacebo/Portfile
@@ -21,10 +21,22 @@ checksums               rmd160  f9d4bd9d95cb62c4af47afd0e5a0d1eaf3270896 \
                         sha256  51324e1550b0c78eb5960ea6f23d8b36c0a418eab30b98a46db34bc3c2c86f5d \
                         size    840851
 
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # For now, due to: https://trac.macports.org/ticket/68962
+    github.setup        haasn libplacebo 5.264.1 v
+    checksums           rmd160  06f222bcd4147881bffb5837cd00a63e940260ef \
+                        sha256  47dac5926da6e0682ea545536ea143b7bba3eef139c9b96606c8f1fb44404c5f \
+                        size    725437
+} else {
+    depends_lib-append  port:xxhashlib
+
+    configure.args-append \
+                        -Dxxhash=enabled
+}
+
 depends_build-append    port:fast-float \
                         port:pkgconfig
-depends_lib-append      port:lcms2 \
-                        port:xxhashlib
+depends_lib-append      port:lcms2
 
 configure.args-append   -Dvulkan=disabled \
                         -Dopengl=disabled \
@@ -35,7 +47,6 @@ configure.args-append   -Dvulkan=disabled \
                         -Ddemos=false \
                         -Dtests=false \
                         -Dglslang=disabled \
-                        -Dxxhash=enabled \
                         -Dlcms=enabled \
                         -Dunwind=disabled
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68962

P. S. This does not help us to fix `mpv` 0.37.0, but it is broken for several other reasons anyway.

UPD. Pause this until `legacysupport` issue is investigated. This may not fix PowerPC, but might fix 10.6 x86.

#### Description

Add a fallback.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
