### PR TITLE
stellarium: Don't use exiv2; do use eigen3 and glm

### DIFF
--- a/science/stellarium/Portfile
+++ b/science/stellarium/Portfile
@@ -6,9 +6,9 @@ PortGroup       cmake 1.1
 PortGroup       qt5 1.0
 
 github.setup    Stellarium stellarium 23.4 v
+revision        1
 github.tarball_from \
                 releases
-revision        0
 
 categories      science
 installs_libs   no
@@ -50,6 +50,11 @@ depends_lib-append \
     path:lib/pkgconfig/glib-2.0.pc:glib2 \
     port:fontconfig \
     port:freetype
+
+# for ShowMySky plugin
+depends_lib-append \
+    port:eigen3 \
+    port:glm
 
 # fix the install prefix for MP use only
 patchfiles-append patch-CMakeLists.txt.diff

--- a/science/stellarium/Portfile
+++ b/science/stellarium/Portfile
@@ -62,6 +62,13 @@ if {![tbool configure.ccache]} {
     configure.args-append -DCCACHE_PROGRAM=""
 }
 
+# prevent opportunistic use of exiv2 by LensDistortionEstimator plugin since
+# it requires a newer version of exiv2 than we currently have in MacPorts.
+# https://trac.macports.org/ticket/68991
+# https://trac.macports.org/ticket/69170
+configure.args-append \
+    -DCMAKE_DISABLE_FIND_PACKAGE_exiv2=ON
+
 # special args for our needs
 configure.args-append \
     -DMP_APPLICATIONS_DIR=${applications_dir}


### PR DESCRIPTION
#### Description

This PR changes two things:

1. Don't use exiv2 even if it is found. It is searched for by the LensDistortionEstimator plugin but it appears to be optional. If it were found, it would fail to build, because it requires a newer version of exiv2 than we currently have in MacPorts.
2. Do depend on eigen3 and glm. The ShowMySky pluing looks for these, and if it doesn't find them, it appears to use its own internal copies:

```
-- CPM: Adding package ShowMySky-Qt5@0.3.1 (0.3.1)
-- Looking for C++ include glm/glm.hpp
-- Looking for C++ include glm/glm.hpp - not found
-- CPM: ShowMySky-Qt5: Adding package glm@ ()
-- CPM: ShowMySky-Qt5: Adding package Eigen3@3.4.0 (3.4.0)
-- ABI version: 15
-- Will build ShowMySky library
```

After adding the dependencies, it uses MacPorts versions:

```
-- CPM: Adding package ShowMySky-Qt5@0.3.1 (0.3.1)
-- Looking for C++ include glm/glm.hpp
-- Looking for C++ include glm/glm.hpp - found
-- Checking that GLM has the required features
-- Checking that GLM has the required features - done
-- CPM: ShowMySky-Qt5: Using local package Eigen3@3.4.0
-- ABI version: 15
-- Will build ShowMySky library
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 21G1974 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
