### PR TITLE
openjdk17: update to 17.0.10

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk17
 # See https://github.com/openjdk/jdk17u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             17.0.9
-set build 8
+version             17.0.10
+set build 11
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,15 +19,16 @@ master_sites        https://git.openjdk.java.net/jdk17u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk17u-${distname}
 
-checksums           rmd160  63df3fe18f78d7d604abead60d44150c80ad318a \
-                    sha256  365c6b7d506f25e2249cac7658ada8b72b8652ceb15bbc8316de3e6fe8ea0976 \
-                    size    106427433
+checksums           rmd160  dab270e839d8b9d06e4f9675920a323a4a320dc3 \
+                    sha256  fac2539384ba8d86cdcf3553e69aaf4001a3cec1134bbf6f5f04f64f0acbc055 \
+                    size    106398664
 
 depends_lib         port:freetype
 depends_build       port:openjdk17-bootstrap \
                     port:autoconf \
                     port:gmake \
                     port:bash
+depends_run         port:libiconv
 
 pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.10.

This also adds `libiconv` as run dependency. Closes: https://trac.macports.org/ticket/68278

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?