### PR TITLE
Io: set arch and no universal

### DIFF
--- a/lang/Io/Portfile
+++ b/lang/Io/Portfile
@@ -68,6 +68,10 @@ patchfiles              Cairo-clang-warnings.patch \
 
 configure.python        ${prefix}/bin/python3.7
 
+# Builds currently fail on apple silicon even in universal mode
+supported_archs         ppc ppc64 i386 x86_64
+universal_variant       no
+
 # ../../_build/binaries/io_static: No such file or directory
 use_parallel_build      no
 


### PR DESCRIPTION
#### Description

* Currently failing on arm64 even in universal, so disabling
* Setting to just x86 et al for now until upstream can fix

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.3 23D56
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
