### PR TITLE
toxic: update to 0.13.1

### DIFF
--- a/net/toxcore/Portfile
+++ b/net/toxcore/Portfile
@@ -5,6 +5,8 @@ PortGroup               cmake 1.1
 PortGroup               github 1.0
 
 # Released version is too outdated, we need a newer one: https://github.com/JFreegman/toxic/issues/644
+# At the same time, the latest may not work either: https://github.com/JFreegman/toxic/issues/656
+# Prior to updating please make sure toxic builds against a new version.
 github.setup            TokTok c-toxcore 6c35cef63f8243fd1831a269ba34add90df7b3fc
 name                    toxcore
 version                 2023.11.18

--- a/net/toxic/Portfile
+++ b/net/toxic/Portfile
@@ -8,17 +8,18 @@ PortGroup               makefile 1.0
 # clock_gettime in game_base
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup            JFreegman toxic 0.12.0 v
-revision                1
+github.setup            JFreegman toxic 0.13.1 v
+revision                0
 categories              net security
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
 license                 GPL-3
 description             An ncurses-based Tox client
 long_description        Toxic is a Tox-based instant messaging and video chat client.
 homepage                https://toktok.ltd
-checksums               rmd160  57b846ed357e34994eaf171d01ae6c8c99e4fc51 \
-                        sha256  d6ba0a68b1d44a144483dafb14403df10a6701af96ea9cbc5e1f17e78cb1f975 \
-                        size    1218711
+checksums               rmd160  c44e017ba9065450211f8422143e3b12f5e3bb60 \
+                        sha256  f178fd29b071df6a7ad7567147dd143a2d7812a8d4c83dc96bb4cb34b01fffe8 \
+                        size    1226663
+github.tarball_from     archive
 
 depends_build-append    port:pkgconfig
 depends_lib-append      path:lib/pkgconfig/glib-2.0.pc:glib2 \


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
