### PR TITLE
libretroshare: update to 2023.12.27

### DIFF
--- a/net/libretroshare/Portfile
+++ b/net/libretroshare/Portfile
@@ -6,9 +6,9 @@ PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 PortGroup               openssl 1.0
 
-github.setup            RetroShare libretroshare 78739f1eb504503b12f107109356624da49e75ef
-version                 2023.11.26
-revision                1
+github.setup            RetroShare libretroshare ac1c5f3019ff17c695758dabec0ee8e540d401e0
+version                 2023.12.27
+revision                0
 categories              net devel security
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
 license                 {AGPL-3 Apache-2 GPL-3 LGPL-3 MIT}
@@ -17,9 +17,9 @@ long_description        {*}${description} RetroShare functionalities (file shari
                         are implemented under the hood by libretroshare which offer a documented C++ and JSON API. \
                         While RetroShare is an application on its own, libretroshare is meant to be used as part of other programs.
 homepage                https://retroshare.cc
-checksums               rmd160  243ca1fe218b0991112acdd17767aef8fbb3a1d4 \
-                        sha256  75107d398b5b45a0a93e3913750163c0207d5d260c30de06b215638a04ccc43f \
-                        size    1929414
+checksums               rmd160  b07628538b21a4e98860d63a6ea3dae8399a8dd3 \
+                        sha256  e735d4c9bc661467beef2b5698caa8d757e35044ecb875c50ca46f8cfba3f408 \
+                        size    1929429
 github.tarball_from     archive
 
 # getline, strnlen


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
