### PR TITLE
knot-resolver: new port (version 5.7.0); luajit: update to 2.1.1703358377; knot: add libknot subport

### DIFF
--- a/lang/luajit/Portfile
+++ b/lang/luajit/Portfile
@@ -8,12 +8,12 @@ PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 set branch          2.1
-set version_date    2023-11-15T00:41:31Z
-github.setup        LuaJIT LuaJIT 43d0a19158ceabaa51b0462c1ebc97612b420a2e
+set version_date    2023-12-23T19:06:17Z
+github.setup        LuaJIT LuaJIT c525bcb9024510cad9e170e12b6209aedb330f83
 revision            0
-checksums           rmd160  ed8b213cdff2939efa0c1203a2b018d02abc84e2 \
-                    sha256  4fefa19bc5600928fb13c928bf5325eaa1c78f2c1738a8ac9552154ef178bb9a \
-                    size    1078803
+checksums           rmd160  db4a5de50bfef270d080ae8023b77f879997cbee \
+                    sha256  eb20affc70a9e97a8a0e1e0b10456f220fca7637a198e4a937b5fc827dd1ef95 \
+                    size    1079440
 
 set version_date_s  [clock scan "${version_date}" -format {%Y-%m-%dT%H:%M:%SZ} -timezone :UTC]
 version             ${branch}.${version_date_s}
@@ -21,7 +21,7 @@ version             ${branch}.${version_date_s}
 name                luajit
 categories          lang
 license             MIT
-maintainers         nomaintainer
+maintainers         {@catap korins.ky:kirill} openmaintainer
 
 description         a Just-In-Time Compiler for Lua
 long_description    LuaJIT is a Just-In-Time Compiler for the Lua programming language.
@@ -33,7 +33,9 @@ conflicts           luajit-openresty
 patchfiles          powerpc.patch
 
 post-patch {
-    reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/etc/luajit.pc
+    reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/etc/luajit.pc \
+                                        ${worksrcpath}/src/luaconf.h \
+                                        ${worksrcpath}/src/Makefile
 
     # Remove -march=i686 from CCOPT_x86
     reinplace -E {s|-march=[a-z0-9_]+||g} ${worksrcpath}/src/Makefile

--- a/net/knot-resolver/Portfile
+++ b/net/knot-resolver/Portfile
@@ -1,0 +1,54 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           meson 1.0
+PortGroup           legacysupport 1.1
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
+
+name                knot-resolver
+version             5.7.0
+revision            0
+categories          net
+license             GPL-3+
+maintainers         {mps @Schamschula} {@catap korins.ky:kirill} openmaintainer
+description         The Knot Resolver is a caching DNS resolver scalable from \
+                    huge resolver farms down to home network routers.
+long_description    {*}${description}
+homepage            https://www.knot-resolver.cz
+master_sites        https://secure.nic.cz/files/knot-dns/ \
+                    https://sources.openwrt.org
+
+use_xz              yes
+
+checksums           rmd160  dad1144e2020404141437896fe602ad64a8d9d08 \
+                    sha256  383ef6db1cccabd2dd788ea9385f05e98a2bafdfeb7f0eda57ff9d572f4fad71 \
+                    size    1926196
+
+depends_build       port:pkgconfig
+
+depends_lib         path:lib/libluajit-5.1.2.dylib:luajit \
+                    path:lib/pkgconfig/gnutls.pc:gnutls \
+                    path:lib/pkgconfig/libknot.pc:libknot \
+                    port:fstrm \
+                    port:jemalloc \
+                    port:libuv \
+                    port:lmdb \
+                    port:nghttp2 \
+                    port:protobuf-c
+
+patchfiles-append   respect-pkgconfig-libdir.diff
+
+# Should match knot port
+platforms {darwin >= 15}
+
+startupitem.create      yes
+startupitem.netchange   yes
+startupitem.executable  ${prefix}/sbin/kresd -n ${prefix}/var/run/knot-resolver
+
+destroot.keepdirs       ${destroot}${prefix}/var/run/knot-resolver
+
+post-destroot {
+    xinstall -m 755 -o root -d ${destroot}${prefix}/var/run/knot-resolver
+}

--- a/net/knot-resolver/files/respect-pkgconfig-libdir.diff
+++ b/net/knot-resolver/files/respect-pkgconfig-libdir.diff
@@ -1,0 +1,16 @@
+diff --git meson.build meson.build
+index 0b343043..ddf0f553 100644
+--- meson.build
++++ meson.build
+@@ -189,9 +189,9 @@ conf_data.set_quoted('ROOTHINTS', root_hints)
+ conf_data.set_quoted('LIBEXT', libext)
+ conf_data.set_quoted('OPERATING_SYSTEM', host_machine.system())
+ conf_data.set_quoted('libzscanner_SONAME',
+-  libzscanner.get_pkgconfig_variable('soname'))
++  libzscanner.get_pkgconfig_variable('libdir') / libzscanner.get_pkgconfig_variable('soname'))
+ conf_data.set_quoted('libknot_SONAME',
+-  libknot.get_pkgconfig_variable('soname'))
++  libknot.get_pkgconfig_variable('libdir') / libknot.get_pkgconfig_variable('soname'))
+ conf_data.set('ENABLE_LIBSYSTEMD', libsystemd.found().to_int())
+ conf_data.set('ENABLE_SENDMMSG', sendmmsg.to_int())
+ conf_data.set('ENABLE_XDP', xdp.to_int())

--- a/net/knot/Portfile
+++ b/net/knot/Portfile
@@ -36,6 +36,7 @@ depends_lib         port:fstrm \
                     port:protobuf-c \
                     port:userspace-rcu
 
+# Should match knot-resolver port
 platforms {darwin >= 15}
 
 patchfiles          patch-src-knot-server-quic-handler.c.diff

--- a/net/knot/Portfile
+++ b/net/knot/Portfile
@@ -11,7 +11,7 @@ version             3.3.3
 revision            0
 categories          net
 license             GPL-3+
-maintainers         {mps @Schamschula} openmaintainer
+maintainers         {mps @Schamschula} {@catap korins.ky:kirill} openmaintainer
 description         Knot DNS is a high-performance authoritative-only DNS server which \
                     supports all key features of the modern domain name system.
 long_description    {*}${description}
@@ -66,3 +66,17 @@ Edit as necessary. (See the knot.conf manpage for additional information.)
 
 You will also need to created *.zone files. See ${prefix}/etc/knot/example.com.zone.
 "
+
+subport libknot {
+    # cleanup note and startupitem
+    notes
+    startupitem.create  no
+
+    # remove not relevant files
+    post-destroot {
+        file delete -force -- ${destroot}${prefix}/bin
+        file delete -force -- ${destroot}${prefix}/etc
+        file delete -force -- ${destroot}${prefix}/sbin
+        file delete -force -- ${destroot}${prefix}/share
+    }
+}


### PR DESCRIPTION
#### Description

Here a brand new port knot-resolver which requires to extract `libknot` as separated port to avoid installing knot.

I also updated luajit and add myself as maintainer.

Thus, I've added myself as co-maintainer to knot port, and added @Schamschula to this new port because them are quite linked.

I hope you're ok with this.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->