### PR TITLE
openjdk*: change libiconv from run to lib dependency

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -23,12 +23,12 @@ checksums           rmd160  99ff7e4128c9082f7da5e29059015fe4a6604c69 \
                     sha256  5ed47173679cdfefa0cb9fc92d443413e05ab2e157a29bb86e829d7f6a80913a \
                     size    116235391
 
-depends_lib         port:freetype
+depends_lib         port:freetype \
+                    port:libiconv
 depends_build       port:autoconf \
                     port:gmake \
                     port:bash \
                     port:openjdk11-bootstrap
-depends_run         port:libiconv
 
 pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4

--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -23,12 +23,12 @@ checksums           rmd160  dab270e839d8b9d06e4f9675920a323a4a320dc3 \
                     sha256  fac2539384ba8d86cdcf3553e69aaf4001a3cec1134bbf6f5f04f64f0acbc055 \
                     size    106398664
 
-depends_lib         port:freetype
+depends_lib         port:freetype \
+                    port:libiconv
 depends_build       port:openjdk17-bootstrap \
                     port:autoconf \
                     port:gmake \
                     port:bash
-depends_run         port:libiconv
 
 pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4

--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -23,12 +23,12 @@ checksums           rmd160  840b44086b26c773b28e9a6f3333c6769e5bc41f \
                     sha256  17eda717843ffbbacc7de4bdcd934f404a23a57ebb3cda3cec630a668651531f \
                     size    112252812
 
-depends_lib         port:freetype
+depends_lib         port:freetype \
+                    port:libiconv
 depends_build       port:openjdk21-zulu \
                     port:autoconf \
                     port:gmake \
                     port:bash
-depends_run         port:libiconv
 
 pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4


### PR DESCRIPTION
#### Description

Follow-up to https://github.com/macports/macports-ports/pull/22261 for OpenJDK 11, 17 and 21.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on

macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?