### PR TITLE
borgbackup: Add missing py-cython dependency

### DIFF
--- a/sysutils/borgbackup/Portfile
+++ b/sysutils/borgbackup/Portfile
@@ -30,6 +30,7 @@ checksums           rmd160  191115a3fb4fc1347b91bc3ddce40fb2fc8d4bfa \
 python.default_version  312
 
 depends_build-append \
+                    port:py${python.version}-cython \
                     port:py${python.version}-pkgconfig \
                     port:py${python.version}-setuptools_scm \
                     port:py${python.version}-sphinx \


### PR DESCRIPTION
#### Description

No revbump, because the port will either build correctly, or not at all.

Closes: https://trac.macports.org/ticket/69004

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.3 22G436 x86_64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
