### PR TITLE
jdk17: update to 17.0.10

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk17-mac
-version      17.0.9
+version      17.0.10
 revision     0
 
 description  Oracle Java SE Development Kit 17
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/17/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  53f15befd2ef0a6ca17de4a846b0c1638daa3e9e \
-                 sha256  336f3d0cfd3cac9b16c14830a43c1ee3f63810b0dae2f3e17a824185b83e3e85 \
-                 size    178913008
+    checksums    rmd160  2272fd55801daf37148ac21f7ed060f1674cf2da \
+                 sha256  7b68b833f392aa543ba538f94c60fd477581fef96a9c1ae059fa4158e9ce75ff \
+                 size    178930871
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  dfa7fddd185f6ccad9dc07b9652449702736fa9f \
-                 sha256  b65346d61ccfef1ba0fc994709295d196007d5fef1a0aa8c0f2eaf97bdd530b7 \
-                 size    176350219
+    checksums    rmd160  bfe8ef24aae795bc177732962688d244739ebdc4 \
+                 sha256  d5bec93922815e9337040678ddf3f40e50b63c2b588cf63574fa1f2010206042 \
+                 size    176369331
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 17.0.10.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?