### PR TITLE
pandoc: Build from source on recent macOS

### DIFF
--- a/textproc/pandoc/Portfile
+++ b/textproc/pandoc/Portfile
@@ -4,8 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        jgm pandoc 3.1.11.1
-github.tarball_from releases
-revision            0
+revision            1
 categories          textproc haskell
 license             GPL-3
 maintainers         {judaew @judaew} openmaintainer
@@ -26,41 +25,120 @@ long_description    Pandoc is a Haskell library for converting from \
 
 homepage            https://pandoc.org
 
-use_zip             yes
 installs_libs       no
 
 # See https://trac.macports.org/ticket/48971
 notes-append       "For PDF support, please install the texlive-latex and texlive-fonts-recommended packages."
 
-switch ${build_arch} {
-    x86_64 {
-        distfiles           pandoc-${version}-x86_64-macOS${extract.suffix}
-        checksums           rmd160  5d101a09cd57bf6fcefad62be021b1a6e16e6ef7 \
-                            sha256  0018eddd489389ac4e6cf6f4711c1ad49574361c04282e075400fad2c0050084 \
-                            size    21209103
-        set worksrcpath ${workpath}/pandoc-${version}-x86_64
-    }
-    arm64 {
-        distfiles           pandoc-${version}-arm64-macOS${extract.suffix}
-        checksums           rmd160  5c9a2ce62cf19b779be6593194aadc9d1fe482a5 \
-                            sha256  fa38ad91d8f1f09549ae16830ade3a26650b03cb9a29c68b41b55ea7fab0aa2d \
-                            size    34443762
-        set worksrcpath ${workpath}/pandoc-${version}-arm64
-    }
-    default {
-        known_fail  yes
-        pre-fetch {
-            ui_error "${subport} @ ${version} only supported for architectures ${supported_archs}"
-            return -code error "Unsupported architecture: ${build_arch}"
+set minimum_major_version_for_source 21
+
+# set build_arch/os.arch/os.major by hand to get binary x86_64/arm64 checksums
+# sudo port -d checksum pandoc os.arch=arm os.major=20 build_arch=arm64
+# sudo port -d checksum pandoc os.arch=i386 os.major=20 build_arch=x86_64
+# run `sudo port clean --all pandoc` afterwards
+
+if {(${os.platform} eq {darwin}
+     && ${os.major} >= ${minimum_major_version_for_source})
+    || ${os.platform} ne {darwin}} {
+
+    checksums       rmd160  db179bb241ff7a7c017dbb638b49411f2cc19889 \
+                    sha256  a486bc7eb78f32ea080e033d29a78659bdbe5fcb77e9277e0af5944f29196d90 \
+                    size    7626371
+
+    compiler.blacklist-append \
+                   {clang < 900}
+
+    # https://trac.macports.org/ticket/48971
+    variant stack \
+        description {Use stack to build.} {}
+    if { [variant_isset "stack"] } {
+        PortGroup   haskell_stack 1.0
+    } else {
+        PortGroup   haskell_cabal 1.0
+
+        # https://github.com/jgm/pandoc/blob/main/macos/make_macos_release.sh
+        set cabalopts   {-fembed_data_files -fserver -flua}
+        build.target    all
+        build.post_args-prepend \
+                    {*}${cabalopts}
+
+        destroot.target exe:${subport}
+        destroot.post_args-prepend \
+                    {*}${cabalopts}
+
+        post-destroot {
+            # https://github.com/jgm/pandoc/blob/main/macos/Makefile
+            ln -s   ${prefix}/bin/${subport} \
+                    ${destroot}${prefix}/bin/${subport}-lua
+            ln -s   ${prefix}/bin/${subport} \
+                    ${destroot}${prefix}/bin/${subport}-server
+            xinstall -d ${destroot}${prefix}/share/doc
+            copy    ${worksrcpath}/doc \
+                    ${destroot}${prefix}/share/doc/${subport}
+            system -W ${worksrcpath} \
+                     "${destroot}${prefix}/bin/${subport} -s COPYING.md -Vpagetitle=License -o \"${destroot}${prefix}/share/doc/${subport}/license.html\""
+            xinstall -m 0644 -W ${worksrcpath} \
+                    AUTHORS.md \
+                    BUGS \
+                    CONTRIBUTING.md \
+                    MANUAL.txt \
+                    README.md \
+                    ${destroot}${prefix}/share/doc/${subport}
+            xinstall -m 0644 \
+                    ${worksrcpath}/pandoc-cli/man/pandoc.1 \
+                    ${worksrcpath}/pandoc-cli/man/pandoc-lua.1 \
+                    ${worksrcpath}/pandoc-cli/man/pandoc-server.1 \
+                    ${destroot}${prefix}/share/man/man1
         }
     }
-}
 
-use_configure       no
+    test.run        yes
+    test.pre_args   run
+    test.args       test-${subport}
+    test.post_args-prepend \
+                    {*}${cabalopts}
+    test.post_args-append \
+                    {-- '-p markdown'}
+} else {
+    # binary support for older macOS versions
+    github.tarball_from releases
+    use_zip         yes
 
-build {}
+    switch ${build_arch} {
+        x86_64 {
+            distfiles       pandoc-${version}-x86_64-macOS${extract.suffix}
+            checksums       rmd160  5d101a09cd57bf6fcefad62be021b1a6e16e6ef7 \
+                            sha256  0018eddd489389ac4e6cf6f4711c1ad49574361c04282e075400fad2c0050084 \
+                            size    21209103
+            set worksrcpath ${workpath}/pandoc-${version}-x86_64
+        }
+        arm64 {
+            distfiles       pandoc-${version}-arm64-macOS${extract.suffix}
+            checksums       rmd160  5c9a2ce62cf19b779be6593194aadc9d1fe482a5 \
+                            sha256  fa38ad91d8f1f09549ae16830ade3a26650b03cb9a29c68b41b55ea7fab0aa2d \
+                            size    34443762
+            set worksrcpath ${workpath}/pandoc-${version}-arm64
+        }
+        default {
+            known_fail  yes
+            pre-fetch {
+                ui_error "${subport} @ ${version} only supported for architectures ${supported_archs}"
+                return -code error "Unsupported architecture: ${build_arch}"
+            }
+        }
+    }
 
-destroot {
-    xinstall -m 0755 {*}[glob ${worksrcpath}/bin/*] ${destroot}${prefix}/bin
-    xinstall -m 0755 {*}[glob ${worksrcpath}/share/man/man1/*] ${destroot}${prefix}/share/man/man1
+    use_configure   no
+
+    build {}
+
+    destroot {
+        xinstall -m 0755 ${worksrcpath}/bin/${subport} ${destroot}${prefix}/bin
+        # https://github.com/jgm/pandoc/blob/main/macos/Makefile
+        ln -s   ${prefix}/bin/${subport} \
+                    ${destroot}${prefix}/bin/${subport}-lua
+        ln -s   ${prefix}/bin/${subport} \
+                    ${destroot}${prefix}/bin/${subport}-server
+        xinstall -m 0755 {*}[glob ${worksrcpath}/share/man/man1/*] ${destroot}${prefix}/share/man/man1
+    }
 }


### PR DESCRIPTION
#### Description

Builds of `pandoc` from source were removed in https://github.com/macports/macports-ports/commit/4d9c1684e0091d3cce995851c8f6182f9bff9dd2.

I believe that `pandoc` should be built from source when possible because it gives us greater control over the build and installation details. One example is the binary release install in the current commit, which installs three copies of the same binary (`pandoc` == `pandoc-lua` == `pandoc-server`). Source builds also allow use of the `test` phase in the Portfile.

I've refactored the previous source build of `pandoc` to make it consistent with upstream's build procedure: [Makefile](https://github.com/jgm/pandoc/blob/main/macos/Makefile) and [make_macos_release.sh](https://github.com/jgm/pandoc/blob/main/macos/make_macos_release.sh).

The binary releases are also useful on platforms where source builds are not possible. I've done my best to specify the conditions when binary releases are used, and welcome feedback.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3 23D56 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
