### PR TITLE
py-mako: add py312 support

### DIFF
--- a/python/py-mako/Portfile
+++ b/python/py-mako/Portfile
@@ -12,7 +12,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     27 37 38 39 310 311
+python.versions     27 37 38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer


### PR DESCRIPTION
#### Description

Simply add support for Python 3.12 to the py-mako package.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
