### PR TITLE
turbo: new port in editors

### DIFF
--- a/editors/turbo/Portfile
+++ b/editors/turbo/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+
+github.setup        magiblot turbo 8d42224c563865b232727e93169c81f11cd53fe1
+version             2024.01.07
+revision            0
+categories          editors sysutils
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Experimental text editor based on Scintilla and Turbo Vision
+long_description    Turbo is an experimental text editor for the terminal, \
+                    based on the Scintilla code editing component by Neil Hodgson \
+                    and the Turbo Vision application framework.
+
+fetch.type          git
+
+post-fetch {
+    system -W ${worksrcpath} "${git.cmd} submodule update --init"
+}
+
+depends_lib-append  port:libmagic \
+                    port:ncurses
+
+compiler.cxx_standard 2017
+
+configure.args-append \
+                    -DTURBO_BUILD_APP=ON \
+                    -DTURBO_BUILD_EXAMPLES=OFF \
+                    -DTURBO_BUILD_TESTS=OFF \
+                    -DTURBO_OPTIMIZE_BUILD=OFF
+
+variant tests description "Build and run tests" {
+    depends_build-append \
+                    port:gtest
+    configure.args-replace \
+                    -DTURBO_BUILD_TESTS=OFF -DTURBO_BUILD_TESTS=ON
+    test.run        yes
+    # Tests will run at the end of the build.
+    # No special target needed.
+    test            { }
+}
+
+# FIXME: on PowerPC no graphical output in the terminal, despite
+# all tests passing: https://github.com/magiblot/turbo/issues/65


### PR DESCRIPTION
#### Description

New port: https://github.com/magiblot/turbo

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1
Xcode 15.2

macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
