### PR TITLE
py-pyobjc: update to 10.1, remove py37, support 10.9

### DIFF
--- a/python/py-pyobjc/Portfile
+++ b/python/py-pyobjc/Portfile
@@ -3,20 +3,22 @@
 PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        ronaldoussoren pyobjc 9.0.1 v
+github.setup        ronaldoussoren pyobjc 10.1 v
 revision            0
 
-checksums           rmd160  48c007d79cc79ae59ca9cb64820b0682a9a94341 \
-                    sha256  3c09850f383c7a3a6141b961a8ce14df5fe45502624cf9f26bd333f831b76d43 \
-                    size    20026079
+checksums           rmd160  4ed3e4de68817e52920dc72bc9d2a3e667c56b80 \
+                    sha256  079c59f41c75c36fbbbc9b72f49b6afdaeedbc503f6263c9c8d7542303d93c89 \
+                    size    25557538
 
 name                py-pyobjc
 categories-append   devel
 license             MIT
 maintainers         openmaintainer {danchr @danchr}
-# https://trac.macports.org/ticket/67338
-platforms           {darwin >= 18}
+
+# https://pyobjc.readthedocs.io/en/latest/install.html
+platforms           {darwin >= 13}
 
 description         bidirectional bridge between python and Objective C
 long_description    The PyObjC project aims to provide a bridge between \
@@ -28,7 +30,7 @@ long_description    The PyObjC project aims to provide a bridge between \
                     Python based functionality.
 homepage            https://pyobjc.readthedocs.io
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append \
@@ -50,6 +52,9 @@ if {${name} ne ${subport}} {
         depends_lib-append \
                     port:libffi
     }
