### PR TITLE
orc: use -stc=c99 to fix building

### DIFF
--- a/devel/orc/Portfile
+++ b/devel/orc/Portfile
@@ -6,7 +6,7 @@ PortGroup           muniversal 1.1
 
 name                orc
 version             0.4.35
-revision            0
+revision            1
 
 checksums           rmd160  36c0c05e14886bab375ba2a01dc40c405e2eb66b \
                     sha256  718cdb60db0d5f7d4fc8eb955cd0f149e0ecc78dcd5abdc6ce3be95221b793b9 \
@@ -18,12 +18,15 @@ long_description    Orc is a library and set of tools for compiling \
 
 maintainers         nomaintainer
 categories          devel
-platforms           darwin
 license             BSD
 homepage            https://gstreamer.freedesktop.org/modules/orc.html
 master_sites        https://gstreamer.freedesktop.org/src/orc/
 
 use_xz              yes
+
+# atomics.c: error: ‘for’ loop initial declaration used outside C99 mode
+configure.cflags-append \
+                    -std=c99
 
 test.run            yes
 


### PR DESCRIPTION
#### Description

Fix build after recent update: it needs C99 at least now.

P. S. Revbumping, since compiler flag may lead to not strictly identical binary.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
