### PR TITLE
net/wireshark4:  revbump to 4.2.2

### DIFF
--- a/net/wireshark4/Portfile
+++ b/net/wireshark4/Portfile
@@ -30,12 +30,12 @@ if { ${os.platform} eq "darwin" && ${os.major} < 16 } {
     }
 }
 
-version         4.2.1
+version         4.2.2
 revision        0
 
-checksums       sha256  50669fb0894310b68372ec8ff6a353d4c23b692121c529b8806b2e332b7d8770 \
-                sha1    3fa6ddbac07fb64ed5e447086542cabb9e4cfee0 \
-                size    44942940
+checksums       sha256  9e3672be8c6caf9279a5a13582d6711ab699ae2a79323e92a99409c1ead98521 \
+                sha1    b14f94019c0a0d01409d57736dd458c23fceba78 \
+                size    44918888
 
 livecheck.type  regex
 livecheck.url   ${homepage}download.html


### PR DESCRIPTION
#### Description

revbump  to 4.2.2
###### Type(s)
update
###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
