### PR TITLE
libass: use path-style dependency

### DIFF
--- a/gnome/gstreamer010-gst-plugins-bad/Portfile
+++ b/gnome/gstreamer010-gst-plugins-bad/Portfile
@@ -38,7 +38,7 @@ depends_lib         port:gstreamer010-gst-plugins-base \
                     port:dirac \
                     port:faad2 \
                     port:jasper \
-                    port:libass \
+                    path:lib/pkgconfig/libass.pc:libass \
                     port:libdc1394 \
                     port:libdca \
                     port:libdvdread port:libdvdnav \

--- a/gnome/gstreamer1-gst-plugins-bad/Portfile
+++ b/gnome/gstreamer1-gst-plugins-bad/Portfile
@@ -38,7 +38,7 @@ depends_lib         port:gstreamer1-gst-plugins-base \
                     port:faad2 \
                     port:fluidsynth \
                     port:lcms2 \
-                    port:libass \
+                    path:lib/pkgconfig/libass.pc:libass \
                     port:libdca \
                     port:libde265 \
                     port:libdvdread \

--- a/multimedia/QMPlay2/Portfile
+++ b/multimedia/QMPlay2/Portfile
@@ -144,7 +144,7 @@ long_description    QMPlay2 is a video and audio player. It can play all formats
                     Rayman 2 music and chiptunes. It contains YouTube and Prostopleer browser.
 
 depends_lib-append  path:lib/libavcodec.dylib:ffmpeg \
-                    port:libass \
+                    path:lib/pkgconfig/libass.pc:libass \
                     port:libcddb \
                     port:libcdio \
                     port:portaudio \

--- a/multimedia/VLC2/Portfile
+++ b/multimedia/VLC2/Portfile
@@ -96,7 +96,7 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
                         path:lib/pkgconfig/gnutls.pc:gnutls \
                         path:include/turbojpeg.h:libjpeg-turbo \
                         port:lame \
-                        port:libass \
+                        path:lib/pkgconfig/libass.pc:libass \
                         port:libbluray \
                         port:libcddb \
                         port:libcdio \

--- a/multimedia/avidemux/Portfile
+++ b/multimedia/avidemux/Portfile
@@ -68,7 +68,7 @@ depends_build-append        port:bash \
 depends_lib-append          port:fontconfig \
                             port:freetype \
                             port:fribidi \
-                            port:libass \
+                            path:lib/pkgconfig/libass.pc:libass \
                             port:libmad \
                             port:zlib
 

--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -81,7 +81,7 @@ depends_lib-append \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
                     path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     port:lame \
-                    port:libass \
+                    path:lib/pkgconfig/libass.pc:libass \
                     port:libbluray \
                     port:libiconv \
                     port:libmodplug \

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -81,7 +81,7 @@ depends_lib-append \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
                     path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     port:lame \
-                    port:libass \
+                    path:lib/pkgconfig/libass.pc:libass \
                     port:libbluray \
                     port:libiconv \
                     port:libmodplug \

--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -79,7 +79,7 @@ depends_lib-append \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
                     path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                     port:lame \
-                    port:libass \
+                    path:lib/pkgconfig/libass.pc:libass \
                     port:libbluray \
                     port:libiconv \
                     port:libmodplug \

--- a/multimedia/mpv-legacy/Portfile
+++ b/multimedia/mpv-legacy/Portfile
@@ -48,7 +48,7 @@ depends_lib             path:lib/libavcodec.dylib:ffmpeg \
                         path:bin/perl:perl5 \
                         port:libiconv \
                         port:zlib \
-                        port:libass \
+                        path:lib/pkgconfig/libass.pc:libass \
                         port:lcms2
 
 universal_variant       no

--- a/multimedia/mpv/Portfile
+++ b/multimedia/mpv/Portfile
@@ -36,7 +36,7 @@ depends_lib             path:lib/libavcodec.dylib:ffmpeg \
                         path:bin/perl:perl5 \
                         port:libiconv \
                         port:zlib \
-                        port:libass \
+                        path:lib/pkgconfig/libass.pc:libass \
                         port:lcms2 \
                         port:libplacebo
 

--- a/multimedia/mythtv.27/Portfile
+++ b/multimedia/mythtv.27/Portfile
@@ -86,7 +86,7 @@ subport mythtv-core${majorversion} {
 	set mysqlver        mariadb
 
 	depends_lib         port:bzip2 \
-						port:libass \
+						path:lib/pkgconfig/libass.pc:libass \
 						port:libcdio \
 						port:libdvdcss \
 						port:libiconv \

--- a/multimedia/mythtv.28/Portfile
+++ b/multimedia/mythtv.28/Portfile
@@ -73,7 +73,7 @@ if {$subport eq "mythtv-core${majorversion}"} {
 
     depends_lib-append  port:bzip2 \
                         port:exiv2 \
-                        port:libass \
+                        path:lib/pkgconfig/libass.pc:libass \
                         port:libbluray \
                         port:libcdio \
                         port:libdvdcss \

--- a/multimedia/vapoursynth/Portfile
+++ b/multimedia/vapoursynth/Portfile
@@ -42,7 +42,7 @@ depends_build-append    port:autoconf \
 
 depends_lib-append      path:lib/libavcodec.dylib:ffmpeg \
                         port:ImageMagick \
-                        port:libass \
+                        path:lib/pkgconfig/libass.pc:libass \
                         port:libiconv \
                         port:python${python_version} \
                         port:zimg


### PR DESCRIPTION
[skip ci]

#### Description

Skipping CI, because there is no change to the ports, only a switch to path-style dependency, which is needed in order to support using `libass-devel`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
