### PR TITLE
google-glog: fix compiler blacklist

### DIFF
--- a/devel/google-glog/Portfile
+++ b/devel/google-glog/Portfile
@@ -1,9 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
-PortGroup           cmake 1.1
 
 name                google-glog
 github.setup        google glog 0.6.0 v
@@ -35,14 +36,7 @@ compiler.cxx_standard \
 # https://trac.macports.org/ticket/65645
 # #pragma GCC diagnostic inside functions available from gcc-4.6.
 compiler.blacklist-append \
-                    *gcc-4.2 *gcc-4.3 *gcc-4.4 *gcc-4.5
-
-# Rosetta ignores blacklist and still tries to use llvm-g++-4.2.
-# Prioritize newer gcc; list versions that are realistically used and confirmed to build and work.
-platform darwin 10 powerpc {
-    compiler.whitelist \
-                    macports-gcc-12 macports-gcc-11 macports-gcc-10 macports-gcc-7 macports-gcc-6
-}
+                    {*gcc-4.[0-5]} {clang < 421}
 
 configure.args-append \
                     -DWITH_GFLAGS=OFF \


### PR DESCRIPTION
#### Description

1. `gcc-4.0` has to be blacklisted too, otherwise it may get picked, and build fails.
2. We do not need whitelist and a special case for Rosetta, just blacklist old Xcode clang of 10.6.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
