### PR TITLE
qt(59|511|513|5)-qtlocation: `conflicts_build rapidjson rapidjson-devel`

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -1608,6 +1608,10 @@ foreach {module module_info} [array get modules] {
                 # do not allow ${prefix}/include/boost to conflict with bundled boost (in bundled mapbox-gl-native)
                 conflicts_build boost
 
+                # https://trac.macports.org/ticket/68508
+                # do not allow ${prefix}/include/rapidjson to conflict with bundled rapidjson (in bundled mapbox-gl-native)
+                conflicts_build rapidjson rapidjson-devel
+
                 # https://trac.macports.org/ticket/67417
                 # include/mbgl/util/unique_any.hpp: error: no member named 'move' in namespace 'std'
                 patchfiles-append  patch-qtlocation-mbgl-unique_any.hpp.diff

--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -1353,6 +1353,10 @@ foreach {module module_info} [array get modules] {
                 # do not allow ${prefix}/include/boost to conflict with bundled boost (in bundled mapbox-gl-native)
                 conflicts_build boost
 
+                # https://trac.macports.org/ticket/68508
+                # do not allow ${prefix}/include/rapidjson to conflict with bundled rapidjson (in bundled mapbox-gl-native)
+                conflicts_build rapidjson rapidjson-devel
+
                 # qtlocation uses
                 #    Gypsy (https://gypsy.freedesktop.org/wiki/)
                 #    if they can be found

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -1373,6 +1373,10 @@ foreach {module module_info} [array get modules] {
                 # do not allow ${prefix}/include/boost to conflict with bundled boost (in bundled mapbox-gl-native)
                 conflicts_build boost
 
+                # https://trac.macports.org/ticket/68508
+                # do not allow ${prefix}/include/rapidjson to conflict with bundled rapidjson (in bundled mapbox-gl-native)
+                conflicts_build rapidjson rapidjson-devel
+
                 # qtlocation uses
                 #    Gypsy (https://gypsy.freedesktop.org/wiki/)
                 #    if they can be found

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -1339,6 +1339,10 @@ foreach {module module_info} [array get modules] {
                 #   error: expected ';' at end of declaration list
                 conflicts_build boost
 
+                # https://trac.macports.org/ticket/68508
+                # do not allow ${prefix}/include/rapidjson to conflict with bundled rapidjson (in bundled mapbox-gl-native)
+                conflicts_build rapidjson rapidjson-devel
+
                 # qtlocation uses
                 #    Gypsy (https://gypsy.freedesktop.org/wiki/)
                 #    if they can be found


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68508

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Not tested beyond getting the expected error when trying to build `qt5-qtlocation` while `rapidjson-devel` is active.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
