### PR TITLE
symfony-cli: update to 5.7.7

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.7.6
+version             5.7.7
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  e4f63698393e817dd2198ac183a83b0af77f8c56 \
-                        sha256  351971c0a9dce67c27bf5469a1662a54d4e2a533197c69e7599dbe964c0101e5 \
-                        size    259468
+    checksums           rmd160  248589f4b6604f877c703c1a03af8112ad9e5dd0 \
+                        sha256  9c497939492df4a39bd90f41c6299e453de726e8211866c018a2483b572501ce \
+                        size    259352
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  7cae4bd72749ca965d96cbfeef71dad27c793bf0 \
-                        sha256  c228c3b19290a919afee7540aa32706819a5c37914d0278eb55b08219fd93d53 \
-                        size    11150160
+    checksums           rmd160  9908f1f37d00a1b4c7b2e5a83743a69bcab3af1c \
+                        sha256  8362a9c9b849e707a8be3b3f8b4502670893bcf8a5db406b991b1186c3f1199c \
+                        size    11150537
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.7.7

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
