### PR TITLE
CI: properly terminate md code blocks for lint results

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
               else
                 echo "##### ⚠️ ${subport}" >> $GITHUB_STEP_SUMMARY
               fi
-              printf '```\n%s```\n' "$messages" >> $GITHUB_STEP_SUMMARY
+              printf '```\n%s\n```\n' "$messages" >> $GITHUB_STEP_SUMMARY
 
               # See https://github.com/actions/toolkit/issues/193#issuecomment-605394935
               encoded_messages="port lint ${subport}:%0A"


### PR DESCRIPTION
#### Description
In GitHub markdown, the triple backtick <tt>&#96;&#96;&#96;</tt> delimiters for fenced code blocks must appear at the beginning of a line. But the `port lint` results in `$messages` currently does not end with a newline.

Example of current markdown (from https://github.com/macports/macports-ports/actions/runs/7331068218?pr=21938#summary-19963178535):

````
##### ⚠️ qt5-qtbase
```
Error: Line 1758 repeats inclusion of PortGroup conflicts_build
Error: Line 1854 repeats inclusion of PortGroup conflicts_build
Error: Line 1977 repeats inclusion of PortGroup qmake5
Error: Line 2032 repeats inclusion of PortGroup qmake5
Error: Line 2318 repeats inclusion of PortGroup obsolete```
##### ⚠️ qt5-sqlite-plugin
```
Error: Line 1758 repeats inclusion of PortGroup conflicts_build
Error: Line 1854 repeats inclusion of PortGroup conflicts_build
Error: Line 1977 repeats inclusion of PortGroup qmake5
Error: Line 2032 repeats inclusion of PortGroup qmake5
Error: Line 2318 repeats inclusion of PortGroup obsolete```
````

which is rendered as:

> ##### ⚠️ qt5-qtbase
> ```
> Error: Line 1758 repeats inclusion of PortGroup conflicts_build
> Error: Line 1854 repeats inclusion of PortGroup conflicts_build
> Error: Line 1977 repeats inclusion of PortGroup qmake5
> Error: Line 2032 repeats inclusion of PortGroup qmake5
> Error: Line 2318 repeats inclusion of PortGroup obsolete```
> ##### ⚠️ qt5-sqlite-plugin
> ```
> Error: Line 1758 repeats inclusion of PortGroup conflicts_build
> Error: Line 1854 repeats inclusion of PortGroup conflicts_build
> Error: Line 1977 repeats inclusion of PortGroup qmake5
> Error: Line 2032 repeats inclusion of PortGroup qmake5
> Error: Line 2318 repeats inclusion of PortGroup obsolete```

Example after change:

````
##### ⚠️ qt5-qtbase
```
Error: Line 1758 repeats inclusion of PortGroup conflicts_build
Error: Line 1854 repeats inclusion of PortGroup conflicts_build
Error: Line 1977 repeats inclusion of PortGroup qmake5
Error: Line 2032 repeats inclusion of PortGroup qmake5
Error: Line 2318 repeats inclusion of PortGroup obsolete
```
##### ⚠️ qt5-sqlite-plugin
```
Error: Line 1758 repeats inclusion of PortGroup conflicts_build
Error: Line 1854 repeats inclusion of PortGroup conflicts_build
Error: Line 1977 repeats inclusion of PortGroup qmake5
Error: Line 2032 repeats inclusion of PortGroup qmake5
Error: Line 2318 repeats inclusion of PortGroup obsolete
```
````

which is rendered as:

> ##### ⚠️ qt5-qtbase
> ```
> Error: Line 1758 repeats inclusion of PortGroup conflicts_build
> Error: Line 1854 repeats inclusion of PortGroup conflicts_build
> Error: Line 1977 repeats inclusion of PortGroup qmake5
> Error: Line 2032 repeats inclusion of PortGroup qmake5
> Error: Line 2318 repeats inclusion of PortGroup obsolete
> ```
> ##### ⚠️ qt5-sqlite-plugin
> ```
> Error: Line 1758 repeats inclusion of PortGroup conflicts_build
> Error: Line 1854 repeats inclusion of PortGroup conflicts_build
> Error: Line 1977 repeats inclusion of PortGroup qmake5
> Error: Line 2032 repeats inclusion of PortGroup qmake5
> Error: Line 2318 repeats inclusion of PortGroup obsolete
> ```

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
