### PR TITLE
atomvm: set correct c_standard, fix build on older macOS

### DIFF
--- a/erlang/atomvm/Portfile
+++ b/erlang/atomvm/Portfile
@@ -3,6 +3,11 @@
 PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
+PortGroup               compiler_blacklist_versions 1.0
+PortGroup               legacysupport 1.1
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 16
 
 github.setup            atomvm atomvm 0.6.0-alpha.2 v
 revision                0
@@ -24,6 +29,13 @@ depends_build-append    port:erlang \
                         port:elixir \
                         port:gperf
 depends_lib-append      port:mbedtls3
+
+# CMake Error at src/platforms/generic_unix/CMakeLists.txt:25 (target_compile_features):
+# target_compile_features The compiler feature "c_std_11" is not known to C compiler
+compiler.c_standard     2011
+# CMake Error at src/libAtomVM/CMakeLists.txt:155 (message):
+# Platform doesn't support atomic pointers
+compiler.blacklist-append {clang < 900}
 
 test.run                yes
 test.cmd                tests/test-erlang && \

--- a/erlang/atomvm/Portfile
+++ b/erlang/atomvm/Portfile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               github 1.0
 PortGroup               cmake 1.1
 PortGroup               compiler_blacklist_versions 1.0
+PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 
 # clock_gettime


### PR DESCRIPTION
#### Description

Fix the build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
