### PR TITLE
qt6-qtbase: Fix building on MacOS 10.14 SDK

### DIFF
--- a/aqua/qt6/files/patch-qtbase-macos_10.14_sdk.diff
+++ b/aqua/qt6/files/patch-qtbase-macos_10.14_sdk.diff
@@ -37,16 +37,17 @@ Upstream-Status: Inappropriate [violates DRY]
              driverInfoStruct.deviceType = QRhiDriverInfo::ExternalDevice;
              break;
          default:
-@@ -403,7 +403,7 @@
+@@ -403,7 +403,9 @@
      caps.maxTextureSize = 16384;
      caps.baseVertexAndInstance = true;
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
      if (@available(macOS 10.15, *))
--        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamilyApple7];
-+        caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamily(1007)]; // MTLGPUFamilyApple7
+         caps.isAppleGPU = [d->dev supportsFamily:MTLGPUFamilyApple7];
++#endif
      caps.maxThreadGroupSize = 1024;
  #elif defined(Q_OS_TVOS)
      if ([d->dev supportsFeatureSet: MTLFeatureSet(30003)]) // MTLFeatureSet_tvOS_GPUFamily2_v1
-@@ -2543,6 +2543,26 @@
+@@ -2543,6 +2545,26 @@
          return srgb ? MTLPixelFormatASTC_12x10_sRGB : MTLPixelFormatASTC_12x10_LDR;
      case QRhiTexture::ASTC_12x12:
          return srgb ? MTLPixelFormatASTC_12x12_sRGB : MTLPixelFormatASTC_12x12_LDR;
@@ -95,3 +96,17 @@ Upstream-Status: Inappropriate [violates DRY]
  #else
          desc.storageMode = MTLStorageModeMemoryless;
          d->format = MTLPixelFormatDepth32Float_Stencil8;
+--- src/plugins/platforms/cocoa/qcocoascreen.mm.orig	2023-02-14 09:26:04.000000000 +0100
++++ src/plugins/platforms/cocoa/qcocoascreen.mm	2023-12-28 11:31:59.000000000 +0100
+@@ -271,9 +271,11 @@
+     float refresh = CGDisplayModeGetRefreshRate(displayMode);
+     m_refreshRate = refresh > 0 ? refresh : 60.0;
+ 
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+     if (@available(macOS 10.15, *))
+         m_name = QString::fromNSString(nsScreen.localizedName);
+     else
++#endif
+         m_name = displayName(m_displayId);
+ 
+     const bool didChangeGeometry = m_geometry != previousGeometry || m_availableGeometry != previousAvailableGeometry;


### PR DESCRIPTION
#### Description

As it turns out, #21831 fixed only building under macOS 10.14 with SDK 10.15. Therefore, it helped the buildbot to build qt6-qtbase on 10.15, but 10.14 binary package fails.
Here is a followup that fixes building qt6-qtbase on SDK 10.14. 

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Xcode 11.7 11E801a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
