### PR TITLE
osxphotos: update to 0.67.0

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.66.0
+version                 0.67.0
 revision                0
 
 categories              graphics python
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  d605827f76d919aadebe19aefb152dfb77f3757c \
-                        sha256  04cd5c4d1d549eb4fd67d2aed07bfce89e079ac78462645fe8c4595eba954f0f \
-                        size    2061210
+checksums               rmd160  024a3cc6bf136269ca36a09bfcd1ee268f0b8036 \
+                        sha256  a963d18321b2027ba682b8717510b919e01245005b8746d8ad423f57a57b6a84 \
+                        size    2083318
 
 python.default_version  311
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.67.0.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?