### PR TITLE
tilemaker: update to 3.0.0

### DIFF
--- a/gis/tilemaker/Portfile
+++ b/gis/tilemaker/Portfile
@@ -5,8 +5,8 @@ PortGroup           github 1.0
 PortGroup           cmake 1.1
 PortGroup           boost 1.0
 
-github.setup        systemed tilemaker 2.4.0 v
-revision            2
+github.setup        systemed tilemaker 3.0.0 v
+revision            0
 
 categories          gis
 license             FTWPL
@@ -17,9 +17,9 @@ long_description    {*}${description}
 
 installs_libs       no
 
-checksums           rmd160  bc0f9002a6499b88780abdcb8bef2871e2edd174 \
-                    sha256  228545ac07814dab7e1a043bb1752f7407471240e9ca09f0b2eac026dcf567b0 \
-                    size    42973680
+checksums           rmd160  4b97345985fb94445c44c7d624cbdfc86057e064 \
+                    sha256  1e2115d52975d5e3c1f89192c442de620cf1cb0f80b92a7836dad88c0f247b8b \
+                    size    43684576
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/systemed/tilemaker/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

