### PR TITLE
openldap-devel: also blacklist old clang of Xcode 3.2.6

### DIFF
--- a/databases/openldap-devel/Portfile
+++ b/databases/openldap-devel/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           muniversal 1.0
 PortGroup           legacysupport 1.1
 
@@ -94,7 +95,7 @@ configure.args-append \
 
 # slap-config.h: error: redefinition of typedef ‘ConfigArgs’
 compiler.blacklist-append \
-                    *gcc-4.0 *gcc-4.2
+                    *gcc-4.0 *gcc-4.2 {clang < 421}
 
 startupitem.create  yes
 startupitem.name    slapd


### PR DESCRIPTION
#### Description

Turned out, same error with archaic Xcode clang:
```
In file included from bconfig.c:40:
slap-config.h:182: error: redefinition of typedef ‘ConfigArgs’
slap.h:1325: error: previous declaration of ‘ConfigArgs’ was here
In file included from config.c:52:
slap-config.h:182: error: redefinition of typedef ‘ConfigArgs’
slap.h:1325: error: previous declaration of ‘ConfigArgs’ was here
In file included from syncprov.c:28:
../slap-config.h:182: error: redefinition of typedef ‘ConfigArgs’
../slap.h:1325: error: previous declaration of ‘ConfigArgs’ was here
make[2]: *** [config.o] Error 1
```

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Server
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
