### PR TITLE
libfmt10: update to 10.2.1

### DIFF
--- a/devel/libfmt10/Portfile
+++ b/devel/libfmt10/Portfile
@@ -7,12 +7,12 @@ PortGroup           compiler_blacklist_versions 1.0
 PortGroup           conflicts_build 1.0
 PortGroup           github 1.0
 
-github.setup        fmtlib fmt 10.1.1
+github.setup        fmtlib fmt 10.2.1
 name                libfmt10
 revision            0
-checksums           rmd160  6fe307eb6853ffaf4f96313f77375101344a709c \
-                    sha256  78b8c0a72b1c35e4443a7e308df52498252d1cefc2b08c9a97bc9ee6cfe61f8b \
-                    size    851454
+checksums           rmd160  e6c385e8789599ed098ca5ea4094b0c8a788029f \
+                    sha256  1250e4cc58bf06ee631567523f48848dc4596133e163f02615c97f78bab6c811 \
+                    size    854665
 
 categories          devel
 license             MIT


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69086

#### Description

Considering that aside of one all dependents of `libfmt10` are my ports, and this is a simple update, I hope this is okay, and we can close the related ticket.
I ran tests on Sonoma and Snow Leopard, and have `folly` and friends, `tiledb` etc. built against this version.

@mascguy Please take a look.
@danchr Could you confirm that `watchman` works for you with this version? 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2
Xcode 15.2

macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
