### PR TITLE
various ports: use Python 3.12

### DIFF
--- a/devel/git-cola/Portfile
+++ b/devel/git-cola/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                git-cola
-version             4.1.0
+version             4.5.0
 revision            0
 
 supported_archs     noarch
@@ -18,14 +18,13 @@ description         The highly caffeinated Git GUI
 long_description    git-cola is a powerful Git GUI with a slick and \
                     intuitive user interface.
 
-checksums           rmd160  effbd5a8d4ce0ddafdbd1fe1604ec88f58d35612 \
-                    sha256  d77ba2eb1d1240f47cc44f5fcb9230cc65681834e7e27edf17c5ada462d3fb07 \
-                    size    1140358
+checksums           rmd160  b7e697a4196f37e0fa3b2e4f39d1475b6d10853c \
+                    sha256  2fb8db5c2cd5558dafa966fad54678301b7c2dbb1c47eb7b1a548de7da6ce2ec \
+                    size    1248805
 
 homepage            https://git-cola.github.io/
 
-python.default_version 311
-python.pep517       yes
+python.default_version 312
 
 patchfiles          patch-pyqt-version.diff
 

--- a/devel/git-filter-repo/Portfile
+++ b/devel/git-filter-repo/Portfile
@@ -6,7 +6,7 @@ PortGroup           python 1.0
 
 github.setup        newren git-filter-repo 2.38.0 v
 github.tarball_from releases
-revision            1
+revision            2
 categories          devel
 platforms           {darwin any}
 
@@ -32,7 +32,7 @@ depends_run         port:git
 
 use_xz              yes
 
-python.default_version 311
+python.default_version 312
 
 patchfiles-append   53556108509c75827521240c227848a736348088.patch
 

--- a/devel/git-remote-hg/Portfile
+++ b/devel/git-remote-hg/Portfile
@@ -1,27 +1,31 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup github    1.0
-PortGroup python    1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
 
 name                git-remote-hg
-github.setup        mnauw git-remote-hg 1.0.3.2 v
-revision            1
+github.setup        mnauw git-remote-hg 1.0.4 v
+github.tarball_from archive
+revision            0
+
 categories          devel python
-platforms           darwin
+supported_archs     noarch
+platforms           {darwin any}
 maintainers         {landonf @landonf} openmaintainer
 license             GPL-2
 description         Transparent bidirectional bridge between Git and Mercurial for Git
 long_description    {*}${description}.
 
-checksums           rmd160  3c3c5dc2975cda2bf8e44752c2efd312f5b9342c \
-                    sha256  4c2f91c3c1a83b3a4a6162b56e97872388f4b17fc9d2a6aedf2cd613256767f6 \
-                    size    66640
+checksums           rmd160  4738123fa3c4ef4594f26902b93c783f077c8053 \
+                    sha256  0645042e42295c978fff5c73828dd030d565de2d4daae87f0ed788aade699fdc \
+                    size    66859
 
-python.default_version 311
+python.default_version 312
 
