### PR TITLE
lima: Upgrade to v0.20.1

### DIFF
--- a/sysutils/lima/Portfile
+++ b/sysutils/lima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/lima-vm/lima 0.20.0 v
+go.setup            github.com/lima-vm/lima 0.20.1 v
 go.offline_build    no
 github.tarball_from archive
 revision            0
@@ -23,9 +23,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 
 depends_run         port:qemu
 
-checksums           rmd160  8d2cae1a879b5001b385f85d2a1ba0be77e2d470 \
-                    sha256  935cb2816973c6b7bb8c19169d6f731a4a839cf636e53d78a1db09458784a6d7 \
-                    size    6093229
+checksums           rmd160  6c1ecf713ed8b63351d5e5032337362acf8751d9 \
+                    sha256  3e8b16572a23d69ad16ef72f15b1697c35b5eacaf6c1f0943b6ebfb8bfaf1fd7 \
+                    size    6093418
 
 build.cmd           make
 


### PR DESCRIPTION
#### Description

lima: Upgrade to v0.20.1

##### Tested on

macOS 14.3 23D56 arm64
Xcode 15.1 15C65

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
