### PR TITLE
nektarpp: update to 5.5.0

### DIFF
--- a/science/nektarpp/Portfile
+++ b/science/nektarpp/Portfile
@@ -7,7 +7,7 @@ PortGroup               gitlab 1.0
 PortGroup               boost 1.0
 
 gitlab.instance         https://gitlab.nektar.info
-gitlab.setup            nektar nektar 5.4.0 v
+gitlab.setup            nektar nektar 5.5.0 v
 
 boost.version           1.76
 
@@ -33,16 +33,17 @@ master_sites            ${master_sites}:main \
 set main_distfile       ${distfiles}
 distfiles               ${main_distfile}:main
 
-checksums               nektar-5.4.0.tar.bz2 \
-                        rmd160  29a4f935109ef15fc8e2ffd2f2a511461f0bd123 \
-                        sha256  f0f7ac8a73278e7d308e950ea4542d29df8425e8df36325da097aec0eabc2ecc \
-                        size    62123363
+checksums               nektar-5.5.0.tar.bz2 \
+                        rmd160  e4dcf6abbb6e2d08a3fb727c28665d77df2a978e \
+                        sha256  cfc9a0c52c83b6f68e13e11dd9f2ca47a131d33730723ef690ed866166d0f408 \
+                        size    63767065
 
 # Only the full Nektar++ source should be extracted - CMake will extract any
 # third-party dependencies.
 extract.only            ${main_distfile}
 
-patchfiles              no-homebrew.patch
+patchfiles              no-homebrew.patch \
+                        zlib-1.3.patch
 
 compiler.cxx_standard   2011
 cmake.build_type        Release

--- a/science/nektarpp/files/zlib-1.3.patch
+++ b/science/nektarpp/files/zlib-1.3.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/ThirdPartyZlib.cmake b/cmake/ThirdPartyZlib.cmake
+index dd8c4811b..c5cf57441 100644
+--- cmake/ThirdPartyZlib.cmake.orig
++++ cmake/ThirdPartyZlib.cmake
+@@ -16,7 +16,7 @@ IF(WIN32)
+     SET(BUILD_ZLIB ON)
+ ELSE()
+     FIND_PACKAGE(ZLIB QUIET)
+-    IF (ZLIB_FOUND AND NOT ZLIB_VERSION_PATCH LESS 7)
++    IF (ZLIB_FOUND AND ZLIB_VERSION_STRING VERSION_GREATER 1.2.8)
+         SET(BUILD_ZLIB OFF)
+     ELSE ()
+         SET(BUILD_ZLIB ON)

--- a/science/opencascade/Portfile
+++ b/science/opencascade/Portfile
@@ -6,7 +6,7 @@ PortGroup                   muniversal 1.0
 
 name                        opencascade
 version                     7.7.0
-revision                    2
+revision                    3
 categories                  science
 license                     LGPL-2
 maintainers                 {mcalhoun @MarcusCalhoun-Lopez} openmaintainer


### PR DESCRIPTION
#### Description

Updates `nektarpp` to 5.5.0. Patches small issue with `zlib` detection which has been submitted upstream for next release.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.2 23C64 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
