### PR TITLE
net/wireshark4: revbump to 4.2.1

### DIFF
--- a/net/wireshark4/Portfile
+++ b/net/wireshark4/Portfile
@@ -30,12 +30,12 @@ if { ${os.platform} eq "darwin" && ${os.major} < 16 } {
     }
 }
 
-version         4.2.0
+version         4.2.1
 revision        0
 
-checksums       sha256  0e428492f4c3625d61a7ccff008dc0e429d16ab8caccad4403157ea92b48a75b \
-                sha1    939871febe92cb2eea5527578d3cd815721b58bf \
-                size    44941948
+checksums       sha256  50669fb0894310b68372ec8ff6a353d4c23b692121c529b8806b2e332b7d8770 \
+                sha1    3fa6ddbac07fb64ed5e447086542cabb9e4cfee0 \
+                size    44942940
 
 livecheck.type  regex
 livecheck.url   ${homepage}download.html


### PR DESCRIPTION
#### Description

net/wireshark4: revbump to 4.2.1

###### Type(s)
Update

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
