### PR TITLE
maven3: mark platforms as "any"

### DIFF
--- a/java/maven3/Portfile
+++ b/java/maven3/Portfile
@@ -11,7 +11,7 @@ revision        0
 categories      java devel
 license         Apache-2
 maintainers     {breun.nl:nils @breun} openmaintainer
-platforms       darwin
+platforms       any
 supported_archs noarch
 
 description     A Java-based build and project management environment.


### PR DESCRIPTION
#### Description

The contents of the maven3 port are the same on all platforms and OS versions so it should be `platforms any` (all other maven* ports are already).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
