### PR TITLE
watchman: revbump after folly update, use libfmt10

### DIFF
--- a/sysutils/watchman/Portfile
+++ b/sysutils/watchman/Portfile
@@ -10,7 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 boost.version       1.81
 
 github.setup        facebook watchman 2023.11.13.00 v
-revision            0
+revision            1
 
 categories          sysutils
 maintainers         {danchr @danchr} openmaintainer
@@ -20,13 +20,19 @@ description         watches files and takes action when they change
 long_description    ${description}
 supported_archs     arm64 x86_64
 
-set port_libfmt     libfmt9
+set port_libfmt     libfmt10
 cmake.module_path-append \
                     ${prefix}/lib/${port_libfmt}/cmake
 
+set py_ver          3.12
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+
 depends_build-append \
                     port:cpptoml \
-                    port:pkgconfig
+                    port:pkgconfig \
+                    port:py${py_ver_nodot}-setuptools \
+                    port:python${py_ver_nodot}
+
 depends_lib-append  port:pcre \
                     port:folly \
                     port:edencommon \


### PR DESCRIPTION
#### Description

For some reason CI did not pass initially for this (no error locally though), so it was omitted from `folly` & friends update. Revbump is required, however.
Let us try to fix it now.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`? (There are multiple lint warnings due to how crates are listed, but I do not touch that part here.)
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
