### PR TITLE
GtkWave : Update gtkwave to 3.3.117

### DIFF
--- a/cad/gtkwave/Portfile
+++ b/cad/gtkwave/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       app 1.0
 
 name            gtkwave
-version         3.3.115
+version         3.3.117
 revision        0
 
 categories      cad
@@ -19,17 +19,17 @@ long_description \
 homepage        http://gtkwave.sourceforge.net
 master_sites    sourceforge:project/gtkwave/gtkwave-${version}
 
-checksums       rmd160  8299c47c7d8a42f26e6d8a402df0ee3cfe2fe56d \
-                sha256  570e7f295a35cdd5ba173d4e3b6adb29e78354e76cc21a7ce2932551863e7bb9 \
-                size    3511620
+checksums       rmd160  7e1556072540ab5ef1b94dc2a823533ba6ba15ba \
+                sha256  55520fc308244c5dc99d5a3f42f5e782eb8e6a9e81cece5c84ea3f11875bff13 \
+                size    3506108
 
 depends_build-append \
                 port:pkgconfig
 
 depends_lib-append \
                 port:bzip2 \
-                path:lib/pkgconfig/gtk+-2.0.pc:gtk2 \
-                port:gtk-osx-application-gtk2 \
+                path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                port:gtk-osx-application-gtk3 \
                 path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                 path:lib/pkgconfig/pango.pc:pango \
                 port:tk \
@@ -40,9 +40,7 @@ configure.args-append \
                 --with-tcl=${prefix}/lib \
                 --with-tk=${prefix}/lib \
                 --disable-mime-update \
-                --disable-silent-rules \
-                "GTK_MAC_CFLAGS=\"\$(${prefix}/bin/pkg-config --cflags gtk-mac-integration-gtk2)\"" \
-                "GTK_MAC_LIBS=\"\$(${prefix}/bin/pkg-config --libs gtk-mac-integration-gtk2)\""
+                --disable-silent-rules
 
 post-activate {
         system "${prefix}/bin/update-desktop-database -q ${prefix}/share/applications; true"


### PR DESCRIPTION
#### Description

Updated GtkWave from 3.3.115 to 3.3.117.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
