### PR TITLE
sfm: fix prefix

### DIFF
--- a/sysutils/sfm/Portfile
+++ b/sysutils/sfm/Portfile
@@ -6,13 +6,15 @@ PortGroup               makefile 1.0
 PortGroup               legacysupport 1.0
 
 github.setup            afify sfm 0.4 v
+revision                0
 categories              sysutils
 license                 ISC
-maintainers             {@sikmir gmail.com:sikmir} openmaintainer
-platforms               darwin
+maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             Simple file manager
 long_description        ${name} is a simple file manager for unix-like systems.
 
 checksums               rmd160  cbe737b636406924d5b11a1f200ba133b75165ab \
                         sha256  2446bcd8c27903aaaac128e08993308ea107023f822eedb058a855c5469c96ae \
                         size    29519
+
+destroot.args           PREFIX=${prefix}


### PR DESCRIPTION
#### Description
Fix install prefix

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? 
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
