### PR TITLE
termdebug: new port (version 2.2)

### DIFF
--- a/sysutils/termdebug/Portfile
+++ b/sysutils/termdebug/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                termdebug
+version             2.2
+revision            0
+
+homepage            https://os.ghalkes.nl/
+
+description         \
+    Termdebug is a set of utilities to record and replay the input and output \
+    of terminal programs
+
+long_description    \
+    {*}${description} Its main goal is to aid in developing and debugging \
+    terminal programs. Other programs such as termrec/termplay, \
+    nethack-recorder\/player and script\/scriptreplay only record the output. \
+    However, when debugging an interactive terminal program, the input is \
+    often as important as the output.
+
+categories          sysutils
+installs_libs       no
+license             GPL-3
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  d8a50687cbe6f8f434844381790fcc1cc7846e24 \
+                    sha256  06bd95bb6eeb1581bc4fbadc0111500f1d016ca0ba34c21ddf39b78857de5969 \
+                    size    148192
+
+depends_build-append \
+                    port:libtool \
+                    port:pkgconfig
+
+depends_lib-append  port:cairo \
+                    port:ncurses \
+                    port:pango \
+                    port:libunistring
+
+master_sites        ${homepage}/dist/
+distname            ${name}-${version}
+use_bzip2           yes
+
+configure.env-append \
+                    LIBTOOL=${prefix}/bin/glibtool
+configure.args-append \
+                    --without-gettext


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
