### PR TITLE
gmt6: update to 6.5.0

### DIFF
--- a/science/gmt5/Portfile
+++ b/science/gmt5/Portfile
@@ -10,13 +10,13 @@ github.tarball_from releases
 distname            ${github.project}-${github.version}-src
 revision            17
 subport gmt6 {
-    github.setup    GenericMappingTools gmt 6.4.0
-    revision        4
+    github.setup    GenericMappingTools gmt 6.5.0
+    revision        0
     epoch           1
 }
 categories          science
 platforms           darwin
-maintainers         {gmail.com:seisman.info @seisman} openmaintainer
+maintainers         {me.com:remko.scharroo @remkos} openmaintainer
 license             GPL-3
 description         The Generic Mapping Tools
 long_description GMT is an open source collection of ~120 tools \
@@ -43,9 +43,9 @@ if {${subport} eq "gmt5"} {
                         sha256  078d4997507cb15344c74a874568985e45bdbd6d3a72d330c74c47f4c0359bb1 \
                         size    59175704
 } else {
-    checksums           rmd160  528bb99f70e9bc9281c7565fb7bbd8da3016a7be \
-                        sha256  b46effe59cf96f50c6ef6b031863310d819e63b2ed1aa873f94d70c619490672 \
-                        size    55875004
+    checksums           rmd160  3e47113d134bde756b98906a4704b3151902c4d1 \
+                        sha256  4022adb44033f9c1d5a4d275b69506449e4d486efe2218313f3ff7a6c6c3141e \
+                        size    58696516
 }
 
 depends_lib         port:curl \


### PR DESCRIPTION
#### Description

Simple upgrade to upstream version 6.5.0.
Also changed maintainer from @seisman to @remkos 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 x86_64
Command Line Tools 15.1.0.0.1.1700200546


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