-depends_build       port:asciidoc \
-                    port:py${python.version}-setuptools
+depends_build-append \
+                    port:asciidoc
+
 depends_lib-append  port:mercurial
 
 post-patch {

--- a/devel/git-review/Portfile
+++ b/devel/git-review/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                git-review
 version             2.3.1
-revision            0
+revision            1
 platforms           {darwin any}
 license             Apache-2
 categories          devel python
@@ -13,7 +13,7 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 supported_archs     noarch
 
-homepage            http://docs.openstack.org/infra/git-review
+homepage            https://docs.opendev.org/opendev/git-review
 
 description         Tool to submit code to Gerrit
 
@@ -25,17 +25,17 @@ checksums           rmd160  c7216693210085e9493fbf7276c39f12e8c3d4c5 \
                     sha256  24e938136eecb6e6cbb38b5e2b034a286b70b5bb8b5a2853585c9ed23636014f \
                     size    66400
 
-python.default_version      310
+python.default_version 312
 
 depends_build-append \
-                    port:py${python.version}-pbr \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-pbr
 
 depends_lib-append  \
                     port:py${python.version}-requests \
                     port:py${python.version}-six
 
 test.run            yes
+python.test_framework
 test.env            PYTHONPATH=${worksrcpath}/build/lib
 test.cmd            ${python.bin} -m git_review.cmd --help
 

--- a/devel/git-when-merged/Portfile
+++ b/devel/git-when-merged/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                git-when-merged
 version             1.2.1
-revision            0
+revision            1
 categories          devel
 platforms           {darwin any}
 
@@ -21,14 +21,12 @@ checksums           rmd160  ec01b393b53884a6774b7b37ef3cfb2798ac3ef8 \
 description         Determine when a particular commit was merged into a git branch
 long_description    {*}${description}
 
-python.default_version 310
+python.default_version 312
 
 supported_archs     noarch
 
 patchfiles-append   0001-Loosen-build-requirements.patch
 patch.pre_args      -p1
-
-use_configure       no
 
 depends_build-append \
     port:py${python.version}-setuptools \

--- a/devel/gitless/Portfile
+++ b/devel/gitless/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           python 1.0
 
 github.setup        sdg-mit gitless 0.8.8 v
-revision            1
+revision            2
 categories          devel python
 platforms           darwin
 license             GPL-2
@@ -16,16 +16,14 @@ description         Version control system built on top of Git
 long_description    Gitless is a version control system built on top of Git, \
                     with simpler commands and syntax. Gitless can be used on \
                     any Git repository and be mixed with regular git commands.
-homepage            http://gitless.com/
+homepage            https://gitless.com/
 
 checksums           rmd160  bee4c60e28cc698cf006c645583ca9e19355ae65 \
                     sha256  a5f145f5c8aa56fbd08c4d2f8291a016a2ad00295efb7d1e5df082e03ad75b14 \
                     size    42454
 
-python.default_version 38
+python.default_version 312
 
-depends_build-append \
-                    port:py${python.version}-setuptools
 depends_run-append  port:git
 depends_lib-append  port:py${python.version}-pygit2 \
                     port:py${python.version}-clint \

--- a/devel/gomp/Portfile
+++ b/devel/gomp/Portfile
@@ -5,6 +5,8 @@ PortGroup           python 1.0
 
 name                gomp
 version             1.1.0
+revision            1
+
 platforms           {darwin any}
 supported_archs     noarch
 license             MIT
@@ -26,6 +28,4 @@ checksums           rmd160  e2eef3683d3a7bd544dcb175491dc94e69d6bb63 \
                     sha256  0bc2e81e29b89613d7cab7d28df6eca9191b7af73facdf9e8fce2ffc2220d886 \
                     size    6358
 
-python.default_version  38
-
-depends_build-append    port:py${python.version}-setuptools
+python.default_version 312

--- a/devel/hg-credentials/Portfile
+++ b/devel/hg-credentials/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 
 name                    hg-credentials
 version                 0.1.2
-revision                0
+revision                1
 
 categories              devel
 license                 GPL-2
@@ -22,8 +22,7 @@ checksums               rmd160  d8d49eaa372d9632ac2fded5a576624a2a6bd202 \
                         sha256  ff77d95ec9899a51c48723b21e8b3919c92ac21d54e33472c060073fdd4073e6 \
                         size    16745
 
-python.default_version  311
-python.pep517           yes
+python.default_version  312
 
 depends_lib-append      port:mercurial
 

--- a/devel/hg-evolve/Portfile
+++ b/devel/hg-evolve/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 
 name                    hg-evolve
 version                 11.1.0
-revision                0
+revision                1
 checksums               rmd160  199708a63592b1ae28a29a0014882551a184d52a \
                         sha256  b0cbc7bc7c0bb8c4f42da1f65c50de3ee78f6f00978ef97ae9019d11147493a8 \
                         size    858080
@@ -28,13 +28,13 @@ long_description        Additional history rewriting commands for Mercurial \
                         developers to safely rewrite the same parts of history \
                         in a distributed way.
 
-python.default_version  311
-python.pep517           yes
+python.default_version  312
 
 depends_lib-append      port:mercurial
 depends_test-append     port:dash
 
 test.run                yes
+python.test_framework
 
 test.cmd                ${python.bin} ./run-tests.py
 test.args               -v -j ${build.jobs} --shell=${prefix}/bin/dash

--- a/devel/hg-git/Portfile
+++ b/devel/hg-git/Portfile
@@ -5,7 +5,7 @@ PortGroup               python 1.0
 
 name                    hg-git
 version                 1.1.0
-revision                0
+revision                1
 
 categories              devel
 license                 GPL-2
@@ -25,12 +25,12 @@ checksums               rmd160  0611c428e88be04f473da2f8a8c0a176b8e79a0d \
                         sha256  6ed11a9862ea082e4f4628311db7b8f7f6e724d5469ba0b37fce7625a01d077f \
                         size    218228
 
-python.default_version  311
-python.pep517           yes
+python.default_version  312
 
 depends_build-append    port:py${python.version}-setuptools_scm
 
-depends_lib-append      port:mercurial port:py${python.version}-dulwich
+depends_lib-append      port:mercurial \
+                        port:py${python.version}-dulwich
 
 # used by urllib3 for better compression when cloning using HTTP, e.g.
 # from Github
@@ -49,6 +49,7 @@ hggit =
 "
 
 test.run               yes
+python.test_framework
 
 pre-test {
     # output some useful diagnostics

--- a/devel/hg-keyring/Portfile
+++ b/devel/hg-keyring/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                hg-keyring
 version             1.4.3
-revision            0
+revision            1
 
 categories-prepend  devel
 platforms           {darwin any}
@@ -24,7 +24,7 @@ checksums           rmd160  01d83415398e12dd87e9a8fe80643c136c72155e \
                     sha256  deb5cdfe81f660099efafb0802e194c8ec52f54802b53a812c3565dbce5c83c7 \
                     size    29988
 
-python.default_version  311
+python.default_version  312
 python.rootname         mercurial_keyring
 
 depends_lib-append      port:mercurial \
@@ -37,10 +37,6 @@ To enable the keyring extension, add the following to your ~/.hgrc:
 \[extensions\]
 mercurial_keyring =
 "
-
-depends_build-append \
-                    port:py${python.version}-setuptools
-
 
 post-destroot {
     set docdir ${prefix}/share/doc/${subport}

--- a/devel/howdoi/Portfile
+++ b/devel/howdoi/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                howdoi
 version             2.0.20
-revision            0
+revision            1
 
 categories          devel python
 license             MIT
@@ -22,10 +22,7 @@ checksums           rmd160  4659f8af52e5146758cbe11de1fe92746b61f33e \
                     sha256  51cd40c53e0c0f8f8da88f480eb7423183be2350ab4f0a4d9d4763ca6ac3e2a9 \
                     size    27595
 
-python.default_version 310
-
-depends_build-append \
-                    port:py${python.version}-setuptools
+python.default_version 312
 
 depends_lib-append  port:py${python.version}-appdirs \
                     port:py${python.version}-cachelib \
@@ -37,6 +34,5 @@ depends_lib-append  port:py${python.version}-appdirs \
                     port:py${python.version}-requests
 
 test.run            yes
+python.test_framework
 test.cmd            ${python.bin} test_howdoi.py
-test.target
-test.env            PYTHONPATH=${worksrcpath}/build/lib

--- a/devel/legit/Portfile
+++ b/devel/legit/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               python 1.0
 
 github.setup            frostming legit 1.2.0
-revision                3
+revision                4
 categories              devel
 platforms               {darwin any}
 maintainers             {khindenburg @kurthindenburg} openmaintainer
@@ -21,9 +21,7 @@ checksums               rmd160  b9ba740951cdb07ebcce1738149193137292f468 \
                         sha256  cbcb08b70b8b2ebd97f82ba3fdc9420006cf961fb38dd09cbfe4078170228d92 \
                         size    33972
 
-python.default_version  311
-
-depends_build-append    port:py${python.version}-setuptools
+python.default_version  312
 
 depends_lib-append      port:py${python.version}-appdirs \
                         port:py${python.version}-certifi \

--- a/devel/mercurial/Portfile
+++ b/devel/mercurial/Portfile
@@ -14,7 +14,7 @@ name                mercurial
 # also, please remember that the rust variant needs love too:
 # cargo2port rust/Cargo.lock | pbcopy
 version             6.6.2
-revision            0
+revision            1
 categories          devel python
 platforms           darwin
 license             GPL-2+
@@ -43,7 +43,7 @@ checksums           ${distname}${extract.suffix}  \
                     sha256  cb494d7be7ddc2fc9d3171c88830af9c02b21c753e3e5113defac9c0373b4b60 \
                     size    8252567
 
-python.default_version 311
+python.default_version 312
 python.pep517       no
 
 # https://trac.macports.org/ticket/65938

--- a/devel/tortoisehg/Portfile
+++ b/devel/tortoisehg/Portfile
@@ -10,7 +10,7 @@ PortGroup           gitlab 1.0
 # TortoiseHg generally does not retain compatibility
 gitlab.instance     https://foss.heptapod.net
 gitlab.setup        mercurial/tortoisehg thg 6.5.1
-revision            0
+revision            1
 checksums           rmd160  2655e2601fef357baf8fa2dc9583f146c5e40a60 \
                     sha256  d1ba8862cff5748c3ccb9d1ad275fb803e23119c9f1abd61bf49b6d041822e35 \
                     size    7657421
@@ -27,7 +27,7 @@ long_description    A set of graphical tools for the Mercurial distributed \
                     source control management system.
 
 # must be same as Mercurial
-python.default_version 311
+python.default_version 312
 
 # we use qt5 only if macOS is 10.12 or later
 # as defined on qt5 port

--- a/python/py-cachelib/Portfile
+++ b/python/py-cachelib/Portfile
@@ -5,6 +5,8 @@ PortGroup           python 1.0
 
 name                py-cachelib
 version             0.10.2
+revision            0
+
 license             BSD
 supported_archs     noarch
 platforms           {darwin any}
@@ -20,5 +22,4 @@ checksums           rmd160 8f451260b7aff590a278ab4d97ae136cae2a3570 \
                     sha256 593faeee62a7c037d50fc835617a01b887503f972fb52b188ae7e50e9cb69740 \
                     size   32323
 
-python.versions     38 39 310 311
-python.pep517       yes
+python.versions     38 39 310 311 312

--- a/python/py-crayons/Portfile
+++ b/python/py-crayons/Portfile
@@ -24,9 +24,8 @@ checksums           rmd160  0485a9b2b99241129558adfde9b5a2206cdd6646 \
                     sha256  bd33b7547800f2cfbd26b38431f9e64b487a7de74a947b0fafc89b45a601813f \
                     size    4582
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
     depends_lib-append      port:py${python.version}-colorama
 }

--- a/python/py-deprecated/Portfile
+++ b/python/py-deprecated/Portfile
@@ -2,10 +2,10 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           github 1.0
 
-github.setup        tantale deprecated 1.2.13 v
 name                py-deprecated
+python.rootname     Deprecated
+version             1.2.14
 revision            0
 
 license             MIT
@@ -17,18 +17,15 @@ description         Python @deprecated decorator to deprecate old python classes
                     functions or methods.
 long_description    {*}${description}
 
-checksums           rmd160  e90b93e891a9663d5414a93e8fd2ea8947230bb5 \
-                    sha256  9614258d5b732865438b4b1d037222dab5874f8bdcdbce6e8972472623feaacd \
-                    size    2971658
+homepage            https://github.com/tantale/deprecated
 
-python.versions     37 38 39 310 311
+checksums           rmd160  3a64e3bcfa00eb1957a4c776c8f605abfe022509 \
+                    sha256  e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3 \
+                    size    2974416
+
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
     depends_run-append \
                     port:py${python.version}-wrapt
-
-    livecheck.type  none
 }

--- a/python/py-iniparse/Portfile
+++ b/python/py-iniparse/Portfile
@@ -23,12 +23,9 @@ checksums           rmd160  9f111a446f0e4ecce1573b14e3018312aa8017ec \
                     sha256  932e5239d526e7acb504017bb707be67019ac428a6932368e6851691093aa842 \
                     size    32233
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools \
-
     depends_lib-append \
                     port:py${python.version}-six
 

--- a/python/py-keep/Portfile
+++ b/python/py-keep/Portfile
@@ -21,12 +21,9 @@ checksums           rmd160  5bef8733deb9231da85b96993d381eb169533909 \
                     sha256  3abbe445347711cecd9cbb80dab4a0777418972fc14a14e9387d0d2ae4b6adb7 \
                     size    13044
 
-python.versions     39 310
+python.versions     39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
-
     depends_lib-append  port:py${python.version}-click \
                         port:py${python.version}-pygithub \
                         port:py${python.version}-requests \

--- a/python/py-mercurial_extension_utils/Portfile
+++ b/python/py-mercurial_extension_utils/Portfile
@@ -21,12 +21,9 @@ checksums           rmd160  364e9f8eeb6c5788cfc42c034cca7c1bc68b5772 \
                     sha256  760188c5eda51e040a20e313cac2abed0eaeed320dfdd3fa4e8ba477fed5f644 \
                     size    32100
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
     depends_run-append \
                     port:mercurial
 }

