### PR TITLE
LimeChat: provide version for old system

### DIFF
--- a/aqua/LimeChat/Portfile
+++ b/aqua/LimeChat/Portfile
@@ -4,9 +4,26 @@ PortSystem              1.0
 PortGroup               xcode 1.0
 PortGroup               github 1.0
 
-github.setup            psychs limechat 2.47
-
 name                    LimeChat
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # Peg until this is addressed: https://github.com/psychs/limechat/issues/340
+    github.setup        psychs limechat 2.26
+    checksums           sha256  fb4cb99bc2b26defb623d33ae46f500674c25e0f4bd1eda0ec44cef9e88a2e64 \
+                        rmd160  3851851afa4e2b010090a2f487fcc025519450ce \
+                        size    3567569
+    github.tarball_from archive
+
+    patchfiles-append   0001-Unbreak-the-build-10.5.patch
+
+    xcode.target        LimeChat
+} else {
+    github.setup        psychs limechat 2.47
+    checksums           sha256  cb07c833d8bff0057b6bd1b38ee687e82a18466f8ab9e8b3c8db54ba21f48a12 \
+                        rmd160  fa81e57d258280ff50d1a44e7f1759680554212e \
+                        size    3540775
+}
+
 categories              aqua irc
 license                 GPL-2
 platforms               macosx
@@ -19,10 +36,6 @@ long_description        LimeChat is an IRC client for Mac OS X that's \
                         fast and stable, offering one window for \
                         multiple servers and rich keyboard shortcuts \
                         for your comfortable operations.
-
-checksums               sha256  cb07c833d8bff0057b6bd1b38ee687e82a18466f8ab9e8b3c8db54ba21f48a12 \
-                        rmd160  fa81e57d258280ff50d1a44e7f1759680554212e \
-                        size    3540775
 
 xcode.build.settings-append \
                         CODE_SIGN_IDENTITY= \

--- a/aqua/LimeChat/files/0001-Unbreak-the-build-10.5.patch
+++ b/aqua/LimeChat/files/0001-Unbreak-the-build-10.5.patch
@@ -1,0 +1,57 @@
+From 19e9267016ee0d784c30bc60982b14e4bc375b2f Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 7 Feb 2024 02:54:50 +0800
+Subject: [PATCH] Unbreak the build
+
+---
+ Classes/IRC/IRCTreeItem.h          | 2 +-
+ Classes/IRC/IRCWorld.h             | 2 +-
+ LimeChat.xcodeproj/project.pbxproj | 4 ----
+ 3 files changed, 2 insertions(+), 6 deletions(-)
+
+diff --git Classes/IRC/IRCTreeItem.h Classes/IRC/IRCTreeItem.h
+index f2da123b..555d1064 100644
+--- Classes/IRC/IRCTreeItem.h
++++ Classes/IRC/IRCTreeItem.h
+@@ -8,7 +8,7 @@
+ @class LogController;
+ 
+ 
+-@interface IRCTreeItem : NSObject <NSTableViewDataSource, NSTableViewDelegate>
++@interface IRCTreeItem : NSObject
+ {
+ 	int uid;
+ 	LogController* log;
+diff --git Classes/IRC/IRCWorld.h Classes/IRC/IRCWorld.h
+index 0d0648a6..3bb5749c 100644
+--- Classes/IRC/IRCWorld.h
++++ Classes/IRC/IRCWorld.h
+@@ -24,7 +24,7 @@
+ @class AppController;
+ 
+ 
+-@interface IRCWorld : NSObject <NSOutlineViewDataSource, NSOutlineViewDelegate>
++@interface IRCWorld : NSObject
+ {
+ 	AppController* app;
+ 	MainWindow* window;
+diff --git LimeChat.xcodeproj/project.pbxproj LimeChat.xcodeproj/project.pbxproj
+index 6c5ec038..f002d69a 100644
+--- LimeChat.xcodeproj/project.pbxproj
++++ LimeChat.xcodeproj/project.pbxproj
+@@ -1738,7 +1737,6 @@
+ 				PREBINDING = NO;
+ 				PRODUCT_NAME = LimeChat;
+ 				SDKROOT = macosx;
+-				VALID_ARCHS = "i386 x86_64";
+ 				WRAPPER_EXTENSION = app;
+ 				ZERO_LINK = YES;
+ 			};
+@@ -1769,7 +1766,6 @@
+ 				PREBINDING = NO;
+ 				PRODUCT_NAME = LimeChat;
+ 				SDKROOT = macosx;
+-				VALID_ARCHS = "i386 x86_64";
+ 				WRAPPER_EXTENSION = app;
+ 				ZERO_LINK = NO;
+ 			};


### PR DESCRIPTION
#### Description

With a tiny fix, I got it built on Leopard.

(There is no change to the current version used on newer systems.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
