### PR TITLE
libgit2-devel: update to 1.7.2

### DIFF
--- a/devel/libgit2-devel/Portfile
+++ b/devel/libgit2-devel/Portfile
@@ -11,9 +11,9 @@ conflicts           libgit2
 set my_name         libgit2
 
 # don't forget to update py-pygit2 and libgit2-glib as well
-github.setup        libgit2 libgit2 1.7.1 v
+github.setup        libgit2 libgit2 1.7.2 v
 github.tarball_from archive
-revision            1
+revision            0
 epoch               0
 
 categories          devel
@@ -30,9 +30,9 @@ homepage            https://libgit2.org/
 
 dist_subdir         ${my_name}
 
-checksums           rmd160  5dad52197aaa08f44f5faab10935e566ae51da6b \
-                    sha256  17d2b292f21be3892b704dddff29327b3564f96099a1c53b00edc23160c71327 \
-                    size    7548081
+checksums           rmd160  53aa89485a37b91cf11aae5ef63bfa6193f6246b \
+                    sha256  de384e29d7efc9330c6cdb126ebf88342b5025d920dcb7c645defad85195ea7f \
+                    size    7548186
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
Fixes: CVE-2024-24577

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
