### PR TITLE
skaffold: update to 2.10.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.10.0 v
+github.setup        GoogleContainerTools skaffold 2.10.1 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  ad12a479ed81841720f14e26a212306842aabad0 \
-                    sha256  6c448ac8d2e311606d3887ba5ec9a450584bc82902f25d19a66bcdf8030f0e3a \
-                    size    60597031
+checksums           rmd160  5ecb2160827a7b8a83da5a78559460a69c26cd56 \
+                    sha256  f1a83938c9481a6de8cc454f7d065388873f785832a33849cefac36a38bb8050 \
+                    size    60595890
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.10.1.

###### Tested on

macOS 14.3 23D56 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?