### PR TITLE
openjdk11: update to 11.0.22

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk11
 # See https://github.com/openjdk/jdk11u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             11.0.21
-set build 9
+version             11.0.22
+set build 7
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,15 +19,16 @@ master_sites        https://git.openjdk.java.net/jdk11u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk11u-${distname}
 
-checksums           rmd160  e7dfdc7ff99070622fe746304623c503bf4a2292 \
-                    sha256  b89e87c38640c586857ae6108b3f9c3211337e4cd5d8913c8d56d66bdccab014 \
-                    size    116292058
+checksums           rmd160  99ff7e4128c9082f7da5e29059015fe4a6604c69 \
+                    sha256  5ed47173679cdfefa0cb9fc92d443413e05ab2e157a29bb86e829d7f6a80913a \
+                    size    116235391
 
 depends_lib         port:freetype
 depends_build       port:autoconf \
                     port:gmake \
                     port:bash \
                     port:openjdk11-bootstrap
+depends_run         port:libiconv
 
 pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4


### PR DESCRIPTION
#### Description

Update to OpenJDK 11.0.22.

Also adds `libiconv` as a run dependency, to fix https://trac.macports.org/ticket/68278 for `openjdk11`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?