### PR TITLE
py-threadpoolctl: add py312; drop py37; enable tests

### DIFF
--- a/python/py-threadpoolctl/Portfile
+++ b/python/py-threadpoolctl/Portfile
@@ -11,7 +11,7 @@ supported_archs     noarch
 platforms           {darwin any}
 license             BSD
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,9 +24,8 @@ checksums           rmd160  bc71e6ea121d307c1dcc2619ee2763a945838817 \
                     sha256  c96a0ba3bdddeaca37dc4cc7344aafad41cdb8c313f74fdfe387a867bba93355 \
                     size    36266
 
-python.pep517       yes
+patchfiles-append patch-test.diff
+
 python.pep517_backend   flit
 
-if {${name} ne ${subport}} {
-    livecheck.type      none
-}
+test.run  yes

--- a/python/py-threadpoolctl/files/patch-test.diff
+++ b/python/py-threadpoolctl/files/patch-test.diff
@@ -1,0 +1,12 @@
+Addressed upstream https://github.com/joblib/threadpoolctl/issues/162
+
+--- tests/test_threadpoolctl.py.orig
++++ tests/test_threadpoolctl.py
+@@ -600,6 +600,7 @@
+     expected_openblas_architectures = (
+         # XXX: add more as needed by CI or developer laptops
+         "armv8",
++        "ARMV8",
+         "Haswell",
+         "Prescott",  # see: https://github.com/xianyi/OpenBLAS/pull/3485
+         "SkylakeX",


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Add Python 3.12 and drop Python 3.7 subport of `py-threadpoolctl`; also enable test.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1 23C71 arm64
Xcode 15.1 15C65

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
