### PR TITLE
CronniX: fix fetching, svn repo is no more, restrict supported platforms

### DIFF
--- a/aqua/CronniX/Portfile
+++ b/aqua/CronniX/Portfile
@@ -6,22 +6,28 @@ PortGroup               xcode 1.0
 name                    CronniX
 version                 3.0.2
 categories              aqua
+platforms               {darwin < 16}
 maintainers             ryandesign
 license                 GPL-3
 homepage                https://code.google.com/p/cronnix/
 xcode.target            ${name}
 
-fetch.type              svn
-svn.url                 http://cronnix.googlecode.com/svn/trunk
-svn.revision            83
-worksrcdir              trunk
+master_sites            https://storage.googleapis.com/google-code-archive-source/v2/code.google.com/cronnix/
+distname                source-archive
+use_zip                 yes
+
+checksums               rmd160  d958a5dc581a267a02dd126f736679e96ecf59f7 \
+                        sha256  65e62c65910e4e0d95d1aaffb159c1a6872664e4507543a5e9f30ca347b9760e \
+                        size    13555624
+
+worksrcdir              cronnix/trunk
 
 description \
     graphical frontend for scheduling cronjobs
 
 long_description \
-    ${name} is a Mac OS X frontend to the Unix scheduler cron. Cron is a \
-    system service that allows scheduled execution of scripts and programs.
+    ${name} is a Mac OS X frontend to the Unix scheduler cron. Cron is \
+    a system service that allows scheduled execution of scripts and programs.
 
 post-destroot {
     fs-traverse dir ${destroot} {
@@ -31,6 +37,4 @@ post-destroot {
     }
 }
 
-livecheck.type          regex
-livecheck.url           http://cronnix.googlecode.com/svn/tags
-livecheck.regex         release-(\[0-9.\]+)
+livecheck.type          none


### PR DESCRIPTION
#### Description

@ryandesign I know this is your port and not an openmaintainer one, but I hope this is okay, it is just a technical fix to enable building it after svn repo is gone, without any changes to the code itself.

The code is from 2008, and does not build on new macOS. I set restriction based on the history:
https://ports.macports.org/port/CronniX/details
https://ports.macports.org/port/CronniX/stats/?days=365&days_ago=0
Please let me know if that is wrong.

On 10.6 the port builds fine as-is, once downloading the source is fixed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
