### PR TITLE
saga: update to 9.3.0 and new py*-pysaga subports

### DIFF
--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -23,7 +23,8 @@ long_description    SAGA - System for Automated Geoscientific Analyses - is\
                     It uses wxWidgets as a GUI.
 
 homepage            https://saga-gis.sourceforge.io/en/index.html
-master_sites        sourceforge:project/saga-gis/SAGA%20-%20[lindex [split ${version} "."] 0]/SAGA%20-%20${version}
+set master_sites_in sourceforge:project/saga-gis/SAGA%20-%20[lindex [split ${version} "."] 0]/SAGA%20-%20${version}
+master_sites        ${master_sites_in}
 
 checksums           rmd160  7d2b7c16a1744e3e027eeea60e7298567a49e962 \
                     sha256  cc1769e04cb3a5cdb5ce1036f940fa2eb5cd1feb127dbd1abceb1cc426c6c631 \
@@ -38,15 +39,26 @@ depends_build-append \
                     port:pkgconfig \
                     port:swig
 
+if {${subport} eq ${name}} {
 # SAGA 9.1.0 do not support PROJ 8+ API
-depends_lib-append  port:${wxWidgets.port} \
+    depends_lib-append  \
+                    port:${wxWidgets.port} \
                     port:gdal \
                     port:proj7 \
                     port:opencv4 \
                     port:pdal \
                     port:curl \
                     port:tiff
-
+} else {
+    depends_build-append \
+                    port:${wxWidgets.port} \
+                    port:gdal \
+                    port:proj7 \
+                    port:opencv4 \
+                    port:pdal \
+                    port:curl \
+                    port:tiff
+}
 compiler.cxx_standard       2014
 
 configure.pkg_config_path-append \
@@ -73,111 +85,134 @@ configure.args-append       -DWITH_TOOLS=ON \
                             -DWITH_TOOLS_RIEGL=OFF \
                             -DWITH_TOOLS_VIGRA=OFF \
 
