### PR TITLE
folly and friends: update to 2024.01.22.00; support tests in folly

### DIFF
--- a/devel/edencommon/Portfile
+++ b/devel/edencommon/Portfile
@@ -13,11 +13,11 @@ legacysupport.newest_darwin_requires_legacy 10
 
 boost.version       1.81
 
-github.setup        facebookexperimental edencommon 2024.01.08.00 v
+github.setup        facebookexperimental edencommon 2024.01.22.00 v
 revision            0
-checksums           rmd160  c44d41318dcc634643e1f567cabcdcad14b4a84b \
-                    sha256  3e962dbb69e1f70ea4394b3216db0649969b10c2c0a7431bea2d1f042c6bf33d \
-                    size    150088
+checksums           rmd160  c41ed94b3c82568b7dffb8ec271641b838837c05 \
+                    sha256  62d34f9ac46f4b89bd44fa75f4160ef16bcf13ab3ba6e3397e80965f2ed634ab \
+                    size    150070
 
 categories          devel
 license             BSD

--- a/devel/fatal/Portfile
+++ b/devel/fatal/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        facebook fatal 2024.01.08.00 v
+github.setup        facebook fatal 2024.01.22.00 v
 revision            0
 categories          devel
 license             BSD
@@ -13,9 +13,9 @@ long_description    Fatal is a library for fast prototyping software in modern C
                     It provides facilities to enhance the expressive power of C++. \
                     The library is heavily based on template meta-programming, \
                     while keeping the complexity under-the-hood.
-checksums           rmd160  f0935f449f1d907a5d05fda2458cf77fbaf29ba7 \
-                    sha256  992e2c0a9677a4318904ba6c38fecf2f43ed2d9324720123cf3224d5c433efa0 \
-                    size    651578
+checksums           rmd160  f0d1394e2caba996ea4ffdb060c88dd160d73834 \
+                    sha256  025c66195bb3a958cb379bad7feff9c4ecc9ede5e3b82284148b8603d10b6415 \
+                    size    651590
 github.tarball_from releases
 distname            ${name}-v${version}
 extract.mkdir       yes

--- a/devel/fb303/Portfile
+++ b/devel/fb303/Portfile
@@ -10,12 +10,12 @@ PortGroup           openssl 1.0
 
 boost.version       1.81
 
-github.setup        facebook fb303 2024.01.08.00 v
+github.setup        facebook fb303 2024.01.22.00 v
 epoch               1
 revision            0
-checksums           rmd160  f42d9df12e451e5a7b1e85edb770142d7c0792dd \
-                    sha256  b0b70695da62e3df1d2afd8b0d5ef58547960b92110dc3accb06e98c006d7704 \
-                    size    242585
+checksums           rmd160  59ba4d8b461c8cacfc5e1dbf16aa52087297c681 \
+                    sha256  ca1f8552ae5fc63da87b16fe71fdf96f2e7c1684b459193177e207174156e1b7 \
+                    size    242596
 
 categories          devel
 license             Apache-2
@@ -72,11 +72,13 @@ platform darwin {
         configure.ldflags-append \
                             -latomic
     }
+    # The following does not seem to be needed anymore.
+    # Possibly, has been fixed in GCC. Yet, retain the block for now.
     # Fixes alignment-related static assert failures on PPC:
-    if {${build_arch} in [list ppc ppc64]} {
-        configure.cflags-append \
-                            -malign-natural
-        configure.cxxflags-append \
-                            -malign-natural
-    }
+    #   if {${build_arch} in [list ppc ppc64]} {
+    #       configure.cflags-append \
+    #                       -malign-natural
+    #       configure.cxxflags-append \
+    #                       -malign-natural
+    #   }
 }

--- a/devel/fbthrift/Portfile
+++ b/devel/fbthrift/Portfile
@@ -10,11 +10,11 @@ PortGroup           openssl 1.0
 
 boost.version       1.81
 
-github.setup        facebook fbthrift 2024.01.08.00 v
+github.setup        facebook fbthrift 2024.01.22.00 v
 revision            0
-checksums           rmd160  4e3e58e64f03549c4f226c7249090052f211f7c3 \
-                    sha256  31250e325acd763052f40764154ceec9517da4a8e027efc132a266daac82d486 \
-                    size    14154593
+checksums           rmd160  a03861b9f5ef568565ff73586bcb303ae1c96164 \
+                    sha256  928cbabaa25b70b7998a452269e5d53cd003b5d5fe0fb104cc5c30af4054c883 \
+                    size    14217550
 
 categories          devel
 license             Apache-2

--- a/devel/fizz/Portfile
+++ b/devel/fizz/Portfile
@@ -5,19 +5,19 @@ PortGroup           boost 1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
-PortGroup           openssl 1.0
 PortGroup           legacysupport 1.1
+PortGroup           openssl 1.0
 
 # O_CLOEXEC
 legacysupport.newest_darwin_requires_legacy 10
 
 boost.version       1.81
 
-github.setup        facebookincubator fizz 2024.01.08.00 v
+github.setup        facebookincubator fizz 2024.01.22.00 v
 revision            0
-checksums           rmd160  1ada4432177892ea54580be6bdaaced8f0bc2c75 \
-                    sha256  ec2dc1b2238e654e8b40b63157cfe343f44e05a59da53e095aadd5e4ec627144 \
-                    size    680888
+checksums           rmd160  0ee5499538022431f588c0c17b18695f1d867e68 \
+                    sha256  52781edd21618dc6ff4c65c5be9b7b674cc6b9c33dbd688f9bbf2360894f505f \
+                    size    681625
 
 categories          devel
 license             BSD
@@ -49,6 +49,9 @@ depends_lib-append  port:bzip2 \
 
 cmake.source_dir    ${worksrcpath}/${name}
 
