### PR TITLE
py-wsproto: update to 1.2.0

### DIFF
--- a/python/py-wsproto/Portfile
+++ b/python/py-wsproto/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-wsproto
-version             1.0.0
+version             1.2.0
 revision            0
 
 categories-append   net www
@@ -16,13 +16,13 @@ maintainers         nomaintainer
 description         WebSockets state-machine based protocol implementation
 long_description    {*}${description}
 
-homepage            https://github.com/python-hyper/wsproto
+homepage            https://python-hyper.org/projects/wsproto
 
-checksums           rmd160  75d221dfd371b1a4490b80dde90b778c00e50440 \
-                    sha256  868776f8456997ad0d9720f7322b746bbe9193751b5b290b7f924659377c8c38 \
-                    size    53423
+checksums           rmd160  4fffd38fba7eb24ef5bba7b872de840e4d7085e6 \
+                    sha256  ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065 \
+                    size    53425
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

- add py312 subport

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?