### PR TITLE
py312-pylint: Fix select file

### DIFF
--- a/python/py-pylint/Portfile
+++ b/python/py-pylint/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 name                py-pylint
 version             3.0.3
-revision            0
+revision            1
 
 categories-append   devel
 platforms           {darwin any}

--- a/python/py-pylint/files/pylint312
+++ b/python/py-pylint/files/pylint312
@@ -1,4 +1,4 @@
-${frameworks_dir}/Python.framework/Versions/3.12/bin/epylint
+-
 ${frameworks_dir}/Python.framework/Versions/3.12/bin/pylint
 ${frameworks_dir}/Python.framework/Versions/3.12/bin/pyreverse
 ${frameworks_dir}/Python.framework/Versions/3.12/bin/symilar


### PR DESCRIPTION
#### Description

```
$ sudo port select --set pylint pylint312
Selecting 'pylint312' for 'pylint' failed: could not create new link "/opt/local/bin/epylint": target "/opt/local/Library/Frameworks/Python.framework/Versions/3.12/bin/epylint" doesn't exist
```

py312-pylint does not install an epylint binary. Remove it from the select group to fix the select failure.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?