### PR TITLE
ffmpeg, ffmpeg6, ffmpeg-devel: Add flite variant

### DIFF
--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.4
-revision            5
+revision            4
 epoch               2
 
 license             LGPL-2.1+

--- a/multimedia/ffmpeg-devel/Portfile
+++ b/multimedia/ffmpeg-devel/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.4
-revision            4
+revision            5
 epoch               2
 
 license             LGPL-2.1+
@@ -492,6 +492,13 @@ variant rav1e description {Enable codec rav1e} {
                     --enable-librav1e
     depends_lib-append \
                     port:rav1e
+}
+
+variant flite description {Enable flite audio source} {
+    configure.args-append \
+                    --enable-libflite
+    depends_lib-append \
+                    port:flite
 }
 
 if {![variant_isset rav1e]} {

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg-devel
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.4
-revision            5
+revision            4
 epoch               1
 
 license             LGPL-2.1+

--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg-devel
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.4
-revision            4
+revision            5
 epoch               1
 
 license             LGPL-2.1+
@@ -492,6 +492,13 @@ variant rav1e description {Enable codec rav1e} {
                     --enable-librav1e
     depends_lib-append \
                     port:rav1e
+}
+
+variant flite description {Enable flite audio source} {
+    configure.args-append \
+                    --enable-libflite
+    depends_lib-append \
+                    port:flite
 }
 
 if {![variant_isset rav1e]} {

--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -17,7 +17,7 @@ name                ffmpeg6
 set my_name         ffmpeg
 
 version             6.1
-revision            2
+revision            1
 epoch               0
 
 license             LGPL-2.1+

--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -17,7 +17,7 @@ name                ffmpeg6
 set my_name         ffmpeg
 
 version             6.1
-revision            1
+revision            2
 epoch               0
 
 license             LGPL-2.1+
@@ -492,6 +492,13 @@ variant rav1e description {Enable codec rav1e} {
                     --enable-librav1e
     depends_lib-append \
                     port:rav1e
+}
+
+variant flite description {Enable flite audio source} {
+    configure.args-append \
+                    --enable-libflite
+    depends_lib-append \
+                    port:flite
 }
 
 if {![variant_isset rav1e]} {


### PR DESCRIPTION
#### Description

Add `flite` variant to `ffmpeg`, `ffmpeg6` and `ffmpeg-devel`
Supports libflite voice synth audio source.
https://ffmpeg.org/ffmpeg-filters.html#flite

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
