### PR TITLE
fpc: fix os.version bug

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                fpc
 version             3.2.2
 categories          lang pascal
-platforms           darwin
+platforms           macosx
 license             {GPL-2 LGPL-2}
 maintainers         {@kamischi web.de:karl-michael.schindler} openmaintainer
 description         Free Pascal, an open source Pascal and Object Pascal compiler.
@@ -45,7 +45,7 @@ universal_variant   no
 
 set fpcbasepath     ${prefix}/libexec/${name}
 
-if {${os.major} >= 13} { # Ventura, fix obsolete linker options
+if {${os.platform} eq "darwin" && ${os.major} >= 22} { # 13, Ventura, fix obsolete linker options
     patchfiles-append   t_darwin.pas.patch
 }
 
@@ -261,12 +261,14 @@ if {${subport} eq "${name}"} {
         }
     }
 
-    if       {${os.major} >= 11}   { # Big Sur
-        set otherOptions "-WM11.0 -XR${configure.sdkroot}"
-    } elseif {[vercmp ${os.version} 10.9] >= 0} { # Mavericks
-        set otherOptions "-WM10.9"
-    } else   {
-        set otherOptions ""
+    if {${os.platform} eq "darwin"} {
+        if       {${os.major} >= 20} { # 11, Big Sur
+            set otherOptions "-WM11.0 -XR${configure.sdkroot}"
+        } elseif {${os.major} >= 13} { # 10.9, Mavericks
+            set otherOptions "-WM10.9"
+        } else   {
+            set otherOptions ""
+        }
     }
 
     worksrcdir          ${name}build-${version}/fpcsrc
@@ -279,7 +281,7 @@ if {${subport} eq "${name}"} {
 
     # codesign for older systems does not have a --remove-signature option
     # work around: replace codesign by a dummy.
-    if {[vercmp ${os.version} 10.11] <= 0} { # El Capitan
+    if {${os.platform} eq "darwin" && ${os.major} <= 15} { # 10.11, El Capitan
         build.args-append   CODESIGN=/usr/bin/true
     }
 
@@ -310,10 +312,12 @@ if {${subport} eq "${name}"} {
         system "patch ${destroot}${fpcbasepath}/etc/fpc.cfg ${filespath}/fpc.cfg.patch"
 
         # remove the -WM option for older systems or update it as needed
-        if {[vercmp ${os.version} 10.7] < 0} { # Lion
-            reinplace "s|-WM10.9||g" ${destroot}${fpcbasepath}/etc/fpc.cfg
-        } elseif {${os.major} >=  11} { # Big Sur
-            reinplace "s|-WM10.9|-WM11.0|g" ${destroot}${fpcbasepath}/etc/fpc.cfg
+        if {${os.platform} eq "darwin"} {
+            if       {${os.major} < 11}   { # 10.7, Lion
+                reinplace "s|-WM10.9||g" ${destroot}${fpcbasepath}/etc/fpc.cfg
+            } elseif {${os.major} >=  20} { # 11, Big Sur
+                reinplace "s|-WM10.9|-WM11.0|g" ${destroot}${fpcbasepath}/etc/fpc.cfg
+            }
         }
 
         # set prefix of search path for qt4pas


### PR DESCRIPTION
os.version is the darwin version. macos_version is the macOS version.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.4 22G513 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
