### PR TITLE
ntpsec: update to 1.2.3

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 PortGroup           openssl 1.0
 
 name                ntpsec
-version             1.2.2a
+version             1.2.3
 revision            0
 categories          sysutils net
 maintainers         {fwright.net:fw @fhgwright} openmaintainer
@@ -20,21 +20,9 @@ homepage            https://www.ntpsec.org/
 conflicts           ntp openntpd
 
 master_sites        ftp://ftp.ntpsec.org/pub/releases/
-checksums           rmd160  a00b6cddeb16087bd2c139340142519f68fefd5b \
-                    sha256  e0ce93af222a0a9860e6f5a51aadba9bb5ca601d80b2aea118a62f0a3226950e \
-                    size    2710790
-
-# 10.5 x86_64 builds successfully and passes all build tests, but doesn't
-# actually work.  This has apparently been true forever, but until recently,
-# dependency issues prevented building it at all.  Since this is a rare case
-# and not really a regression, we simply disallow it for now.  It's unknown
-# whether 10.4 x86_64 has the same issue, but we also disallow that out of
-# conservatism.  This should be removed once the code is fixed.
-#
-# This bug has been verified as still present as of 1.2.2.
-if { ${os.platform} eq "darwin" && ${os.major} < 10 } {
-    supported_archs     i386 ppc
-}
+checksums           rmd160  f6ee175289710afd8c053dd39a5a825d995c7a15 \
+                    sha256  750b7337b3b42b5573700a8d5a483e1bf556e447549177a670c7c00fb9049375 \
+                    size    2725081
 
 # ntpsec requires Python 2.6, 2.7, or 3.3+.
 # We skip 2.6 and 3.3, but keep 2.7 and 3.4+.
@@ -102,13 +90,6 @@ openssl.branch      3
 
 depends_build-append port:bison port:pkgconfig
 #depends_lib-append  port:python${pyver_no_dot}
-
-# Python 3.12+ has deprecated distutils, which is needed by the build.
-# It remains available via setuptools, so we add the dependency.
-# This seems to have been fixed upstream, so the next release can remove this.
-if {${pyver_no_dot} >= 312} {
-    depends_build-append port:py${pyver_no_dot}-setuptools
-}
 
 # Consolidated patchfile, based on GitHub/fhgwright/macports-releases
 patchfiles          patch-allfixes.diff

--- a/sysutils/ntpsec/files/patch-allfixes.diff
+++ b/sysutils/ntpsec/files/patch-allfixes.diff
@@ -1,5 +1,5 @@
 --- attic/backwards.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ attic/backwards.c	2023-08-09 00:16:14.000000000 -0700
++++ attic/backwards.c	2023-12-30 22:12:39.000000000 -0800
 @@ -7,6 +7,8 @@
  #include <stdlib.h>
  #include <time.h>
@@ -9,8 +9,8 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  static void ts_print(struct timespec *ts0, struct timespec *ts1);
---- attic/clocks.c.orig	2023-08-02 21:19:11.000000000 -0700
-+++ attic/clocks.c	2023-08-09 00:16:14.000000000 -0700
+--- attic/clocks.c.orig	2023-12-28 20:53:56.000000000 -0800
++++ attic/clocks.c	2023-12-30 22:12:39.000000000 -0800
 @@ -9,6 +9,8 @@
  #include <unistd.h>
  
