### PR TITLE
py-scikit-learn: update to 1.4.0; update and pin 1.3.2 to py38

### DIFF
--- a/python/py-scikit-learn/Portfile
+++ b/python/py-scikit-learn/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           compiler_wrapper 1.0
 
 name                py-scikit-learn
-version             1.2.2
+version             1.4.0
 revision            0
 categories-append   science
 license             BSD
@@ -24,19 +24,26 @@ long_description    Scikit-learn integrates machine learning algorithms \
 
 homepage            https://scikit-learn.org/
 
-checksums           rmd160  92664f8b16d4c531c1b8f13a486a1cae4a43a0aa \
-                    sha256  8429aea30ec24e7a8c7ed8a3fa6213adf3814a6efbea09e16e0a0c71e1a1a3d7 \
-                    size    7269934
+checksums           rmd160  e57fdc4df798cbf7f16839f13f22a1c8d329d6b5 \
+                    sha256  d4373c984eba20e393216edd51a3e3eede56cbe93d4247516d205643c3b93121 \
+                    size    7706781
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                        port:py${python.version}-setuptools \
                         path:bin/cython-${python.branch}:py${python.version}-cython
 
     depends_lib-append  port:py${python.version}-numpy \
                         port:py${python.version}-scipy \
                         port:py${python.version}-joblib \
                         port:py${python.version}-threadpoolctl
+
+    if {${python.version} == 38} {
+        version             1.3.2
+        revision            0
+        checksums           rmd160  3f496523de9ba2f515836b92f4d8ca94375ba625 \
+                            sha256  a2f54c76accc15a34bfb9066e6c7a56c1e7235dda5762b990792330b52ccfb05 \
+                            size    7510251
+    }
 
     compiler.openmp_version 2.5
     depends_lib-append  port:libomp


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update `py-scikit-learn` to version 1.4.0; update and pin version 1.3.2 to py38.

Due to non-existing py312 ports for `py-joblib` and `py-threadpoolctl` (which neither seem to be ready for Python 3.12) , py312 cannot be added.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
