### PR TITLE
qt5-mysql-plugin, qt6-mysql-plugin new variants

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -957,6 +957,14 @@ array set sql_plugins {
             ""
         }
         {
+            "mysql82"
+            "port:mysql82"
+            "${prefix}/include/mysql82/mysql"
+            "${prefix}/lib/mysql82/mysql"
+            "-lmysqlclient"
+            ""
+        }
+        {
             "mysql81"
             "port:mysql81"
             "${prefix}/include/mysql81/mysql"

--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -710,7 +710,7 @@ array set sql_plugins {
                     -DMySQL_LIBRARY=${prefix}/lib/mariadb-10.8/mysql/libmariadb.dylib
                 }
             }
-            mariadb10_9 {
+            mariadb10_7 {
                 "port:mariadb-10.7"
                 {
                     -DMySQL_INCLUDE_DIR=${prefix}/include/mariadb-10.7/mysql
@@ -750,6 +750,13 @@ array set sql_plugins {
                 {
                     -DMySQL_INCLUDE_DIR=${prefix}/include/mysql81/mysql
                     -DMySQL_LIBRARY=${prefix}/lib/mysql81/mysql/libmysqlclient.dylib
+                }
+            }
+            mysql82 {
+                "port:mysql82"
+                {
+                    -DMySQL_INCLUDE_DIR=${prefix}/include/mysql82/mysql
+                    -DMySQL_LIBRARY=${prefix}/lib/mysql82/mysql/libmysqlclient.dylib
                 }
             }
         }


### PR DESCRIPTION
  Update mysql related variants as follows:
qt5-mysql-plugin:
  - Add MYSQL82 variant
 
qt6-mysql-plugin:
  - Add MYSQL82 variant
  - Fix mariadb10_7 typo

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.3 23D56 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
