### PR TITLE
qt6-qtpositioning: Fix building on MacOS 10.14 SDK

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -1018,6 +1018,10 @@ subport ${name}-qtspeech {
                                     -no-speechd
 }
 
+subport ${name}-qtpositioning {
+    patchfiles-append               patch-qtpositioning-macos_10.14_sdk.diff
+}
+
 if { ${subport} eq "${name}-qtbase" || ${subport} eq "${name}-qtbase-docs" } {
     # allow building with macOS 10.14 SDK
     # see https://trac.macports.org/ticket/64345

--- a/aqua/qt6/files/patch-qtpositioning-macos_10.14_sdk.diff
+++ b/aqua/qt6/files/patch-qtpositioning-macos_10.14_sdk.diff
@@ -1,0 +1,17 @@
+--- src/plugins/position/corelocation/qgeopositioninfosource_cl.mm.orig	2023-03-12 03:16:54.000000000 +0100
++++ src/plugins/position/corelocation/qgeopositioninfosource_cl.mm	2023-12-30 18:29:00.000000000 +0200
+@@ -52,12 +52,14 @@
+ #ifndef Q_OS_TVOS
+     if (newLocation.course >= 0) {
+         location.setAttribute(QGeoPositionInfo::Direction, newLocation.course);
++#if !defined(Q_OS_MACOS) || MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+         if (__builtin_available(iOS 13.4, watchOS 6.2, macOS 10.15.4, *)) {
+             if (newLocation.courseAccuracy >= 0) {
+                 location.setAttribute(QGeoPositionInfo::DirectionAccuracy,
+                                       newLocation.courseAccuracy);
+             }
+         }
++#endif
+     }
+     if (newLocation.speed >= 0)
+         location.setAttribute(QGeoPositionInfo::GroundSpeed, newLocation.speed);


### PR DESCRIPTION
#### Description

This is a part of https://github.com/macports/macports-ports/pull/19407. It's a patch allowing to build qt6-qtpositioning with the 10.14 SDK.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
