### PR TITLE
py-sphinx-copybutton: Add py312 support

### DIFF
--- a/python/py-sphinx-copybutton/Portfile
+++ b/python/py-sphinx-copybutton/Portfile
@@ -18,7 +18,7 @@ long_description    {*}$description
 
 homepage            https://sphinx-copybutton.readthedocs.io/en/latest/
 
-python.versions     38 39
+python.versions     38 39 310 311 312
 
 # Has a submodule that isn't included in the release tarballs.
 fetch.type          git


### PR DESCRIPTION
#### Description

Add support for Python 3.12 (and 3.11 and 3.10) to the py-sphinx-copybutton package.

Since these versions were not supported before, and nothing changes for the already existing subports, no version bump is needed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
