### PR TITLE
netcdf @4.9.2: Add missing dependencies

### DIFF
--- a/science/netcdf/Portfile
+++ b/science/netcdf/Portfile
@@ -13,7 +13,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 epoch                       3
 github.setup                Unidata netcdf-c 4.9.2 v
-revision                    1
+revision                    2
 name                        netcdf
 maintainers                 {takeshi @tenomoto} openmaintainer
 categories                  science
@@ -59,7 +59,11 @@ if {[variant_isset netcdf4]} {
 }
 
 variant netcdf4 description {enable support for netcdf-4 API} {
-    depends_lib-append      port:hdf5
+    depends_lib-append      port:hdf5 \
+                            port:blosc \
+                            port:bzip2 \
+                            port:zlib \
+                            port:zstd
     configure.args-delete   -DENABLE_NETCDF_4=OFF
     configure.args-append   -DENABLE_NETCDF_4=ON
 }
@@ -72,7 +76,8 @@ variant hdf4 description {enable support for hdf4} {
 }
 
 variant dap description {enable dap} {
-    depends_lib-append      port:curl
+    depends_lib-append      port:curl \
+                            port:libxml2
     configure.args-delete   -DENABLE_DAP=OFF
     configure.args-append   -DENABLE_DAP=ON \
                             -DENABLE_DAP_REMOTE_TESTS=OFF


### PR DESCRIPTION
* Hard linked dependencies were causing downstream failures, e.g. netcdf-fortran.
* Reference: https://trac.macports.org/ticket/68124
* Add missing dependencies which may have been opportunistically hard linked.
* Missing libxml2 added for DAP.
* Missing bzip2, zlib, zstd added for compression filters.
* Add blosc as external library for compression filter.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.3 (darwin/23.3.0) arch i386
MacPorts 2.9.0
Xcode 15.2, CLT 15.1.0.0.1.1700200546
SDK 14

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `sudo port -s install`?
- [ ] tested basic functionality of all binary files?
- [x] tested basic functionality of the primary binary library?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->