### PR TITLE
libjxl: unbreak build on systems which need __STDC_FORMAT_MACROS

### DIFF
--- a/graphics/libjxl/Portfile
+++ b/graphics/libjxl/Portfile
@@ -45,7 +45,8 @@ post-extract {
 }
 
 patchfiles          include_order.patch \
-                    find_asciidoc.patch
+                    find_asciidoc.patch \
+                    STDC_FORMAT_MACROS.patch
 
 if {${os.platform} eq "darwin" && ${os.major} <= 15} {
     # No support for sized operator delete

--- a/graphics/libjxl/files/STDC_FORMAT_MACROS.patch
+++ b/graphics/libjxl/files/STDC_FORMAT_MACROS.patch
@@ -1,0 +1,26 @@
+From ede3f6187e31f2fa46e3b68103489a81a1be0b94 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Thu, 4 Jan 2024 12:16:41 +0800
+Subject: [PATCH] enc_aux_out.cc: define __STDC_FORMAT_MACROS if undefined
+
+Fixes: https://github.com/libjxl/libjxl/issues/3091
+See also: https://github.com/libjxl/libjxl/commit/97ec970d06ad04254f2cdcbe0bf8bba3166372b6
+---
+ lib/jxl/enc_aux_out.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git lib/jxl/enc_aux_out.cc lib/jxl/enc_aux_out.cc
+index 1c141d17..cbe7d0d1 100644
+--- lib/jxl/enc_aux_out.cc
++++ lib/jxl/enc_aux_out.cc
+@@ -5,6 +5,10 @@
+ 
+ #include "lib/jxl/enc_aux_out.h"
+ 
++#ifndef __STDC_FORMAT_MACROS
++#define __STDC_FORMAT_MACROS
++#endif
++
+ #include <inttypes.h>
+ #include <stddef.h>
+ #include <stdint.h>


### PR DESCRIPTION
#### Description

0.9.0 is again broken, use a standard fix which has been already used earlier for this port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
