### PR TITLE
fizz: fix build on i386 with libstdc++

### DIFF
--- a/devel/fizz/Portfile
+++ b/devel/fizz/Portfile
@@ -49,10 +49,10 @@ depends_lib-append  port:bzip2 \
 
 cmake.source_dir    ${worksrcpath}/${name}
 
-# At the moment unclear whether it is a libstdc++ issue or specifically
-# powerpc issue. But Macports only uses libstdc++ on powerpc anyway.
+# Confirmed to fail both on powerpc and i386
+# if libstdc++ with gcc are used.
 # https://github.com/facebookincubator/fizz/issues/109
-platform darwin powerpc {
+if {${configure.cxx_stdlib} ne "libc++"} {
     patchfiles-append \
                     0001-Revert-Read-b64-encoded-ECH-Config-List-in-fizz-clie.patch \
                     0002-Revert-235358c8b2e613b85d47b2088c21f7bd344910ec.patch


### PR DESCRIPTION
#### Description

A small fix for i386.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 i386
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
