### PR TITLE
caddy: use darccio/mergo, fixing github stealth update

### DIFF
--- a/www/caddy/Portfile
+++ b/www/caddy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 go.setup            github.com/caddyserver/caddy 2.7.6 v
-revision            0
+revision            1
 categories          www
 license             Apache-2
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
@@ -551,10 +551,11 @@ go.vendors          howett.net/plist \
                         sha256  f69af10ff08c0e87f92dac3ee5172d8ed02463725b74edfc8943ef018a1a632d \
                         size    5343 \
                     github.com/imdario/mergo \
-                        lock    v0.3.13 \
-                        rmd160  2e6fc2ada1f9d67c92a0d23dd0535e53760d7f16 \
-                        sha256  781fa2e7eb42828228bf9c524c955603f25664bb4ae741a34603067084bd0abc \
-                        size    22811 \
+                        repo    github.com/darccio/mergo \
+                        lock    v0.3.12 \
+                        rmd160  92146df5e8cd63505a96de7ae6acb66051afd211 \
+                        sha256  b9d17589da0e392f6da103b4b4007f53dad384f26cd9468b602c02cec717f2b2 \
+                        size    22341 \
                     github.com/huandu/xstrings \
                         lock    v1.3.3 \
                         rmd160  64a2e87712cb657ec7d79273ed8f81ca1d13fc03 \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Closes: https://trac.macports.org/ticket/69132

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
