### PR TITLE
argtable3: fix build with old gcc, enable tests

### DIFF
--- a/devel/argtable3/Portfile
+++ b/devel/argtable3/Portfile
@@ -19,5 +19,18 @@ checksums           sha256  f12badf34f6be07263af85955d1f4e4a6f9e0a6d7023ffaed2a2
                     rmd160  ff3752c38cef00094e654f7f5e451f7942ab2bc4 \
                     size    510475
 
+# https://github.com/argtable/argtable3/issues/88
+if {[string match *gcc-4.* ${configure.compiler}]} {
+    patchfiles-append \
+                    patch-gcc-4.diff
+}
+
 configure.args-append \
                     -DBUILD_SHARED_LIBS=ON
+
+# Needed to run tests:
+configure.pre_args-replace \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+
+test.run            yes

--- a/devel/argtable3/files/patch-gcc-4.diff
+++ b/devel/argtable3/files/patch-gcc-4.diff
@@ -1,0 +1,10 @@
+--- src/CMakeLists.txt	2022-10-23 10:20:16.000000000 +0800
++++ src/CMakeLists.txt	2024-01-05 21:22:45.000000000 +0800
+@@ -39,7 +39,6 @@
+ else(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c89")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion")
+-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpedantic")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra")
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+ endif()


### PR DESCRIPTION
#### Description

Simple fix for old gcc. Support testing.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
