### PR TITLE
bpytop: Use Python 3.12

### DIFF
--- a/sysutils/bpytop/Portfile
+++ b/sysutils/bpytop/Portfile
@@ -6,7 +6,7 @@ PortGroup           makefile    1.0
 
 github.setup        aristocratos bpytop 1.0.68 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         \
     Linux/macOS/FreeBSD resource monitor
@@ -26,7 +26,7 @@ checksums           rmd160  b1fadf6be303b0f7b650d545daad71778210a23d \
                     sha256  3a936f8899efb66246e82bbcab33249bf94aabcefbe410e56f045a1ce3c9949f \
                     size    632649
 
-set python_branch   3.9
+set python_branch   3.12
 set python_version  [join [split ${python_branch} "."] ""]
 set python_bin      ${prefix}/bin/python${python_branch}
 


### PR DESCRIPTION
#### Description

The default python version in MacPorts is now 3.12 since January 1st. bpytop still uses 3.9, but can just as well use 3.12, so switch to that. That allows me to remove Python 3.9 from my system.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.3 22G436 x86_64
Xcode 15.0.1 15A507

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
