### PR TITLE
py-fiona: update to 1.9.5

### DIFF
--- a/python/py-fiona/Portfile
+++ b/python/py-fiona/Portfile
@@ -4,9 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-fiona
-python.rootname     Fiona
-version             1.9.4.post1
-revision            4
+version             1.9.5
 categories-append   gis
 license             BSD
 
@@ -23,9 +21,10 @@ long_description    Fiona provides uncomplicated Python interfaces \
 
 homepage            https://github.com/Toblerity/Fiona
 
-checksums           rmd160  f1b9081836b611bb7d9337e8847a679a1c02f68c \
-                    sha256  5679d3f7e0d513035eb72e59527bb90486859af4405755dfc739138633106120 \
-                    size    924293
+checksums           md5 e5b533bdfc5cc48fba7257e1c0285552 \
+                    rmd160 8708aa5419f4c01eb2edfd74d5dfa33b369b1198 \
+                    sha256 99e2604332caa7692855c2ae6ed91e1fffdf9b59449aa8032dd18e070e59a2f7 \
+                    size   409295
 
 if {${name} ne ${subport}} {
 
@@ -39,10 +38,10 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-click-plugins \
                         port:py${python.version}-cligj \
                         port:py${python.version}-munch \
-                        port:py${python.version}-setuptools \
                         port:gdal
-
-    post-patch {
-        reinplace "s|oldest-supported-numpy|numpy|g" ${worksrcpath}/pyproject.toml
+    if {${python.version} < 310} {
+        depends_lib-append  port:py${python.version}-importlib-metadata
     }
+
+    patchfiles          pyproject.toml.patch 
 }

--- a/python/py-fiona/files/pyproject.toml.patch
+++ b/python/py-fiona/files/pyproject.toml.patch
@@ -1,0 +1,11 @@
+--- pyproject.toml.orig	2023-10-13 06:14:23
++++ pyproject.toml	2023-12-28 20:40:07
+@@ -2,7 +2,7 @@
+ requires = [
+     "cython~=3.0.2",
+     "oldest-supported-numpy",
+-    "setuptools>=67.8",
++    "setuptools",
+     "wheel",
+ ]
+ build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Now compatible with (and requires) Cython 3.
