### PR TITLE
jdk21: update to 21.0.2

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      21.0.1
+version      21.0.2
 revision     0
 
 description  Oracle Java SE Development Kit 21
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/21/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  719e5af9e8dc49947c2fd2cb02720d24c5098ad9 \
-                 sha256  1aba93aea7da081df4ad393fb7eca69e04111d7c4a395b43d5d7d45945d6a671 \
-                 size    193119291
+    checksums    rmd160  c3011bf9e5682f8f12048730b535e881e233f0ac \
+                 sha256  197a923b1f7ea2b224fafdfb9c3ef5fc8eb197d9817d7631d96da02b619f5975 \
+                 size    193307033
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  1f9430e284d5ec4b35eeb63937b3bb6145919991 \
-                 sha256  465a7a6cb2144b63876aa86ac4e294157db9eabad9740542218d198515071e6f \
-                 size    190761631
+    checksums    rmd160  52ea466df3eb3f27b67d11868b9d68ddbd054530 \
+                 sha256  4b94951f03efe44cb6656e43f1098db3ce254a00412f9d22dff18a8328a7efdd \
+                 size    190953252
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 21.0.2.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?