### PR TITLE
ninja: bump Python from 3.11 to 3.12

### DIFF
--- a/devel/ninja/Portfile
+++ b/devel/ninja/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 
 epoch               1
 github.setup        ninja-build ninja 1.11.1 v
-revision            1
+revision            2
 
 checksums           rmd160  f4df91397c25c64f5ab31df5e2390c54ced99ae2 \
                     sha256  31747ae633213f1eda3842686f83c2aa1412e0f5691d1c14dbbcc67fe7400cea \
@@ -43,7 +43,7 @@ patchfiles          patch-configure.py-bootstrap-only.diff \
 depends_build-append \
                     port:re2c
 
-set py_ver          3.11
+set py_ver          3.12
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_lib-append  port:python${py_ver_nodot}


### PR DESCRIPTION
#### Description

Change the version of Python underlying ninja from 3.11 to 3.12, as for now most all python package in macports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
