### PR TITLE
py-scikit-image: update to 0.22.0

### DIFF
--- a/python/py-scikit-image/Portfile
+++ b/python/py-scikit-image/Portfile
@@ -4,12 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-scikit-image
-version             0.19.3
-revision            1
+python.rootname     scikit_image
+version             0.22.0
+revision            0
 categories-append   science
 license             BSD
 
 python.versions     38 39 310 311
+python.pep517_backend   meson
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -21,21 +23,22 @@ long_description    Image processing algorithms for SciPy, including IO, \
 
 homepage            https://scikit-image.org/
 
-checksums           rmd160  01818b658757b079f536110fd1af458bdc236b79 \
-                    sha256  24b5367de1762da6ee126dd8f30cc4e7efda474e0d7d70685433f0e3aa2ec450 \
-                    size    22232287
+checksums           md5 91dbff8962b4231ca0a9666f43c0d71f \
+                    rmd160 fb8347226da3f17fd149414ce0aeaf93d43993e9 \
+                    sha256 018d734df1d2da2719087d15f679d19285fce97cd37695103deadfaef2873236 \
+                    size   22685018
 
 if {${name} ne ${subport}} {
     compiler.openmp_version 2.5
 
     depends_build-append \
-                        port:py${python.version}-setuptools \
                         path:bin/cython-${python.branch}:py${python.version}-cython \
                         port:py${python.version}-pythran
 
-    depends_lib-append  port:py${python.version}-numpy \
-                        port:py${python.version}-scipy \
-                        port:py${python.version}-packaging
+    depends_lib-append  port:py${python.version}-lazy_loader \
+                        port:py${python.version}-numpy \
+                        port:py${python.version}-packaging \
+                        port:py${python.version}-scipy
 
     depends_run-append  port:py${python.version}-matplotlib \
                         port:py${python.version}-networkx \
@@ -44,7 +47,21 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-pywavelets \
                         port:py${python.version}-tifffile
 
-    patchfiles          patch-pyproject.toml.diff
+    post-patch {
+        reinplace "s|#!/usr/bin/env python|#!/usr/bin/env python3|" \
+            {*}[glob -directory ${worksrcpath}/skimage/_build_utils {[a-z]*.py}]
+    }
 
-    use_parallel_build  no
+    if {${python.version} == 38} {
+        version             0.21.0
+        revision            0
+        checksums           md5 de3b2910a7f3f3b239111fee4f31eaf1 \
+                            rmd160 7566fecf15bbe02f0015c4c664afac59fb049ff8 \
+                            sha256 b33e823c54e6f11873ea390ee49ef832b82b9f70752c8759efd09d5a4e3d87f0
+        patchfiles-append   pyproject.toml-0.21.0.diff
+    } else {
+        patchfiles-append   patch-pyproject.toml.diff
+    }
+
+    build.env-append        PATH=${python.prefix}/bin:$::env(PATH)
 }

--- a/python/py-scikit-image/files/patch-pyproject.toml.diff
+++ b/python/py-scikit-image/files/patch-pyproject.toml.diff
@@ -1,11 +1,22 @@
---- pyproject.toml.orig	2022-06-12 13:10:33.000000000 -0500
-+++ pyproject.toml	2023-01-28 18:58:03.000000000 -0600
-@@ -1,7 +1,7 @@
- [build-system]
+--- pyproject.toml.orig	2023-10-04 07:14:28
++++ pyproject.toml	2023-12-27 14:16:12
+@@ -118,18 +118,11 @@
+ build-backend = 'mesonpy'
  requires = [
-     "wheel",
--    "setuptools<=59.4",
-+    "setuptools",
-     "packaging",
-     "Cython>=0.29.24,<3.0",
-     "pythran",
+     'meson-python>=0.14',
+-    'wheel',
+-    'setuptools>=67',
+     'packaging>=21',
+     'Cython>=0.29.32',
+     'pythran',
+     'lazy_loader>=0.3',
+-    "numpy==1.22.4; python_version=='3.9' and platform_python_implementation != 'PyPy'",
+-    "numpy==1.22.4; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
+-    "numpy==1.22.4; python_version=='3.10' and platform_system != 'Windows' and platform_python_implementation != 'PyPy'",
+-    "numpy==1.23.3; python_version=='3.11' and platform_python_implementation != 'PyPy'",
+-    "numpy; python_version>='3.12'",
+-    "numpy; python_version>='3.9' and platform_python_implementation=='PyPy'",
++    "numpy",
+ ]
+ 
+ [tool.spin]

--- a/python/py-scikit-image/files/pyproject.toml-0.21.0.diff
+++ b/python/py-scikit-image/files/pyproject.toml-0.21.0.diff
@@ -1,0 +1,23 @@
+--- pyproject.toml.orig	1970-01-01 10:00:00
++++ pyproject.toml	2023-12-27 14:21:00
+@@ -135,19 +135,11 @@
+ build-backend = 'mesonpy'
+ requires = [
+     'meson-python>=0.13',
+-    'wheel',
+-    'setuptools>=67',
+     'packaging>=21',
+     'Cython>=0.29.32',
+     'pythran',
+     'lazy_loader>=0.2',
+-    "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
+-    "numpy==1.21.1; python_version=='3.8' and platform_python_implementation != 'PyPy'",
+-    "numpy==1.21.1; python_version=='3.9' and platform_python_implementation != 'PyPy'",
+-    "numpy==1.21.6; python_version=='3.10' and platform_system != 'Windows' and platform_python_implementation != 'PyPy'",
+-    "numpy==1.23.3; python_version=='3.11' and platform_python_implementation != 'PyPy'",
+-    "numpy; python_version>='3.12'",
+-    "numpy; python_version>='3.8' and platform_python_implementation=='PyPy'",
++    "numpy",
+ ]
+ [tool.spin]
+ package = 'skimage'


### PR DESCRIPTION
Now compatible with Cython 3. Updating py38 to 0.21.0 instead as that is the last version that supports it.
