### PR TITLE
glib2: fix gdbus-codegen

### DIFF
--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -14,7 +14,7 @@ name                        glib2
 conflicts                   glib2-devel
 set my_name                 glib
 version                     2.78.3
-revision                    1
+revision                    2
 checksums                   rmd160  6f4e18d58ad6eac3f38251f24b6495cf5a96e2a3 \
                             sha256  609801dd373796e515972bf95fc0b2daa44545481ee2f465c4f204d224b2bc21 \
                             size    5321388
@@ -55,7 +55,8 @@ patchfiles-append           libintl.patch \
                             patch-meson_build-atomic-test-older-clang-versions.diff \
                             universal.patch \
                             patch-glib2-findfolders-before-SL.diff \
-                            patch-declarations.diff
+                            patch-declarations.diff \
+                            no-distutils.patch
 
 platform darwin {
     if {${os.major} < 11} {
@@ -82,6 +83,7 @@ depends_lib-append          port:gettext-runtime \
                             port:libiconv \
                             port:pcre2 \
                             port:python${py_ver_nodot} \
+                            port:py${py_ver_nodot}-packaging \
                             port:zlib
 
 # Python only needed for scripts

--- a/devel/glib2/files/no-distutils.patch
+++ b/devel/glib2/files/no-distutils.patch
@@ -1,0 +1,32 @@
+From 6ef967a0f930ce37a8c9b5aff969693b34714291 Mon Sep 17 00:00:00 2001
+From: Jordan Williams <jordan@jwillikers.com>
+Date: Fri, 1 Dec 2023 09:53:50 -0600
+Subject: [PATCH] Switch from the deprecated distutils module to the packaging
+ module
+
+The distutils module was removed in Python 3.12.
+---
+ gio/gdbus-2.0/codegen/utils.py      | 4 ++--
+
+diff --git a/gio/gdbus-2.0/codegen/utils.py b/gio/gdbus-2.0/codegen/utils.py
+index 02046108da..08f1ba9731 100644
+--- gio/gdbus-2.0/codegen/utils.py
++++ gio/gdbus-2.0/codegen/utils.py
+@@ -19,7 +19,7 @@
+ #
+ # Author: David Zeuthen <davidz@redhat.com>
+ 
+-import distutils.version
++import packaging.version
+ import os
+ import sys
+ 
+@@ -166,4 +166,4 @@ def version_cmp_key(key):
+         v = str(key[0])
+     else:
+         v = "0"
+-    return (distutils.version.LooseVersion(v), key[1])
++    return (packaging.version.Version(v), key[1])
+-- 
+GitLab
+


### PR DESCRIPTION
Use the packaging module instead of the removed distutils.

Closes: https://trac.macports.org/ticket/69036

- [x] bugfix
