### PR TITLE
hdf5: Another attempt at fixing wrapper scripts

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -114,17 +114,12 @@ post-destroot {
 
     # ensure libraries are found and that they are from MacPorts
     # see https://trac.macports.org/ticket/67507
-    if {[ mpi_variant_isset ]} {
-        # see https://github.com/macports/macports-ports/commit/1e09f24922857968ec9e4429085a4d06b636baf2#commitcomment-115333262
-        set bins    {h5c++ h5pcc}
-    } else {
-        set bins    {h5c++ h5cc}
-    }
-    if {[ variant_isset fortran ]} {
-        append bins " " h5fc
-    }
-    reinplace   -W ${destroot}${prefix}/bin "s|-lsz|${prefix}/lib/libaec/lib/libsz.dylib|g" {*}${bins}
-    reinplace   -W ${destroot}${prefix}/bin "s|-lz|${prefix}/lib/libz.dylib|g"              {*}${bins}
+    # Depending on build config, a number of different files need to be patched
+    # just let the system find which ones need it for this build.
+    system -W ${destroot}${prefix}/bin \
+        "grep -Il --null -- '-lsz -lz' * | xargs -0 sed -I '' \
+          -e 's^-lsz^${prefix}/lib/libaec/lib/libsz.dylib^' \
+          -e 's^-lz^${prefix}/lib/libz.dylib^'"
 }
 
 test.run            yes


### PR DESCRIPTION
A number of wrapper scripts need to have their -lsz -lz link line fixed; which ones depends on build config. Rather than have a matrix of all the different potential files that need patching, just find them at build time and fix them up.

Another attempt at:
 Fixes https://trac.macports.org/ticket/69254

Maintainer update.