### PR TITLE
socket_vmnet: new port (1.1.3)

### DIFF
--- a/net/socket_vmnet/Portfile
+++ b/net/socket_vmnet/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        lima-vm socket_vmnet 1.1.3 v
+
+categories          net
+maintainers         {sub-pop.net:link @subpop} \
+                    openmaintainer
+license             APL-2.0
+
+description         vmnet.framework support for rootless QEMU
+long_description    Daemon to provide access to vmnet.framework for rootless QEMU
+homepage            https://github.com/lima-vm/socket_vmnet
+
+checksums           rmd160 c72c72fe8471df6d31df287d8df843e49d3a1fed \
+                    sha256 f5ec3fa24ad2c857b2b555f4fc91b39cbf3e9c4bc3191fb64c46ee7f49027b47 \
+                    size 18738
+
+use_configure       no
+build.args          VERSION=${version} \
+                    SOURCE_DATE_EPOCH=1696806366 \
+                    PREFIX=${prefix}
+destroot.target     install.bin install.doc
+destroot.args       ${build.args}
+
+startupitem.create     yes
+startupitem.logfile    /var/log/${name}.log
+startupitem.user       root
+startupitem.executable ${prefix}/bin/socket_vmnet --vmnet-gateway=192.168.105.1 /var/run/socket_vmnet


### PR DESCRIPTION
#### Description

Add new port for [`socket_vmnet`](https://github.com/lima-vm/socket_vmnet)

###### Type(s)

- [x] submission
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
