### PR TITLE
py-llfuse: update to 1.5.0

### DIFF
--- a/python/py-llfuse/Portfile
+++ b/python/py-llfuse/Portfile
@@ -6,7 +6,7 @@ PortGroup           fuse 1.0
 
 name                py-llfuse
 version             1.5.0
-revision            1
+revision            0
 checksums           rmd160  81cd43b01454815baaf97ddc920099c8315a20c9 \
                     sha256  d094448bb4eb20099537be53dc2b5b2c0369d36bde09207a9bb228cc3cd58ee1 \
                     size    869259

--- a/python/py-llfuse/Portfile
+++ b/python/py-llfuse/Portfile
@@ -5,11 +5,11 @@ PortGroup           python 1.0
 PortGroup           fuse 1.0
 
 name                py-llfuse
-version             1.3.8
+version             1.5.0
 revision            1
-checksums           rmd160  8d36d4c44959e6c51a89b60bbb44ddb39c836920 \
-                    sha256  b9b573108a840fbaa5c8f037160cc541f21b8cbdc15c5c8a39d5ac8c1b6c4cbc \
-                    size    481447
+checksums           rmd160  81cd43b01454815baaf97ddc920099c8315a20c9 \
+                    sha256  d094448bb4eb20099537be53dc2b5b2c0369d36bde09207a9bb228cc3cd58ee1 \
+                    size    869259
 
 categories-append   devel fuse
 license             LGPL-2+
@@ -21,7 +21,7 @@ long_description    Python-LLFUSE is a set of Python bindings for the low \
 
 homepage            https://github.com/python-llfuse/python-llfuse/
 
-python.versions     37 38 39 310
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append    port:pkgconfig \


### PR DESCRIPTION
Also adds a python312 version which fixes the borgbackup +fuse variant which broke when that was updated to use python312: de2b363

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 arm64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
