### PR TITLE
cryfs: update to 0.11.4

### DIFF
--- a/net/cryfs/Portfile
+++ b/net/cryfs/Portfile
@@ -6,7 +6,7 @@ PortGroup                 github 1.0
 PortGroup                 cmake 1.1
 PortGroup                 boost 1.0
 
-github.setup              cryfs cryfs 0.11.2
+github.setup              cryfs cryfs 0.11.4
 revision                  0
 github.tarball_from       releases
 
@@ -24,24 +24,28 @@ long_description          CryFS encrypts your files, so you can safely store the
 
 homepage                  https://www.cryfs.org/
 
-checksums                 rmd160  798106ac28621532695bf29ec39c47e64f5bf674 \
-                          sha256  a89ab8fea2d494b496867107ec0a3772fe606ebd71ef12152fcd233f463a2c00 \
-                          size    10419264
+checksums                 rmd160  dc9eb50bad04492bb7b610066661492384665d76 \
+                          sha256  6caca6276ce5aec40bf321fd0911b0af7bcffc44c3cb82ff5c5af944d6f75a45 \
+                          size    10420289
 
 extract.mkdir             yes
 
 patchfiles                gitversion_python3_fix.diff
 post-patch {
-    reinplace "s|@@PYTHONBIN@@|${prefix}/bin/python3.10|g" ${worksrcpath}/src/gitversion/gitversion.cmake
+    reinplace "s|@@PYTHONBIN@@|${prefix}/bin/python3.12|g" ${worksrcpath}/src/gitversion/gitversion.cmake
 }
 
 depends_build-append      path:lib/libssl.dylib:openssl \
                           port:range-v3 \
                           port:spdlog \
-                          port:python310
+                          port:python312
 
 depends_lib-append        port:curl \
                           port:libomp
+
+# This has to match the version of libfmt used by spdlog.
+# See https://trac.macports.org/ticket/68248
+cmake.module_path-append  ${prefix}/lib/libfmt10/cmake
 
 cmake.build_type          Release
 universal_variant         no

--- a/net/cryfs/files/gitversion_python3_fix.diff
+++ b/net/cryfs/files/gitversion_python3_fix.diff
@@ -1,10 +1,10 @@
---- src/gitversion/gitversion.cmake.orig	2022-02-22 06:22:55.000000000 +0100
-+++ src/gitversion/gitversion.cmake	2022-05-07 15:40:30.000000000 +0200
+--- src/gitversion/gitversion.cmake.orig	2023-07-20 07:26:32.000000000 +0200
++++ src/gitversion/gitversion.cmake	2024-01-28 00:47:33.000000000 +0100
 @@ -1,7 +1,7 @@
  set(DIR_OF_GITVERSION_TOOL "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "DIR_OF_GITVERSION_TOOL")
  
  function (get_git_version OUTPUT_VARIABLE)
--    EXECUTE_PROCESS(COMMAND python ${DIR_OF_GITVERSION_TOOL}/getversion.py
+-    EXECUTE_PROCESS(COMMAND python3 ${DIR_OF_GITVERSION_TOOL}/getversion.py
 +    EXECUTE_PROCESS(COMMAND @@PYTHONBIN@@ ${DIR_OF_GITVERSION_TOOL}/getversion.py
          WORKING_DIRECTORY ${DIR_OF_GITVERSION_TOOL}
          OUTPUT_VARIABLE VERSION


### PR DESCRIPTION
#### Description

- update cryfs to latest version : 0.11.4
- fix libfmt10 dependency: fixes https://trac.macports.org/ticket/69167

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7 21G816 arm64
Xcode 13.3 13E113

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

