### PR TITLE
openjdk17-microsoft: update to 17.0.10

### DIFF
--- a/java/openjdk17-microsoft/Portfile
+++ b/java/openjdk17-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-17
 supported_archs  x86_64 arm64
 
-version      17.0.9
-set build    8
+version      17.0.10
+set build    7
 revision     0
 
 description  Microsoft Build of OpenJDK 17 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  057e9f5b04239844584e48d7c6e05b1b0a0b1095 \
-                 sha256  36050e3a2457c970ebc74c53ccd2cf116f9306c1649520fe3f31ad9cf63fbe62 \
-                 size    187921151
+    checksums    rmd160  4344e55e936672f6542ac9b8160317a88f6154d0 \
+                 sha256  f2d093db063fed08500d04b6d8bb3c8358b6b4d3bff4c9a6261493c4948405e7 \
+                 size    187939937
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  b6e3315ae3d7fd5a00463bcfe32cebd08aa9eda8 \
-                 sha256  fe3c923b35dbc47177debc551dbadcd50c9c336c697b324ea8958af3ad8905b0 \
-                 size    178408153
+    checksums    rmd160  64f989e318821bdef2c963904fe1eb3c851e3bd0 \
+                 sha256  74bdfd4395d46422806e2760fc49948f4e6786ef20835f5379d1bf8d3c0ae040 \
+                 size    185827335
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 17.0.10.

###### Tested on

macOS 14.3 23D56 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?