### PR TITLE
testssl: new port

### DIFF
--- a/security/testssl/Portfile
+++ b/security/testssl/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        drwetter testssl.sh 3.0.8 v
+github.tarball_from archive
+name                testssl
+revision            0
+categories          security
+platforms           any
+supported_archs     noarch
+license             GPL-2
+maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
+
+description         Test TLS/SSL encryption anywhere on any port
+
+long_description    testssl.sh is a free command line tool which checks a \
+                    server's service on any port for the support of TLS/SSL \
+                    ciphers, protocols as well as some cryptographic flaws.
+
+homepage            https://testssl.sh
+
+checksums           rmd160  928e25e6cabe34eafdb0f56154e724dae11da915 \
+                    sha256  22c5dc6dfc7500db94b6f8a48775f72b5149d0a372b8552ed7666016ee79edf0 \
+                    size    9372229
+
+use_configure       no
+build               {}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/libexec/${name}
+    copy ${worksrcpath}/testssl.sh ${worksrcpath}/etc \
+        ${destroot}${prefix}/libexec/${name}
+    ln -s ../libexec/${name}/testssl.sh ${destroot}${prefix}/bin/testssl.sh
+    copy ${worksrcpath}/doc/testssl.1 ${destroot}${prefix}/share/man/man1/
+}


### PR DESCRIPTION
#### Description

[Test TLS/SSL encryption anywhere on any port](https://github.com/drwetter/testssl.sh)

###### Tested on
macOS 14.2.1 23C71 x86_64
Xcode 15.2 15C500b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?