### PR TITLE
google-cloud-sdk: update to 459.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             458.0.1
+version             459.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  7fb40c2e82157af6be7a9fb5805b7d8fae332606 \
-                    sha256  fa1919776b16bb694a40e8e807d1c3d9589918d4ccffa2bff3f95fed4abf51fa \
-                    size    122371622
+    checksums       rmd160  102729e728f43a242c3672cb8cef5020c77dc873 \
+                    sha256  93ad798c964841c7089278f97a2956a339416fe3b21a046672d23a06965e24fe \
+                    size    122477949
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  ca4f0d31772c8cee1490da8da60d381aea7b24ce \
-                    sha256  a8027789a9b52f43718c269914a57670e60b6e05550d5dc01770823d4eace19c \
-                    size    123657786
+    checksums       rmd160  eaa69d4e524895916dd234eee84aeba7b208bffb \
+                    sha256  62bb34962e70e0002cd97221ec642c0f63bbfe3d18466e41b39b4e3401504073 \
+                    size    123762074
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  788d3c053781743a4ce3846921692e2654c9d80f \
-                    sha256  c88a5edad240ee4eb1708f6bdaaffce77a9ff94166944c61f92023ef2a896f64 \
-                    size    120725443
+    checksums       rmd160  271bb992d74690c427b50e86f390e6f03c376c53 \
+                    sha256  6db5fbcd67fa4eef7a24219d7fba5c9b39d4e19a25f0e1a5824105f69c0cf0a4 \
+                    size    120830031
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -42,7 +42,7 @@ master_sites        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/
 worksrcdir          ${name}
 
 # Most recent supported Python version according to https://cloud.google.com/sdk/docs/install#mac
-python.default_version 311
+python.default_version 312
 
 post-patch {
     # Default to the MacPorts Python binary


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 459.0.0.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?