### PR TITLE
alacritty: update to 0.13.1

### DIFF
--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        alacritty alacritty 0.13.0 v
+github.setup        alacritty alacritty 0.13.1 v
 github.tarball_from archive
 revision            0
 
@@ -19,12 +19,13 @@ categories          aqua shells
 installs_libs       no
 license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    {@akierig fastmail.de:akierig} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  8cc78d8ae70b3ad7f26a55d0148aac41c5491d9e \
-                    sha256  1c1cebf20e10bb26dc8bc735bb2d02eb88df89180d6c59f5d946a0a1d3d585b2 \
-                    size    1628187
+                    rmd160  16d9a2355caa05b94ab81aaf9286af6e2ab9d4bf \
+                    sha256  38a42e23e1e6faaa9e300347df3f7b58b6182908a701517aac6e296fbdf37451 \
+                    size    1629538
 
 depends_build-append \
                     port:scdoc
@@ -335,7 +336,7 @@ cargo.crates \
     windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
     windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
-    winit                           0.29.7  7fd430cd4560ee9c48885a4ef473b609a56796e37b1e18222abee146143f7457 \
+    winit                           0.29.9  c2376dab13e09c01ad8b679f0dbc7038af4ec43d9a91344338e37bd686481550 \
     winnow                          0.5.30  9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5 \
     winreg                          0.51.0  937f3df7948156640f46aacef17a70db0de5917bda9c92b0f751f3a955b588fc \
     wio                              0.2.2  5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5 \


### PR DESCRIPTION
#### Description

alacritty: update to 0.13.1

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
