### PR TITLE
onetbb: fix building tbbbind

### DIFF
--- a/devel/onetbb/Portfile
+++ b/devel/onetbb/Portfile
@@ -9,7 +9,7 @@ github.setup        oneapi-src oneTBB 2021.11.0 v
 github.tarball_from archive
 
 name                onetbb
-revision            0
+revision            1
 categories          devel parallel
 platforms           darwin
 license             Apache-2
@@ -29,7 +29,9 @@ patchfiles          patch-onetbb-older-platforms.diff
 
 compiler.blacklist-append   {clang < 700}
 
-depends_lib-append  port:hwloc
+depends_build-append    port:pkgconfig
+
+depends_lib-append      port:hwloc
 
 compiler.cxx_standard  2011
 


### PR DESCRIPTION
###### Type(s)

- [x] bugfix

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?