### PR TITLE
catch2: update to 3.5.2

### DIFF
--- a/devel/catch2/Portfile
+++ b/devel/catch2/Portfile
@@ -5,7 +5,8 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        catchorg Catch2 3.5.1 v
+github.setup        catchorg Catch2 3.5.2 v
+github.tarball_from archive
 name                catch2
 revision            0
 
@@ -16,10 +17,9 @@ maintainers         {gmail.com:howarth.at.macports @jwhowarth} openmaintainer
 description         Catch 2: a modern, C++-native, header-only, test framework for unit-tests
 long_description    ${description}, TDD and BDD - using C++14, C++17 and later.
 
-checksums           rmd160  1a86e7effe9dc43eb7f104f040e130f0b81e6e62 \
-                    sha256  49c3ca7a68f1c8ec71307736bc6ed14fec21631707e1be9af45daf4037e75a08 \
-                    size    1159629
-github.tarball_from archive
+checksums           rmd160  d711022fe9a29886f1797175fab3b165ffcc16a5 \
+                    sha256  269543a49eb76f40b3f93ff231d4c24c27a7e16c90e47d2e45bcc564de470c6e \
+                    size    1159985
 
 compiler.cxx_standard 2014
 


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
