### PR TITLE
SuiteSparse: update to 7.6.0

### DIFF
--- a/math/SuiteSparse/Portfile
+++ b/math/SuiteSparse/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                DrTimothyAldenDavis SuiteSparse 7.5.1 v
+github.setup                DrTimothyAldenDavis SuiteSparse 7.6.0 v
 # subports have independent revisions
 revision                    0
 epoch                       20200517
@@ -17,15 +17,15 @@ long_description            SuiteSparse is a single archive that contains all pa
 
 homepage                    https://people.engr.tamu.edu/davis/suitesparse.html
 
-checksums                   rmd160  e6ab4056b07d8136c8fdf2bb0bb7eb1f733f04e0 \
-                            sha256  e45ae6caf9f66e009c8fcf3940a2a300dac5b6aae17aa96b3c052e2f79849aed \
-                            size    85466945
+checksums                   rmd160  76a21ff5cc4458b60c40c8a59c530f75c3c9aa57 \
+                            sha256  3178af2e5d2fa58fde129ab6fffccecdc380dee79cd7e8e3de05577cd5119cfd \
+                            size    85512801
 
 configure.optflags          -O3
 
 compiler.c_standard         2011
 
-# We keep SUITESPARSE_USE_STRICT at the default value of OFF and 
+# We keep SUITESPARSE_USE_STRICT at the default value of OFF and
 # SUITESPARSE_USE_OPENMP at the default value of ON. This way OpenMP will be
 # used only when the compiler supports it. OpenMP is enabled on a case-by-case
 # basis for some subports by adding 'compiler.openmp_version 4.0' and setting
@@ -33,7 +33,7 @@ compiler.c_standard         2011
 #
 # Additionally we set:
 # -DBUILD_STATIC_LIBS=OFF: Disable building static libraries
-# -DSUITESPARSE_INCLUDEDIR_POSTFIX="": Install headers into 'include' instead of 
+# -DSUITESPARSE_INCLUDEDIR_POSTFIX="": Install headers into 'include' instead of
 # 'include/suitesparse' for compatibility with older packages such as sundials5.
 configure.args-append       -DBUILD_STATIC_LIBS=OFF -DSUITESPARSE_INCLUDEDIR_POSTFIX=""
 
@@ -43,7 +43,7 @@ compiler.log_verbose_output no
 subport SuiteSparse_config {
     PortGroup               linear_algebra 1.0
 
-    version                 7.5.1
+    version                 7.6.0
     revision                0
     # from the README.txt:
     #    "[n]o licensing restrictions apply"
@@ -57,7 +57,7 @@ subport SuiteSparse_config {
 }
 
 subport SuiteSparse_GraphBLAS {
-    version                 9.0.0
+    version                 9.0.1
     revision                0
     license                 Apache-2
     long_description-append ${subport}: graph algorithms in the language of linear algebra.
@@ -73,7 +73,7 @@ subport SuiteSparse_GraphBLAS {
 }
 
 subport SuiteSparse_LAGraph {
-    version                 1.1.1
+    version                 1.1.2
     revision                0
     depends_lib-append      port:SuiteSparse_GraphBLAS
     license                 BSD
@@ -84,7 +84,7 @@ subport SuiteSparse_LAGraph {
 }
 
 subport SuiteSparse_Mongoose {
-    version                 3.3.1
+    version                 3.3.2
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 GPL-3
@@ -117,7 +117,7 @@ subport SuiteSparse_CAMD {
 }
 
 subport SuiteSparse_CCOLAMD {
-    version                 3.3.1
+    version                 3.3.2
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 BSD
@@ -125,7 +125,7 @@ subport SuiteSparse_CCOLAMD {
 }
 
 subport SuiteSparse_COLAMD {
-    version                 3.3.1
+    version                 3.3.2
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 BSD
@@ -135,7 +135,7 @@ subport SuiteSparse_COLAMD {
 subport SuiteSparse_CHOLMOD {
     PortGroup               linear_algebra 1.0
 
-    version                 5.1.1
+    version                 5.2.0
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CAMD port:SuiteSparse_COLAMD port:SuiteSparse_CCOLAMD
     license                 LGPL-2.1+
@@ -165,7 +165,7 @@ subport SuiteSparse_LDL {
 }
 
 subport SuiteSparse_KLU {
-    version                 2.3.1
+    version                 2.3.2
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_BTF port:SuiteSparse_COLAMD port:SuiteSparse_CHOLMOD
     license                 LGPL-2.1+
@@ -175,7 +175,7 @@ subport SuiteSparse_KLU {
 subport SuiteSparse_UMFPACK {
     PortGroup               linear_algebra 1.0
 
-    version                 6.3.1
+    version                 6.3.2
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CHOLMOD
     license                 GPL-2+
@@ -197,7 +197,7 @@ subport SuiteSparse_RBio {
 subport SuiteSparse_SPQR {
     PortGroup               linear_algebra 1.0
 
-    version                 4.3.1
+    version                 4.3.2
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_COLAMD port:SuiteSparse_CHOLMOD
     license                 GPL-2+
@@ -210,7 +210,7 @@ subport SuiteSparse_SPQR {
 }
 
 subport SuiteSparse_SPEX {
-    version                 2.3.1
+    version                 2.3.2
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_COLAMD \
                             port:gmp \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
