### PR TITLE
py-bugsnag: update to 4.6.1

### DIFF
--- a/python/py-bugsnag/Portfile
+++ b/python/py-bugsnag/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-bugsnag
-version             4.6.0
+version             4.6.1
 revision            0
 categories-append   devel
 license             MIT
@@ -19,9 +19,9 @@ homepage            https://github.com/bugsnag/bugsnag-python
 description         Automatic error monitoring for django, flask etc.
 long_description    {*}${description}
 
-checksums           rmd160  8efcf5e236d4382185a4fa1731d62d3e0088916c \
-                    sha256  abe8716036a33d5911fc01cb7d346afc4f287cedd47a92cda28512fc22c837fe \
-                    size    67321
+checksums           rmd160  060d95451330a6739a95e4954a4d42454ab59ad2 \
+                    sha256  1b3a6ea4bfb01362493d3f763bac99356668c28e9f5f352f92e043b4a2f51daa \
+                    size    67857
 
 if {${name} ne ${subport}} {
     depends_lib-append \


### PR DESCRIPTION
#### Description

Simple update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
