### PR TITLE
i2pd: update to 2.50.2

### DIFF
--- a/security/i2pd/Portfile
+++ b/security/i2pd/Portfile
@@ -7,7 +7,7 @@ PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 PortGroup               openssl 1.0
 
-github.setup            PurpleI2P i2pd 2.50.0
+github.setup            PurpleI2P i2pd 2.50.2
 revision                0
 categories              security net
 maintainers             {@barracuda156 gmail.com:vital.had} {@catap korins.ky:kirill} openmaintainer
@@ -16,9 +16,9 @@ description             End-to-End encrypted and anonymous Internet
 long_description        {*}${description}
 homepage                https://i2pd.website \
                         https://i2pd.readthedocs.io
-checksums               rmd160  80166b191ba457245a313e72e457e1a01f109954 \
-                        sha256  67c8ba5ea03b09fe2a85820f6d5b3025ad6c4301cbca3fa44c0accfbe5c7def7 \
-                        size    660300
+checksums               rmd160  3ce357d1d2344afe59f5923a997a0801ed986d84 \
+                        sha256  ae2ec4732c38fda71b4b48ce83624dd8b2e05083f2c94a03d20cafb616f63ca5 \
+                        size    663010
 github.tarball_from     archive
 
 depends_lib-append      port:zlib
@@ -68,12 +68,6 @@ if {${build_arch} in [list ppc ppc64]} {
     # https://github.com/boostorg/smart_ptr/issues/105
     configure.cxxflags-append \
                         -DBOOST_SP_USE_STD_ATOMIC
-}
-
-# Temporary fix for: https://github.com/PurpleI2P/i2pd/issues/1908
-# Drop once fixed in upstream release.
-if {(${configure.build_arch} in [list i386 ppc]) && [string match *gcc* ${configure.compiler}]} {
-    configure.ldflags-append -latomic
 }
 
 post-destroot {


### PR DESCRIPTION
#### Description

Update.
`-latomic` hack not needed anymore, upstream fixed atomics support detection.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
