### PR TITLE
jdk21-graalvm: update to 21.0.2

### DIFF
--- a/java/jdk21-graalvm/Portfile
+++ b/java/jdk21-graalvm/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava21-mac
 supported_archs  x86_64 arm64
 
-version     21.0.1
+version     21.0.2
 revision    0
 
 master_sites https://download.oracle.com/graalvm/21/archive/
@@ -33,17 +33,17 @@ long_description Oracle GraalVM for JDK 21 compiles your Java applications ahead
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  e2ecd742af1fac4d0811a96b4fbd6fb078613415 \
-                 sha256  0647d57ec98d7aa19d2801b3ec58697d7eb44a408df511bd49d39f0150a08f87 \
-                 size    316619362
+    checksums    rmd160  0323837a61555d485fa14ca5f307073402ed63ce \
+                 sha256  3e24632f27be74d039508ea2b0b7862ef8c40784f55785cf6b6e40b4b28d9d53 \
+                 size    316581361
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  7e8696ef1a8d8d5e89da7ed8b35195ee8b56df50 \
-                 sha256  4b5ddffad649b3e64853ba230b6e8f7acd65322bb8f11852e0521ab1bb4d8b03 \
-                 size    329260794
+    checksums    rmd160  73e08ce8d9755306ec3575b03b4cae9cb0313a60 \
+                 sha256  b504f7c570836a9c6b1b92813c5123718636d0ff0f832321129a4fe3a7b9a0b3 \
+                 size    329328620
 }
 
-worksrcdir   graalvm-jdk-${version}+12.1
+worksrcdir   graalvm-jdk-${version}+13.1
 
 variant Applets \
     description { Advertise the JVM capability "Applets".} {}


### PR DESCRIPTION
#### Description

Update to GraalVM for JDK 21.0.2.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?