### PR TITLE
QtPass: add a version for Qt4

### DIFF
--- a/aqua/QtPass/Portfile
+++ b/aqua/QtPass/Portfile
@@ -2,11 +2,47 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
-PortGroup               qt5 1.0
-PortGroup               qmake5 1.0
 
-github.setup            IJHack QtPass 1.4.0 v
-revision                0
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    PortGroup               qmake 1.0
+
+    # From 1.2.0 it is broken, see: https://github.com/IJHack/QtPass/issues/665
+    github.setup            IJHack QtPass 1.1.6 v
+    revision                0
+
+    github.tarball_from     archive
+    checksums               rmd160  8d709714afbd413eb47df3df4d27e2f2ec4c0c0f \
+                            sha256  d24d95de129ce716b9b0fde6114407f860ce8c77106bd0ee6a12e8e4e0deb42b \
+                            size    325329
+
+    patchfiles-append       0001-qtpass.pro-remove-a-breaking-setting.patch
+
+    destroot {
+        copy ${worksrcpath}/${name}.app ${destroot}${applications_dir}
+    }
+} else {
+    PortGroup               qt5 1.0
+    PortGroup               qmake5 1.0
+
+    github.setup            IJHack QtPass 1.4.0 v
+    revision                0
+
+    github.tarball_from     releases
+    checksums               rmd160  136092a5e9b14445524bc30ca82826233807da6e \
+                            sha256  9abe9cde35a412b26b6376a5e8996dfeeeb5910fe6a723b78bcf954656fca0e6 \
+                            size    581368
+
+    qt5.min_version         5.10
+    qt5.depends_component   qtsvg qttools qttranslations
+    qt5.mac_sdk             macosx
+
+    compiler.cxx_standard   2011
+
+    destroot {
+        copy ${worksrcpath}/main/${name}.app ${destroot}${applications_dir}
+    }
+}
+
 categories              aqua security
 license                 GPL-3+
 maintainers             nomaintainer
@@ -26,22 +62,7 @@ long_description \
 
 homepage                https://qtpass.org
 
-github.tarball_from     releases
-checksums               rmd160  136092a5e9b14445524bc30ca82826233807da6e \
-                        sha256  9abe9cde35a412b26b6376a5e8996dfeeeb5910fe6a723b78bcf954656fca0e6 \
-                        size    581368
-
-compiler.cxx_standard   2011
-
-qt5.min_version         5.10
-qt5.depends_component   qtsvg qttools qttranslations
-qt5.mac_sdk             macosx
-
 configure.args-append   CONFIG+=release
-
-destroot {
-    copy ${worksrcpath}/main/${name}.app ${destroot}${applications_dir}
-}
 
 test.run                yes
 test.target             check

--- a/aqua/QtPass/files/0001-qtpass.pro-remove-a-breaking-setting.patch
+++ b/aqua/QtPass/files/0001-qtpass.pro-remove-a-breaking-setting.patch
@@ -1,0 +1,17 @@
+From fb336757af8686be2cce0141e7fe2db3e7b3a2c3 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Sun, 31 Dec 2023 12:55:14 +0800
+Subject: [PATCH] qtpass.pro: remove a breaking setting
+
+diff --git qtpass.pro qtpass.pro
+index 9ccb3805..3892fbc8 100644
+--- qtpass.pro
++++ qtpass.pro
+@@ -16,7 +16,6 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+ 
+ macx {
+     TARGET = QtPass
+-    QMAKE_MAC_SDK = macosx
+     QT += svg
+ } else {
+     TARGET = qtpass


### PR DESCRIPTION
#### Description

@sideeffect42 I have found a version which build and works. (1.2.0+ are broken, and no time to try fixing those. I have referred the issue in the portfile.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

![qtpass](https://github.com/macports/macports-ports/assets/92015510/7ca6fdb7-bba0-4592-aae2-dfb9f5fb3553)
