### PR TITLE
openjdk11: update URLs

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -14,8 +14,8 @@ maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
 description         OpenJDK 11
 long_description    JDK 11 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
-homepage            https://openjdk.java.net/
-master_sites        https://git.openjdk.java.net/jdk11u/archive/refs/tags
+homepage            https://openjdk.org/projects/jdk/11/
+master_sites        https://github.com/openjdk/jdk11u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk11u-${distname}
 


### PR DESCRIPTION
#### Description

https://openjdk.java.net/ has been redirected to https://openjdk.org/, and https://openjdk.org/projects/jdk/ mentions that the code repository is now located on GitHub.

###### Tested on

macOS 14.3 23D56 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?