### PR TITLE
emacs{,-app}-devel: update tree-sitter dependencies

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -118,7 +118,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     github.setup    emacs-mirror emacs d9462e24a967e32d550ee886b5150f0cc78358f6
     epoch           5
     version         20240108
-    revision        0
+    revision        1
 
     master_sites    ${github.master_sites}
 
@@ -313,7 +313,8 @@ variant treesitter description {Builds emacs with tree-sitter support} {
         depends_run-append \
             port:tree-sitter-html \
             port:tree-sitter-heex \
-            port:tree-sitter-elixir
+            port:tree-sitter-elixir \
+            port:tree-sitter-lua
     }
 }
 


### PR DESCRIPTION
#### Description

lua-ts-mode was added at some point, so add dependency on tree-sitter-lua

Also the x86_64 Sonoma build had a spurious failure. This PR doesn't address that, but it will effectively retry the build.
https://build.macports.org/builders/ports-14_x86_64-builder/builds/25035

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
