### PR TITLE
openjdk8-corretto: update 8.402.07.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -6,9 +6,9 @@ name             openjdk8-corretto
 categories       java devel
 maintainers      {breun.nl:nils @breun} openmaintainer
 
-# See https://github.com/corretto/corretto-8/blob/release-8.392.08.1/CHANGELOG.md for minimum supported OS version
-# macOS 11 → Darwin 20 (https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version)
-platforms        {darwin any} {darwin >= 20}
+# See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto for minimum supported OS version
+# macOS 12 → Darwin 21 (https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version)
+platforms        {darwin any} {darwin >= 21}
 
 # This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
 license          GPL-2 NoMirror
@@ -19,7 +19,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      8.392.08.1
+version      8.402.07.1
 revision     0
 
 description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  4a055f2b8cacf5acb5cc277b1ac5df25986b4ddf \
-                 sha256  2ea69e415912f7ad5358d016b1a82068e36c2a625d8573cd28c1c2a9a5b39cba \
-                 size    118773590
+    checksums    rmd160  d76b560c56636cc208bf29d07fce8305b04a2f6a \
+                 sha256  b5eaa548b0d0582564d692a9ca247e7c90acfa27e535b5ce7b0bcd1994826329 \
+                 size    118453867
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  063ccc2bd0d79220a6472ba3c30dd169584c2d2c \
-                 sha256  eb1aedaad5505605f17a81692f9882edbcb69f34494330dd5cd2a31f65bbd0e0 \
-                 size    103788913
+    checksums    rmd160  4efdcd68df1f586b7a982d407fd5b8c450a888f6 \
+                 sha256  040452fbcad94ecb24dab9e715bb32a8711acde48a98b51164704e90d550d638 \
+                 size    102893896
 }
 
 worksrcdir   amazon-corretto-8.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.402.07.1.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?