### PR TITLE
gallery-dl: update to 1.26.6

### DIFF
--- a/net/gallery-dl/Portfile
+++ b/net/gallery-dl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        mikf gallery-dl 1.26.4 v
+github.setup        mikf gallery-dl 1.26.6 v
 github.tarball_from releases
 distname            gallery_dl-${github.version}
 
@@ -12,9 +12,9 @@ categories          net
 maintainers         {@akierig fastmail.de:akierig} openmaintainer
 revision            0
 
-checksums           rmd160  3da42410d3f8cc158db4282fa49e0a9ce42de059 \
-                    sha256  aa83561fb7e898e40474ecf4fac117b5f85722d3e87d231b0ef40298770e3d7a \
-                    size    481951
+checksums           rmd160  87f932ddc0a3f389d1afc02508091c02c6acb5b0 \
+                    sha256  420bf0c47f306f0c5f8d969e6bcf6c20db476d25f222ae571a95948baace5fe9 \
+                    size    487990
 
 description         command-line program to download image galleries and \
                     collections from several image hosting sites
@@ -24,10 +24,9 @@ long_description    ${name} is a {*}${description}. It is a cross-platform tool 
 
 supported_archs     noarch
 license             GPL-2
-python.default_version 311
+python.default_version 312
 
-depends_build-append \
-                    port:py${python.version}-setuptools
+depends_build-append port:py${python.version}-setuptools
 
 depends_lib-append  port:py${python.version}-brotli \
                     port:py${python.version}-requests \


### PR DESCRIPTION
#### Description

* update to 1.26.6
* changed default python to v3.12
* depends on #22089 for python 3.12 support

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
