### PR TITLE
openjdk21-oracle: update to 21.0.2

### DIFF
--- a/java/openjdk21-oracle/Portfile
+++ b/java/openjdk21-oracle/Portfile
@@ -14,24 +14,24 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://jdk.java.net/21/
-version      21.0.1
+version      21.0.2
 revision     0
 
 description  Oracle OpenJDK 21
 long_description Open-source Oracle build of OpenJDK 21, the Java Development Kit, an implementation of the Java SE Platform.
 
-master_sites https://download.java.net/java/GA/jdk${version}/415e3f918a1f4062a0074a2794853d0d/12/GPL/
+master_sites https://download.java.net/java/GA/jdk${version}/f2283984656d49d69e91c558476027ac/13/GPL/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     openjdk-${version}_macos-x64_bin
-    checksums    rmd160  314515d3ab5cf47134d62f9b57fa9fb672d2d6ac \
-                 sha256  1ca6db9e6c09752f842eee6b86a2f7e51b76ae38e007e936b9382b4c3134e9ea \
-                 size    199707267
+    checksums    rmd160  d26458966b57c86f71198d8d89945773a55065f2 \
+                 sha256  8fd09e15dc406387a0aba70bf5d99692874e999bf9cd9208b452b5d76ac922d3 \
+                 size    199891097
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     openjdk-${version}_macos-aarch64_bin
-    checksums    rmd160  c54e71c09b625b50af5189a7fe315a09ace647ff \
-                 sha256  9760eaa019b6d214a06bd44a304f3700ac057d025000bdfb9739b61080969a96 \
-                 size    197340389
+    checksums    rmd160  29400ca0c1c6e000b6522d11cf962c93f1dafa40 \
+                 sha256  b3d588e16ec1e0ef9805d8a696591bd518a5cea62567da8f53b5ce32d11d22e4 \
+                 size    197537405
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle OpenJDK 21.0.2.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?