### PR TITLE
libgit2: update to 1.7.2

### DIFF
--- a/devel/libgit2/Portfile
+++ b/devel/libgit2/Portfile
@@ -11,7 +11,7 @@ conflicts           libgit2-devel
 set my_name         libgit2
 
 # don't forget to update py-pygit2 and libgit2-glib as well
-github.setup        libgit2 libgit2 1.7.1 v
+github.setup        libgit2 libgit2 1.7.2 v
 github.tarball_from archive
 revision            0
 epoch               1
@@ -30,9 +30,9 @@ homepage            https://libgit2.org/
 
 dist_subdir         ${my_name}
 
-checksums           rmd160  5dad52197aaa08f44f5faab10935e566ae51da6b \
-                    sha256  17d2b292f21be3892b704dddff29327b3564f96099a1c53b00edc23160c71327 \
-                    size    7548081
+checksums           rmd160  53aa89485a37b91cf11aae5ef63bfa6193f6246b \
+                    sha256  de384e29d7efc9330c6cdb126ebf88342b5025d920dcb7c645defad85195ea7f \
+                    size    7548186
 
 depends_build-append \
                     port:pkgconfig

--- a/gnome/libgit2-glib/Portfile
+++ b/gnome/libgit2-glib/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson  1.0
 
 gitlab.instance     https://gitlab.gnome.org
 gitlab.setup        GNOME libgit2-glib 1.2.0 v
-revision            0
+revision            1
 
 categories          gnome devel
 license             LGPL-2+

--- a/python/py-pygit2/Portfile
+++ b/python/py-pygit2/Portfile
@@ -4,7 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        libgit2 pygit2 1.13.1 v
+github.setup        libgit2 pygit2 1.14.0 v
+github.tarball_from archive
 name                py-pygit2
 revision            0
 
@@ -17,11 +18,11 @@ description         Python bindings for libgit2
 long_description    Pygit2 is a set of Python bindings to the libgit2 shared \
                     library, libgit2 implements the core of Git.
 
-checksums           rmd160  9536559ac1a19b3524ed590e813e2151c3edef59 \
-                    sha256  af1363da68f3a032a9b23f2f334020153969a9599453ce97f196952c2209bdd4 \
-                    size    760485
+checksums           rmd160  89aa862096e8d87b15f5301c82d5dfe47c4a9094 \
+                    sha256  48ab8a41d080a2e8bd46aa5d6a74ea4d2a7c7d0aecb44ccef9d6bc3880d907c9 \
+                    size    788381
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \


### PR DESCRIPTION
Fixes:  CVE-2024-24577

Updates `py-pygit2` and revbumps `libgit2-glib`.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
