### PR TITLE
antlr @2.7.7: Add java portgroup, fix build

### DIFF
--- a/lang/antlr/Portfile
+++ b/lang/antlr/Portfile
@@ -1,14 +1,16 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem            1.0
+PortGroup             java 1.0
 
 name                  antlr
 version               2.7.7
-revision              3
+revision              4
 categories            lang java
 license               public-domain
 platforms             darwin
-maintainers           nomaintainer
+maintainers           {@Dave-Allured noaa.gov:dave.allured} \
+                      openmaintainer
 
 description           antlr is ANother Tool for Language Recognition
 long_description      ANTLR, ANother Tool for Language Recognition, is a \
@@ -21,14 +23,24 @@ homepage              http://www.antlr2.org/
 master_sites          ${homepage}download/ \
                       https://www.mirrorservice.org/sites/distfiles.finkmirrors.net/
 
-checksums             md5    01cc9a2a454dd33dcd8c856ec89af090         \
-                      sha1   802655c343cc7806aaf1ec2177a0e663ff209de1 \
-                      rmd160 0b7951a28b748e912721fe0f6de4095d9f8da57d
+checksums             rmd160  0b7951a28b748e912721fe0f6de4095d9f8da57d \
+                      sha256  853aeb021aef7586bda29e74a6b03006bcb565a755c86b66032d8ec31b67dbb9 \
+                      size    1816180
 
 patchfiles            patch-configure.diff antlr-DESTDIR.patch \
                       patch-lib-cpp-antlr-CharScanner.hpp.diff
 
 variant               universal {}
+
+# Required java version.
+java.version          1.4+
+
+# LTS JDK port to install if required java not found
+java.fallback         openjdk8
+
+# JDK only needed at build time, but java PG sets lib dependency.
+# So declare no conflict to allow redistribution of binaries.
+license_noconflict    ${java.fallback}
 
 configure.env         CLASSPATH=.
 configure.args        --disable-csharp


### PR DESCRIPTION
* Add java portgroup to fix **buildbot** builds on recent OS versions.
* Add required java version, etc.
* Update to modern checksum types.
* Add myself as maintainer.
* Maybe fixes:  https://trac.macports.org/ticket/65225

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 12.7.2 21G1974 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?