### PR TITLE
pcre2: allow build on x86 with libstdc++

### DIFF
--- a/devel/pcre/Portfile
+++ b/devel/pcre/Portfile
@@ -85,6 +85,17 @@ platform darwin 8 {
     }
 }
 
+if {${subport} eq "pcre2" && ${os.platform} eq "darwin"} {
+    # This is specific to Intel and libstdc++.
+    # https://trac.macports.org/ticket/67477
+    # https://trac.macports.org/ticket/69073
+    if {${os.major} < 11 && ${configure.build_arch} in "i386 x86_64" \
+        && ${configure.cxx_stdlib} ne "libc++"} {
+            configure.args-replace \
+                    --enable-jit --disable-jit
+    }
+}
+
 test.run            yes
 test.target         check
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/67477
Closes: https://trac.macports.org/ticket/69073

#### Description

This PR unbreaks `pcre2` for Intel systems when Macports is configured to use 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 i386
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
