### PR TITLE
openjdk11-temurin: update to 11.0.22

### DIFF
--- a/java/openjdk11-temurin/Portfile
+++ b/java/openjdk11-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      11.0.21
-set build    9
+version      11.0.22
+set build    7
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 11
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin11-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK11U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  7fc424cc69b7677034657fc73b2ab3df6b00334a \
-                 sha256  39e30e333d01f70765f0fdc57332bc2c5ae101392bcc315ef06f472d80d8e2d7 \
-                 size    188046241
+    checksums    rmd160  9cb6e57227d32f36fea61a83e3ae8121b1b71629 \
+                 sha256  5e9d108a7959843cf99c90f1fc79a9860801ff7c13b288d54cd659215e8655fd \
+                 size    187409838
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK11U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  906927629a790cbca1cdd0be7de246fbcdd45270 \
-                 sha256  3be236f2cf9612cd38cd6b7cfa4b8eef642a88beab0cd37c6ccf1766d755b4cc \
-                 size    185950980
+    checksums    rmd160  3c8e69f09f0756918cc9145da6ddfc22f72e1dc4 \
+                 sha256  4243345d963f8247e430590c6f857b9e020d9ff0ec8f20a8b7e0cd4fff2cbd78 \
+                 size    184751528
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 11.0.22.

###### Tested on

macOS 14.3 23D56 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?