### PR TITLE
qgit: use Qt5 on new systems

### DIFF
--- a/devel/qgit/Portfile
+++ b/devel/qgit/Portfile
@@ -2,25 +2,45 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           qt4 1.0
 
-# If updating beyond Qt4 compatibility, please add a version/subport, while retaining existing one for older OSs.
-github.setup        tibirna qgit 2.7 qgit-
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
+    # New version requires Qt5 5.11+. To minimize number of versions, use Qt4 for all early systems.
+    PortGroup       qt4 1.0
+
+    github.setup    tibirna qgit 2.7 qgit-
+    checksums       rmd160  82052f8402610065bf64bba38cc66d4fcbc14cf1 \
+                    sha256  183d116b2fb38c6a76c99577f6cc86f0241f8b6bdc74042be4cb8631567f5e9e \
+                    size    259624
+    github.tarball_from archive
+
+    patchfiles-append   patch-fix-comparison.diff
+
+    pre-configure {
+        configure.args-append \
+                        CONFIG+=\"${qt_arch_types}\"
+    }
+} else {
+    PortGroup       qt5 1.0
+
+    # This one should be updated following upstream.
+    github.setup    tibirna qgit 2.10 qgit-
+    checksums       rmd160  84864b94ef24469f1c40b4e064d385a4653935f1 \
+                    sha256  1fc74fbd25c8ccbee9f7d4a8817b0a82ffa5a3a281b324febe4e90ea7c721153 \
+                    size    222077
+    github.tarball_from archive
+
+    # App icon seems corrupt on arm64: https://github.com/tibirna/qgit/issues/141
+}
+
 categories          devel
 license             GPL-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         A Qt graphical interface to git repositories
 long_description    {*}${description}
 
-checksums           rmd160  82052f8402610065bf64bba38cc66d4fcbc14cf1 \
-                    sha256  183d116b2fb38c6a76c99577f6cc86f0241f8b6bdc74042be4cb8631567f5e9e \
-                    size    259624
-github.tarball_from archive
-
 depends_lib-append  port:git
 
-patchfiles          patch_src_qgit.cpp.diff \
-                    patch-fix-comparison.diff
+patchfiles-append   patch_src_qgit.cpp.diff
 
 variant debug description "Build as both release and debug" {}
 
@@ -36,10 +56,6 @@ post-patch {
 
 # --disable-dependency-tracking is not recognized.
 configure.universal_args-delete --disable-dependency-tracking
-
-pre-configure {
-    configure.args-append CONFIG+=\"${qt_arch_types}\"
-}
 
 configure.cmd       ${qt_qmake_cmd}
 configure.pre_args


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/65362

#### Description

Add a version for new systems with Qt5.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1
Xcode 15.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