-variant gui description "Build with GUI interface" {
-    configure.args-replace  -DWITH_GUI=OFF -DWITH_GUI=ON
-}
+# Variants
+if {${subport} eq ${name}} {
 
-# Set ODBC variant
-variant unixodbc conflicts iodbc description {Build ODBC driver against unixODBC} {
-    depends_lib-append      port:unixODBC
-}
-
-variant iodbc conflicts unixodbc description {Build ODBC driver against iODBC} {
-    depends_lib-append      port:libiodbc
-}
-
-if {![variant_isset unixodbc] && ![variant_isset iodbc]} {
-    default_variants        +unixodbc
-}
-
-variant vigra description "Add VIGRA support" {
-    pre-configure {
-        # If HDF5 is built with a mpi variant, we need to know the path to "mpi.h".
-        # Figure out HDF5's mpi include directory:
-        set mpl_include_dir ""
-        if {![catch {set result [active_variants hdf5 openmpi]}]} {
-            if {$result} {
-                set mpl_include_dir "-I${prefix}/include/openmpi-mp"
-            }
-        }
-        if {![catch {set result [active_variants hdf5 mpich]}]} {
-            if {$result} {
-                set mpl_include_dir "-I${prefix}/include/mpich-mp"
-            }
-        }
-        if {$mpl_include_dir ne ""} {
-            configure.cxxflags-append ${mpl_include_dir}
-        }
+    variant gui description "Build with GUI interface" {
+        configure.args-replace  -DWITH_GUI=OFF -DWITH_GUI=ON
     }
 
-    configure.args-replace     -DWITH_TOOLS_VIGRA=OFF -DWITH_TOOLS_VIGRA=ON \
-                               -DWITH_MRMR=OFF -DWITH_MRMR=ON
-    depends_lib-append         port:vigra \
-                               port:hdf5 \
-                               port:fftw-3
-}
+    # Set ODBC variant
+    variant unixodbc conflicts iodbc description {Build ODBC driver against unixODBC} {
+        depends_lib-append      port:unixODBC
+    }
 
-variant libharu description "Add libHaru support for PDF creation" {
-    configure.args-replace  -DWITH_TOOLS_HPDF=OFF -DWITH_TOOLS_HPDF=ON
-    depends_lib-append      port:libharu
-}
+    variant iodbc conflicts unixodbc description {Build ODBC driver against iODBC} {
+        depends_lib-append      port:libiodbc
+    }
 
-# Set Python variant
-set python_suffixes {39 310 311}
-set python_variants {}
+    if {![variant_isset unixodbc] && ![variant_isset iodbc]} {
+        default_variants        +unixodbc
+    }
 
-foreach pyver ${python_suffixes} {
-    lappend python_variants python${pyver}
-}
-
-foreach pyver ${python_suffixes} {
-    set index [lsearch -exact ${python_variants} python${pyver}]
-    set py_dot_ver [string index ${pyver} 0].[string range ${pyver} 1 end]
-    set conf [lreplace ${python_variants} ${index} ${index}]
-
-    variant python${pyver} description "Add Python ${py_dot_ver} API" conflicts {*}${conf} "
-        depends_lib-append      port:python${pyver} \
-                                port:swig-python
-        configure.args-replace  -DWITH_PYTHON=OFF -DWITH_PYTHON=ON
-        configure.args-append   -DWITH_PYTHON_PKG=ON
-        post-patch {
-            reinplace \"s|@PYVER@|${py_dot_ver}|\" \
-              ${worksrcpath}/saga-gis/src/saga_core/saga_api/saga_api_python/CMakeLists.txt
+    variant vigra description "Add VIGRA support" {
+        pre-configure {
+            # If HDF5 is built with a mpi variant, we need to know the path to "mpi.h".
+            # Figure out HDF5's mpi include directory:
+            set mpl_include_dir ""
+            if {![catch {set result [active_variants hdf5 openmpi]}]} {
+                if {$result} {
+                    set mpl_include_dir "-I${prefix}/include/openmpi-mp"
+                }
+            }
+            if {![catch {set result [active_variants hdf5 mpich]}]} {
+                if {$result} {
+                    set mpl_include_dir "-I${prefix}/include/mpich-mp"
+                }
+            }
+            if {$mpl_include_dir ne ""} {
+                configure.cxxflags-append ${mpl_include_dir}
+            }
         }
-    "
+
+        configure.args-replace     -DWITH_TOOLS_VIGRA=OFF -DWITH_TOOLS_VIGRA=ON \
+                                   -DWITH_MRMR=OFF -DWITH_MRMR=ON
+        depends_lib-append         port:vigra \
+                                   port:hdf5 \
+                                   port:fftw-3
+    }
+
+    variant libharu description "Add libHaru support for PDF creation" {
+        configure.args-replace  -DWITH_TOOLS_HPDF=OFF -DWITH_TOOLS_HPDF=ON
+        depends_lib-append      port:libharu
+    }
+
+    # Set PostgreSQL variant
+    set postgresql_suffixes {12 13 14 15}
+    set postgresql_variants {}
+    foreach suffix ${postgresql_suffixes} {
+        lappend postgresql_variants postgresql${suffix}
+    }
+    foreach suffix ${postgresql_suffixes} {
+        set vrt postgresql${suffix}
+        set index [lsearch -exact ${postgresql_variants} ${vrt}]
+        set conf [lreplace ${postgresql_variants} ${index} ${index}]
+        variant ${vrt} description "Use PostgreSQL ${suffix}" conflicts {*}${conf} "
+            depends_lib-append      port:${vrt}
+            configure.env-append    POSTGRES_HOME=${prefix}/lib/${vrt}
+            configure.args-replace  -DWITH_TOOLS_POSTGRES=OFF -DWITH_TOOLS_POSTGRES=ON
+        "
+    }
+    # PostgreSQL default
+    set pgdefault "if {"
+    foreach suffix ${postgresql_suffixes} {
+        set pgdefault "${pgdefault}!\[variant_isset postgresql${suffix}\] && "
+    }
+    set pgdefault [string range ${pgdefault} 0 end-4]
+    set pgdefault "${pgdefault}} { default_variants +postgresql15 }"
+    eval ${pgdefault}
 }
 
-# Set PostgreSQL variant
-set postgresql_suffixes {12 13 14 15}
+# Python subports
+set python_versions {39 310 311 312}
+foreach v ${python_versions} {
+    subport py${v}-py${name} {
+        PortGroup           python 1.0
 
-set postgresql_variants {}
-foreach suffix ${postgresql_suffixes} {
-    lappend postgresql_variants postgresql${suffix}
+        categories          gis python
+
+        depends_lib-append  port:${name}
+
+        use_configure       yes
+
+        python.default_version  ${v}
+        python.add_dependencies no
+        build.cmd           make
+        build.target
+        destroot.cmd        make install
+        destroot.destdir    DESTDIR=${destroot}
+
+        master_sites        ${master_sites_in}
+        
+        livecheck.type      none
+    }
 }
 
-foreach suffix ${postgresql_suffixes} {
-    set vrt postgresql${suffix}
-    set index [lsearch -exact ${postgresql_variants} ${vrt}]
-    set conf [lreplace ${postgresql_variants} ${index} ${index}]
+# Python bindings for supported Python versions
+if {[string match "py*" ${subport}]} {
+    description             PySAGA, Python ${python.branch} bindings for SAGA
+    long_description        {*}${description}.
 
-    variant ${vrt} description "Use PostgreSQL ${suffix}" conflicts {*}${conf} "
-        depends_lib-append      port:${vrt}
-        configure.env-append    POSTGRES_HOME=${prefix}/lib/${vrt}
-        configure.args-replace  -DWITH_TOOLS_POSTGRES=OFF -DWITH_TOOLS_POSTGRES=ON
-    "
+    depends_lib-append      port:python${python.version}
+    depends_build-append    port:swig-python
+
+    configure.args-replace  -DWITH_PYTHON=OFF -DWITH_PYTHON=ON
+    configure.args-append   -DWITH_PYTHON_PKG=ON
+    post-patch {
+        reinplace "s|@PYVER@|${python.branch}|" \
+          ${worksrcpath}/saga-gis/src/saga_core/saga_api/saga_api_python/CMakeLists.txt
+    }
+
+    post-destroot {
+        xinstall -d ${destroot}${python.pkgd}
+        move ${destroot}${prefix}/lib/python${python.branch}/site-packages/PySAGA \
+            ${destroot}${python.pkgd}
+        delete --force ${destroot}${prefix}/bin
+        delete --force ${destroot}${prefix}/include
+        delete --force ${destroot}${prefix}/lib
+        delete --force ${destroot}${prefix}/share
+    }
 }
-
-# PostgreSQL default
-set pgdefault "if {"
-
-foreach suffix ${postgresql_suffixes} {
-    set pgdefault "${pgdefault}!\[variant_isset postgresql${suffix}\] && "
-}
-
-set pgdefault [string range ${pgdefault} 0 end-4]
-set pgdefault "${pgdefault}} { default_variants +postgresql15 }"
-
-eval ${pgdefault}
 
 destroot.target             install
 

--- a/gis/saga/Portfile
+++ b/gis/saga/Portfile
@@ -10,7 +10,7 @@ wxWidgets.use       wxWidgets-3.2
 name                saga
 categories          gis
 license             GPL
-version             9.2.1
+version             9.3.0
 revision            0
 maintainers         {vince @Veence} {yahoo.com:n_larsson @nilason} openmaintainer
 
@@ -25,9 +25,9 @@ long_description    SAGA - System for Automated Geoscientific Analyses - is\
 homepage            https://saga-gis.sourceforge.io/en/index.html
 master_sites        sourceforge:project/saga-gis/SAGA%20-%20[lindex [split ${version} "."] 0]/SAGA%20-%20${version}
 
-checksums           rmd160  29d02b19bde03d61935ec3be8f6039e0eba14735 \
-                    sha256  ab6879ebd182b67afe27b1cf7a3d383acb15e6620293ce8f8ae644869aed392a \
-                    size    8678505
+checksums           rmd160  7d2b7c16a1744e3e027eeea60e7298567a49e962 \
+                    sha256  cc1769e04cb3a5cdb5ce1036f940fa2eb5cd1feb127dbd1abceb1cc426c6c631 \
+                    size    9085741
 
 cmake.source_dir    ${worksrcpath}/saga-gis
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update `saga` to version 9.3.0 and add new `py*-pysaga` subports, which replaces former `saga` Python variants.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
