### PR TITLE
[zig] Update Portfile to fix __mh_execute_header issue on macOS Sonoma

### DIFF
--- a/lang/zig/Portfile
+++ b/lang/zig/Portfile
@@ -43,3 +43,4 @@ compiler.whitelist  macports-clang-${llvm_version}
 cmake.module_path   ${prefix}/libexec/llvm-${llvm_version} \
                     ${prefix}
 cmake_share_module_dir ${prefix}/libexec/llvm-${llvm_version}
+configure.args-append -DCMAKE_INSTALL_RPATH="${prefix}/libexec/llvm-16/lib" -DCMAKE_EXE_LINKER_FLAGS="-ld_classic"


### PR DESCRIPTION
#### Description
This commit updates the Zig Portfile by adding `-DCMAKE_INSTALL_RPATH` and 
`-DCMAKE_EXE_LINKER_FLAGS` flags. This change addresses a duplicate symbol 
issue with `__mh_execute_header` encountered on macOS Sonoma with Zig 0.11.0, 
ensuring proper dynamic linking and resolving build failures.

Closes: https://trac.macports.org/ticket/68281

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.3 23D56 arm64
Xcode 15.2 15C500b
macOS 14.3X
Xcode 15.2 / Command Line Tools 15.1.0

###### Verification
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
