### PR TITLE
mmg3d4: do not force arch and target, unbreak non-x86_64

### DIFF
--- a/science/mmg3d4/Portfile
+++ b/science/mmg3d4/Portfile
@@ -7,7 +7,6 @@ name                    mmg3d4
 revision                3
 version                 4.0.2
 categories              science math
-platforms               darwin
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 license                 GPL-3+
 homepage                https://www.mmgtools.org
@@ -22,6 +21,9 @@ distname                ${name}-${version}-Source
 checksums               rmd160  1734928f83e427712527005afd6d556b7cc62cf9 \
                         sha256  5067cab6fa5b7478ccfd50f7ae1a00a356d66c8cbc014c20b89ad54857c227dd \
                         size    167168
+
+# The source forces 10.4 target with x86_64 arch.
+patchfiles-append       patch-fix-arch.diff
 
 depends_lib-append      port:scotch
 

--- a/science/mmg3d4/files/patch-fix-arch.diff
+++ b/science/mmg3d4/files/patch-fix-arch.diff
@@ -1,0 +1,15 @@
+--- CMakeLists.txt	2015-02-20 23:13:03.000000000 +0800
++++ CMakeLists.txt	2024-01-30 00:23:18.000000000 +0800
+@@ -23,10 +23,10 @@
+   SET(CMAKE_C_FLAGS "-Wno-char-subscripts ${CMAKE_C_FLAGS}")
+   IF(APPLE)
+     # Add flags to the compiler to work on old mac
+-    ADD_DEFINITIONS( -mmacosx-version-min=10.4 -arch x86_64)
++    # ADD_DEFINITIONS( -mmacosx-version-min=10.4 -arch x86_64)
+ 
+     # To avoid pbs with binary files...
+-    SET(CMAKE_EXE_LINKER_FLAGS "-arch x86_64 ${CMAKE_EXE_LINKER_FLAGS}")
++    # SET(CMAKE_EXE_LINKER_FLAGS "-arch x86_64 ${CMAKE_EXE_LINKER_FLAGS}")
+ 
+     # Determine if the processor supports 64bit execution
+     EXECUTE_PROCESS(


### PR DESCRIPTION
#### Description

The source does something both crazy and redundant which breaks the build for non-x86_64 archs with GCC.
Fix it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
