### PR TITLE
py-psycopg2: update to 2.9.9

### DIFF
--- a/python/py-psycopg2/Portfile
+++ b/python/py-psycopg2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-psycopg2
-version             2.9.7
+version             2.9.9
 revision            0
 
 categories-append   databases
@@ -19,13 +19,13 @@ long_description    Psycopg2 is a postgresql database adapter for python. \
                     designed for heavily multi-threaded applications \
                     featuring connection pooling.
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 
 homepage            https://www.psycopg.org
 
-checksums           rmd160  42b328b22e36dad279552cedad23bbb5b0594bb5 \
-                    sha256  f00cc35bd7119f1fed17b85bd1007855194dde2cbd8de01ab8ebb17487440ad8 \
-                    size    383496
+checksums           rmd160  97b402df4a2cbb6d85c8f796265379114141657c \
+                    sha256  d1454bde93fb1e224166811694d600e746430c006fbb031ea06ecc2ea41bf156 \
+                    size    384926
 
 proc pgsql_variant_set {} {
     if {
@@ -34,7 +34,8 @@ proc pgsql_variant_set {} {
         [variant_isset postgresql12] ||
         [variant_isset postgresql13] ||
         [variant_isset postgresql14] ||
-        [variant_isset postgresql15]
+        [variant_isset postgresql15] ||
+        [variant_isset postgresql16]
     } {
         return yes
     } else {
@@ -55,6 +56,8 @@ proc pgsql_version {} {
         set pgsql_ver 14
     } elseif {[variant_isset postgresql15]} {
         set pgsql_ver 15
+    } elseif {[variant_isset postgresql16]} {
+        set pgsql_ver 16
     } else {
         error "No postgresql variant enabled"
     }
@@ -82,7 +85,7 @@ if {${name} ne ${subport}} {
         livecheck.type none
     } else {
         if {![pgsql_variant_set]} {
-            default_variants +postgresql15
+            default_variants +postgresql16
         }
     }
 
@@ -107,29 +110,34 @@ if {${name} ne ${subport}} {
             ${worksrcpath}/setup.cfg
     }
 
-    variant postgresql10 conflicts postgresql15 \
-            postgresql11 postgresql12 postgresql13 postgresql14 \
+    variant postgresql10 conflicts postgresql16 \
+            postgresql11 postgresql12 postgresql13 postgresql14 postgresql15 \
             description "Build using postgresql v10" {}
 
-    variant postgresql11 conflicts postgresql15 \
-            postgresql10 postgresql12 postgresql13 postgresql14 \
+    variant postgresql11 conflicts postgresql16 \
+            postgresql10 postgresql12 postgresql13 postgresql14 postgresql15 \
             description "Build using postgresql v11" {}
 
-    variant postgresql12 conflicts postgresql15 \
-            postgresql10 postgresql11 postgresql13 postgresql14 \
+    variant postgresql12 conflicts postgresql16 \
+            postgresql10 postgresql11 postgresql13 postgresql14 postgresql15 \
             description "Build using postgresql v12" {}
 
-    variant postgresql13 conflicts postgresql15 \
-            postgresql10 postgresql11 postgresql12 postgresql14 \
+    variant postgresql13 conflicts postgresql16 \
+            postgresql10 postgresql11 postgresql12 postgresql14 postgresql15 \
             description "Build using postgresql v13" {}
 
-    variant postgresql14 conflicts postgresql15 \
-            postgresql10 postgresql11 postgresql12 postgresql13 \
+    variant postgresql14 conflicts postgresql16 \
+            postgresql10 postgresql11 postgresql12 postgresql13 postgresql15 \
             description "Build using postgresql v14" {}
 
-    variant postgresql15 conflicts \
+    variant postgresql15 conflicts postgresql16 \
             postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 \
             description "Build using postgresql v15" {}
+
+    variant postgresql16 conflicts \
+            postgresql10 postgresql11 postgresql12 postgresql13 postgresql14 \
+            postgresql15 \
+            description "Build using postgresql v16" {}
 }
 
 universal_variant       no


### PR DESCRIPTION
#### Description

- add py312 subport
- add postgresql16 variant and set as default

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.1 15C65

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?