### PR TITLE
py-pyproj: update to 3.6.1

### DIFF
--- a/python/py-pyproj/Portfile
+++ b/python/py-pyproj/Portfile
@@ -4,10 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pyproj
-version             3.6.0
-revision            1
+version             3.6.1
 categories-append   devel
-platforms           darwin
 license             MIT
 
 python.versions     37 38 39 310 311
@@ -22,9 +20,10 @@ long_description    Pyrex wrapper to provide python interfaces to PROJ.4 \
 
 homepage            https://pyproj4.github.io/pyproj
 
-checksums           rmd160  361e1640e9ae1049460a74e3f679348e11d36d93 \
-                    sha256  a5b111865b3f0f8b77b3983f2fbe4dd6248fc09d3730295949977c8dcd988062 \
-                    size    224432
+checksums           md5 09a67b757bc473b47fb2e247b9994228 \
+                    rmd160 4cea140c609a5e74dfb0de338e321bd670320329 \
+                    sha256 44aa7c704c2b7d8fb3d483bbf75af6cb2350d30a63b144279a09b75fead501bf \
+                    size   225131
 
 if {${name} ne ${subport}} {
 
@@ -92,8 +91,16 @@ if {${name} ne ${subport}} {
         }
     }
 
-    depends_build-append \
-                        path:bin/cython-${python.branch}:py${python.version}-cython
+    if {${python.version} <= 38} {
+        depends_build-append \
+                        port:py${python.version}-cython-compat
+        set compat_path [string replace ${python.pkgd} 0 [string length ${python.prefix}]-1 ${prefix}/lib/py${python.version}-cython-compat]
+        build.env-append    PYTHONPATH=${compat_path}
+        destroot.env-append PYTHONPATH=${compat_path}
+    } else {
+        depends_build-append \
+                        port:py${python.version}-cython
+    }
 
     depends_lib-append  port:py${python.version}-certifi
 


### PR DESCRIPTION
Now compatible with Cython 3. Using py-cython-compat for older versions.
