### PR TITLE
janet: Update to 1.32.0

### DIFF
--- a/lang/janet/Portfile
+++ b/lang/janet/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
-github.setup        janet-lang janet 1.22.0 v
+github.setup        janet-lang janet 1.32.0 v
 revision            0
 
 categories          lang
@@ -23,9 +23,9 @@ long_description    Janet is a functional and imperative programming \
 
 homepage            https://janet-lang.org/
 
-checksums           rmd160  7e02e3db9be2b43252339eef553a9a52d586e341 \
-                    sha256  ce07c705aea3ec751ba7db3385f8dc0ddfad75a6ff1f86dc525476e977a8e4e1 \
-                    size    494150
+checksums           rmd160  0ebe89b01b96d708bb85fd5176a2442f84661079 \
+                    sha256  ec6dfd0a81b1ddb8587527502f92e02a72b6f9b8418dee9e384e90c052384c2e \
+                    size    557022
 
 # Fixes passing correct link flags to boot_strap janet
 #   and incorrect use of environ on macOS.

--- a/lang/janet/files/fix-janet_boot-link-legacysupport.diff
+++ b/lang/janet/files/fix-janet_boot-link-legacysupport.diff
@@ -1,14 +1,13 @@
 diff --git a/Makefile b/Makefile
-index da5e1260..d94c13f8 100644
+index abee818d..5eaec2c2 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -146,7 +146,7 @@ build/%.boot.o: src/%.c $(JANET_HEADERS) $(JANET_LOCAL_HEADERS) Makefile
+@@ -177,7 +177,7 @@ build/%.boot.o: src/%.c $(JANET_HEADERS) $(JANET_LOCAL_HEADERS) Makefile
  	$(CC) $(BOOT_CFLAGS) -o $@ -c $<
  
- build/janet_boot: $(JANET_BOOT_OBJECTS)
+ $(JANET_BOOT): $(JANET_BOOT_OBJECTS)
 -	$(CC) $(BOOT_CFLAGS) -o $@ $(JANET_BOOT_OBJECTS) $(CLIBS)
 +	$(CC) $(BOOT_CFLAGS) -o $@ $(JANET_BOOT_OBJECTS) $(CLIBS) $(LDFLAGS)
  
  # Now the reason we bootstrap in the first place
- build/c/janet.c: build/janet_boot src/boot/boot.janet
-
+ build/c/janet.c: $(JANET_BOOT) src/boot/boot.janet


### PR DESCRIPTION
#### Description

Update janet to the latest version, v1.32.0

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.6.3 22G436 arm64
Xcode 15.1 15C65

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
