### PR TITLE
google-cloud-sdk: update to 461.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             459.0.0
+version             461.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  102729e728f43a242c3672cb8cef5020c77dc873 \
-                    sha256  93ad798c964841c7089278f97a2956a339416fe3b21a046672d23a06965e24fe \
-                    size    122477949
+    checksums       rmd160  608173944e0a638f582b2780e9d91b194af4e0d3 \
+                    sha256  f393a224f64433114ad756e57a0f59c7a4ffed13f2ed4463a12d4cb11c08c284 \
+                    size    122572373
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  eaa69d4e524895916dd234eee84aeba7b208bffb \
-                    sha256  62bb34962e70e0002cd97221ec642c0f63bbfe3d18466e41b39b4e3401504073 \
-                    size    123762074
+    checksums       rmd160  535947aba32b7fe958a079ea8d633a45b4c4813c \
+                    sha256  4d85319f89d7b90b661bf083e7ef8cfa167b7e05a152ba26f8fe7b7b3c98234b \
+                    size    123856556
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  271bb992d74690c427b50e86f390e6f03c376c53 \
-                    sha256  6db5fbcd67fa4eef7a24219d7fba5c9b39d4e19a25f0e1a5824105f69c0cf0a4 \
-                    size    120830031
+    checksums       rmd160  09bc8ae9fdfb0966f17f2080c81bbf4407126b8c \
+                    sha256  5d01298b5a9811be9d08d037a6785d58e910a947841d3ea38418fd46799211b0 \
+                    size    120924667
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 461.0.0.

###### Tested on

macOS 14.3 23D56 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?