### PR TITLE
SuiteSparse_GraphBLAS: workaround for El Capitan 10.11 and earlier

### DIFF
--- a/math/SuiteSparse/Portfile
+++ b/math/SuiteSparse/Portfile
@@ -65,6 +65,11 @@ subport SuiteSparse_GraphBLAS {
     compiler.cxx_standard   2011
     # OpenMP is essential for reasonable performance with GraphBLAS
     configure.args-append   -DGRAPHBLAS_USE_OPENMP=ON
+    # Workaround on El Capitan and earlier
+    # See https://github.com/DrTimothyAldenDavis/SuiteSparse/issues/735
+    if {${os.platform} eq "darwin" && ${os.major} <= 15} {
+        configure.args-append   -DGBNCPUFEAT=ON
+    }
 }
 
 subport SuiteSparse_LAGraph {


### PR DESCRIPTION
#### Description

This is a tentative workaround to fix the build on El Capitan and earlier. I tested that the package compiled with this flag on Sonoma, but I was unable to verify it directly on El Capitan. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
