### PR TITLE
py-sqlalchemy: update to 2.0.23, add py312 subport

### DIFF
--- a/python/py-sqlalchemy/Portfile
+++ b/python/py-sqlalchemy/Portfile
@@ -5,12 +5,12 @@ PortGroup           python 1.0
 
 name                py-sqlalchemy
 python.rootname     SQLAlchemy
-version             2.0.19
+version             2.0.23
 revision            0
 categories-append   databases
 license             MIT
 
-python.versions     27 36 37 38 39 310 311
+python.versions     27 36 37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer
@@ -23,9 +23,9 @@ long_description    SQLAlchemy is the Python SQL toolkit and Object \
 
 homepage            http://www.sqlalchemy.org/
 
-checksums           rmd160  6962e1f15e800082594a3cc4e72539aad2c49cc0 \
-                    sha256  77a14fa20264af73ddcdb1e2b9c5a829b8cc6b8304d0f093271980e36c200a3f \
-                    size    9425046
+checksums           rmd160  79ca48cb6161c85fac1c3722c98cc6d94784d4a2 \
+                    sha256  c1bda93cbbe4aa2aa0aa8655c5aeda505cd219ff3e8da91d1d329e143e4aff69 \
+                    size    9474103
 
 if {${name} ne ${subport}} {
     if {${python.version} < 37} {


### PR DESCRIPTION
#### Description

Updating from 2.0.19 to 2.0.23 and adding subport for Python 3.12, which should have been supported [since 2.0.16](https://docs.sqlalchemy.org/en/20/changelog/changelog_20.html#change-2.0.16). PyPI does not yet explicitly state that 3.12 is supported.

Tested by importing `sqlalchemy` in Python 3.12 and following the first couple of examples in the [tutorial](https://docs.sqlalchemy.org/en/20/tutorial/index.html).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

No tests enabled in this port. The only variant is universal, which I did not build because it required lots of i386 variants that I did not have on my system.