+# At the moment unclear whether it is a libstdc++ issue or specifically
+# powerpc issue. But Macports only uses libstdc++ on powerpc anyway.
+# https://github.com/facebookincubator/fizz/issues/109
 platform darwin powerpc {
     patchfiles-append \
                     0001-Revert-Read-b64-encoded-ECH-Config-List-in-fizz-clie.patch \

--- a/devel/folly/Portfile
+++ b/devel/folly/Portfile
@@ -20,11 +20,11 @@ if {[string match *clang* ${configure.compiler}]} {
 # NB: Facebook does not do API stability, apparently, so please don't
 # upgrade without also upgrading its dependents, as listed by:
 # port list rdepends:folly
-github.setup        facebook folly 2024.01.08.00 v
+github.setup        facebook folly 2024.01.22.00 v
 revision            0
-checksums           rmd160  be1a27c48af23af50cee6268fd14a9fbaf5f454b \
-                    sha256  97334f8c7a8dfd933381c0afacd3ab48000f3a90f74d83482b8ec259b997d039 \
-                    size    3962098
+checksums           rmd160  440ea5d76c1325aa933757de92871a85111c56f0 \
+                    sha256  8423580be1c7cd6a60ae3fd7ba8ace5b26e86b80de6933901a219d7027692036 \
+                    size    3968413
 
 categories          devel
 license             Apache-2
@@ -69,18 +69,18 @@ depends_lib-append  port:bzip2 \
 
 cmake.generator     Ninja
 
+# https://github.com/facebook/folly/pull/2124
+# https://github.com/facebook/folly/pull/1907
 patchfiles-append   patch-older-systems.diff
 
 configure.args-append   -DBUILD_SHARED_LIBS=ON \
                         -DFOLLY_USE_JEMALLOC=0
 
+compiler.thread_local_storage \
+                        yes
 compiler.cxx_standard   2017
 configure.cxxflags-append \
                         -std=c++17
-
-# error: TARGET_OS_xxx not defined, evaluates to 0
-configure.cppflags-append \
-                        -Wno-undef-prefix
 
 # error: typedef redefinition with different types ('uint8_t' (aka 'unsigned char') vs 'enum clockid_t')
 compiler.blacklist-append {clang < 1100}
@@ -116,9 +116,13 @@ platform darwin {
             configure.ldflags-append \
                                 -latomic
         }
+    } elseif {[string match *clang* ${configure.compiler}]} {
+        # error: TARGET_OS_xxx not defined, evaluates to 0
+        configure.cppflags-append \
+                                -Wno-undef-prefix
     }
     # Fix for building in Rosetta, so that x86 SSE is not invoked:
-    if {${os.major} == 10 && ${build_arch} eq "ppc"} {
+    if {${os.major} == 10 && ${configure.build_arch} eq "ppc"} {
         configure.args-append   -DCMAKE_LIBRARY_ARCHITECTURE="ppc" \
                                 -DIS_X86_64_ARCH=OFF
     }
@@ -140,4 +144,39 @@ variant native description {Build with best native support for local CPU capabil
         configure.cxxflags-append \
                                 -march=native
     }
+}
+
+# FIXME: at the moment about 90% of tests pass on PowerPC.
+# This is somewhat worse than Sonoma arm64, where 91% of tests pass.
+# https://github.com/facebook/folly/issues/2128
+variant tests description {Enable testing} {
+    configure.pre_args-replace  -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                                -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+
+    configure.args-append       -DBUILD_TESTS=ON
+
+    pre-test {
+        if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libc++"} {
+            foreach testexec    [glob ${cmake.build_dir}/*test] {
+                move            ${testexec} \
+                                ${testexec}-orig
+
+                set  wrapper    [open "${testexec}" w 0755]
+                puts ${wrapper} "#!/bin/bash"
+                puts ${wrapper} ""
+                puts ${wrapper} {if [ -n "$DYLD_LIBRARY_PATH" ]; then}
+                puts ${wrapper} "   DYLD_LIBRARY_PATH=${prefix}/lib/libgcc:\./:\${DYLD_LIBRARY_PATH}"
+                puts ${wrapper} {else}
+                puts ${wrapper} "   DYLD_LIBRARY_PATH=${prefix}/lib/libgcc:\./"
+                puts ${wrapper} {fi}
+                puts ${wrapper} {export DYLD_LIBRARY_PATH}
+                puts ${wrapper} ""
+                puts ${wrapper} {exec "${0}-orig" "$@"}
+                close $wrapper
+            }
+        }
+        # test infrastructure uses /bin/ps, which is forbidden by sandboxing
+        append portsandbox_profile " (allow process-exec (literal \"/bin/ps\") (with no-profile))"
+    }
+    test.run                    yes
 }

--- a/devel/folly/files/patch-older-systems.diff
+++ b/devel/folly/files/patch-older-systems.diff
@@ -1,3 +1,247 @@
+diff --git CMake/folly-deps.cmake CMake/folly-deps.cmake
+index c72273a73..eb4627637 100644
+--- CMake/folly-deps.cmake
++++ CMake/folly-deps.cmake
+@@ -247,7 +247,7 @@ check_cxx_source_compiles("
+   FOLLY_STDLIB_LIBCPP
+ )
+ 
+-if (APPLE)
++if (APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+   list (APPEND CMAKE_REQUIRED_LIBRARIES c++abi)
+   list (APPEND FOLLY_LINK_LIBRARIES c++abi)
+ endif ()
+diff --git CMakeLists.txt CMakeLists.txt
+index 01a28eeab..2383b30cb 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -708,7 +708,7 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
+       TEST bits_test_2 SOURCES BitsTest.cpp
+       TEST bitvector_test SOURCES BitVectorCodingTest.cpp
+       TEST dynamic_parser_test SOURCES DynamicParserTest.cpp
+-      TEST eliasfano_test SOURCES EliasFanoCodingTest.cpp
++      TEST eliasfano_test APPLE_DISABLED SOURCES EliasFanoCodingTest.cpp
+       TEST event_count_test SOURCES EventCountTest.cpp
+       # FunctionSchedulerTest has a lot of timing-dependent checks,
+       # and tends to fail on heavily loaded systems.
+@@ -993,7 +993,7 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
+       TEST atomic_hash_map_test HANGING
+         SOURCES AtomicHashMapTest.cpp
+       TEST atomic_linked_list_test SOURCES AtomicLinkedListTest.cpp
+-      TEST atomic_unordered_map_test SOURCES AtomicUnorderedMapTest.cpp
++      TEST atomic_unordered_map_test APPLE_DISABLED SOURCES AtomicUnorderedMapTest.cpp
+       TEST base64_test SOURCES base64_test.cpp
+       TEST clock_gettime_wrappers_test SOURCES ClockGettimeWrappersTest.cpp
+       TEST concurrent_bit_set_test SOURCES ConcurrentBitSetTest.cpp
+@@ -1005,7 +1005,7 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
+       TEST cpu_id_test SOURCES CpuIdTest.cpp
+       TEST demangle_test SOURCES DemangleTest.cpp
+       TEST deterministic_schedule_test SOURCES DeterministicScheduleTest.cpp
+-      TEST discriminated_ptr_test SOURCES DiscriminatedPtrTest.cpp
++      TEST discriminated_ptr_test APPLE_DISABLED SOURCES DiscriminatedPtrTest.cpp
+       TEST dynamic_test SOURCES DynamicTest.cpp
+       TEST dynamic_converter_test SOURCES DynamicConverterTest.cpp
+       TEST dynamic_other_test SOURCES DynamicOtherTest.cpp
+diff --git folly/ConstexprMath.h folly/ConstexprMath.h
+index 5df7ae5a6..6fe2b6430 100644
+--- folly/ConstexprMath.h
++++ folly/ConstexprMath.h
+@@ -42,15 +42,25 @@ using enable_if_floating_t =
+ ///
+ /// mimic: std::numbers::e_v, C++20
+ template <typename T>
++#if defined(__ppc__) || defined(__i386__)
++FOLLY_INLINE_VARIABLE constexpr T e_v = detail::enable_if_floating_t<T>(
++    2.71828182845904523536028747135266250);
++#else
+ FOLLY_INLINE_VARIABLE constexpr T e_v = detail::enable_if_floating_t<T>(
+     2.71828182845904523536028747135266249775724709369995L);
++#endif
+ 
+ /// ln2_v
+ ///
+ /// mimic: std::numbers::ln2_v, C++20
+ template <typename T>
++#if defined(__ppc__) || defined(__i386__)
++FOLLY_INLINE_VARIABLE constexpr T ln2_v = detail::enable_if_floating_t<T>(
++    0.693147180559945309417232121458176568);
++#else
+ FOLLY_INLINE_VARIABLE constexpr T ln2_v = detail::enable_if_floating_t<T>(
+     0.69314718055994530941723212145817656807550013436025L);
++#endif
+ 
+ /// e
+ ///
+diff --git folly/DiscriminatedPtr.h folly/DiscriminatedPtr.h
+index 4284cdf72..582f9a6a7 100644
+--- folly/DiscriminatedPtr.h
++++ folly/DiscriminatedPtr.h
+@@ -35,8 +35,8 @@
+ #include <folly/Portability.h>
+ #include <folly/detail/DiscriminatedPtrDetail.h>
+ 
+-#if !FOLLY_X64 && !FOLLY_AARCH64 && !FOLLY_PPC64 && !FOLLY_RISCV64
+-#error "DiscriminatedPtr is x64, arm64, ppc64 and riscv64 specific code."
++#if !FOLLY_X64 && !FOLLY_AARCH64 && !FOLLY_PPC && !FOLLY_PPC64 && !FOLLY_RISCV64
++#error "DiscriminatedPtr is x64, arm64, ppc, ppc64 and riscv64 specific code."
+ #endif
+ 
+ namespace folly {
+diff --git folly/File.cpp folly/File.cpp
+index f61fc3cc7..c5c9966d3 100644
+--- folly/File.cpp
++++ folly/File.cpp
+@@ -118,8 +118,10 @@ File File::dupCloseOnExec() const {
+     int fd;
+ #ifdef _WIN32
+     fd = ::dup(fd_);
+-#else
++#elif defined(F_DUPFD_CLOEXEC)
+     fd = ::fcntl(fd_, F_DUPFD_CLOEXEC, 0);
++#else
++    fd = ::dup(fd_);
+ #endif
+     checkUnixError(fd, "dup() failed");
+ 
+diff --git folly/Portability.h folly/Portability.h
+index 5e1c1dee1..b59bb2358 100644
+--- folly/Portability.h
++++ folly/Portability.h
+@@ -115,12 +115,18 @@ constexpr bool kHasUnalignedAccess = false;
+ #define FOLLY_AARCH64 0
+ #endif
+ 
+-#if defined(__powerpc64__)
++#if defined(__powerpc64__) || defined(__ppc64__)
+ #define FOLLY_PPC64 1
+ #else
+ #define FOLLY_PPC64 0
+ #endif
+ 
++#if defined(__ppc__)
++#define FOLLY_PPC 1
++#else
++#define FOLLY_PPC 0
++#endif
++
+ #if defined(__s390x__)
+ #define FOLLY_S390X 1
+ #else
+@@ -138,6 +144,7 @@ constexpr bool kIsArchArm = FOLLY_ARM == 1;
+ constexpr bool kIsArchAmd64 = FOLLY_X64 == 1;
+ constexpr bool kIsArchAArch64 = FOLLY_AARCH64 == 1;
+ constexpr bool kIsArchPPC64 = FOLLY_PPC64 == 1;
++constexpr bool kIsArchPPC = FOLLY_PPC == 1;
+ constexpr bool kIsArchS390X = FOLLY_S390X == 1;
+ constexpr bool kIsArchRISCV64 = FOLLY_RISCV64 == 1;
+ } // namespace folly
+@@ -302,6 +309,9 @@ constexpr auto kIsLittleEndian = false;
+ #else
+ constexpr auto kIsLittleEndian = true;
+ #endif
++#elif defined(__APPLE__) && defined(__POWERPC__)
++// Darwin ppc/ppc64
++constexpr auto kIsLittleEndian = false;
+ #else
+ constexpr auto kIsLittleEndian = __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__;
+ #endif
+diff --git folly/Synchronized.h folly/Synchronized.h
+index d563e4aec..e55eaefbf 100644
+--- folly/Synchronized.h
++++ folly/Synchronized.h
+@@ -1510,8 +1510,10 @@ class LockedPtr {
+ 
+   SynchronizedType* parent() const {
+     using simulacrum = typename SynchronizedType::Simulacrum;
++#ifndef __ppc__
+     static_assert(sizeof(simulacrum) == sizeof(SynchronizedType), "mismatch");
+     static_assert(alignof(simulacrum) == alignof(SynchronizedType), "mismatch");
++#endif
+     constexpr auto off = offsetof(simulacrum, mutex_);
+     const auto raw = reinterpret_cast<char*>(lock_.mutex());
+     return reinterpret_cast<SynchronizedType*>(raw - (raw ? off : 0));
+diff --git folly/detail/base64_detail/Base64SWAR.cpp folly/detail/base64_detail/Base64SWAR.cpp
+index 72fc4278c..06d0ce4aa 100644
+--- folly/detail/base64_detail/Base64SWAR.cpp
++++ folly/detail/base64_detail/Base64SWAR.cpp
+@@ -103,8 +103,13 @@ constexpr auto kBase64SwarDecodeTable =
+ template <bool isURL>
+ std::uint32_t base64DecodeSWARMainLoop(
+     const char*& f, const char* l, char*& o) noexcept {
++
++#ifdef __POWERPC__
++  #warning "This code may not work on a Big-endian architecture yet."
++#else
+   static_assert(
+       folly::kIsLittleEndian, "Big endian requires a redesigned table");
++#endif
+ 
+   std::uint32_t errorAccumulator = 0;
+ 
+diff --git folly/experimental/EliasFanoCoding.h folly/experimental/EliasFanoCoding.h
+index 03c266d0f..43d90b8a4 100644
+--- folly/experimental/EliasFanoCoding.h
++++ folly/experimental/EliasFanoCoding.h
+@@ -42,7 +42,11 @@
+ namespace folly {
+ namespace compression {
+ 
+-static_assert(kIsLittleEndian, "EliasFanoCoding.h requires little endianness");
++#ifdef __POWERPC__
++  #warning "This code may not work on a Big-endian architecture yet."
++#else
++  static_assert(kIsLittleEndian, "EliasFanoCoding.h requires little endianness");
++#endif
+ 
+ constexpr size_t kCacheLineSize = 64;
+ 
+diff --git folly/hash/test/ChecksumBenchmark.cpp folly/hash/test/ChecksumBenchmark.cpp
+index c9a1d7212..1f4061751 100644
+--- folly/hash/test/ChecksumBenchmark.cpp
++++ folly/hash/test/ChecksumBenchmark.cpp
+@@ -19,6 +19,10 @@
+ #include <folly/Benchmark.h>
+ #include <folly/hash/Checksum.h>
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ constexpr size_t kBufSize = 512 * 1024;
+ uint8_t* buf;
+ 
+@@ -58,7 +62,11 @@ int main(int argc, char** argv) {
+   gflags::ParseCommandLineFlags(&argc, &argv, true);
+   google::InitGoogleLogging(argv[0]);
+ 
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < 101500
++  buf = static_cast<uint8_t*>(malloc(kBufSize + 64));
++#else
+   buf = static_cast<uint8_t*>(std::aligned_alloc(4096, kBufSize + 64));
++#endif
+ 
+   std::default_random_engine rng(1729); // Deterministic seed.
+   std::uniform_int_distribution<uint16_t> dist(0, 255);
+diff --git folly/io/async/AsyncUDPSocket.cpp folly/io/async/AsyncUDPSocket.cpp
+index d95698cc8..00421573a 100644
+--- folly/io/async/AsyncUDPSocket.cpp
++++ folly/io/async/AsyncUDPSocket.cpp
+@@ -262,6 +262,7 @@ void AsyncUDPSocket::init(sa_family_t family, BindOptions bindOptions) {
+             "failed to set IPV6_RECVTCLASS on the socket",
+             errno);
+       }
++    #ifdef IP_RECVTOS
+     } else if (family == AF_INET) {
+       if (netops::setsockopt(
+               socket, IPPROTO_IP, IP_RECVTOS, &flag, sizeof(flag)) != 0) {
+@@ -270,6 +271,7 @@ void AsyncUDPSocket::init(sa_family_t family, BindOptions bindOptions) {
+             "failed to set IP_RECVTOS on the socket",
+             errno);
+       }
++    #endif
+     }
+   }
+ 
 diff --git folly/io/async/fdsock/AsyncFdSocket.h folly/io/async/fdsock/AsyncFdSocket.h
 index d3d84bb58..8fbfbd9ba 100644
 --- folly/io/async/fdsock/AsyncFdSocket.h
@@ -19,140 +263,6 @@ index d3d84bb58..8fbfbd9ba 100644
  namespace folly {
  
  // Including `gtest/gtest_prod.h` would make gtest/gmock a hard dep
-
-diff --git CMake/folly-deps.cmake CMake/folly-deps.cmake
-index 989259a87..7fa4cb4e5 100644
---- CMake/folly-deps.cmake
-+++ CMake/folly-deps.cmake
-@@ -247,7 +250,7 @@ check_cxx_source_compiles("
-   FOLLY_STDLIB_LIBCPP
- )
- 
--if (APPLE)
-+if (APPLE AND NOT(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
-   list (APPEND CMAKE_REQUIRED_LIBRARIES c++abi)
-   list (APPEND FOLLY_LINK_LIBRARIES c++abi)
- endif ()
-diff --git CMakeLists.txt CMakeLists.txt
-index dfd4c3820..d02121df0 100644
---- CMakeLists.txt
-+++ CMakeLists.txt
-@@ -261,6 +261,16 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
- endif()
- 
- # base64 SIMD files compilation
-+
-+if (APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64")
-+  message(
-+    STATUS
-+    "PowerPC Big Endian has a limited support, "
-+    "skipping building Base64SWAR of base64"
-+  )
-+  list(REMOVE_ITEM files ${FOLLY_DIR}/detail/base64_detail/Base64SWAR.cpp)
-+endif()
-+
- if (NOT(${IS_X86_64_ARCH}))
-   message(
-     STATUS
-diff --git folly/File.cpp folly/File.cpp
-index 401eb7a01..c50a6d7e5 100644
---- folly/File.cpp
-+++ folly/File.cpp
-@@ -120,8 +120,10 @@ File File::dupCloseOnExec() const {
-     int fd;
- #ifdef _WIN32
-     fd = ::dup(fd_);
--#else
-+#elif defined(F_DUPFD_CLOEXEC)
-     fd = ::fcntl(fd_, F_DUPFD_CLOEXEC, 0);
-+#else
-+    fd = ::dup(fd_);
- #endif
-     checkUnixError(fd, "dup() failed");
- 
-diff --git folly/Portability.h folly/Portability.h
-index 24ba108bb..933d240e7 100644
---- folly/Portability.h
-+++ folly/Portability.h
-@@ -103,12 +103,18 @@ constexpr bool kHasUnalignedAccess = false;
- #define FOLLY_AARCH64 0
- #endif
- 
--#if defined(__powerpc64__)
-+#if defined(__powerpc64__) || defined(__ppc64__)
- #define FOLLY_PPC64 1
- #else
- #define FOLLY_PPC64 0
- #endif
- 
-+#if defined(__ppc__)
-+#define FOLLY_PPC 1
-+#else
-+#define FOLLY_PPC 0
-+#endif
-+
- #if defined(__s390x__)
- #define FOLLY_S390X 1
- #else
-@@ -120,6 +126,7 @@ constexpr bool kIsArchArm = FOLLY_ARM == 1;
- constexpr bool kIsArchAmd64 = FOLLY_X64 == 1;
- constexpr bool kIsArchAArch64 = FOLLY_AARCH64 == 1;
- constexpr bool kIsArchPPC64 = FOLLY_PPC64 == 1;
-+constexpr bool kIsArchPPC = FOLLY_PPC == 1;
- constexpr bool kIsArchS390X = FOLLY_S390X == 1;
- } // namespace folly
- 
-@@ -272,6 +279,9 @@ constexpr auto kIsLittleEndian = false;
- #else
- constexpr auto kIsLittleEndian = true;
- #endif
-+#elif defined(__APPLE__) && defined(__POWERPC__)
-+// Darwin ppc/ppc64
-+constexpr auto kIsLittleEndian = false;
- #else
- constexpr auto kIsLittleEndian = __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__;
- #endif
-diff --git folly/detail/base64_detail/Base64Api.cpp folly/detail/base64_detail/Base64Api.cpp
-index 9c8493c06..4ada55281 100644
---- folly/detail/base64_detail/Base64Api.cpp
-+++ folly/detail/base64_detail/Base64Api.cpp
-@@ -31,10 +31,16 @@ Base64RuntimeImpl base64EncodeSelectImplementation() {
-         base64URLDecodeSWAR};
-   }
- #endif
-+#if defined(__POWERPC__) || (defined(__powerpc__) && defined(WORDS_BIGENDIAN)) // PowerPC BE
-+  return {
-+      base64EncodeScalar,
-+      base64URLEncode};
-+#else // Everything but PowerPC BE
-   return {
-       base64EncodeScalar,
-       base64URLEncodeScalar,
-       base64DecodeSWAR,
-       base64URLDecodeSWAR};
-+#endif
- }
- } // namespace folly::detail::base64_detail
-diff --git folly/io/async/AsyncUDPSocket.cpp folly/io/async/AsyncUDPSocket.cpp
-index ce0e33e96..6748c9aab 100644
---- folly/io/async/AsyncUDPSocket.cpp
-+++ folly/io/async/AsyncUDPSocket.cpp
-@@ -262,6 +262,7 @@ void AsyncUDPSocket::init(sa_family_t family, BindOptions bindOptions) {
-             "failed to set IPV6_RECVTCLASS on the socket",
-             errno);
-       }
-+  #ifdef IP_RECVTOS
-     } else if (family == AF_INET) {
-       if (netops::setsockopt(
-               socket, IPPROTO_IP, IP_RECVTOS, &flag, sizeof(flag)) != 0) {
-@@ -270,6 +271,7 @@ void AsyncUDPSocket::init(sa_family_t family, BindOptions bindOptions) {
-             "failed to set IP_RECVTOS on the socket",
-             errno);
-       }
-+  #endif
-     }
-   }
- 
 diff --git folly/net/NetOps.h folly/net/NetOps.h
 index 674a216a2..c5881a7d9 100644
 --- folly/net/NetOps.h
@@ -188,23 +298,26 @@ index 09a8a9907..d3a6caac4 100644
  using tcp_info = ::tcp_connection_info;
  const int tcp_info_sock_opt = TCP_CONNECTION_INFO;
 diff --git folly/portability/Asm.h folly/portability/Asm.h
-index e71da91c7..e1924c0e4 100644
+index e71da91c7..2fdafe6cf 100644
 --- folly/portability/Asm.h
 +++ folly/portability/Asm.h
-@@ -43,8 +43,10 @@ inline void asm_volatile_pause() {
+@@ -43,8 +43,12 @@ inline void asm_volatile_pause() {
    asm volatile("isb");
  #elif (defined(__arm__) && !(__ARM_ARCH < 7))
    asm volatile("yield");
 -#elif FOLLY_PPC64
-+#elif FOLLY_PPC64 && !(defined(__APPLE__))
-   asm volatile("or 27,27,27");
-+#elif (FOLLY_PPC || FOLLY_PPC64) && defined(__APPLE__)
-+  __asm__ volatile ("or r27,r27,r27" ::: "memory");
+-  asm volatile("or 27,27,27");
++#elif FOLLY_PPC || FOLLY_PPC64
++  #ifdef __APPLE__
++    __asm__ volatile ("or r27,r27,r27" ::: "memory");
++  #else
++    asm volatile("or 27,27,27");
++  #endif
  #endif
  }
  } // namespace folly
 diff --git folly/portability/Time.cpp folly/portability/Time.cpp
-index 88f00150f..3f882b473 100644
+index 4039ea814..1351826ea 100644
 --- folly/portability/Time.cpp
 +++ folly/portability/Time.cpp
 @@ -37,11 +37,13 @@ static void duration_to_ts(
@@ -230,7 +343,7 @@ index 88f00150f..3f882b473 100644
    mach_msg_type_number_t task_basic_info_count = MACH_TASK_BASIC_INFO_COUNT;
    kern_result = task_info(
 @@ -74,6 +77,18 @@ static int clock_process_cputime(struct timespec* ts) {
-   if (UNLIKELY(kern_result != KERN_SUCCESS)) {
+   if (FOLLY_UNLIKELY(kern_result != KERN_SUCCESS)) {
      return -1;
    }
 +#else
@@ -241,7 +354,7 @@ index 88f00150f..3f882b473 100644
 +      TASK_BASIC_INFO,
 +      (thread_info_t)&task_basic_info,
 +      &task_basic_info_count);
-+  if (UNLIKELY(kern_result != KERN_SUCCESS)) {
++  if (FOLLY_UNLIKELY(kern_result != KERN_SUCCESS)) {
 +    return -1;
 +  }
 +#endif
@@ -303,28 +416,230 @@ index 88f00150f..3f882b473 100644
      default:
        errno = EINVAL;
        return -1;
+diff --git folly/synchronization/AtomicRef.h folly/synchronization/AtomicRef.h
+index b4408130c..54772a164 100644
+--- folly/synchronization/AtomicRef.h
++++ folly/synchronization/AtomicRef.h
+@@ -28,7 +28,9 @@ namespace detail {
+ template <typename T>
+ struct atomic_ref_base {
+   static_assert(sizeof(T) == sizeof(std::atomic<T>), "size mismatch");
++#ifndef __ppc__
+   static_assert(alignof(T) == alignof(std::atomic<T>), "alignment mismatch");
++#endif
+   static_assert(is_trivially_copyable_v<T>, "value not trivially-copyable");
+ 
+   explicit atomic_ref_base(T& ref) : ref_(ref) {}
+@@ -156,9 +158,11 @@ struct make_atomic_ref_t {
+   template <
+       typename T,
+       std::enable_if_t<
+-          is_trivially_copyable_v<T> && sizeof(T) == sizeof(std::atomic<T>) &&
+-              alignof(T) == alignof(std::atomic<T>),
+-          int> = 0>
++          is_trivially_copyable_v<T> && sizeof(T) == sizeof(std::atomic<T>)
++#ifndef __ppc__
++          && alignof(T) == alignof(std::atomic<T>)
++#endif
++          , int> = 0>
+   atomic_ref<T> operator()(T& ref) const {
+     return atomic_ref<T>{ref};
+   }
+diff --git folly/synchronization/NativeSemaphore.h folly/synchronization/NativeSemaphore.h
+index f894eed63..2d7c195af 100644
+--- folly/synchronization/NativeSemaphore.h
++++ folly/synchronization/NativeSemaphore.h
+@@ -20,13 +20,17 @@
+ #include <limits>
+ #include <stdexcept>
+ 
++#if defined(__APPLE__)
++#include <AvailabilityMacros.h>
++#endif
++
+ #include <folly/Utility.h>
+ #include <folly/lang/Exception.h>
+ #include <folly/portability/Windows.h>
+ 
+ #if defined(_WIN32)
+ 
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED > 1050) && !defined(__ppc__)
+ 
+ #include <dispatch/dispatch.h> // @manual
+ 
+@@ -94,7 +98,7 @@ class NativeSemaphore {
+   HANDLE sem_{INVALID_HANDLE_VALUE};
+ };
+ 
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED > 1050) && !defined(__ppc__)
+ 
+ class NativeSemaphore {
+  public:
 diff --git folly/system/ThreadId.cpp folly/system/ThreadId.cpp
-index e426b39e1..b297d671f 100644
+index fa365a641..bd3760921 100644
 --- folly/system/ThreadId.cpp
 +++ folly/system/ThreadId.cpp
-@@ -40,9 +40,17 @@ namespace detail {
+@@ -40,9 +40,13 @@ namespace detail {
  
  uint64_t getOSThreadIDSlow() {
  #if __APPLE__
 -  uint64_t tid;
 -  pthread_threadid_np(nullptr, &tid);
 -  return tid;
-+  #if MAC_OS_X_VERSION_MAX_ALLOWED < 1070
-+    uint64_t tid;
-+    tid = pthread_mach_thread_np(pthread_self());
-+  #elif MAC_OS_X_VERSION_MIN_REQUIRED < 1070
-+    uint64_t tid;
-+    tid = pthread_mach_thread_np(pthread_self());
-+  #else
++  #ifndef __POWERPC__
 +    uint64_t tid;
 +    pthread_threadid_np(nullptr, &tid);
 +    return tid;
++  #else
++    return 0;
 +  #endif
  #elif defined(_WIN32)
    return uint64_t(GetCurrentThreadId());
  #elif defined(__FreeBSD__)
+diff --git folly/system/ThreadName.cpp folly/system/ThreadName.cpp
+index 6dc5878cc..d61fd49fe 100644
+--- folly/system/ThreadName.cpp
++++ folly/system/ThreadName.cpp
+@@ -56,9 +56,9 @@
+ #define FOLLY_HAS_PTHREAD_SETNAME_NP_THREAD_NAME 0
+ #endif
+ 
+-#if defined(__APPLE__)
+-#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
+-    __MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
++#if defined(__APPLE__) && !defined(__POWERPC__)
++#if defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
++    MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+ // macOS 10.6+ has pthread_setname_np(const char*) (1 param)
+ #define FOLLY_HAS_PTHREAD_SETNAME_NP_NAME 1
+ #elif defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && \
+diff --git folly/test/ConstexprMathTest.cpp folly/test/ConstexprMathTest.cpp
+index db61e050c..c478fc138 100644
+--- folly/test/ConstexprMathTest.cpp
++++ folly/test/ConstexprMathTest.cpp
+@@ -985,10 +985,12 @@ TEST_F(ConstexprMathTest, constexpr_exp_floating) {
+     constexpr auto a = folly::constexpr_exp(3.3);
+     EXPECT_DOUBLE_EQ(std::exp(3.3), a);
+   }
++#ifndef __ppc__
+   {
+     constexpr auto a = folly::constexpr_exp(471.L);
+     EXPECT_DOUBLE_EQ(std::exp(471.L), a);
+   }
++#endif
+   {
+     constexpr auto a = folly::constexpr_exp(600.);
+     EXPECT_NE(lim::infinity(), a);
+diff --git folly/test/IteratorsTest.cpp folly/test/IteratorsTest.cpp
+index 63195eced..db1235f7e 100644
+--- folly/test/IteratorsTest.cpp
++++ folly/test/IteratorsTest.cpp
+@@ -42,7 +42,9 @@ TEST(IteratorsTest, IterFacadeHasCorrectTraits) {
+   static_assert(
+       std::is_same<TR::iterator_category, std::forward_iterator_tag>::value,
+       "");
++#ifndef __ppc__
+   static_assert(std::is_same<TR::difference_type, ssize_t>::value, "");
++#endif
+ }
+ 
+ TEST(IteratorsTest, SimpleIteratorFacade) {
+@@ -85,7 +87,9 @@ TEST(IteratorsTest, IterAdaptorHasCorrectTraits) {
+   static_assert(
+       std::is_same<TR::iterator_category, std::forward_iterator_tag>::value,
+       "");
++#ifndef __ppc__
+   static_assert(std::is_same<TR::difference_type, ssize_t>::value, "");
++#endif
+ }
+ 
+ TEST(IteratorsTest, IterAdaptorWithPointer) {
+diff --git folly/test/MemsetBenchmark.cpp folly/test/MemsetBenchmark.cpp
+index 139987d0d..62423f925 100644
+--- folly/test/MemsetBenchmark.cpp
++++ folly/test/MemsetBenchmark.cpp
+@@ -25,6 +25,10 @@
+ #include <folly/Preprocessor.h>
+ #include <folly/portability/GFlags.h>
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ DEFINE_uint32(min_size, 1, "Minimum size to benchmark");
+ DEFINE_uint32(max_size, 32768, "Maximum size to benchmark");
+ DEFINE_bool(linear, false, "Test all sizes [min_size, max_size]");
+@@ -86,7 +90,11 @@ int main(int argc, char** argv) {
+   assert(FLAGS_step > 0);
+ 
+   size_t totalBufSize = (FLAGS_max_size + FLAGS_page_offset + 4095) & ~4095;
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < 101500
++  temp_buf = (uint8_t*)malloc(totalBufSize);
++#else
+   temp_buf = (uint8_t*)aligned_alloc(4096, totalBufSize);
++#endif
+   // Make sure all pages are allocated
+   for (size_t i = 0; i < totalBufSize; i++) {
+     temp_buf[i] = 0;
+diff --git folly/test/MemsetTest.cpp folly/test/MemsetTest.cpp
+index b1deaca05..b65b53acd 100644
+--- folly/test/MemsetTest.cpp
++++ folly/test/MemsetTest.cpp
+@@ -21,6 +21,10 @@
+ 
+ #include <folly/portability/GTest.h>
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ constexpr size_t kPageSize = 4096;
+ constexpr uint8_t kBufEnd = 0xDB;
+ 
+@@ -45,8 +49,13 @@ void testMemsetImpl(uint8_t* buf, size_t maxLen) {
+ 
+ TEST(MemsetAsmTest, alignedBuffer) {
+   constexpr size_t kMaxSize = 2 * kPageSize;
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < 101500
++  uint8_t* buf = reinterpret_cast<uint8_t*>(
++      malloc(kMaxSize + 2 * kPageSize));
++#else
+   uint8_t* buf = reinterpret_cast<uint8_t*>(
+       aligned_alloc(kPageSize, kMaxSize + 2 * kPageSize));
++#endif
+   // Get buffer aligned power of 2 from 16 all the way up to a page size
+   for (size_t alignment = 16; alignment <= kPageSize; alignment <<= 1) {
+     testMemsetImpl(buf + (alignment % kPageSize), kMaxSize);
+@@ -55,8 +64,13 @@ TEST(MemsetAsmTest, alignedBuffer) {
+ }
+ 
+ TEST(MemsetAsmTest, unalignedBuffer) {
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < 101500
++  uint8_t* buf =
++      reinterpret_cast<uint8_t*>(malloc(2 * kPageSize));
++#else
+   uint8_t* buf =
+       reinterpret_cast<uint8_t*>(aligned_alloc(kPageSize, 2 * kPageSize));
++#endif
+   for (size_t alignment = 1; alignment <= 192; alignment++) {
+     testMemsetImpl(buf + alignment, 256);
+   }
+diff --git folly/test/OptionalTest.cpp folly/test/OptionalTest.cpp
+index 016b60639..e0123348a 100644
+--- folly/test/OptionalTest.cpp
++++ folly/test/OptionalTest.cpp
+@@ -56,9 +56,11 @@ struct NoDefault {
+ 
+ } // namespace
+ 
++#ifndef __ppc__
+ static_assert(sizeof(Optional<char>) == 2, "");
+-static_assert(sizeof(Optional<int>) == 8, "");
+ static_assert(sizeof(Optional<NoDefault>) == 4, "");
++#endif
++static_assert(sizeof(Optional<int>) == 8, "");
+ static_assert(sizeof(Optional<char>) == sizeof(boost::optional<char>), "");
+ static_assert(sizeof(Optional<short>) == sizeof(boost::optional<short>), "");
+ static_assert(sizeof(Optional<int>) == sizeof(boost::optional<int>), "");

--- a/devel/mvfst/Portfile
+++ b/devel/mvfst/Portfile
@@ -12,11 +12,11 @@ boost.version       1.81
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 16
 
-github.setup        facebook mvfst 2024.01.08.00 v
+github.setup        facebook mvfst 2024.01.22.00 v
 revision            0
-checksums           rmd160  9247704722512dfa2284d053028b2a607976e0b4 \
-                    sha256  cd479fa95041e436f012aae2402b82d62534ac43df72b4e41d47f2ca67092a02 \
-                    size    1869433
+checksums           rmd160  337e53d358f9795676b89c63a49bd4ada73e0e78 \
+                    sha256  4c60554c2f22afea7e80c4cb42265d8c8e86f9ae052df83608c22759fb35fa09 \
+                    size    1856652
 github.tarball_from archive
 
 categories          devel net security

--- a/devel/proxygen/Portfile
+++ b/devel/proxygen/Portfile
@@ -13,7 +13,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 boost.version       1.81
 
-github.setup        facebook proxygen 2024.01.08.00 v
+github.setup        facebook proxygen 2024.01.22.00 v
 revision            0
 categories          devel
 license             BSD
@@ -25,9 +25,9 @@ long_description    This project comprises the core C++ HTTP abstractions used a
                     Future releases will provide simple client APIs as well. The framework supports \
                     HTTP/1.1, SPDY/3, SPDY/3.1, HTTP/2 and HTTP/3. The goal is to provide a simple, \
                     performant and modern C++ HTTP library.
-checksums           rmd160  43440bc8f6c41e57696df945641e39e97f1b045b \
-                    sha256  390cf1cf7a591ea3ac36ae497ce54391bda8894268bbb239839abf3bd8dbf587 \
-                    size    1167499
+checksums           rmd160  03da53ba5ec34c487536177a9dc9a60add39ae3e \
+                    sha256  ffe0517f630a0ac21a31ee0a0b949ae05f5f4620c08cbcb322fc421b1631655f \
+                    size    1167540
 github.tarball_from archive
 
 patchfiles          patch-tcpinfo.diff

--- a/devel/wangle/Portfile
+++ b/devel/wangle/Portfile
@@ -10,19 +10,19 @@ PortGroup           openssl 1.0
 
 boost.version       1.81
 
-github.setup        facebook wangle 2024.01.08.00 v
+github.setup        facebook wangle 2024.01.22.00 v
 revision            0
-checksums           rmd160  6a0bcde4b6ef03985167ce94f83c7e55605bca0e \
-                    sha256  6ab623c6deea78f53425ecbd36526a826feddac313a7c24895cdceb6c8dc6720 \
-                    size    347111
+checksums           rmd160  3313d5f37220d805abb51d118e9e5c353f5dc507 \
+                    sha256  b6b0a43021604bf4cb51aa895ca47e7846f17a36b1419313d7d0c793bb742d0f \
+                    size    346847
 
 categories          devel
 license             BSD
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 
 description         Wangle is a framework providing a set of common \
-                    client/server abstractions for building services in a \
-                    consistent, modular, and composable way.
+                    client/server abstractions for building services \
+                    in a consistent, modular, and composable way.
 long_description    {*}${description}
 
 github.tarball_from releases

--- a/sysutils/watchman/Portfile
+++ b/sysutils/watchman/Portfile
@@ -10,7 +10,7 @@ PortGroup           compiler_blacklist_versions 1.0
 boost.version       1.81
 
 github.setup        facebook watchman 2023.11.13.00 v
-revision            1
+revision            2
 
 categories          sysutils
 maintainers         {danchr @danchr} openmaintainer


### PR DESCRIPTION
#### Description

This adds support for testing in `folly` and updates everything to the latest versions.
`watchman` is revbumped.

(P. S. I am not gonna keep updating these ports every two weeks, it is unfeasible, but since I am adding support for tests to `folly`, do updates as well.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

macOS 14.2.1
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
