### PR TITLE
colima: Upgrade to 0.6.8

### DIFF
--- a/sysutils/colima/Portfile
+++ b/sysutils/colima/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/abiosoft/colima 0.6.7 v
+go.setup            github.com/abiosoft/colima 0.6.8 v
 github.tarball_from archive
 revision            0
 
@@ -18,9 +18,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {macports.halostatue.ca:austin @halostatue} \
                     openmaintainer
 
-checksums           rmd160  855f02e1a84da3347a9166d08af7fc96c850e44f \
-                    sha256  e0ebd208098d4b92d2c37c62f72e7d999b83c10895b620339dca80471c4462d6 \
-                    size    608510
+checksums           rmd160  95dd98a7d2120e968c45f057a8af79a186e1c03d \
+                    sha256  cfac3e086bbf706b550592fdac787f13b05cc43e361277cf06da59429afb6ea5 \
+                    size    608519
 
 depends_run         port:lima
 
@@ -41,4 +41,10 @@ destroot {
 notes {
     If upgrading from Colima 0.5.6 or earlier, both colima instances and
     profiles must be deleted and recreated.
+
+    Colima 0.6.8 addresses several CVEs. Newly created colima instances
+    are automatically patched. Existing instances should upgrade manually:
+
+      colima ssh -- \
+        sh -c "sudo apt update && sudo apt install -y containerd.io"
 }


### PR DESCRIPTION
#### Description

colima: Upgrade to 0.6.8

A comment has been added for addressing CVEs inside existing Colima
instances. This causes a single nitpick failure, but it is _correct_
in this case.

##### Tested on

macOS 14.3 23D56 arm64
Xcode 15.1 15C65

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