@@ -20,9 +20,9 @@
  struct table {
    const int type;
    const char* name;
---- attic/cmac-timing.c.orig	2023-08-02 21:19:11.000000000 -0700
-+++ attic/cmac-timing.c	2023-08-09 00:16:14.000000000 -0700
-@@ -35,6 +35,8 @@
+--- attic/cmac-timing.c.orig	2023-12-28 20:53:53.000000000 -0800
++++ attic/cmac-timing.c	2023-12-30 22:12:39.000000000 -0800
+@@ -36,6 +36,8 @@
  #include <openssl/params.h> 
  #endif
  
@@ -31,19 +31,19 @@
  #define UNUSED_ARG(arg)         ((void)(arg))
  
  
---- attic/digest-timing.c.orig	2023-08-02 21:19:11.000000000 -0700
-+++ attic/digest-timing.c	2023-08-09 00:16:14.000000000 -0700
-@@ -33,6 +33,8 @@
+--- attic/digest-timing.c.orig	2023-12-28 20:53:56.000000000 -0800
++++ attic/digest-timing.c	2023-12-30 22:12:39.000000000 -0800
+@@ -32,6 +32,8 @@
+ #include <openssl/objects.h>
  #include <openssl/ssl.h>
- #endif
  
 +#include "ntp_machine.h"	/* For clock_gettime fallback */
 +
  #define UNUSED_ARG(arg)         ((void)(arg))
  
- #ifndef EVP_MD_CTX_reset
---- attic/random.c.orig	2023-08-02 21:19:11.000000000 -0700
-+++ attic/random.c	2023-08-09 00:16:14.000000000 -0700
+ #ifndef EVP_MD_CTX_new
+--- attic/random.c.orig	2023-12-28 20:53:56.000000000 -0800
++++ attic/random.c	2023-12-30 22:12:39.000000000 -0800
 @@ -10,6 +10,8 @@
  #include <openssl/opensslv.h>    /* for OPENSSL_VERSION_NUMBER */
  #include <openssl/rand.h>
@@ -54,7 +54,7 @@
  #define BILLION 1000000000
  #define HISTSIZE 2500
 --- include/ntp_machine.h.orig	2022-12-22 22:08:52.000000000 -0800
-+++ include/ntp_machine.h	2023-08-09 00:16:14.000000000 -0700
++++ include/ntp_machine.h	2023-12-30 22:12:39.000000000 -0800
 @@ -13,14 +13,145 @@
  
  #ifndef CLOCK_REALTIME
@@ -207,9 +207,9 @@
  
  int ntp_set_tod (struct timespec *tvs);
  
---- include/ntp_stdlib.h.orig	2022-12-22 22:08:52.000000000 -0800
-+++ include/ntp_stdlib.h	2023-08-09 00:16:14.000000000 -0700
-@@ -95,7 +95,9 @@ extern	const char * eventstr	(int);
+--- include/ntp_stdlib.h.orig	2023-12-28 20:53:56.000000000 -0800
++++ include/ntp_stdlib.h	2023-12-30 22:12:39.000000000 -0800
+@@ -103,7 +103,9 @@ extern	const char * eventstr	(int);
  extern	const char * ceventstr	(int);
  extern	const char * res_match_flags(unsigned short);
  extern	const char * res_access_flags(unsigned short);
@@ -220,7 +220,7 @@
  extern	const char * socktoa	(const sockaddr_u *);
  extern	const char * socktoa_r	(const sockaddr_u *sock, char *buf, size_t buflen);
 --- include/ntp_syscall.h.orig	2022-12-22 22:08:52.000000000 -0800
-+++ include/ntp_syscall.h	2023-08-09 00:16:14.000000000 -0700
++++ include/ntp_syscall.h	2023-12-30 22:12:39.000000000 -0800
 @@ -9,9 +9,11 @@
  #ifndef GUARD_NTP_SYSCALL_H
  #define GUARD_NTP_SYSCALL_H
@@ -233,8 +233,8 @@
  
  /*
   * The units of the maxerror and esterror fields vary by platform.  If
---- libntp/clockwork.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ libntp/clockwork.c	2023-08-09 00:16:14.000000000 -0700
+--- libntp/clockwork.c.orig	2023-12-28 20:53:56.000000000 -0800
++++ libntp/clockwork.c	2023-12-30 22:12:39.000000000 -0800
 @@ -5,8 +5,10 @@
  #include "config.h"
  
@@ -249,7 +249,7 @@
  #include "ntp.h"
  #include "ntp_machine.h"
 --- libntp/statestr.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ libntp/statestr.c	2023-08-09 00:16:14.000000000 -0700
++++ libntp/statestr.c	2023-12-30 22:12:39.000000000 -0800
 @@ -12,7 +12,9 @@
  #include "lib_strbuf.h"
  #include "ntp_refclock.h"
@@ -350,133 +350,62 @@
  
  /*
   * statustoa - return a descriptive string for a peer status
---- ntpd/ntp_control.c.orig	2023-08-02 21:19:11.000000000 -0700
-+++ ntpd/ntp_control.c	2023-08-09 00:16:14.000000000 -0700
-@@ -1388,6 +1388,7 @@ ctl_putsys(
- 	char str[256];
- 	double dtemp;
- 	const char *ss;
-+#ifdef HAVE_KERNEL_PLL
- 	static struct timex ntx;
- 	static unsigned long ntp_adjtime_time;
+--- ntpd/ntp_control.c.orig	2023-12-28 20:53:56.000000000 -0800
++++ ntpd/ntp_control.c	2023-12-30 22:12:39.000000000 -0800
+@@ -35,7 +35,9 @@ struct utsname utsnamebuf;
  
-@@ -1403,6 +1404,7 @@ ctl_putsys(
- 		else
-                     ntp_adjtime_time = current_time;
+ /* Variables that need updating each time. */
+ static leap_signature_t lsig;
++#ifdef HAVE_KERNEL_PLL
+ static struct timex ntx;
++#endif	/* HAVE_KERNEL_PLL */
+ 
+ /*
+  * Statistic counters to keep track of requests and responses.
+@@ -364,6 +366,7 @@ static const struct var sys_var[] = {
+   Var_uli("authcmacdecrypts", RO, authcmacdecrypt),
+   Var_uli("authcmacfails", RO, authcmacfail),
+ 
++#ifdef HAVE_KERNEL_PLL
+ /* kerninfo: Kernel timekeeping info */
+   Var_kli("koffset", RO|N_CLOCK|KNUToMS, ntx.offset),
+   Var_kli("kfreq", RO|N_CLOCK|K_16, ntx.freq),
+@@ -381,6 +384,7 @@ static const struct var sys_var[] = {
+   Var_li("kppscaliberrs", RO|N_CLOCK, ntx.errcnt),
+   Var_li("kppsjitexc", RO|N_CLOCK, ntx.jitcnt),
+   Var_li("kppsstbexc", RO|N_CLOCK, ntx.stbcnt),
++#endif	/* HAVE_KERNEL_PLL */
+ 
+ 
+ /* refclock stuff in ntp_io */
+@@ -1395,7 +1399,9 @@ ctl_putarray(
+  */
+ static void
+ ctl_putsys(const struct var * v) {
++#ifdef HAVE_KERNEL_PLL
+ 	static unsigned long ntp_adjtime_time;
++#endif	/* HAVE_KERNEL_PLL */
+ 	static unsigned long ntp_leap_time;
+ 
+ /* older compilers don't allow declarations on each case without {} */
+@@ -1407,6 +1413,7 @@ ctl_putsys(const struct var * v) {
+  * This should get pushed up a layer: flag, once per request
+  * This could get data from 2 samples if the clock ticks while we are working..
+  */
++#ifdef HAVE_KERNEL_PLL
+ 	/* The Kernel clock variables need up-to-date output of ntp_adjtime() */
+ 	if (v->flags&N_CLOCK && current_time != ntp_adjtime_time) {
+ 		ZERO(ntx);
+@@ -1415,6 +1422,7 @@ ctl_putsys(const struct var * v) {
+                             "MODE6: ntp_adjtime() for mode 6 query failed: %s", strerror(errno));
+                 ntp_adjtime_time = current_time;
  	}
 +#endif	/* HAVE_KERNEL_PLL */
  
- 	switch (varid) {
- 
-@@ -1703,45 +1705,94 @@ ctl_putsys(
- 	CASE_UINT(CS_AUTHRESET, current_time - auth_timereset);
- 
- 		/*
--		 * CTL_IF_KERNPPS() puts a zero if kernel hard PPS is not
-+		 * CTL_IF_KERNLOOP() puts a zero if the kernel loop is
-+		 * unavailable, otherwise calls putfunc with args.
-+		 */
-+#ifndef HAVE_KERNEL_PLL
-+# define	CTL_IF_KERNLOOP(putfunc, args)	\
-+		ctl_putint(sys_var[varid].text, 0)
-+#else
-+# define	CTL_IF_KERNLOOP(putfunc, args)	\
-+		putfunc args
-+#endif
-+
-+		/*
-+		 * CTL_IF_KERNPPS() puts a zero if either the kernel
-+		 * loop is unavailable, or kernel hard PPS is not
- 		 * active, otherwise calls putfunc with args.
- 		 */
-+#ifndef HAVE_KERNEL_PLL
-+# define	CTL_IF_KERNPPS(putfunc, args)	\
-+		ctl_putint(sys_var[varid].text, 0)
-+#else
- # define	CTL_IF_KERNPPS(putfunc, args)			\
- 		if (0 == ntx.shift)				\
- 			ctl_putint(sys_var[varid].text, 0);	\
- 		else						\
- 			putfunc args	/* no trailing ; */
-+#endif
- 
- 	case CS_K_OFFSET:
--		ctl_putdblf(sys_var[varid].text, false, -1,
--			ntp_error_in_seconds(ntx.offset) * MS_PER_S);
-+		CTL_IF_KERNLOOP(
-+			ctl_putdblf,
-+			(sys_var[varid].text, false, -1,
-+			 ntp_error_in_seconds(ntx.offset) * MS_PER_S)
-+		);
- 		break;
- 
--	CASE_SFP(CS_K_FREQ, ntx.freq);
-+	case CS_K_FREQ:
-+		CTL_IF_KERNLOOP(
-+			ctl_putsfp,
-+			(CV_NAME, ntx.freq)
-+		);
-+		break;
- 
- 	case CS_K_MAXERR:
--		ctl_putdblf(sys_var[varid].text, false, 6,
--			    ntp_error_in_seconds(ntx.maxerror) * MS_PER_S);
-+		CTL_IF_KERNLOOP(
-+			ctl_putdblf,
-+			(sys_var[varid].text, false, 6,
-+			 ntp_error_in_seconds(ntx.maxerror) * MS_PER_S)
-+		);
- 		break;
- 
- 	case CS_K_ESTERR:
--		ctl_putdblf(sys_var[varid].text, false, 6,
--			 ntp_error_in_seconds(ntx.esterror) * MS_PER_S);
-+		CTL_IF_KERNLOOP(
-+			ctl_putdblf,
-+			(sys_var[varid].text, false, 6,
-+			 ntp_error_in_seconds(ntx.esterror) * MS_PER_S)
-+		);
- 		break;
- 
- 	case CS_K_STFLAGS:
-+#ifndef HAVE_KERNEL_PLL
-+		ss = "";
-+#else
- 		ss = k_st_flags((uint32_t)ntx.status);
-+#endif
- 		ctl_putstr(sys_var[varid].text, ss, strlen(ss));
- 		break;
- 
--	CASE_INT(CS_K_TIMECONST, ntx.constant);
-+	case CS_K_TIMECONST:
-+		CTL_IF_KERNLOOP(
-+			ctl_putint,
-+			(CV_NAME, ntx.constant)
-+		);
-+		break;
- 
- 	case CS_K_PRECISION:
--		ctl_putdblf(sys_var[varid].text, false, 6,
--			    ntp_error_in_seconds(ntx.precision) * MS_PER_S);
-+		CTL_IF_KERNLOOP(
-+			ctl_putdblf,
-+			(sys_var[varid].text, false, 6,
-+			 ntp_error_in_seconds(ntx.precision) * MS_PER_S)
-+		);
- 		break;
- 
--	CASE_SFP(CS_K_FREQTOL, ntx.tolerance);
-+	case CS_K_FREQTOL:
-+		CTL_IF_KERNLOOP(
-+			ctl_putsfp,
-+			(CV_NAME, ntx.tolerance)
-+		);
-+		break;
- 
- 	case CS_K_PPS_FREQ:
- 		CTL_IF_KERNPPS(
---- ntpd/ntp_loopfilter.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpd/ntp_loopfilter.c	2023-08-09 00:16:14.000000000 -0700
+ 	/* The leap second variables need up-to-date info */
+         if (v->flags&N_LEAP && current_time != ntp_leap_time) {
+--- ntpd/ntp_loopfilter.c.orig	2023-12-28 20:53:56.000000000 -0800
++++ ntpd/ntp_loopfilter.c	2023-12-30 22:12:39.000000000 -0800
 @@ -23,8 +23,10 @@
  
  #define NTP_MAXFREQ	500e-6
@@ -570,7 +499,7 @@
  	/*
  	 * This code segment works when clock adjustments are made using
  	 * precision time kernel support and the ntp_adjtime() system
-@@ -817,6 +832,7 @@ local_clock(
+@@ -810,6 +825,7 @@ local_clock(
  		}
  #endif /* STA_NANO */
  	}
@@ -578,7 +507,7 @@
  
  	/*
  	 * Clamp the frequency within the tolerance range and calculate
-@@ -928,8 +944,10 @@ adj_host_clock(
+@@ -921,8 +937,10 @@ adj_host_clock(
  	} else if (freq_cnt > 0) {
  		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(1));
  		freq_cnt--;
@@ -589,7 +518,7 @@
  	} else {
  		offset_adj = clock_offset / (CLOCK_PLL * ULOGTOD(clkstate.sys_poll));
  	}
-@@ -940,9 +958,11 @@ adj_host_clock(
+@@ -933,9 +951,11 @@ adj_host_clock(
  	 * set_freq().  Otherwise it is a component of the adj_systime()
  	 * offset.
  	 */
@@ -601,7 +530,7 @@
  		freq_adj = loop_data.drift_comp;
  
  	/* Bound absolute value of total adjustment to NTP_MAXFREQ. */
-@@ -1031,6 +1051,7 @@ set_freq(
+@@ -1024,6 +1044,7 @@ set_freq(
  
  	loop_data.drift_comp = freq;
  	loop_desc = "ntpd";
@@ -609,7 +538,7 @@
  	if (clock_ctl.pll_control) {
  		int ntp_adj_ret;
  		ZERO(ntv);
-@@ -1043,10 +1064,12 @@ set_freq(
+@@ -1036,10 +1057,12 @@ set_freq(
  		    ntp_adjtime_error_handler(__func__, &ntv, ntp_adj_ret, errno, false, false, __LINE__ - 1);
  		}
  	}
@@ -622,7 +551,7 @@
  static void
  start_kern_loop(void)
  {
-@@ -1082,8 +1105,10 @@ start_kern_loop(void)
+@@ -1075,8 +1098,10 @@ start_kern_loop(void)
  	  	    "kernel time sync enabled");
  	}
  }
@@ -633,7 +562,7 @@
  static void
  stop_kern_loop(void)
  {
-@@ -1091,6 +1116,7 @@ stop_kern_loop(void)
+@@ -1084,6 +1109,7 @@ stop_kern_loop(void)
  		report_event(EVNT_KERN, NULL,
  		    "kernel time sync disabled");
  }
@@ -641,7 +570,7 @@
  
  
  /*
-@@ -1103,11 +1129,15 @@ select_loop(
+@@ -1096,11 +1122,15 @@ select_loop(
  {
  	if (clock_ctl.kern_enable == use_kern_loop)
  		return;
@@ -657,7 +586,7 @@
  	/*
  	 * If this loop selection change occurs after initial startup,
  	 * call set_freq() to switch the frequency compensation to or
-@@ -1163,10 +1193,12 @@ loop_config(
+@@ -1156,10 +1186,12 @@ loop_config(
  	 * variables. Otherwise, continue leaving no harm behind.
  	 */
  	case LOOP_DRIFTINIT:
@@ -670,7 +599,7 @@
  
  		/*
  		 * Initialize frequency if given; otherwise, begin frequency
-@@ -1185,11 +1217,14 @@ loop_config(
+@@ -1178,11 +1210,14 @@ loop_config(
  			rstclock(EVNT_FSET, 0);
  		else
  			rstclock(EVNT_NSET, 0);
@@ -685,7 +614,7 @@
  		if (!loop_data.lockclock && (clock_ctl.pll_control && clock_ctl.kern_enable)) {
  			memset((char *)&ntv, 0, sizeof(ntv));
  			ntv.modes = MOD_STATUS;
-@@ -1199,6 +1234,7 @@ loop_config(
+@@ -1192,6 +1227,7 @@ loop_config(
  				pll_status,
  				ntv.status);
  		   }
@@ -693,13 +622,137 @@
  #endif
  		break;
  
-@@ -1279,4 +1315,3 @@ loop_config(
+@@ -1272,4 +1308,3 @@ loop_config(
  		    "CONFIG: loop_config: unsupported option %d", item);
  	}
  }
 -
---- ntpd/ntp_timer.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpd/ntp_timer.c	2023-08-09 00:16:14.000000000 -0700
+--- ntpd/ntp_packetstamp.c.orig	2022-12-22 22:08:52.000000000 -0800
++++ ntpd/ntp_packetstamp.c	2023-12-30 22:12:39.000000000 -0800
+@@ -6,6 +6,7 @@
+  */
+ #include "config.h"
+ 
++#include <stdint.h>
+ #ifdef HAVE_SYS_IOCTL_H
+ # include <sys/ioctl.h>
+ #endif
+@@ -33,6 +34,44 @@
+  *
+  */
+ 
++/*
++ * OSX prior to 10.6 defines CMSG_DATA incorrectly in 64-bit builds, due to
++ * bad alignment assumptions.
++ *
++ * In those OS versions we substitute a version of the definition from >=10.6.
++ */
++
++#if defined(__APPLE__) \
++  && (!defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) \
++      || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1060)
++
++#define	__DARWIN_ALIGNBYTES32 (sizeof(__uint32_t) - 1)
++#define	__DARWIN_ALIGN32(p) \
++	((size_t)((char *)(size_t)(p) \
++	 + __DARWIN_ALIGNBYTES32) &~ __DARWIN_ALIGNBYTES32)
++
++/* given pointer to struct cmsghdr, return pointer to data */
++#undef CMSG_DATA
++#define	CMSG_DATA(cmsg) ((unsigned char *)(cmsg) + \
++	__DARWIN_ALIGN32(sizeof(struct cmsghdr)))
++
++#endif /* OSX < 10.6 */
++
++/*
++ * Packet timestamps use the kernel's notion of time_t, which may not match
++ * the userspace version.  We need to accomodate both 32- and 64-bit
++ * versions.
++ */
++
++struct timeval_32 {
++	uint32_t	tv_sec;  /* Unsigned to get past 2038 */
++	int32_t		tv_usec;
++};
++
++struct timeval_64 {
++	int64_t		tv_sec;
++	int32_t		tv_usec;
++};
+ 
+ void
+ enable_packetstamps(
+@@ -104,10 +143,11 @@ fetch_packetstamp(
+ 	)
+ {
+ 	struct cmsghdr *	cmsghdr;
++	int			datalen;
+ #if defined(SO_TIMESTAMPNS) || defined(SO_TS_CLOCK)
+ 	struct timespec *	tsp;
+ #elif defined(SO_TIMESTAMP)
+-	struct timeval *	tvp;
++	struct timeval		tv;
+ #endif
+ #ifdef ENABLE_FUZZ
+ 	unsigned long		ticks;
+@@ -124,6 +164,7 @@ fetch_packetstamp(
+ 		exit(2);
+ 		/* return ts;	** Kludge to use time from select. */
+ 	}
++	datalen = cmsghdr->cmsg_len - sizeof(*cmsghdr);
+ #if defined(SO_TIMESTAMPNS)
+ 	/* Linux and ?? */
+ 	if (SCM_TIMESTAMPNS != cmsghdr->cmsg_type) {
+@@ -160,16 +201,42 @@ fetch_packetstamp(
+ 		(long)tsp->tv_sec, tsp->tv_nsec));
+ 	nts = tspec_stamp_to_lfp(*tsp);
+ #elif defined(SO_TIMESTAMP)
+-	tvp = (struct timeval *)CMSG_DATA(cmsghdr);
++	switch (datalen) {
++
++	case sizeof(struct timeval_32):
++		{
++		struct timeval_32 *tvp = (struct timeval_32 *)
++						CMSG_DATA(cmsghdr);
++		tv.tv_sec = tvp->tv_sec; tv.tv_usec = tvp->tv_usec;
++		}
++		break;
++
++	case sizeof(struct timeval_64):
++		{
++		struct timeval_64 *tvp = (struct timeval_64 *)
++						CMSG_DATA(cmsghdr);
++		tv.tv_sec = tvp->tv_sec; tv.tv_usec = tvp->tv_usec;
++		}
++		break;
++
++	default:
++		DPRINT(4,
++			("fetch_timestamp: bad timestamp length %d",
++			datalen));
++		msyslog(LOG_ERR,
++			"ERR: fetch_timestamp: bad timestamp length %d",
++			datalen);
++		exit(2);
++	}
+ #ifdef ENABLE_FUZZ
+ 	if (sys_tick > measured_tick && sys_tick > S_PER_NS) {
+-	    ticks = (unsigned long) ((tvp->tv_usec * S_PER_NS) / sys_tick);
+-	    tvp->tv_usec = (long)(ticks * US_PER_S * sys_tick);
++	    ticks = (unsigned long) ((tv.tv_usec * S_PER_NS) / sys_tick);
++	    tv.tv_usec = (long)(ticks * US_PER_S * sys_tick);
+ 	}
+ #endif
+ 	DPRINT(4, ("fetch_timestamp: system usec network time stamp: %jd.%06ld\n",
+-		(intmax_t)tvp->tv_sec, (long)tvp->tv_usec));
+-	nts = tspec_stamp_to_lfp(tval_to_tspec(*tvp));
++		(intmax_t)tv.tv_sec, (long)tv.tv_usec));
++	nts = tspec_stamp_to_lfp(tval_to_tspec(tv));
+ #else
+ # error "Can't get packet timestamp"
+ #endif
+--- ntpd/ntp_timer.c.orig	2023-12-28 20:53:56.000000000 -0800
++++ ntpd/ntp_timer.c	2023-12-30 22:12:39.000000000 -0800
 @@ -13,7 +13,9 @@
  #include <signal.h>
  #include <unistd.h>
@@ -723,7 +776,7 @@
  	leap_smear.enabled = (leap_smear_intv != 0);
  #endif
 --- ntpd/refclock_local.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpd/refclock_local.c	2023-08-09 00:16:14.000000000 -0700
++++ ntpd/refclock_local.c	2023-12-30 22:12:39.000000000 -0800
 @@ -158,6 +158,7 @@ local_poll(
  	 * If another process is disciplining the system clock, we set
  	 * the leap bits and quality indicators from the kernel.
@@ -746,8 +799,8 @@
  	pp->lastref = pp->lastrec;
  	refclock_receive(peer);
  }
---- ntpfrob/precision.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ ntpfrob/precision.c	2023-08-09 00:16:14.000000000 -0700
+--- ntpfrob/precision.c.orig	2023-12-28 20:53:56.000000000 -0800
++++ ntpfrob/precision.c	2023-12-30 22:12:39.000000000 -0800
 @@ -11,6 +11,7 @@
  #include "ntp_types.h"
  #include "ntp_calendar.h"
@@ -757,7 +810,7 @@
  #define	DEFAULT_SYS_PRECISION	-99
  
 --- tests/libntp/statestr.c.orig	2022-12-22 22:08:52.000000000 -0800
-+++ tests/libntp/statestr.c	2023-08-09 00:16:14.000000000 -0700
++++ tests/libntp/statestr.c	2023-12-30 22:12:39.000000000 -0800
 @@ -4,7 +4,9 @@
  #include "unity.h"
  #include "unity_fixture.h"
@@ -779,7 +832,7 @@
  
  // statustoa
 --- wafhelpers/bin_test.py.orig	2022-12-22 22:08:52.000000000 -0800
-+++ wafhelpers/bin_test.py	2023-08-09 00:16:14.000000000 -0700
++++ wafhelpers/bin_test.py	2023-12-30 22:12:39.000000000 -0800
 @@ -103,6 +103,12 @@ def cmd_bin_test(ctx):
      if ctx.env['PYTHON_CURSES']:
          cmd_map_python.update(cmd_map_python_curses)
@@ -793,8 +846,8 @@
      for cmd in sorted(cmd_map):
          if not run(cmd, cmd_map[cmd] % version):
              fails += 1
---- wafhelpers/options.py.orig	2023-08-02 21:19:11.000000000 -0700
-+++ wafhelpers/options.py	2023-08-09 00:16:14.000000000 -0700
+--- wafhelpers/options.py.orig	2023-12-28 20:53:56.000000000 -0800
++++ wafhelpers/options.py	2023-12-30 22:12:39.000000000 -0800
 @@ -23,6 +23,8 @@ def options_cmd(ctx, config):
                     help="Droproot earlier (breaks SHM and NetBSD).")
      grp.add_option('--enable-seccomp', action='store_true',
@@ -804,9 +857,9 @@
      grp.add_option('--disable-mdns-registration', action='store_true',
                     default=False, help="Disable MDNS registration.")
      grp.add_option(
---- wscript.orig	2023-08-02 21:19:11.000000000 -0700
-+++ wscript	2023-08-09 00:16:14.000000000 -0700
-@@ -585,7 +585,7 @@ int main(int argc, char **argv) {
+--- wscript.orig	2023-12-28 20:53:56.000000000 -0800
++++ wscript	2023-12-30 22:12:39.000000000 -0800
+@@ -587,7 +587,7 @@ int main(int argc, char **argv) {
      structures = (
          ("struct if_laddrconf", ["sys/types.h", "net/if6.h"], False),
          ("struct if_laddrreq", ["sys/types.h", "net/if6.h"], False),
@@ -815,7 +868,7 @@
          ("struct ntptimeval", ["sys/time.h", "sys/timex.h"], False),
      )
      for (s, h, r) in structures:
-@@ -808,6 +808,21 @@ int main(int argc, char **argv) {
+@@ -812,6 +812,21 @@ int main(int argc, char **argv) {
          ctx.define("ENABLE_FUZZ", 1,
                     comment="Enable fuzzing low bits of time")
  


### PR DESCRIPTION
This includes the patches for compatibility with macOS<10.13, which can also be seen (more readably) at:

    https://gitlab.com/fhgwright/ntpsec/tree/macports-1_2_3

Now allows 10.5 x86_64, since the bugs affecting it have been fixed (in patches here).  10.4 x86_64 would probably also work, but currently has broken dependencies.

Also removes now-unnecessary dependency on py312-setuptools.

TESTED:
Built (including running tests) and ran operationally on 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-10.15 x86_64, and 11.x-14.x arm64.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.2 21G1974, arm64, Xcode 14.2 14C18
macOS 13.6.3 22G436, arm64, Xcode 15.1 15C65
macOS 14.2.1 23C71, arm64, Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
