### PR TITLE
symfony-cli: update to 5.8.0

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.7.8
+version             5.8.0
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  5e1d1d4a4216107b9210f09d28cb494ba4053cb8 \
-                        sha256  ad9c524a1d28964b7ba0510fa1008e5489d1037ae3c768bc02ca8ee3b99d172e \
-                        size    259332
+    checksums           rmd160  53d25d5b6792d3bb091885fb7c00477ff5f9e098 \
+                        sha256  73c1cdd95b52329c81cf35570216c5e06ffdac939b1bf4db4dd61207a67caef8 \
+                        size    262230
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  041dc38cb57ac58825aa814fe5a501eebc20cdb9 \
-                        sha256  4394464a0b4b071ec7aabb358c01f772bc5ae00f74e907864bfc3420e115ae2f \
-                        size    11143468
+    checksums           rmd160  70d6d309712d83bb895ce380359f6ed32460cbd4 \
+                        sha256  05f06d60ba7674b82cb9fc54ca2f7bb73eeec43c44c92a518db0e0eb2e6fb5e5 \
+                        size    11147752
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.0

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
