### PR TITLE
various Python ports: drop subports for EOL Python versions

### DIFF
--- a/python/py-DAWG/Portfile
+++ b/python/py-DAWG/Portfile
@@ -9,20 +9,15 @@ revision            0
 categories-append   devel
 license             MIT
 
-python.versions     37 38
+python.versions     38
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Fast and memory efficient DAWG for Python.
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://github.com/pytries/DAWG/
 
 checksums           rmd160  dc48adfff0a90cce906ba78ed3a5d7d69490952e \
                     sha256  34881e06278d4a54cf0b402c0c8b587bef0caa78f0eee595adc7a2aa530e48ce \
                     size    371078
-
-if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-}

--- a/python/py-Faker/Portfile
+++ b/python/py-Faker/Portfile
@@ -22,12 +22,9 @@ checksums           rmd160  87406003a8349de26c4f6e804f1f830480843822 \
                     sha256  b7f76bb1b2ac4cdc54442d955e36e477c387000f31ce46887fb9722a041be60b \
                     size    1708228
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
     depends_run-append \
                     port:py${python.version}-Pillow \
                     port:py${python.version}-dateutil \

--- a/python/py-PyRSS2Gen/Portfile
+++ b/python/py-PyRSS2Gen/Portfile
@@ -5,6 +5,8 @@ PortGroup           python 1.0
 
 name                py-PyRSS2Gen
 version             1.1
+revision            0
+
 categories-append   devel
 platforms           {darwin any}
 supported_archs     noarch
@@ -12,7 +14,7 @@ license             BSD
 maintainers         nomaintainer
 
 description         A Python library for generating RSS 2.0 feeds
-long_description    ${description}
+long_description    {*}${description}
 homepage            http://www.dalkescientific.com/Python/PyRSS2Gen.html
 
 master_sites        http://www.dalkescientific.com/Python/
@@ -21,7 +23,11 @@ checksums           rmd160  0dea97364066f78189b99a512015e851601aa2fa \
                     sha256  2a9a3ee7c8e30cb40434ef3a295f9a60166f7d8c3eaefac9f46f7ed4b27c2269 \
                     size    9149
 
