### PR TITLE
CsoundQt: new port in aqua/audio

### DIFF
--- a/aqua/CsoundQt/Portfile
+++ b/aqua/CsoundQt/Portfile
@@ -1,0 +1,101 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   github 1.0
+PortGroup                   active_variants 1.1
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    PortGroup               qmake 1.0
+
+    github.setup            CsoundQt CsoundQt 0.9.7
+    revision                0
+    checksums               rmd160  de2e910e66ae1f9290091b11168a5a6515c183f8 \
+                            sha256  c12242d4e1f745ac2c1ae23d1ef72661d68cb51baf110c17140deb1c994cfa1f \
+                            size    66170886
+    github.tarball_from     archive
+
+    patchfiles-append       patch-qcs-macx.diff \
+                            patch-fix-includes.diff \
+                            patch-qt4-compat.diff
+} else {
+    PortGroup               qmake5 1.0
+
+    github.setup            CsoundQt CsoundQt 1.1.1 v
+    revision                0
+    checksums               rmd160  c274b03cccda9092311a477d1f12058391c0cbbe \
+                            sha256  652fa51dc19acae031919216ec8043cb3767763008a62a134854940e2d065326 \
+                            size    67621515
+    github.tarball_from     archive
+
+    qt5.depends_component   qtxmlpatterns
+
+    patchfiles-append       patch-qcs-macx-qt5.diff
+}
+
+categories                  aqua audio
+license                     LGPL-2.1+
+maintainers                 {@barracuda156 gmail.com:vital.had} openmaintainer
+
+description                 ${name} is a frontend for Csound
+long_description            {*}${description} featuring a highlighting editor \
+                            with autocomplete, interactive widgets and integrated help. \
+                            It is cross-platform and aims to be a simple yet powerful \
+                            and complete development environment for Csound.
+
+homepage                    https://csoundqt.github.io
+
+depends_lib-append          port:csound \
+                            port:libsndfile
+
+compiler.cxx_standard       2011
+
+post-patch {
+    reinplace "s,@PREFIX@,${prefix},g" ${worksrcpath}/qcs-macx.pro ${worksrcpath}/qcs.pro ${worksrcpath}/config.pri
+    reinplace "s,@CC@,${configure.cc},g" ${worksrcpath}/qcs.pro
+    reinplace "s,@CXX@,${configure.cxx},g" ${worksrcpath}/qcs.pro
+    reinplace "s,@DESTDIR@,${worksrcpath}," ${worksrcpath}/qcs.pro
+    reinplace "s,@CFLAGS@,${configure.cppflags} ${configure.cflags} [get_canonical_archflags cc]," ${worksrcpath}/qcs.pro
+    reinplace "s,@CXXFLAGS@,${configure.cppflags} ${configure.cxxflags} [get_canonical_archflags cxx]," ${worksrcpath}/qcs.pro
+    reinplace "s,@LFLAGS@,[get_canonical_archflags ld]," ${worksrcpath}/qcs.pro
+}
+
+if {${configure.build_arch} ni [list arm i386 ppc]} {
+    default_variants-append +double
+}
+
+if [variant_isset double] {
+    set cs_conf             CONFIG+=build64
+    set libname             CsoundLib64
+    set appname             ${name}-d-cs6
+} else {
+    set cs_conf             CONFIG+=build32
+    set libname             CsoundLib
+    set appname             ${name}-f-cs6
+}
+
+configure {
+    system -W ${worksrcpath} "${qt_qmake_cmd} qcs.pro ${cs_conf}"
+}
+
+build.cmd                   make
+build.target
+
+set cs_framework_path       ${libname}.framework/Versions/6.0
+set csoundlib               ${cs_framework_path}/${libname}
+
+destroot {
+    system -W ${worksrcpath} "install_name_tool -change ${prefix}/lib/${csoundlib} ${frameworks_dir}/${csoundlib} ./${appname}.app/Contents/MacOS/${appname}"
+    move ${worksrcpath}/${appname}.app ${destroot}${applications_dir}/${name}.app
+}
+
+variant double description "Use double precision" {
+    require_active_variants port:csound double
+}
+
+if {![catch {set result [active_variants csound double]}]} {
+    if {$result} {
+        if {![variant_isset double]} {
+            return -code error "csound has been built with double precision, please install ${name} with +double."
+        }
+    }
+}

