### PR TITLE
rocksdb: Fix build in presence of older version

### DIFF
--- a/databases/rocksdb/Portfile
+++ b/databases/rocksdb/Portfile
@@ -40,6 +40,7 @@ patchfiles          0001-rocksdb-fixes-for-macOS-PPC.patch \
 compiler.cxx_standard 2017
 compiler.thread_local_storage yes
 
+# DCMAKE_INCLUDE_DIRECTORIES_BEFORE=ON fixes the build while an older version is installed, see #69079
 configure.args-append \
                     -DWITH_JEMALLOC=OFF \
                     -DWITH_LIBURING=OFF \
@@ -51,7 +52,8 @@ configure.args-append \
                     -DROCKSDB_BUILD_SHARED=ON \
                     -DWITH_BZ2=ON \
                     -DWITH_MD_LIBRARY=ON \
-                    -DWITH_TBB=OFF
+                    -DWITH_TBB=OFF \
+                    -DCMAKE_INCLUDE_DIRECTORIES_BEFORE=ON
 
 if {[string match *gcc* ${configure.compiler}]} {
     # version_set.cc: error: 'rocksdb::{anonymous}::ManifestPicker::ManifestPicker' defined but not used


### PR DESCRIPTION
No revbump because rocksdb either builds correctly, or not at all.

Closes: https://trac.macports.org/ticket/69079

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