-python.versions     27 35 36
+python.versions     27
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     {PyRSS2Gen-(\d+(?:\.\d+)*)}
 
 if {${subport} ne ${name}} {
     post-destroot {
@@ -29,9 +35,4 @@ if {${subport} ne ${name}} {
         xinstall -d ${destroot}${docdir}
         xinstall -m 644 -W ${worksrcpath} LICENSE README ${destroot}${docdir}
     }
-    livecheck.type      none
-} else {
-    livecheck.type      regex
-    livecheck.url       ${homepage}
-    livecheck.regex     {PyRSS2Gen-(\d+(?:\.\d+)*)}
 }

--- a/python/py-XlsxWriter/Portfile
+++ b/python/py-XlsxWriter/Portfile
@@ -8,7 +8,7 @@ github.setup        jmcnamara XlsxWriter 3.1.9 RELEASE_
 name                py-XlsxWriter
 revision            0
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 license             BSD
 maintainers         {eborisch @eborisch} \
                     openmaintainer

--- a/python/py-acora/Portfile
+++ b/python/py-acora/Portfile
@@ -9,12 +9,12 @@ revision            0
 categories-append   textproc devel
 license             BSD
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Fast multi-keyword search engine for text strings.
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://pypi.python.org/pypi/acora
 

--- a/python/py-actdiag/Portfile
+++ b/python/py-actdiag/Portfile
@@ -11,7 +11,7 @@ license             Apache-2
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -25,6 +25,5 @@ checksums           rmd160  d512bc74eec38a16537a551deddc99609d1945a0 \
                     size    2574809
 
 if {${name} ne ${subport}} {
-    depends_lib-append  port:py${python.version}-setuptools \
-                        port:py${python.version}-blockdiag
+    depends_lib-append  port:py${python.version}-blockdiag
 }

--- a/python/py-aenum/Portfile
+++ b/python/py-aenum/Portfile
@@ -11,8 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
-python.pep517       yes
+python.versions     38 39 310 311
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-affine/Portfile
+++ b/python/py-affine/Portfile
@@ -11,8 +11,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311 312
-python.pep517       yes
+python.versions     38 39 310 311 312
 python.pep517_backend flit
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-aiofiles/Portfile
+++ b/python/py-aiofiles/Portfile
@@ -21,6 +21,5 @@ checksums           rmd160  a3e0af5b40a0a4dfe4fa88893d37aa64fad689b9 \
                     sha256  84ec2218d8419404abcb9f0c02df3f34c6e0a68ed41072acfb1cef5cbc29051a \
                     size    32072
 
-python.versions     37 38 39 310 311
-python.pep517       yes
+python.versions     38 39 310 311
 python.pep517_backend hatch

--- a/python/py-aioitertools/Portfile
+++ b/python/py-aioitertools/Portfile
@@ -11,7 +11,7 @@ platforms           {darwin any}
 license             MIT
 supported_archs     noarch
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 python.pep517_backend   flit
 
 maintainers         {stromnov @stromnov} openmaintainer

--- a/python/py-aiorpcX/Portfile
+++ b/python/py-aiorpcX/Portfile
@@ -4,13 +4,15 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-aiorpcX
-version             0.10.5
+version             0.22.1
+revision            0
+
 categories-append   devel
 license             MIT
 platforms           {darwin any}
 supported_archs     noarch
 
-python.versions     37
+python.versions     312
 
 maintainers         {ipglider.org:miguel @ipglider} openmaintainer
 
@@ -20,11 +22,6 @@ long_description    Transport, protocol and framing-independent async RPC \
 
 homepage            https://github.com/kyuupichan/aiorpcX
 
-checksums           rmd160  dc19faecb046a21c87e0c9c2f3c45c2fcc6e3a5b \
-                    sha256  21add307084497c19c911d369f9e995c7cd9bd0ef74485cb5509682080559330 \
-                    size    23549
-
-if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
-    depends_lib-append      port:py${python.version}-attrs
-}
+checksums           rmd160  5d88b5e7227de549a275123ad806cf18503ee9e7 \
+                    sha256  6026f7bed3432e206589c94dcf599be8cd85b5736b118c7275845c1bd922a553 \
+                    size    28803

--- a/python/py-altair/Portfile
+++ b/python/py-altair/Portfile
@@ -12,8 +12,7 @@ license             BSD
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311
-python.pep517       yes
+python.versions     38 39 310 311
 python.pep517_backend hatch
 
 maintainers         {stromnov @stromnov} openmaintainer
@@ -33,10 +32,6 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-numpy \
                         port:py${python.version}-pandas \
                         port:py${python.version}-toolz
