### PR TITLE
openjdk21-temurin: update to 21.0.2

### DIFF
--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      21.0.1
-set build    12
+version      21.0.2
+set build    13
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 21
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin21-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK21U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  4a820fe6cfd7077e32c3d8224f0ca6a00d3c0d85 \
-                 sha256  35f3cbc86d7ff0a01facefd741d5cfb675867e0a5ec137f62ba071d2511a45c9 \
-                 size    194340703
+    checksums    rmd160  8c130d84b0942c0e7a44942fb1ff067b8ce4d2df \
+                 sha256  ba696ec46c1ca2b1b64c4e9838e21a2d62a1a4b6857a0770adc64451510065db \
+                 size    194433403
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK21U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  41fa00ef620467e55ce56d06b942845c5ea7b8ff \
-                 sha256  0d29257c9bcb5f20f5c4643ef9437f36b10376863eddaf6248d09093796c6b30 \
-                 size    191704753
+    checksums    rmd160  17ea1f40c30d0d3e30d2696bcf5fb42e34118552 \
+                 sha256  57d9e0f0e8639f9f2fb1837518fd83043f23953ff69a677f885aa060994d0c19 \
+                 size    191948584
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 21.0.2.

###### Tested on

macOS 14.3 23D56 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?