### PR TITLE
py-pydantic and deps: restore py37 subport

### DIFF
--- a/python/py-annotated_types/Portfile
+++ b/python/py-annotated_types/Portfile
@@ -10,7 +10,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     38 39 310 311 312
+python.versions     37 38 39 310 311 312
 
 maintainers         nomaintainer
 
@@ -25,3 +25,16 @@ checksums           rmd160  fc8a60ece27a6c7ebab89f72922c2fb7f56cfc53 \
 
 python.pep517_backend \
                     hatch
+
+if {$subport ne $name} {
+    if {${python.version} < 39} {
+        depends_run-append  port:py${python.version}-typing_extensions
+    }
+    if {${python.version} == 37} {
+        version     0.5.0
+        revision    0
+        checksums   md5 45a0d68f2cb300d45126622d2724b78a \
+                    rmd160 0b8cf348d4d10706459b2393aac8fdfc83a80cc3 \
+                    sha256 47cdc3490d9ac1506ce92c7aaa76c579dc3509ff11e098fc867e5130ab7be802
+    }
+}

--- a/python/py-pydantic/Portfile
+++ b/python/py-pydantic/Portfile
@@ -10,7 +10,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     38 39 310 311 312
+python.versions     37 38 39 310 311 312
 
 maintainers         {@jandemter demter.de:jan} openmaintainer
 
@@ -31,10 +31,14 @@ if {${name} ne ${subport}} {
                     hatch
 
     depends_build-append \
-                    port:py${python.version}-setuptools \
                     port:py${python.version}-hatch-fancy-pypi-readme
 
     depends_run-append \
                     port:py${python.version}-annotated_types \
-                    port:py${python.version}-pydantic_core
+                    port:py${python.version}-pydantic_core \
+                    port:py${python.version}-typing_extensions
+    if {${python.version} == 37} {
+        depends_run-append \
+                    port:py${python.version}-importlib-metadata
+    }
 }

--- a/python/py-pydantic_core/Portfile
+++ b/python/py-pydantic_core/Portfile
@@ -9,7 +9,7 @@ version             2.16.1
 categories-append   devel
 license             MIT
 
-python.versions     38 39 310 311 312
+python.versions     37 38 39 310 311 312
 
 maintainers         nomaintainer
 
@@ -33,6 +33,7 @@ if {${name} ne ${subport}} {
                     "cargo update"
     }
 
