### PR TITLE
bash: update gettext deps

### DIFF
--- a/shells/bash/Portfile
+++ b/shells/bash/Portfile
@@ -234,11 +234,12 @@ if {${subport} eq ${name}} {
     patchfiles-append  patch-configure.diff
 }
 
-depends_build           bin:bison:bison
+depends_build           bin:bison:bison \
+                        port:gettext
 # ar: internal ranlib command failed
 depends_build-append    port:cctools
 
-depends_lib             port:gettext \
+depends_lib             port:gettext-runtime \
                         port:ncurses
 
 variant universal {}


### PR DESCRIPTION
#### Description

gettext itself is only needed at build time; only gettext-runtime is used at runtime.

- [x] enhancement
