### PR TITLE
ruby-build: Upgrade to 20240119

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20240116 v
+github.setup        rbenv ruby-build 20240119 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  d3ff3dc87c785ba9f5c4cec6b6c4301c1f2e12f6 \
-                    sha256  fa4bcc5d0f4535f536e34d4a8a6b68cbdb4449204c74ab0f92efcc2175fc1d34 \
-                    size    87795
+checksums           rmd160  a8ef2d46da792a47a90e8866ee6e0f04658aabbc \
+                    sha256  43a2d0ad75f09b5d8cf658af3d262dec7c4cd6a6795a718712bd8d192a54758b \
+                    size    87854
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Upgrade to 20240119

##### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
