### PR TITLE
openjdk21: add libiconv as a run dependency

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -6,7 +6,7 @@ name                openjdk21
 # See https://github.com/openjdk/jdk21u/tags for the version and build number that matches the latest tag that ends with '-ga'
 version             21.0.2
 set build 13
-revision            0
+revision            1
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -28,6 +28,7 @@ depends_build       port:openjdk21-zulu \
                     port:autoconf \
                     port:gmake \
                     port:bash
+depends_run         port:libiconv
 
 pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4


### PR DESCRIPTION
#### Description

Add `libiconv` as a run dependency. Fixes https://trac.macports.org/ticket/68278 for `openjdk21`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?