### PR TITLE
symfony-cli: update to 5.8.2

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.1
+version             5.8.2
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  98d6b1a6e940f157eed1c4531412726eeb123dee \
-                        sha256  c19477856c4cf78e25984f9d0c76bc77d74a4c0b7e92e6f3d4e9dfe00d4e76bd \
-                        size    262165
+    checksums           rmd160  ebb4dcb67e8dbcedd1bcc5ab197bdb96d0a738a8 \
+                        sha256  e800fc176e0576a70c1740a62d8b1296c6d30ffed50d1908ed6c26234bd400e9 \
+                        size    262043
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  c4aea7d7351cc033aacd419e94e8837296e87102 \
-                        sha256  75c3df5aa16e568913a3a2c5eb2962ead04a6903109aba928091e19956812d56 \
-                        size    11147959
+    checksums           rmd160  c64a98eee60ef5a92e99c48d4d2cc0ca4f2ab9d9 \
+                        sha256  7f01a0718d6d446b9195b73edcdc9dccdeafa909495ebdda1d51301cb44bb499 \
+                        size    11147341
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.2

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
