### PR TITLE
openjdk21: update to 21.0.2

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk21
 # See https://github.com/openjdk/jdk21u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             21.0.1
-set build 12
+version             21.0.2
+set build 13
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,9 +19,9 @@ master_sites        https://git.openjdk.java.net/jdk21u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk21u-${distname}
 
-checksums           rmd160  1466d1c7bce4e5997d2a6a9e5bff15321348fdc0 \
-                    sha256  4414ebc898e53489c2325ff6cb1a73640840f31c2fd671bd598e23c8a87e88ad \
-                    size    112241360
+checksums           rmd160  840b44086b26c773b28e9a6f3333c6769e5bc41f \
+                    sha256  17eda717843ffbbacc7de4bdcd934f404a23a57ebb3cda3cec630a668651531f \
+                    size    112252812
 
 depends_lib         port:freetype
 depends_build       port:openjdk21-zulu \


### PR DESCRIPTION
#### Description

Update to OpenJDK 21.0.2.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?