### PR TITLE
google-cloud-sdk: update to 462.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             461.0.0
+version             462.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  608173944e0a638f582b2780e9d91b194af4e0d3 \
-                    sha256  f393a224f64433114ad756e57a0f59c7a4ffed13f2ed4463a12d4cb11c08c284 \
-                    size    122572373
+    checksums       rmd160  9e493052060645deff2dd97811cae84bbecfe0e0 \
+                    sha256  a0e8c382e2e80b3f06f107b30152c3b7aca85237c2111a7c930bf7a591619292 \
+                    size    127652416
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  535947aba32b7fe958a079ea8d633a45b4c4813c \
-                    sha256  4d85319f89d7b90b661bf083e7ef8cfa167b7e05a152ba26f8fe7b7b3c98234b \
-                    size    123856556
+    checksums       rmd160  4a9bcbfda1a66444b4d980843a05e929e996bb9b \
+                    sha256  65f60929dc96e71619ea165a0a2f6ab520c1fa9c6a50bd402be0a04aa7a2f648 \
+                    size    128939836
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  09bc8ae9fdfb0966f17f2080c81bbf4407126b8c \
-                    sha256  5d01298b5a9811be9d08d037a6785d58e910a947841d3ea38418fd46799211b0 \
-                    size    120924667
+    checksums       rmd160  2e7c646a49e805d55ab9ca5034e6c1f0f7286288 \
+                    sha256  2d4b441318711035c53e9837f77cebc7731b25537181c2e90904c061103dfb47 \
+                    size    126001856
 }
 
 homepage            https://cloud.google.com/sdk/
@@ -148,29 +148,20 @@ destroot {
     }
     ln -s ../libexec/${name}/bin/git-credential-gcloud.sh ${destroot}${prefix}/bin/git-credential-gcloud
 
-    if {[variant_isset bash_completion]} {
-        # set completions_path ${prefix}/share/bash-completion/completions
-        set completions_path ${prefix}/etc/bash_completion.d
-        xinstall -d ${destroot}${completions_path}
-        xinstall -m 644 ${worksrcpath}/completion.bash.inc ${destroot}${completions_path}/google-cloud-sdk
-    }
+    # bash completion
+    set bash_completions_path ${prefix}/etc/bash_completion.d
+    xinstall -d ${destroot}${bash_completions_path}
+    xinstall -m 644 ${worksrcpath}/completion.bash.inc ${destroot}${bash_completions_path}/google-cloud-sdk
 
-    if {[variant_isset zsh_completion]} {
-        set gcloud_libexec ${destroot}${prefix}/libexec/google-cloud-sdk
-        xinstall -m 644 ${worksrcpath}/completion.zsh.inc ${gcloud_libexec}
-    }
+    # zsh completion
+    set gcloud_libexec ${destroot}${prefix}/libexec/google-cloud-sdk
+    xinstall -m 644 ${worksrcpath}/completion.zsh.inc ${gcloud_libexec}
 }
 
-variant bash_completion {
-    depends_run-append path:etc/bash_completion:bash-completion
-}
-
-variant zsh_completion description {Enable completion support for zsh} {
-    notes "
-        google-cloud-sdk zsh completions aren't loaded automatically.
-        You must source them manually in your .zshrc:
-            source '${prefix}/libexec/google-cloud-sdk/completion.zsh.inc'"
-}
+notes "
+    google-cloud-sdk zsh completions aren't loaded automatically.
+    You must source them manually in your .zshrc:
+        source '${prefix}/libexec/google-cloud-sdk/completion.zsh.inc'"
 
 livecheck.url       https://cloud.google.com/sdk/docs/install-sdk
 livecheck.regex     {google-cloud-cli-([\d\.]+)-darwin}


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 462.0.0, install bash and zsh completion files by default.

###### Tested on

macOS 14.3 23D56 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?