-
-    if {${python.version} < 38} {
-        depends_lib-append  port:py${python.version}-importlib-metadata
-    }
 
     if {${python.version} < 311} {
         depends_lib-append  port:py${python.version}-typing_extensions

--- a/python/py-aniso8601/Portfile
+++ b/python/py-aniso8601/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  8ad04ab28aed5de651b589d4fd09db88a126adee \
                     sha256  72e3117667eedf66951bb2d93f4296a56b94b078a8a95905a052611fb3f1b973 \
                     size    47345
 
-python.versions     27 37 38 39 310
+python.versions     27 38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append    port:py${python.version}-setuptools

--- a/python/py-ansicolor/Portfile
+++ b/python/py-ansicolor/Portfile
@@ -5,6 +5,8 @@ PortGroup           python 1.0
 
 name                py-ansicolor
 version             0.3.2
+revision            0
+
 categories-append   devel
 license             Apache-2
 platforms           {darwin any}
@@ -13,8 +15,7 @@ maintainers         {@gpanders gpanders.com:greg} \
                     openmaintainer
 
 description         A library to produce ANSI color output
-long_description    A library to produce ANSI color output \
-                    and colored highlighting and diffing.
+long_description    {*}${description} and colored highlighting and diffing.
 
 homepage            https://github.com/numerodix/ansicolor
 
@@ -22,8 +23,4 @@ checksums           rmd160  7b54e765e294c2ab6f178958342b39bbd0824646 \
                     sha256  3b840a6b1184b5f1568635b1adab28147947522707d41ceba02d5ed0a0877279 \
                     size    9725
 
-python.versions     37 38 39
-
-if {${name} ne ${subport}} {
-    depends_build-append port:py${python.version}-setuptools
-}
+python.versions     38 39

--- a/python/py-aplpy/Portfile
+++ b/python/py-aplpy/Portfile
@@ -6,6 +6,8 @@ PortGroup           python 1.0
 name                py-aplpy
 python.rootname     APLpy
 version             1.1.1
+revision            0
+
 categories-append   science
 platforms           {darwin any}
 supported_archs     noarch
@@ -26,7 +28,8 @@ checksums           md5     634422c006dcd366d5504af3349e9d10 \
                     rmd160  99edddf30cd7635edd8ffe9d1466c2ead1584525 \
                     sha256  1c3bc9972da5f738435449e5e8483824129f2a18e7426f0a8c2c06a1ef3b4b4b
 
-python.versions     37 38 39
+python.versions     38 39
+python.pep517       no
 
 if {${name} ne ${subport}} {
 
@@ -52,6 +55,4 @@ if {${name} ne ${subport}} {
     }
 
     default_variants    +rgb +avm +ds9
-
-    livecheck.type  none
 }

--- a/python/py-argcomplete/Portfile
+++ b/python/py-argcomplete/Portfile
@@ -5,6 +5,8 @@ PortGroup           python 1.0
 
 name                py-argcomplete
 version             3.1.6
+revision            0
+
 license             Apache-2
 platforms           {darwin any}
 supported_archs     noarch
@@ -19,7 +21,7 @@ checksums           rmd160  c2a792d077645ff81a29d2af00129a0e0252e7e1 \
                     sha256  3b1f07d133332547a53c79437527c00be48cca3807b1d4ca5cab1b26313386a6 \
                     size    79685
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build   port:py${python.version}-setuptools_scm

--- a/python/py-asgiref/Portfile
+++ b/python/py-asgiref/Portfile
@@ -5,6 +5,7 @@ PortGroup           python 1.0
 
 name                py-asgiref
 version             3.7.2
+revision            0
 
 checksums           rmd160  4d3c5eff9dc994b06c5c6d94d6d70541a0d98825 \
                     sha256  9e0ce3aa93a819ba5b45120216b23878cf6e8525eb3848653452b4192b92afed \
@@ -20,4 +21,4 @@ long_description    {*}${description}
 
 homepage            https://asgi.readthedocs.io/en/latest
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311

--- a/python/py-asn1crypto/Portfile
+++ b/python/py-asn1crypto/Portfile
@@ -11,8 +11,7 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311 312
-python.pep517       yes
+python.versions     38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-astroML_addons/Portfile
+++ b/python/py-astroML_addons/Portfile
@@ -13,7 +13,7 @@ license             BSD
 platforms           darwin
 maintainers         {aronnax @lpsinger} openmaintainer
 
-python.versions     37 38 39
+python.versions     38 39
 
 description         performance add-ons for the astroML package
 

--- a/python/py-astroplan/Portfile
+++ b/python/py-astroplan/Portfile
@@ -6,6 +6,8 @@ PortGroup           github 1.0
 
 github.setup        astropy astroplan 0.7 v
 name                py-${name}
+revision            0
+
 maintainers         {aronnax @lpsinger} openmaintainer
 categories-append   science
 description         Observation planning package for astronomers
@@ -25,7 +27,8 @@ checksums           rmd160  365a8e8673a063e40d841b7709e148f6fe935bc1 \
                     sha256  b2fc6acdbab8dfeafe2be60c74c578513468c607385a977510f7ca02342a7cab \
                     size    145344
 
-python.versions     37 38 39
+python.versions     38 39
+python.pep517       no
 
 if {${name} ne ${subport}} {
 
@@ -45,6 +48,4 @@ if {${name} ne ${subport}} {
     post-patch {
         reinplace -W ${worksrcpath} "s/auto_use = True/auto_use = False/" setup.cfg
     }
-
-    livecheck.type      none
 }

--- a/python/py-astropy-healpix/Portfile
+++ b/python/py-astropy-healpix/Portfile
@@ -10,12 +10,12 @@ revision            1
 
 distname            astropy_healpix-${version}
 categories-append   science
-python.versions     37 38 39 310
+python.versions     38 39 310
 license             BSD
 maintainers         {aronnax @lpsinger} openmaintainer
 
 description         BSD-licensed HEALPix for Astropy
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://github.com/astropy/astropy-healpix
 

--- a/python/py-astroscrappy/Portfile
+++ b/python/py-astroscrappy/Portfile
@@ -1,12 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup python 1.0
-PortGroup github 1.0
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
 
 github.setup        astropy astroscrappy 1.0.5 v
 name                py-astroscrappy
-python.versions     37 38 39
+revision            0
+
 categories-append   science
 license             BSD
 platforms           darwin
@@ -20,9 +21,10 @@ checksums           rmd160  282062da64c4f6d9fbcee38928c016d11b4e1e56 \
                     sha256  a541119c3fe9c9e01a96ac103e880f9b6497f671f364314f608876c8259e9b16 \
                     size    56004
 
-if {${subport} ne ${name}} {
-    livecheck.type          none
+python.versions     38 39
+python.pep517       no
 
+if {${subport} ne ${name}} {
     depends_build-append    port:py${python.version}-astropy-helpers \
                             port:py${python.version}-cython
 

--- a/python/py-asttokens/Portfile
+++ b/python/py-asttokens/Portfile
@@ -11,7 +11,7 @@ license             Apache-2
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 

--- a/python/py-asyncmy/Portfile
+++ b/python/py-asyncmy/Portfile
@@ -20,10 +20,9 @@ checksums           rmd160  dfc6a3b7fa881b38a81a94ecc87a832e7c1d0cde \
                     sha256  cf3ef3d1ada385d231f23fffcbf1fe040bae8575b187746633fbef6e7cff2844 \
                     size    62791
 
-python.versions     37 38 39 310
+python.versions     38 39 310
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-cython \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-cython
 }

--- a/python/py-atomicwrites/Portfile
+++ b/python/py-atomicwrites/Portfile
@@ -21,11 +21,13 @@ checksums           rmd160  3e5b123eea6caa43cec69097bf7cec347c783f74 \
                     sha256  81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11 \
                     size    14227
 
-python.versions     27 37 38 39 310 311 312
+python.versions     27 38 39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
     test.run        yes
+
+    if {${python.version} == 27} {
+        depends_build-append \
+                    port:py${python.version}-setuptools
+        }
 }

--- a/python/py-atpy/Portfile
+++ b/python/py-atpy/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-atpy
+python.rootname     ATpy
 version             0.9.7
 revision            2
 maintainers         nomaintainer
@@ -20,15 +21,13 @@ platforms           {darwin any}
 supported_archs     noarch
 license             MIT
 
-homepage            http://atpy.readthedocs.org/
-master_sites        pypi:A/ATpy/
-distname            ATpy-${version}
+homepage            https://atpy.readthedocs.org/
 
 checksums           rmd160  a2c76ef4ac595d0f9cbfb0a21d3bf1bf98b088cf \
                     sha256  4286bb0e4de30df16d6ffd14eb92e4bd47cba2b486834ca95db512c830d0693c \
                     size    663163
 
-python.versions     37 38 39
+python.versions     38 39
 
 if {${name} ne ${subport}} {
 
@@ -42,6 +41,4 @@ if {${name} ne ${subport}} {
     variant vo description {Include support for VO cone search} {
         depends_run-append  port:py${python.version}-vo
     }
-
-    livecheck.type  none
 }

--- a/python/py-autoflake/Portfile
+++ b/python/py-autoflake/Portfile
@@ -20,20 +20,11 @@ checksums           rmd160  abd9a71c5f2583f0678caca23bd0140979a5ab18 \
                     sha256  62b7b6449a692c3c9b0c916919bbc21648da7281e8506bcf8d3f8280e431ebc1 \
                     size    27377
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 
-python.pep517           yes
 python.pep517_backend   hatch
 
 if {${name} ne ${subport}} {
-    if {${python.version} == 37} {
-        version     2.1.1
-        revision    0
-        checksums   rmd160  7e78a1647bad484acfecb5765d001ec0962d68d4 \
-                    sha256  75524b48d42d6537041d91f17573b8a98cb645642f9f05c7fcc68de10b1cade3 \
-                    size    26564
-    }
-
     depends_lib-append \
                     port:py${python.version}-pyflakes
 

--- a/python/py-avro/Portfile
+++ b/python/py-avro/Portfile
@@ -22,11 +22,8 @@ checksums           rmd160  60ced3747c5983814cd971c239fa510a10f2e5b9 \
                     sha256  b3a405df5aa8654b992d2aca7b80482b858a1919a44dc0b10a682162e8ee340a \
                     size    68125
 
-python.versions     37 38 39
+python.versions     38 39
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
-
     test.run        yes
 }

--- a/python/py-axolotl-curve25519/Portfile
+++ b/python/py-axolotl-curve25519/Portfile
@@ -20,10 +20,4 @@ checksums           rmd160  31f9e2dc684d65ccd42e914ae303e5b2d2fb611a \
                     sha256  0705a66297ebd2f508a60dc94e22881c754301eb81db93963322f6b3bdcb63a3 \
                     size    79941
 
-python.versions     37 38
-
-if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
-
-    livecheck.type  none
-}
+python.versions     38

--- a/python/py-axolotl/Portfile
+++ b/python/py-axolotl/Portfile
@@ -22,20 +22,14 @@ checksums           rmd160  bd830ee43a670a2b5601d74a2d0097251136b9ac \
                     sha256  fe0e8147423f8dc4ec1077ea18ca5a54091366d22faa903a772ee6ea88b88daf \
                     size    38180
 
-python.versions     37 38
+python.versions     38
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
-
     depends_run-append      port:py${python.version}-cryptography \
                             port:py${python.version}-axolotl-curve25519 \
                             port:py${python.version}-protobuf3
 
-    depends_test-append     port:py${python.version}-nose
-
     test.run        yes
-    test.cmd        nosetests-${python.branch}
+    python.test_framework nose
     test.target     axolotl.tests
-
-    livecheck.type  none
 }

--- a/python/py-mitmproxy/Portfile
+++ b/python/py-mitmproxy/Portfile
@@ -32,11 +32,9 @@ checksums           rmd160  7668d0fe20ad33e026de91345ceb966d408f4774 \
 
 patchfiles          patch-test_version.py.diff
 
-python.versions     37 38 39 310 311
+python.versions     38 39 310 311
 
 if {${name} ne ${subport}} {
-    depends_build-append    port:py${python.version}-setuptools
-
     depends_lib-append      port:py${python.version}-asn1 \
                             port:py${python.version}-asgiref \
                             port:py${python.version}-blinker \

--- a/python/py-stack_data/Portfile
+++ b/python/py-stack_data/Portfile
@@ -11,14 +11,14 @@ license             MIT
 supported_archs     noarch
 platforms           {darwin any}
 
-python.versions     37 38 39 310 311 312
+python.versions     38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 
 description         Library that extracts data from stack frames and tracebacks.
 long_description    {*}${description}
 
-homepage            http://github.com/alexmojaki/stack_data
+homepage            https://github.com/alexmojaki/stack_data
 
 checksums           rmd160  efcb75f494894cf7c02bac7fbca844a02b3c1165 \
                     sha256  836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \


### PR DESCRIPTION
#### Description
Drop subports for EOL Python versions - only build failure is for `py-astroscrappy`, this currently doesn't build anywhere either and has thus nothing to do with this PR.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.3 23D56 x86_64
Xcode 15.2 15C500b


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
