### PR TITLE
virt-manager: use python312

### DIFF
--- a/gnome/virt-manager/Portfile
+++ b/gnome/virt-manager/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           app 1.0
 
 github.setup        virt-manager virt-manager 4.1.0 v
-revision            2
+revision            3
 checksums           rmd160  75b773577e04827d808cc85f3a781d1135026215 \
                     sha256  950681d7b32dc61669278ad94ef31da33109bf6fcf0426ed82dfd7379aa590a2 \
                     size    3151412
@@ -37,7 +37,7 @@ patchfiles-append   patch-no-kvm-warning.diff
 patchfiles-append   patch-not-in-usr.diff
 patchfiles-append   patch-hvf-support.diff
 
-python.default_version  311
+python.default_version  312
 python.pep517           no
 
 # Note: 'gettext' only needed at build time. No need for a runtime dep on


### PR DESCRIPTION
###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?