### PR TITLE
gnucash: use_mp_libcxx on older macos

### DIFF
--- a/gnome/gnucash/Portfile
+++ b/gnome/gnucash/Portfile
@@ -4,6 +4,10 @@ PortSystem        1.0
 PortGroup         perl5 1.0
 PortGroup         cmake 1.1
 PortGroup         boost 1.0
+PortGroup         legacysupport 1.1
+
+legacysupport.newest_darwin_requires_legacy 17
+legacysupport.use_mp_libcxx                 yes
 
 name              gnucash
 conflicts         gnucash gnucash-devel
@@ -55,6 +59,13 @@ post-patch {
 }
 
 configure.env-append PKG_CONFIG_GLIB_2_0_LIBDIR=${workpath}
+
+if { ${os.platform} eq "darwin" && ${os.major} <= [option legacysupport.newest_darwin_requires_legacy] &&
+        [option legacysupport.use_mp_libcxx] && ${configure.cxx_stdlib} eq "libc++" } {
+            # This is required when compiling with guile for older macos
+            # The env variable is used in common/cmake_modules/GncAddSchemeTargets.cmake
+            configure.env-append DYLD_LIBRARY_PATH=${prefix}/lib/libcxx
+        }
 
 boost.version               1.76
 


### PR DESCRIPTION
This will fix build errors on El Capitan (and probably other macos versions)

See commit message for errors that are fixed.

~~Build still fails later on, but I don't know how to fix that one.~~

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.11.6 15G22010 x86_64
Xcode 7.3.1 7D1014

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
