### PR TITLE
py-pyobjc: offer fallback for 32-bit builds and < 10.9

### DIFF
--- a/python/py-pyobjc/Portfile
+++ b/python/py-pyobjc/Portfile
@@ -5,20 +5,17 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        ronaldoussoren pyobjc 10.1 v
-revision            0
-
-checksums           rmd160  4ed3e4de68817e52920dc72bc9d2a3e667c56b80 \
-                    sha256  079c59f41c75c36fbbbc9b72f49b6afdaeedbc503f6263c9c8d7542303d93c89 \
-                    size    25557538
-
 name                py-pyobjc
 categories-append   devel
 license             MIT
 maintainers         openmaintainer {danchr @danchr}
 
+# Current version is supported presently on macOS 10.9+.
+# Older systems, as well as all 32-bit builds are supported
+# via a fallback version. References:
 # https://pyobjc.readthedocs.io/en/latest/install.html
-platforms           {darwin >= 13}
+# https://github.com/ronaldoussoren/pyobjc/issues/587
+platforms           {darwin >= 9}
 
 description         bidirectional bridge between python and Objective C
 long_description    The PyObjC project aims to provide a bridge between \
@@ -30,87 +27,165 @@ long_description    The PyObjC project aims to provide a bridge between \
                     Python based functionality.
 homepage            https://pyobjc.readthedocs.io
 
