### PR TITLE
libaacs: provide fallback for systems that don’t support blocks

### DIFF
--- a/multimedia/libaacs/Portfile
+++ b/multimedia/libaacs/Portfile
@@ -7,7 +7,6 @@ version             0.11.1
 revision            0
 categories          multimedia
 license             LGPL-2.1
-platforms           darwin
 maintainers         {i0ntempest @i0ntempest} openmaintainer
 description         AACS support library for Blu-ray playback
 
@@ -31,10 +30,20 @@ checksums           rmd160  960e9ce613c4c23dc90ff9df48476d71b6edfc0b \
                     sha256  a88aa0ebe4c98a77f7aeffd92ab3ef64ac548c6b822e8248a8b926725bea0a39 \
                     size    325669
 
-#Shameless copy from libsdl2
 platform macosx {
-    if {${os.major} <= 10} {
-        # Build requires at least 10.7.3 SDK, even when targeting 10.6
+    # This chunk is only relevant for old systems.
+    if {${configure.build_arch} in [list ppc ppc64] || ${os.major} < 10} {
+        # Newer versions need blocks, which are not yet supported by gcc:
+        # https://trac.macports.org/ticket/64909
+        version     0.9.0
+        checksums   rmd160  f96e4c6aa3c06c79bf8e023a5c02a8dead407259 \
+                    sha256  47e0bdc9c9f0f6146ed7b4cc78ed1527a04a537012cf540cf5211e06a248bace \
+                    size    316323
+        # https://trac.macports.org/ticket/60782
+        patchfiles  Makefile.in-0.9.0.diff
+    } elseif {${os.major} == 10} {
+        # Shameless copy from libsdl2
+        # On Intel build requires at least 10.7.3 SDK, even when targeting 10.6
         set lion_sdkpath ${developer_dir}/SDKs/MacOSX10.7.sdk
         if {[file exists $lion_sdkpath]} {
             configure.sdkroot $lion_sdkpath

--- a/multimedia/libaacs/files/Makefile.in-0.9.0.diff
+++ b/multimedia/libaacs/files/Makefile.in-0.9.0.diff
@@ -1,0 +1,12 @@
+--- Makefile.in.orig	2017-05-04 17:29:17.000000000 +1000
++++ Makefile.in	2020-07-05 18:49:48.000000000 +1000
+@@ -483,7 +508,8 @@
+ ACLOCAL_AMFLAGS = -I m4
+ EXTRA_DIST = bootstrap COPYING KEYDB.cfg README.txt ChangeLog
+ SET_INCLUDES = -I$(top_srcdir)/src -I$(top_builddir)/src/libaacs
+-AM_CFLAGS = -std=c99 $(SET_FEATURES) $(SET_INCLUDES) $(LIBGCRYPT_CFLAGS) $(GPG_ERROR_CFLAGS)
++AM_CFLAGS = -std=c99 $(LIBGCRYPT_CFLAGS) $(GPG_ERROR_CFLAGS)
++AM_CPPFLAGS = $(SET_FEATURES) $(SET_INCLUDES)
+ AM_YFLAGS = -d -p libaacs_yy
+ lib_LTLIBRARIES = libaacs.la
+ libaacs_la_SOURCES = src/libaacs/aacs.h src/libaacs/aacs.c \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/64909

#### Description

This just restores an earlier version as it was in Macports for PowerPC systems, which cannot use 10.7 SDK and which have no clang to support blocks.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
