### PR TITLE
git-tools: update to 2022.12

### DIFF
--- a/devel/git-tools/Portfile
+++ b/devel/git-tools/Portfile
@@ -3,13 +3,14 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            MestreLion git-tools 40f8174bf0f4db100c902be7e883dd70cfd1995f
-version                 20210806
+github.setup            MestreLion git-tools 2022.12 v
+github.tarball_from     archive
 revision                0
+epoch                   1
 
-checksums               rmd160  17a570b3644306c3bf1f7fcea7c8d06502f52b70 \
-                        sha256  859504bc65a447352c99d0595a92214d24bd8dd97ebb7e6b3ec3b0c19742dc56 \
-                        size    32998
+checksums               rmd160  f2603d88fd3eb320dd83b626e1682166942b50ca \
+                        sha256  b01e3b8de268ee07854e6cc66d78db6ed6cbc3e71dfeded8456138881bdf97f1 \
+                        size    38072
 
 maintainers             {@telotortium gmail.com:rirelan} openmaintainer
 platforms               any


### PR DESCRIPTION
###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.1 15C65

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?