### PR TITLE
hdf5: Only patch h5fc on +fortran.

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -116,9 +116,12 @@ post-destroot {
     # see https://trac.macports.org/ticket/67507
     if {[ mpi_variant_isset ]} {
         # see https://github.com/macports/macports-ports/commit/1e09f24922857968ec9e4429085a4d06b636baf2#commitcomment-115333262
-        set bins    {h5c++ h5pcc h5fc}
+        set bins    {h5c++ h5pcc}
     } else {
-        set bins    {h5c++ h5cc h5fc}
+        set bins    {h5c++ h5cc}
+    }
+    if {[ variant_isset fortran ]} {
+        append bins " " h5fc
     }
     reinplace   -W ${destroot}${prefix}/bin "s|-lsz|${prefix}/lib/libaec/lib/libsz.dylib|g" {*}${bins}
     reinplace   -W ${destroot}${prefix}/bin "s|-lz|${prefix}/lib/libz.dylib|g"              {*}${bins}


### PR DESCRIPTION
Maintainer update.

Fixes: https://trac.macports.org/ticket/69254

No rev-bump as successful builds don't change.