### PR TITLE
smtube: use Qt5 on newer systems; depend on MPlayer via default variant, support QMPlay2 optionally

### DIFF
--- a/www/smtube/Portfile
+++ b/www/smtube/Portfile
@@ -57,7 +57,7 @@ pre-build {
                                -out src/smtube.icns"
 }
 
-build.dir            ${worksrcpath}/src
+build.dir           ${worksrcpath}/src
 
 # fixme - the translations are made, but forcing the installed app to find them
 # is proving somewhat difficult.

--- a/www/smtube/Portfile
+++ b/www/smtube/Portfile
@@ -1,10 +1,19 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           qmake 1.0
+
+if {${os.platform} eq "darwin" && ${os.major} < 17} {
+    PortGroup       qmake 1.0
+
+} else {
+    PortGroup       qmake5 1.0
+
+    qt5.depends_component   qttools qtwebkit-examples
+}
 
 name                smtube
 version             21.10.0
+revision            1
 
 categories          www
 license             GPL-2+

--- a/www/smtube/Portfile
+++ b/www/smtube/Portfile
@@ -8,7 +8,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 17} {
 } else {
     PortGroup       qmake5 1.0
 
-    qt5.depends_component   qttools qtwebkit-examples
+    qt5.depends_component   qttools qtwebkit
 }
 
 name                smtube

--- a/www/smtube/Portfile
+++ b/www/smtube/Portfile
@@ -34,8 +34,7 @@ checksums           rmd160  febb3403f24f6f621870ffd243b3291666f0d87d \
 depends_build-append \
                     port:makeicns
 
-depends_run-append  path:${prefix}/bin/mplayer:MPlayer \
-                    port:yt-dlp
+depends_run-append  port:yt-dlp
 
 configure.dir       ${worksrcpath}/src
 
@@ -44,6 +43,7 @@ patchfiles          patch-smplayer.diff
 post-patch {
     reinplace "s|@@PREFIX@@|${prefix}|g" ${worksrcpath}/src/players.cpp \
                                          ${worksrcpath}/src/retrieveyoutubeurl.cpp
+    reinplace "s|@@APPLICATIONS@@|${applications_dir}|" ${worksrcpath}/src/players.cpp
 }
 
 pre-build {
@@ -75,3 +75,19 @@ notes "
 The mechanism smtube uses has changed slightly. You may notice\
 a slight delay before the video starts to play.
 "
+
+variant mplayer description "Use MPlayer for playback" {
+    depends_run-append   path:${prefix}/bin/mplayer:MPlayer
+}
+
+variant qmplay2 description "Use QMPlay2 for playback" {
+    depends_run-append   port:QMPlay2
+
+    notes-append "
+    To use QMPlay2 for playback, please launch ${name}, open Preferences>Players,\
+    click Add predefined players and move QMPlay2 to the top of the list.
+    "
+}
+
+# Notice, there is no conflict between variants, they merely add a runtime dep.
+default_variants-append  +mplayer

--- a/www/smtube/files/patch-smplayer.diff
+++ b/www/smtube/files/patch-smplayer.diff
@@ -2,19 +2,31 @@ diff --git src/players.cpp src/players.cpp
 index 21afed2..4b46c04 100644
 --- src/players.cpp
 +++ src/players.cpp
-@@ -105,10 +105,10 @@ Players::Players() {
+@@ -106,16 +106,17 @@
  		 << Player("SMPlayer (audio)", "smplayer.exe", "%u -media-title %t", true, false, Player::Audio)
  		 << Player("SMPlayer (add to playlist)", "smplayer.exe", "-add-to-playlist %u", true, true, Player::VideoAudio);
  #else
 -	list << Player("SMPlayer", "smplayer", "%u", true, true, Player::Video)
 +	list << Player("MPlayer", "@@PREFIX@@/bin/mplayer", "%u -title %t", false, false, Player::Video)
-+         << Player("SMPlayer", "smplayer", "%u", true, true, Player::Video)
++		 << Player("mpv", "@@PREFIX@@/bin/mpv", "%u --title=%t", false, true, Player::Video)
++		 << Player("mpv + youtube-dl", "@@PREFIX@@/bin/mpv", "--ytdl --ytdl-format=best %u", true, true, Player::Video)
++		 << Player("VLC", "@@PREFIX@@/bin/vlc", "%u --meta-title=%t", false, true, Player::VideoAudio)
++		 << Player("QMPlay2", "@@APPLICATIONS@@/QMPlay2.app/Contents/MacOS/QMPlay2", "%u", false, false, Player::VideoAudio)
++		 << Player("SMPlayer", "smplayer", "%u", true, true, Player::Video)
  		 << Player("SMPlayer (audio)", "smplayer", "%u -media-title %t", true, false, Player::Audio)
  		 << Player("SMPlayer (add to playlist)", "smplayer", "-add-to-playlist %u", true, true, Player::VideoAudio)
 -		 << Player("MPlayer", "mplayer", "%u -title %t", false, false, Player::Video)
- 		 << Player("VLC", "vlc", "%u --meta-title=%t", false, true, Player::VideoAudio)
+-		 << Player("VLC", "vlc", "%u --meta-title=%t", false, true, Player::VideoAudio)
  		 << Player("Dragon Player", "dragon", "%u", false, false, Player::VideoAudio)
  		 << Player("Totem", "totem", "%u", false, false, Player::VideoAudio)
+-		 << Player("GNOME-MPlayer", "gnome-mplayer", "%u", false, false, Player::VideoAudio)
+-		 << Player("mpv", "mpv", "%u --title=%t", false, true, Player::Video)
+-		 << Player("mpv + youtube-dl", "mpv", "--ytdl --ytdl-format=best %u", true, true, Player::Video);
++		 << Player("GNOME-MPlayer", "gnome-mplayer", "%u", false, false, Player::VideoAudio);
+ 	#ifdef D_PLAYERS
+ 	list << Player("uget", "uget-gtk", "--quiet --folder=/tmp --filename=%f %u", false, false, Player::VideoAudio);
+ 	#endif
+
 diff --git src/retrieveyoutubeurl.cpp src/retrieveyoutubeurl.cpp
 index 416956c..e2196cd 100644
 --- src/retrieveyoutubeurl.cpp


### PR DESCRIPTION
#### Description

1. Use Qt5 on newer systems. Leave older on Qt4.
2. Do not force a user to build MPlayer if it is not desired. Instead, depend on it by default via a variant.
3. Support QMPlay2 via a non-default variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
