### PR TITLE
qt6-qtdeclarative: Fix building with Xcode 11.3

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -951,6 +951,7 @@ foreach {driver driver_info} [array get sql_plugins] {
 # Special Cases
 ###############################################################################
 subport ${name}-qtdeclarative {
+    patchfiles-append               patch-qtdeclarative-xcode11.3.diff
 }
 
 subport ${name}-qttools {

--- a/aqua/qt6/files/patch-qtdeclarative-xcode11.3.diff
+++ b/aqua/qt6/files/patch-qtdeclarative-xcode11.3.diff
@@ -1,0 +1,22 @@
+--- src/qml/jsruntime/qv4engine_p.h.orig	2023-03-11 23:23:17.000000000 +0100
++++ src/qml/jsruntime/qv4engine_p.h	2023-07-08 21:48:13.000000000 +0200
+@@ -774,7 +774,7 @@
+ };
+ 
+ #define CHECK_STACK_LIMITS(v4) if ((v4)->checkStackLimits()) return Encode::undefined(); \
+-    ExecutionEngineCallDepthRecorder _executionEngineCallDepthRecorder(v4);
++    ExecutionEngineCallDepthRecorder<1> _executionEngineCallDepthRecorder(v4);
+ 
+ template<int Frames = 1>
+ struct ExecutionEngineCallDepthRecorder
+--- src/qml/jsruntime/qv4vme_moth.cpp.orig	2023-03-11 23:23:17.000000000 +0100
++++ src/qml/jsruntime/qv4vme_moth.cpp	2023-07-08 21:59:27.000000000 +0200
+@@ -400,7 +400,7 @@
+         frame->setReturnValueUndefined();
+         return;
+     }
+-    ExecutionEngineCallDepthRecorder executionEngineCallDepthRecorder(engine);
++    ExecutionEngineCallDepthRecorder<1> executionEngineCallDepthRecorder(engine);
+ 
+     Function *function = frame->v4Function;
+     Q_ASSERT(function->aotFunction);


### PR DESCRIPTION
#### Description

This is a minor patch, a part of #19407. It is required to build qt6-qtdeclarative with Xcode 11.3, the last Xcode working on MacOS 10.14, where clang++ does not support template argument default value deduction. 

It is not required by the 10.14 buildbot, where Xcode is even older and MacPorts clang++ is being used instead.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
