### PR TITLE
qt6-qtspeech: Fix building with MacOS 10.14 SDK

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -1012,6 +1012,8 @@ subport ${name}-qtsvg {
 }
 
 subport ${name}-qtspeech {
+    patchfiles-append               patch-qtspeech-macos_10.14_sdk.diff
+
     # ALSA is Linux only (https://www.alsa-project.org/wiki/Main_Page)
     # Speech Dispatcher *might* be made to work on macOS (https://freebsoft.org/speechd)
     configure.args-append           -no-flite-alsa \

--- a/aqua/qt6/files/patch-qtspeech-macos_10.14_sdk.diff
+++ b/aqua/qt6/files/patch-qtspeech-macos_10.14_sdk.diff
@@ -1,0 +1,26 @@
+--- src/plugins/tts/darwin/qtexttospeech_darwin.mm.orig	2023-03-12 05:16:00.000000000 +0100
++++ src/plugins/tts/darwin/qtexttospeech_darwin.mm	2023-07-09 02:30:51.000000000 +0200
+@@ -2,6 +2,7 @@
+ // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only
+ 
+ #include <AVFoundation/AVFoundation.h>
++#include <../../System/Library/Frameworks/AVFoundation.framework/Frameworks/AVFAudio.framework/Headers/AVSpeechSynthesis.h>  // 10.14 SDK fix
+ 
+ #include "qtexttospeech_darwin.h"
+ 
+@@ -281,6 +282,7 @@
+ {
+     // only from macOS 10.15 and iOS 13 on
+     const QVoice::Gender gender = [avVoice]{
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+         if (@available(macos 10.15, ios 13, *)) {
+             switch (avVoice.gender) {
+             case AVSpeechSynthesisVoiceGenderMale:
+@@ -291,6 +293,7 @@
+                 break;
+             };
+         }
++#endif
+         return QVoice::Unknown;
+     }();
+ 


### PR DESCRIPTION
#### Description

This is a part of https://github.com/macports/macports-ports/pull/19407. It's a patch allowing to build qt6-qtspeech with the 10.14 SDK. In addition to the usual `#ifdef` around 10.15+ API usage, it adds a hack to work around a [10.14 SDK bug](https://developer.apple.com/forums/thread/120758).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.14.6 18G9323 x86_64
Xcode 11.3.1 11C505

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
