### PR TITLE
openjdk21-corretto: update to 21.0.2.13.1

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -6,9 +6,9 @@ name             openjdk21-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://github.com/corretto/corretto-21/blob/release-21.0.1.12.1/CHANGELOG.md
+# See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto
 # and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms        {darwin any} {darwin >= 20}
+platforms        {darwin any} {darwin >= 21}
 
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -19,7 +19,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-21/releases
-version      21.0.1.12.1
+version      21.0.2.13.1
 revision     0
 
 description  Amazon Corretto OpenJDK 21 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  191a6fcd2423674560c580a343472fcf19ee8d2a \
-                 sha256  cafff566097c6f440afe5aac6e268073d8b5ceadcf7898eeb364753d00743074 \
-                 size    202914841
+    checksums    rmd160  c95951b3d03d6b750beb8bac79993672305735b4 \
+                 sha256  c8629aaabb7641220f61797ea08d9b8c50f15a989c67363f5075fb20ff2c7679 \
+                 size    203261361
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  0f0628ac3cc80773524b600784634d3416a52844 \
-                 sha256  0c4e08fc4b7c0c887651a97f315d6995eeac38627eb7bca0cb3c698d21af349f \
-                 size    200716011
+    checksums    rmd160  f5337b9494c8d88fe36337cfd9d7d64d031c9b12 \
+                 sha256  14bb4b9146a15daad93b273a952f88f4e0e6256b2cdd9f45c1447555000a27ac \
+                 size    201066708
 }
 
 worksrcdir   amazon-corretto-21.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 21.0.2.13.1.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?