### PR TITLE
include-what-you-use: update to 0.21

### DIFF
--- a/devel/include-what-you-use/Portfile
+++ b/devel/include-what-you-use/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        include-what-you-use include-what-you-use 0.20
+github.setup        include-what-you-use include-what-you-use 0.21
 github.tarball_from archive
 revision            0
 categories          devel
@@ -16,11 +16,11 @@ description         A tool for use with clang to analyze #includes in C and C++ 
 
 long_description    {*}${description}
 
-checksums           rmd160  7e6da7cc8c3e9300516597bcfceba56c66b5c1a0 \
-                    sha256  4fe4bd5581ee60bb2bcf1bf40f087a8c5b090d943d0376233638f30f29af0e2e \
-                    size    766208
+checksums           rmd160  70834a92aaed0d19e1c345191f48279b5d1f360c \
+                    sha256  a472fe8587376d041585c72e5643200f8929899f787725f0ba9e5b3d3820d401 \
+                    size    776263
 
-set llvm_version    16
+set llvm_version    17
 set llvm_dir        ${prefix}/libexec/llvm-${llvm_version}
 
 depends_lib-append  port:clang-${llvm_version}
@@ -35,6 +35,8 @@ post-destroot {
     # level above. Run it via xcrun so it picks up system include directories.
     xinstall -d ${destroot}${llvm_dir}/bin
     move ${destroot}${prefix}/bin/${name} ${destroot}${llvm_dir}/bin
-    system -W "${destroot}${prefix}/bin" \
-        "echo '#!/bin/sh\nexec xcrun ${llvm_dir}/bin/${name} \"$@\"' > ${name} && chmod +x ${name}"
+    system -W "${destroot}${prefix}/bin" "
+        echo '#!/bin/sh\nexec xcrun ${llvm_dir}/bin/${name} \"$@\"' >${name} &&
+        chmod +x ${name}
+    "
 }


### PR DESCRIPTION
###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?