### PR TITLE
difftastic: Upgrade to 0.55.0

### DIFF
--- a/devel/difftastic/Portfile
+++ b/devel/difftastic/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        Wilfred difftastic 0.54.0
+github.setup        Wilfred difftastic 0.55.0
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,10 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  e7443edd3285f15268bf00d4c5b64961e5e382b7 \
-                    sha256  04f13ccf32fa55d1835eb9cbaec0a3c062d217a83c049e9a1f16ae3c22ed361a \
-                    size    58647254 \
+checksums           ${distname}${extract.suffix} \
+                    rmd160  4e0049e5eae913b67cd10c9466ccba50d6144930 \
+                    sha256  b2ff408736bd1b357dc518fa2bcd9c938110a72b8cbebe45a4c9af3b5337c5b5 \
+                    size    61809092 
 
 build.pre_args-delete \
                     --frozen --offline


### PR DESCRIPTION
#### Description

difftastic: Upgrade to 0.55.0

##### Tested on

macOS 14.3 23D56 arm64
Xcode 15.1 15C65

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
