### PR TITLE
symfony-cli: update to 5.7.8

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.7.7
+version             5.7.8
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  248589f4b6604f877c703c1a03af8112ad9e5dd0 \
-                        sha256  9c497939492df4a39bd90f41c6299e453de726e8211866c018a2483b572501ce \
-                        size    259352
+    checksums           rmd160  5e1d1d4a4216107b9210f09d28cb494ba4053cb8 \
+                        sha256  ad9c524a1d28964b7ba0510fa1008e5489d1037ae3c768bc02ca8ee3b99d172e \
+                        size    259332
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  9908f1f37d00a1b4c7b2e5a83743a69bcab3af1c \
-                        sha256  8362a9c9b849e707a8be3b3f8b4502670893bcf8a5db406b991b1186c3f1199c \
-                        size    11150537
+    checksums           rmd160  041dc38cb57ac58825aa814fe5a501eebc20cdb9 \
+                        sha256  4394464a0b4b071ec7aabb358c01f772bc5ae00f74e907864bfc3420e115ae2f \
+                        size    11143468
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.7.8

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
