### PR TITLE
PG_gpg_verify: Use MacPorts's shellescape

### DIFF
--- a/_resources/port1.0/group/gpg_verify-1.0.tcl
+++ b/_resources/port1.0/group/gpg_verify-1.0.tcl
@@ -52,23 +52,18 @@ pre-checksum {
     }
 }
 
-# Remove this proc and switch to shellescape once MacPorts 2.7.0 is released.
-proc gpg_verify.shellescape {arg} {
-    return [regsub -all -- {[^A-Za-z0-9.:@%/+=_-]} $arg {\\&}]
-}
-
 proc gpg_verify.verify_gpg_signature {pubkey_file signature_file test_file} {
     # pre-load public key to avoid keyserver downtime issues
     # https://pgp.mit.edu/pks/lookup?op=get&search=0x${gpg_keyid}
     # note: tcl exec will return error if error messages not directed to /dev/null
     system "[option gpg_verify.gpg] \
-        --homedir [gpg_verify.shellescape [option gpg_verify.gpg_homedir]] \
-        --import [gpg_verify.shellescape ${pubkey_file}] 2>/dev/null || /usr/bin/true"
+        --homedir [shellescape [option gpg_verify.gpg_homedir]] \
+        --import [shellescape ${pubkey_file}] 2>/dev/null || /usr/bin/true"
     set gpg_verification [exec /bin/sh -c \
-        "if [gpg_verify.shellescape [option gpg_verify.gpg]] \
-            --homedir [gpg_verify.shellescape [option gpg_verify.gpg_homedir]] \
-            --verify [gpg_verify.shellescape ${signature_file}] \
-            [gpg_verify.shellescape ${test_file}] 2>/dev/null; \
+        "if [shellescape [option gpg_verify.gpg]] \
+            --homedir [shellescape [option gpg_verify.gpg_homedir]] \
+            --verify [shellescape ${signature_file}] \
+            [shellescape ${test_file}] 2>/dev/null; \
             then echo 'VERIFIED'; else echo 'UNVERIFIED'; fi"]
     if {[string trim ${gpg_verification}] ne "VERIFIED"} {
         error "GPG signature verification failed on ${test_file} with pubkey file ${pubkey_file}."


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
