### PR TITLE
libsndfile: do not use gcc-4.2 on Intel

### DIFF
--- a/audio/libsndfile/Portfile
+++ b/audio/libsndfile/Portfile
@@ -43,6 +43,12 @@ configure.args \
     --disable-test-coverage \
     --enable-external-libs
 
+if {${configure.build_arch} in [list i386 x86_64]} {
+    # This is an Intel-specific issue: sources use immintrin.h,
+    # and Xcode gcc does not have it.
+    compiler.blacklist-append *gcc-4.0 *gcc-4.2
+}
+
 variant no_external_libs conflicts experimental description {Disable FLAC, Ogg, Vorbis and Opus support} {
     depends_build-delete    port:pkgconfig
     depends_lib-delete      port:flac port:libogg port:libvorbis port:libopus


### PR DESCRIPTION
#### Description

Sources use `immintrin.h` which old Apple gcc apparently does not have, so the build breaks down on undefined stuff.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
