### PR TITLE
py27-protobuf3: revert to last compatible version

### DIFF
--- a/python/py-protobuf3/Portfile
+++ b/python/py-protobuf3/Portfile
@@ -5,7 +5,7 @@ PortGroup       compiler_blacklist_versions 1.0
 PortGroup       python 1.0
 PortGroup       github 1.0
 
-# note the python package is a major version greater than the cpp package 
+# note the python package is a major version greater than the cpp package
 set release_version \
                 21.12
 name            py-protobuf3
@@ -64,6 +64,20 @@ if {${name} ne ${subport}} {
                     port:protobuf3-cpp \
                     port:py${python.version}-six
 
+    if {${python.version} == 27} {
+        # Use the last compatible version.
+        set release_version \
+                        17.3
+        version         3.${release_version}
+        revision        0
+        checksums       sha256  3253c6d17ec0bb6f6382e555cf5ca0a9ffab8d81b691f100f96ce9f5e753018e \
+                        rmd160  548d88f3d75b8c75fe43eb0d620e8f40757e1566 \
+                        size    5038061
+        github.setup    google protobuf ${version} v
+        master_sites    https://github.com/google/protobuf/releases/download/v${release_version}
+        distfiles       protobuf-python-${version}.tar.gz
+    }
+
     if {${python.version} > 36} {
            depends_lib-append \
                port:py${python.version}-flatbuffers
@@ -71,11 +85,13 @@ if {${name} ne ${subport}} {
 
     worksrcdir      ${worksrcdir}/python
 
-    # tricks to force the right -stdlib setting
-    # and to put a needed CXX flag on the 10.6 build
-    # see https://trac.macports.org/ticket/56482
-    patchfiles-append \
+    if {${python.version} > 27} {
+        # tricks to force the right -stdlib setting
+        # and to put a needed CXX flag on the 10.6 build
+        # see https://trac.macports.org/ticket/56482
+        patchfiles-append \
                     patch-py-protobuf3-settings.diff
+    }
 
     if {${python.version} >= 311} {
         patchfiles-append \
@@ -107,10 +123,12 @@ if {${name} ne ${subport}} {
     }
 
 
-    test.run        yes
-    python.test_framework
-    test.cmd        "${python.bin} setup.py"
-    test.target     test --cpp_implementation
+    if {${python.version} > 27} {
+        test.run        yes
+        python.test_framework
+        test.cmd        "${python.bin} setup.py"
+        test.target     test --cpp_implementation
+    }
 }
 
 github.livecheck.regex  {([0-9.]+)}


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/67518

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
