### PR TITLE
socket_vmnet: Add minimum darwin version requirement

### DIFF
--- a/net/socket_vmnet/Portfile
+++ b/net/socket_vmnet/Portfile
@@ -10,6 +10,8 @@ maintainers         {sub-pop.net:link @subpop} \
                     openmaintainer
 license             APL-2.0
 
+platforms           {darwin >= 19}
+
 description         vmnet.framework support for rootless QEMU
 long_description    Daemon to provide access to vmnet.framework for rootless QEMU
 homepage            https://github.com/lima-vm/socket_vmnet


### PR DESCRIPTION
#### Description

socket_vmnet only works on macOS 10.15 and newer. Specify this as a platforms requirement on darwin >= 19.

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.2.1 23C71 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
