### PR TITLE
py-pulp: update to 2.8.0 and add py312 subport

### DIFF
--- a/python/py-pulp/Portfile
+++ b/python/py-pulp/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        coin-or pulp 2.7.0
+github.setup        coin-or pulp 2.8.0
 revision            0
 name                py-${github.project}
 github.tarball_from tarball
@@ -23,14 +23,13 @@ long_description    PuLP is an LP modeler written in Python. PuLP can generate M
 
 homepage            https://coin-or.github.io/pulp/
 
-checksums           rmd160  4d38dc7b0a50a1c04dae849e3bba970d35ef9177 \
-                    sha256  7434e4213b4486b6c50434022c472451d8819c78f34db2153dfe8d85ade07920 \
-                    size    28002026
+checksums           rmd160  a378276a676bd186ac77b8de363f5e389092cb9c \
+                    sha256  0235b020862e14e8419c9a4e904a8b9f0f2e379cdb15cd17c694c8c9e609bf57 \
+                    size    31433659
 
-python.versions     39 310 311
+python.versions     39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-pytest-runner \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-pytest-runner
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update `py-pulp` to version 2.8.0 and add py312 subport.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
