### PR TITLE
ruby-build: Upgrade to 20231225

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20231211 v
+github.setup        rbenv ruby-build 20231225 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  b62f6d3ddca204b8f62152090a2311e3b05f9874 \
-                    sha256  fa57f35fd814a5b638d8aea9ddaa13eff6ae4927a39a09e6e7e130721246c538 \
-                    size    87328
+checksums           rmd160  72c8b12e72bb625c2cd3fe8f156b54c98123a050 \
+                    sha256  6e97008a983c24aa4e8674e68a5e41abaa6a111adc318f02e237d16cc68b498e \
+                    size    87325
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

The traditional Ruby Christmas release. MRI 3.3.0.

##### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
