### PR TITLE
kafkacat: rename to kcat and update to 1.7.1

### DIFF
--- a/net/kafkacat/Portfile
+++ b/net/kafkacat/Portfile
@@ -1,22 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           obsolete 1.0
 
-github.setup        edenhill kafkacat 1.5.0
+name                kafkacat
+version             1.5.0
 categories          net
 platforms           darwin
 license             BSD
 maintainers         {@alexeyt820 gmail.com:alexey.trenikhin+macports} openmaintainer
-description         Generic command line non-JVM Apache Kafka producer and consumer
-long_description    Generic non-JVM producer and consumer for Apache Kafka >=0.8, think of it as a netcat for Kafka.
 
-checksums           sha256 bbbb60e5f591f896c44246e8fb4dd13f7974f1032a3404e8e9fdc77865293bfb \
-                    rmd160 dba7019d9da4e74dd722fcef3aa1e54eb8174a0f \
-                    size 124695 
+replaced_by         kcat
+revision            1
+livecheck.type      none
 
-configure.args      --enable-json
-
-depends_lib         port:yajl \
-                    port:librdkafka
-
+# remove after 2025-01-31

--- a/net/kcat/Portfile
+++ b/net/kcat/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        edenhill kcat 1.7.1
+categories          net
+platforms           darwin
+license             BSD
+maintainers         {gmail.com:alexey.trenikhin+macports @alexeyt820} \
+                    openmaintainer
+description         Generic command line non-JVM Apache Kafka producer and consumer
+long_description    Generic non-JVM producer and consumer for Apache Kafka >=0.8, think of it as a netcat for Kafka.
+
+checksums           sha256 3a7943b028d94884ba95890fadd50f1e09326f66473ce9c99289fabf40385255 \
+                    rmd160 9a964e418c945c03215ebee1f891aabf135e1808 \
+                    size 142743
+
+configure.args      --enable-json
+
+depends_lib         port:yajl \
+                    port:librdkafka


### PR DESCRIPTION
#### Description

kafkacat has been renamed to kcat to adhere to the Apache Software Foundation's (ASF) trademark policies.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
