### PR TITLE
vile: Update to 9.8z

### DIFF
--- a/editors/vile/Portfile
+++ b/editors/vile/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 
 name                vile
-version             9.8y
+version             9.8z
 revision            0
-checksums           rmd160  0a278c188d356c208afbe8e0dded769a8c1ad7e4 \
-                    sha256  1b67f1ef34f5f2075722ab46184bb149735e8538fa912fc07c985c92f78fe381 \
-                    size    2477410
+checksums           rmd160  b1d04a30eea056de1b3ce8ec95052de1c1213920 \
+                    sha256  0b3286c327b70a939f21992d22e42b5c1f8a6e953bd9ab9afa624ea2719272f7 \
+                    size    2491799
 
 categories          editors
 platforms           darwin


### PR DESCRIPTION
#### Description

- improve UTF-8 support
- reduce compiler-warnings in configure script checks
- provide workaround for reported locale issue with MacOS

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.3 22G436 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
