### PR TITLE
ruby-build: update to 20240116

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20231225 v
+github.setup        rbenv ruby-build 20240116 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,16 +17,11 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  72c8b12e72bb625c2cd3fe8f156b54c98123a050 \
-                    sha256  6e97008a983c24aa4e8674e68a5e41abaa6a111adc318f02e237d16cc68b498e \
-                    size    87325
+checksums           rmd160  d3ff3dc87c785ba9f5c4cec6b6c4301c1f2e12f6 \
+                    sha256  fa4bcc5d0f4535f536e34d4a8a6b68cbdb4449204c74ab0f92efcc2175fc1d34 \
+                    size    87795
 
 use_configure       no
 build {}
 destroot.cmd        ./install.sh
 destroot.env        PREFIX=${destroot}${prefix}
-
-notes {
-    The ruby-build port no longer installs rbenv automatically. If required, please
-    install the port rbenv manually.
-}


### PR DESCRIPTION
#### Description

ruby-build: update to 20240116

Also remove the note as the dependency on rbenv was removed in December
2022, so there should be no need to remind people of this fact any
longer.

##### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
