### PR TITLE
sqlite3: fix pointer size for ppc64

### DIFF
--- a/databases/sqlite3/Portfile
+++ b/databases/sqlite3/Portfile
@@ -6,9 +6,8 @@ PortGroup           clang_dependency 1.0
 name                sqlite3
 # don't forget to update the checksums for sqlite3-tools when updating sqlite3
 version             3.45.1
-revision            0
+revision            1
 categories          databases
-platforms           darwin
 license             public-domain
 
 maintainers         {mps @Schamschula} openmaintainer
@@ -42,12 +41,15 @@ if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"}
     clang_dependency.extra_versions 3.7
 }
 
+# Drop defines-ppc patches with 3.46.0: https://sqlite.org/forum/forumpost/fc4bfa307db74d04
 if {${subport} ne "${name}-tools"} {
     configure.checks.implicit_function_declaration.whitelist-append strchr
 
-    patchfiles      patch-sqlite3_fix-atomic-clang-4.diff
+    patchfiles      patch-sqlite3_fix-atomic-clang-4.diff \
+                    patch-sqlite3_fix-defines-ppc.diff
 } else {
-    patchfiles      patch-sqlite3-tools_fix-atomic-clang-4.diff
+    patchfiles      patch-sqlite3-tools_fix-atomic-clang-4.diff \
+                    patch-sqlite3-tools_fix-defines-ppc.diff
 }
 
 configure.args      --enable-threadsafe \

--- a/databases/sqlite3/files/patch-sqlite3-tools_fix-defines-ppc.diff
+++ b/databases/sqlite3/files/patch-sqlite3-tools_fix-defines-ppc.diff
@@ -1,0 +1,35 @@
+--- src/sqliteInt.h	2024-01-31
++++ src/sqliteInt.h	2024-01-31
+@@ -886,7 +886,7 @@
+ #   define SQLITE_PTRSIZE __SIZEOF_POINTER__
+ # elif defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
+        defined(_M_ARM)   || defined(__arm__)    || defined(__x86)   ||    \
+-      (defined(__APPLE__) && defined(__POWERPC__)) ||                     \
++      (defined(__APPLE__) && defined(__ppc__))  ||                        \
+       (defined(__TOS_AIX__) && !defined(__64BIT__))
+ #   define SQLITE_PTRSIZE 4
+ # else
+
+--- src/tclsqlite.c	2024-01-31
++++ src/tclsqlite.c	2024-01-31
+@@ -60,7 +60,7 @@
+ #     define SQLITE_PTRSIZE __SIZEOF_POINTER__
+ #   elif defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
+          defined(_M_ARM)   || defined(__arm__)    || defined(__x86)   ||    \
+-        (defined(__APPLE__) && defined(__POWERPC__)) ||                     \
++        (defined(__APPLE__) && defined(__ppc__))  ||                        \
+         (defined(__TOS_AIX__) && !defined(__64BIT__))
+ #     define SQLITE_PTRSIZE 4
+ #   else
+
+--- config.guess	2024-01-31
++++ config.guess	2024-01-31
+@@ -1425,7 +1425,7 @@
+ 		esac
+ 	    fi
+ 	    # On 10.4-10.6 one might compile for PowerPC via gcc -arch ppc
+-	    if (echo '#ifdef __POWERPC__'; echo IS_PPC; echo '#endif') | \
++	    if (echo '#ifdef __ppc__'; echo IS_PPC; echo '#endif') | \
+ 		   (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
+ 		   grep IS_PPC >/dev/null
+ 	    then

--- a/databases/sqlite3/files/patch-sqlite3_fix-defines-ppc.diff
+++ b/databases/sqlite3/files/patch-sqlite3_fix-defines-ppc.diff
@@ -1,0 +1,35 @@
+--- sqlite3.c	2024-01-31
++++ sqlite3.c	2024-01-31
+@@ -14860,7 +14860,7 @@
+ #   define SQLITE_PTRSIZE __SIZEOF_POINTER__
+ # elif defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
+        defined(_M_ARM)   || defined(__arm__)    || defined(__x86)   ||    \
+-      (defined(__APPLE__) && defined(__POWERPC__)) ||                     \
++      (defined(__APPLE__) && defined(__ppc__)) ||                         \
+       (defined(__TOS_AIX__) && !defined(__64BIT__))
+ #   define SQLITE_PTRSIZE 4
+ # else
+
+--- tea/generic/tclsqlite3.c	2024-01-31
++++ tea/generic/tclsqlite3.c	2024-01-31
+@@ -65,7 +65,7 @@
+ #     define SQLITE_PTRSIZE __SIZEOF_POINTER__
+ #   elif defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
+          defined(_M_ARM)   || defined(__arm__)    || defined(__x86)   ||    \
+-        (defined(__APPLE__) && defined(__POWERPC__)) ||                     \
++        (defined(__APPLE__) && defined(__ppc__)) ||                         \
+         (defined(__TOS_AIX__) && !defined(__64BIT__))
+ #     define SQLITE_PTRSIZE 4
+ #   else
+
+--- config.guess	2024-01-31
++++ config.guess	2024-01-31
+@@ -1425,7 +1425,7 @@
+ 		esac
+ 	    fi
+ 	    # On 10.4-10.6 one might compile for PowerPC via gcc -arch ppc
+-	    if (echo '#ifdef __POWERPC__'; echo IS_PPC; echo '#endif') | \
++	    if (echo '#ifdef __ppc__'; echo IS_PPC; echo '#endif') | \
+ 		   (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
+ 		   grep IS_PPC >/dev/null
+ 	    then


### PR DESCRIPTION
#### Description

Existing code sets pointer size to 4 bytes for `ppc64`. Fix that.
See also: https://sqlite.org/forum/forumpost/0aab76f91c

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
