### PR TITLE
arghandler: fix install location of CMake config files

### DIFF
--- a/devel/arghandler/Portfile
+++ b/devel/arghandler/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 
 github.setup        adishavit argh 1.3.2 v
 name                arghandler
-revision            0
+revision            1
 categories          devel
 license             BSD
 platforms           any
@@ -18,7 +18,8 @@ checksums           rmd160  34498b93e41f4dd5e4a0a4af7c64c63c0f59cefb \
                     sha256  f0c1900e67459da00fd2e31a022d666a5b0c9195b714030811355925b16b779e \
                     size    101455
 
-patchfiles          0001-Fix-building-tests-on-PPC.patch
+patchfiles          0001-Fix-building-tests-on-PPC.patch \
+                    0002-CMakeLists-fix-installation-on-macOS.patch
 
 compiler.cxx_standard 2011
 compiler.thread_local_storage yes

--- a/devel/arghandler/files/0002-CMakeLists-fix-installation-on-macOS.patch
+++ b/devel/arghandler/files/0002-CMakeLists-fix-installation-on-macOS.patch
@@ -1,0 +1,24 @@
+https://github.com/adishavit/argh/pull/83
+
+From 8d085d1ad8b9946a7d2a1cd28777ff2e15145803 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Thu, 4 Jan 2024 04:40:39 +0800
+Subject: [PATCH] CMakeLists: fix installation on macOS
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git CMakeLists.txt CMakeLists.txt
+index 93181be..72f157f 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -42,7 +42,7 @@ if(ARGH_MASTER_PROJECT)
+ 	install(FILES "${CMAKE_CURRENT_LIST_DIR}/LICENSE" DESTINATION ${CMAKE_INSTALL_DOCDIR})
+ 	install(FILES "${CMAKE_CURRENT_LIST_DIR}/README.md" DESTINATION ${CMAKE_INSTALL_DOCDIR})
+ 
+-	if(CMAKE_SYSTEM_NAME STREQUAL Linux)
++	if(APPLE OR CMAKE_SYSTEM_NAME STREQUAL Linux)
+ 	# this might be a bit too restrictive, since for other (BSD, ...) this might apply also
+ 	# but this can be fixed later in extra pull requests from people on the platform
+ 		install(FILES argh-config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/argh)


### PR DESCRIPTION
#### Description

Fix installation.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1
Xcode 15.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
