### PR TITLE
libpaper-utils: fix broken binaries

### DIFF
--- a/print/libpaper/Portfile
+++ b/print/libpaper/Portfile
@@ -26,6 +26,7 @@ long_description \
                 actions based on a system- or user-specified paper size.
 
 subport libpaper-utils {
+    revision    1
     # We introduce a subport for files with different licenses.
     # Including them in the 'libpaper' port would prevent the
     # distribution of MacPorts binary archives for some prominent
@@ -61,6 +62,12 @@ if {${subport} eq ${name}} {
     depends_lib-append  port:libpaper
 
     post-destroot {
+        # https://trac.macports.org/ticket/69112
+        foreach bin {paper paperconf} {
+            system "install_name_tool -change @rpath/libpaper.2.dylib \
+                  ${prefix}/lib/libpaper.2.dylib \
+                  ${destroot}${prefix}/bin/$bin"
+        }
         # remove library-related files (which are already present)
         delete "${destroot}${prefix}/etc"
         delete "${destroot}${prefix}/include"

--- a/print/libpaper/Portfile
+++ b/print/libpaper/Portfile
@@ -13,7 +13,7 @@ checksums       rmd160  6b3898d28155228927fa78f55bc747fbcd8e0bc2 \
                 sha256  1fda0cf64efa46b9684a4ccc17df4386c4cc83254805419222c064bf62ea001f \
                 size    1264200
 
-github.tarball_from  releases
+github.tarball_from releases
 
 categories      print
 # libpaper is LGPLv2.1+, paperspecs is public domain
@@ -31,29 +31,29 @@ subport libpaper-utils {
     # Including them in the 'libpaper' port would prevent the
     # distribution of MacPorts binary archives for some prominent
     # tools like Ghostscript or ImagicMagick.
-    description       The executables of the libpaper package
-    long_description  Provide the new 'paper' and deprecated 'paperconf' \
-                      utility programs that come with the libpaper \
-                      library. Both are used to print paper size \
-                      information.
+    description         The executables of the libpaper package
+    long_description    Provide the new 'paper' and deprecated 'paperconf' \
+                        utility programs that come with the libpaper \
+                        library. Both are used to print paper size \
+                        information.
     # `paper` is GPL-3+, `paperconf` is GPL-2
-    license           GPL-3+ GPL-2
+    license             GPL-3+ GPL-2
 }
 
 configure.args  --enable-relocatable \
                 --disable-silent-rules
 
 if {${subport} eq ${name}} {
-    test.run     yes
-    test.target  check
+    test.run    yes
+    test.target check
 
     post-destroot {
         # Using --enable-relocatable is unfortunately needed for the
         # tests to work, but we don't actually want to use rpath in the
         # installed library.
         system "install_name_tool -id \
-                  ${prefix}/lib/libpaper.2.dylib \
-                  ${destroot}${prefix}/lib/libpaper.2.dylib"
+                ${prefix}/lib/libpaper.2.dylib \
+                ${destroot}${prefix}/lib/libpaper.2.dylib"
         # remove `paper` and `paperconf`
         delete "${destroot}${prefix}/bin"
         delete "${destroot}${prefix}/share/man/man1"
@@ -65,8 +65,8 @@ if {${subport} eq ${name}} {
         # https://trac.macports.org/ticket/69112
         foreach bin {paper paperconf} {
             system "install_name_tool -change @rpath/libpaper.2.dylib \
-                  ${prefix}/lib/libpaper.2.dylib \
-                  ${destroot}${prefix}/bin/$bin"
+                ${prefix}/lib/libpaper.2.dylib \
+                ${destroot}${prefix}/bin/$bin"
         }
         # remove library-related files (which are already present)
         delete "${destroot}${prefix}/etc"


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/69112

#### Description

Currently installed binaries are unusable. Fix that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
