### PR TITLE
libdispatch-legacy: new port in devel

### DIFF
--- a/devel/libdispatch-legacy/Portfile
+++ b/devel/libdispatch-legacy/Portfile
@@ -1,0 +1,102 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           xcode 1.0
+
+name                libdispatch-legacy
+version             84.5.5
+categories          devel
+platforms           {darwin < 11}
+license             Apache-2
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Grand Central Dispatch for PowerPC systems and pre-Snow Leopard x86
+long_description    Grand Central Dispatch (GCD or libdispatch) provides comprehensive support \
+                    for concurrent code execution on multicore hardware. This port in meant \
+                    for systems without a native libdispatch. It corresponds to macOS 10.6.7 release.
+homepage            https://opensource.apple.com/releases
+set apple_sources   https://github.com/apple-oss-distributions
+master_sites-append ${apple_sources}/Libc/archive/refs/tags/:Libc \
+                    ${apple_sources}/libclosure/archive/refs/tags/:libclosure \
+                    ${apple_sources}/libdispatch/archive/refs/tags/:libdispatch \
+                    ${apple_sources}/xnu/archive/refs/tags/:xnu
+
+set LIBC            Libc-594.9.5
+set LIBCLOSURE      libclosure-38
+set LIBDISPATCH     libdispatch-${version}
+set XNU             xnu-1504.15.3
+
+distfiles           ${LIBDISPATCH}.tar.gz:libdispatch \
+                    ${LIBC}.tar.gz:Libc \
+                    ${LIBCLOSURE}.tar.gz:libclosure \
+                    ${XNU}.tar.gz:xnu
+
+checksums           ${LIBDISPATCH}.tar.gz \
+                    rmd160  cd291e5bc6e65bc75995017f763fa2f69c5ed76c \
+                    sha256  26e87bb08ccfc71b8d867d2732f154a56b8500d33311108ca5fff81fc9eaea3f \
+                    size    171043 \
+                    ${LIBC}.tar.gz \
+                    rmd160  309ac37e61607088a9bab0f2f889de95c02e0342 \
+                    sha256  71a60d57ff02b1125be6c689d9cfc66f4f76de85293068504ed63f881b8dbcf3 \
+                    size    2128046 \
+                    ${LIBCLOSURE}.tar.gz \
+                    rmd160  37a0c0c1748d8f6e090b950ca8ed88fbe4da5d4a \
+                    sha256  5739bdb251444acb7d2c7f7032763db6601de36a20c2ed55af63b56f093a257c \
+                    size    139164 \
+                    ${XNU}.tar.gz \
+                    rmd160  438bef8a0c85b45e7b0e87fe455906bd64446285 \
+                    sha256  05cc3e9617581f8f9bfa434901fb902761c89bbcf770d822e84a31dd625c2b58 \
+                    size    8872451
+
+extract {
+    ui_msg "---> Extracting sources"
+    foreach libsource [list ${LIBC} ${LIBCLOSURE} ${LIBDISPATCH} ${XNU}] {
+        xinstall -d ${workpath}/${libsource}
+        system -W ${workpath} "tar -xf ${distpath}/$libsource.tar.gz -C $libsource --strip-components 1"
+    }
+}
+
+post-extract {
+    ln -s ${workpath}/${XNU}/osfmk ${workpath}/${XNU}/libkern/System
+}
+
+patchfiles-append   patch-project.pbxproj.diff
+
+worksrcdir          ${workpath}/${LIBDISPATCH}
+
+compiler.blacklist  apple* macports*
+
+# sterilize MacPorts build environment; we want nothing picked from MP prefix
+compiler.cpath
+compiler.library_path
+
+configure.cxx_stdlib
+
+configure.cflags
+configure.cxxflags
+configure.cppflags
+configure.optflags
+configure.ldflags
+
+post-patch {
+    reinplace "s|@LIBC@|${LIBC}|g" ${worksrcpath}/libdispatch.xcodeproj/project.pbxproj
+    reinplace "s|@LIBCLOSURE@|${LIBCLOSURE}|g" ${worksrcpath}/libdispatch.xcodeproj/project.pbxproj
+    reinplace "s|@XNU@|${XNU}|g" ${worksrcpath}/libdispatch.xcodeproj/project.pbxproj
+}
+
+xcode.target        libdispatch
+
+use_parallel_build  no
+
+default_variants    +universal
+
+destroot {
+    set dispatch_build ${workpath}/${LIBDISPATCH}/build/Release
+    set dispatch_root ${destroot}${prefix}/libexec/dispatch
+    xinstall -d ${dispatch_root}/lib
+    foreach lib {libdispatch.a libdispatch_debug.a libdispatch_profile.a} {
+        copy ${dispatch_build}/${lib} ${dispatch_root}/lib
+    }
+    foreach incdir {include local} {
+        copy ${dispatch_build}/usr/${incdir} ${dispatch_root}
+    }
+}

--- a/devel/libdispatch-legacy/files/patch-project.pbxproj.diff
+++ b/devel/libdispatch-legacy/files/patch-project.pbxproj.diff
@@ -1,0 +1,32 @@
+--- libdispatch.xcodeproj/project.pbxproj	2021-10-06 13:21:40.000000000 +0800
++++ libdispatch.xcodeproj/project.pbxproj	2023-12-28 11:50:04.000000000 +0800
+@@ -378,10 +378,10 @@
+ 					"-fdiagnostics-show-option",
+ 					"-fsched-interblock",
+ 					"-freorder-blocks",
+-					"-Xarch_x86_64",
+-					"-momit-leaf-frame-pointer",
+-					"-Xarch_i386",
+-					"-momit-leaf-frame-pointer",
++					"-DPRIVATE",
++					"-I../@LIBC@/pthreads",
++					"-I../@LIBCLOSURE@",
++					"-I../@XNU@/libkern",
+ 				);
+ 				OTHER_CFLAGS_debug = "-O0 -fstack-protector -fno-inline -DDISPATCH_DEBUG=1";
+ 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/dispatch;
+@@ -423,10 +423,10 @@
+ 					"-fdiagnostics-show-option",
+ 					"-fsched-interblock",
+ 					"-freorder-blocks",
+-					"-Xarch_x86_64",
+-					"-momit-leaf-frame-pointer",
+-					"-Xarch_i386",
+-					"-momit-leaf-frame-pointer",
++					"-DPRIVATE",
++					"-I../@LIBC@/pthreads",
++					"-I../@LIBCLOSURE@",
++					"-I../@XNU@/libkern",
+ 				);
+ 				OTHER_CFLAGS_debug = "-O0 -fstack-protector -fno-inline -DDISPATCH_DEBUG=1";
+ 				PREBINDING = NO;


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/65988

#### Description

Turns out, `libdispatch` with Xcode gcc. Confirmed on 10.6.8 for `ppc + i386 + x86_64`.
I followed this procedure: https://arstechnica.com/civis/threads/so-i-want-to-step-through-grand-central-dispatch-in-xcode.1116554/#post-20651316

Putting it in a dedicated prefix, so that it is not found by accident.

P. S. This port makes no sense on 10.7+, where there is a native and newer libdispatch, so restrict to <11.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
