### PR TITLE
jemalloc-devel: new subport to track upstream

### DIFF
--- a/devel/jemalloc/Portfile
+++ b/devel/jemalloc/Portfile
@@ -4,33 +4,47 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           muniversal 1.1
 
-github.setup        jemalloc jemalloc 5.3.0
-revision            4
+name                jemalloc
 license             BSD
 categories          devel
-maintainers         nomaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 
 description         a general-purpose scalable concurrent malloc(3) implementation
 long_description    ${name} is {*}${description}
 
 homepage            https://jemalloc.net
 
-use_bzip2           yes
+if {${subport} eq ${name}} {
+    github.setup        jemalloc jemalloc 5.3.0
+    revision            4
+    conflicts           jemalloc-devel
+    checksums           rmd160  ff8f2958d88705927b7566d219763dda2eb7edda \
+                        sha256  2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa \
+                        size    736023
+    github.tarball_from releases
+    use_bzip2           yes
 
-checksums           rmd160  ff8f2958d88705927b7566d219763dda2eb7edda \
-                    sha256  2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa \
-                    size    736023
+    patchfiles-append   patch-quantum.diff \
+                        patch-Makefile.diff
 
-github.tarball_from releases
+    # building as x86_64 on an arm64 Mac gives an error if rosetta is installed
+    # https://trac.macports.org/ticket/65671
+    patchfiles-append   patch-universal.diff
+}
+
+subport jemalloc-devel {
+    github.setup        jemalloc jemalloc f96010b7fa8ce5f83802144bdebf2bb7a6679649
+    version             2024.01.24
+    conflicts           jemalloc
+    checksums           rmd160  803128a4cd13f06e708023b832dff33c2c014f11 \
+                        sha256  876c695ce41da086461b6a4585d3788edcec890a8ce355a832a4f4ee7fae2583 \
+                        size    834513
+    github.tarball_from archive
+
+    use_autoreconf      yes
+}
 
 compiler.cxx_standard 2014
-
-patchfiles          patch-quantum.diff \
-                    patch-Makefile.diff
-
-# building as x86_64 on an arm64 Mac gives an error if rosetta is installed
-# https://trac.macports.org/ticket/65671
-patchfiles-append   patch-universal.diff
 
 configure.args-append --with-jemalloc-prefix=
 


### PR DESCRIPTION
#### Description

Non-devel port is preserved as-is, so no revbump needed.

P. S. I also take maintainership, since some of my ports depend on it and I have committed to its upstream earlier.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
