### PR TITLE
google-cloud-sdk: update to 463.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             462.0.1
+version             463.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  ce43f97c7b216ac54469fa5f6f8f3c50dc4c2f98 \
-                    sha256  3917c9c7ed3d2ed93f6d0182e2e858d8211730316d436f2998631811d64292e1 \
-                    size    127653951
+    checksums       rmd160  dd20866fe2dbe478bc814bde6824c4a707b91dee \
+                    sha256  6dc1b75d42ab14c5f8949ae9caa6f5167b18754a76b6d70271826ff512087b88 \
+                    size    127704735
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  661c14d0c9cce743b108c861dbbd9e96ba803001 \
-                    sha256  8a8c4feaf9c0b3e43ad391805f5122b836a1b1246eaf6c1c1af96e259641812d \
-                    size    128939919
+    checksums       rmd160  a0770b74908654594afbdb9938794900cbec259f \
+                    sha256  98be2c530022c3cea5744a70bf37c6c9c1d9a05934d741f442ac5127a79c1734 \
+                    size    128990247
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  f31684a939760dc36014350c5bb6ebf5d57664f6 \
-                    sha256  cbe69148cea749e42f1b1e70b59ec7dcbd6097763358c3c45e1f6a9c17b80178 \
-                    size    126001745
+    checksums       rmd160  8867e608b931c9fe0fca932e23bb1a952a48ffa5 \
+                    sha256  f9386574da1e6524a8c5f03b5f2945f85e5a312c5e0469ee82c2a72387b38a58 \
+                    size    126053298
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 463.0.0.

###### Tested on

macOS 14.3 23D56 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?