### PR TITLE
pcaudiolib: make deps explicit, revbump due to pulseaudio update

### DIFF
--- a/audio/pcaudiolib/Portfile
+++ b/audio/pcaudiolib/Portfile
@@ -5,7 +5,7 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
 github.setup        espeak-ng pcaudiolib 1.2
-revision            1
+revision            2
 checksums           rmd160  9f9d15d3c4302d5e9003047c773e60f26a445dc2 \
                     sha256  6fae11e87425482acbb12c4e001282d329be097074573060f893349255d3664b \
                     size    377066
@@ -15,7 +15,6 @@ checksums           rmd160  9f9d15d3c4302d5e9003047c773e60f26a445dc2 \
 dist_subdir         ${name}/${version}_1
 
 categories          audio
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-3+
 
@@ -25,7 +24,9 @@ long_description    The Portable C Audio Library (pcaudiolib) provides a C API t
 
 github.tarball_from releases
 
-depends_build       port:pkgconfig
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:pulseaudio
 
 patchfiles          dynamic_lookup-11.patch
 
@@ -37,7 +38,12 @@ compiler.c_standard 2011
 compiler.blacklist-append \
                     {clang < 601}
 
-configure.args      --disable-silent-rules
+configure.args-append \
+                    --disable-silent-rules \
+                    --with-coreaudio \
+                    --with-pulseaudio \
+                    --without-alsa \
+                    --without-qsa
 
 test.run            yes
 test.target         check


### PR DESCRIPTION
#### Description

`pcaudiolib` by default links to `pulseaudio`, however that has not been mentioned in the portfile. In result it was omitted from revbumping, and now broken.
Fix dependency, revbump, also make configure args explicit.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
