### PR TITLE
bitcoin: fix build on macOS < 10.13

### DIFF
--- a/finance/bitcoin/Portfile
+++ b/finance/bitcoin/Portfile
@@ -57,6 +57,13 @@ configure.args          --disable-ccache \
 
 compiler.cxx_standard   2017
 
+# pool.h:161:27: error: aligned allocation function
+# of type 'void *(std::size_t, std::align_val_t)'
+# is only available on macOS 10.13 or newer
+if {${os.platform} eq "darwin" && ${os.major} < 17} {
+    configure.cxxflags-append -fno-aligned-allocation
+}
+
 configure.args-append   --with-daemon=no
 configure.args-append   --with-gui=no
 configure.args-append   --enable-wallet=no


### PR DESCRIPTION
#### Description

https://github.com/macports/macports-ports/pull/17706
https://build.macports.org/builders/ports-10.12_x86_64-builder/builds/258902/steps/install-port/logs/stdio

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
