### PR TITLE
bash: update to 026

### DIFF
--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                bash
 set bash_version    5.2
-set bash_patchlevel 21
+set bash_patchlevel 26
 subport bash50 {
     # used by bashdb port
     set bash_version    5.0
@@ -131,7 +131,27 @@ if {${subport} eq ${name}} {
                         bash52-021 \
                         rmd160  afa6fea5edd7d253a49b5cfca67293d37e064adb \
                         sha256  8334b88117ad047598f23581aeb0c66c0248cdd77abc3b4e259133aa307650cd \
-                        size    1890
+                        size    1890 \
+                        bash52-022 \
+                        rmd160  458bf889fc9d3fea00558deaf4e0d119badc1d7c \
+                        sha256  78b5230a49594ec30811e72dcd0f56d1089710ec7828621022d08507aa57e470 \
+                        size    1305 \
+                        bash52-023 \
+                        rmd160  38f12fc2e5486afff99259592ca68f88717fb6c4 \
+                        sha256  af905502e2106c8510ba2085aa2b56e64830fc0fdf6ee67ebb459ac11696dcd3 \
+                        size    1817 \
+                        bash52-024 \
+                        rmd160  64770d95e7d974160115b524b661ab8e06ee960c \
+                        sha256  971534490117eb05d97d7fd81f5f9d8daf927b4d581231844ffae485651b02c3 \
+                        size    2298 \
+                        bash52-025 \
+                        rmd160  ea44747bf5642655d0452ebbfc5d3a1bd706afd2 \
+                        sha256  5138f487e7cf71a6323dc81d22419906f1535b89835cc2ff68847e1a35613075 \
+                        size    1454 \
+                        bash52-026 \
+                        rmd160  9a4710c808def2c4d1337c81bd761936be0d9bc5 \
+                        sha256  96ee1f549aa0b530521e36bdc0ba7661602cfaee409f7023cac744dd42852eac \
+                        size    1372
 } elseif {${subport} eq "bash50"} {
    checksums           ${distname}${extract.suffix} \
                        rmd160  a081428a896d617855499376b670eca3433a27c1 \


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
