### PR TITLE
py-prompt_toolkit: update to 3.0.43

### DIFF
--- a/python/py-prompt_toolkit/Portfile
+++ b/python/py-prompt_toolkit/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-prompt_toolkit
-version             3.0.38
+version             3.0.43
 revision            0
 
 license             BSD
@@ -18,9 +18,9 @@ python.versions     27 37 38 39 310 311 312
 
 homepage            https://github.com/prompt-toolkit/python-prompt-toolkit
 
-checksums           rmd160  a80667eab9baa4d84e4dbe41c0da9679d529c628 \
-                    sha256  23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b \
-                    size    422834
+checksums           rmd160  b61f192b100dd0ad9b229adf10a70453a1246783 \
+                    sha256  3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d \
+                    size    425733
 
 if {${name} ne ${subport}} {
     if {${python.version} eq 27} {


### PR DESCRIPTION
#### Description

Update to prompt_toolkit 3.0.43.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?