### PR TITLE
hdf5: Avoid duplicate LC_RPATH's

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 name                hdf5
 version             1.14.3
 set mainversion     [lrange [split ${version} -] 0 0]
-revision            1
+revision            2
 set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
 categories          science
 maintainers         {eborisch @eborisch} openmaintainer
@@ -56,6 +56,9 @@ compiler.blacklist-append \
                     {clang < 500}
 
 compiler.c_standard 1999
+
+# Avoid duplicate LC_RPATH's in dylibs, satisfy Xcode 15 linker.
+compilers.add_gcc_rpath_support no
 
 # Use lib/hdf5 rather than hdf5/lib plugin directory
 configure.args \


### PR DESCRIPTION
#### Description

* Avoid duplicate LC_RPATH's in hdf5 fortran dylibs, using new compiler PG option.
* Rev bump to push out the corrected dylibs.

This PR attempts to fix builds for dependent ports on Ventura and Sonoma, with Xcode 15.  The Xcode 15 linker has a new rule against duplicate LC_RPATH's.  Rev bump is needed to push out the corrected dylibs.

This is a follow-up to the recent PR https://github.com/macports/macports-ports/pull/21946 which tried but failed to fix the same problem with port hdf5.

The fix for duplicate LC_RPATH's was copied from the recent OpenBLAS fix for the same thing: https://github.com/macports/macports-ports/pull/21765

###### Type(s)

- [x] bugfix

###### Tested on

macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `port -vs install`?
- [ ] tested basic functionality of all binary files?
- [x] tested basic functionality of ONE binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
