### PR TITLE
openjdk8-zulu: update to 8.76.0.17

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      8.74.0.17
+version      8.76.0.17
 revision     0
 
-set openjdk_version 8.0.392
+set openjdk_version 8.0.402
 
 description  Azul Zulu Community OpenJDK 8 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  fb8e8bb7390e9919bda571fd4d99ff9f6c1d7157 \
-                 sha256  ab29ecd51033c8804cd0711c225266c3b757518c90040cb279e329bf1eb9b387 \
-                 size    106613490
+    checksums    rmd160  8947d7c00cc6a001a201ed76ed986940da1a6686 \
+                 sha256  79d66a0c4b327500831300b56420c5fcc8d65539ee40d59c291da4fd18da2042 \
+                 size    106619658
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  a35839f6ce4efc0e393d4f30a39e2daccaea296f \
-                 sha256  51b5187e3d50fd469a67c4a9e2e816cb14e6247a51a24d8a96b88d2bdc512714 \
-                 size    104523687
+    checksums    rmd160  347c1e9fa66bf8e5f99ba56dd75cafdc10f0fdab \
+                 sha256  d153e53ae341dfd8039d4fa92b40c64d25234c74ed628c5a460dd80f62f22d78 \
+                 size    104513477
 }
 
 worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.76.0.17 (OpenJDK 8u402).

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?