### PR TITLE
x2goclient: restore Qt4 version, unbreak the build for macOS < 10.7

### DIFF
--- a/aqua/x2goclient/Portfile
+++ b/aqua/x2goclient/Portfile
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               qmake5 1.0
 PortGroup               openssl 1.0
 
 name                    x2goclient
@@ -27,7 +26,21 @@ master_sites            https://code.x2go.org/releases/source/${name}/
 
 installs_libs           no
 
-qt5.depends_component   qttools qtsvg qtdeclarative
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    PortGroup           qmake 1.0
+
+    # Apple gcc do not support -stdlib= flag. gcc10+ do, but at the moment Macports gcc on PowerPC are built without it.
+    if {[string match gcc-4.* ${configure.compiler}] || [string match apple-gcc-* ${configure.compiler}] ||
+        [string match macports-gcc-* ${configure.compiler}] && {configure.build_arch} in [list ppc ppc64]} {
+            patchfiles-append \
+                        patch-unbreak-gcc.diff
+    }
+} else {
+    PortGroup           qmake5 1.0
+
+    qt5.depends_component \
+                        qttools qtsvg qtdeclarative
+}
 
 depends_lib-append      port:libssh \
                         port:xorg-libX11
@@ -37,7 +50,7 @@ depends_run-append      port:pulseaudio \
                         port:xmodmap \
                         port:xauth
 
-patchfiles              patch-x2goclient-sshsubprocess-bind.diff \
+patchfiles-append       patch-x2goclient-sshsubprocess-bind.diff \
                         patch-x2go-VERSION-changes.diff
 
 post-patch {

--- a/aqua/x2goclient/files/patch-unbreak-gcc.diff
+++ b/aqua/x2goclient/files/patch-unbreak-gcc.diff
@@ -1,0 +1,17 @@
+Setting these flags is wrong and breaks the build:
+cc1plus: error: unrecognized command line option "-stdlib=libstdc++"
+
+--- x2goclient.pro	2023-06-29 04:09:48.000000000 +0800
++++ x2goclient.pro	2023-12-31 07:27:02.000000000 +0800
+@@ -242,11 +242,6 @@
+   message("building $$TARGET with ldap and cups")
+   LIBS += -framework LDAP -lcups -lcrypto -lssl -lz
+ 
+-  !isEmpty(OSX_STDLIB) {
+-    QMAKE_CXXFLAGS += -stdlib=$${OSX_STDLIB}
+-    QMAKE_LFLAGS += -stdlib=$${OSX_STDLIB}
+-  }
+-
+   !isEmpty(MACPORTS_INCLUDE_PATH) {
+     INCLUDEPATH += $${MACPORTS_INCLUDE_PATH}
+   }


### PR DESCRIPTION
#### Description

There was no reason to have it broken, the app builds fine with Qt4.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
