### PR TITLE
symfony-cli: update to 5.8.4

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.3
+version             5.8.4
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  fdb2731c60ddc8a018ddb00eff99861aae4e9d2b \
-                        sha256  dddecb683a8f1c68f96ea27f1b1cc60dfe068a061897bb31b2180c23eee1abf2 \
-                        size    262007
+    checksums           rmd160  893a6871f0e0a70073699d1722c0fad313c9ca9d \
+                        sha256  38e58071cc16c7ce669e0dc105455ccd5767169708bc326087983660657abe43 \
+                        size    262194
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  34c969603547842b55b7f14cabe725df5ac7bf03 \
-                        sha256  80d5a7c66b7abc57abd6b7d556532b949ea79c9193fe8e8d46c7b2d1b78d4f4d \
-                        size    11147319
+    checksums           rmd160  f6fbda7db6c4ab86775fb33c2eabd5ef85b6073a \
+                        sha256  4e37e207b07457463cb2bf9eaf7ff67fff5f71a18dd49d4ba5f3acf74b5f8931 \
+                        size    11152063
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.4

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