--- a/python/py-pygit2/Portfile
+++ b/python/py-pygit2/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  9536559ac1a19b3524ed590e813e2151c3edef59 \
                     sha256  af1363da68f3a032a9b23f2f334020153969a9599453ce97f196952c2209bdd4 \
                     size    760485
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pygithub/Portfile
+++ b/python/py-pygithub/Portfile
@@ -23,17 +23,12 @@ checksums           rmd160  9eabb1440224f445ec49014290df6c3214afe374 \
                     sha256  1bbfff9372047ff3f21d5cd8e07720f3dbfdaf6462fcaed9d815f528f1ba7283 \
                     size    158046
 
-python.versions     38 39 310
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                        port:py${python.version}-setuptools
-
     depends_run-append \
                         port:py${python.version}-deprecated \
                         port:py${python.version}-jwt \
                         port:py${python.version}-pynacl \
                         port:py${python.version}-requests \
-
-    livecheck.type      none
 }

--- a/python/py-re2/Portfile
+++ b/python/py-re2/Portfile
@@ -21,8 +21,7 @@ checksums           rmd160  8d370f3855fd0daacb35880e26db284acc64fc77 \
                     sha256  236ed6f80d9db39888d5cc2abde5ca62d89e13a0f7ebdee24e371b4ddb29cc12 \
                     size    11685
 
-python.versions     37 38 39 310 311
-python.pep517       yes
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-terminaltables/Portfile
+++ b/python/py-terminaltables/Portfile
@@ -15,10 +15,8 @@ description         Generate simple tables in terminals from a nested list of st
 long_description    Easily draw tables in terminal/console applications from \
                     a list of lists of strings. Supports multi-line rows.
 
-python.versions     37 38 39 310 311
-python.pep517       yes
-python.pep517_backend \
-                    poetry
+python.versions     38 39 310 311 312
+python.pep517_backend poetry
 
 homepage            https://robpol86.github.io/${python.rootname}/
 


### PR DESCRIPTION
#### Description
Python 3.12 is MacPorts' default Python version since January 1st, start having ports use this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.3 23D56 x86_64
Xcode 15.2 15C500b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
