### PR TITLE
openjdk11-corretto: update to 11.0.22.7.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -6,9 +6,9 @@ name             openjdk11-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://github.com/corretto/corretto-11/blob/release-11.0.21.9.1/CHANGELOG.md
+# See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto
 # and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
-platforms        {darwin any} {darwin >= 20}
+platforms        {darwin any} {darwin >= 21}
 
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -19,7 +19,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      11.0.21.9.1
+version      11.0.22.7.1
 revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  3d707310a4f54d0b5ca97718e9c27abd6a07576f \
-                 sha256  2ce6100b43b102dbd631ec53c14b39b5251e319e431dc4cae2abf5059d2e04fd \
-                 size    188103525
+    checksums    rmd160  39fea7de5639fae58ab4869e4764188abdaafda1 \
+                 sha256  820ed56b43c1f61b329a6b1af0e2dea2af62b3ec0523b1d7bb6af08e4b893204 \
+                 size    187626669
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  8f0fb57a27b258995a5b5bded86bdd59bc4b6043 \
-                 sha256  c5f5a059203de3b1b3c239331082f36dcad0f261c80a1766e2dc7ab46807f6bd \
-                 size    186393704
+    checksums    rmd160  cba79e0f01d5e0907d9e6b95bba1b4b0e9be2b28 \
+                 sha256  f0f2794187d6af76ce65d70a7f483ee61b991280f055af8ce0196c2f06f8b73e \
+                 size    185207203
 }
 
 worksrcdir   amazon-corretto-11.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.22.7.1.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?