### PR TITLE
jdk17-graalvm: update to 17.0.10

### DIFF
--- a/java/jdk17-graalvm/Portfile
+++ b/java/jdk17-graalvm/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava17-mac
 supported_archs  x86_64 arm64
 
-version     17.0.9
+version     17.0.10
 revision    0
 
 master_sites https://download.oracle.com/graalvm/17/archive/
@@ -33,14 +33,14 @@ long_description Oracle GraalVM for JDK 17 compiles your Java applications ahead
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  18ad02606012513fb15ed2a4f5963640baf30080 \
-                 sha256  29dc9855874e6633df21fd00902ca99ae4a6527add708cee58c84ac61e78c626 \
-                 size    313382790
+    checksums    rmd160  500f10cf0aaf60703151eb2538acd11bff137306 \
+                 sha256  14f4bd6417809905f86e786c779d0fc2feb840d7dac35ae3503eb25af0530da0 \
+                 size    313651594
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  69b2ecc375b7ec5147a13130d599b1865339bd05 \
-                 sha256  2214b6ecb32faacc84dffcbfae930450abe77c31730c4b6310e22d8f743959a5 \
-                 size    367115949
+    checksums    rmd160  1fcf801b00f2df5b7227ac8300440b6ff299117c \
+                 sha256  e944c5ce5da56e683fc8f1a57191b46d9cb702930b1688bda064fcf467d876b8 \
+                 size    367385416
 }
 
 worksrcdir   graalvm-jdk-${version}+11.1


### PR DESCRIPTION
#### Description

Update to GraalVM for JDK 17.0.10.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?