### PR TITLE
symfony-cli: update to 5.8.7

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.6
+version             5.8.7
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  3b03caf6772136ea8666b9bde58ac46250293263 \
-                        sha256  10424997b3f0fd0234159c02802de6d3f64168d64b388f1fb07b7c070d752d49 \
-                        size    263218
+    checksums           rmd160  2db39c9b944f412cbc416f60e0fe0ff28baf62eb \
+                        sha256  4a5a00570678e02336a6617b7f923a66c2a5b948d6e82efa80de8127054ad17b \
+                        size    263653
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  cb363c2c12ea9d88c6e97f072d50e15bb59b7c43 \
-                        sha256  1fdfc990feaf4820c42955a9467af538038dfa1d7a76e79e74f3f375e8ba5336 \
-                        size    11151832
+    checksums           rmd160  25639f0e3e2bea3d99c7299db69e69220e0dd03d \
+                        sha256  828d4c17369cad65a1805e0fced81fc2a73ec86240c0e25a73770c0b9ecb93ba \
+                        size    11153849
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.7

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
