### PR TITLE
GPXSee: update to 13.13

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.10
+github.setup        tumic0 GPXSee 13.13
 revision            0
 
-checksums           rmd160  85fd162bf2b822edea1c90935581bf3796dd2048 \
-                    sha256  a531ee041c14e00e8d637ade4d29a766628e3b75b4472b08edb6d72d3ff506cf \
-                    size    5541000
+checksums           rmd160  f9c86564eeaeb7cff4c109bd4b13decdc78c0f40 \
+                    sha256  7da902bfa67d6fcf61a6fb936f0dbff6671d7ac6fea066bab37406b6952c09c3 \
+                    size    5551762
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
