### PR TITLE
hyfetch: Upgrade to Python 3.12

### DIFF
--- a/python/hyfetch/Portfile
+++ b/python/hyfetch/Portfile
@@ -6,7 +6,7 @@ PortGroup               python 1.0
 python.rootname         HyFetch
 name                    [string tolower ${python.rootname}]
 version                 1.4.11
-revision                1
+revision                2
 categories-append       sysutils
 platforms               {darwin any}
 supported_archs         noarch
@@ -23,7 +23,7 @@ checksums               rmd160  2239681635a7608f2f99d466247f852756d74607 \
                         size    278449
 
 # This should stay consistent with the python PG default
-python.default_version  311
+python.default_version  312
 
 depends_run-append      port:py${python.version}-setuptools \
                         port:py${python.version}-typing_extensions


### PR DESCRIPTION
#### Description

Given that the `python` PG has recently upgrade to 3.12, `hyfetch` should follow this default.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
