### PR TITLE
openjdk17-sap: update to 17.0.10

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.9
+version      17.0.10
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  6392ec3c2a38083a96da87bcf1cdae6bd4c612c5 \
-                 sha256  b025d24f1ae1ab0834b262ea0ff4c4f0fd823ad88732d444a3ec676d8d2d1952 \
-                 size    180760527
+    checksums    rmd160  458aa35e154fcf9aec0dbfd54e12fe681c299173 \
+                 sha256  e46767f542377315bd7986454cbc227711ae89c0e273ec51c6dd65177062a914 \
+                 size    188267984
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  de1be3a553635868d5580176d7a312d0d865240a \
-                 sha256  dd731745e9b43e589bde40535368376b4e11452377a40848ff05eca19c54bf24 \
-                 size    178654317
+    checksums    rmd160  3c8bc616c2e0712c885631ad424a08b0633cbf1a \
+                 sha256  5f52866432a5b4df193b332cce51195e5f3b1bdd5507338c10c125d8a3e2bbdc \
+                 size    186151337
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SapMachine 17.0.10.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?