### PR TITLE
caddy: checksum mismatch in go dep

### DIFF
--- a/www/caddy/Portfile
+++ b/www/caddy/Portfile
@@ -539,10 +539,10 @@ go.vendors          howett.net/plist \
                         rmd160  88f9577df93ac0f8801d8960adc7f28e38867f3e \
                         sha256  f69af10ff08c0e87f92dac3ee5172d8ed02463725b74edfc8943ef018a1a632d \
                         size    5343 \
-                    github.com/imdario/mergo \
+                    github.com/darccio/mergo \
                         lock    v0.3.12 \
-                        rmd160  44dbd1f58fd9ea7697f302c86f110ab796b5a041 \
-                        sha256  dadb5b52d2de5fe7336eda4c331eefb0d4be716a5844cc7ab15c96b9b6e07b2d \
+                        rmd160  92146df5e8cd63505a96de7ae6acb66051afd211 \
+                        sha256  b9d17589da0e392f6da103b4b4007f53dad384f26cd9468b602c02cec717f2b2 \
                         size    22341 \
                     github.com/huandu/xstrings \
                         lock    v1.3.3 \


### PR DESCRIPTION
#### Description

Caddy fails to build with a checksum error. Apparently the checksum, but not file size, of the tar file for imdario-mergo-v0.3.12.tar.gz has changed.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
