### PR TITLE
TeXShop: restore version for old systems

### DIFF
--- a/aqua/TeXShop/Portfile
+++ b/aqua/TeXShop/Portfile
@@ -79,7 +79,43 @@ platform darwin {
         livecheck.type  none
     }
 
-    if {${os.major} < 20} {
+    if {${os.major} < 11} {
+        # Version for legacy systems.
+        version     2.47
+        revision    0
+        checksums   rmd160  cd02b93bafa72de885338d32e98c61de39e11aa6 \
+                    sha256  cd8f9fd827d9b080423da0f1d9664bdbfdfebb4525bbb7542ee54c44e2f9ce19 \
+                    size    75049777
+
+        distname    texshopsource[strsed ${version} {/\.//}]
+        worksrcdir  texshopsource-${version}
+
+        post-extract    {
+            set sparkle "Sparkle.framework/Versions/A/Sparkle"
+            set ogrekit "OgreKit.framework/Versions/A/OgreKit"
+            if {![variant_isset universal]} {
+                # thin the bundled frameworks
+                system "cd ${worksrcpath} && lipo -thin ${configure.build_arch} $sparkle -output $sparkle"
+                system "cd ${worksrcpath} && lipo -thin ${configure.build_arch} $ogrekit -output $ogrekit"
+            } elseif {${os.major} == 8} {
+                # Tiger chokes on the x86_64
+                system "cd ${worksrcpath} && lipo -remove x86_64 $sparkle -output $sparkle"
+            }
+            reinplace "s|defaultConfigurationName = Debug|defaultConfigurationName = Release|" ${worksrcpath}/${name}.xcodeproj/project.pbxproj
+            reinplace "s|GCC_VERSION_i386 = 4\.0|GCC_VERSION_i386 = [lindex [split ${configure.objc} -] 1]|g" ${worksrcpath}/3rdparty/OgreKit/OgreKit.xcodeproj/project.pbxproj
+            reinplace "s|GCC_VERSION_ppc = 3\.3|GCC_VERSION_ppc = [lindex [split ${configure.objc} -] 1]|g" ${worksrcpath}/3rdparty/OgreKit/OgreKit.xcodeproj/project.pbxproj
+            reinplace "s|GCC_VERSION = 4\.0|GCC_VERSION = [lindex [split ${configure.objc} -] 1]|" ${worksrcpath}/TeXShop.xcodeproj/project.pbxproj
+            reinplace "s|GCC_VERSION = 4\.0|GCC_VERSION = [lindex [split ${configure.objc} -] 1]|" ${worksrcpath}/3rdparty/TeX-mdimporter/TeX.xcodeproj/project.pbxproj
+        }
+        patchfiles             patch-TSDocument.m.diff
+        compiler.blacklist     clang
+        destroot.target        ${name}
+
+        notes "If you intend to use the Lilypond engine, please copy ${applications_dir}/${name}.app/Contents/Resources/${name}/Engines/Lilypond.engine to ~/Library/${name}/Engines/Lilypond.engine"
+
+        livecheck.type  none
+
+    } elseif {${os.major} < 20} {
         version     4.44
         revision    0
         checksums   rmd160  bcbccbd35ecbf9f09d38e43a7bc5392f1e0f419c \
@@ -103,7 +139,6 @@ platform darwin {
         livecheck.type  none
     }
 
-    platforms {darwin >= 15}
 }
 
 build.target            ${name}
@@ -118,6 +153,11 @@ xcode.destroot.settings INSTALL_MODE_FLAG=755 {*}${xcode.build.settings}
 
 post-destroot {
     file delete -force ${destroot}${applications_dir}/TeX.mdimporter
+
+    if {${os.platform} eq "darwin" && ${os.major} < 11} {
+        xinstall -m 755 ${filespath}/lilypond.engine ${destroot}${applications_dir}/${name}.app/Contents/Resources/${name}/Engines/Lilypond.engine
+        reinplace s|@@PREFIX@@|${prefix}|g ${destroot}${applications_dir}/${name}.app/Contents/Resources/${name}/Engines/Lilypond.engine
+    }
 }
 
 livecheck.type      regex

--- a/aqua/TeXShop/files/lilypond.engine
+++ b/aqua/TeXShop/files/lilypond.engine
@@ -1,0 +1,4 @@
+#!/bin/tcsh
+
+set path=($path @@PREFIX@@)
+lilypond "$1"

--- a/aqua/TeXShop/files/patch-TSDocument.m.diff
+++ b/aqua/TeXShop/files/patch-TSDocument.m.diff
@@ -1,0 +1,29 @@
+--- Sources/TSDocument.m.orig	2012-05-28 15:18:07.000000000 -0500
++++ Sources/TSDocument.m	2012-08-27 14:55:07.000000000 -0500
+@@ -1209,7 +1209,8 @@
+ 				if ([theChecker setLanguage:spellcheckString]) {
+ 					spellLanguageChanged = YES;
+ 					if ([theChecker respondsToSelector:@selector(setAutomaticallyIdentifiesLanguages:)])
+-						automaticLanguage = [theChecker setAutomaticallyIdentifiesLanguages:NO];
++						automaticLanguage = NO;
++						[theChecker setAutomaticallyIdentifiesLanguages:NO];
+ 					if (spellLanguage != nil)
+ 						[spellLanguage release];
+ 					spellLanguage = [spellcheckString retain];
+@@ -1426,12 +1427,14 @@
+ 	if (spellLanguage != nil) {
+ 		[theChecker setLanguage:spellLanguage]; 
+ 		if ([theChecker respondsToSelector:@selector(setAutomaticallyIdentifiesLanguages:)])
+-			automaticLanguage = [theChecker setAutomaticallyIdentifiesLanguages:NO];
++			automaticLanguage = NO;
++			[theChecker setAutomaticallyIdentifiesLanguages:NO];
+ 	}
+ 	else {
+ 		[theChecker setLanguage:defaultLanguage]; 
+ 		if ([theChecker respondsToSelector:@selector(setAutomaticallyIdentifiesLanguages:)])
+-			automaticLanguage = [theChecker setAutomaticallyIdentifiesLanguages:automaticLanguage];
++			automaticLanguage = NO;
++			[theChecker setAutomaticallyIdentifiesLanguages:automaticLanguage];
+ 	}
+ }
+ 


### PR DESCRIPTION
#### Description

Restore a version for pre-Lion systems. (This merely restores what we already had before.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
