### PR TITLE
libocca: fix older Intel builds

### DIFF
--- a/devel/libocca/Portfile
+++ b/devel/libocca/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 github.setup        libocca occa 1.6.0 v
 name                libocca
-revision            0
+revision            1
 categories          devel parallel
 license             BSD
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -33,6 +33,11 @@ compilers.setup         require_fortran
 
 # By default it installs into a weird location:
 patchfiles-append   0001-CMakeLists-fix-install-paths.patch
+
+# Drop once this is merged: https://github.com/libocca/occa/pull/739
+patchfiles-append   0002-sys.cpp-add-missing-AvailabilityMacros.h.patch \
+                    0003-sys.cpp-use-clock_gettime-on-macOS-when-supported.patch \
+                    0004-sys.cpp-update-pthread_threadid-code-for-macOS.patch
 
 post-patch {
     reinplace "s,@DESTROOTDIR@,${destroot}${prefix}," ${worksrcpath}/CMakeLists.txt

--- a/devel/libocca/files/0002-sys.cpp-add-missing-AvailabilityMacros.h.patch
+++ b/devel/libocca/files/0002-sys.cpp-add-missing-AvailabilityMacros.h.patch
@@ -1,0 +1,21 @@
+From 8dac9813b33ce2f4717b0a9df42b306d00987e27 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 2 Feb 2024 13:41:22 +0800
+Subject: [PATCH] sys.cpp: add missing AvailabilityMacros.h
+
+---
+ src/occa/internal/utils/sys.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git src/occa/internal/utils/sys.cpp src/occa/internal/utils/sys.cpp
+index 01d6b0ed..e1e3722b 100644
+--- src/occa/internal/utils/sys.cpp
++++ src/occa/internal/utils/sys.cpp
+@@ -19,6 +19,7 @@
+ #    include <errno.h>
+ #    include <sys/sysinfo.h>
+ #  else // OCCA_MACOS_OS
++#    include <AvailabilityMacros.h>
+ #    include <mach/mach_host.h>
+ #    ifdef __clang__
+ #      include <CoreServices/CoreServices.h>

--- a/devel/libocca/files/0003-sys.cpp-use-clock_gettime-on-macOS-when-supported.patch
+++ b/devel/libocca/files/0003-sys.cpp-use-clock_gettime-on-macOS-when-supported.patch
@@ -1,0 +1,31 @@
+From e93734170303080330cda549d8f547496c8f5048 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 2 Feb 2024 14:36:27 +0800
+Subject: [PATCH] sys.cpp: use clock_gettime on macOS when supported
+
+---
+ src/occa/internal/utils/sys.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git src/occa/internal/utils/sys.cpp src/occa/internal/utils/sys.cpp
+index e1e3722b..dbaf3212 100644
+--- src/occa/internal/utils/sys.cpp
++++ src/occa/internal/utils/sys.cpp
+@@ -21,7 +21,7 @@
+ #  else // OCCA_MACOS_OS
+ #    include <AvailabilityMacros.h>
+ #    include <mach/mach_host.h>
+-#    ifdef __clang__
++#    if MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
+ #      include <CoreServices/CoreServices.h>
+ #      include <mach/mach_time.h>
+ #    else
+@@ -83,7 +83,7 @@ namespace occa {
+ 
+       return (double) (ct.tv_sec + (1.0e-9 * ct.tv_nsec));
+ #elif (OCCA_OS == OCCA_MACOS_OS)
+-#  if defined __clang__ && defined CLOCK_UPTIME_RAW
++#  if MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
+       uint64_t nanoseconds = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+ 
+       return 1.0e-9 * nanoseconds;

--- a/devel/libocca/files/0004-sys.cpp-update-pthread_threadid-code-for-macOS.patch
+++ b/devel/libocca/files/0004-sys.cpp-update-pthread_threadid-code-for-macOS.patch
@@ -1,0 +1,30 @@
+From edcd035130c5924d284dff1e8915b776be6dd586 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 2 Feb 2024 14:39:29 +0800
+Subject: [PATCH] sys.cpp: update pthread_threadid code for macOS
+
+---
+ src/occa/internal/utils/sys.cpp | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git src/occa/internal/utils/sys.cpp src/occa/internal/utils/sys.cpp
+index dbaf3212..46273aec 100644
+--- src/occa/internal/utils/sys.cpp
++++ src/occa/internal/utils/sys.cpp
+@@ -402,12 +402,13 @@ namespace occa {
+ 
+     int getTID() {
+ #if (OCCA_OS & (OCCA_LINUX_OS | OCCA_MACOS_OS))
+-#if OCCA_OS == OCCA_MACOS_OS & (MAC_OS_X_VERSION_MAX_ALLOWED >= 101200)
++#if OCCA_OS == OCCA_MACOS_OS & (MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)
+       uint64_t tid64;
+-      pthread_threadid_np(NULL, &tid64);
++      pthread_threadid_np(nullptr, &tid64);
+       pid_t tid = (pid_t)tid64;
+ #else
+-      pid_t tid = syscall(SYS_gettid);
++      uint64_t tid;
++      tid = pthread_mach_thread_np(pthread_self());
+ #endif
+       return tid;
+ #else


### PR DESCRIPTION
#### Description

Fix the build for older Intel systems.

P. S. Revbumping justified, since there is a change in the code which applies to some older systems where the port was not broken.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5 x86_64
Xcode 5.4

macOS 10.6.8 Rosetta (to verify nothing breaks with GCC)
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
