### PR TITLE
binaryen: don't enforce -Werror

### DIFF
--- a/lang/binaryen/Portfile
+++ b/lang/binaryen/Portfile
@@ -20,6 +20,6 @@ checksums                   rmd160  e112ff854fdb5a4f09a593afa849a918ddebb295 \
 
 depends_build-append        port:python311
 configure.args-append       -DPYTHON_EXECUTABLE=${prefix}/bin/python3.11 \
-                            -DBUILD_TESTS=OFF
+                            -DBUILD_TESTS=OFF -DENABLE_WERROR=OFF
 
 compiler.cxx_standard       2017


### PR DESCRIPTION


#### Description

Fixes install failure due to enforced `-Werror`, as the package itself had build warnings.
```
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_lang_binaryen/binaryen/work/binaryen-111/third_party/llvm-project/include/llvm/ADT/DenseMap.h:128:16: error: variable 'NumEntries' set but not used [-Werror,-Wunused-but-set-variable]
:info:build       unsigned NumEntries = getNumEntries();
:info:build                ^
:info:build /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_lang_binaryen/binaryen/work/binaryen-111/src/wasm/wasm-binary.cpp:860:13: error: variable 'emitted' set but not used [-Werror,-Wunused-but-set-variable]
:info:build       Index emitted = 0;
:info:build             ^
:info:build 1 error generated.
:info:build make[2]: *** [src/wasm/CMakeFiles/wasm.dir/wasm-debug.cpp.o] Error 1
```
Also mentioned in ticket https://trac.macports.org/ticket/68969

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 x86_64
Xcode 14.1 14B47b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
