### PR TITLE
prelude-manager: Use MacPorts libev and net-snmp

### DIFF
--- a/security/prelude-manager/Portfile
+++ b/security/prelude-manager/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                prelude-manager
 version             5.2.0
-
+revision            1
 categories          security
 license             GPL-2+
 maintainers         {ctreleaven @ctreleaven} openmaintainer
@@ -32,30 +32,48 @@ checksums           md5     adfbb45ce1607ccf5607a9bd2f9aa800 \
                     sha256  91f7f7d736f4e29a9a9a345f8eb5f7a72ee5487c3b4a0284abd2e40f58943db0 \
                     size    1564874
 
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig
 
-depends_lib         port:libprelude \
+depends_lib         port:libev \
+                    port:libprelude \
                     port:libpreludedb \
+                    port:libtool \
                     port:libxml2 \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
                     port:libgeoip \
                     port:libmaxminddb \
+                    port:net-snmp \
                     port:tcp_wrappers
 
+patchfiles          no-libev.patch
+
 # Avoid build errors on various configurations
+# and we are patching Makefile.am.
 use_autoreconf      yes
 autoreconf.args     -fvi
 
+# https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr
+configure.checks.implicit_function_declaration.whitelist-append strchr
+
+# prelude-manager's configure script expects to find libev via pkg-config but
+# libev does not provide a pkg-config file.
+# http://lists.schmorp.de/pipermail/libev/2009q1/000572.html
+# http://lists.schmorp.de/pipermail/libev/2009q4/000804.html
+configure.env-append \
+                    "LIBEV_CFLAGS=${configure.cppflags}" \
+                    "LIBEV_LIBS=-lev"
+
 configure.args      --disable-silent-rules \
                     --enable-libmaxminddb \
-                    --mandir=${prefix}/share/man \
-                    --localstatedir=${prefix}/var
+                    --enable-snmp \
+                    --localstatedir=${prefix}/var \
+                    --with-libev \
+                    --with-libwrap=${prefix}
 
-destroot.keepdirs \
-        ${destroot}${prefix}/var/run/prelude-manager
+destroot.keepdirs   ${destroot}${prefix}/var/spool/prelude-manager \
+                    ${destroot}${prefix}/var/run/prelude-manager
 
 post-destroot {
-        system "touch ${destroot}${prefix}/var/spool/prelude-manager/.turd"
         reinplace "s|= /var|= ${prefix}/var|g" ${destroot}${prefix}/etc/prelude-manager/prelude-manager.conf
 }
 

--- a/security/prelude-manager/files/no-libev.patch
+++ b/security/prelude-manager/files/no-libev.patch
@@ -1,0 +1,14 @@
+Do not try to build the libev subdirectory; we are using MacPorts libev.
+
+Fixes:
+
+make[2]: *** No rule to make target `all'.  Stop.
+--- Makefile.am.orig	2020-09-09 09:42:01.000000000 -0500
++++ Makefile.am	2024-01-22 23:58:56.000000000 -0600
+@@ -1,5 +1,5 @@
+ ACLOCAL_AMFLAGS = -I m4 -I libmissing/m4
+-SUBDIRS = docs libev libmissing m4 plugins src
++SUBDIRS = docs libmissing m4 plugins src
+ 
+ EXTRA_DIST = AUTHORS COPYING HACKING.README INSTALL NEWS README \
+              selinux/prelude-manager.te \


### PR DESCRIPTION
#### Description

Fixes build failure on recent macOS whose net-snmp-config is broken.

Closes: https://trac.macports.org/ticket/69153

Switch pkgconfig dependency to path:-based to accommodate pkgconf.

Add libtool dependency because prelude-manager links with libltdl.dylib.

Add net-snmp dependency and --enable-snmp configure arg for clarity.

Add libev dependency and --with-libev configure arg to tell it to use MacPorts libev and patch Makefile.am to avoid trying to build the bundled libev which would fail. Add LIBEV_CFLAGS and LIBEV_LIBS environment variables because the configure script expects to find libev via pkg-config but libev doesn't provide a pkg-config file.

Remove --mandir=${prefix}/share/man configure arg; that's the default.

Add --with-libwrap=${prefix} configure arg to suppress an ld warning that otherwise appears due to an improperly written configure script.

Suppress warning about intentional implicit declaration of strchr.

Use destroot.keepdirs to create the turd file in ${destroot}${prefix}/var/spool/prelude-manager rather than doing it manually.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 21G1974 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
