### PR TITLE
gpac: fix build on sonoma

### DIFF
--- a/multimedia/gpac/Portfile
+++ b/multimedia/gpac/Portfile
@@ -6,7 +6,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        gpac gpac 2.2.1 v
-revision            1
+revision            2
 categories          multimedia
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
 license             LGPL-2.1+
@@ -75,10 +75,10 @@ compiler.blacklist-append {clang < 700}
 compiler.c_standard   2011
 
 # pulseaudio is recognized if installed but build fails
-
+# -fno-builtin-strrchr to fix https://trac.macports.org/ticket/68589
 configure.args      --cc="${configure.cc}" \
                     --cxx="${configure.cxx}" \
-                    --extra-cflags="${configure.cc_archflags}" \
+                    --extra-cflags="${configure.cc_archflags} -fno-builtin-strrchr" \
                     --extra-ldflags="${configure.ld_archflags}" \
                     --mandir=${prefix}/share/man \
                     --disable-pulseaudio \


### PR DESCRIPTION
#### Description

Fixes: https://trac.macports.org/ticket/68589

###### Type(s)

- [x] bugfix

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?