### PR TITLE
direnv: upgrade to 2.33.0

### DIFF
--- a/devel/direnv/Portfile
+++ b/devel/direnv/Portfile
@@ -20,7 +20,7 @@ long_description    \
 
 homepage            https://direnv.net/
 
-go.setup            github.com/direnv/direnv 2.32.3 v
+go.setup            github.com/direnv/direnv 2.33.0 v
 revision            0
 
 destroot {
@@ -28,29 +28,29 @@ destroot {
 }
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  fadec9d9295ca2da1dfdb492de15b9b3b5e4797f \
-                        sha256  7f38ae29982baf02e4f265e438e18123fd87197ca382cc2b06587add2c082e36 \
-                        size    87684
+                        rmd160  3e0c6233f6c9dcde6cd8928d28915716f3865eb2 \
+                        sha256  a081224fba92d4f0a2f393af8d83bfa3395c6085f65d5613fbc5e48620b1b8a6 \
+                        size    90794
 
 # see ${WORKSRCPATH}/gopath/src/github.com/direnv/direnv/go.sum
 # pick the most recent version of each and verify downloading and building
 go.vendors          golang.org/x/sys \
-                        lock    bc2c85ada10a \
-                        rmd160  c4b2c26618cd3f02fe04653b3a4fbe6707de5716 \
-                        sha256  b2526b52942c803a1687e16f87942bd0f0701b5d260fbaa35d53231e0a520577 \
-                        size    1303117 \
+                        lock    v0.6.0 \
+                        rmd160  eed022d31d3cd2b2a5c7d1bad325b6667db1d831 \
+                        sha256  28b3d661c0b094ccb133bb2f30a2db8fcd64be036f4fc42ee6c2ab4b00867bd3 \
+                        size    1435230 \
                     golang.org/x/mod \
-                        lock    v0.5.1 \
-                        rmd160  6aac73c99cc5111f9b4675fbfeee0871ecea71a7 \
-                        sha256  1c5e2438581c6755be6c984375c51f93cee56b00de0898cdd61ce3d64c938d38 \
-                        size    112675 \
+                        lock    v0.13.0 \
+                        rmd160  995441ddb549ed539535e747368a5e127e866921 \
+                        sha256  c08f2ff1b105ebfd0d0686e8290c7a86670d4706fa783f2b3457423e5478d013 \
+                        size    122050 \
                     github.com/mattn/go-isatty \
-                        lock    v0.0.14 \
-                        rmd160  8ebfd3a6f2898a729e41dff6b5359e88959c46e1 \
-                        sha256  dc141c207a7f4eb83992df90ca087841a0a3aab5a4f2b528bf81d42a186bcc1e \
-                        size    4705 \
+                        lock    v0.0.20 \
+                        rmd160  ef20ccdf87de8b704c0c7118625b2beb31d8f1b4 \
+                        sha256  397549e98cf5d40df585f31dc7902f017c37be88c64311dd2b4aeccab4009949 \
+                        size    4717 \
                     github.com/BurntSushi/toml \
-                        lock    v1.2.0 \
-                        rmd160  b6af60be88cbeac8ed5e5124d187cf5e1a98864d \
-                        sha256  7cc755999d3c804cfeee6e464cc800cee299a33877dfd901671f3574e2eb80fd \
-                        size    96599
+                        lock    v1.3.2 \
+                        rmd160  d34d7e7532c67412d48f3777a5bba8cd5a04b0cd \
+                        sha256  ba788b5f21507f40faa972bc86cb87d8929c798959f7402152d86120ac357d05 \
+                        size    119417


### PR DESCRIPTION
#### Description

direnv: upgrade to 2.33.0

##### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
