### PR TITLE
socket_vmnet: patch to include correct Availability header

### DIFF
--- a/net/socket_vmnet/Portfile
+++ b/net/socket_vmnet/Portfile
@@ -18,6 +18,10 @@ checksums           rmd160 c72c72fe8471df6d31df287d8df843e49d3a1fed \
                     sha256 f5ec3fa24ad2c857b2b555f4fc91b39cbf3e9c4bc3191fb64c46ee7f49027b47 \
                     size 18738
 
+# Submitted upstream: https://github.com/lima-vm/socket_vmnet/pull/40
+patchfiles          fix-include-Availability-header.diff
+patch.pre_args      -p1
+
 use_configure       no
 build.args          VERSION=${version} \
                     SOURCE_DATE_EPOCH=1696806366 \

--- a/net/socket_vmnet/files/fix-include-Availability-header.diff
+++ b/net/socket_vmnet/files/fix-include-Availability-header.diff
@@ -1,0 +1,13 @@
+diff --git a/cli.c b/cli.c
+index dd4f710..7557512 100644
+--- a/cli.c
++++ b/cli.c
+@@ -5,7 +5,7 @@
+ #include <arpa/inet.h>
+ #include <getopt.h>
+ 
+-#include <availability.h>
++#include <Availability.h>
+ #include <uuid/uuid.h>
+ 
+ #include "cli.h"


### PR DESCRIPTION
#### Description

Include Availability.h to support compiling on case-sensitive filesystems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
