### PR TITLE
emacs{,-app}: update to 29.2; emacs{,-app}-devel: update to 20240118

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -115,16 +115,16 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
 
     # do not forget to check that configure hasn't introduce some suprises via
     # git diff [old]..[new] -- '**/configure.ac'
-    github.setup    emacs-mirror emacs d9462e24a967e32d550ee886b5150f0cc78358f6
+    github.setup    emacs-mirror emacs 2c887f497c723c2397888e2f406faa4de3a8208a
     epoch           5
-    version         20240108
-    revision        1
+    version         20240118
+    revision        0
 
     master_sites    ${github.master_sites}
 
-    checksums       rmd160  452c9aefa1645fd87776b4621aa42884bcff7a64 \
-                    sha256  aae2c28d1e8553d0fa324ed0271f4b4b6c2a97e3f60c5df10f72c03bc46cf295 \
-                    size    49647016
+    checksums       rmd160  ff0c37c5f8df3e7e0c8c65fdeca086d64a455129 \
+                    sha256  b8e0ae5ecca0d2f908759dacd00503f2d4e44562443ce2ac6c5f335dc8960f52 \
+                    size    49660683
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"

--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -102,12 +102,12 @@ platform darwin {
 }
 
 if {$subport eq $name || $subport eq "emacs-app"} {
-    version         29.1
-    revision        3
+    version         29.2
+    revision        0
 
-    checksums       rmd160  c306a0554d77ee472600ed28af4751211dc1ec70 \
-                    sha256  5b80e0475b0e619d2ad395ef5bc481b7cb9f13894ed23c301210572040e4b5b1 \
-                    size    78324084
+    checksums       rmd160  24fe37b47e21e9b6b4730832ed7cbe848e7a180d \
+                    sha256  ac8773eb17d8b3c0c4a3bccbb478f7c359266b458563f9a5e2c23c53c05e4e59 \
+                    size    78459766
 }
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->