### PR TITLE
include-what-you-use: use libc++ mapping file

### DIFF
--- a/devel/include-what-you-use/Portfile
+++ b/devel/include-what-you-use/Portfile
@@ -6,7 +6,7 @@ PortGroup           cmake 1.1
 
 github.setup        include-what-you-use include-what-you-use 0.21
 github.tarball_from archive
-revision            0
+revision            1
 categories          devel
 license             NCSA
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
@@ -36,7 +36,9 @@ post-destroot {
     xinstall -d ${destroot}${llvm_dir}/bin
     move ${destroot}${prefix}/bin/${name} ${destroot}${llvm_dir}/bin
     system -W "${destroot}${prefix}/bin" "
-        echo '#!/bin/sh\nexec xcrun ${llvm_dir}/bin/${name} \"$@\"' >${name} &&
+        echo '#!/bin/sh\nexec xcrun ${llvm_dir}/bin/${name} \
+            -Xiwyu --mapping_file=${llvm_dir}/include/c++/v1/libcxx.imp \
+            \"$@\"' >${name} &&
         chmod +x ${name}
     "
 }


### PR DESCRIPTION
#### Description

This leads to better results for C++ files.

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?