### PR TITLE
madness: update to 2024.01.19

### DIFF
--- a/science/madness/Portfile
+++ b/science/madness/Portfile
@@ -9,8 +9,8 @@ PortGroup           legacysupport 1.1
 
 boost.version       1.81
 
-github.setup        m-a-d-n-e-s-s madness d108709161b5ee55ba238065e5e7ba62f888bcb8
-version             2023.12.03
+github.setup        m-a-d-n-e-s-s madness 7dabba157b5828c2658ac8d75bfd7374526782bd
+version             2024.01.19
 revision            0
 categories          science math
 license             GPL-2
@@ -20,9 +20,9 @@ long_description    MADNESS provides a high-level environment for the solution \
                     of integral and differential equations in many dimensions \
                     using adaptive, fast methods with guaranteed precision \
                     based on multi-resolution analysis and novel separated representations.
-checksums           rmd160  88ca6a5dffdf8801e3c6cc26c28930836632ee61 \
-                    sha256  aca84aaa43affa39f7b3a204ac0a920890905dd20426194ec122251fbc691215 \
-                    size    36734418
+checksums           rmd160  8bdc7e21cfde5b63f3b4a026720a7b17f7e54d59 \
+                    sha256  6fd61cf121ba4a23a0d2ed4a52dd9220ce6914f2c2155c7dc41159acb3fe6f18 \
+                    size    36742800
 github.tarball_from archive
 
 set py_ver          3.11


### PR DESCRIPTION
#### Description

Simple update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
