### PR TITLE
py-libusb1: Use Python 3.12

### DIFF
--- a/python/py-libusb1/Portfile
+++ b/python/py-libusb1/Portfile
@@ -21,7 +21,6 @@ checksums               rmd160  a1757aa095e386ef6ec416940e6ebb83ca6a5ded \
                         size    83013
 
 python.versions         38 39 310 311 312
-python.default_version  311
 
 if {${name} ne ${subport}} {
     depends_lib-append      lib:libusb-1.0:libusb


### PR DESCRIPTION
#### Description

Given that the `python` PG has recently upgraded to 3.12, `py-libusb1` should follow this default.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
