### PR TITLE
antlr:  Whitespace only

### DIFF
--- a/lang/antlr/Portfile
+++ b/lang/antlr/Portfile
@@ -2,37 +2,40 @@
 
 PortSystem 1.0
 
-name			antlr
-version			2.7.7
-revision		3
-categories		lang java
-license			public-domain
-platforms		darwin
-maintainers		nomaintainer
-description		antlr is ANother Tool for Language Recognition
-long_description	ANTLR, ANother Tool for Language Recognition, is a \
-			language tool that provides a framework for \
-			constructing recognizers, compilers, and translators \
-			from grammatical descriptions containing Java, C#, or \
-			C++ actions. 
+name                  antlr
+version               2.7.7
+revision              3
+categories            lang java
+license               public-domain
+platforms             darwin
+maintainers           nomaintainer
 
-homepage		http://www.antlr2.org/
-master_sites		${homepage}download/ \
-			https://www.mirrorservice.org/sites/distfiles.finkmirrors.net/
-checksums		md5    01cc9a2a454dd33dcd8c856ec89af090         \
-            sha1   802655c343cc7806aaf1ec2177a0e663ff209de1 \
-            rmd160 0b7951a28b748e912721fe0f6de4095d9f8da57d
-patchfiles		patch-configure.diff antlr-DESTDIR.patch \
-                patch-lib-cpp-antlr-CharScanner.hpp.diff
+description           antlr is ANother Tool for Language Recognition
+long_description      ANTLR, ANother Tool for Language Recognition, is a \
+                      language tool that provides a framework for \
+                      constructing recognizers, compilers, and translators \
+                      from grammatical descriptions containing Java, C#, or \
+                      C++ actions.
 
-variant universal {}
+homepage              http://www.antlr2.org/
+master_sites          ${homepage}download/ \
+                      https://www.mirrorservice.org/sites/distfiles.finkmirrors.net/
 
-configure.env		CLASSPATH=.
-configure.args		--disable-csharp
+checksums             md5    01cc9a2a454dd33dcd8c856ec89af090         \
+                      sha1   802655c343cc7806aaf1ec2177a0e663ff209de1 \
+                      rmd160 0b7951a28b748e912721fe0f6de4095d9f8da57d
 
-build.args      CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
-                LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
+patchfiles            patch-configure.diff antlr-DESTDIR.patch \
+                      patch-lib-cpp-antlr-CharScanner.hpp.diff
 
-livecheck.type  regex
-livecheck.url   ${homepage}download.html
-livecheck.regex ${name}-(\\d+(?:\\.\\d+)*)
+variant               universal {}
+
+configure.env         CLASSPATH=.
+configure.args        --disable-csharp
+
+build.args            CXXFLAGS="${configure.cxxflags} [get_canonical_archflags cxx]" \
+                      LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
+
+livecheck.type        regex
+livecheck.url         ${homepage}download.html
+livecheck.regex       ${name}-(\\d+(?:\\.\\d+)*)


### PR DESCRIPTION
* Fix tabs.
* Align columns to usual standard.
* Add a little vertical spacing.
* Preparation for bugfix PR.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 11, 12, 13.  X86 only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->