### PR TITLE
HexFiend: Update to 2.17.1

### DIFF
--- a/editors/HexFiend/Portfile
+++ b/editors/HexFiend/Portfile
@@ -5,10 +5,10 @@ PortGroup       xcode 1.0
 PortGroup       xcodeversion 1.0
 PortGroup       github 1.0
 
-github.setup    HexFiend HexFiend 2.16.0 v
-checksums       rmd160  f8fc576c829919d805f80049f2ef928bc49a0aee \
-                sha256  c362fa3bc5fdf20ce965913ef17f171b918dbea04e5abaef95a34df3dc51c4fb \
-                size    4630697
+github.setup    HexFiend HexFiend 2.17.1 v
+checksums       rmd160  c4d5c7634cd9c397119d98bd946e7abd47b4b873 \
+                sha256  d86053ba33366053d28a50852d310ae01d12132d59377176e1e9add26b46fb90 \
+                size    4657473
 
 epoch           1
 categories      editors aqua


### PR DESCRIPTION
#### Description
update hexfiend to 2.17.1 (latest version)
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
