### PR TITLE
Remove gpanders as port maintainer

### DIFF
--- a/devel/vint/Portfile
+++ b/devel/vint/Portfile
@@ -10,8 +10,7 @@ categories              devel python
 platforms               {darwin any}
 supported_archs         noarch
 homepage                https://github.com/Vimjas/vint
-maintainers             {@gpanders gpanders.com:greg} \
-                        openmaintainer
+maintainers             nomaintainer
 
 description             Lint tool for Vim script language
 long_description        Vint is a Vim script language linter that aims to \

--- a/lua/lua-ansicolors/Portfile
+++ b/lua/lua-ansicolors/Portfile
@@ -9,7 +9,7 @@ revision            0
 epoch               1
 luarocks.rock       ansicolors-${version}-3.src.rock
 license             MIT
-maintainers         @gpanders openmaintainer
+maintainers         nomaintainer
 
 description         Ansicolors is a simple Lua function for printing to the console in color
 long_description    {*}${description}.

--- a/lua/lua-argparse/Portfile
+++ b/lua/lua-argparse/Portfile
@@ -9,7 +9,7 @@ revision            0
 epoch               1
 luarocks.rock       argparse-${version}-1.src.rock
 license             MIT
-maintainers         @gpanders openmaintainer
+maintainers         nomaintainer
 
 description         Argparse is a feature-rich command line parser for Lua inspired by argparse for Python
 long_description    {*}${description}.

--- a/lua/lua-checks/Portfile
+++ b/lua/lua-checks/Portfile
@@ -9,7 +9,7 @@ revision            0
 epoch               1
 luarocks.rock       checks-${version}-3.src.rock
 license             Eclipse
-maintainers         @gpanders openmaintainer
+maintainers         nomaintainer
 
 description         Provides a `checks()` function for Lua
 long_description    This library declares a `checks()` function and a \

--- a/lua/lua-luacheck/Portfile
+++ b/lua/lua-luacheck/Portfile
@@ -9,7 +9,7 @@ version             1.1.0
 revision            0
 luarocks.rock       luacheck-${version}-1.src.rock
 license             MIT
-maintainers         @gpanders openmaintainer
+maintainers         nomaintainer
 
 description         A tool for linting and static analysis of Lua code
 long_description    Luacheck is a static analyzer and a linter for Lua. \

--- a/lua/lua-luafilesystem/Portfile
+++ b/lua/lua-luafilesystem/Portfile
@@ -9,7 +9,7 @@ revision            0
 epoch               1
 luarocks.rock       luafilesystem-${version}-1.src.rock
 license             MIT
-maintainers         @gpanders openmaintainer
+maintainers         nomaintainer
 
 description         Lua library to complement the set of functions related to file systems offered by the standard Lua distribution.
 long_description    {*}${description}.

--- a/lua/lua-metalua-parser/Portfile
+++ b/lua/lua-metalua-parser/Portfile
@@ -9,7 +9,7 @@ revision            0
 epoch               1
 luarocks.rock       metalua-parser-${version}-2.src.rock
 license             {EPL MIT}
-maintainers         @gpanders openmaintainer
+maintainers         nomaintainer
 
 description         Define and generate an AST format for Lua programs
 long_description    This is a subset of the full Metalua compiler. It defines and \

--- a/lua/lua-readline/Portfile
+++ b/lua/lua-readline/Portfile
@@ -8,7 +8,7 @@ version             3.2
 revision            0
 luarocks.rock       readline-${version}-0.src.rock
 license             MIT
-maintainers         @gpanders openmaintainer
+maintainers         nomaintainer
 
 description         Lua interface for readline packages.
 long_description    This module is a Lua interface to various \"readline\" \

--- a/lua/stylua/Portfile
+++ b/lua/stylua/Portfile
@@ -8,8 +8,7 @@ github.setup        johnnymorganz stylua 0.19.1 v
 revision            0
 categories          lua
 platforms           darwin
-maintainers         {gpanders.com:greg @gpanders} \
-                    {judaew @judaew} \
+maintainers         {judaew @judaew} \
                     openmaintainer
 license             MPL-2
 

--- a/mail/mutt_ics/Portfile
+++ b/mail/mutt_ics/Portfile
@@ -10,8 +10,7 @@ categories          mail python
 platforms           {darwin any}
 supported_archs     noarch
 homepage            https://github.com/dmedvinsky/mutt-ics
-maintainers         {@gpanders gpanders.com:greg} \
-                    openmaintainer
+maintainers         nomaintainer
 
 description         A tool to show calendar event details in Mutt
 long_description    mutt_ics allows you to view calendar attachments inline \

--- a/net/nextdns/Portfile
+++ b/net/nextdns/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/nextdns/nextdns 1.37.4 v
 revision            0
 categories          net sysutils
-maintainers         {@gpanders gpanders.com:greg} openmaintainer
+maintainers         nomaintainer
 license             MIT
 
 homepage            https://nextdns.io

--- a/python/py-ansicolor/Portfile
+++ b/python/py-ansicolor/Portfile
@@ -11,8 +11,7 @@ categories-append   devel
 license             Apache-2
 platforms           {darwin any}
 supported_archs     noarch
-maintainers         {@gpanders gpanders.com:greg} \
-                    openmaintainer
+maintainers         nomaintainer
 
 description         A library to produce ANSI color output
 long_description    {*}${description} and colored highlighting and diffing.

--- a/sysutils/neovim-remote/Portfile
+++ b/sysutils/neovim-remote/Portfile
@@ -11,7 +11,7 @@ categories          sysutils editors
 platforms           {darwin any}
 supported_archs     noarch
 license             MIT
-maintainers         {@gpanders gpanders.com:greg} openmaintainer
+maintainers         nomaintainer
 
 description         Control nvim processes using "nvr" commandline tool
 long_description \

--- a/sysutils/netdata/Portfile
+++ b/sysutils/netdata/Portfile
@@ -10,8 +10,7 @@ revision                0
 
 distname                ${name}-v${version}
 
-maintainers             {@gpanders gpanders.com:greg} \
-                        {gmail.com:herby.gillot @herbygillot} \
+maintainers             {gmail.com:herby.gillot @herbygillot} \
                         openmaintainer
 categories              sysutils
 license                 GPL-3

--- a/sysutils/pushbroom/Portfile
+++ b/sysutils/pushbroom/Portfile
@@ -11,7 +11,7 @@ categories          sysutils python
 platforms           {darwin any}
 supported_archs     noarch
 license             MIT
-maintainers         {gpanders.com:greg @gpanders} openmaintainer
+maintainers         nomaintainer
 
 description         Sweep your filesystem clear of clutter
 long_description    ${name} is a command line utility that removes old files \

--- a/textproc/ijq/Portfile
+++ b/textproc/ijq/Portfile
@@ -14,7 +14,6 @@ categories          textproc devel sysutils
 installs_libs       no
 license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
-                    {@gpanders gpanders.com:greg} \
                     openmaintainer
 
 depends_build-append \


### PR DESCRIPTION
#### Description

Remove @gpanders as port maintainer.

---

I have not been an active MacPorts maintainer for quite some time now. This is long overdue, but better late than never.
