### PR TITLE
py-anyio: update to 4.2.0, drop py37 subport (along with dependents)

### DIFF
--- a/python/py-anyio/Portfile
+++ b/python/py-anyio/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-anyio
-version             3.7.1
+version             4.2.0
 revision            0
 categories-append   devel
 license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 python.pep517       yes
 
 maintainers         {stromnov @stromnov} openmaintainer
@@ -21,9 +21,9 @@ long_description    {*}${description}
 
 homepage            https://github.com/agronholm/anyio
 
-checksums           rmd160  97fa8656e9ecb92030c9868a93a957793dea81d3 \
-                    sha256  44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780 \
-                    size    142927
+checksums           rmd160  b65397d80ea5b955560233bf1e52c874f35bbc5d \
+                    sha256  e1875bb4b4e2de1669f4bc7869b6d3f54231cdced71605e6e64c9be77e3be50f \
+                    size    158770
 
 if {${name} ne ${subport}} {
     depends_build-append \
@@ -33,10 +33,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-sniffio
 
     if {${python.version} < 311} {
-        depends_lib-append  port:py${python.version}-exceptiongroup
-    }
-
-    if {${python.version} < 38} {
-        depends_lib-append  port:py${python.version}-typing_extensions
+        depends_lib-append \
+                        port:py${python.version}-exceptiongroup \
+                        port:py${python.version}-typing_extensions
     }
 }

--- a/python/py-httpcore/Portfile
+++ b/python/py-httpcore/Portfile
@@ -19,7 +19,7 @@ checksums           rmd160  5775f27cbd7d635c34f9510f90b2577b92d5b48c \
                     sha256  9fc092e4799b26174648e54b74ed5f683132a464e95643b226e00c2ed2fa6535 \
                     size    81036
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 
 python.pep517       yes
 python.pep517_backend \

--- a/python/py-httpx/Portfile
+++ b/python/py-httpx/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  0a28253781bb7f49676aefa1d9a102dcc176e8d6 \
                     sha256  8b8fcaa0c8ea7b05edd69a094e63a2094c4efcb48129fb757361bc423c0ad9e8 \
                     size    123889
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 
 python.pep517       yes
 python.pep517_backend hatch

--- a/python/py-ipywidgets/Portfile
+++ b/python/py-ipywidgets/Portfile
@@ -10,7 +10,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jupyter/Portfile
+++ b/python/py-jupyter/Portfile
@@ -12,7 +12,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jupyter_server/Portfile
+++ b/python/py-jupyter_server/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jupyterlab/Portfile
+++ b/python/py-jupyterlab/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jupyterlab_server/Portfile
+++ b/python/py-jupyterlab_server/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jupyterlab_widgets/Portfile
+++ b/python/py-jupyterlab_widgets/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-jupytext/Portfile
+++ b/python/py-jupytext/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  62152c16bb75bd6523b004ec96fcaa9db16cc13f \
                     sha256  3171e3e2827cbd63556158eb1df107e6e38e38e14c74612ac6cc7a29f4215298 \
                     size    5235055
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_lib-append      port:py${python.version}-setuptools \

--- a/python/py-nbclassic/Portfile
+++ b/python/py-nbclassic/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-plotly/Portfile
+++ b/python/py-plotly/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  1664fe0be9598b22ab79dbaa75c15161aabc0b9c \
                     sha256  822eabe53997d5ebf23c77e1d1fcbf3bb6aa745eb05d532afd4b6f9a2e2ab02f \
                     size    7757675
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-starlette/Portfile
+++ b/python/py-starlette/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  defb5f505ab7c47b500b7c8c215ee705fdc0362f \
                     sha256  a4dc2a3448fb059000868d7eb774dd71229261b6d49b6851e7849bec69c0a011 \
                     size    2844300
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 python.pep517       yes
 python.pep517_backend hatch
 

--- a/python/py-tensorflow-datasets/Portfile
+++ b/python/py-tensorflow-datasets/Portfile
@@ -24,7 +24,7 @@ checksums           rmd160  a4cdd40935581a920dd1d2bad2c546a991b7f2f6 \
                     sha256  0f700096c82f288833714f6120f3cd4a1d08e22095dda182cc4d3ac31b66977a \
                     size    208979612
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-vega/Portfile
+++ b/python/py-vega/Portfile
@@ -11,7 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 


### PR DESCRIPTION
#### Description

Update `py-anyio` to 4.2.0. As this version no longer supports Python 3.7 drop support for `py-anyio` and its dependents.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] versionupdate
- [X] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.3 22G436 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
