### PR TITLE
hdf5: rev bump, fix duplicate LC_RPATH

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 name                hdf5
 version             1.14.3
 set mainversion     [lrange [split ${version} -] 0 0]
-revision            0
+revision            1
 set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
 categories          science
 maintainers         {eborisch @eborisch} openmaintainer


### PR DESCRIPTION
#### Description

* Rev bump only.
* Pushes rebuilds for Ventura and Sonoma with Xcode 15 linker.
* Flushes out the old duplicate LC_RPATH's in the previous **fortran** dylib builds, in the binary distribution files.
* May fix mysterious configure failures in dependent ports.  We'll see about that, later.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

The local test on Monterey is not relevant for this fix, because Monterey does not have the new linker.
What is important, is that CI for Ventura/OS13-x86 and **Xcode 15** shows the correct signature for this bug fix:
**ld: warning: ignoring duplicate libraries:**

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->