### PR TITLE
openjdk8: Update 8u372 --> 8u402

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -20,7 +20,7 @@ maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
 description         OpenJDK 8
 long_description    JDK 8 and JRE 8 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
-homepage            https://openjdk.org/
+homepage            https://openjdk.org/projects/jdk8u/
 master_sites        https://github.com/openjdk/jdk8u/archive/refs/tags/
 
 distname            jdk${major}u${update}-ga

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -8,11 +8,11 @@ name                openjdk8
 # https://github.com/openjdk/jdk8u/tags
 # Tags: https://github.com/openjdk/jdk8u/tags
 set major 8
-set update 372
+set update 402
 # Set to the build of the 'jdk8u${update}-b${build}' tag that corresponds to the latest tag with '-ga'
-set build 07
+set build 06
 version             ${major}u${update}
-revision            2
+revision            0
 categories          java devel
 supported_archs     ppc x86_64 arm64
 license             GPL-2+
@@ -21,13 +21,15 @@ description         OpenJDK 8
 long_description    JDK 8 and JRE 8 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/
-master_sites        https://git.openjdk.org/jdk8u/archive/refs/tags/
+master_sites        https://git.openjdk.org/jdk8u/archive/refs/tags/ \
+                    https://github.com/openjdk/jdk8u/archive/refs/tags/
+
 distname            jdk${major}u${update}-ga
 worksrcdir          jdk8u-${distname}
 
-checksums           rmd160  7ffec6da71e24d2913b717b5f31d6be9c2fa7b7e \
-                    sha256  3235a744b51896beb1e8b738412982ebc06e2affb9d50ae3371203d9a46504da \
-                    size    88002433
+checksums           rmd160  9a0a302cfa7a4d0ec7ddbcb1ea7364f383388bba \
+                    sha256  4e7495914ca02ef8e3d467d0026ff76672891b4ba026b4200aeb9a0666e22238 \
+                    size    93136112
 
 patchfiles          0001-8181503-Can-t-compile-hotspot-with-c-11.patch \
                     0002-Support-XCode-3-14.patch \
@@ -162,7 +164,7 @@ variant server \
 variant release \
     conflicts debug \
     description {OpenJDK with no debug information, all optimizations and no asserts} {
-    configure.args-append  --with-debug-level=release 
+    configure.args-append  --with-debug-level=release
 }
 
 variant debug \
@@ -254,7 +256,7 @@ export JAVA_HOME=${jdk_path}/Contents/Home
 If you want to make the JRE installed by the ${name} the default JRE, add this to shell profile:
 export JAVA_HOME=${jre_path}/Contents/Home
 "
-    
+
 livecheck.type      regex
 livecheck.url       https://github.com/openjdk/jdk8u/tags
 livecheck.regex     jdk(8u\[0-9\]+)-ga

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -21,8 +21,7 @@ description         OpenJDK 8
 long_description    JDK 8 and JRE 8 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/
-master_sites        https://git.openjdk.org/jdk8u/archive/refs/tags/ \
-                    https://github.com/openjdk/jdk8u/archive/refs/tags/
+master_sites        https://github.com/openjdk/jdk8u/archive/refs/tags/
 
 distname            jdk${major}u${update}-ga
 worksrcdir          jdk8u-${distname}


### PR DESCRIPTION
* Update openjdk8 8u372.b07 --> 8u402.b06 (ga).
* Add github.com/openjdk/jdk8u to master sites (git.openjdk.org did not work).
* Fix lint nitpicks for whitespace.

Reference:  https://trac.macports.org/ticket/69120

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on

CI passes.  OS 11, 12, 13.  X86 only.

**PARTIALLY TESTED:**
macOS 12.7.3 21H1015 x86_64
Xcode 14.2 / Command Line Tools 14.2.0

* Build completes.
* Install fails due to local security restriction against user writes into /Library.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?