### PR TITLE
cabal: allow building under MacPorts again

### DIFF
--- a/lang/cabal/Portfile
+++ b/lang/cabal/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                cabal
 version             3.10.2.0
-revision            0
+revision            1
 categories          lang haskell devel
 platforms           darwin
 license             BSD
@@ -152,10 +152,8 @@ if {[exists extract.rename]} {
                     "CABAL_CONFIG=${haskell_cabal.cabal_root}/config" \
                     "GHC=${prefix}/bin/ghc"
 
-    # https://github.com/haskell/cabal/issues/8360#issuecomment-1220918581
     build.target    ${name}-install \
-                    --project-file=cabal.project.release \
-                    --allow-newer
+                    --project-file=cabal.project.release
     build.post_args-append \
                     --bindir=${prefix}/bin \
                     --datadir=${prefix}/share/${subport}


### PR DESCRIPTION
#### Description

The recently released haskell tar-0.6 introduces some breaking changes that prevent Cabal from building on MacPorts because of its previous use of `--allow-newer` in `build.target`. This line was deliberately added (https://github.com/haskell/cabal/issues/8360#issuecomment-1220918581), but it causes persistent build failure.

##### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
