### PR TITLE
crystal: update to 1.11.0

### DIFF
--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        crystal-lang crystal 1.9.2
+github.setup        crystal-lang crystal 1.11.0
 github.tarball_from archive
 revision            0
 categories          lang
@@ -18,7 +18,7 @@ long_description    Crystal is a fast, compiled programming language with a \
 
 homepage            https://crystal-lang.org
 
-set llvm_version    16
+set llvm_version    17
 
 # pkg-config is used when compiling user programs
 depends_lib         port:boehmgc \
@@ -41,13 +41,13 @@ master_sites-append https://github.com/crystal-lang/${name}/releases/download/${
 distfiles-append    ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix}:bootstrap
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  aa8a326f49a9571d9a9479bb9a9192b79583d334 \
-                    sha256  1e2e6974b0e2e152e5fae5388415ddb7e192378c8ac215c6f386fdaf9018e54f \
-                    size    3245770 \
+                    rmd160  4946400941a24d3307c5d4847599611acdc914f7 \
+                    sha256  3c4eeb1191478770172a6fa7c4afb074526db9ecf0a80d434d1f4a6441414ae6 \
+                    size    3619256 \
                     ${name}-${cr_full_ver}-${os.platform}-universal${extract.suffix} \
-                    rmd160  ff0d4e591fd77d6954e3f88bad89192ec545a191 \
-                    sha256  acb602799bac700f1f9e9c3cddd1ba62e5ab1ae520e47d7339e4b255d51c4d89 \
-                    size    57025349
+                    rmd160  86d329bbb6e20a1e7482d091a86ce60d3e955389 \
+                    sha256  c3aed8624c76047c03b607754781d2e8380b7005dc8a0d926cc044f893368fba \
+                    size    57811159
 
 patchfiles          patch-static.diff
 


### PR DESCRIPTION
###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?