### PR TITLE
libnotify: update to 0.8.1

### DIFF
--- a/devel/libnotify/Portfile
+++ b/devel/libnotify/Portfile
@@ -3,8 +3,10 @@
 PortSystem          1.0
 PortGroup           meson 1.0
 
+# Something was broken with gtk-docs target in 0.8.2:
+# https://gitlab.gnome.org/GNOME/libnotify/-/issues/38
 name                libnotify
-version             0.7.9
+version             0.8.1
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          devel gnome
 maintainers         nomaintainer
@@ -13,7 +15,6 @@ long_description \
                     The Desktop Notifications framework provides a standard way of doing \
                     passive pop-up notifications.
 
-platforms           darwin
 license             LGPL-2.1+
 
 homepage            http://library.gnome.org/devel/libnotify/
@@ -21,9 +22,9 @@ master_sites        gnome:sources/${name}/${branch}
 
 use_xz              yes
 
-checksums           rmd160  688b9378c50403c48dbccf607f60b9e384ee5528 \
-                    sha256  66c0517ed16df7af258e83208faaf5069727dfd66995c4bbc51c16954d674761 \
-                    size    98148
+checksums           rmd160  fcc1f33890d2f717522cc80a0818cc416f7f7969 \
+                    sha256  d033e6d4d6ccbf46a436c31628a4b661b36dca1f5d4174fe0173e274f4e62557 \
+                    size    105368
 
 depends_build-append \
                     port:pkgconfig \


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
