### PR TITLE
docker: update to 24.0.7

### DIFF
--- a/devel/docker/Portfile
+++ b/devel/docker/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/docker/cli 24.0.6 v
+go.setup            github.com/docker/cli 24.0.7 v
 revision            0
 name                docker
 categories          devel
@@ -16,9 +16,9 @@ long_description    Docker is an open source project to pack, ship \
                     This port contains command line utilities for interacting \
                     with Docker, but not the core daemon.
 
-checksums           rmd160  6f94dbb32290e93ac789907e9526c6e9a1bedf19 \
-                    sha256  2b0d42fdf03568b02ad39ac2f68fa69a47a659f457db562518c084bdf9932da5 \
-                    size    6244734
+checksums           rmd160  8c600588f89a4f48c2d43150f2e1545734296b16 \
+                    sha256  77bead764ac523e50fbe185cbfcc52e1b9e7de595994da515f4ae90d558a7e6b \
+                    size    6451562
 
 build.target        github.com/docker/cli/cmd/docker
 


### PR DESCRIPTION
#### Description

Update to Docker 24.0.7.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?