### PR TITLE
fish: update to 3.7.0; adopt

### DIFF
--- a/shells/fish/Portfile
+++ b/shells/fish/Portfile
@@ -5,18 +5,18 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               legacysupport 1.0
 
-github.setup            fish-shell fish-shell 3.6.4
+github.setup            fish-shell fish-shell 3.7.0
 revision                0
-checksums               rmd160  de7189d46546a655b04bf702316153d0c5c620a5 \
-                        sha256  0f3f610e580de092fbe882c8aa76623ecf91bb16fdf0543241e6e90d5d4bc393 \
-                        size    2911364
+checksums               rmd160  3f1a905801932f0a868b4c07e461e490a39d894a \
+                        sha256  df1b7378b714f0690b285ed9e4e58afe270ac98dbc9ca5839589c1afcca33ab1 \
+                        size    2961912
 
 name                    fish
 license                 GPL-2
 categories              shells
-maintainers             nomaintainer
+maintainers             {@akierig fastmail.de:akierig} openmaintainer
 
-description             A command line shell for the 90s
+description             The friendly interactive shell: a command line shell for the 90s
 long_description        fish is a smart and user-friendly command line shell for OS X, Linux, and the rest of the family
 
 homepage                https://fishshell.com/


### PR DESCRIPTION
#### Description

- fish: update to 3.7.0
- adopt unmaintained port

###### Type(s)

- [x] bugfix
- [x] enhancement
- [x] security fix

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
