### PR TITLE
xtide: update to 2.15.5

### DIFF
--- a/science/xtide/Portfile
+++ b/science/xtide/Portfile
@@ -4,7 +4,7 @@ PortSystem 1.0
 PortGroup  compiler_blacklist_versions 1.0
 
 name			xtide
-version         2.15.1
+version         2.15.5
 maintainers     {dstrubbe @dstrubbe} openmaintainer
 
 description		Tide prediction software, with a large database of locations.
@@ -13,9 +13,9 @@ long_description	XTide is a package that provides tide and current predictions \
                     can be generated, or a tide clock can be provided on your desktop. \
                     For x11, plain command line, and as an http server.
 
-use_bzip2               yes
-homepage                http://www.flaterco.com/xtide/
-master_sites            ftp://ftp.flaterco.com/xtide/
+use_xz                  yes
+homepage                https://www.flaterco.com/xtide/
+master_sites            https://flaterco.com/files/xtide/
 
 set docdir              ${prefix}/share/doc/${subport}
 set harmonics_dir       ${prefix}/share/${name}/harmonics
@@ -28,12 +28,12 @@ livecheck.url           ${homepage}files.html
 
 if {${name} eq ${subport}} {
     categories          science x11
-    revision            2
+    revision            0
     license             GPL-3+
-    master_sites-append https://src.fedoraproject.org/repo/pkgs/${name}/${distfiles}/59de866e0684e123419d7a1c97ea23a5/
 
-    checksums           rmd160  a4924c09f452e63da12012781bea7607f9178ec4 \
-                        sha256  e5c4afbb17269fdde296e853f2cb84845ed1c1bb1932f780047ad71d623bc681
+    checksums           rmd160  511be213fbed76a78f993c4bc60dbdd6dd280604 \
+                        sha256  b9460dcf167e8d9544dcb34a751516d14a97fc3f4aebc6a8bb5ca5f2710d7164 \
+                        size    574972
 
     depends_lib         port:libpng \
                         port:libtcd
@@ -83,8 +83,9 @@ subport ${name}-wvs {
     worksrcdir
     distname            wvs
 
-    checksums           rmd160  0e83b847efc635f18bd96cc5a29149d5af41dc4d \
-                        sha256  4e996ce2e608d612ba78e35cdf50c2c73b01fce06bd5b561a7fe957ea75d6d75
+    checksums           rmd160  ca4512c44fc0a7d13b83f2f83fb97526ea321372 \
+                        sha256  4b505d80099cf9c43405f687b55aa2c0f9a4412f3172c8c9897035e51834bc67 \
+                        size    32521228
 
     use_configure       no
 
@@ -102,7 +103,7 @@ subport ${name}-wvs {
 
 subport ${name}-data {
     categories          science
-    version             20180101
+    version             20240104
     revision            0
     license             public-domain
     supported_archs     noarch
@@ -114,11 +115,10 @@ subport ${name}-data {
 
     worksrcdir          harmonics-dwf-${version}
     distname            ${worksrcdir}-free
-    master_sites-append https://src.fedoraproject.org/repo/pkgs/${name}/${distfiles}/sha512/c252c99b85e2bf87e11f6334339d1919d9e63b797ba25b08189b8d2dfe98a352550d14ffc54c253c09845f2bce02981b8049c95654b14c34a77d687f4aeed27f
 
-    checksums           rmd160  61ac5640c463376517d0d2f20c0be3037ac815ef \
-                        sha256  59566acd8083fed0bde18294d3344331797fed068352a53d6580673cb246b1fc \
-                        size    545679
+    checksums           rmd160  af2aed1336ff375fa6be466e3b53e13859172ce5 \
+                        sha256  2a50e29051f72b5df51a763b4c61b0fe7df5209208b18a76443d02e990f6da85 \
+                        size    863340
 
     use_configure       no
 


### PR DESCRIPTION
 - update xtide to 2.15.5
 - update xtide-data to 20240104
 - fix master site URL
 - fetch files from official master site instead of Fedora
 - Closes: https://trac.macports.org/ticket/69148

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
