### PR TITLE
SuiteSparse: update to 7.5.1

### DIFF
--- a/math/SuiteSparse/Portfile
+++ b/math/SuiteSparse/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                DrTimothyAldenDavis SuiteSparse 7.4.0 v
+github.setup                DrTimothyAldenDavis SuiteSparse 7.5.1 v
 # subports have independent revisions
 revision                    0
 epoch                       20200517
@@ -17,20 +17,13 @@ long_description            SuiteSparse is a single archive that contains all pa
 
 homepage                    https://people.engr.tamu.edu/davis/suitesparse.html
 
-checksums                   rmd160  8539e35f47729cdc1843e7999b02bca3bc244272 \
-                            sha256  9f976f83405baf55ba24e9494ce3f526251b972f4554ffe9046c21706be87559 \
-                            size    85408692
+checksums                   rmd160  e6ab4056b07d8136c8fdf2bb0bb7eb1f733f04e0 \
+                            sha256  e45ae6caf9f66e009c8fcf3940a2a300dac5b6aae17aa96b3c052e2f79849aed \
+                            size    85466945
 
 configure.optflags          -O3
 
 compiler.c_standard         2011
-
-# Defining __NOEXTENSIONS__ is necessary on OS X 10.6 and earlier
-# This prevents math.h from using the non-standard symbols Real and Imag
-# which conflict with several SuiteSparse packages (at least KLU and CHOLMOD).
-if {${os.platform} eq "darwin" && ${os.major} <= 10} {
-    configure.cppflags-append -D__NOEXTENSIONS__
-}
 
 # We keep SUITESPARSE_USE_STRICT at the default value of OFF and 
 # SUITESPARSE_USE_OPENMP at the default value of ON. This way OpenMP will be
@@ -50,7 +43,7 @@ compiler.log_verbose_output no
 subport SuiteSparse_config {
     PortGroup               linear_algebra 1.0
 
-    version                 7.4.0
+    version                 7.5.1
     revision                0
     # from the README.txt:
     #    "[n]o licensing restrictions apply"
@@ -64,7 +57,7 @@ subport SuiteSparse_config {
 }
 
 subport SuiteSparse_GraphBLAS {
-    version                 8.3.1
+    version                 9.0.0
     revision                0
     license                 Apache-2
     long_description-append ${subport}: graph algorithms in the language of linear algebra.
@@ -75,7 +68,7 @@ subport SuiteSparse_GraphBLAS {
 }
 
 subport SuiteSparse_LAGraph {
-    version                 1.1.0
+    version                 1.1.1
     revision                0
     depends_lib-append      port:SuiteSparse_GraphBLAS
     license                 BSD
@@ -86,7 +79,7 @@ subport SuiteSparse_LAGraph {
 }
 
 subport SuiteSparse_Mongoose {
-    version                 3.3.0
+    version                 3.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 GPL-3
@@ -95,7 +88,7 @@ subport SuiteSparse_Mongoose {
 }
 
 subport SuiteSparse_AMD {
-    version                 3.3.0
+    version                 3.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 BSD
@@ -103,7 +96,7 @@ subport SuiteSparse_AMD {
 }
 
 subport SuiteSparse_BTF {
-    version                 2.3.0
+    version                 2.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 LGPL-2.1+
@@ -111,7 +104,7 @@ subport SuiteSparse_BTF {
 }
 
 subport SuiteSparse_CAMD {
-    version                 3.3.0
+    version                 3.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 BSD
@@ -119,7 +112,7 @@ subport SuiteSparse_CAMD {
 }
 
 subport SuiteSparse_CCOLAMD {
-    version                 3.3.0
+    version                 3.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 BSD
@@ -127,7 +120,7 @@ subport SuiteSparse_CCOLAMD {
 }
 
 subport SuiteSparse_COLAMD {
-    version                 3.3.0
+    version                 3.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 BSD
@@ -137,7 +130,7 @@ subport SuiteSparse_COLAMD {
 subport SuiteSparse_CHOLMOD {
     PortGroup               linear_algebra 1.0
 
-    version                 5.1.0
+    version                 5.1.1
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CAMD port:SuiteSparse_COLAMD port:SuiteSparse_CCOLAMD
     license                 LGPL-2.1+
@@ -151,7 +144,7 @@ subport SuiteSparse_CHOLMOD {
 }
 
 subport SuiteSparse_CXSparse {
-    version                 4.3.0
+    version                 4.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 LGPL-2.1+
@@ -159,7 +152,7 @@ subport SuiteSparse_CXSparse {
 }
 
 subport SuiteSparse_LDL {
-    version                 3.3.0
+    version                 3.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD
     license                 LGPL-2.1+
@@ -167,7 +160,7 @@ subport SuiteSparse_LDL {
 }
 
 subport SuiteSparse_KLU {
-    version                 2.3.0
+    version                 2.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_BTF port:SuiteSparse_COLAMD port:SuiteSparse_CHOLMOD
     license                 LGPL-2.1+
@@ -177,7 +170,7 @@ subport SuiteSparse_KLU {
 subport SuiteSparse_UMFPACK {
     PortGroup               linear_algebra 1.0
 
-    version                 6.3.0
+    version                 6.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CHOLMOD
     license                 GPL-2+
@@ -189,7 +182,7 @@ subport SuiteSparse_UMFPACK {
 }
 
 subport SuiteSparse_RBio {
-    version                 4.3.0
+    version                 4.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 GPL-2+
@@ -199,7 +192,7 @@ subport SuiteSparse_RBio {
 subport SuiteSparse_SPQR {
     PortGroup               linear_algebra 1.0
 
-    version                 4.3.0
+    version                 4.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_COLAMD port:SuiteSparse_CHOLMOD
     license                 GPL-2+
@@ -212,7 +205,7 @@ subport SuiteSparse_SPQR {
 }
 
 subport SuiteSparse_SPEX {
-    version                 2.3.0
+    version                 2.3.1
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_COLAMD \
                             port:gmp \


### PR DESCRIPTION
 - update to 7.5.1
 - remove no-longer-needed workarounds, which are now included in upstream

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.3 22G436 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
