### PR TITLE
openjdk17-zulu: update to 17.48.15

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.46.19
+version      17.48.15
 revision     0
 
-set openjdk_version 17.0.9
+set openjdk_version 17.0.10
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  fd8f5f3c2ada6d311e7703ae466f8b4921363ad3 \
-                 sha256  19271b74c3f3b21f4978eda8f09908c063c456cea57265d71475ceefef5aa0ac \
-                 size    194260499
+    checksums    rmd160  74a23bb2e685acab7c3e3a523c43f50e967453dd \
+                 sha256  86e48a1af3a7ac4500884d8c25b7475ad176b1a78b19a424665957cc3a3ca3e8 \
+                 size    194280558
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  b707761c64657cde18ad62b54894e5704300d200 \
-                 sha256  d6837676e55b97772b6512e253fdaf8ab282bb216c0f8366b6c5905cd02b5056 \
-                 size    192126889
+    checksums    rmd160  d42f4f65e342f65cf3b0bae6a4e5c925b30a9f86 \
+                 sha256  92e1221d291be1616d3c1de6d00f7af0b3d9c3b5a5d2c2aaba16f30c5f2f412f \
+                 size    192149620
 }
 
 worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.48.15 (OpenJDK 17.0.10).

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?