### PR TITLE
luit: update to 2.0.20240102

### DIFF
--- a/x11/luit/Portfile
+++ b/x11/luit/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                luit
-version             2.0.20230201
+version             2.0.20240102
 categories          x11
 license             X11
 platforms           darwin
@@ -16,9 +16,9 @@ master_sites        https://invisible-island.net/archives/${name}/current/ \
 
 extract.suffix      .tgz
 
-checksums           rmd160  fce2228878f600df8a5f690184f56d15fa236617 \
-                    sha256  07a066ff9b54c259775dc6af4e4bc53b5870cfcd8a5bdb20d4e441c384e8efae \
-                    size    209814
+checksums           rmd160  64072e13ca3f6249ab469dcc36a16c821d4c5380 \
+                    sha256  29d5f02ad655a11f010727264f1207fd3a8299254b93f13b68f2a958c00a0771 \
+                    size    211146
 
 installs_libs       no
 use_parallel_build  yes


### PR DESCRIPTION
#### Description

Reduce compiler-warnings in configure scripts.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.3 22G436 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
