### PR TITLE
qt(59|511|513)-qtlocation: add missing header include

### DIFF
--- a/aqua/qt511/Portfile
+++ b/aqua/qt511/Portfile
@@ -1357,6 +1357,10 @@ foreach {module module_info} [array get modules] {
                 # do not allow ${prefix}/include/rapidjson to conflict with bundled rapidjson (in bundled mapbox-gl-native)
                 conflicts_build rapidjson rapidjson-devel
 
+                # https://trac.macports.org/ticket/67417
+                # include/mbgl/util/unique_any.hpp: error: no member named 'move' in namespace 'std'
+                patchfiles-append  patch-qtlocation-mbgl-unique_any.hpp.diff
+
                 # qtlocation uses
                 #    Gypsy (https://gypsy.freedesktop.org/wiki/)
                 #    if they can be found

--- a/aqua/qt511/files/patch-qtlocation-mbgl-unique_any.hpp.diff
+++ b/aqua/qt511/files/patch-qtlocation-mbgl-unique_any.hpp.diff
@@ -1,0 +1,11 @@
+--- src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp.orig	2023-05-13 13:07:39.000000000 -0400
++++ src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp	2023-05-13 13:08:21.000000000 -0400
+@@ -3,6 +3,8 @@
+ #include <typeinfo>
+ #include <type_traits>
+ #include <stdexcept>
++#include <utility> // std::move
++
+ namespace mbgl {
+ namespace util {
+ 

--- a/aqua/qt513/Portfile
+++ b/aqua/qt513/Portfile
@@ -1377,6 +1377,10 @@ foreach {module module_info} [array get modules] {
                 # do not allow ${prefix}/include/rapidjson to conflict with bundled rapidjson (in bundled mapbox-gl-native)
                 conflicts_build rapidjson rapidjson-devel
 
+                # https://trac.macports.org/ticket/67417
+                # include/mbgl/util/unique_any.hpp: error: no member named 'move' in namespace 'std'
+                patchfiles-append  patch-qtlocation-mbgl-unique_any.hpp.diff
+
                 # qtlocation uses
                 #    Gypsy (https://gypsy.freedesktop.org/wiki/)
                 #    if they can be found

--- a/aqua/qt513/files/patch-qtlocation-mbgl-unique_any.hpp.diff
+++ b/aqua/qt513/files/patch-qtlocation-mbgl-unique_any.hpp.diff
@@ -1,0 +1,11 @@
+--- src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp.orig	2023-05-13 13:07:39.000000000 -0400
++++ src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp	2023-05-13 13:08:21.000000000 -0400
+@@ -3,6 +3,8 @@
+ #include <typeinfo>
+ #include <type_traits>
+ #include <stdexcept>
++#include <utility> // std::move
++
+ namespace mbgl {
+ namespace util {
+ 

--- a/aqua/qt59/Portfile
+++ b/aqua/qt59/Portfile
@@ -1343,6 +1343,10 @@ foreach {module module_info} [array get modules] {
                 # do not allow ${prefix}/include/rapidjson to conflict with bundled rapidjson (in bundled mapbox-gl-native)
                 conflicts_build rapidjson rapidjson-devel
 
+                # https://trac.macports.org/ticket/67417
+                # include/mbgl/util/unique_any.hpp: error: no member named 'move' in namespace 'std'
+                patchfiles-append  patch-qtlocation-mbgl-unique_any.hpp.diff
+
                 # qtlocation uses
                 #    Gypsy (https://gypsy.freedesktop.org/wiki/)
                 #    if they can be found

--- a/aqua/qt59/files/patch-qtlocation-mbgl-unique_any.hpp.diff
+++ b/aqua/qt59/files/patch-qtlocation-mbgl-unique_any.hpp.diff
@@ -1,0 +1,11 @@
+--- src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp.orig	2023-05-13 13:07:39.000000000 -0400
++++ src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp	2023-05-13 13:08:21.000000000 -0400
+@@ -3,6 +3,8 @@
+ #include <typeinfo>
+ #include <type_traits>
+ #include <stdexcept>
++#include <utility> // std::move
++
+ namespace mbgl {
+ namespace util {
+ 


### PR DESCRIPTION
As already done for qt5-qtlocation.

See: https://trac.macports.org/ticket/67417

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Not tested beyond patch phase.
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
