### PR TITLE
hdf5: Update link-line in h5fc

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -9,7 +9,7 @@ PortGroup           compiler_blacklist_versions 1.0
 name                hdf5
 version             1.14.3
 set mainversion     [lrange [split ${version} -] 0 0]
-revision            2
+revision            3
 set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
 categories          science
 maintainers         {eborisch @eborisch} openmaintainer
@@ -116,9 +116,9 @@ post-destroot {
     # see https://trac.macports.org/ticket/67507
     if {[ mpi_variant_isset ]} {
         # see https://github.com/macports/macports-ports/commit/1e09f24922857968ec9e4429085a4d06b636baf2#commitcomment-115333262
-        set bins    {h5c++ h5pcc}
+        set bins    {h5c++ h5pcc h5fc}
     } else {
-        set bins    {h5c++ h5cc}
+        set bins    {h5c++ h5cc h5fc}
     }
     reinplace   -W ${destroot}${prefix}/bin "s|-lsz|${prefix}/lib/libaec/lib/libsz.dylib|g" {*}${bins}
     reinplace   -W ${destroot}${prefix}/bin "s|-lz|${prefix}/lib/libz.dylib|g"              {*}${bins}


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69207

Maintainer update.