### PR TITLE
py-iso3166: update to 2.1.1

### DIFF
--- a/python/py-iso3166/Portfile
+++ b/python/py-iso3166/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-iso3166
-version             1.0.1
+version             2.1.1
 revision            0
 
 platforms           {darwin any}
@@ -18,13 +18,13 @@ long_description    {*}${description}. ISO 3166-1 defines two-letter, three-lett
                     module that converts between these codes and the corresponding\
                     country name.
 
-homepage            http://github.com/deactivated/python-iso3166
+homepage            https://github.com/deactivated/python-iso3166
 
-checksums           rmd160  039173f3a626294db4537dbf387e1c81c2d89b29 \
-                    sha256  b1e58dbcf50fbb2c9c418ec7a6057f0cdb30b8f822ac852f72e71ba769dae8c5 \
-                    size    10052
+checksums           rmd160  735478f1a0cea7a3c5f18ef477ed66dbc0739cfd \
+                    sha256  fcd551b8dda66b44e9f9e6d6bbbee3a1145a22447c0a556e5d0fb1ad1e491719 \
+                    size    12807
 
-python.versions     38
+python.versions     38 39 310 311 312
 
 if {$subport ne $name} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

- add more python subports

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?