### PR TITLE
abcl: avoid java PG

### DIFF
--- a/_resources/port1.0/group/common_lisp-1.0.tcl
+++ b/_resources/port1.0/group/common_lisp-1.0.tcl
@@ -40,7 +40,7 @@ options common_lisp.ccl
 default common_lisp.ccl         [expr { ${os.platform} eq "darwin" && ${os.major} >= 14  && ${os.arch} ne "arm" }]
 
 options common_lisp.abcl
-# ABCL requires java and support OpenJDK 11 before 10.14 fragile
+# ABCL requires java and support OpenJDK 21 before 10.14 fragile
 default common_lisp.abcl        [expr { ${os.platform} eq "darwin" && ${os.major} >= 18 }]
 
 options common_lisp.build_run

--- a/lang/abcl/Portfile
+++ b/lang/abcl/Portfile
@@ -1,11 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup           java 1.0
+PortSystem          1.0
 
 name                abcl
 version             1.9.2
-revision            4
+revision            5
 categories          lang java
 license             GPL-2
 supported_archs     noarch
@@ -41,9 +40,12 @@ depends_build-append \
 # It needed for implementation of FFI, not build
 depends_run-append  port:maven3
 
-# It may work on openjdk6 and openjdk7, but officially it is 1.8+
-java.version        1.8+
-java.fallback       openjdk11
+# java PG may add or may not add java dependencies, it depends on what is installed on the system,
+# anyway, ABCL cached used java inside produced scripts, and won't work without the same java.
+# To avoid hell by undetermenistic behaviour, I simple use the latest JDK TLS.
+depends_lib-append  port:openjdk21
+set java_home       ${prefix}/Library/Java/JavaVirtualMachines/jdk-21-macports.jdk/Contents/Home
+
 use_configure       no
 
 patchfiles-append   patch-macports-xdg-data-dir.diff \
@@ -57,11 +59,8 @@ post-patch {
 
 build.cmd           ant
 build.target        abcl
-pre-configure {
-    # This must be called to set ${java.home}
-    java::java_set_env
-    build.args      -Djava.path=${java.home}/bin/java
-}
+build.env-append    JAVA_HOME=${java_home}
+build.args          -Djava.path=${java_home}/bin/java
 
 post-build {
     reinplace "s|${worksrcpath}/dist/abcl.jar|${prefix}/share/java/abcl/abcl.jar|g" \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->