### PR TITLE
catch2: update to 3.5.1

### DIFF
--- a/devel/catch2/Portfile
+++ b/devel/catch2/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        catchorg Catch2 3.5.0 v
+github.setup        catchorg Catch2 3.5.1 v
 name                catch2
 revision            0
 
@@ -16,9 +16,9 @@ maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
 description         Catch 2: a modern, C++-native, header-only, test framework for unit-tests
 long_description    ${description}, TDD and BDD - using C++14, C++17 and later.
 
-checksums           rmd160  b802c77384a464265740b5aed33f6e62b390bf4d \
-                    sha256  f6d4f8d78a9b59ec72a81d49f58d18eb317372ac07f8d9432710a079e69fd66a \
-                    size    1155736
+checksums           rmd160  1a86e7effe9dc43eb7f104f040e130f0b81e6e62 \
+                    sha256  49c3ca7a68f1c8ec71307736bc6ed14fec21631707e1be9af45daf4037e75a08 \
+                    size    1159629
 github.tarball_from archive
 
 compiler.cxx_standard 2014


### PR DESCRIPTION
#### Description

Simple update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
