### PR TITLE
GtkWave: Reverted GTKWave 3.3.117 to GTK2+quartz.

### DIFF
--- a/cad/gtkwave/Portfile
+++ b/cad/gtkwave/Portfile
@@ -28,8 +28,8 @@ depends_build-append \
 
 depends_lib-append \
                 port:bzip2 \
-                path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
-                port:gtk-osx-application-gtk3 \
+                path:lib/pkgconfig/gtk+-2.0.pc:gtk2 \
+                port:gtk-osx-application-gtk2 \
                 path:lib/pkgconfig/harfbuzz.pc:harfbuzz \
                 path:lib/pkgconfig/pango.pc:pango \
                 port:tk \
@@ -40,6 +40,8 @@ configure.args-append \
                 --with-tcl=${prefix}/lib \
                 --with-tk=${prefix}/lib \
                 --disable-mime-update \
+                "GTK_MAC_CFLAGS=\"\$(${prefix}/bin/pkg-config --cflags gtk-mac-integration-gtk2)\"" \
+                "GTK_MAC_LIBS=\"\$(${prefix}/bin/pkg-config --libs gtk-mac-integration-gtk2)\""\
                 --disable-silent-rules
 
 post-activate {

--- a/cad/gtkwave/Portfile
+++ b/cad/gtkwave/Portfile
@@ -5,7 +5,7 @@ PortGroup       app 1.0
 
 name            gtkwave
 version         3.3.117
-revision        0
+revision        1
 
 categories      cad
 license         GPL-2+


### PR DESCRIPTION
#### Description

Reverted the Gtk3 back to Gtk2 to fix compilation issues reported here: https://trac.macports.org/ticket/69290

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.0 23A344 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
