### PR TITLE
py-trio-websocket: new port

### DIFF
--- a/python/py-trio-websocket/Portfile
+++ b/python/py-trio-websocket/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-trio-websocket
+version             0.11.1
+license             MIT
+platforms           {darwin any}
+supported_archs     noarch
+maintainers         nomaintainer
+
+description         WebSocket client and server implementation for Python Trio
+
+long_description    This library implements both server and client aspects of \
+                    the the WebSocket protocol, striving for safety, \
+                    correctness, and ergonomics.
+
+homepage            https://trio-websocket.readthedocs.io
+
+checksums           rmd160  6e1a69eb64384343ac4ea95e222bc0f6255d48c0 \
+                    sha256  18c11793647703c158b1f6e62de638acada927344d534e3c7628eedcb746839f \
+                    size    26511
+
+python.versions     38 39 310 311 312
+
+if {${name} ne ${subport}} {
+    if {${python.version} < 311} {
+        depends_lib-append  port:py${python.version}-exceptiongroup
+    }
+
+    depends_lib-append  port:py${python.version}-trio \
+                        port:py${python.version}-wsproto
+}


### PR DESCRIPTION
#### Description

[WebSocket client and server implementation for Python Trio](https://github.com/python-trio/trio-websocket)

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?