### PR TITLE
sfeed: update to 2.0

### DIFF
--- a/net/sfeed/Portfile
+++ b/net/sfeed/Portfile
@@ -5,7 +5,7 @@ PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 name                sfeed
-version             1.9
+version             2.0
 revision            0
 license             ISC
 
@@ -18,9 +18,9 @@ homepage            https://git.codemadness.org/${name}/
 
 master_sites        https://codemadness.org/releases/${name}/
 
-checksums           rmd160  337b9ab719bf4b63fd6867e6912856cccce61246 \
-                    sha256  7261dada0e4010ea09f67d1fd737404d691b9c7e5e7362334228c117d98a5646 \
-                    size    67718
+checksums           rmd160  fcd51fe0b3cfbbbb2d01b1bee773e532574a3a33 \
+                    sha256  8e6a7e6e1d7e86034ae27035e37a8f7fc98bc25fe35120bd18ff07e04f18e91d \
+                    size    67584
 
 depends_lib-append  port:ncurses
 


### PR DESCRIPTION
#### Description
[Changelog](https://git.codemadness.org/sfeed/)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