--- a/aqua/CsoundQt/files/patch-fix-includes.diff
+++ b/aqua/CsoundQt/files/patch-fix-includes.diff
@@ -1,0 +1,22 @@
+--- src/csoundengine.cpp	2020-01-16
++++ src/csoundengine.cpp	2023-12-31
+@@ -20,6 +20,8 @@
+     02111-1307 USA
+ */
+ 
++#include <unistd.h>
++
+ #ifdef USE_QT5
+ #include <QtConcurrent>
+ #endif
+
+--- src/widgetlayout.cpp	2020-01-16
++++ src/widgetlayout.cpp	2023-12-31
+@@ -21,6 +21,7 @@
+ */
+ 
+ #include <cstdlib>
++#include <unistd.h>
+ 
+ #include <QThread>
+ 

--- a/aqua/CsoundQt/files/patch-qcs-macx-qt5.diff
+++ b/aqua/CsoundQt/files/patch-qcs-macx-qt5.diff
@@ -1,0 +1,159 @@
+--- qcs-macx.pro.orig	2023-12-31 21:39:25
++++ qcs-macx.pro	2023-12-31 22:03:55
+@@ -5,40 +5,30 @@
+ 	message(Building CsoundQt for Macintosh OS X.)
+ }
+ 
+-CONFIG += x86_64
+-QMAKE_CXXFLAGS += -arch x86_64
+-
+ build32: MAC_LIB = CsoundLib
+ build64: MAC_LIB = CsoundLib64
+ 
+-#paths set up for using the csound from installed package
++# paths set up for using the csound from installed package
+ HOME_DIRECTORY =
+ 
+ # Set default paths
+-CSOUND_FRAMEWORK_DIR = Library/Frameworks/$${MAC_LIB}.framework/Versions/Current
+-DEFAULT_CSOUND_API_INCLUDE_DIRS =  $${CSOUND_FRAMEWORK_DIR}/Headers \
+-        $${CSOUND_FRAMEWORK_DIR}/Headers \
+-        /usr/local/include/csound \
+-        /usr/local/opt/csound/Frameworks/CsoundLib64.framework/Headers
++CSOUND_FRAMEWORK_DIR = @PREFIX@/Library/Frameworks/$${MAC_LIB}.framework/Versions/6.0
++DEFAULT_CSOUND_API_INCLUDE_DIRS = $${CSOUND_FRAMEWORK_DIR}/Headers \
++        @PREFIX@/include/csound
+         
+ DEFAULT_CSOUND_INTERFACES_INCLUDE_DIRS = $${DEFAULT_CSOUND_API_INCLUDE_DIRS}
+-DEFAULT_CSOUND_LIBRARY_DIRS = $${HOME_DIRECTORY}/$${CSOUND_FRAMEWORK_DIR} \
+-        /$${CSOUND_FRAMEWORK_DIR} \
+-        /usr/local/lib \
+-        /usr/local/opt/csound/Frameworks/CsoundLib64.framework/Versions/Current
+-        
++DEFAULT_CSOUND_LIBRARY_DIRS = $${CSOUND_FRAMEWORK_DIR} \
++        @PREFIX@/lib
+ 
+ build32:DEFAULT_CSOUND_LIBS = CsoundLib
+ build64:DEFAULT_CSOUND_LIBS = CsoundLib64
+ 
+-# For OS X, the PythonQt.1.0.0.dylib and the libPythonQt.1.dylib must be on /usr/local/lib or other lib path
+-DEFAULT_PYTHON_INCLUDE_DIR = /usr/local/include \
+-        /usr/include
+-DEFAULT_PYTHONQT_LIBRARY_DIRS = /usr/local/lib \
+-        /usr/lib
++# For OS X, the PythonQt.1.0.0.dylib and the libPythonQt.1.dylib must be on @PREFIX@/lib or other lib path
++DEFAULT_PYTHON_INCLUDE_DIR = @PREFIX@/include
++DEFAULT_PYTHONQT_LIBRARY_DIRS = @PREFIX@/lib
+ 
+ PYTHONQT_VARIANTS = "pythonqt" "PythonQt3.2" "PythonQt3.1" "PythonQt3.0" "PythonQt" "PythonQt2.0.1"
+-for (pyqtdir, PYTHONQT_VARIANTS) {
++for(pyqtdir, PYTHONQT_VARIANTS) {
+ 	DEFAULT_PYTHONQT_SRC_DIRS += ../../../$$pyqtdir \
+ 		../$$pyqtdir \
+ 		$$pyqtdir
+@@ -70,9 +60,9 @@
+ }
+ 
+ #LIBS += -framework QtCore -framework QtGui -framework QtXml
+-LCSOUND = -F$${HOME_DIRECTORY}/Library/Frameworks -F/Library/Frameworks -F/usr/local/opt/csound/Frameworks -framework $${MAC_LIB}
++LCSOUND = -F@PREFIX@/Library/Frameworks -framework $${MAC_LIB}
+ 
+-LCSND = -L/usr/local/lib -lcsnd6.6.0
++LCSND = -L@PREFIX@/lib -lcsnd6.6.0
+ 
+ QMAKE_INFO_PLIST = $${PWD}/src/MyInfo.plist
+ ICON = $${PWD}/images/qtcs.icns
+
+--- qcs.pro.orig	2023-12-31 21:39:25
++++ qcs.pro	2023-12-31 22:08:38
+@@ -35,6 +35,15 @@
+ # qmake qcs.pro INSTALL_DIR=~ SHARE_DIR=~/.local/share
+ ################################################################################
+ 
++QMAKE_CC=@CC@
++QMAKE_CXX=@CXX@
++QMAKE_CFLAGS=@CFLAGS@
++QMAKE_CXXFLAGS=@CXXFLAGS@
++QMAKE_LFLAGS=@LFLAGS@
++QMAKE_LINK_C=@CC@
++QMAKE_LINK_C_SHLIB=@CC@
++QMAKE_LINK=@CXX@
++QMAKE_LINK_SHLIB=@CXX@
+ 
+ #Support for Qt4 dropped from v0.9.8 de facto, v1.0.0 declaring it here:
+ lessThan(QT_MAJOR_VERSION,5): error("Qt5 or higher required. Use CsoundQt 0.9.7 or earlier to build for Qt4.")
+@@ -163,13 +172,15 @@
+ CONFIG += c++11
+ }
+ 
++CSOUND_API_INCLUDE_DIR = @PREFIX@/Library/Frameworks/$${MAC_LIB}.framework/Versions/6.0/Headers
++CSOUND_INTERFACES_INCLUDE_DIR = @PREFIX@/include/csound
++
+ INCLUDEPATH *= $${CSOUND_API_INCLUDE_DIR}
+ INCLUDEPATH *= $${CSOUND_INTERFACES_INCLUDE_DIR}
+ 
+ INCLUDEPATH += $$PWD/csound/include
+ 
+-#DESTDIR = $${_PRO_FILE_PWD_}/bin
+-DESTDIR = bin
++DESTDIR = @DESTDIR@
+ MOC_DIR = build/moc
+ UI_DIR = build/ui
+ RCC_DIR = build/rc
+@@ -189,10 +200,10 @@
+ # use 'sudo make install' for system wide installation
+ unix:!macx {
+     isEmpty(INSTALL_DIR) {
+-		INSTALL_DIR=/usr/local  # ~  #for HOME
++		INSTALL_DIR=@PREFIX@  # ~  #for HOME
+     }
+ 	isEmpty(SHARE_DIR) {
+-        SHARE_DIR=/usr/share # ~/.local/share for HOME install
++        SHARE_DIR=@PREFIX@/share # ~/.local/share for HOME install
+ 	}
+ 
+ 	target.path = $$INSTALL_DIR/bin
+@@ -200,7 +211,7 @@
+ 	INSTALLS += target
+ 
+ 	postInstall.path = $$INSTALL_DIR/bin
+-	postInstall.commands = cd  $(INSTALL_ROOT)/$$INSTALL_DIR/bin; ln -sf $$TARGET csoundqt
++	postInstall.commands = cd $(INSTALL_ROOT)/$$INSTALL_DIR/bin; ln -sf $$TARGET csoundqt
+ 	INSTALLS += postInstall
+ 
+ 	# see comments: https://github.com/CsoundQt/CsoundQt/issues/258
+
+--- config.pri.orig	2023-12-31 21:39:25
++++ config.pri	2023-12-31 21:58:26
+@@ -11,7 +11,7 @@
+ 
+ DEFAULT_RTMIDI_DIRS = "rtmidi"
+ RTMIDI_VERSIONS = "rtmidi-5.0.0" "rtmidi-4.0.0" "rtmidi-3.0.0" "rtmidi-2.1.1" "rtmidi-2.1.0" "rtmidi-2.0.1" "rtmidi-1.0.15"
+-for (rtdir, RTMIDI_VERSIONS) {
++for(rtdir, RTMIDI_VERSIONS) {
+     DEFAULT_RTMIDI_DIRNAME=$$rtdir
+     DEFAULT_RTMIDI_DIRS += $${DEFAULT_RTMIDI_DIRNAME} \
+       ../$${DEFAULT_RTMIDI_DIRNAME} \
+@@ -129,19 +129,12 @@
+ rtmidi {
+ # check if RTMIDI is found in system
+ unix:!macx {
+-    exists("/usr/include/rtmidi")  {
+-		RTMIDI_DIR = "/usr/include/rtmidi"
+-		!no_messages:message(RtMidi found in /usr/include/rtmidi)
++    exists("@PREFIX@/include/rtmidi")  {
++		RTMIDI_DIR = "@PREFIX@/include/rtmidi"
++		!no_messages:message(RtMidi found in @PREFIX@/include/rtmidi)
+         CONFIG -= rtmidi
+         CONFIG += system_rtmidi
+     }
+-    exists("/usr/local/include/rtmidi")  {
+-        RTMIDI_DIR = "/usr/local/include/rtmidi"
+-        !no_messages:message(RtMidi found in /usr/local/include/rtmidi)
+-        CONFIG -= rtmidi
+-        CONFIG += system_rtmidi
+-    }
+-
+ }
+ 
+ isEmpty(RTMIDI_DIR) {

--- a/aqua/CsoundQt/files/patch-qcs-macx.diff
+++ b/aqua/CsoundQt/files/patch-qcs-macx.diff
@@ -1,0 +1,165 @@
+Fixes paths, drops hardcoded archs, fixes unknown test function error:
+https://forum.qt.io/topic/35403/qmake-gives-unknown-test-function-for
+
+Notice that in the context of this port build64 does not necessarily mean 64-bit arch,
+but just uses doubles. CsoundLib64 builds fine on 32-bit.
+
+--- qcs-macx.pro	2020-07-03 05:55:55.000000000 +0800
++++ qcs-macx.pro	2023-12-31 14:53:05.000000000 +0800
+@@ -5,18 +5,6 @@
+ 	message(Building CsoundQt for Macintosh OS X.)
+ }
+ 
+-i386:  {
+-CONFIG += i386
+-QMAKE_CXXFLAGS += -arch i386
+-} else:universal {
+-QMAKE_CXXFLAGS += -arch i386
+-CONFIG += i386
+-CONFIG += ppc
+-} else {
+-CONFIG += x86_64
+-QMAKE_CXXFLAGS += -arch x86_64
+-}
+-
+ build32: MAC_LIB = CsoundLib
+ build64: MAC_LIB = CsoundLib64
+ 
+@@ -24,25 +12,21 @@
+ HOME_DIRECTORY =
+ 
+ # Set default paths
+-CSOUND_FRAMEWORK_DIR = /Library/Frameworks/$${MAC_LIB}.framework/Versions/Current
+-DEFAULT_CSOUND_API_INCLUDE_DIRS =  $${CSOUND_FRAMEWORK_DIR}/Headers \
+-        $${CSOUND_FRAMEWORK_DIR}/Headers \
+-        /usr/local/include/csound
++CSOUND_FRAMEWORK_DIR = @PREFIX@/Library/Frameworks/$${MAC_LIB}.framework/Versions/6.0
++DEFAULT_CSOUND_API_INCLUDE_DIRS = $${CSOUND_FRAMEWORK_DIR}/Headers \
++        @PREFIX@/include/csound
+ DEFAULT_CSOUND_INTERFACES_INCLUDE_DIRS = $${DEFAULT_CSOUND_API_INCLUDE_DIRS}
+-DEFAULT_CSOUND_LIBRARY_DIRS = $${HOME_DIRECTORY}/$${CSOUND_FRAMEWORK_DIR} \
+-        $${CSOUND_FRAMEWORK_DIR} \
+-        /usr/local/lib
++DEFAULT_CSOUND_LIBRARY_DIRS = $${CSOUND_FRAMEWORK_DIR} \
++        @PREFIX@/lib
+ build32:DEFAULT_CSOUND_LIBS = CsoundLib
+ build64:DEFAULT_CSOUND_LIBS = CsoundLib64
+ 
+ # For OS X, the PythonQt.1.0.0.dylib and the libPythonQt.1.dylib must be on /usr/local/lib or other lib path
+-DEFAULT_PYTHON_INCLUDE_DIR = /usr/local/include \
+-        /usr/include
+-DEFAULT_PYTHONQT_LIBRARY_DIRS = /usr/local/lib \
+-        /usr/lib
++DEFAULT_PYTHON_INCLUDE_DIR = @PREFIX@/include
++DEFAULT_PYTHONQT_LIBRARY_DIRS = @PREFIX@/lib
+ 
+-PYTHONQT_VARIANTS =  "PythonQt3.2" "PythonQt3.1" "PythonQt3.0" "PythonQt" "PythonQt2.0.1"
+-for (pyqtdir, PYTHONQT_VARIANTS) {
++PYTHONQT_VARIANTS = "PythonQt3.2" "PythonQt3.1" "PythonQt3.0" "PythonQt" "PythonQt2.0.1"
++for(pyqtdir, PYTHONQT_VARIANTS) {
+ 	DEFAULT_PYTHONQT_SRC_DIRS += ../../../$$pyqtdir \
+ 		../$$pyqtdir \
+ 		$$pyqtdir
+@@ -69,8 +53,8 @@
+ RESOURCES += "src/quteapp_d_osx.qrc"
+ }
+ #LIBS += -framework QtCore -framework QtGui -framework QtXml
+-LCSOUND = -F$${HOME_DIRECTORY}/Library/Frameworks -F/Library/Frameworks -framework $${MAC_LIB}
+-csound6: LCSND = -L/usr/local/lib -lcsnd6.6.0
++LCSOUND = -F@PREFIX@/Library/Frameworks -framework $${MAC_LIB}
++csound6: LCSND = -L@PREFIX@/lib -lcsnd6.6.0
+ else: LCSND = -l_csnd
+ 
+ QMAKE_INFO_PLIST = $${PWD}/src/MyInfo.plist
+
+--- qcs.pro	2020-07-03 05:55:55.000000000 +0800
++++ qcs.pro	2023-12-31 18:20:56.000000000 +0800
+@@ -34,6 +34,15 @@
+ # qmake qcs.pro INSTALL_DIR=~ SHARE_DIR=~/.local/share
+ ################################################################################
+ 
++QMAKE_CC=@CC@
++QMAKE_CXX=@CXX@
++QMAKE_CFLAGS=@CFLAGS@
++QMAKE_CXXFLAGS=@CXXFLAGS@
++QMAKE_LFLAGS=@LFLAGS@
++QMAKE_LINK_C=@CC@
++QMAKE_LINK_C_SHLIB=@CC@
++QMAKE_LINK=@CXX@
++QMAKE_LINK_SHLIB=@CXX@
+ 
+ DEFINES += NOMINMAX
+ # DEFINES += USE_WIDGET_MUTEX
+@@ -46,7 +55,7 @@
+ greaterThan(QT_MAJOR_VERSION, 4){
+ CONFIG += c++11
+ } else {
+-QMAKE_CXXFLAGS += -std=c++0x
++QMAKE_CXXFLAGS += -std=c++11
+ }
+ 
+ !csound5 {
+@@ -170,11 +179,14 @@
+ CONFIG += c++11
+ }
+ 
++CSOUND_API_INCLUDE_DIR = @PREFIX@/Library/Frameworks/$${MAC_LIB}.framework/Versions/6.0/Headers
++CSOUND_INTERFACES_INCLUDE_DIR = @PREFIX@/include/csound
++
+ INCLUDEPATH *= $${CSOUND_API_INCLUDE_DIR}
+ INCLUDEPATH *= $${CSOUND_INTERFACES_INCLUDE_DIR}
+ 
+ #DESTDIR = $${_PRO_FILE_PWD_}/bin
+-DESTDIR = bin
++DESTDIR = @DESTDIR@
+ MOC_DIR = build/moc
+ UI_DIR = build/ui
+ RCC_DIR = build/rc
+@@ -194,10 +206,10 @@
+ # use 'sudo make install' for system wide installation
+ unix:!macx {
+     isEmpty(INSTALL_DIR) {
+-		INSTALL_DIR=/usr/local  # ~  #for HOME
++		INSTALL_DIR=@PREFIX@  # ~  #for HOME
+     }
+ 	isEmpty(SHARE_DIR) {
+-        SHARE_DIR=/usr/share # ~/.local/share for HOME install
++        SHARE_DIR=@PREFIX@/share # ~/.local/share for HOME install
+ 	}
+ 
+ 	target.path = $$INSTALL_DIR/bin
+
+--- config.pri	2020-07-03 05:55:55.000000000 +0800
++++ config.pri	2023-12-31 14:55:46.000000000 +0800
+@@ -10,7 +10,7 @@
+ OBJECTS_DIR = "$${TMPDIR}/obj"
+ 
+ RTMIDI_VERSIONS = "rtmidi-4.0.0" "rtmidi-3.0.0" "rtmidi-2.1.1" "rtmidi-2.1.0" "rtmidi-2.0.1" "rtmidi-1.0.15"
+-for (rtdir, RTMIDI_VERSIONS) {
++for(rtdir, RTMIDI_VERSIONS) {
+ 	DEFAULT_RTMIDI_DIRNAME=$$rtdir
+ 	DEFAULT_RTMIDI_DIRS += $${DEFAULT_RTMIDI_DIRNAME} \
+ 	  ../$${DEFAULT_RTMIDI_DIRNAME} \
+@@ -128,19 +128,12 @@
+ rtmidi {
+ # check if RTMIDI is found in system
+ unix:!macx {
+-    exists("/usr/include/rtmidi")  {
+-		RTMIDI_DIR = "/usr/include/rtmidi"
+-		!no_messages:message(RtMidi found in /usr/include/rtmidi)
++    exists("@PREFIX@/include/rtmidi")  {
++		RTMIDI_DIR = "@PREFIX@/include/rtmidi"
++		!no_messages:message(RtMidi found in @PREFIX@/include/rtmidi)
+         CONFIG -= rtmidi
+         CONFIG += system_rtmidi
+     }
+-    exists("/usr/local/include/rtmidi")  {
+-        RTMIDI_DIR = "/usr/local/include/rtmidi"
+-        !no_messages:message(RtMidi found in /usr/local/include/rtmidi)
+-        CONFIG -= rtmidi
+-        CONFIG += system_rtmidi
+-    }
+-
+ }
+ 
+ isEmpty(RTMIDI_DIR) {

--- a/aqua/CsoundQt/files/patch-qt4-compat.diff
+++ b/aqua/CsoundQt/files/patch-qt4-compat.diff
@@ -1,0 +1,47 @@
+Reverts a broken commit: https://github.com/CsoundQt/CsoundQt/commit/9da46b9e139a869416fb85568568b57392a2de43
+And masks some corrupt code.
+
+--- src/qutecsound.cpp	2020-01-16
++++ src/qutecsound.cpp	2023-12-31
+@@ -5665,21 +5665,7 @@
+     QListWidgetItem *item = list->currentItem();
+ 	if (!item) {
+ 		qDebug() << "Empty list. Create empty score file";
+-		QString companion = "";
+-		if (documentPages[curPage]->getFileName().endsWith(".orc")) {
+-			// create an empty score file to run the orchestra scorelessly
+-
+-#ifdef USE_QT5
+-			companion = QStandardPaths::writableLocation(QStandardPaths::TempLocation) + "/empty.sco"; // QT >5.0
+-			QFile f(companion); // does it create it here
+-#else
+-            companion = QDesktopServices::storageLocation(QDesktopServices::TempLocation) + "/empty.sco";
+-#endif
+-			f.open(QIODevice::ReadWrite | QIODevice::Text);
+-			f.close();
+-			qDebug() << "Created empty score file as companion: " << companion;
+-		}
+-		documentPages[curPage]->setCompanionFileName(companion);
++		documentPages[curPage]->setCompanionFileName("");
+ 		return;
+ 	}
+ 	QString itemText = item->text();
+
+--- src/qutewidget.cpp	2020-01-16
++++ src/qutewidget.cpp	2023-12-31
+@@ -311,10 +311,11 @@
+ 		menu.addSeparator();
+ 	}
+ 
+-	if (acceptsMidi()) {
+-		menu.addAction(tr("Midi learn"), this, &QuteWidget::openMidiDialog  ); //midi learn act
+-		menu.addSeparator();
+-	}
++// The following code is broken, no matching function available.
++// 	if (acceptsMidi()) {
++// 		menu.addAction(tr("Midi learn"), this, &QuteWidget::openMidiDialog  ); //midi learn act
++// 		menu.addSeparator();
++// 	}
+ 
+ 	QList<QAction *> actionList = getParentActionList();
+ 

--- a/audio/csound/Portfile
+++ b/audio/csound/Portfile
@@ -6,10 +6,10 @@ PortGroup           github  1.0
 
 github.setup        csound csound 6.18.1
 github.tarball_from archive
-revision            2
+revision            3
 categories          audio
 license             LGPL-2.1+
-maintainers         nomaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 
 homepage            https://www.csound.com
 
@@ -41,16 +41,20 @@ patchfiles          MAC_OS_X_VERSION.patch
 patchfiles-append   0001-Use-correct-clang-options-in-CMakeLists.patch \
                     0002-Altivec-code-is-broken-for-Darwin-so-disable-it-ther.patch
 
-cmake.out_of_source yes
 compiler.cxx_standard   2011
 
-configure.args-append   -DFAIL_MISSING=ON \
+configure.args-append   -DBUILD_CXX_INTERFACE=ON \
                         -DBUILD_DSSI_OPCODES=OFF \
                         -DBUILD_JAVA_INTERFACE=OFF \
                         -DBUILD_LUA_INTERFACE=OFF \
                         -DBUILD_TESTS=OFF \
+                        -DBUILD_UTILITIES=ON \
                         -DCS_FRAMEWORK_DEST=${frameworks_dir} \
+                        -DFAIL_MISSING=ON \
                         -DUSE_ALSA=OFF \
+                        -DUSE_CURL=ON \
+                        -DUSE_DOUBLE=OFF \
+                        -DUSE_GETTEXT=ON \
                         -DUSE_JACK=OFF \
                         -DUSE_PORTAUDIO=OFF \
                         -DUSE_PORTMIDI=OFF \
@@ -60,16 +64,55 @@ configure.args-append   -DFAIL_MISSING=ON \
 # Building static lib does not hurt even without tests enabled, since dylib is still built as well.
 configure.args-append   -DBUILD_STATIC_LIBRARY=ON
 
+if {${configure.build_arch} ni [list arm i386 ppc]} {
+    default_variants-append +double
+}
+
+if [variant_isset double] {
+    set libname         CsoundLib64
+} else {
+    set libname         CsoundLib
+}
+
+set cs_framework_path   ${libname}.framework/Versions/6.0
+set csoundlib           ${cs_framework_path}/${libname}
+
 post-destroot {
     # While this is not immediately obvious upon install, dylib and binaries are built with wrong paths:
     # /opt/local/lib/CsoundLib64.framework/Versions/6.0/CsoundLib64
     # At the same time this is installed correctly into the framework directory, so the path points to nothing.
     # CMakeLists are a mess, and it is unclear what in particular breaks this. Fix paths in destroot:
-    set csoundlib CsoundLib64.framework/Versions/6.0/CsoundLib64
+    system -W ${destroot}${frameworks_dir} "install_name_tool -id ${frameworks_dir}/${csoundlib} ./${csoundlib}"
     system -W ${destroot}${prefix}/lib "install_name_tool -change ${prefix}/lib/${csoundlib} ${frameworks_dir}/${csoundlib} ./libcsnd6.6.0.dylib"
     foreach bin [glob ${destroot}${prefix}/bin/*] {
         system "install_name_tool -change ${prefix}/lib/${csoundlib} ${frameworks_dir}/${csoundlib} ${bin}"
     }
+    # Existing targets also omit headers from /interfaces, which are needed for some dependents:
+    # https://github.com/CsoundQt/CsoundQt/issues/392
+    xinstall -d ${destroot}${prefix}/include/${name}
+    fs-traverse f ${worksrcpath}/interfaces {
+        if {[file isfile ${f}] && ([file extension ${f}] == ".h" || [file extension ${f}] == ".hpp")} {
+            copy ${f} ${destroot}${prefix}/include/${name}/
+        }
+    }
+}
+
+variant double description "Use double precision" {
+    # See: http://www.csounds.com/manual/html/MiscCsound64.html
+    configure.args-replace  -DUSE_DOUBLE=OFF \
+                            -DUSE_DOUBLE=ON
+}
+
+variant portaudio conflicts pulseaudio description "Use PortAudio" {
+    depends_build-append    port:portaudio
+    configure.args-replace  -DUSE_PORTAUDIO=OFF \
+                            -DUSE_PORTAUDIO=ON
+}
+
+variant pulseaudio conflicts portaudio description "Use PulseAudio" {
+    depends_build-append    port:pulseaudio
+    configure.args-replace  -DUSE_PULSEAUDIO=OFF \
+                            -DUSE_PULSEAUDIO=ON
 }
 
 variant tests description "Build tests" {
@@ -78,7 +121,7 @@ variant tests description "Build tests" {
                             -DBUILD_TESTS=ON
 
     # Otherwise libraries are looked for in the prefix, which fails, if the port has not been installed earlier.
-    test.env-append         DYLD_LIBRARY_PATH=${cmake.build_dir}:${cmake.build_dir}/CsoundLib64.framework/Versions/6.0
+    test.env-append         DYLD_LIBRARY_PATH=${cmake.build_dir}:${cmake.build_dir}/${cs_framework_path}
     test.run                yes
 }
 


### PR DESCRIPTION
#### Description

New port: https://github.com/CsoundQt/CsoundQt
Qt5 and Qt4 versions.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

macOS 14.2.1
Xcode 15.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
