### PR TITLE
QtPBFImagePlugin: update to 3.0

### DIFF
--- a/graphics/QtPBFImagePlugin/Portfile
+++ b/graphics/QtPBFImagePlugin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 QtPBFImagePlugin 2.6
+github.setup        tumic0 QtPBFImagePlugin 3.0
 revision            0
 categories          graphics
 license             LGPL-3
@@ -13,9 +13,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         PBF image plugin for Qt5
 long_description    Qt image plugin for displaying Mapbox vector tiles.
 
-checksums           rmd160  fd4c6a4e539a4a60b33ae67e1f2f5299afc4a0a5 \
-                    sha256  cabf91bdfe3d1cf8577ec2e0d4459cbe9c98b582bff706c5687248db25a8104a \
-                    size    197462
+checksums           rmd160  0078133ec58927ee14282d7b0f427d24a74a0027 \
+                    sha256  0a6f57b5d86a3f5e8b8bf19633f3b177f035d037567280d3d49cad6c984380ad \
+                    size    197701
 
 # Upstream links to static 'libprotobuf-lite', but needs to be dylib
 patchfiles-append   patch-protobuf-dylib.diff


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:QtPBFImagePlugin/QtPBFImagePlugin/libqt5-qtpbfimageformat.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
