### PR TITLE
boost176: add py312 support

### DIFF
--- a/devel/boost176/Portfile
+++ b/devel/boost176/Portfile
@@ -255,7 +255,7 @@ post-destroot {
     }
 }
 
-set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11}
+set pythons_versions {2.7 3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12}
 
 set pythons_ports {}
 foreach v ${pythons_versions} {
@@ -301,7 +301,7 @@ foreach v ${pythons_versions} {
 }
 
 if {![variant_isset debug]} {
-    set selected_python python311
+    set selected_python python312
     foreach v ${pythons_versions} {
         set s [string map {. {}} ${v}]
         if {[variant_isset python${s}]} {


### PR DESCRIPTION
#### Description

Add support for Python version 3.12 to boost176

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
