### PR TITLE
privoxy: ECC changes

### DIFF
--- a/www/privoxy/Portfile
+++ b/www/privoxy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                privoxy
 version             3.0.34
-revision            0
+revision            1
 categories          www security net
 platforms           darwin
 license             GPL-2
@@ -352,7 +352,7 @@ if {${name} eq ${subport}} {
                 "sh <<TLS_PRIVOXY_ROOT_CA
                 # initialize
                 touch index.txt
-                echo 1000 > serial
+                echo '01' > serial
 
                 # CA encrypted key
                 # EC
@@ -369,7 +369,7 @@ if {${name} eq ${subport}} {
 
                 # CA certificate
                 openssl req -config openssl.cnf \\
-                    -new -x509 -days 1460 -sha256 \\
+                    -new -x509 -days 1460 -sha384 \\
                     -extensions v3_ca \\
                     -out certs/ca.cert.pem -key private/ca.key.pem \\
                     -passin file:private/passphrase.txt -batch
@@ -456,7 +456,7 @@ TLS_PRIVOXY_ROOT_CA
             #     -pass file:private/passphrase.txt
 
             # Certificate PEM, DER, and P12
-            openssl req -config openssl.cnf -new -x509 -days 3650 -sha256 \\
+            openssl req -config openssl.cnf -new -x509 -days 3650 -sha384 \\
                 -extensions v3_ca -out certs/ca.cert.pem \\
                 -key private/ca.key.pem -passin file:private/passphrase.txt \\
                 -batch

--- a/www/privoxy/files/openssl.cnf
+++ b/www/privoxy/files/openssl.cnf
@@ -45,7 +45,7 @@
 
 # CA certificate
 # openssl req -config openssl.cnf \
-#     -new -x509 -days 3650 -sha256 -extensions v3_ca -out certs/ca.cert.pem \
+#     -new -x509 -days 3650 -sha384 -extensions v3_ca -out certs/ca.cert.pem \
 #     -key private/ca.key.pem -passin file:private/passphrase.txt -batch
 
 # CA certificate text verification

--- a/www/privoxy/files/patch-ssl_common.h.diff
+++ b/www/privoxy/files/patch-ssl_common.h.diff
@@ -19,7 +19,7 @@
 +/*
 + * See <openssl/obj_mac.h>
 + */
-+#define EC_GROUP_NAME                    SN_secp384r1      /* EC group name */
++#define EC_GROUP_NAME                    SN_X9_62_prime256v1 /* EC group name */
 +#endif
 +
  #define ERROR_BUF_SIZE                   1024              /* Size of buffer for error messages */


### PR DESCRIPTION
* Use (much faster) prime256v1 for generated certificates and default SHA-256 digest
* Use appropriate SHA-384 digest for P-384 CA example

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
