### PR TITLE
openjdk21-microsoft: update to 21.0.2

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-21
 supported_archs  x86_64 arm64
 
-version      21.0.1
-set build    12
+version      21.0.2
+set build    13
 revision     0
 
 description  Microsoft Build of OpenJDK 21 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  74b100ca28bcc314b99ac8db93acc47486a878cf \
-                 sha256  1853c84eb8bc3b4f3077eaaa88b51b005232b151c662ba29429eb7b2984cf43c \
-                 size    202563953
+    checksums    rmd160  eacba13da46ff6680683c08899da0d2bcf924f21 \
+                 sha256  33c92626121e81e13796b974192d821b11f628b3133bbc9957c043e931a28667 \
+                 size    202912867
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  a16814940bbf2d6a61714defa57341d670b3fdb4 \
-                 sha256  e44086601c580bb7b2c5b77f14c0512f1715f6f90cb11ddb43c046322294f12b \
-                 size    191796793
+    checksums    rmd160  bf792c77e27d801ff37bbc8438edc27ff102526b \
+                 sha256  efaab69d58d6515438aa6344c1ef019a3b211ab5bd13338f1fd2343be16f4ff2 \
+                 size    200420322
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 21.0.2.

###### Tested on

macOS 14.3 23D56 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?