+    if {${python.version} >= 38} {
     # cd ${worksrcpath}
     # sudo cargo update
     # egrep -e '^(name|version|checksum) = ' Cargo.lock | perl -pe 's/^(?:name|version|checksum) = "(.+)"/$1/' | tr '\n' ' ' | perl -pe 's|([0-9a-f]{64})|\1 \\\n|g' | pbcopy
@@ -118,4 +119,94 @@ if {${name} ne ${subport}} {
                     windows_x86_64_msvc 0.48.0 1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a \
                     zerocopy 0.7.32 74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be \
                     zerocopy-derive 0.7.32 9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6
+    } elseif {${python.version} == 37} {
+        version     2.14.6
+        revision    0
+        checksums   pydantic_core-${version}${extract.suffix} \
+                    md5 8d279adb88516627b64ab2196ab9b1f9 \
+                    rmd160 fd78cf60683531bf55e3d5fef6187ef3e474b474 \
+                    sha256 1fd0c1d395372843fba13a51c28e3bb9d59bd7aebfeb17358ffaaa1e4dbbe948
+
+        cargo.crates \
+             ahash 0.8.6 91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a \
+             aho-corasick 1.0.2 43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41 \
+             autocfg 1.1.0 d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+             base64 0.21.5 35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9 \
+             bitflags 1.3.2 bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+             cc 1.0.79 50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f \
+             cfg-if 1.0.0 baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+             enum_dispatch 0.3.12 8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e \
+             equivalent 1.0.1 5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
+             form_urlencoded 1.2.0 a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652 \
+             getrandom 0.2.10 be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427 \
+             hashbrown 0.14.0 2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a \
+             heck 0.4.1 95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+             idna 0.4.0 7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c \
+             indexmap 2.0.0 d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d \
+             indoc 2.0.4 1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8 \
+             itoa 1.0.8 62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a \
+             jiter 0.0.4 b27d419c535bf7b50ad355278b1159cbf0cc8d507ea003d625b17bf0375720b8 \
+             lexical-core 0.8.5 2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46 \
+             lexical-parse-float 0.8.5 683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f \
+             lexical-parse-integer 0.8.6 6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9 \
+             lexical-util 0.8.5 5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc \
+             lexical-write-float 0.8.5 accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862 \
+             lexical-write-integer 0.8.5 e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446 \
+             libc 0.2.147 b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3 \
+             lock_api 0.4.10 c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16 \
+             memchr 2.6.3 8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c \
+             memoffset 0.9.0 5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
+             num-bigint 0.4.4 608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0 \
+             num-integer 0.1.45 225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9 \
+             num-traits 0.2.16 f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2 \
+             once_cell 1.18.0 dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d \
+             parking_lot 0.12.1 3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
+             parking_lot_core 0.9.8 93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447 \
+             percent-encoding 2.3.0 9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94 \
+             proc-macro2 1.0.69 134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da \
+             pyo3 0.20.0 04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b \
+             pyo3-build-config 0.20.0 a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5 \
+             pyo3-ffi 0.20.0 214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b \
+             pyo3-macros 0.20.0 dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b \
+             pyo3-macros-backend 0.20.0 7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424 \
+             python3-dll-a 0.2.9 d5f07cd4412be8fa09a721d40007c483981bbe072cd6a21f2e83e04ec8f8343f \
+             quote 1.0.29 573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105 \
+             redox_syscall 0.3.5 567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
+             regex 1.10.2 380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343 \
+             regex-automata 0.4.3 5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f \
+             regex-syntax 0.8.2 c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+             rustversion 1.0.13 dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f \
+             ryu 1.0.14 fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9 \
+             scopeguard 1.1.0 d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
+             serde 1.0.190 91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7 \
+             serde_derive 1.0.190 67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3 \
+             serde_json 1.0.108 3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b \
+             smallvec 1.11.1 942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a \
+             speedate 0.13.0 242f76c50fd18cbf098607090ade73a08d39cfd84ea835f3796a2c855223b19b \
+             static_assertions 1.1.0 a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
+             strum 0.25.0 290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125 \
+             strum_macros 0.25.3 23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0 \
+             syn 2.0.38 e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b \
+             target-lexicon 0.12.9 df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0 \
+             tinyvec 1.6.0 87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+             tinyvec_macros 0.1.1 1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
+             unicode-bidi 0.3.13 92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460 \
+             unicode-ident 1.0.10 22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73 \
+             unicode-normalization 0.1.22 5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
+             unindent 0.2.3 c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce \
+             url 2.4.1 143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5 \
+             uuid 1.5.0 88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc \
+             version_check 0.9.4 49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+             wasi 0.11.0+wasi-snapshot-preview1 9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+             windows-targets 0.48.1 05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f \
+             windows_aarch64_gnullvm 0.48.0 91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc \
+             windows_aarch64_msvc 0.48.0 b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3 \
+             windows_i686_gnu 0.48.0 622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241 \
+             windows_i686_msvc 0.48.0 4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00 \
+             windows_x86_64_gnu 0.48.0 ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1 \
+             windows_x86_64_gnullvm 0.48.0 7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953 \
+             windows_x86_64_msvc 0.48.0 1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a \
+             zerocopy 0.7.20 dd66a62464e3ffd4e37bd09950c2b9dd6c4f8767380fabba0d523f9a775bc85a \
+             zerocopy-derive 0.7.20 255c4596d41e6916ced49cfafea18727b24d67878fa180ddfd69b9df34fd1726
+    }
 }


### PR DESCRIPTION
This still has at least one dependent. Also adding missing typing_extensions dependencies.