### PR TITLE
linear_algebra port group: remove workaround for Xcode 15

### DIFF
--- a/_resources/port1.0/group/linear_algebra-1.0.tcl
+++ b/_resources/port1.0/group/linear_algebra-1.0.tcl
@@ -114,15 +114,6 @@ variant openblas conflicts accelerate atlas blis flexiblas description {Build wi
     }
     linalglib               -lopenblas
     cmake_linalglib         -DBLA_VENDOR=OpenBLAS
-
-    # The new linker in Xcode 15 is buggy, causing build failures for many (but not all)
-    # ports that link to OpenBLAS. The -Wl,-ld_classic option below reverts to the
-    # classic linker.
-    #
-    # TODO: This is a temporary solution, the classic linker will be removed in a future release by Apple.
-    if { ( [vercmp ${xcodeversion} 15 ] >= 0 ) || ( [vercmp ${xcodecltversion} 15 ] >= 0 ) } {
-        linalglib-append    -Wl,-ld_classic
-    }
 }
 
 if {![variant_isset accelerate] && ![variant_isset openblas] && ![variant_isset atlas] \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
