### PR TITLE
QMPlay2: fix for pre-Sierra systems

### DIFF
--- a/multimedia/QMPlay2/Portfile
+++ b/multimedia/QMPlay2/Portfile
@@ -6,7 +6,8 @@ PortGroup           cmake 1.1
 
 name                QMPlay2
 
-if {${os.platform} eq "darwin" && ${os.major} < 11} {
+# Currently Qt5 is broken on 10.7.
+if {${os.platform} eq "darwin" && ${os.major} < 12} {
     PortGroup       qt4 1.0
 
     github.setup    zaps166 QMPlay2 b76e6ea46b4a32bb2becc9444ddc6f5fdff699cd
@@ -61,17 +62,33 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 
     qt5.depends_component qtdeclarative qttools qttranslations
 
-    github.setup    zaps166 QMPlay2 23.10.22
-    revision        0
-    checksums       rmd160  8a4c9db6811e577ebeae5c40c279fd64f550ece2 \
-                    sha256  d81c5a81a8839ac441eb7466eb16931aab92f71fd784a3b3e1d709272c4237cf \
-                    size    1442072
-    github.tarball_from releases
-    distname        ${name}-src-${version}
-    use_xz          yes
+    # Support for Qt5 < 5.10 has been dropped in 21.03.09:
+    # https://github.com/zaps166/QMPlay2/commit/02684fec6217ac87a37dbd40d7b07683122e5997
+    if {${os.platform} eq "darwin" && ${os.major} < 15} {
+        github.setup    zaps166 QMPlay2 20.12.16
+        revision        0
+        checksums       rmd160  582ec7368e582b4b29280d6c76d4dc54d1fd0bb3 \
+                        sha256  d6a5425f552e33a70b254ed27631878f20ea92850ccf221c2f2322200783d278 \
+                        size    1564588
+        github.tarball_from releases
+        distname        ${name}-src-${version}
 
-    patchfiles-append \
-                    2001-Fix-Qt-paths.patch
+        patchfiles-append \
+                        1001-Fix-Qt-paths.patch
+     } else {
+        github.setup    zaps166 QMPlay2 23.10.22
+        revision        1
+        checksums       rmd160  8a4c9db6811e577ebeae5c40c279fd64f550ece2 \
+                        sha256  d81c5a81a8839ac441eb7466eb16931aab92f71fd784a3b3e1d709272c4237cf \
+                        size    1442072
+        github.tarball_from releases
+        distname        ${name}-src-${version}
+
+        patchfiles-append \
+                        2001-Fix-Qt-paths.patch
+    }
+
+    use_xz          yes
 
     configure.args-append \
                     -DCMAKE_LINK_DEPENDS_NO_SHARED=OFF \
@@ -80,6 +97,12 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
                     -DUSE_OPENGL=ON \
                     -DUSE_RUBBERBAND=ON \
                     -DUSE_UPDATES=OFF
+
+    # VTBOpenGL.cpp: error: use of undeclared identifier 'kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange'
+    if {${os.platform} eq "darwin" && ${os.major} < 17} {
+        configure.args-append \
+                    -DUSE_FFMPEG_VTB=OFF
+    }
 
     depends_lib-append \
                     port:rubberband
@@ -92,12 +115,22 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
         system "install_name_tool -change ${prefix}/lib/libqmplay2.dylib \
                     ${applications_dir}/${name}.app/Contents/MacOS/libqmplay2.dylib \
                     ${destroot}${applications_dir}/${name}.app/Contents/MacOS/QMPlay2"
-        foreach so [ exec find ${destroot}${applications_dir}/${name}.app/Contents/MacOS/modules -name "\*.so" ] {
-            regsub ":$" ${so} "" destroot_so_path
-            regsub ${destroot} ${destroot_so_path} "" so_path
-            system "install_name_tool -id ${so_path} ${destroot_so_path}"
-            system "install_name_tool -change ${prefix}/lib/libqmplay2.dylib ${applications_dir}/${name}.app/Contents/MacOS/libqmplay2.dylib \
-                ${destroot_so_path}"
+        if {${os.platform} eq "darwin" && ${os.major} < 15} {
+            foreach dylib [ exec find ${destroot}${applications_dir}/${name}.app/Contents/MacOS/modules -name "\*.dylib" ] {
+                regsub ":$" ${dylib} "" destroot_dylib_path
+                regsub ${destroot} ${destroot_dylib_path} "" dylib_path
+                system "install_name_tool -id ${dylib_path} ${destroot_dylib_path}"
+                system "install_name_tool -change ${prefix}/lib/libqmplay2.dylib ${applications_dir}/${name}.app/Contents/MacOS/libqmplay2.dylib \
+                    ${destroot_dylib_path}"
+            }
+        } else {
+            foreach so [ exec find ${destroot}${applications_dir}/${name}.app/Contents/MacOS/modules -name "\*.so" ] {
+                regsub ":$" ${so} "" destroot_so_path
+                regsub ${destroot} ${destroot_so_path} "" so_path
+                system "install_name_tool -id ${so_path} ${destroot_so_path}"
+                system "install_name_tool -change ${prefix}/lib/libqmplay2.dylib ${applications_dir}/${name}.app/Contents/MacOS/libqmplay2.dylib \
+                    ${destroot_so_path}"
+            }
         }
     }
 }

--- a/multimedia/QMPlay2/files/1001-Fix-Qt-paths.patch
+++ b/multimedia/QMPlay2/files/1001-Fix-Qt-paths.patch
@@ -1,24 +1,17 @@
-From 3cbc61634d8b30a34166630d254ad84e747038b7 Mon Sep 17 00:00:00 2001
-From: Sergey Fedorov <vital.had@gmail.com>
-Date: Mon, 25 Dec 2023 07:25:56 +0800
-Subject: [PATCH] Fix Qt paths
-
-diff --git src/gui/CMakeLists.txt src/gui/CMakeLists.txt
-index 33a67ac1..6bac8fa0 100644
---- src/gui/CMakeLists.txt
-+++ src/gui/CMakeLists.txt
-@@ -237,8 +237,8 @@
+--- src/gui/CMakeLists.txt	2020-12-16 07:37:48
++++ src/gui/CMakeLists.txt	2023-12-29 15:08:25
+@@ -227,8 +227,8 @@
  elseif(APPLE)
      install(TARGETS ${PROJECT_NAME} BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
  
--    set(QT_LIBS_DIR "${${QT_PREFIX}Widgets_DIR}/../..")
+-    set(QT_LIBS_DIR "${Qt5Widgets_DIR}/../..")
 -    set(QT_PLUGINS_DIR "${QT_LIBS_DIR}/../plugins")
 +    set(QT_LIBS_DIR "@qt_libs_dir@")
 +    set(QT_PLUGINS_DIR "@qt_plugins_dir@")
      install(FILES
          "${QT_PLUGINS_DIR}/platforms/libqcocoa.dylib"
          DESTINATION "${MAC_BUNDLE_PATH}/Contents/plugins/platforms")
-@@ -259,23 +259,7 @@
+@@ -249,23 +249,7 @@
          DESTINATION "${MAC_BUNDLE_PATH}/Contents"
          FILES_MATCHING
          PATTERN "qtbase_*.qm")


### PR DESCRIPTION
#### Description

I have nothing to test this on and rely on buildbots logs, but I did confirm that v. 20.12.16 which should build with Qt5 < 5.10 and which I use therefore as a fallback does build on Sonoma.

On Sierra and El Capitan Videotoolbox module fails to build: https://build.macports.org/builders/ports-10.12_x86_64-builder/builds/255792/steps/install-port/logs/stdio
I turn it off for those OS.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1
Xcode 15.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
