### PR TITLE
qt6-qtmultimedia: Fix building on 10.14 SDK

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -992,6 +992,8 @@ subport ${name}-qtwebengine {
 }
 
 subport ${name}-qtmultimedia {
+    patchfiles-append               patch-qtmultimedia-macos_10.14_sdk.diff
+
     # GStreamer will be found if gstreamer1 and gstreamer1-gst-plugins-base are installed
     # however, an error will ensue since the GStreamer support requires "Linux DMA buffer support"
     # see

--- a/aqua/qt6/files/patch-qtmultimedia-macos_10.14_sdk.diff
+++ b/aqua/qt6/files/patch-qtmultimedia-macos_10.14_sdk.diff
@@ -1,0 +1,51 @@
+--- src/multimedia/darwin/qcoreaudioutils.mm.orig	2023-03-12 04:46:05.000000000 +0100
++++ src/multimedia/darwin/qcoreaudioutils.mm	2023-07-08 23:42:48.000000000 +0200
+@@ -119,11 +119,13 @@
+         { QAudioFormat::TopFrontLeft, kAudioChannelLabel_VerticalHeightLeft },
+         { QAudioFormat::TopFrontRight, kAudioChannelLabel_VerticalHeightRight },
+         { QAudioFormat::TopFrontCenter, kAudioChannelLabel_VerticalHeightCenter },
+-        { QAudioFormat::TopCenter, kAudioChannelLabel_CenterTopMiddle },
++        { QAudioFormat::TopCenter, kAudioChannelLabel_TopCenterSurround },
+         { QAudioFormat::TopBackLeft, kAudioChannelLabel_TopBackLeft },
+         { QAudioFormat::TopBackRight, kAudioChannelLabel_TopBackRight },
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+         { QAudioFormat::TopSideLeft, kAudioChannelLabel_LeftTopMiddle },
+         { QAudioFormat::TopSideRight, kAudioChannelLabel_RightTopMiddle },
++#endif
+         { QAudioFormat::TopBackCenter, kAudioChannelLabel_TopBackCenter },
+ };
+ 
+--- src/plugins/multimedia/darwin/camera/qavfcamerabase.mm.orig	2023-03-12 04:46:05.000000000 +0100
++++ src/plugins/multimedia/darwin/camera/qavfcamerabase.mm	2023-07-09 00:18:24.000000000 +0200
+@@ -93,18 +93,20 @@
+ #endif // defined(Q_OS_IOS)
+ 
+ bool isFlashAvailable(AVCaptureDevice* captureDevice) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+     if (@available(macOS 10.15, *)) {
+         return [captureDevice isFlashAvailable];
+     }
+-
++#endif
+     return true;
+ }
+ 
+ bool isTorchAvailable(AVCaptureDevice* captureDevice) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+     if (@available(macOS 10.15, *)) {
+         return [captureDevice isTorchAvailable];
+     }
+-
++#endif
+     return true;
+ }
+ 
+@@ -723,7 +725,7 @@
+ 
+     if (@available(macOS 10.15, *)) {
+         AVCaptureDevice *captureDevice = device();
+-        return captureDevice && [captureDevice isExposureModeSupported:AVCaptureExposureModeCustom];
++        return captureDevice && [captureDevice isExposureModeSupported:AVCaptureExposureMode(3)]; // AVCaptureExposureModeCustom
+     }
+ 
+     return false;


### PR DESCRIPTION
#### Description

This is a part of #19407. It's a patch allowing to build qt6-qtmultimedia with the 10.14 SDK.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
