### PR TITLE
mpich: Blanket disable of commons flag.

### DIFF
--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -21,7 +21,7 @@ PortGroup           mpiutil 1.0
 # make sure to keep in sync with mpi-doc
 name                mpich
 version             4.1.2
-revision            1
+revision            2
 
 license             BSD
 categories          science parallel net

--- a/science/mpich/Portfile
+++ b/science/mpich/Portfile
@@ -188,12 +188,10 @@ if {${subport_enabled}} {
                     patch-ch4-ipv6.diff \
                     patch-mpich-darwin-powerpc.diff
 
-    if {[vercmp ${xcodeversion} >= 15.0]} {
-        post-patch {
-            reinplace \
-                "s/commons_use_dylibs_works=yes/commons_use_dylibs_works=no/" \
-                configure
-        }
+    post-patch {
+        reinplace \
+            "s/commons_use_dylibs_works=yes/commons_use_dylibs_works=no/" \
+            configure
     }
 
     platform darwin powerpc {


### PR DESCRIPTION
Maintainer update.

Based on the comments in the upstream config file, this option was there for _ifort_, and it's causing issues for various combinations of XC 15/14 and others. Blanket disable on our builds for now.