### PR TITLE
tinyproxy: fix startupitem

### DIFF
--- a/net/tinyproxy/Portfile
+++ b/net/tinyproxy/Portfile
@@ -4,9 +4,8 @@ PortSystem              1.0
 PortGroup               github 1.0
 
 github.setup            tinyproxy tinyproxy 1.11.1
-revision                0
+revision                1
 categories              net www
-platforms               darwin
 maintainers             nomaintainer
 license                 GPL-2+
 
@@ -32,32 +31,48 @@ depends_build-append    port:asciidoc \
 configure.args          --disable-regexcheck \
                         --disable-silent-rules
 
+set conf_dir            ${prefix}/etc/${name}
+set log_dir             ${prefix}/var/log/${name}
+set run_dir             ${prefix}/var/run/${name}
+set doc_dir             ${prefix}/share/doc/${name}
+
+destroot.keepdirs       ${destroot}${conf_dir} \
+                        ${destroot}${log_dir} \
+                        ${destroot}${run_dir}
+
 post-destroot {
-    xinstall -d -o nobody -g nobody ${destroot}${prefix}/var/run/tinyproxy
+    xinstall -d -o nobody -g nobody ${destroot}${log_dir}
+    move ${destroot}${conf_dir}/tinyproxy.conf ${destroot}${doc_dir}
+}
 
-    move ${destroot}${prefix}/etc/tinyproxy/tinyproxy.conf ${destroot}${prefix}/etc/tinyproxy/tinyproxy.conf.default
-
-    set docdir ${destroot}${prefix}/share/doc/${name}
-    xinstall -d ${docdir}
-    xinstall -m 644 -W ${worksrcpath} \
-        AUTHORS \
-        ChangeLog \
-        COPYING \
-        docs/http-error-codes.txt \
-        docs/http-rfcs.txt \
-        README \
-        TODO \
-        ${docdir}
+post-activate {
+    if {![file exists ${conf_dir}/tinyproxy.conf]} {
+        copy ${doc_dir}/tinyproxy.conf ${conf_dir}/
+    }
 }
 
 startupitem.create      yes
 startupitem.netchange   yes
-startupitem.executable  ${prefix}/sbin/tinyproxy -c ${prefix}/etc/tinyproxy/tinyproxy.conf -d
+startupitem.executable  ${prefix}/bin/tinyproxy -d
 
-variant reverse description {Enable reverse proxying} {
-    configure.args-append   --enable-reverse
+variant xtinyproxy description {Enable X-Tinyproxy header support} {
+    configure.args-append   --enable-xtinyproxy
+}
+
+variant filter description {Enable URL filtering} {
+    configure.args-append   --enable-filter
+}
+
+variant upstream description {Enable upstream proxying} {
+    configure.args-append   --enable-upstream
 }
 
 variant transparent description {Enable transparent proxying} {
     configure.args-append   --enable-transparent
 }
+
+variant reverse description {Enable reverse proxying} {
+    configure.args-append   --enable-reverse
+}
+
+default_variants        +xtinyproxy +filter +upstream +transparent +reverse


### PR DESCRIPTION
#### Description

- clean up port
- add and enable more variants

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.1 15C65

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?