### PR TITLE
girara: Update to 0.4.2

### DIFF
--- a/devel/girara/Portfile
+++ b/devel/girara/Portfile
@@ -1,18 +1,23 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           compiler_blacklist_versions 1.0
+PortGroup           gitlab 1.0
 PortGroup           meson 1.0
 
-name                girara
-version             0.3.7
+gitlab.instance     https://git.pwmt.org
+gitlab.setup        pwmt girara 0.4.2
 revision            0
+checksums           rmd160  f294a35542ae78368580e9752b0d7e6c5091010a \
+                    sha256  ce79d5d69fa0d2004b1d322ee6fe86a8e3a2b4628db57b4e4d88f318af46c044 \
+                    size    60875
+
 categories          devel gnome
-platforms           darwin
 license             zlib
 maintainers         {gmail.com:starkhalo @harciga} \
                     openmaintainer
+
 description         Cross-platform widget toolkit based on GTK+
+
 long_description \
     girara is a library that implements a user interface that focuses on    \
     simplicity and minimalism. Currently based on GTK+, a cross-platform    \
@@ -23,25 +28,19 @@ long_description \
     the application and the status bar which provides the user with current \
     information.
 
-homepage            https://git.pwmt.org/pwmt/girara/
-
-master_sites        ${homepage}/-/archive/${version}
-
-checksums           rmd160  62befd8f03d46831af6c54b4f2e6da13be65f993 \
-                    sha256  41342213f8e745258f1db28cbb6ccc27a63009a5e001bf791bbe01ce436d4db7 \
-                    size    73831
-
 depends_build-append \
-                    port:pkgconfig \
-                    port:intltool
+                    port:gettext \
+                    path:bin/pkg-config:pkgconfig
 
-depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
+depends_lib         port:gettext-runtime \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
-                    port:libnotify \
-                    port:json-c
+                    port:json-glib
 
-# blacklist compilers that don't support -std=c11
-compiler.blacklist  *gcc-4.* {clang < 300}
+compiler.c_standard 2017
+
+configure.args-append \
+                    -Ddocs=disabled
 
 platform darwin     {
 # Before 10.7 there's no getline() in stdio.h
@@ -53,10 +52,5 @@ platform darwin     {
 # http://www.opensource.apple.com/source/cvs/cvs-47/cvs/lib/getdelim.c?txt
 # http://www.opensource.apple.com/source/cvs/cvs-47/cvs/lib/getdelim.h?txt
         patchfiles-append   patch-getline.diff
-        configure.args-append  -Ddocs=disabled
     }
 }
-
-livecheck.type      regex
-livecheck.url       ${homepage}/tags
-livecheck.regex     [quotemeta ${name}]-(\\d\\.\\d\\.\\d)[quotemeta ${extract.suffix}]


### PR DESCRIPTION
#### Description

* Update to 0.4.2
* Use gitlab portgroup instead of specifying homepage, master_sites, livecheck manually
* Use `compiler.c_standard` instead of blacklisting compilers manually; project now uses C17 not C11
* Remove `platforms darwin`; that's the default now
* Change pkgconfig build dependency to `path` syntax so that pkgconf could satisfy it
* Remove intltool build dependency because this project doesn't use it, at least not anymore
* Add gettext build dependency because it uses `msgfmt`
* Add gettext-runtime library dependency because it links with libintl.dylib
* Remove libnotify library dependency because libnotify support is now off by default and has been removed from subsequent upstream code already
* JSON support is now provided by json-glib not json-c
* Add `-Ddocs=disabled` to `configure.args` on all systems not just on pre-Lion, otherwise it looks for `doxygen`, but even if it finds `doxygen`, what it builds with it doesn't seem to get installed 

I have not tested the pre-existing patch for pre-Lion systems that adds implementations of `getline` and `getdelim` and do not understand how they could ever have worked since the patch only adds new source code files; it never references them from anywhere.

Closes: https://trac.macports.org/ticket/69271

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 21G1974 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
