### PR TITLE
netcdf-fortran: revbump, flush broken Sonoma build

### DIFF
--- a/science/netcdf-fortran/Portfile
+++ b/science/netcdf-fortran/Portfile
@@ -21,7 +21,7 @@ PortGroup                   github 1.0
 mpi.enforce_variant         netcdf
 
 github.setup                Unidata netcdf-fortran 4.6.1 v
-revision                    3
+revision                    4
 maintainers                 {takeshi @tenomoto} \
                             {@Dave-Allured noaa.gov:dave.allured} \
                             openmaintainer


### PR DESCRIPTION
#### Description

* Rev bump only.
* Maybe fix broken Sonoma build.
* Rebuild needed after secondary dependency hdf5 was fixed.

Maybe fixes https://trac.macports.org/ticket/68124 for Sonoma only.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
