### PR TITLE
py312-scipy: fix BLAS variants

### DIFF
--- a/python/py-scipy/Portfile
+++ b/python/py-scipy/Portfile
@@ -13,7 +13,7 @@ PortGroup               python 1.0
 legacysupport.newest_darwin_requires_legacy 12
 
 github.setup            scipy scipy 1.11.4 v
-revision                0
+revision                1
 
 checksums               rmd160  8120272e76e1065f8f6b5aaf3fa7fd450d56e4c3 \
                         sha256  90a2b78e7f5733b9de748f589f09225013685f9b218275257f8a8168ededaeaa \
@@ -30,10 +30,6 @@ long_description        {*}${description}
 homepage                https://www.scipy.org/
 
 python.versions         38 39 310 311 312
-
-# When updating to meson.build later, please do it conditionally,
-# unless build is confirmed on older systems as well.
-python.pep517           no
 
 python.add_archflags    no
 universal_variant       no
@@ -114,29 +110,20 @@ if {${name} ne ${subport}} {
         reinplace "s|@MACOS_V@|${macosx_deployment_target}|g" ${worksrcpath}/scipy/_build_utils/compiler_helper.py
     }
 
-    if {${python.version} == 312} {
-        python.pep517   yes
-        python.pep517_backend meson
+    if {${python.version} >= 312} {
+        python.pep517_backend   meson
 
-        depends_build-append \
-                            port:pkgconfig
+        depends_build-append    port:pkgconfig
 
-        # TODO: implement variants with different BLAS/LAPACK implementations; these need to be fixed in the
-        #       py-numpy port as well after the switch to meson
-        depends_lib-append  path:lib/libopenblas.dylib:OpenBLAS
-
-        patchfiles-append   patch-pyproject.toml.diff
+        patchfiles-append       patch-pyproject.toml.diff
 
         configure.fflags-append -fno-second-underscore
 
-        # meson build systems is looking for default filenames without the version suffix
-        pre-build {
-            ln -s ${prefix}/bin/pybind11-config-${python.branch} ${worksrcpath}/pybind11-config
-            ln -s ${prefix}/bin/cython-${python.branch} ${worksrcpath}/cython
-            ln -s ${prefix}/bin/pythran-${python.branch} ${worksrcpath}/pythran
-        build.env-append    PATH=$env(PATH):${worksrcpath}
-        }
+        build.env-append        PATH=${python.prefix}/bin:$env(PATH) \
+                                PKG_CONFIG_PATH=${python.pkgd}/pybind11/share/pkgconfig:${filespath}/pkgconfig
     } else {
+        python.pep517           no
+
         worksrcdir              ${distname}
         build.env-append        "CCFLAGS=-I${prefix}/include -L${prefix}/lib"
         destroot.env-append     "CCFLAGS=-I${prefix}/include -L${prefix}/lib"
@@ -162,120 +149,161 @@ if {${name} ne ${subport}} {
                                 CXXFLAGS=${configure.cxx_archflags} \
                                 CPPFLAGS=${configure.cppflags}
         }
+    }
 
-        post-destroot {
-            # for some reason read-world is not set
-            system "chmod -R a+r ${destroot}${prefix}"
-        }
+    post-destroot {
+        # for some reason read-world is not set
+        system "chmod -R a+r ${destroot}${prefix}"
+    }
 
-        variant atlas conflicts openblas mkl description "Use MacPorts ATLAS libraries" {
-            depends_lib-append  port:atlas
-        }
+    variant atlas conflicts openblas mkl description "Use MacPorts ATLAS libraries" {
+        depends_lib-append  port:atlas
+    }
 
-        variant openblas conflicts atlas mkl description "Use MacPorts OpenBLAS Libraries" {
-            depends_lib-append  path:lib/libopenblas.dylib:OpenBLAS
-        }
+    variant openblas conflicts atlas mkl description "Use MacPorts OpenBLAS Libraries" {
+        depends_lib-append  path:lib/libopenblas.dylib:OpenBLAS
+    }
 
-        variant mkl conflicts atlas openblas description "Use MacPorts MKL Libraries" {
-            depends_lib-append  port:py${python.version}-mkl \
-                                port:py${python.version}-mkl-include
-        }
+    variant mkl conflicts atlas openblas description "Use MacPorts MKL Libraries" {
+        depends_lib-append  port:py${python.version}-mkl \
+                            port:py${python.version}-mkl-include
+    }
 
-        # Make +openblas a default variant, at least temporarily, to
-        # overcome issues with Apple's /usr/lib/libblas.* and
-        # /usr/lib/liblapack.* missing a symbol. see also:
-        # https://trac.macports.org/ticket/57829
-        if {![variant_isset atlas] &&
-            ![variant_isset openblas] &&
-            ![variant_isset mkl]} {
-            default_variants +openblas
-        }
+    # Make +openblas a default variant, at least temporarily, to
+    # overcome issues with Apple's /usr/lib/libblas.* and
+    # /usr/lib/liblapack.* missing a symbol. see also:
+    # https://trac.macports.org/ticket/57829
+    if {![variant_isset atlas] &&
+        ![variant_isset openblas] &&
+        ![variant_isset mkl]} {
+        default_variants +openblas
+    }
 
-        if {[variant_isset atlas]} {
-            # use MacPorts atlas
-            build.env-append    OPENBLAS=None \
-                                MKLROOT=None \
-                                ATLAS=${prefix}/lib \
-                                LAPACK=${prefix}/lib \
-                                BLAS=${prefix}/lib
-            destroot.env-append OPENBLAS=None \
-                                MKLROOT=None \
-                                ATLAS=${prefix}/lib \
-                                LAPACK=${prefix}/lib \
-                                BLAS=${prefix}/lib
-
-            pre-fetch {
-                # scipy needs fortran; so we only need to check if atlas is
-                # compiled with +nofortran
-                if {![catch {set result [active_variants atlas "" nofortran]}]} {
-                    if {!$result} {
-                        return -code error \
-    "You have selected the +atlas variant but atlas was built with +nofortran.\
-    scipy needs a fortran enabled atlas. Please rebuild atlas without the +nofortran\
-    variant."
-                    }
-                }
-
-                # also check that numpy has the atlas variant active
-                if {![catch {set result [active_variants py${python.version}-numpy atlas ""]}]} {
-                    if {!$result} {
-
-                        return -code error \
-    "You have selected the +atlas variant but py${python.version}-numpy does not\
-    have the +atlas variant active. Please ensure that numpy is activated with the\
-    +atlas variant."
-                    }
-                }
-            }
-
-        } elseif {[variant_isset openblas]} {
-            # use MacPorts OpenBLAS
-            build.env-append    OPENBLAS=${prefix}/lib \
-                                ATLAS=None \
-                                MKLROOT=None
-            destroot.env-append OPENBLAS=${prefix}/lib \
-                                ATLAS=None \
-                                MKLROOT=None
-
-        } elseif {[variant_isset mkl]} {
-            # use MacPorts MKL
-            build.env-append    OPENBLAS=None \
-                                ATLAS=None \
-                                MKLROOT=${python.prefix}
-            destroot.env-append OPENBLAS=None \
-                                ATLAS=None \
-                                MKLROOT=${python.prefix}
-
-            pre-fetch {
-                # check that numpy has the mkl variant active
-                if {![catch {set result [active_variants py${python.version}-numpy mkl ""]}]} {
-                    if {!$result} {
-
-                        return -code error \
-    "You have selected the +mkl variant but py${python.version}-numpy does not\
-    have the +mkl variant active. Please ensure that numpy is activated with the\
-    +mkl variant."
-                    }
-                }
-            }
-
-            # set absolute path to remove references to @rpath/libmkl_rt.2.dylib
-            post-destroot {
-                foreach soname [exec find ${destroot}${python.pkgd}/scipy -name "*.so"] {
-                    system "install_name_tool -change @rpath/libmkl_rt.2.dylib ${python.prefix}/lib/libmkl_rt.2.dylib ${soname}"
-                    }
-            }
-
+    if {[variant_isset atlas]} {
+        # use MacPorts atlas
+        if {${python.version} >= 312} {
+            build.args-append \
+                            -Csetup-args=-Dblas=atlas \
+                            -Csetup-args=-Dlapack=atlas
         } else {
-            # use Accelerate BLAS
-            build.env-append    OPENBLAS=None \
-                                ATLAS=None \
-                                LAPACK=/usr/lib \
-                                BLAS=/usr/lib
-            destroot.env-append OPENBLAS=None \
-                                ATLAS=None \
-                                LAPACK=/usr/lib \
-                                BLAS=/usr/lib
+            build.env-append \
+                            OPENBLAS=None \
+                            MKLROOT=None \
+                            ATLAS=${prefix}/lib \
+                            LAPACK=${prefix}/lib \
+                            BLAS=${prefix}/lib
+            destroot.env-append \
+                            OPENBLAS=None \
+                            MKLROOT=None \
+                            ATLAS=${prefix}/lib \
+                            LAPACK=${prefix}/lib \
+                            BLAS=${prefix}/lib
+        }
+
+        pre-fetch {
+            # scipy needs fortran; so we only need to check if atlas is
+            # compiled with +nofortran
+            if {![catch {set result [active_variants atlas "" nofortran]}]} {
+                if {!$result} {
+                    return -code error \
+"You have selected the +atlas variant but atlas was built with +nofortran.\
+scipy needs a fortran enabled atlas. Please rebuild atlas without the +nofortran\
+variant."
+                }
+            }
+
+            # also check that numpy has the atlas variant active
+            if {![catch {set result [active_variants py${python.version}-numpy atlas ""]}]} {
+                if {!$result} {
+
+                    return -code error \
+"You have selected the +atlas variant but py${python.version}-numpy does not\
+have the +atlas variant active. Please ensure that numpy is activated with the\
++atlas variant."
+                }
+            }
+        }
+
+    } elseif {[variant_isset openblas]} {
+        # use MacPorts OpenBLAS
+        if {${python.version} >= 312} {
+            build.args-append \
+                            -Csetup-args=-Dblas=openblas \
+                            -Csetup-args=-Dlapack=openblas
+        } else {
+            build.env-append \
+                            OPENBLAS=${prefix}/lib \
+                            ATLAS=None \
+                            MKLROOT=None
+            destroot.env-append \
+                            OPENBLAS=${prefix}/lib \
+                            ATLAS=None \
+                            MKLROOT=None
+        }
+
+    } elseif {[variant_isset mkl]} {
+        # use MacPorts MKL
+        if {${python.version} >= 312} {
+            build.args-append \
+                            -Csetup-args=-Dblas=mkl \
+                            -Csetup-args=-Dlapack=mkl
+            build.env-append \
+                            "LDFLAGS=-L${python.prefix}/lib"
+        } else {
+            build.env-append \
+                            OPENBLAS=None \
+                            ATLAS=None \
+                            MKLROOT=${python.prefix}
+            destroot.env-append \
+                            OPENBLAS=None \
+                            ATLAS=None \
+                            MKLROOT=${python.prefix}
+        }
+
+        pre-fetch {
+            # check that numpy has the mkl variant active
+            if {![catch {set result [active_variants py${python.version}-numpy mkl ""]}]} {
+                if {!$result} {
+
+                    return -code error \
+"You have selected the +mkl variant but py${python.version}-numpy does not\
+have the +mkl variant active. Please ensure that numpy is activated with the\
++mkl variant."
+                }
+            }
+        }
+
+        # set absolute path to remove references to @rpath/libmkl_rt.2.dylib
+        post-destroot {
+            foreach soname [exec find ${destroot}${python.pkgd}/scipy -name "*.so"] {
+                system "install_name_tool -change @rpath/libmkl_rt.2.dylib ${python.prefix}/lib/libmkl_rt.2.dylib ${soname}"
+                }
+        }
+
+    } else {
+        # use Accelerate BLAS (macOS 13.3 and later)
+        if {${python.version} >= 312} {
+            build.args-append \
+                            -Csetup-args=-Dblas=accelerate \
+                            -Csetup-args=-Dlapack=accelerate
+        } else {
+            build.env-append \
+                            OPENBLAS=None \
+                            ATLAS=None \
+                            LAPACK=/usr/lib \
+                            BLAS=/usr/lib
+            destroot.env-append \
+                            OPENBLAS=None \
+                            ATLAS=None \
+                            LAPACK=/usr/lib \
+                            BLAS=/usr/lib
+        }
+        pre-fetch {
+            if {${os.major} < 22 || (${os.major} == 22 && ${os.minor} < 4)} {
+                return -code error \
+"Fallback on Accelerate BLAS requires macOS 13.3 or later. Please select a\
+BLAS variant"
+            }
         }
     }
 }

--- a/python/py-scipy/files/pkgconfig/atlas.pc
+++ b/python/py-scipy/files/pkgconfig/atlas.pc
@@ -1,0 +1,4 @@
+Name: atlas
+Description: ATLAS
+Version:
+Libs: -ltatlas

--- a/python/py-scipy/files/pkgconfig/mkl.pc
+++ b/python/py-scipy/files/pkgconfig/mkl.pc
@@ -1,0 +1,4 @@
+Name: mkl
+Description: Intel MKL
+Version:
+Libs: -lmkl_rt.2


### PR DESCRIPTION
#### Description

Note: Originally a PR for adding py312 subport and switching build system to Meson for Python >= 3.12, I have reduced it to one that fixes the BLAS variants when building with Meson. I have therefore edited this comment.

I tested my original code with all combinations of subports py311 and py312 and variants `+atlas`, `+openblas` and `+mkl`, as well as `-openblas` (Accelerate). Tested by importing `scipy` and using functions from `scipy.linalg.blas` and `scipy.linalg.lapack` (exception for Accelerate, see below).

The rebased solution is tested with py311 (`+atlas`) and py312 (`+atlas` and default). The rebase only involved moving a few instructions that were common to all variants. The variant-specific code was untouched.

Note that I tested building the Accelerate variant on a system that lacks a couple of symbols (macOS 11 is the max version that my HW supports), but I verified that this variant is linked against the same libraries as the py311 subport and that it fails “the right way” (i.e., complains about missing BLAS symbols in Accelerate when I try to use BLAS functionality). Then I added a guard to the Portfile to make the installation fail on pre-fetch if attempting to link against Accelerate on macOS < 13.3.

Main changes:
* I followed the recommendation in the [SciPy docs](https://docs.scipy.org/doc/scipy/building/blas_lapack.html#using-pkg-config-to-detect-libraries-in-a-nonstandard-location) on finding BLAS libraries, i.e., “craft your own pkg-config file. It […] may be located anywhere”. This was only necessary for ATLAS and MKL, and the only purpose of these .pc files is to let Meson know that the libraries exist and to provide the right linker flags (these flags could perhaps be set in the Portfile instead).
  * Meson uses CMake as fallback solution when pkg-config does not find the library. It was supposed to support an option `cmake_module_path` to `dependency`, which I thought I could use to point it to MKL’s CMake config file, but that did not work (log indicates that the option is ignored). Intel will axe macOS support in MKL with the first release in 2024, so I did not think it was a priority to look more into this, especially considering that I had to use the pkg-config file solution for ATLAS.
* Set BLAS library using Meson build options instead of environment variables

Notes:
* I explicitly link against ATLAS with `-ltatlas` and against MKL with `-lmkl_rt.2` to match what was done before
* For Cython etc. to work, I copied the solution from `py-pywavelets`, which is to add `${python.prefix}/bin` to `PATH` during the build phase. I have replaced the symlink-based solution on master.

Potential problems:
* From what I read, it is possible that Meson does not work on older releases of Mac OS X (especially PowerPC?). If this is the case, it must be restricted to versions older than OS X 10.9. I do not have a PowerPC system to test on. Per discussion below, the problem will not be relevant until the same issue is solved for py312-numpy.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

MKL variant and Accelerate:
macOS 11.6.2 20G314 x86_64
Xcode 13.2 13C90

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Tests: There are no tests turned on in the Portfile.

Binary files: no binaries to test. Tested by importing `scipy` into the REPL and using a couple of functions instead

Variants: I have tested the various BLAS variants, but so far I have only tested one compiler variant properly (gfortran). The current SciPy version requires GCC >= 8, so variants `gcc5`, `gcc6` and `gcc7` do not work anyway.

On my system `+gcc13` fails both for the new `py312` subport and the old `py311` subport (on libc++ stuff, it seems, not SciPy code). It seems to be because GCC tries to use libc++, but no matter what I do in the Portfile I cannot stop it from overwriting my `CXXFLAGS` with `-stdlib=libc++`. I had to manually `cd` to the build directory and import the environment variables, then set `-stdlib=libstdc++` in `CXXFLAGS` instead and call the build command. Then it would finally pass the correct compiler flags and the build succeeded.
