### PR TITLE
add: update to 20240110

### DIFF
--- a/math/add/Portfile
+++ b/math/add/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                add
-version             20230205
+version             20240110
 revision            0
 categories          math
 license             BSD
@@ -18,9 +18,9 @@ master_sites        https://invisible-island.net/archives/${name}/ \
                     https://invisible-mirror.net/archives/${name}/
 extract.suffix      .tgz
 
-checksums           rmd160  179c058be44f43fdfe083f67dc50f90724aef804 \
-                    sha256  68e216241100d0cf098e139c24fe04880b9be60a8643cd82f8925ac0ce3d7260 \
-                    size    179162
+checksums           rmd160  9a46b04b25ba3b75d748e70e27208e6eb94e8964 \
+                    sha256  038c814e6349f29595357e05e7059f730ba4513138d11f4bcd8f3dcb3a045e8b \
+                    size    180324
 
 depends_lib         port:ncurses
 


### PR DESCRIPTION
#### Description

Reduce compiler-warnings in configure script checks

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.3 22G436 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
