### PR TITLE
openjdk17-corretto: update to 17.0.10.7.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -6,9 +6,9 @@ name             openjdk17-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://github.com/corretto/corretto-17/blob/release-17.0.9.8.1/CHANGELOG.md
+# See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto
 # and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms        {darwin any} {darwin >= 20}
+platforms        {darwin any} {darwin >= 21}
 
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -19,7 +19,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.9.8.1
+version      17.0.10.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  7022d6eac1e19f4ae0ea4d0d6c737c59b5534ef8 \
-                 sha256  7eed832eb25b6bb9fed5172a02931804ed0bf65dc86a2ddc751aa7648bb35c43 \
-                 size    188321953
+    checksums    rmd160  77a3b7b6e190dd80ed3f2214852f1fc10eef2413 \
+                 sha256  03b56d0cc1d0d62f4cf6f1eb365380cad19fc35bc7a42051c6735183b78e3323 \
+                 size    188439197
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  3f8134fe8c3c1c28beef2dcf827ea123eeb9b150 \
-                 sha256  8a0c542e78e47cb5de1db40763692d55b977f1d0b31c5f0ebf2dd426fa33a2f4 \
-                 size    186351524
+    checksums    rmd160  d34a7592e9db95d28ff39e5ecc2dc78f1ef81e5e \
+                 sha256  8bea3c09966e0d44c56f61d31d28c12a8df8d8ec0ef18ed2f6146c303abae754 \
+                 size    186538073
 }
 
 worksrcdir   amazon-corretto-17.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.10.7.1.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?