### PR TITLE
libtorrent-devel, rtorrent-devel: update to 20230316

### DIFF
--- a/net/libtorrent-devel/Portfile
+++ b/net/libtorrent-devel/Portfile
@@ -2,17 +2,17 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           openssl 1.0
 
-github.setup        rakshasa libtorrent 3a6a61a4138048134f9048aef81a52f9bf821b29
-version             20181027
-revision            2
+github.setup        rakshasa libtorrent 91f8cf4b0358d9b4480079ca7798fa7d9aec76b5
+version             20230316
+revision            0
 
 name                libtorrent-devel
 conflicts           libtorrent
 set real_name       libtorrent
 
 categories          net
-platforms           darwin
 maintainers         nomaintainer
 license             {GPL-2+ OpenSSLException}
 
@@ -23,27 +23,19 @@ long_description    libTorrent is a BitTorrent library written in C++ for \
                     storing of data that other clients and libraries suffer from. \
                     This is the "unstable" release of libTorrent.
 
-checksums           rmd160  84fccee8263f2f0df34939d4a3de5abdace69bb2 \
-                    sha256  84b9f0f5f3d5819db889e4a012436132d37e5442376eeddb118668c1a764dd61 \
-                    size    357393
+checksums           rmd160  4eb674b37eac0ab8561cf1496cc4b989326e65c2 \
+                    sha256  3d9a0df0a882dbce755aab7229bb733e6c9bd1f420780bacc6bc1c014110cf6e \
+                    size    387414
+github.tarball_from archive
 
 use_autoreconf      yes
-autoreconf.cmd      ./autogen.sh
-
-depends_build-append \
-                    port:pkgconfig \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool
 
 # malformed object (unknown load command 2)
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     depends_build-append port:cctools
 }
 
-depends_lib-append \
-                    path:lib/libssl.dylib:openssl \
-                    port:libsigcxx2
+depends_lib-append  port:libsigcxx2
 
 compiler.cxx_standard   2011
 
@@ -57,6 +49,9 @@ post-destroot {
         ${destroot}${docdir}
 }
 
+# FIXME: 32-bit systems need to switch to C++11 atomics instead of __sync* builtins:
+# https://github.com/rakshasa/libtorrent/issues/163
+# Once done, perhaps 10.5 can be also enabled back.
 if {${os.platform} eq "darwin" && ${os.major} <= 9} {
     # currently broken, ticket #27289
     known_fail  yes

--- a/net/rtorrent-devel/Portfile
+++ b/net/rtorrent-devel/Portfile
@@ -3,17 +3,18 @@
 PortSystem          1.0
 PortGroup           active_variants 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+PortGroup           openssl 1.0
 
-github.setup        rakshasa rtorrent c62fa6a75649efe8cedb91c66d1b05b2b1be8872
-version             20181027
-revision            2
+github.setup        rakshasa rtorrent 1da0e3476dcabbf74b2e836d6b4c37b4d96bde09
+version             20230316
+revision            0
 
 name                rtorrent-devel
 conflicts           rtorrent
 set real_name       rtorrent
 
 categories          net
-platforms           darwin
 maintainers         nomaintainer
 license             {GPL-2+ OpenSSLException}
 
@@ -25,29 +26,25 @@ long_description    rTorrent is a console-based BitTorrent client. It aims to \
                     and session management. \
                     This is the "unstable" release of rTorrent.
 
-checksums           rmd160  f01865e7060a062e0fe39bfb7dfaa362c0ccaabb \
-                    sha256  6021a28ac91935ba0b15ff78ca44d70bdcab8c368d62829062610f1bf7baa478 \
-                    size    249150
+checksums           rmd160  756e3c8e96a8a56507d0ffecd50bd11596b30b8c \
+                    sha256  dc5bab8e06b4fa7ba8c956dd67efed7fd0452e545ce49ba25f3bfa8ae584ed84 \
+                    size    265245
+github.tarball_from archive
 
 use_autoreconf      yes
-autoreconf.cmd      ./autogen.sh
 
 depends_build-append \
-                    port:pkgconfig \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool
+                    port:autoconf-archive
 
 # malformed object (unknown load command 2)
 if {${os.platform} eq "darwin" && ${os.major} <= 10} {
     depends_build-append port:cctools
 }
 
-depends_lib         port:curl \
+depends_lib-append  port:curl \
                     port:libsigcxx2 \
                     port:libtorrent-devel \
                     port:ncurses \
-                    path:lib/libssl.dylib:openssl \
                     port:zlib
 
 # https://github.com/rakshasa/rtorrent/wiki/Installing#non-blocking-hostname-lookup-in-curl
@@ -59,11 +56,16 @@ configure.args      --mandir=${prefix}/share/man \
                     --disable-debug \
                     --enable-ipv6
 
+legacysupport.redirect_bins rtorrent
+
 variant xmlrpc description {Enable XMLRPC interface} {
     configure.args-append   --with-xmlrpc-c
     depends_lib-append      port:xmlrpc-c
 }
 
+# FIXME: 32-bit systems need to switch to C++11 atomics in libtorrent:
+# https://github.com/rakshasa/libtorrent/issues/163
+# Once done, perhaps 10.5 can be also enabled back.
 if {${os.platform} eq "darwin" && ${os.major} <= 9} {
     # currently broken, ticket #27289
     known_fail  yes


### PR DESCRIPTION
#### Description

-devel ports have not been updated for years.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1
Xcode 15.2

macOS 10.6
Xcode 3.2

P. S. `rtorrent-devel` wants a non-default variant of `curl`, I am not sure such a thing will work on CI. It does build without that still, however. If this fails, I could first comment that line out, confirm the build, then add it back with skip ci.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
