### PR TITLE
dav1d: fix build on macOS <10.7

### DIFF
--- a/multimedia/dav1d/Portfile
+++ b/multimedia/dav1d/Portfile
@@ -6,8 +6,8 @@ PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           legacysupport 1.1
 
-# posix_memalign
-legacysupport.newest_darwin_requires_legacy 9
+# posix_memalign, see comment below
+legacysupport.newest_darwin_requires_legacy 10
 
 name                dav1d
 # Please increase the revision of libheif, ffmpeg and ffmpeg-devel whenever
@@ -36,6 +36,21 @@ extract.rename      yes
 }
 
 use_bzip2           yes
+
+# https://code.videolan.org/videolan/dav1d/-/merge_requests/1532
+# https://github.com/RIOT-OS/RIOT/issues/2361
+# Changes to the build script in version 1.3.0
+# forced the inclusion of malloc.h which was
+# never appears on macOS.
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    patchfiles-append   patch-ignore-malloc.diff
+    # fallback to memalign() breaks the build and
+    # the meson configure script never detects
+    # posix_memalign() from legacysupport - let's
+    # forcibly turn it on manually
+    configure.cflags-append \
+                        -DHAVE_POSIX_MEMALIGN
+}
 
 # see https://trac.macports.org/ticket/62618
 # patch can be applied always, but limit to < darwin 10 so no chance of troubles

--- a/multimedia/dav1d/files/patch-ignore-malloc.diff
+++ b/multimedia/dav1d/files/patch-ignore-malloc.diff
@@ -1,0 +1,13 @@
+--- src/mem.h
++++ src/mem.h
+@@ -32,10 +32,6 @@
+ 
+ #include <stdlib.h>
+ 
+-#if defined(_WIN32) || !defined(HAVE_POSIX_MEMALIGN)
+-#include <malloc.h>
+-#endif
+-
+ #include "dav1d/dav1d.h"
+ 
+ #include "common/attributes.h"


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
