### PR TITLE
newsraft: new port

### DIFF
--- a/net/newsraft/Portfile
+++ b/net/newsraft/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           legacysupport 1.1
+PortGroup           makefile 1.0
+PortGroup           codeberg 1.0
+
+codeberg.setup      newsraft newsraft 0.23 newsraft-
+revision            0
+
+categories          net
+license             ISC
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+description         Feed reader for terminal
+long_description    {*}${description}
+
+checksums           rmd160  cca3f1900994a43caad4c8454c2d97061ad1754e \
+                    sha256  22c835f56ff84a4aadc86d9e56a5d8e531cc966ff6a1404f0b3f8f1a1a0655dc \
+                    size    139740
+
+depends_build       port:pkgconfig
+
+depends_lib-append  port:curl \
+                    port:expat \
+                    port:gumbo-parser \
+                    port:ncurses \
+                    port:sqlite3 \
+                    port:yajl


### PR DESCRIPTION
#### Description
https://codeberg.org/newsraft/newsraft - Feed reader for terminal

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
