### PR TITLE
adept2: update to 2024.01.24

### DIFF
--- a/math/adept2/Portfile
+++ b/math/adept2/Portfile
@@ -5,19 +5,19 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 PortGroup           linear_algebra 1.0
 
-github.setup        rjhogan Adept-2 74492d7fbc9fca1ab62705c86d53f2e298cdb096
+github.setup        rjhogan Adept-2 9ac1eaa0b3ae95d230504f11d52b9cc4b43ef112
 name                adept2
-version             2023.10.03
-revision            2
+version             2024.01.24
+revision            0
 categories          math
 license             Apache-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Fast automatic differentiation library in C++
 long_description    Combined array and automatic differentiation library in C++.
 homepage            https://www.met.reading.ac.uk/clouds/adept
-checksums           rmd160  1a43dfac902646c7a51a727d8d34a5caf59158a4 \
-                    sha256  529472e8a7b57bfe6ff6836e3bdc5b28a4200aa7b7b8a3d4d7f27e4b856cff19 \
-                    size    328130
+checksums           rmd160  eb7b29f03b31d26c9361b333002198493cf93f42 \
+                    sha256  82c62d658ceb2654b313a709a13a3beeb318701bc50abf20c5891d42ecaa6abb \
+                    size    333335
 github.tarball_from archive
 
 set_default_variants    no


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