-python.versions     38 39 310 311 312
+if {${os.platform} eq "darwin" && ${os.major} >= 13 \
+    && ${configure.build_arch} ni [list i386 ppc]} {
 
-if {${name} ne ${subport}} {
-    depends_lib-append \
+    github.setup    ronaldoussoren pyobjc 10.1 v
+    revision        0
+
+    checksums       rmd160  4ed3e4de68817e52920dc72bc9d2a3e667c56b80 \
+                    sha256  079c59f41c75c36fbbbc9b72f49b6afdaeedbc503f6263c9c8d7542303d93c89 \
+                    size    25557538
+
+    python.versions 38 39 310 311 312
+
+    if {${name} ne ${subport}} {
+        depends_lib-append \
                     port:py${python.version}-setuptools
-    depends_build-append \
+        depends_build-append \
                     port:py${python.version}-sphinx \
                     port:py${python.version}-sphinxcontrib-blockdiag
 
-    patchfiles-append \
+        patchfiles-append \
                     patch-docs-conf.py.diff \
                     patch-pyobjc-core-setup.py.diff \
                     patch-setup-no-werror.diff \
                     patch-development-support-_install_tool.py-no-setup.diff
 
-    # use system libffi on Catalina and Big Sur until upstream merges
-    # and releases Apple's changes
-    # https://trac.macports.org/ticket/62475
-    if {${os.major} < 19} {
-        depends_lib-append \
-                    port:libffi
-    }
-
-    use_xcode                  yes
-    compiler.blacklist-append  {clang < 900}
-
-    post-patch {
-        reinplace \
-            "s/sphinx-build /sphinx-build-${python.branch} /g" \
-            ${worksrcpath}/docs/Makefile
-
-        # see comment above
+        # use system libffi on Catalina and Big Sur until upstream merges
+        # and releases Apple's changes
+        # https://trac.macports.org/ticket/62475
         if {${os.major} < 19} {
-            # force using both our libffi _and_ its headers
-            reinplace \
-                "s,/usr/include/ffi,${prefix}/include,g" \
-                ${worksrcpath}/pyobjc-core/setup.py
-
-            reinplace \
-                "s,<ffi/ffi.h>,<ffi.h>,g" \
-                ${worksrcpath}/pyobjc-core/Modules/objc/libffi_support.h
-        } else {
-            # force linking against system libffi by path, so that we
-            # bypass CPython's dependency on it
-            reinplace \
-                "s,-lffi,${configure.sdkroot}/usr/lib/libffi.tbd,g" \
-                ${worksrcpath}/pyobjc-core/setup.py
+            depends_lib-append \
+                    port:libffi
         }
-    }
 
-    if {${configure.sdkroot} eq ""} {
-        if {${os.platform} eq "darwin" && ${os.major} == 13} {
-            # Fix for 10.9: use SIMD headers from 10.10 SDK
-            set sdkroot "${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk"
-        } else {
-            set sdkroot "/"
+        use_xcode                  yes
+        compiler.blacklist-append  {clang < 900}
+
+        post-patch {
+            reinplace \
+                "s/sphinx-build /sphinx-build-${python.branch} /g" \
+                ${worksrcpath}/docs/Makefile
+
+            # see comment above
+            if {${os.major} < 19} {
+                # force using both our libffi _and_ its headers
+                reinplace \
+                    "s,/usr/include/ffi,${prefix}/include,g" \
+                    ${worksrcpath}/pyobjc-core/setup.py
+
+                reinplace \
+                    "s,<ffi/ffi.h>,<ffi.h>,g" \
+                    ${worksrcpath}/pyobjc-core/Modules/objc/libffi_support.h
+            } else {
+                # force linking against system libffi by path, so that we
+                # bypass CPython's dependency on it
+                reinplace \
+                    "s,-lffi,${configure.sdkroot}/usr/lib/libffi.tbd,g" \
+                    ${worksrcpath}/pyobjc-core/setup.py
+            }
         }
-    } else {
-        set sdkroot ${configure.sdkroot}
-    }
 
-    build.env-append    SDKROOT=${sdkroot}
-    destroot.env-append SDKROOT=${sdkroot}
+        if {${configure.sdkroot} eq ""} {
+            if {${os.platform} eq "darwin" && ${os.major} == 13} {
+                # Fix for 10.9: use SIMD headers from 10.10 SDK
+                set sdkroot "${developer_dir}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk"
+            } else {
+                set sdkroot "/"
+            }
+        } else {
+            set sdkroot ${configure.sdkroot}
+        }
 
-    python.pep517       yes
+        build.env-append    SDKROOT=${sdkroot}
+        destroot.env-append SDKROOT=${sdkroot}
 
-    build.cmd-prepend   ${python.bin} ${filespath}/multibuild.py ${build.jobs}
-    destroot.cmd-prepend \
+        python.pep517       yes
+
+        build.cmd-prepend   ${python.bin} ${filespath}/multibuild.py ${build.jobs}
+        destroot.cmd-prepend \
                         ${python.bin} ${filespath}/multiinstall.py ${workpath}
-    destroot.target
+        destroot.target
 
-    # build the documentation
-    post-build {
-        system -W ${worksrcpath}/docs "make -j${build.jobs} html"
+        # build the documentation
+        post-build {
+            system -W ${worksrcpath}/docs "make -j${build.jobs} html"
+        }
+
+        post-destroot {
+            xinstall -m 644 -W ${worksrcpath}/pyobjc-core HISTORIC.txt Install.txt \
+                License.txt README.txt \
+                ${destroot}${prefix}/share/doc/${subport}
+            copy ${worksrcpath}/docs/_build/html ${destroot}${prefix}/share/doc/${subport}/html
+        }
     }
 
-    post-destroot {
-        xinstall -m 644 -W ${worksrcpath}/pyobjc-core HISTORIC.txt Install.txt \
-            License.txt README.txt \
-            ${destroot}${prefix}/share/doc/${subport}
-        copy ${worksrcpath}/docs/_build/html ${destroot}${prefix}/share/doc/${subport}/html
+} else {
+    # Fallback version for old systems, advised by upstream. Please keep pegged.
+    github.setup    ronaldoussoren pyobjc 6.2.2 v
+    revision        0
+
+    checksums       rmd160  7387bc8c6ec744ca2cf6328036dde9826bcb2763 \
+                    sha256  0730edcdc5ca0bbc1e10983d3a7ef143ea80dfec9db8b02eb81d64e4fc18635f \
+                    size    13008288
+    github.tarball_from archive
+
+    python.versions 38 39 310
+
+    if {${name} ne ${subport}} {
+        depends_lib-append \
+                    port:libffi \
+                    port:py${python.version}-setuptools
+        depends_build \
+                    port:py${python.version}-sphinx
+
+        # The patches below suppresses cleaning on incremental builds,
+        # as MacPorts handles that itself, and disables a sphinx extension
+        # not in MacPorts.
+        patchfiles-append \
+                    patch-docs-conf.py-6.2.2.diff \
+                    patch-install.py-6.2.2.diff
+
+        post-patch {
+            reinplace "s|use-system-libffi = 0|\\
+                use-system-libffi = 1\\
+                deployment-target = ${macosx_deployment_target}\\
+                |" ${worksrcpath}/pyobjc-core/setup.cfg
+
+            reinplace \
+                "s/sphinx-build /sphinx-build-${python.branch} /g" \
+                ${worksrcpath}/docs/Makefile
+        }
+
+        if {${configure.sdkroot} eq ""} {
+            set sdkroot "/"
+        } else {
+            set sdkroot ${configure.sdkroot}
+        }
+
+        build.env-append    SDKROOT=${sdkroot}
+        destroot.env-append SDKROOT=${sdkroot}
+
+        # The pyobjc build system is vaguely horrible, so do everything
+        # in the destroot target.
+        build {
+            system -W ${worksrcpath}/docs "make html"
+        }
+
+        # Don't pass --no-user-cfg, as the build system subclasses
+        # the install command from distutils, not setuptools – in fact,
+        # doing so breaks the build...
+        destroot.cmd "${python.bin} install.py"
+
+        post-destroot {
+            xinstall -m 644 -W ${worksrcpath}/pyobjc-core HISTORIC.txt Install.txt \
+               License.txt README.txt \
+               ${destroot}${prefix}/share/doc/${subport}
+            copy ${worksrcpath}/docs/_build/html ${destroot}${prefix}/share/doc/${subport}/html
+        }
+
+        livecheck.type  none
     }
 }
 

--- a/python/py-pyobjc/files/patch-docs-conf.py-6.2.2.diff
+++ b/python/py-pyobjc/files/patch-docs-conf.py-6.2.2.diff
@@ -1,0 +1,10 @@
+--- docs/conf.py.orig	2020-04-01 07:47:09.000000000 -0400
++++ docs/conf.py	2020-04-01 07:47:25.000000000 -0400
+@@ -34,7 +34,6 @@
+     "sphinx.ext.ifconfig",
+     "sphinx.ext.extlinks",
+     "examples",
+-    "sphinx_sitemap",
+ ]
+ 
+ extlinks = {"issue": ("https://github.com/ronaldoussoren/pyobjc/issues/%s", "issue ")}

--- a/python/py-pyobjc/files/patch-install.py-6.2.2.diff
+++ b/python/py-pyobjc/files/patch-install.py-6.2.2.diff
@@ -1,0 +1,20 @@
+--- install.py.orig	2020-03-25 12:26:08.000000000 -0400
++++ install.py	2020-04-01 07:49:00.000000000 -0400
+@@ -187,17 +187,6 @@
+ def build_project(project, extra_args):
+     proj_dir = os.path.join(TOPDIR, project)
+ 
+-    # First ask distutils to clean up
+-    print("Cleaning {!r} using {!r}".format(project, sys.executable))
+-    status = subprocess.call([sys.executable, "setup.py", "clean"], cwd=proj_dir)
+-    if status != 0:
+-        print("Cleaning of {!r} failed, status {}".format(project, status))
+-        return False
+-
+-    # Explicitly remove the 'build' directory, just in case...
+-    if os.path.exists(os.path.join(proj_dir, "build")):
+-        shutil.rmtree(os.path.join(proj_dir, "build"))
+-
+     print("Installing {!r} using {!r}".format(project, sys.executable))
+     status = subprocess.call(
+         [sys.executable, "setup.py", "install"] + extra_args, cwd=proj_dir


### PR DESCRIPTION
#### Description

@reneeotten Could you please review this?

I used the version recommended by the developer here: https://github.com/ronaldoussoren/pyobjc/issues/587#issuecomment-1876703680
The port is what Macports had earlier, I only dropped old Pythons to match the current version, and did not include 311/312, since they seem not to build, and upstream warned that it may be the case.

P. S. I think for the ease of maintenance it is better to keep the code in two distinct chunks (current and fallback) rather than sorting out common arguments vs unique. This way anyone updating the port later need not bother about what is there for old systems, and nothing will be accidentally broken, hopefully.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
