### PR TITLE
ldid-procursus: fix for < 10.14

### DIFF
--- a/devel/ldid-procursus/Portfile
+++ b/devel/ldid-procursus/Portfile
@@ -1,16 +1,20 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
-PortGroup           openssl 1.0
+PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
+PortGroup           openssl 1.0
+
+# https://trac.macports.org/ticket/69047
+legacysupport.use_mp_libcxx yes
 
 name                ldid-procursus
 version             2.1.5-procursus7
 revision            1
 categories          devel
 license             AGPL-3
-platforms           {darwin >= 18}
 conflicts           ldid
 maintainers         {@therealketo procurs.us:team} openmaintainer
 description         Put real or fake signatures in a Mach-O.
@@ -28,7 +32,8 @@ universal_variant   no
 
 compiler.cxx_standard \
                     2011
-
+compiler.blacklist-append \
+                    {clang < 1100}
 post-destroot {
     set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
     xinstall -d ${zsh_comp_path}


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/69047

#### Description

PR https://github.com/macports/macports-ports/pull/20729 restricted `ldid-procursus` to Darwin 18+. It is not necessary, it builds fine even on 10.6.
What it needs is to use a newer C++ runtime than those systems have. GCC already provides it; Clangs need Macports one.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5
Xcode 5.1.1

macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
