### PR TITLE
gvisor-tap-vsock: update to 0.7.1, add @catap as co-maintainer

### DIFF
--- a/net/gvisor-tap-vsock/Portfile
+++ b/net/gvisor-tap-vsock/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/containers/gvisor-tap-vsock 0.7.0 v
+go.setup            github.com/containers/gvisor-tap-vsock 0.7.1 v
 github.tarball_from archive
 revision            0
 
 categories          net
 license             Apache-2
-maintainers         {judaew @judaew} openmaintainer
+maintainers         {judaew @judaew} {@catap korins.ky:kirill} openmaintainer
 
 description         A new network stack based on gVisor
 long_description    \
@@ -17,9 +17,9 @@ long_description    \
     the network stack of gVisor. Compared to libslirp, gvisor-tap-vsock \
     brings a configurable DNS server and dynamic port forwarding.
 
-checksums           rmd160  52b1ad33a03722353faa6473d7776c2cb089cfd7 \
-                    sha256  e526b8bf568a5145f4f265a8d450483be27c82717e60f4f22902589a78f68e1f \
-                    size    4264425
+checksums           rmd160  2ad36235d8bf62fed9d6e44ee8aecfd6c15a9506 \
+                    sha256  cbc97a44b6ca8f6c427ac58e193aa39c28674e4f1d2af09b5a9e35d1d3bb7fd3 \
+                    size    10311217
 
 # FIXME: This port currently can't be built without allowing go mod to fetch
 go.offline_build no


### PR DESCRIPTION
See https://github.com/macports/macports-ports/pull/22004

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2 23C64 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
