### PR TITLE
moe: update to 1.14

### DIFF
--- a/editors/moe/Portfile
+++ b/editors/moe/Portfile
@@ -3,12 +3,11 @@
 PortSystem          1.0
 
 name                moe
-version             1.13
+version             1.14
 revision            0
 
 categories          editors
-platforms           darwin
-license             GPL-3
+license             GPL-2+
 
 maintainers         nomaintainer
 
@@ -25,10 +24,16 @@ homepage            https://www.gnu.org/software/moe/
 master_sites        gnu
 use_lzip            yes
 
-checksums           rmd160  41d4a3951e71f42408dc56967684acc69ffcd8b4 \
-                    sha256  43a557bc512f89d6c718e5f41029cfe3a055682620eb8dbece6302f34a26146b \
-                    size    91414
+checksums           rmd160  072d7605ea422b0b333351641771b43fe4e31241 \
+                    sha256  f4babd6ce0ae19516f983454fb20d32dff71ad316337ac6bf93a42a5ff209c9d \
+                    size    92905
 
-depends_lib         port:ncurses
+depends_build-append \
+                    bin:makeinfo:texinfo
+depends_lib-append  port:ncurses
 
-configure.args      --infodir=${prefix}/share/info
+configure.args      CXX="${configure.cxx}" \
+                    CPPFLAGS="${configure.cppflags}" \
+                    CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
+                    LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]" \
+                    MAKEINFO="${prefix}/bin/makeinfo"


### PR DESCRIPTION
https://lists.gnu.org/archive/html/info-gnu/2024-01/msg00012.html

* remove platforms line and correct license to GPL-2+

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
