### PR TITLE
qt(59|511)-qtscript: allow C++20 compilers to work

### DIFF
--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -1572,6 +1572,11 @@ foreach {module module_info} [array get modules] {
                 if {[variant_isset examples]} {
                     depends_lib-append  port:${name}-qttools
                 }
+
+                # see https://trac.macports.org/ticket/59321
+                post-extract {
+                    move ${worksrcpath}/src/3rdparty/javascriptcore/VERSION ${worksrcpath}/src/3rdparty/javascriptcore/VERSION.txt
+                }
             }
 
             # special case

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -1550,6 +1550,11 @@ foreach {module module_info} [array get modules] {
                 if {[variant_isset examples]} {
                     depends_lib-append  port:${name}-qttools
                 }
+
+                # see https://trac.macports.org/ticket/59321
+                post-extract {
+                    move ${worksrcpath}/src/3rdparty/javascriptcore/VERSION ${worksrcpath}/src/3rdparty/javascriptcore/VERSION.txt
+                }
             }
 
             # special case


### PR DESCRIPTION
As done previously for older Qt versions: e1b366527ad1c0f7bc8e42005df2285aaa1c606c

See: https://trac.macports.org/ticket/59321

#### Description
> C++20 will likely have a header file called version.
> Qt Script has a file called VERSION.
> On a case-insensitive file systems, the wrong file will be found.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Only tested extract phase.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
