### PR TITLE
py-psutil: Fix build on OS X < 10.9

### DIFF
--- a/python/py-psutil/Portfile
+++ b/python/py-psutil/Portfile
@@ -30,4 +30,5 @@ long_description    psutil is a module providing an interface for retrieving \
 homepage            https://github.com/giampaolo/psutil
 
 patchfiles          CoreFoundation.patch \
-                    u_char.patch
+                    u_char.patch \
+                    struct-sockaddr.patch

--- a/python/py-psutil/files/struct-sockaddr.patch
+++ b/python/py-psutil/files/struct-sockaddr.patch
@@ -1,0 +1,20 @@
+Include <sys/socket.h> before <net/if.h> to fix build failure on OS X < 10.9:
+
+error: field has incomplete type 'struct sockaddr'
+
+https://github.com/giampaolo/psutil/issues/2365
+--- psutil/arch/osx/net.c.orig	2023-06-01 11:41:59.000000000 -0500
++++ psutil/arch/osx/net.c	2024-01-29 03:00:55.000000000 -0600
+@@ -9,11 +9,11 @@
+ // https://github.com/giampaolo/psutil/blame/efd7ed3/psutil/_psutil_osx.c
+ 
+ #include <Python.h>
++#include <sys/socket.h> // must be included before <net/if.h>
+ #include <net/if.h>
+ #include <net/if_dl.h>
+ #include <net/route.h>
+ #include <sys/sysctl.h>
+-#include <sys/socket.h>
+ 
+ #include "../../_psutil_common.h"
+ 


### PR DESCRIPTION
#### Description

py-psutil: Fix build on OS X < 10.9

I have tested that this still builds on macOS 12. ~~I have not tested on an affected OS but I believe this will fix it... We can watch what happens on the Buildbot after it's merged.~~ I've also tested on 10.7 now.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 21G1974 x86_64
Xcode 14.2 14C18

Mac OS X 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
