### PR TITLE
openjdk21-graalvm: update to 21.0.2

### DIFF
--- a/java/openjdk21-graalvm/Portfile
+++ b/java/openjdk21-graalvm/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version     21.0.1
-set build 12
+version     21.0.2
+set build 13
 revision    0
 
 description  GraalVM Community Edition based on OpenJDK 21
@@ -26,14 +26,14 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-community-jdk-${version}_macos-x64_bin
-    checksums    rmd160  0b88d7e121eb9ae0c9c9a7f68d70fd04930f94f0 \
-                 sha256  dafe240fb9e420cfef84ad8871b85cffc64988fd5520c4601e15b04687317a6a \
-                 size    281488634
+    checksums    rmd160  ba74a936ce5b22b3525dc91a4918efb9a16bb391 \
+                 sha256  7a8aa93fa45d1721908477abf4732a32637d420ffcb66ada9fb6456440b0d9e1 \
+                 size    281788205
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-community-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  2a8d93b1ce44dd0c77497fef12237dc6b83a9d3d \
-                 sha256  50c42bc748e528a9702eaa66e894cf6d125a19b91f1df1c3a484bdcf02feff44 \
-                 size    294239130
+    checksums    rmd160  39e18ded954e06bfd4132615e3b47ca9c3655928 \
+                 sha256  515e3a93acc7e1938daba83eda4272e5495fd302d7cdd99ec7ebf408ed505ab7 \
+                 size    294564421
 }
 
 worksrcdir   graalvm-community-openjdk-${version}+${build}.1


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 21.0.2.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?