### PR TITLE
QJson4: new port in devel

### DIFF
--- a/devel/QJson4/Portfile
+++ b/devel/QJson4/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           qmake 1.0
+
+name                QJson4
+github.setup        eteran qjson4 fceaaf0786a924966cfaba7b23a95742a0a6b547
+version             2024.01.16
+categories          devel
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-2
+
+description         Qt4 library providing an API compatible with Qt5 JSON implementation
+long_description    {*}${description}
+
+checksums           rmd160  4a0c70ea301facb4ea1624b3a733e9f9b560e228 \
+                    sha256  70e556e70c3a1e56337530fa4aebade364c080074158c8939cd8b0e29d01fa13 \
+                    size    19771
+github.tarball_from archive
+
+patchfiles          0001-Fix-building-library.patch
+
+post-patch {
+    reinplace "s|@PREFIX@|${prefix}|" ${worksrcpath}/QJson4.pro
+}
+
+post-destroot {
+    set incdir ${destroot}${prefix}/include/${name}
+    xinstall -d ${incdir}
+    foreach h [glob ${worksrcpath}/*.h] {
+        xinstall -m 0644 -W ${worksrcpath} ${h} ${incdir}
+    }
+}

--- a/devel/QJson4/files/0001-Fix-building-library.patch
+++ b/devel/QJson4/files/0001-Fix-building-library.patch
@@ -1,0 +1,87 @@
+From 6c8fd25da6eea41846acf1b2ccedd02eddef5086 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Jan 2024 06:31:37 +0800
+Subject: [PATCH] Fix building library
+
+---
+ QJson4.pri | 20 --------------------
+ QJson4.pro | 40 ++++++++++++++++++++++++----------------
+ 2 files changed, 24 insertions(+), 36 deletions(-)
+ delete mode 100644 QJson4.pri
+
+diff --git QJson4.pri QJson4.pri
+deleted file mode 100644
+index b0bce68..0000000
+--- QJson4.pri
++++ /dev/null
+@@ -1,20 +0,0 @@
+-DEPENDPATH  += .
+-INCLUDEPATH += .
+-
+-# Input
+-HEADERS += $$PWD/QJsonArray.h        \
+-           $$PWD/QJsonDocument.h     \
+-           $$PWD/QJsonObject.h       \
+-           $$PWD/QJsonParseError.h   \
+-           $$PWD/QJsonValue.h        \
+-           $$PWD/QJsonValueRef.h     \
+-           $$PWD/QJsonParser.h       \
+-           $$PWD/QJsonRoot.h
+-
+-SOURCES += $$PWD/QJsonArray.cpp      \
+-           $$PWD/QJsonDocument.cpp   \
+-           $$PWD/QJsonObject.cpp     \
+-           $$PWD/QJsonParseError.cpp \
+-           $$PWD/QJsonValue.cpp      \
+-           $$PWD/QJsonValueRef.cpp   \
+-           $$PWD/QJsonParser.cpp
+diff --git QJson4.pro QJson4.pro
+index 10acba1..4fdb3e3 100644
+--- QJson4.pro
++++ QJson4.pro
+@@ -1,21 +1,29 @@
++QT -= gui
+ 
+-TEMPLATE = app
+-TARGET   = test
++TARGET = QJson4
++TEMPLATE = lib
++CONFIG += sharedlib
+ 
+-include($$PWD/QJson4.pri)
++SOURCES += \
++    QJsonValueRef.cpp \
++    QJsonValue.cpp \
++    QJsonParser.cpp \
++    QJsonParseError.cpp \
++    QJsonObject.cpp \
++    QJsonDocument.cpp \
++    QJsonArray.cpp
+ 
+-SOURCES += main.cpp
++HEADERS += \
++    QJsonValueRef.h \
++    QJsonValue.h \
++    QJsonRoot.h \
++    QJsonParser.h \
++    QJsonParseError.h \
++    QJsonObject.h \
++    QJsonDocument.h \
++    QJsonArray.h
+ 
+-CONFIG(debug, debug|release) {
+-	OBJECTS_DIR = $${OUT_PWD}/.debug/obj
+-	MOC_DIR     = $${OUT_PWD}/.debug/moc
+-	RCC_DIR     = $${OUT_PWD}/.debug/rcc
+-	UI_DIR      = $${OUT_PWD}/.debug/uic
+-}
+-
+-CONFIG(release, debug|release) {
+-	OBJECTS_DIR = $${OUT_PWD}/.release/obj
+-	MOC_DIR     = $${OUT_PWD}/.release/moc
+-	RCC_DIR     = $${OUT_PWD}/.release/rcc
+-	UI_DIR      = $${OUT_PWD}/.release/uic
++unix: {
++    target.path = @PREFIX@/lib
++    INSTALLS += target
+ }


### PR DESCRIPTION
#### Description

A library providing an API compatible with Qt5 JSON implementation:
https://github.com/eteran/qjson4

P. S. I need this to backport some improvements for QMPlay2 player.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
