### PR TITLE
iwyu: new port (version 0.21)

### DIFF
--- a/devel/iwyu/Portfile
+++ b/devel/iwyu/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem           1.0
+PortGroup            cmake 1.1
+
+name                 iwyu
+version              0.21
+categories           devel
+license              GPL-3
+maintainers          nomaintainer
+platforms            darwin
+description          A tool for use with clang to analyze #includes in C and C++ source files
+long_description     "Include what you use" means this: for every symbol (type, function variable, \
+                     or macro) that you use in foo.cc, either foo.cc or foo.h should #include a .h \
+                     file that exports the declaration of that symbol. The include-what-you-use \
+                     tool is a program that can be built with the clang libraries in order to \
+                     analyze #includes of source files to find include-what-you-use violations, \
+                     and suggest fixes for them. \
+                     \
+                     The main goal of include-what-you-use is to remove superfluous #includes. It \
+                     does this both by figuring out what #includes are not actually needed for \
+                     this file (for both .cc and .h files), and replacing #includes with \
+                     forward-declares when possible.
+homepage             https://include-what-you-use.org/
+
+distname             include-what-you-use
+distfiles            ${distname}-${version}.src${extract.suffix}
+master_sites         https://include-what-you-use.org/downloads/
+checksums            rmd160  c3e60deb26e8d2ffc6c1714d955d153dad3132d7 \
+                     sha256  6a351919ff89bda7c95c895472601868db3daab96a958b38e0362890d58760b6 \
+                     size    776165
+
+depends_build-append port:clang-17
+depends_run-append   port:clang-17
+
+patch.pre_args       -p1
+patchfiles           0001-install-scripts-without-language-extension.patch
+
+configure.args-append  -DClang_DIR:PATH=${prefix}/libexec/llvm-17/lib/cmake/clang \
+                       -DLLVM_DIR:PATH=${prefix}/libexec/llvm-17/lib/cmake/llvm
+cmake.install_rpath-append  ${prefix}/libexec/llvm-17/lib
+
+livecheck.type       regex
+livecheck.url        ${master_sites}
+livecheck.regex      {include-what-you-use (\d+(\.\d+)*) \(}

--- a/devel/iwyu/files/0001-install-scripts-without-language-extension.patch
+++ b/devel/iwyu/files/0001-install-scripts-without-language-extension.patch
@@ -1,0 +1,16 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -193,8 +193,13 @@ install(TARGETS
+ )
+ install(PROGRAMS
+   fix_includes.py
++  DESTINATION ${CMAKE_INSTALL_BINDIR}
++  RENAME fix_includes
++)
++install(PROGRAMS
+   iwyu_tool.py
+   DESTINATION ${CMAKE_INSTALL_BINDIR}
++  RENAME iwyu_tool
+ )
+ 
+ # Install mapping files.


### PR DESCRIPTION
###### Tested on
macOS 11.7.10 20G1427 x86_64
Xcode 13.2.1 13C100

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
