### PR TITLE
toot: update to 0.40.2

### DIFF
--- a/net/toot/Portfile
+++ b/net/toot/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        ihabunek toot 0.39.0
+github.setup        ihabunek toot 0.40.2
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  7bf4458c2a3c5dd35f66548094156a03cffba846 \
-                    sha256  8c5626e5586b73d1b940e9edea9276595ee85df5a67c69932a88b001f3e9ca77 \
-                    size    909649
+checksums           rmd160  592462ba04ec2dd07a4d1191f205680398edcef3 \
+                    sha256  c2b8ae33fb82d14f5181772a7eac0e92de61f1637cc7a4691dda90e390ff9753 \
+                    size    912743
 
 python.default_version 311
 


### PR DESCRIPTION
#### Description

toot: update to 0.40.2

left it on python 3.11 since several of the python dependencies don't have 3.12 yet (and technically it's still 2023 here).

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.6.3 22G436 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
