### PR TITLE
openjdk8: libiconv should be in depends_lib

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -46,12 +46,12 @@ if {${os.platform} eq "darwin" && ${os.major} < 14} {
                     0009-Revert-8211301-macos-support-full-window-content-opt.patch
 }
 
-depends_lib         port:freetype
+depends_lib         port:freetype \
+                    port:libiconv
 depends_build       port:autoconf \
                     port:gmake \
                     port:pkgconfig \
                     port:bash
-depends_run         port:libiconv
 
 set tpath /Library/Java
 use_xcode           yes


### PR DESCRIPTION
#### Description

Make sure that `libiconv` is present at build time as well. It previously happened to be present, but only as a transitive dependency of another build dependency.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?