### PR TITLE
dos2unix: Update to 7.5.2

### DIFF
--- a/textproc/dos2unix/Portfile
+++ b/textproc/dos2unix/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           makefile 1.0
 
 name                dos2unix
-version             7.5.1
+version             7.5.2
 revision            0
 categories          textproc
 license             BSD
@@ -27,12 +27,18 @@ homepage            https://waterlan.home.xs4all.nl/dos2unix.html
 master_sites        sourceforge:project/dos2unix/dos2unix/${version} \
                     https://waterlan.home.xs4all.nl/dos2unix
 
-checksums           rmd160  7952d1dcd768109fd41b4fe88ee99e58677443ba \
-                    sha256  da07788bb2e029b0d63f6471d166f68528acd8da2cf14823a188e8a9d5c1fc15 \
-                    size    959228
+checksums           rmd160  52e670594b8ea697e71b037ea396874266c56a02 \
+                    sha256  264742446608442eb48f96c20af6da303cb3a92b364e72cb7e24f88239c4bf3a \
+                    size    991485
 
-depends_lib         port:gettext
+depends_lib-append  port:gettext
 universal_variant   no
 
-destroot.args       prefix=${prefix} \
-                    DOCDIR=${destroot}${prefix}/share/doc/${name}
+makefile.prefix_name \
+                    prefix
+
+makefile.override-append \
+                    PREFIX
+
+destroot.args-append \
+                    docsubdir=${name}


### PR DESCRIPTION
#### Description

Update `dos2unix` to its latest released version, 7.5.2. While updating, I took the time to modernize the Portfile, given that its previous state was "unfinished" in the context of PortGroup fields, new Makefile variables, etc.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
