### PR TITLE
google-cloud-sdk: update to 462.0.1

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             462.0.0
+version             462.0.1
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  9e493052060645deff2dd97811cae84bbecfe0e0 \
-                    sha256  a0e8c382e2e80b3f06f107b30152c3b7aca85237c2111a7c930bf7a591619292 \
-                    size    127652416
+    checksums       rmd160  ce43f97c7b216ac54469fa5f6f8f3c50dc4c2f98 \
+                    sha256  3917c9c7ed3d2ed93f6d0182e2e858d8211730316d436f2998631811d64292e1 \
+                    size    127653951
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  4a9bcbfda1a66444b4d980843a05e929e996bb9b \
-                    sha256  65f60929dc96e71619ea165a0a2f6ab520c1fa9c6a50bd402be0a04aa7a2f648 \
-                    size    128939836
+    checksums       rmd160  661c14d0c9cce743b108c861dbbd9e96ba803001 \
+                    sha256  8a8c4feaf9c0b3e43ad391805f5122b836a1b1246eaf6c1c1af96e259641812d \
+                    size    128939919
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  2e7c646a49e805d55ab9ca5034e6c1f0f7286288 \
-                    sha256  2d4b441318711035c53e9837f77cebc7731b25537181c2e90904c061103dfb47 \
-                    size    126001856
+    checksums       rmd160  f31684a939760dc36014350c5bb6ebf5d57664f6 \
+                    sha256  cbe69148cea749e42f1b1e70b59ec7dcbd6097763358c3c45e1f6a9c17b80178 \
+                    size    126001745
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 462.0.1.

###### Tested on

macOS 14.3 23D56 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?