### PR TITLE
openjdk11-sap: update to 11.0.22

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/11
 supported_archs  x86_64 arm64
 
-version      11.0.21
+version      11.0.22
 revision     0
 
 description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  364e644607b4c338e9f185e377882f1504c6f0a5 \
-                 sha256  76d90d33a25ff61227e178034876c6877dc051933d0af57403b43e8a4b2feb65 \
-                 size    187603436
+    checksums    rmd160  973cc8d65024408ff3a4a432e014a11e57ecb88f \
+                 sha256  b2908cd13e39e13aadbf15b8bcbec0710158b3a6ab43a1fcbece03a8c991de59 \
+                 size    187600512
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  3e730cb01d85a4aff8b8972ec77c4ad1febaf707 \
-                 sha256  3a1a0e45d6de1fdc6874ea91f63713e3cd3e3663865bbe97941e0f8872b2907e \
-                 size    185731157
+    checksums    rmd160  fc803208f350ed476227f6e4338fb0268d2103f6 \
+                 sha256  682c9ef9597e4ee9fef49b24d6b4f44316052553008c23efca6a89eb0344507d \
+                 size    185714756
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SapMachine 11.0.22.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?