### PR TITLE
htop: unbreak build on < 10.9

### DIFF
--- a/sysutils/htop/Portfile
+++ b/sysutils/htop/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        htop-dev htop 3.3.0
-revision            0
+revision            1
 epoch               1
 
 checksums           rmd160  32f836bc4016f2ebf6b2332396993baad5c69ee6 \
@@ -13,7 +13,6 @@ checksums           rmd160  32f836bc4016f2ebf6b2332396993baad5c69ee6 \
                     size    406099
 
 categories          sysutils
-platforms           darwin
 maintainers         {cal @neverpanic} openmaintainer
 license             GPL-2
 
@@ -22,12 +21,18 @@ long_description    ${name} is {*}${description} systems. It aims to be a better
 
 homepage            https://htop.dev
 
-depends_build       port:autoconf \
+depends_build-append \
+                    port:autoconf \
                     port:automake \
                     port:libtool \
                     port:pkgconfig
 
-depends_lib         port:ncurses
+depends_lib-append  port:ncurses
+
+# https://github.com/htop-dev/htop/pull/1381
+patchfiles-append   0001-darwin-Platform.c-use-mach-port.h.patch
+# https://github.com/htop-dev/htop/pull/1383
+patchfiles-append   0002-darwin-PlatformHelpers-fix-CPU-detection-for-PowerPC.patch
 
 pre-configure {
     system -W ${worksrcpath} "sh autogen.sh"

--- a/sysutils/htop/files/0001-darwin-Platform.c-use-mach-port.h.patch
+++ b/sysutils/htop/files/0001-darwin-Platform.c-use-mach-port.h.patch
@@ -1,0 +1,24 @@
+From 541c17c975bc8a4f1f243e568006b0e26ae52c47 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sun, 4 Feb 2024 09:28:26 +0800
+Subject: [PATCH] darwin/Platform.c: use mach/port.h
+
+Unbreak builds on macOS versions where _mach_port_t.h does not exist.
+mach/port.h exists on every macOS and has needed defines.
+---
+ darwin/Platform.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git darwin/Platform.c darwin/Platform.c
+index 387910e1..77b9bcdc 100644
+--- darwin/Platform.c
++++ darwin/Platform.c
+@@ -18,7 +18,7 @@ in the source distribution for its full text.
+ #include <net/if_types.h>
+ #include <net/route.h>
+ #include <sys/socket.h>
+-#include <sys/_types/_mach_port_t.h>
++#include <mach/port.h>
+ 
+ #include <CoreFoundation/CFBase.h>
+ #include <CoreFoundation/CFDictionary.h>

--- a/sysutils/htop/files/0002-darwin-PlatformHelpers-fix-CPU-detection-for-PowerPC.patch
+++ b/sysutils/htop/files/0002-darwin-PlatformHelpers-fix-CPU-detection-for-PowerPC.patch
@@ -1,0 +1,27 @@
+From 497a1e3a4fc254e882745e37f2eb7d9131d0b56a Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Thu, 18 Jan 2024 12:39:56 +0800
+Subject: [PATCH] darwin/PlatformHelpers: fix CPU detection for PowerPC
+
+Closes: https://github.com/htop-dev/htop/issues/1382
+Notice, that hw.cpusubtype outputs a numerical code of a CPU.
+For PowerPC, 100 = G5, 11 = ppc7450, 10 = ppc7400.
+---
+ darwin/PlatformHelpers.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git darwin/PlatformHelpers.c darwin/PlatformHelpers.c
+index a4ea82be..b52346eb 100644
+--- darwin/PlatformHelpers.c
++++ darwin/PlatformHelpers.c
+@@ -60,6 +60,10 @@ bool Platform_KernelVersionIsBetween(KernelVersion lowerBound, KernelVersion upp
+ 
+ void Platform_getCPUBrandString(char* cpuBrandString, size_t cpuBrandStringSize) {
+    if (sysctlbyname("machdep.cpu.brand_string", cpuBrandString, &cpuBrandStringSize, NULL, 0) == -1) {
++   #ifdef __POWERPC__
++      if (sysctlbyname("hw.cpusubtype", cpuBrandString, &cpuBrandStringSize, NULL, 0) != -1)
++         return;
++   #endif
+       fprintf(stderr,
+          "WARN: Unable to determine the CPU brand string.\n"
+          "errno: %i, %s\n", errno, strerror(errno));


### PR DESCRIPTION
#### Description

The PR addresses one bug and one minor issue:
1. Fixes headers for older systems and thus fixes the build.
2. Solves an unnecessary warning re unknown CPU for PowerPC. As far as I can see that value is only used for aarch64, so we just need to get _some_ meaningful output. `hw.cpusubtype` delivers that. More details in the issue referred in the portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

macOS 14.2.1
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
