### PR TITLE
freeimage: fix Big-endian build

### DIFF
--- a/graphics/freeimage/Portfile
+++ b/graphics/freeimage/Portfile
@@ -31,6 +31,11 @@ use_zip             yes
 worksrcdir          FreeImage
 
 patchfiles          patch-c99-fixes.diff
+# https://github.com/AcademySoftwareFoundation/openexr/pull/126
+patchfiles-append   patch-fix-ImfFastHuf.diff
+# https://sourceforge.net/p/freeimage/patches/153
+patchfiles-append   patch-fix-PluginBMP.diff \
+                    patch-fix-PluginDDS.diff
 
 post-patch {
     set makefiles   "${worksrcpath}/Makefile.fip ${worksrcpath}/Makefile.gnu"

--- a/graphics/freeimage/files/patch-fix-ImfFastHuf.diff
+++ b/graphics/freeimage/files/patch-fix-ImfFastHuf.diff
@@ -1,0 +1,47 @@
+--- Source/OpenEXR/IlmImf/ImfFastHuf.cpp.orig	2017-11-18 15:00:24.000000000 +0800
++++ Source/OpenEXR/IlmImf/ImfFastHuf.cpp	2024-01-30 02:54:44.000000000 +0800
+@@ -107,7 +107,7 @@
+     for (int i = 0; i <= MAX_CODE_LEN; ++i)
+     {
+         codeCount[i] = 0;
+-        base[i]      = 0xffffffffffffffffL;
++        base[i]      = 0xffffffffffffffffULL;
+         offset[i]    = 0;
+     }
+ 
+@@ -352,7 +352,7 @@
+ 
+     for (int i = 0; i <= MAX_CODE_LEN; ++i)
+     {
+-        if (base[i] != 0xffffffffffffffffL)
++        if (base[i] != 0xffffffffffffffffULL)
+         {
+             _ljBase[i] = base[i] << (64 - i);
+         }
+@@ -362,7 +362,7 @@
+             // Unused code length - insert dummy values
+             //
+ 
+-            _ljBase[i] = 0xffffffffffffffffL;
++            _ljBase[i] = 0xffffffffffffffffULL;
+         }
+     }
+ 
+@@ -417,7 +417,7 @@
+ 
+     int minIdx = TABLE_LOOKUP_BITS;
+ 
+-    while (minIdx > 0 && _ljBase[minIdx] == 0xffffffffffffffffL)
++    while (minIdx > 0 && _ljBase[minIdx] == 0xffffffffffffffffULL)
+         minIdx--;
+ 
+     if (minIdx < 0)
+@@ -427,7 +427,7 @@
+         // Set the min value such that the table is never tested.
+         //
+ 
+-        _tableMin = 0xffffffffffffffffL;
++        _tableMin = 0xffffffffffffffffULL;
+     }
+     else
+     {

--- a/graphics/freeimage/files/patch-fix-PluginBMP.diff
+++ b/graphics/freeimage/files/patch-fix-PluginBMP.diff
@@ -1,0 +1,29 @@
+--- Source/FreeImage/PluginBMP.cpp.orig	2016-06-15 12:35:30.000000000 +0800
++++ Source/FreeImage/PluginBMP.cpp	2024-01-30 02:26:59.000000000 +0800
+@@ -1419,7 +1419,7 @@
+ 
+ 			free(buffer);
+ #ifdef FREEIMAGE_BIGENDIAN
+-		} else if (bpp == 16) {
++		} else if (dst_bpp == 16) {
+ 			int padding = dst_pitch - dst_width * sizeof(WORD);
+ 			WORD pad = 0;
+ 			WORD pixel;
+@@ -1440,7 +1440,7 @@
+ 			}
+ #endif
+ #if FREEIMAGE_COLORORDER == FREEIMAGE_COLORORDER_RGB
+-		} else if (bpp == 24) {
++		} else if (dst_bpp == 24) {
+ 			int padding = dst_pitch - dst_width * sizeof(FILE_BGR);
+ 			DWORD pad = 0;
+ 			FILE_BGR bgr;
+@@ -1461,7 +1461,7 @@
+ 					}
+ 				}
+ 			}
+-		} else if (bpp == 32) {
++		} else if (dst_bpp == 32) {
+ 			FILE_BGRA bgra;
+ 			for(unsigned y = 0; y < dst_height; y++) {
+ 				BYTE *line = FreeImage_GetScanLine(dib, y);

--- a/graphics/freeimage/files/patch-fix-PluginDDS.diff
+++ b/graphics/freeimage/files/patch-fix-PluginDDS.diff
@@ -1,0 +1,25 @@
+--- Source/FreeImage/PluginDDS.cpp.orig	2018-07-31 17:04:58.000000000 +0800
++++ Source/FreeImage/PluginDDS.cpp	2024-01-30 02:43:14.000000000 +0800
+@@ -356,14 +356,14 @@
+ 	for(int i=0; i<11; i++) {
+ 		SwapLong(&header->surfaceDesc.dwReserved1[i]);
+ 	}
+-	SwapLong(&header->surfaceDesc.ddpfPixelFormat.dwSize);
+-	SwapLong(&header->surfaceDesc.ddpfPixelFormat.dwFlags);
+-	SwapLong(&header->surfaceDesc.ddpfPixelFormat.dwFourCC);
+-	SwapLong(&header->surfaceDesc.ddpfPixelFormat.dwRGBBitCount);
+-	SwapLong(&header->surfaceDesc.ddpfPixelFormat.dwRBitMask);
+-	SwapLong(&header->surfaceDesc.ddpfPixelFormat.dwGBitMask);
+-	SwapLong(&header->surfaceDesc.ddpfPixelFormat.dwBBitMask);
+-	SwapLong(&header->surfaceDesc.ddpfPixelFormat.dwRGBAlphaBitMask);
++	SwapLong(&header->surfaceDesc.ddspf.dwSize);
++	SwapLong(&header->surfaceDesc.ddspf.dwFlags);
++	SwapLong(&header->surfaceDesc.ddspf.dwFourCC);
++	SwapLong(&header->surfaceDesc.ddspf.dwRGBBitCount);
++	SwapLong(&header->surfaceDesc.ddspf.dwRBitMask);
++	SwapLong(&header->surfaceDesc.ddspf.dwGBitMask);
++	SwapLong(&header->surfaceDesc.ddspf.dwBBitMask);
++	SwapLong(&header->surfaceDesc.ddspf.dwRGBAlphaBitMask);
+ 	SwapLong(&header->surfaceDesc.ddsCaps.dwCaps1);
+ 	SwapLong(&header->surfaceDesc.ddsCaps.dwCaps2);
+ 	SwapLong(&header->surfaceDesc.ddsCaps.dwReserved[0]);


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/69232

#### Description

Fix errors in the code. _Looks like no-one ever tried to actually build it in upstream_.

`OpenEXR` fix is borrowed from `OpenEXR` upstream code. Other two fix errors which are merely a result of poor design and lack of trying to compile the code.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
