### PR TITLE
yubico-authenticator and dependencies: Use Python 3.12

### DIFF
--- a/aqua/yubico-authenticator/Portfile
+++ b/aqua/yubico-authenticator/Portfile
@@ -12,7 +12,7 @@ qt5.depends_component \
 
 name                yubico-authenticator
 github.setup        Yubico yubioath-desktop 5.1.0
-revision            3
+revision            4
 categories          aqua security
 license             BSD
 maintainers         nomaintainer
@@ -31,7 +31,7 @@ checksums           rmd160  b35ab9626d8eff8eb4cf02bb6a050bac47107ea6 \
                     size    6322358
 
 # Python version must be synced with pyotherside and yubikey-manager4 ports
-set python.branch   3.10
+set python.branch   3.12
 set python.version  [join [split ${python.branch} "."] ""]
 set python.prefix   ${frameworks_dir}/Python.framework/Versions/${python.branch}
 set python.pkgd     ${python.prefix}/lib/python${python.branch}/site-packages

--- a/devel/pyotherside/Portfile
+++ b/devel/pyotherside/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 qt5.depends_component qtdeclarative
 
 github.setup        thp pyotherside 1.6.0
-revision            0
+revision            1
 categories          devel qt5
 platforms           darwin
 license             ISC
@@ -29,7 +29,7 @@ if { ${os.platform} eq "darwin" && (( ${os.major} >= 15 && ${os.major} <= 16 ) |
 
 qt5.min_version 5.6
 
-set python.branch   3.10
+set python.branch   3.12
 set python.version  [join [split ${python.branch} "."] ""]
 
 depends_lib-append  port:python${python.version}

--- a/python/py-makefun/Portfile
+++ b/python/py-makefun/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-makefun
-version             1.15.1
+version             1.15.2
 license             BSD
 supported_archs     noarch
 platforms           {darwin any}
@@ -17,11 +17,11 @@ long_description    makefun helps you create functions dynamically, with the sig
 
 homepage            https://smarie.github.io/python-makefun/
 
-checksums           rmd160 509882e6a305f4bf834d509f529c2a557bbd306b \
-                    sha256 40b0f118b6ded0d8d78c78f1eb679b8b6b2462e3c1b3e05fb1b2da8cd46b48a5 \
-                    size   74521
+checksums           rmd160  5583cef07ae57541518fe0d5b1f6da93fc1794a1 \
+                    sha256  16f2a2b34d9ee0c2b578c960a1808c974e2822cf79f6e9b9c455aace10882d45 \
+                    size    74602
 
-python.versions     39 310 311
+python.versions     39 310 311 312
 python.pep517       yes
 
 if {${name} ne ${subport}} {

--- a/python/py-pyscard/Portfile
+++ b/python/py-pyscard/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  611442ec4e1eb9efddba4843b572c0b21164c101 \
                     sha256  5e6c08208ec17646ce99037a8e2ba528e06502417064e5f684585a2465fe43d4 \
                     size    177649
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/security/yubikey-manager4/Portfile
+++ b/security/yubikey-manager4/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                yubikey-manager4
 version             4.0.9
-revision            0
+revision            1
 categories-prepend  security
 platforms           {darwin any}
 supported_archs     noarch
@@ -28,7 +28,7 @@ python.rootname     yubikey-manager
 # This must be bumped in step with the yubico-authenticator port's Python
 # version. The full, built app must be tested: Python 3.8 previously failed at
 # runtime.
-python.default_version 310
+python.default_version 312
 
 depends_build-append \
     port:py${python.version}-poetry-core


### PR DESCRIPTION
#### Description

```
yubico-authenticator: Use Python 3.12
pyotherside: Use Python 3.12
yubikey-manager4: Use Python 3.12
py-makefun: Update to 1.15.2, add support for 3.12
py-pyscard: Add support for 3.12
```

I tested yubico-authenticator with those changes. It is working as expected.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
