### PR TITLE
gk: update to v1.5.1

### DIFF
--- a/devel/gk/Portfile
+++ b/devel/gk/Portfile
@@ -3,16 +3,14 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            gitkraken gk-cli 1.1.4 v
+github.setup            gitkraken gk-cli 1.5.1 v
 name                    gk
 github.tarball_from     releases
 
 categories              devel
 license                 CCBY-3
 installs_libs           no
-maintainers             {@sergiolms} \
-                        {@alejandroSuch} \
-                        {@JBUinfo} \
+maintainers             {@sergiolms}\
                         openmaintainer
 
 
@@ -27,13 +25,13 @@ long_description        ${name} is GitKraken on the command line. It makes worki
                         to visualize git information when you need it.
 
 checksums               ${name}_${version}_macOS_arm64.zip \
-                            sha256  225173e85dac0113cec42f613e8f7f13e39d99068d4bcc116fb31ee28233857d \
-                            rmd160  d3fa29869345e5ece6e207cd2dcc7e190d9f8e7c \
-                            size    11444246 \
+                            sha256  0d2191829d02bd435a48d16ef4e28408457aed1b56d10b6bffd88d79ed7a02d6 \
+                            rmd160  f4c8a220f73ab823682546ab9a2c282a045a22e9 \
+                            size    24097888 \
                         ${name}_${version}_macOS_x86_64.zip \
-                            sha256  c937ac62bf66bd9f19946dcd356f5b22638766d285699fa57364374b798ffce4 \
-                            rmd160  6c7b023c5aad57b2c7a733ca10e7330e033fe94f \
-                            size    12110975
+                            sha256  af59717e612fd120918b602f13f2c96cea4345c254a81c3e98dc0d7c0f5a9d77 \
+                            rmd160  eeae414ddcfee68d49eeb3d92ddc93796fa07b47 \
+                            size    25497196
 
 extract.mkdir           yes
 


### PR DESCRIPTION
#### Description

Bump `gk` version to `v1.5.1`

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->
- [x] update
- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.2 22D49 x86_64
Xcode 14.3.1 14E300c

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
