### PR TITLE
openjdk8: add libiconv as run dependency

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -12,7 +12,7 @@ set update 372
 # Set to the build of the 'jdk8u${update}-b${build}' tag that corresponds to the latest tag with '-ga'
 set build 07
 version             ${major}u${update}
-revision            1
+revision            2
 categories          java devel
 supported_archs     ppc x86_64 arm64
 license             GPL-2+
@@ -50,6 +50,7 @@ depends_build       port:autoconf \
                     port:gmake \
                     port:pkgconfig \
                     port:bash
+depends_run         port:libiconv
 
 set tpath /Library/Java
 use_xcode           yes


### PR DESCRIPTION
#### Description

Add `libiconv` as a run dependency to fix https://trac.macports.org/ticket/68278 for `openjdk8`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?