+
+    use_xcode                  yes
+    compiler.blacklist-append  {clang < 900}
 
     post-patch {
         reinplace \
@@ -76,7 +81,12 @@ if {${name} ne ${subport}} {
     }
 
     if {${configure.sdkroot} eq ""} {
-        set sdkroot "/"
+        if {${os.platform} eq "darwin" && ${os.major} == 13} {
+            # Fix for 10.9: use SIMD headers from 10.10 SDK
+            set sdkroot "${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk"
+        } else {
+            set sdkroot "/"
+        }
     } else {
         set sdkroot ${configure.sdkroot}
     }

--- a/python/py-pyobjc/files/patch-setup-no-werror.diff
+++ b/python/py-pyobjc/files/patch-setup-no-werror.diff
@@ -1,7 +1,7 @@
 diff --git pyobjc-core/Tools/pyobjc_setup.py pyobjc-core/Tools/pyobjc_setup.py
 --- pyobjc-core/Tools/pyobjc_setup.py
 +++ pyobjc-core/Tools/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -25,7 +25,7 @@ diff --git pyobjc-core/setup.py pyobjc-core/setup.py
 diff --git pyobjc-framework-AVFoundation/pyobjc_setup.py pyobjc-framework-AVFoundation/pyobjc_setup.py
 --- pyobjc-framework-AVFoundation/pyobjc_setup.py
 +++ pyobjc-framework-AVFoundation/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -38,7 +38,7 @@ diff --git pyobjc-framework-AVFoundation/pyobjc_setup.py pyobjc-framework-AVFoun
 diff --git pyobjc-framework-AVKit/pyobjc_setup.py pyobjc-framework-AVKit/pyobjc_setup.py
 --- pyobjc-framework-AVKit/pyobjc_setup.py
 +++ pyobjc-framework-AVKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -51,7 +51,7 @@ diff --git pyobjc-framework-AVKit/pyobjc_setup.py pyobjc-framework-AVKit/pyobjc_
 diff --git pyobjc-framework-AVRouting/pyobjc_setup.py pyobjc-framework-AVRouting/pyobjc_setup.py
 --- pyobjc-framework-AVRouting/pyobjc_setup.py
 +++ pyobjc-framework-AVRouting/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -64,7 +64,7 @@ diff --git pyobjc-framework-AVRouting/pyobjc_setup.py pyobjc-framework-AVRouting
 diff --git pyobjc-framework-Accessibility/pyobjc_setup.py pyobjc-framework-Accessibility/pyobjc_setup.py
 --- pyobjc-framework-Accessibility/pyobjc_setup.py
 +++ pyobjc-framework-Accessibility/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -77,7 +77,7 @@ diff --git pyobjc-framework-Accessibility/pyobjc_setup.py pyobjc-framework-Acces
 diff --git pyobjc-framework-Accounts/pyobjc_setup.py pyobjc-framework-Accounts/pyobjc_setup.py
 --- pyobjc-framework-Accounts/pyobjc_setup.py
 +++ pyobjc-framework-Accounts/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -90,7 +90,7 @@ diff --git pyobjc-framework-Accounts/pyobjc_setup.py pyobjc-framework-Accounts/p
 diff --git pyobjc-framework-AdServices/pyobjc_setup.py pyobjc-framework-AdServices/pyobjc_setup.py
 --- pyobjc-framework-AdServices/pyobjc_setup.py
 +++ pyobjc-framework-AdServices/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -103,7 +103,7 @@ diff --git pyobjc-framework-AdServices/pyobjc_setup.py pyobjc-framework-AdServic
 diff --git pyobjc-framework-AdSupport/pyobjc_setup.py pyobjc-framework-AdSupport/pyobjc_setup.py
 --- pyobjc-framework-AdSupport/pyobjc_setup.py
 +++ pyobjc-framework-AdSupport/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -116,7 +116,7 @@ diff --git pyobjc-framework-AdSupport/pyobjc_setup.py pyobjc-framework-AdSupport
 diff --git pyobjc-framework-AddressBook/pyobjc_setup.py pyobjc-framework-AddressBook/pyobjc_setup.py
 --- pyobjc-framework-AddressBook/pyobjc_setup.py
 +++ pyobjc-framework-AddressBook/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -129,7 +129,7 @@ diff --git pyobjc-framework-AddressBook/pyobjc_setup.py pyobjc-framework-Address
 diff --git pyobjc-framework-AppTrackingTransparency/pyobjc_setup.py pyobjc-framework-AppTrackingTransparency/pyobjc_setup.py
 --- pyobjc-framework-AppTrackingTransparency/pyobjc_setup.py
 +++ pyobjc-framework-AppTrackingTransparency/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -142,7 +142,7 @@ diff --git pyobjc-framework-AppTrackingTransparency/pyobjc_setup.py pyobjc-frame
 diff --git pyobjc-framework-AppleScriptKit/pyobjc_setup.py pyobjc-framework-AppleScriptKit/pyobjc_setup.py
 --- pyobjc-framework-AppleScriptKit/pyobjc_setup.py
 +++ pyobjc-framework-AppleScriptKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -155,7 +155,7 @@ diff --git pyobjc-framework-AppleScriptKit/pyobjc_setup.py pyobjc-framework-Appl
 diff --git pyobjc-framework-AppleScriptObjC/pyobjc_setup.py pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
 --- pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
 +++ pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -168,7 +168,7 @@ diff --git pyobjc-framework-AppleScriptObjC/pyobjc_setup.py pyobjc-framework-App
 diff --git pyobjc-framework-ApplicationServices/pyobjc_setup.py pyobjc-framework-ApplicationServices/pyobjc_setup.py
 --- pyobjc-framework-ApplicationServices/pyobjc_setup.py
 +++ pyobjc-framework-ApplicationServices/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -181,7 +181,7 @@ diff --git pyobjc-framework-ApplicationServices/pyobjc_setup.py pyobjc-framework
 diff --git pyobjc-framework-AudioVideoBridging/pyobjc_setup.py pyobjc-framework-AudioVideoBridging/pyobjc_setup.py
 --- pyobjc-framework-AudioVideoBridging/pyobjc_setup.py
 +++ pyobjc-framework-AudioVideoBridging/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -194,7 +194,7 @@ diff --git pyobjc-framework-AudioVideoBridging/pyobjc_setup.py pyobjc-framework-
 diff --git pyobjc-framework-AuthenticationServices/pyobjc_setup.py pyobjc-framework-AuthenticationServices/pyobjc_setup.py
 --- pyobjc-framework-AuthenticationServices/pyobjc_setup.py
 +++ pyobjc-framework-AuthenticationServices/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -207,7 +207,7 @@ diff --git pyobjc-framework-AuthenticationServices/pyobjc_setup.py pyobjc-framew
 diff --git pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
 --- pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
 +++ pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -220,7 +220,7 @@ diff --git pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py pyo
 diff --git pyobjc-framework-Automator/pyobjc_setup.py pyobjc-framework-Automator/pyobjc_setup.py
 --- pyobjc-framework-Automator/pyobjc_setup.py
 +++ pyobjc-framework-Automator/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -233,7 +233,7 @@ diff --git pyobjc-framework-Automator/pyobjc_setup.py pyobjc-framework-Automator
 diff --git pyobjc-framework-BackgroundAssets/pyobjc_setup.py pyobjc-framework-BackgroundAssets/pyobjc_setup.py
 --- pyobjc-framework-BackgroundAssets/pyobjc_setup.py
 +++ pyobjc-framework-BackgroundAssets/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -246,7 +246,7 @@ diff --git pyobjc-framework-BackgroundAssets/pyobjc_setup.py pyobjc-framework-Ba
 diff --git pyobjc-framework-BusinessChat/pyobjc_setup.py pyobjc-framework-BusinessChat/pyobjc_setup.py
 --- pyobjc-framework-BusinessChat/pyobjc_setup.py
 +++ pyobjc-framework-BusinessChat/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -259,7 +259,7 @@ diff --git pyobjc-framework-BusinessChat/pyobjc_setup.py pyobjc-framework-Busine
 diff --git pyobjc-framework-CFNetwork/pyobjc_setup.py pyobjc-framework-CFNetwork/pyobjc_setup.py
 --- pyobjc-framework-CFNetwork/pyobjc_setup.py
 +++ pyobjc-framework-CFNetwork/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -272,7 +272,7 @@ diff --git pyobjc-framework-CFNetwork/pyobjc_setup.py pyobjc-framework-CFNetwork
 diff --git pyobjc-framework-CalendarStore/pyobjc_setup.py pyobjc-framework-CalendarStore/pyobjc_setup.py
 --- pyobjc-framework-CalendarStore/pyobjc_setup.py
 +++ pyobjc-framework-CalendarStore/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -285,7 +285,7 @@ diff --git pyobjc-framework-CalendarStore/pyobjc_setup.py pyobjc-framework-Calen
 diff --git pyobjc-framework-CallKit/pyobjc_setup.py pyobjc-framework-CallKit/pyobjc_setup.py
 --- pyobjc-framework-CallKit/pyobjc_setup.py
 +++ pyobjc-framework-CallKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -298,7 +298,7 @@ diff --git pyobjc-framework-CallKit/pyobjc_setup.py pyobjc-framework-CallKit/pyo
 diff --git pyobjc-framework-ClassKit/pyobjc_setup.py pyobjc-framework-ClassKit/pyobjc_setup.py
 --- pyobjc-framework-ClassKit/pyobjc_setup.py
 +++ pyobjc-framework-ClassKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -311,7 +311,7 @@ diff --git pyobjc-framework-ClassKit/pyobjc_setup.py pyobjc-framework-ClassKit/p
 diff --git pyobjc-framework-CloudKit/pyobjc_setup.py pyobjc-framework-CloudKit/pyobjc_setup.py
 --- pyobjc-framework-CloudKit/pyobjc_setup.py
 +++ pyobjc-framework-CloudKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -324,7 +324,7 @@ diff --git pyobjc-framework-CloudKit/pyobjc_setup.py pyobjc-framework-CloudKit/p
 diff --git pyobjc-framework-Cocoa/pyobjc_setup.py pyobjc-framework-Cocoa/pyobjc_setup.py
 --- pyobjc-framework-Cocoa/pyobjc_setup.py
 +++ pyobjc-framework-Cocoa/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -337,7 +337,7 @@ diff --git pyobjc-framework-Cocoa/pyobjc_setup.py pyobjc-framework-Cocoa/pyobjc_
 diff --git pyobjc-framework-Collaboration/pyobjc_setup.py pyobjc-framework-Collaboration/pyobjc_setup.py
 --- pyobjc-framework-Collaboration/pyobjc_setup.py
 +++ pyobjc-framework-Collaboration/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -350,7 +350,7 @@ diff --git pyobjc-framework-Collaboration/pyobjc_setup.py pyobjc-framework-Colla
 diff --git pyobjc-framework-ColorSync/pyobjc_setup.py pyobjc-framework-ColorSync/pyobjc_setup.py
 --- pyobjc-framework-ColorSync/pyobjc_setup.py
 +++ pyobjc-framework-ColorSync/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -363,7 +363,7 @@ diff --git pyobjc-framework-ColorSync/pyobjc_setup.py pyobjc-framework-ColorSync
 diff --git pyobjc-framework-Contacts/pyobjc_setup.py pyobjc-framework-Contacts/pyobjc_setup.py
 --- pyobjc-framework-Contacts/pyobjc_setup.py
 +++ pyobjc-framework-Contacts/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -376,7 +376,7 @@ diff --git pyobjc-framework-Contacts/pyobjc_setup.py pyobjc-framework-Contacts/p
 diff --git pyobjc-framework-ContactsUI/pyobjc_setup.py pyobjc-framework-ContactsUI/pyobjc_setup.py
 --- pyobjc-framework-ContactsUI/pyobjc_setup.py
 +++ pyobjc-framework-ContactsUI/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -389,7 +389,7 @@ diff --git pyobjc-framework-ContactsUI/pyobjc_setup.py pyobjc-framework-Contacts
 diff --git pyobjc-framework-CoreAudio/pyobjc_setup.py pyobjc-framework-CoreAudio/pyobjc_setup.py
 --- pyobjc-framework-CoreAudio/pyobjc_setup.py
 +++ pyobjc-framework-CoreAudio/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -402,7 +402,7 @@ diff --git pyobjc-framework-CoreAudio/pyobjc_setup.py pyobjc-framework-CoreAudio
 diff --git pyobjc-framework-CoreAudioKit/pyobjc_setup.py pyobjc-framework-CoreAudioKit/pyobjc_setup.py
 --- pyobjc-framework-CoreAudioKit/pyobjc_setup.py
 +++ pyobjc-framework-CoreAudioKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -415,7 +415,7 @@ diff --git pyobjc-framework-CoreAudioKit/pyobjc_setup.py pyobjc-framework-CoreAu
 diff --git pyobjc-framework-CoreBluetooth/pyobjc_setup.py pyobjc-framework-CoreBluetooth/pyobjc_setup.py
 --- pyobjc-framework-CoreBluetooth/pyobjc_setup.py
 +++ pyobjc-framework-CoreBluetooth/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -428,7 +428,7 @@ diff --git pyobjc-framework-CoreBluetooth/pyobjc_setup.py pyobjc-framework-CoreB
 diff --git pyobjc-framework-CoreData/pyobjc_setup.py pyobjc-framework-CoreData/pyobjc_setup.py
 --- pyobjc-framework-CoreData/pyobjc_setup.py
 +++ pyobjc-framework-CoreData/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -441,7 +441,7 @@ diff --git pyobjc-framework-CoreData/pyobjc_setup.py pyobjc-framework-CoreData/p
 diff --git pyobjc-framework-CoreHaptics/pyobjc_setup.py pyobjc-framework-CoreHaptics/pyobjc_setup.py
 --- pyobjc-framework-CoreHaptics/pyobjc_setup.py
 +++ pyobjc-framework-CoreHaptics/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -454,7 +454,7 @@ diff --git pyobjc-framework-CoreHaptics/pyobjc_setup.py pyobjc-framework-CoreHap
 diff --git pyobjc-framework-CoreLocation/pyobjc_setup.py pyobjc-framework-CoreLocation/pyobjc_setup.py
 --- pyobjc-framework-CoreLocation/pyobjc_setup.py
 +++ pyobjc-framework-CoreLocation/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -467,7 +467,7 @@ diff --git pyobjc-framework-CoreLocation/pyobjc_setup.py pyobjc-framework-CoreLo
 diff --git pyobjc-framework-CoreMIDI/pyobjc_setup.py pyobjc-framework-CoreMIDI/pyobjc_setup.py
 --- pyobjc-framework-CoreMIDI/pyobjc_setup.py
 +++ pyobjc-framework-CoreMIDI/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -480,7 +480,7 @@ diff --git pyobjc-framework-CoreMIDI/pyobjc_setup.py pyobjc-framework-CoreMIDI/p
 diff --git pyobjc-framework-CoreML/pyobjc_setup.py pyobjc-framework-CoreML/pyobjc_setup.py
 --- pyobjc-framework-CoreML/pyobjc_setup.py
 +++ pyobjc-framework-CoreML/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -493,7 +493,7 @@ diff --git pyobjc-framework-CoreML/pyobjc_setup.py pyobjc-framework-CoreML/pyobj
 diff --git pyobjc-framework-CoreMedia/pyobjc_setup.py pyobjc-framework-CoreMedia/pyobjc_setup.py
 --- pyobjc-framework-CoreMedia/pyobjc_setup.py
 +++ pyobjc-framework-CoreMedia/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -506,7 +506,7 @@ diff --git pyobjc-framework-CoreMedia/pyobjc_setup.py pyobjc-framework-CoreMedia
 diff --git pyobjc-framework-CoreMediaIO/pyobjc_setup.py pyobjc-framework-CoreMediaIO/pyobjc_setup.py
 --- pyobjc-framework-CoreMediaIO/pyobjc_setup.py
 +++ pyobjc-framework-CoreMediaIO/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -519,7 +519,7 @@ diff --git pyobjc-framework-CoreMediaIO/pyobjc_setup.py pyobjc-framework-CoreMed
 diff --git pyobjc-framework-CoreMotion/pyobjc_setup.py pyobjc-framework-CoreMotion/pyobjc_setup.py
 --- pyobjc-framework-CoreMotion/pyobjc_setup.py
 +++ pyobjc-framework-CoreMotion/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -532,7 +532,7 @@ diff --git pyobjc-framework-CoreMotion/pyobjc_setup.py pyobjc-framework-CoreMoti
 diff --git pyobjc-framework-CoreServices/pyobjc_setup.py pyobjc-framework-CoreServices/pyobjc_setup.py
 --- pyobjc-framework-CoreServices/pyobjc_setup.py
 +++ pyobjc-framework-CoreServices/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -545,7 +545,7 @@ diff --git pyobjc-framework-CoreServices/pyobjc_setup.py pyobjc-framework-CoreSe
 diff --git pyobjc-framework-CoreSpotlight/pyobjc_setup.py pyobjc-framework-CoreSpotlight/pyobjc_setup.py
 --- pyobjc-framework-CoreSpotlight/pyobjc_setup.py
 +++ pyobjc-framework-CoreSpotlight/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -558,7 +558,7 @@ diff --git pyobjc-framework-CoreSpotlight/pyobjc_setup.py pyobjc-framework-CoreS
 diff --git pyobjc-framework-CoreText/pyobjc_setup.py pyobjc-framework-CoreText/pyobjc_setup.py
 --- pyobjc-framework-CoreText/pyobjc_setup.py
 +++ pyobjc-framework-CoreText/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -571,7 +571,7 @@ diff --git pyobjc-framework-CoreText/pyobjc_setup.py pyobjc-framework-CoreText/p
 diff --git pyobjc-framework-CoreWLAN/pyobjc_setup.py pyobjc-framework-CoreWLAN/pyobjc_setup.py
 --- pyobjc-framework-CoreWLAN/pyobjc_setup.py
 +++ pyobjc-framework-CoreWLAN/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -584,7 +584,7 @@ diff --git pyobjc-framework-CoreWLAN/pyobjc_setup.py pyobjc-framework-CoreWLAN/p
 diff --git pyobjc-framework-CryptoTokenKit/pyobjc_setup.py pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
 --- pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
 +++ pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -597,7 +597,7 @@ diff --git pyobjc-framework-CryptoTokenKit/pyobjc_setup.py pyobjc-framework-Cryp
 diff --git pyobjc-framework-DVDPlayback/pyobjc_setup.py pyobjc-framework-DVDPlayback/pyobjc_setup.py
 --- pyobjc-framework-DVDPlayback/pyobjc_setup.py
 +++ pyobjc-framework-DVDPlayback/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -610,7 +610,7 @@ diff --git pyobjc-framework-DVDPlayback/pyobjc_setup.py pyobjc-framework-DVDPlay
 diff --git pyobjc-framework-DataDetection/pyobjc_setup.py pyobjc-framework-DataDetection/pyobjc_setup.py
 --- pyobjc-framework-DataDetection/pyobjc_setup.py
 +++ pyobjc-framework-DataDetection/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -623,7 +623,7 @@ diff --git pyobjc-framework-DataDetection/pyobjc_setup.py pyobjc-framework-DataD
 diff --git pyobjc-framework-DeviceCheck/pyobjc_setup.py pyobjc-framework-DeviceCheck/pyobjc_setup.py
 --- pyobjc-framework-DeviceCheck/pyobjc_setup.py
 +++ pyobjc-framework-DeviceCheck/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -636,7 +636,7 @@ diff --git pyobjc-framework-DeviceCheck/pyobjc_setup.py pyobjc-framework-DeviceC
 diff --git pyobjc-framework-DictionaryServices/pyobjc_setup.py pyobjc-framework-DictionaryServices/pyobjc_setup.py
 --- pyobjc-framework-DictionaryServices/pyobjc_setup.py
 +++ pyobjc-framework-DictionaryServices/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -649,7 +649,7 @@ diff --git pyobjc-framework-DictionaryServices/pyobjc_setup.py pyobjc-framework-
 diff --git pyobjc-framework-DiscRecording/pyobjc_setup.py pyobjc-framework-DiscRecording/pyobjc_setup.py
 --- pyobjc-framework-DiscRecording/pyobjc_setup.py
 +++ pyobjc-framework-DiscRecording/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -662,7 +662,7 @@ diff --git pyobjc-framework-DiscRecording/pyobjc_setup.py pyobjc-framework-DiscR
 diff --git pyobjc-framework-DiscRecordingUI/pyobjc_setup.py pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
 --- pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
 +++ pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -675,7 +675,7 @@ diff --git pyobjc-framework-DiscRecordingUI/pyobjc_setup.py pyobjc-framework-Dis
 diff --git pyobjc-framework-DiskArbitration/pyobjc_setup.py pyobjc-framework-DiskArbitration/pyobjc_setup.py
 --- pyobjc-framework-DiskArbitration/pyobjc_setup.py
 +++ pyobjc-framework-DiskArbitration/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -688,7 +688,7 @@ diff --git pyobjc-framework-DiskArbitration/pyobjc_setup.py pyobjc-framework-Dis
 diff --git pyobjc-framework-EventKit/pyobjc_setup.py pyobjc-framework-EventKit/pyobjc_setup.py
 --- pyobjc-framework-EventKit/pyobjc_setup.py
 +++ pyobjc-framework-EventKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -701,7 +701,7 @@ diff --git pyobjc-framework-EventKit/pyobjc_setup.py pyobjc-framework-EventKit/p
 diff --git pyobjc-framework-ExceptionHandling/pyobjc_setup.py pyobjc-framework-ExceptionHandling/pyobjc_setup.py
 --- pyobjc-framework-ExceptionHandling/pyobjc_setup.py
 +++ pyobjc-framework-ExceptionHandling/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -714,7 +714,7 @@ diff --git pyobjc-framework-ExceptionHandling/pyobjc_setup.py pyobjc-framework-E
 diff --git pyobjc-framework-ExecutionPolicy/pyobjc_setup.py pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
 --- pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
 +++ pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -727,7 +727,7 @@ diff --git pyobjc-framework-ExecutionPolicy/pyobjc_setup.py pyobjc-framework-Exe
 diff --git pyobjc-framework-ExtensionKit/pyobjc_setup.py pyobjc-framework-ExtensionKit/pyobjc_setup.py
 --- pyobjc-framework-ExtensionKit/pyobjc_setup.py
 +++ pyobjc-framework-ExtensionKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -740,7 +740,7 @@ diff --git pyobjc-framework-ExtensionKit/pyobjc_setup.py pyobjc-framework-Extens
 diff --git pyobjc-framework-ExternalAccessory/pyobjc_setup.py pyobjc-framework-ExternalAccessory/pyobjc_setup.py
 --- pyobjc-framework-ExternalAccessory/pyobjc_setup.py
 +++ pyobjc-framework-ExternalAccessory/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -753,7 +753,7 @@ diff --git pyobjc-framework-ExternalAccessory/pyobjc_setup.py pyobjc-framework-E
 diff --git pyobjc-framework-FSEvents/pyobjc_setup.py pyobjc-framework-FSEvents/pyobjc_setup.py
 --- pyobjc-framework-FSEvents/pyobjc_setup.py
 +++ pyobjc-framework-FSEvents/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -766,7 +766,7 @@ diff --git pyobjc-framework-FSEvents/pyobjc_setup.py pyobjc-framework-FSEvents/p
 diff --git pyobjc-framework-FileProvider/pyobjc_setup.py pyobjc-framework-FileProvider/pyobjc_setup.py
 --- pyobjc-framework-FileProvider/pyobjc_setup.py
 +++ pyobjc-framework-FileProvider/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -779,7 +779,7 @@ diff --git pyobjc-framework-FileProvider/pyobjc_setup.py pyobjc-framework-FilePr
 diff --git pyobjc-framework-FileProviderUI/pyobjc_setup.py pyobjc-framework-FileProviderUI/pyobjc_setup.py
 --- pyobjc-framework-FileProviderUI/pyobjc_setup.py
 +++ pyobjc-framework-FileProviderUI/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -792,7 +792,7 @@ diff --git pyobjc-framework-FileProviderUI/pyobjc_setup.py pyobjc-framework-File
 diff --git pyobjc-framework-FinderSync/pyobjc_setup.py pyobjc-framework-FinderSync/pyobjc_setup.py
 --- pyobjc-framework-FinderSync/pyobjc_setup.py
 +++ pyobjc-framework-FinderSync/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -805,7 +805,7 @@ diff --git pyobjc-framework-FinderSync/pyobjc_setup.py pyobjc-framework-FinderSy
 diff --git pyobjc-framework-GameCenter/pyobjc_setup.py pyobjc-framework-GameCenter/pyobjc_setup.py
 --- pyobjc-framework-GameCenter/pyobjc_setup.py
 +++ pyobjc-framework-GameCenter/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -818,7 +818,7 @@ diff --git pyobjc-framework-GameCenter/pyobjc_setup.py pyobjc-framework-GameCent
 diff --git pyobjc-framework-GameController/pyobjc_setup.py pyobjc-framework-GameController/pyobjc_setup.py
 --- pyobjc-framework-GameController/pyobjc_setup.py
 +++ pyobjc-framework-GameController/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -831,7 +831,7 @@ diff --git pyobjc-framework-GameController/pyobjc_setup.py pyobjc-framework-Game
 diff --git pyobjc-framework-GameKit/pyobjc_setup.py pyobjc-framework-GameKit/pyobjc_setup.py
 --- pyobjc-framework-GameKit/pyobjc_setup.py
 +++ pyobjc-framework-GameKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -844,7 +844,7 @@ diff --git pyobjc-framework-GameKit/pyobjc_setup.py pyobjc-framework-GameKit/pyo
 diff --git pyobjc-framework-GameplayKit/pyobjc_setup.py pyobjc-framework-GameplayKit/pyobjc_setup.py
 --- pyobjc-framework-GameplayKit/pyobjc_setup.py
 +++ pyobjc-framework-GameplayKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -857,20 +857,7 @@ diff --git pyobjc-framework-GameplayKit/pyobjc_setup.py pyobjc-framework-Gamepla
 diff --git pyobjc-framework-HealthKit/pyobjc_setup.py pyobjc-framework-HealthKit/pyobjc_setup.py
 --- pyobjc-framework-HealthKit/pyobjc_setup.py
 +++ pyobjc-framework-HealthKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
-     if os_level == "10.4":
-         cflags.append("-DNO_OBJC2_RUNTIME")
- 
--    if "-Werror" not in cflags:
--        cflags.append("-Werror")
--
-     if "extra_compile_args" in kwds:
-         kwds["extra_compile_args"] = kwds["extra_compile_args"] + cflags
-     else:
-diff --git pyobjc-framework-IMServicePlugIn/pyobjc_setup.py pyobjc-framework-IMServicePlugIn/pyobjc_setup.py
---- pyobjc-framework-IMServicePlugIn/pyobjc_setup.py
-+++ pyobjc-framework-IMServicePlugIn/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -883,7 +870,7 @@ diff --git pyobjc-framework-IMServicePlugIn/pyobjc_setup.py pyobjc-framework-IMS
 diff --git pyobjc-framework-IOSurface/pyobjc_setup.py pyobjc-framework-IOSurface/pyobjc_setup.py
 --- pyobjc-framework-IOSurface/pyobjc_setup.py
 +++ pyobjc-framework-IOSurface/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -896,7 +883,7 @@ diff --git pyobjc-framework-IOSurface/pyobjc_setup.py pyobjc-framework-IOSurface
 diff --git pyobjc-framework-ImageCaptureCore/pyobjc_setup.py pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
 --- pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
 +++ pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -909,7 +896,7 @@ diff --git pyobjc-framework-ImageCaptureCore/pyobjc_setup.py pyobjc-framework-Im
 diff --git pyobjc-framework-InputMethodKit/pyobjc_setup.py pyobjc-framework-InputMethodKit/pyobjc_setup.py
 --- pyobjc-framework-InputMethodKit/pyobjc_setup.py
 +++ pyobjc-framework-InputMethodKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -922,7 +909,7 @@ diff --git pyobjc-framework-InputMethodKit/pyobjc_setup.py pyobjc-framework-Inpu
 diff --git pyobjc-framework-InstallerPlugins/pyobjc_setup.py pyobjc-framework-InstallerPlugins/pyobjc_setup.py
 --- pyobjc-framework-InstallerPlugins/pyobjc_setup.py
 +++ pyobjc-framework-InstallerPlugins/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -935,7 +922,7 @@ diff --git pyobjc-framework-InstallerPlugins/pyobjc_setup.py pyobjc-framework-In
 diff --git pyobjc-framework-InstantMessage/pyobjc_setup.py pyobjc-framework-InstantMessage/pyobjc_setup.py
 --- pyobjc-framework-InstantMessage/pyobjc_setup.py
 +++ pyobjc-framework-InstantMessage/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -948,7 +935,7 @@ diff --git pyobjc-framework-InstantMessage/pyobjc_setup.py pyobjc-framework-Inst
 diff --git pyobjc-framework-Intents/pyobjc_setup.py pyobjc-framework-Intents/pyobjc_setup.py
 --- pyobjc-framework-Intents/pyobjc_setup.py
 +++ pyobjc-framework-Intents/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -961,7 +948,7 @@ diff --git pyobjc-framework-Intents/pyobjc_setup.py pyobjc-framework-Intents/pyo
 diff --git pyobjc-framework-IntentsUI/pyobjc_setup.py pyobjc-framework-IntentsUI/pyobjc_setup.py
 --- pyobjc-framework-IntentsUI/pyobjc_setup.py
 +++ pyobjc-framework-IntentsUI/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -974,7 +961,7 @@ diff --git pyobjc-framework-IntentsUI/pyobjc_setup.py pyobjc-framework-IntentsUI
 diff --git pyobjc-framework-KernelManagement/pyobjc_setup.py pyobjc-framework-KernelManagement/pyobjc_setup.py
 --- pyobjc-framework-KernelManagement/pyobjc_setup.py
 +++ pyobjc-framework-KernelManagement/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -987,7 +974,7 @@ diff --git pyobjc-framework-KernelManagement/pyobjc_setup.py pyobjc-framework-Ke
 diff --git pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
 --- pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
 +++ pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1000,7 +987,7 @@ diff --git pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py pyobjc-framewo
 diff --git pyobjc-framework-LaunchServices/pyobjc_setup.py pyobjc-framework-LaunchServices/pyobjc_setup.py
 --- pyobjc-framework-LaunchServices/pyobjc_setup.py
 +++ pyobjc-framework-LaunchServices/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1013,7 +1000,7 @@ diff --git pyobjc-framework-LaunchServices/pyobjc_setup.py pyobjc-framework-Laun
 diff --git pyobjc-framework-LinkPresentation/pyobjc_setup.py pyobjc-framework-LinkPresentation/pyobjc_setup.py
 --- pyobjc-framework-LinkPresentation/pyobjc_setup.py
 +++ pyobjc-framework-LinkPresentation/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1026,7 +1013,7 @@ diff --git pyobjc-framework-LinkPresentation/pyobjc_setup.py pyobjc-framework-Li
 diff --git pyobjc-framework-LocalAuthentication/pyobjc_setup.py pyobjc-framework-LocalAuthentication/pyobjc_setup.py
 --- pyobjc-framework-LocalAuthentication/pyobjc_setup.py
 +++ pyobjc-framework-LocalAuthentication/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1039,7 +1026,7 @@ diff --git pyobjc-framework-LocalAuthentication/pyobjc_setup.py pyobjc-framework
 diff --git pyobjc-framework-LocalAuthenticationEmbeddedUI/pyobjc_setup.py pyobjc-framework-LocalAuthenticationEmbeddedUI/pyobjc_setup.py
 --- pyobjc-framework-LocalAuthenticationEmbeddedUI/pyobjc_setup.py
 +++ pyobjc-framework-LocalAuthenticationEmbeddedUI/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1052,7 +1039,7 @@ diff --git pyobjc-framework-LocalAuthenticationEmbeddedUI/pyobjc_setup.py pyobjc
 diff --git pyobjc-framework-MLCompute/pyobjc_setup.py pyobjc-framework-MLCompute/pyobjc_setup.py
 --- pyobjc-framework-MLCompute/pyobjc_setup.py
 +++ pyobjc-framework-MLCompute/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1065,7 +1052,7 @@ diff --git pyobjc-framework-MLCompute/pyobjc_setup.py pyobjc-framework-MLCompute
 diff --git pyobjc-framework-MailKit/pyobjc_setup.py pyobjc-framework-MailKit/pyobjc_setup.py
 --- pyobjc-framework-MailKit/pyobjc_setup.py
 +++ pyobjc-framework-MailKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1078,7 +1065,7 @@ diff --git pyobjc-framework-MailKit/pyobjc_setup.py pyobjc-framework-MailKit/pyo
 diff --git pyobjc-framework-MapKit/pyobjc_setup.py pyobjc-framework-MapKit/pyobjc_setup.py
 --- pyobjc-framework-MapKit/pyobjc_setup.py
 +++ pyobjc-framework-MapKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1091,7 +1078,7 @@ diff --git pyobjc-framework-MapKit/pyobjc_setup.py pyobjc-framework-MapKit/pyobj
 diff --git pyobjc-framework-MediaAccessibility/pyobjc_setup.py pyobjc-framework-MediaAccessibility/pyobjc_setup.py
 --- pyobjc-framework-MediaAccessibility/pyobjc_setup.py
 +++ pyobjc-framework-MediaAccessibility/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1104,7 +1091,7 @@ diff --git pyobjc-framework-MediaAccessibility/pyobjc_setup.py pyobjc-framework-
 diff --git pyobjc-framework-MediaLibrary/pyobjc_setup.py pyobjc-framework-MediaLibrary/pyobjc_setup.py
 --- pyobjc-framework-MediaLibrary/pyobjc_setup.py
 +++ pyobjc-framework-MediaLibrary/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1117,7 +1104,7 @@ diff --git pyobjc-framework-MediaLibrary/pyobjc_setup.py pyobjc-framework-MediaL
 diff --git pyobjc-framework-MediaPlayer/pyobjc_setup.py pyobjc-framework-MediaPlayer/pyobjc_setup.py
 --- pyobjc-framework-MediaPlayer/pyobjc_setup.py
 +++ pyobjc-framework-MediaPlayer/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1130,7 +1117,7 @@ diff --git pyobjc-framework-MediaPlayer/pyobjc_setup.py pyobjc-framework-MediaPl
 diff --git pyobjc-framework-MediaToolbox/pyobjc_setup.py pyobjc-framework-MediaToolbox/pyobjc_setup.py
 --- pyobjc-framework-MediaToolbox/pyobjc_setup.py
 +++ pyobjc-framework-MediaToolbox/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1143,7 +1130,7 @@ diff --git pyobjc-framework-MediaToolbox/pyobjc_setup.py pyobjc-framework-MediaT
 diff --git pyobjc-framework-Metal/pyobjc_setup.py pyobjc-framework-Metal/pyobjc_setup.py
 --- pyobjc-framework-Metal/pyobjc_setup.py
 +++ pyobjc-framework-Metal/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1156,7 +1143,7 @@ diff --git pyobjc-framework-Metal/pyobjc_setup.py pyobjc-framework-Metal/pyobjc_
 diff --git pyobjc-framework-MetalFX/pyobjc_setup.py pyobjc-framework-MetalFX/pyobjc_setup.py
 --- pyobjc-framework-MetalFX/pyobjc_setup.py
 +++ pyobjc-framework-MetalFX/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1169,7 +1156,7 @@ diff --git pyobjc-framework-MetalFX/pyobjc_setup.py pyobjc-framework-MetalFX/pyo
 diff --git pyobjc-framework-MetalKit/pyobjc_setup.py pyobjc-framework-MetalKit/pyobjc_setup.py
 --- pyobjc-framework-MetalKit/pyobjc_setup.py
 +++ pyobjc-framework-MetalKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1182,7 +1169,7 @@ diff --git pyobjc-framework-MetalKit/pyobjc_setup.py pyobjc-framework-MetalKit/p
 diff --git pyobjc-framework-MetalPerformanceShaders/pyobjc_setup.py pyobjc-framework-MetalPerformanceShaders/pyobjc_setup.py
 --- pyobjc-framework-MetalPerformanceShaders/pyobjc_setup.py
 +++ pyobjc-framework-MetalPerformanceShaders/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1195,7 +1182,7 @@ diff --git pyobjc-framework-MetalPerformanceShaders/pyobjc_setup.py pyobjc-frame
 diff --git pyobjc-framework-MetalPerformanceShadersGraph/pyobjc_setup.py pyobjc-framework-MetalPerformanceShadersGraph/pyobjc_setup.py
 --- pyobjc-framework-MetalPerformanceShadersGraph/pyobjc_setup.py
 +++ pyobjc-framework-MetalPerformanceShadersGraph/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1208,7 +1195,7 @@ diff --git pyobjc-framework-MetalPerformanceShadersGraph/pyobjc_setup.py pyobjc-
 diff --git pyobjc-framework-MetricKit/pyobjc_setup.py pyobjc-framework-MetricKit/pyobjc_setup.py
 --- pyobjc-framework-MetricKit/pyobjc_setup.py
 +++ pyobjc-framework-MetricKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1221,7 +1208,7 @@ diff --git pyobjc-framework-MetricKit/pyobjc_setup.py pyobjc-framework-MetricKit
 diff --git pyobjc-framework-ModelIO/pyobjc_setup.py pyobjc-framework-ModelIO/pyobjc_setup.py
 --- pyobjc-framework-ModelIO/pyobjc_setup.py
 +++ pyobjc-framework-ModelIO/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1234,7 +1221,7 @@ diff --git pyobjc-framework-ModelIO/pyobjc_setup.py pyobjc-framework-ModelIO/pyo
 diff --git pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
 --- pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
 +++ pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1247,7 +1234,7 @@ diff --git pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py pyobjc-framewo
 diff --git pyobjc-framework-NaturalLanguage/pyobjc_setup.py pyobjc-framework-NaturalLanguage/pyobjc_setup.py
 --- pyobjc-framework-NaturalLanguage/pyobjc_setup.py
 +++ pyobjc-framework-NaturalLanguage/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1260,7 +1247,7 @@ diff --git pyobjc-framework-NaturalLanguage/pyobjc_setup.py pyobjc-framework-Nat
 diff --git pyobjc-framework-NetFS/pyobjc_setup.py pyobjc-framework-NetFS/pyobjc_setup.py
 --- pyobjc-framework-NetFS/pyobjc_setup.py
 +++ pyobjc-framework-NetFS/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1273,7 +1260,7 @@ diff --git pyobjc-framework-NetFS/pyobjc_setup.py pyobjc-framework-NetFS/pyobjc_
 diff --git pyobjc-framework-Network/pyobjc_setup.py pyobjc-framework-Network/pyobjc_setup.py
 --- pyobjc-framework-Network/pyobjc_setup.py
 +++ pyobjc-framework-Network/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1286,7 +1273,7 @@ diff --git pyobjc-framework-Network/pyobjc_setup.py pyobjc-framework-Network/pyo
 diff --git pyobjc-framework-NetworkExtension/pyobjc_setup.py pyobjc-framework-NetworkExtension/pyobjc_setup.py
 --- pyobjc-framework-NetworkExtension/pyobjc_setup.py
 +++ pyobjc-framework-NetworkExtension/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1299,7 +1286,7 @@ diff --git pyobjc-framework-NetworkExtension/pyobjc_setup.py pyobjc-framework-Ne
 diff --git pyobjc-framework-NotificationCenter/pyobjc_setup.py pyobjc-framework-NotificationCenter/pyobjc_setup.py
 --- pyobjc-framework-NotificationCenter/pyobjc_setup.py
 +++ pyobjc-framework-NotificationCenter/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1312,7 +1299,7 @@ diff --git pyobjc-framework-NotificationCenter/pyobjc_setup.py pyobjc-framework-
 diff --git pyobjc-framework-OSAKit/pyobjc_setup.py pyobjc-framework-OSAKit/pyobjc_setup.py
 --- pyobjc-framework-OSAKit/pyobjc_setup.py
 +++ pyobjc-framework-OSAKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1325,7 +1312,7 @@ diff --git pyobjc-framework-OSAKit/pyobjc_setup.py pyobjc-framework-OSAKit/pyobj
 diff --git pyobjc-framework-OSLog/pyobjc_setup.py pyobjc-framework-OSLog/pyobjc_setup.py
 --- pyobjc-framework-OSLog/pyobjc_setup.py
 +++ pyobjc-framework-OSLog/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1338,7 +1325,7 @@ diff --git pyobjc-framework-OSLog/pyobjc_setup.py pyobjc-framework-OSLog/pyobjc_
 diff --git pyobjc-framework-OpenDirectory/pyobjc_setup.py pyobjc-framework-OpenDirectory/pyobjc_setup.py
 --- pyobjc-framework-OpenDirectory/pyobjc_setup.py
 +++ pyobjc-framework-OpenDirectory/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1351,7 +1338,7 @@ diff --git pyobjc-framework-OpenDirectory/pyobjc_setup.py pyobjc-framework-OpenD
 diff --git pyobjc-framework-PassKit/pyobjc_setup.py pyobjc-framework-PassKit/pyobjc_setup.py
 --- pyobjc-framework-PassKit/pyobjc_setup.py
 +++ pyobjc-framework-PassKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1364,7 +1351,7 @@ diff --git pyobjc-framework-PassKit/pyobjc_setup.py pyobjc-framework-PassKit/pyo
 diff --git pyobjc-framework-PencilKit/pyobjc_setup.py pyobjc-framework-PencilKit/pyobjc_setup.py
 --- pyobjc-framework-PencilKit/pyobjc_setup.py
 +++ pyobjc-framework-PencilKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1377,7 +1364,7 @@ diff --git pyobjc-framework-PencilKit/pyobjc_setup.py pyobjc-framework-PencilKit
 diff --git pyobjc-framework-Photos/pyobjc_setup.py pyobjc-framework-Photos/pyobjc_setup.py
 --- pyobjc-framework-Photos/pyobjc_setup.py
 +++ pyobjc-framework-Photos/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1390,7 +1377,7 @@ diff --git pyobjc-framework-Photos/pyobjc_setup.py pyobjc-framework-Photos/pyobj
 diff --git pyobjc-framework-PhotosUI/pyobjc_setup.py pyobjc-framework-PhotosUI/pyobjc_setup.py
 --- pyobjc-framework-PhotosUI/pyobjc_setup.py
 +++ pyobjc-framework-PhotosUI/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1403,7 +1390,7 @@ diff --git pyobjc-framework-PhotosUI/pyobjc_setup.py pyobjc-framework-PhotosUI/p
 diff --git pyobjc-framework-PreferencePanes/pyobjc_setup.py pyobjc-framework-PreferencePanes/pyobjc_setup.py
 --- pyobjc-framework-PreferencePanes/pyobjc_setup.py
 +++ pyobjc-framework-PreferencePanes/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1416,7 +1403,7 @@ diff --git pyobjc-framework-PreferencePanes/pyobjc_setup.py pyobjc-framework-Pre
 diff --git pyobjc-framework-PubSub/pyobjc_setup.py pyobjc-framework-PubSub/pyobjc_setup.py
 --- pyobjc-framework-PubSub/pyobjc_setup.py
 +++ pyobjc-framework-PubSub/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1429,7 +1416,7 @@ diff --git pyobjc-framework-PubSub/pyobjc_setup.py pyobjc-framework-PubSub/pyobj
 diff --git pyobjc-framework-PushKit/pyobjc_setup.py pyobjc-framework-PushKit/pyobjc_setup.py
 --- pyobjc-framework-PushKit/pyobjc_setup.py
 +++ pyobjc-framework-PushKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1442,7 +1429,7 @@ diff --git pyobjc-framework-PushKit/pyobjc_setup.py pyobjc-framework-PushKit/pyo
 diff --git pyobjc-framework-Quartz/pyobjc_setup.py pyobjc-framework-Quartz/pyobjc_setup.py
 --- pyobjc-framework-Quartz/pyobjc_setup.py
 +++ pyobjc-framework-Quartz/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1455,7 +1442,7 @@ diff --git pyobjc-framework-Quartz/pyobjc_setup.py pyobjc-framework-Quartz/pyobj
 diff --git pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
 --- pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
 +++ pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1468,7 +1455,7 @@ diff --git pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py pyobjc-framewo
 diff --git pyobjc-framework-ReplayKit/pyobjc_setup.py pyobjc-framework-ReplayKit/pyobjc_setup.py
 --- pyobjc-framework-ReplayKit/pyobjc_setup.py
 +++ pyobjc-framework-ReplayKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1481,7 +1468,7 @@ diff --git pyobjc-framework-ReplayKit/pyobjc_setup.py pyobjc-framework-ReplayKit
 diff --git pyobjc-framework-SafariServices/pyobjc_setup.py pyobjc-framework-SafariServices/pyobjc_setup.py
 --- pyobjc-framework-SafariServices/pyobjc_setup.py
 +++ pyobjc-framework-SafariServices/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1494,7 +1481,7 @@ diff --git pyobjc-framework-SafariServices/pyobjc_setup.py pyobjc-framework-Safa
 diff --git pyobjc-framework-SafetyKit/pyobjc_setup.py pyobjc-framework-SafetyKit/pyobjc_setup.py
 --- pyobjc-framework-SafetyKit/pyobjc_setup.py
 +++ pyobjc-framework-SafetyKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1507,7 +1494,7 @@ diff --git pyobjc-framework-SafetyKit/pyobjc_setup.py pyobjc-framework-SafetyKit
 diff --git pyobjc-framework-SceneKit/pyobjc_setup.py pyobjc-framework-SceneKit/pyobjc_setup.py
 --- pyobjc-framework-SceneKit/pyobjc_setup.py
 +++ pyobjc-framework-SceneKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1520,7 +1507,7 @@ diff --git pyobjc-framework-SceneKit/pyobjc_setup.py pyobjc-framework-SceneKit/p
 diff --git pyobjc-framework-ScreenCaptureKit/pyobjc_setup.py pyobjc-framework-ScreenCaptureKit/pyobjc_setup.py
 --- pyobjc-framework-ScreenCaptureKit/pyobjc_setup.py
 +++ pyobjc-framework-ScreenCaptureKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1533,7 +1520,7 @@ diff --git pyobjc-framework-ScreenCaptureKit/pyobjc_setup.py pyobjc-framework-Sc
 diff --git pyobjc-framework-ScreenSaver/pyobjc_setup.py pyobjc-framework-ScreenSaver/pyobjc_setup.py
 --- pyobjc-framework-ScreenSaver/pyobjc_setup.py
 +++ pyobjc-framework-ScreenSaver/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1546,7 +1533,7 @@ diff --git pyobjc-framework-ScreenSaver/pyobjc_setup.py pyobjc-framework-ScreenS
 diff --git pyobjc-framework-ScreenTime/pyobjc_setup.py pyobjc-framework-ScreenTime/pyobjc_setup.py
 --- pyobjc-framework-ScreenTime/pyobjc_setup.py
 +++ pyobjc-framework-ScreenTime/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1559,7 +1546,7 @@ diff --git pyobjc-framework-ScreenTime/pyobjc_setup.py pyobjc-framework-ScreenTi
 diff --git pyobjc-framework-ScriptingBridge/pyobjc_setup.py pyobjc-framework-ScriptingBridge/pyobjc_setup.py
 --- pyobjc-framework-ScriptingBridge/pyobjc_setup.py
 +++ pyobjc-framework-ScriptingBridge/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1572,7 +1559,7 @@ diff --git pyobjc-framework-ScriptingBridge/pyobjc_setup.py pyobjc-framework-Scr
 diff --git pyobjc-framework-SearchKit/pyobjc_setup.py pyobjc-framework-SearchKit/pyobjc_setup.py
 --- pyobjc-framework-SearchKit/pyobjc_setup.py
 +++ pyobjc-framework-SearchKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1585,7 +1572,7 @@ diff --git pyobjc-framework-SearchKit/pyobjc_setup.py pyobjc-framework-SearchKit
 diff --git pyobjc-framework-Security/pyobjc_setup.py pyobjc-framework-Security/pyobjc_setup.py
 --- pyobjc-framework-Security/pyobjc_setup.py
 +++ pyobjc-framework-Security/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1598,7 +1585,7 @@ diff --git pyobjc-framework-Security/pyobjc_setup.py pyobjc-framework-Security/p
 diff --git pyobjc-framework-SecurityFoundation/pyobjc_setup.py pyobjc-framework-SecurityFoundation/pyobjc_setup.py
 --- pyobjc-framework-SecurityFoundation/pyobjc_setup.py
 +++ pyobjc-framework-SecurityFoundation/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1611,7 +1598,7 @@ diff --git pyobjc-framework-SecurityFoundation/pyobjc_setup.py pyobjc-framework-
 diff --git pyobjc-framework-SecurityInterface/pyobjc_setup.py pyobjc-framework-SecurityInterface/pyobjc_setup.py
 --- pyobjc-framework-SecurityInterface/pyobjc_setup.py
 +++ pyobjc-framework-SecurityInterface/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1624,7 +1611,7 @@ diff --git pyobjc-framework-SecurityInterface/pyobjc_setup.py pyobjc-framework-S
 diff --git pyobjc-framework-ServiceManagement/pyobjc_setup.py pyobjc-framework-ServiceManagement/pyobjc_setup.py
 --- pyobjc-framework-ServiceManagement/pyobjc_setup.py
 +++ pyobjc-framework-ServiceManagement/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1637,7 +1624,7 @@ diff --git pyobjc-framework-ServiceManagement/pyobjc_setup.py pyobjc-framework-S
 diff --git pyobjc-framework-SharedWithYou/pyobjc_setup.py pyobjc-framework-SharedWithYou/pyobjc_setup.py
 --- pyobjc-framework-SharedWithYou/pyobjc_setup.py
 +++ pyobjc-framework-SharedWithYou/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1650,7 +1637,7 @@ diff --git pyobjc-framework-SharedWithYou/pyobjc_setup.py pyobjc-framework-Share
 diff --git pyobjc-framework-SharedWithYouCore/pyobjc_setup.py pyobjc-framework-SharedWithYouCore/pyobjc_setup.py
 --- pyobjc-framework-SharedWithYouCore/pyobjc_setup.py
 +++ pyobjc-framework-SharedWithYouCore/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1663,7 +1650,7 @@ diff --git pyobjc-framework-SharedWithYouCore/pyobjc_setup.py pyobjc-framework-S
 diff --git pyobjc-framework-ShazamKit/pyobjc_setup.py pyobjc-framework-ShazamKit/pyobjc_setup.py
 --- pyobjc-framework-ShazamKit/pyobjc_setup.py
 +++ pyobjc-framework-ShazamKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1676,7 +1663,7 @@ diff --git pyobjc-framework-ShazamKit/pyobjc_setup.py pyobjc-framework-ShazamKit
 diff --git pyobjc-framework-Social/pyobjc_setup.py pyobjc-framework-Social/pyobjc_setup.py
 --- pyobjc-framework-Social/pyobjc_setup.py
 +++ pyobjc-framework-Social/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1689,7 +1676,7 @@ diff --git pyobjc-framework-Social/pyobjc_setup.py pyobjc-framework-Social/pyobj
 diff --git pyobjc-framework-SoundAnalysis/pyobjc_setup.py pyobjc-framework-SoundAnalysis/pyobjc_setup.py
 --- pyobjc-framework-SoundAnalysis/pyobjc_setup.py
 +++ pyobjc-framework-SoundAnalysis/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1702,7 +1689,7 @@ diff --git pyobjc-framework-SoundAnalysis/pyobjc_setup.py pyobjc-framework-Sound
 diff --git pyobjc-framework-Speech/pyobjc_setup.py pyobjc-framework-Speech/pyobjc_setup.py
 --- pyobjc-framework-Speech/pyobjc_setup.py
 +++ pyobjc-framework-Speech/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1715,7 +1702,7 @@ diff --git pyobjc-framework-Speech/pyobjc_setup.py pyobjc-framework-Speech/pyobj
 diff --git pyobjc-framework-SpriteKit/pyobjc_setup.py pyobjc-framework-SpriteKit/pyobjc_setup.py
 --- pyobjc-framework-SpriteKit/pyobjc_setup.py
 +++ pyobjc-framework-SpriteKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1728,7 +1715,7 @@ diff --git pyobjc-framework-SpriteKit/pyobjc_setup.py pyobjc-framework-SpriteKit
 diff --git pyobjc-framework-StoreKit/pyobjc_setup.py pyobjc-framework-StoreKit/pyobjc_setup.py
 --- pyobjc-framework-StoreKit/pyobjc_setup.py
 +++ pyobjc-framework-StoreKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1741,7 +1728,7 @@ diff --git pyobjc-framework-StoreKit/pyobjc_setup.py pyobjc-framework-StoreKit/p
 diff --git pyobjc-framework-SyncServices/pyobjc_setup.py pyobjc-framework-SyncServices/pyobjc_setup.py
 --- pyobjc-framework-SyncServices/pyobjc_setup.py
 +++ pyobjc-framework-SyncServices/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1754,7 +1741,7 @@ diff --git pyobjc-framework-SyncServices/pyobjc_setup.py pyobjc-framework-SyncSe
 diff --git pyobjc-framework-SystemConfiguration/pyobjc_setup.py pyobjc-framework-SystemConfiguration/pyobjc_setup.py
 --- pyobjc-framework-SystemConfiguration/pyobjc_setup.py
 +++ pyobjc-framework-SystemConfiguration/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1767,7 +1754,7 @@ diff --git pyobjc-framework-SystemConfiguration/pyobjc_setup.py pyobjc-framework
 diff --git pyobjc-framework-SystemExtensions/pyobjc_setup.py pyobjc-framework-SystemExtensions/pyobjc_setup.py
 --- pyobjc-framework-SystemExtensions/pyobjc_setup.py
 +++ pyobjc-framework-SystemExtensions/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1780,7 +1767,7 @@ diff --git pyobjc-framework-SystemExtensions/pyobjc_setup.py pyobjc-framework-Sy
 diff --git pyobjc-framework-ThreadNetwork/pyobjc_setup.py pyobjc-framework-ThreadNetwork/pyobjc_setup.py
 --- pyobjc-framework-ThreadNetwork/pyobjc_setup.py
 +++ pyobjc-framework-ThreadNetwork/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1793,7 +1780,7 @@ diff --git pyobjc-framework-ThreadNetwork/pyobjc_setup.py pyobjc-framework-Threa
 diff --git pyobjc-framework-UniformTypeIdentifiers/pyobjc_setup.py pyobjc-framework-UniformTypeIdentifiers/pyobjc_setup.py
 --- pyobjc-framework-UniformTypeIdentifiers/pyobjc_setup.py
 +++ pyobjc-framework-UniformTypeIdentifiers/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1806,7 +1793,7 @@ diff --git pyobjc-framework-UniformTypeIdentifiers/pyobjc_setup.py pyobjc-framew
 diff --git pyobjc-framework-UserNotifications/pyobjc_setup.py pyobjc-framework-UserNotifications/pyobjc_setup.py
 --- pyobjc-framework-UserNotifications/pyobjc_setup.py
 +++ pyobjc-framework-UserNotifications/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1819,7 +1806,7 @@ diff --git pyobjc-framework-UserNotifications/pyobjc_setup.py pyobjc-framework-U
 diff --git pyobjc-framework-UserNotificationsUI/pyobjc_setup.py pyobjc-framework-UserNotificationsUI/pyobjc_setup.py
 --- pyobjc-framework-UserNotificationsUI/pyobjc_setup.py
 +++ pyobjc-framework-UserNotificationsUI/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1832,7 +1819,7 @@ diff --git pyobjc-framework-UserNotificationsUI/pyobjc_setup.py pyobjc-framework
 diff --git pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
 --- pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
 +++ pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1845,7 +1832,7 @@ diff --git pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py pyobjc-framew
 diff --git pyobjc-framework-VideoToolbox/pyobjc_setup.py pyobjc-framework-VideoToolbox/pyobjc_setup.py
 --- pyobjc-framework-VideoToolbox/pyobjc_setup.py
 +++ pyobjc-framework-VideoToolbox/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1858,7 +1845,7 @@ diff --git pyobjc-framework-VideoToolbox/pyobjc_setup.py pyobjc-framework-VideoT
 diff --git pyobjc-framework-Virtualization/pyobjc_setup.py pyobjc-framework-Virtualization/pyobjc_setup.py
 --- pyobjc-framework-Virtualization/pyobjc_setup.py
 +++ pyobjc-framework-Virtualization/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1871,7 +1858,7 @@ diff --git pyobjc-framework-Virtualization/pyobjc_setup.py pyobjc-framework-Virt
 diff --git pyobjc-framework-Vision/pyobjc_setup.py pyobjc-framework-Vision/pyobjc_setup.py
 --- pyobjc-framework-Vision/pyobjc_setup.py
 +++ pyobjc-framework-Vision/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1884,7 +1871,7 @@ diff --git pyobjc-framework-Vision/pyobjc_setup.py pyobjc-framework-Vision/pyobj
 diff --git pyobjc-framework-WebKit/pyobjc_setup.py pyobjc-framework-WebKit/pyobjc_setup.py
 --- pyobjc-framework-WebKit/pyobjc_setup.py
 +++ pyobjc-framework-WebKit/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1897,7 +1884,7 @@ diff --git pyobjc-framework-WebKit/pyobjc_setup.py pyobjc-framework-WebKit/pyobj
 diff --git pyobjc-framework-iTunesLibrary/pyobjc_setup.py pyobjc-framework-iTunesLibrary/pyobjc_setup.py
 --- pyobjc-framework-iTunesLibrary/pyobjc_setup.py
 +++ pyobjc-framework-iTunesLibrary/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  
@@ -1910,7 +1897,7 @@ diff --git pyobjc-framework-iTunesLibrary/pyobjc_setup.py pyobjc-framework-iTune
 diff --git pyobjc-framework-libdispatch/pyobjc_setup.py pyobjc-framework-libdispatch/pyobjc_setup.py
 --- pyobjc-framework-libdispatch/pyobjc_setup.py
 +++ pyobjc-framework-libdispatch/pyobjc_setup.py
-@@ -505,9 +505,6 @@ def Extension(*args, **kwds):
+@@ -523,9 +523,6 @@ def Extension(*args, **kwds):
      if os_level == "10.4":
          cflags.append("-DNO_OBJC2_RUNTIME")
  

--- a/python/py-tensorflow-addons/Portfile
+++ b/python/py-tensorflow-addons/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  7c5411b253b2c0e80ed5dda5e69f015db1aacdd3 \
                     sha256  692a428d8f4cfa12c37ce2c1de33d7afb1a86ff90601d7442eabedaf41045ae9 \
                     size    610590
 
-python.versions     37 38 39
+python.versions     38 39
 
 if {${name} ne ${subport}} {
     PortGroup       bazel 1.0

--- a/python/py-zope-component/Portfile
+++ b/python/py-zope-component/Portfile
@@ -20,7 +20,7 @@ long_description    {*}${description}
 
 homepage            https://github.com/zopefoundation/zope.component
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 checksums           rmd160  ed565d05f197bcb4d41937e754134ba82b7e2b76 \
                     sha256  32cbe426ba8fa7b62ce5b211f80f0718a0c749cc7ff09e3f4b43a57f7ccdf5e5 \

--- a/python/py-zope-hookable/Portfile
+++ b/python/py-zope-hookable/Portfile
@@ -18,7 +18,7 @@ long_description    This package supports the efficient creation of \
 
 homepage            https://github.com/zopefoundation/zope.hookable
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 checksums           rmd160  8f2e48b66b4850be8397c5da3cc25363278886d7 \
                     sha256  fb601f00ac87e5aa582a81315ed96768ce3513280729d3f51f79312e2b8b94ac \


### PR DESCRIPTION
#### Description

Updating PyObjC to version 10.1. The developer has made a great effort to support older OS versions, so that OS X 10.9 and later are now supported (down from 10.13).

This version requires Python 3.8 or later, so I removed the py37 subport. I considered pinning 3.7 to the older version, but judging by other commits to master, many py37 subports are now being removed. I have also removed the `py37` subport of four ports that depend on this one: `py37-imagecodecs`, `py37-tensorflow-addons`, `py37-zope-component`, `py37-zope-hookable`.

Changes:
* Blacklist Clang < 900 because they do not support the option `-flto=thin`
* Require full Xcode (`use_xcode yes`) because `xcodebuild` complained that it could not use CommandLineTools (happened both locally on OS X 10.9 and on the macOS 11.0 CI bot)
* 10.9 only: use the OS X 10.10 SDK instead of setting SDK root to `/`. Needed because 10.9 lacks the needed SIMD headers. The 10.10 SDK is included with the latest Xcode versions that 10.9 supports. Solution inspired by `py-lightblue`.
* Updated line numbers in patch, removed patch for `IMServicePlugIn` framework, which no longer exists

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

Notes:
* `lint` gives one warning:
  `Warning: Line 85 seems to hardcode the version number, consider using ${version} instead`
  This is the line where I hardcoded the use of MacOSX10.10.sdk on Darwin 13.
* There are no tests enabled
* There are no binaries to test
* I tested (on Python 3.12) by importing `objc` and calling a couple of utility functions, as well as by building a port that depends on this one and tested it