### PR TITLE
py-setuptools: update to 69.0.3

### DIFF
--- a/python/py-setuptools/Portfile
+++ b/python/py-setuptools/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-setuptools
-version             68.2.2
+version             69.0.3
 categories-append   devel
 # License status is murky. The current maintainer decided to relicense as
 # MIT, but he doesn't appear to have obtained the permission of previous
@@ -24,9 +24,9 @@ platforms           {darwin any}
 
 homepage            https://pypi.org/project/setuptools/
 
-checksums           md5 d967ca2ba7f46db887daee2d5c9bd6a2 \
-                    rmd160 bf736a936c4ae85b9dd546f39fd0c627c8c17675 \
-                    sha256 4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87
+checksums           md5 b82de45aaa6b9bb911226660212ebb83 \
+                    rmd160 3a6425012d063297ee54504524cc5ea56455edc7 \
+                    sha256 be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78
 
 python.versions     26 27 32 33 34 35 36 37 38 39 310 311 312
 python.link_binaries no


### PR DESCRIPTION
#### Description

py-setuptools: update to 69.0.3

Reason: https://trac.macports.org/ticket/69258

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
