### PR TITLE
py-psutil: Update to 5.9.8 and fix build on old macOS

### DIFF
--- a/python/py-psutil/Portfile
+++ b/python/py-psutil/Portfile
@@ -4,8 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-psutil
-version             5.9.7
+version             5.9.8
 revision            0
+checksums           rmd160  56bc1435590589efabe427e690ae922ff190b64d \
+                    sha256  6be126e3225486dff286a8fb9a06246a5253f4c7c53b475ea5f5ac934e64194c \
+                    size    503247
+
 categories-append   devel sysutils
 license             MIT
 
@@ -25,6 +29,5 @@ long_description    psutil is a module providing an interface for retrieving \
 
 homepage            https://github.com/giampaolo/psutil
 
-checksums           rmd160  b484207704227ad959b304e0c0c130562eb160ae \
-                    sha256  3f02134e82cfb5d089fddf20bb2e03fd5cd52395321d1c8458a9e58500ff417c \
-                    size    498429
+patchfiles          CoreFoundation.patch \
+                    u_char.patch

--- a/python/py-psutil/files/CoreFoundation.patch
+++ b/python/py-psutil/files/CoreFoundation.patch
@@ -1,0 +1,14 @@
+Include the CoreFoundation header because on old systems IOPowerSources.h
+neglects to do so.
+
+https://github.com/giampaolo/psutil/issues/2362
+--- psutil/arch/osx/sensors.c.orig	2023-06-01 11:41:59.000000000 -0500
++++ psutil/arch/osx/sensors.c	2024-01-29 01:26:30.000000000 -0600
+@@ -11,6 +11,7 @@
+ // https://github.com/giampaolo/psutil/commit/e0df5da
+ 
+ 
++#include <CoreFoundation/CoreFoundation.h>
+ #include <Python.h>
+ #include <IOKit/ps/IOPowerSources.h>
+ #include <IOKit/ps/IOPSKeys.h>

--- a/python/py-psutil/files/u_char.patch
+++ b/python/py-psutil/files/u_char.patch
@@ -1,0 +1,27 @@
+Include net/if.h before net/if_dl.h
+
+In old versions of macOS, net/if_dl.h neglects to include sys/types.h,
+which results in build failure:
+
+error: unknown type name 'u_char'; did you mean 'char'?
+
+Including net/if.h first works around the problem because net/if.h
+includes sys/types.h.
+
+https://github.com/giampaolo/psutil/issues/2360
+https://github.com/giampaolo/psutil/commit/494d8b84f601a19f4f298ffbb3b47a647384d521
+--- psutil/arch/osx/net.c.orig
++++ psutil/arch/osx/net.c
+@@ -9,11 +9,11 @@
+ // https://github.com/giampaolo/psutil/blame/efd7ed3/psutil/_psutil_osx.c
+ 
+ #include <Python.h>
++#include <net/if.h>
+ #include <net/if_dl.h>
+ #include <net/route.h>
+ #include <sys/sysctl.h>
+ #include <sys/socket.h>
+-#include <net/if.h>
+ 
+ #include "../../_psutil_common.h"
+ 


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/69180

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 21G1974 x86_64
Xcode 14.2 14C18

macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
