### PR TITLE
iv: fix for i386 build

### DIFF
--- a/devel/iv/Portfile
+++ b/devel/iv/Portfile
@@ -32,6 +32,9 @@ patchfiles-append   patch-gc-arm64.diff
 # https://github.com/Constellation/iv/pull/110
 patchfiles-append   patch-static-liblv5.diff
 
+# https://github.com/Constellation/iv/pull/111
+patchfiles-append   patch-fpu.h-fix-i386-on-macOS.diff
+
 post-patch {
     reinplace "s|__PREFIX__|${prefix}|" \
                     ${worksrcpath}/iv/lv5/CMakeLists.txt

--- a/devel/iv/files/patch-fpu.h-fix-i386-on-macOS.diff
+++ b/devel/iv/files/patch-fpu.h-fix-i386-on-macOS.diff
@@ -1,0 +1,23 @@
+From b4a8f8989e3ab3cc82693cc66f4c37cd7a63b1c7 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 9 Feb 2024 05:16:52 +0800
+Subject: [PATCH] fpu.h: fix i386 on macOS
+
+---
+ iv/lv5/fpu.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git iv/lv5/fpu.h iv/lv5/fpu.h
+index 64def8a1..ab296de6 100644
+--- iv/lv5/fpu.h
++++ iv/lv5/fpu.h
+@@ -2,7 +2,8 @@
+ #define IV_LV5_FPU_H_
+ #include <iv/noncopyable.h>
+ #include <iv/platform.h>
+-#if (!defined(IV_USE_SSE) && defined(IV_COMPILER_GCC) && defined(__i386__) && !defined(IV_OS_CYGWIN))  // NOLINT
++#if (!defined(IV_USE_SSE) && defined(IV_COMPILER_GCC) && defined(__i386__) \
++    && !defined(IV_OS_CYGWIN) && !defined(IV_OS_MACOSX))  // NOLINT
+ #include <fpu_control.h>
+ namespace iv {
+ namespace lv5 {


### PR DESCRIPTION
#### Description

No need to revbump.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6 i386
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
