### PR TITLE
ripgrep: update to 14.1.0

### DIFF
--- a/textproc/ripgrep/Portfile
+++ b/textproc/ripgrep/Portfile
@@ -4,14 +4,15 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo 1.0
 
-github.setup        BurntSushi ripgrep 13.0.0
+github.setup        BurntSushi ripgrep 14.1.0
 github.tarball_from archive
-revision            1
+revision            0
 categories          textproc
-platforms           darwin
-maintainers         {raimue @raimue} \
-                    openmaintainer
+installs_libs       no
 license             MIT
+maintainers         {raimue @raimue} \
+                    {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
 
 description         fast command line search tool
 long_description    ripgrep is a command line search tool that combines the \
@@ -19,87 +20,100 @@ long_description    ripgrep is a command line search tool that combines the \
                     raw speed of GNU grep.
 
 cargo.crates \
-    aho-corasick                    0.7.18  1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f \
-    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
-    base64                          0.13.0  904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd \
-    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
-    bstr                            0.2.16  90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279 \
-    bytecount                        0.6.2  72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e \
-    cc                              1.0.68  4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787 \
-    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    aho-corasick                     1.1.2  b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0 \
+    anyhow                          1.0.79  080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    bstr                             1.9.0  c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc \
+    cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    clap                            2.33.3  37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002 \
-    crossbeam-channel                0.5.1  06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4 \
-    crossbeam-utils                  0.8.5  d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db \
-    encoding_rs                     0.8.28  80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065 \
+    crossbeam-channel               0.5.10  82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2 \
+    crossbeam-deque                  0.8.4  fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751 \
+    crossbeam-epoch                 0.9.17  0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d \
+    crossbeam-utils                 0.8.18  c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c \
+    encoding_rs                     0.8.33  7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1 \
     encoding_rs_io                   0.1.7  1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83 \
-    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    fs_extra                         1.2.0  2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394 \
-    glob                             0.3.0  9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574 \
-    hermit-abi                      0.1.18  322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c \
-    itoa                             0.4.7  dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736 \
-    jemalloc-sys                     0.3.2  0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45 \
-    jemallocator                     0.3.2  43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69 \
-    jobserver                       0.1.22  972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd \
-    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                            0.2.97  12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6 \
-    libm                             0.1.4  7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a \
-    log                             0.4.14  51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710 \
-    memchr                           2.4.0  b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc \
-    memmap2                          0.3.0  20ff203f7bdc401350b1dbaa0355135777d25f41c0bbc601851bbd6cf61e8ff5 \
-    num_cpus                        1.13.0  05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3 \
-    once_cell                        1.7.2  af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3 \
-    packed_simd_2                    0.3.5  0e64858a2d3733fdd61adfdd6da89aa202f7ff0e741d2fc7ed1e452ba9dc99d7 \
-    pcre2                            0.2.3  85b30f2f69903b439dd9dc9e824119b82a55bf113b29af8d70948a03c1b11ab1 \
-    pcre2-sys                        0.2.5  dec30e5e9ec37eb8fbf1dea5989bc957fd3df56fbee5061aa7b7a99dbb37b722 \
-    pkg-config                      0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
-    proc-macro2                     1.0.27  f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038 \
-    quote                            1.0.9  c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7 \
-    regex                            1.5.4  d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461 \
-    regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
-    regex-syntax                    0.6.25  f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b \
-    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
+    itoa                            1.0.10  b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c \
+    jemalloc-sys       0.5.4+5.3.0-patched  ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2 \
+    jemallocator                     0.5.4  a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc \
+    jobserver                       0.1.27  8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d \
+    lexopt                           0.3.0  baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401 \
+    libc                           0.2.151  302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4 \
+    libm                             0.2.8  4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058 \
+    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    memchr                           2.7.1  523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149 \
+    memmap2                          0.9.3  45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92 \
+    num-traits                      0.2.17  39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c \
+    packed_simd                      0.3.9  1f9f08af0c877571712e2e3e686ad79efad9657dbf0f7c3c8ba943ff6c38932d \
+    pcre2                            0.2.6  4c9d53a8ea5fc3d3568d3de4bebc12606fd0eb8234c602576f1f1ee4880488a7 \
+    pcre2-sys                        0.2.8  25b8a7b5253a4465b873a21ee7e8d6ec561a57eed5d319621bec36bea35c86ae \
+    pkg-config                      0.3.28  69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a \
+    proc-macro2                     1.0.76  95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c \
+    quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
+    regex                           1.10.2  380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343 \
+    regex-automata                   0.4.3  5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f \
+    regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+    ryu                             1.0.16  f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
-    serde                          1.0.126  ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03 \
-    serde_derive                   1.0.126  963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43 \
-    serde_json                      1.0.64  799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79 \
-    strsim                           0.8.0  8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a \
-    syn                             1.0.73  f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7 \
-    termcolor                        1.1.2  2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4 \
-    textwrap                        0.11.0  d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060 \
-    thread_local                     1.1.3  8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd \
-    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
-    unicode-xid                      0.2.2  8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3 \
-    walkdir                          2.3.2  808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56 \
+    serde                          1.0.195  63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02 \
+    serde_derive                   1.0.195  46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c \
+    serde_json                     1.0.111  176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4 \
+    syn                             2.0.48  0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f \
+    termcolor                        1.4.0  ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449 \
+    textwrap                        0.16.0  222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d \
+    unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
+    walkdir                          2.4.0  d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-util                      0.1.6  f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160  841ccf8bc96143260e6c750d147ff78d8784903e \
-                    sha256  0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2 \
-                    size    505536
+                    rmd160  95d6e7d76694dd681573a66e86cd529b591cb51e \
+                    sha256  33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6 \
+                    size    584473
 
 depends_build-append \
                     port:asciidoc \
                     port:docbook-xsl-nons
 
-destroot {
-    xinstall -m 755 ${worksrcpath}/target/[cargo.rust_platform]/release/rg ${destroot}${prefix}/bin/
-    ln -s rg ${destroot}${prefix}/bin/ripgrep
+set ripgrep_bin     ${worksrcpath}/target/[cargo.rust_platform]/release/rg
 
-    set outpath [glob ${worksrcpath}/target/[cargo.rust_platform]/release/build/ripgrep-*]/out/
-    xinstall -m 644 ${outpath}/rg.1 ${destroot}${prefix}/share/man/man1/
-    xinstall -d -m 755 ${destroot}${prefix}/share/bash-completion/completions
-    xinstall -m 644 ${outpath}/rg.bash ${destroot}${prefix}/share/bash-completion/completions/rg
-    xinstall -d -m 755 ${destroot}${prefix}/share/fish/vendor_completions.d
-    xinstall -m 644 ${outpath}/rg.fish ${destroot}${prefix}/share/fish/vendor_completions.d/
-    xinstall -d -m 755 ${destroot}${prefix}/share/zsh/site-functions
-    xinstall -m 644 ${worksrcpath}/complete/_rg ${destroot}${prefix}/share/zsh/site-functions/
+post-build {
+
+    # Generate shell completions
+    foreach _shell {bash fish zsh} {
+        system -W ${worksrcpath} \
+            "${ripgrep_bin} --generate complete-${_shell} > rg.${_shell}"
+    }
+
+    # Generate man page
+    system -W ${worksrcpath} "${ripgrep_bin} --generate man > rg.1"
 }
 
-variant pcre {
+destroot {
+    # Install ripgrep
+    xinstall -m 0755 ${ripgrep_bin} ${destroot}${prefix}/bin/
+    ln -s rg ${destroot}${prefix}/bin/ripgrep
+
+    # Install shell completions
+    xinstall -d -m 0755 ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0644 ${worksrcpath}/rg.bash \
+        ${destroot}${prefix}/share/bash-completion/completions/rg
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 0644 ${worksrcpath}/rg.fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d/
+
+    xinstall -d -m 0755 ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0644 ${worksrcpath}/rg.zsh \
+        ${destroot}${prefix}/share/zsh/site-functions/_rg
+
+    # Install man page
+    xinstall -m 0644 ${worksrcpath}/rg.1 ${destroot}${prefix}/share/man/man1/
+}
+
+variant pcre description {Build with pcre2} {
     build.args-append       --features 'pcre2'
     depends_lib-append      port:pcre2
 }

--- a/textproc/ripgrep/Portfile
+++ b/textproc/ripgrep/Portfile
@@ -80,7 +80,6 @@ depends_build-append \
 set ripgrep_bin     ${worksrcpath}/target/[cargo.rust_platform]/release/rg
 
 post-build {
-
     # Generate shell completions
     foreach _shell {bash fish zsh} {
         system -W ${worksrcpath} \


### PR DESCRIPTION
~~This probably won't build until https://github.com/macports/macports-ports/pull/21985 gets merged.~~

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
