### PR TITLE
socket_vmnet: use default CFLAGS/LDFLAGS

### DIFF
--- a/net/socket_vmnet/Portfile
+++ b/net/socket_vmnet/Portfile
@@ -21,6 +21,8 @@ checksums           rmd160 c72c72fe8471df6d31df287d8df843e49d3a1fed \
 use_configure       no
 build.args          VERSION=${version} \
                     SOURCE_DATE_EPOCH=1696806366 \
+                    CFLAGS="${configure.cflags}" \
+                    LDFLAGS="${configure.ldflags}" \
                     PREFIX=${prefix}
 destroot.target     install.bin install.doc
 destroot.args       ${build.args}


### PR DESCRIPTION
#### Description

Because socket_vmnet does not use autoconf, the default CFLAGS and LDFLAGS aren't configured. This PR passes them as make variables directly when invoking make.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [-] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
