### PR TITLE
pipx: change default variant to python312

### DIFF
--- a/python/pipx/Portfile
+++ b/python/pipx/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           github 1.0
 
 github.setup        pypa pipx 1.4.3
-revision            0
+revision            1
 checksums           rmd160  10c0763afb4e59d47e8301e32b3a689bd880ebe2 \
                     sha256  79b4b836b4ce497061f8d34348408c6dcec0b6aded0cf36fb3a39cd513ae1517 \
                     size    361782
@@ -29,7 +29,7 @@ if {
     ![variant_isset python311] &&
     ![variant_isset python312]
 } {
-    default_variants +python311
+    default_variants +python312
 }
 
 variant python38 conflicts python39 python310 python311 python312 description {Use Python 3.8} {}


### PR DESCRIPTION
#### Description

pipx: change default variant to python312

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3 23D56 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
