### PR TITLE
py-netcdf4: Add py312 subport

### DIFF
--- a/python/py-netcdf4/Portfile
+++ b/python/py-netcdf4/Portfile
@@ -34,7 +34,7 @@ mpi.setup
 build.env-append    USE_NCCONFIG=1
 destroot.env-append USE_NCCONFIG=1
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 
 # Fixes "Missing dependencies: oldest-supported-numpy"
 # See https://trac.macports.org/ticket/67136
@@ -60,6 +60,9 @@ if {${name} ne ${subport}} {
                     port:hdf5 \
                     port:py${python.version}-numpy \
                     port:py${python.version}-setuptools
+
+    depends_test-append \
+                    port:py${python.version}-certifi
 
     pre-configure {
         # py-netcdf4's setup.py uses nc-config for flags and libs but not compiler


### PR DESCRIPTION
#### Description

Add py312 subport to `py-netcdf4`, as it's the default version of the `python` PG, and fix running tests.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
