### PR TITLE
mlton: update to 20240119, fix older Intel builds

### DIFF
--- a/lang/mlton-bootstrap/Portfile
+++ b/lang/mlton-bootstrap/Portfile
@@ -20,7 +20,7 @@ if {${configure.build_arch} eq "ppc"} {
     # This is the last version for PowerPC from upstream: https://github.com/MLton/mlton/issues/498
     # Please keep it pegged.
     version         20070826
-    revision        0
+    revision        1
     distfiles       mlton-${version}-1.powerpc-darwin.gmp-macports.tgz
     checksums       rmd160  d467be6e7d59f1b16f31a5f45211d5e55f70e58b \
                     sha256  288e0e86872733e6ba0d605f187a6d96097f143605105a2fdd554ad2e4e6303f \
@@ -62,7 +62,7 @@ if {${configure.build_arch} eq "ppc"} {
                     patch-x86_64.diff
     } elseif {${os.major} > 11} {
         version     20180207
-        revision    0
+        revision    1
         distfiles   mlton-${version}-1.amd64-darwin.gmp-homebrew.tgz
         checksums   rmd160  3e5374ed9a12906409c74ba3cc790222b4d877ea \
                     sha256  c164c1f3a3bbce0a0008708984202ac8f7d4dc1a3d2aa83a4faeb41e6d68bf2f \
@@ -115,6 +115,12 @@ post-patch {
 # Not required here, but needed to build the current MLton, and we want to use the same compiler:
 compiler.c_standard 2011
 compiler.blacklist-append {clang < 900}
+
+# mlton-bootstrap bakes in C compiler into its script, like R does.
+# We have to ensure that both mlton-bootstrap and mlton use the identical compiler.
+# For now set it to use clang-16 or gcc-13. When newer compilers are enabled,
+# it should be done for mlton-bootstrap and mlton together, with revbumping both.
+compiler.blacklist-append {macports-clang-1[7-9]} {macports-gcc-1[4-9]}
 
 # While newer versions got makefiles in a bundle, they are optional: https://github.com/MLton/mlton/issues/501
 build {}

--- a/lang/mlton/Portfile
+++ b/lang/mlton/Portfile
@@ -6,8 +6,8 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 PortGroup           openssl 1.0
 
-github.setup        MLton mlton fd6d8705780ea6e223c91a6b33553be1633c4eab
-version             20231123
+github.setup        MLton mlton 2637b22ccdd9cd1268b6b46ff6107066bf8c8888
+version             20240119
 revision            0
 categories          lang ml
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -21,9 +21,9 @@ long_description    MLton is a whole-program optimizing compiler for the Standar
                     a complete implementation of the Standard ML Basis Library, various useful libraries, a simple and fast C foreign function interface, \
                     the ML Basis system for programming with source libraries, and tools such as a lexer generator, a parser generator and a profiler.
 homepage            http://www.mlton.org
-checksums           rmd160  28b69a0cc32a6e297599cd6406f3fccd66f15a9d \
-                    sha256  0c3225ca1500d3e9f272bce84c36b7161147228438939caca9b0415262326819 \
-                    size    14381474
+checksums           rmd160  9e7285aa2a83e6bec1e17fa4ba05cc6b06d17db8 \
+                    sha256  5f71a0ee00baf138988f6a301b036389e089cef9070878a0069de9876f02b9a3 \
+                    size    14381761
 github.tarball_from archive
 
 depends_build-append \
@@ -49,11 +49,21 @@ build.env-append    SH=${prefix}/bin/bash
 compiler.c_standard 2011
 compiler.blacklist-append {clang < 900}
 
+# mlton bakes in C compiler into its script, like R does.
+# We have to ensure that both mlton-bootstrap and mlton use the identical compiler.
+# For now set it to use clang-16 or gcc-13. When newer compilers are enabled,
+# it should be done for mlton-bootstrap and mlton together, with revbumping both.
+compiler.blacklist-append {macports-clang-1[7-9]} {macports-gcc-1[4-9]}
+
 platform darwin 10 {
-    # This is only needed on Rosetta, but will not hurt native 10.6 ppc either.
     if {${configure.build_arch} eq "ppc"} {
+        # This is only needed on Rosetta, but will not hurt native 10.6 ppc either.
         patchfiles-append \
                     patch-rosetta.diff
+    } elseif {${configure.build_arch} eq "x86_64"} {
+        # https://trac.macports.org/ticket/68488
+        patchfiles-append \
+                    patch-10.6-x86_64.diff
     }
 }
 

--- a/lang/mlton/files/patch-10.6-x86_64.diff
+++ b/lang/mlton/files/patch-10.6-x86_64.diff
@@ -1,0 +1,11 @@
+--- bin/platform	2023-07-25 04:08:45.000000000 +0800
++++ bin/platform	2024-01-24 05:08:00.000000000 +0800
+@@ -24,7 +24,7 @@
+ esac
+ 
+ uname=`uname`
+-arch=
++arch=amd64
+ 
+ case "$uname" in
+ AIX)


### PR DESCRIPTION
#### Description

Update to 20240119, fix some failures on buildbots for older Intel systems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
