### PR TITLE
openjdk8-corretto: update to 8.402.08.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      8.402.07.1
+version      8.402.08.1
 revision     0
 
 description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  d76b560c56636cc208bf29d07fce8305b04a2f6a \
-                 sha256  b5eaa548b0d0582564d692a9ca247e7c90acfa27e535b5ce7b0bcd1994826329 \
-                 size    118453867
+    checksums    rmd160  a512f691d8f738122961e63865d5d9e1af5763c5 \
+                 sha256  386b48d3c33de51882f8082c9aad0eea87b0e57e64f1f66b1db6fb17241570d9 \
+                 size    118464710
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  4efdcd68df1f586b7a982d407fd5b8c450a888f6 \
-                 sha256  040452fbcad94ecb24dab9e715bb32a8711acde48a98b51164704e90d550d638 \
-                 size    102893896
+    checksums    rmd160  12b21da69bbd8ade37721550a14218a9b084808c \
+                 sha256  7eadf4efa3571f6726ebb8a498db9a2c257c4fc8db3ba00dd49edc4c1a4bd7cc \
+                 size    102879147
 }
 
 worksrcdir   amazon-corretto-8.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.402.08.1.

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?