### PR TITLE
proxmark3-iceman: fix python not embedding to build

### DIFF
--- a/science/proxmark3-iceman/Portfile
+++ b/science/proxmark3-iceman/Portfile
@@ -47,8 +47,9 @@ depends_build-append \
 # configure phase instead of making new ones before passing them
 # to build and destroot envs.
 
-set python_prefix   ${frameworks_dir}/Python.framework/Versions/3.11
-configure.python    ${prefix}/bin/python3.11
+set python_version  3.11
+set python_prefix   ${frameworks_dir}/Python.framework/Versions/${python_version}
+configure.python    ${prefix}/bin/python${python_version}
 
 configure.pkg_config \
                     ${prefix}/bin/pkg-config
@@ -67,13 +68,13 @@ build.env-append    USE_BREW=0 \
                     SKIPWHEREAMISYSTEM=1 \
                     MACPORTS_PREFIX=${prefix} \
                     PATH=${prefix}/libexec/gnubin:$env(PATH) \
-                    PKG_CONFIG_PATH=${configure.pkg_config_path} \
-                    PKG_CONFIG_ENV=PKG_CONFIG_PATH=${configure.pkg_config_path}
+                    PKG_CONFIG_PATH=${configure.pkg_config_path}
 
 build.args-append   CC=${configure.cc} \
                     CXX=${configure.cxx} \
                     CPP=${configure.cpp} \
-                    LD=${configure.cxx}
+                    LD=${configure.cxx} \
+                    PKG_CONFIG_ENV=PKG_CONFIG_PATH=${configure.pkg_config_path}
 
 variant pm3generic description {Build firmware for PM3GENERIC instead of PM3RDV4} {
     build.args-append   PLATFORM=PM3GENERIC


### PR DESCRIPTION
#### Description

This PR makes the `proxmark3-iceman` port properly include Python 3.11 to upstream's build systen.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
