### PR TITLE
ddptools: fix supported_archs

### DIFF
--- a/audio/ddptools/Portfile
+++ b/audio/ddptools/Portfile
@@ -10,6 +10,7 @@ categories      audio
 platforms       {darwin any}
 maintainers     {breun.nl:nils @breun} openmaintainer
 license         NoMirror
+supported_archs x86_64
 
 description     DDP Mastering Tools
 


### PR DESCRIPTION
#### Description

Fix `supported_archs` for the `ddptools` port. Fixes https://trac.macports.org/ticket/69027