### PR TITLE
alacritty: fix nerdfont variant

### DIFF
--- a/aqua/alacritty/Portfile
+++ b/aqua/alacritty/Portfile
@@ -6,7 +6,7 @@ PortGroup           github  1.0
 
 github.setup        alacritty alacritty 0.13.1 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         A cross-platform, GPU-accelerated terminal emulator
 

--- a/aqua/alacritty/files/crossfont-nerd-symbols.patch
+++ b/aqua/alacritty/files/crossfont-nerd-symbols.patch
@@ -1,6 +1,6 @@
 index 13acd4c..b1ca472 100644
---- ../.home/.cargo/macports/crossfont-0.5.1/src/darwin/mod.rs
-+++ ../.home/.cargo/macports/crossfont-0.5.1/src/darwin/mod.rs
+--- ../.home/.cargo/macports/crossfont-0.7.0/src/darwin/mod.rs
++++ ../.home/.cargo/macports/crossfont-0.7.0/src/darwin/mod.rs
 @@ -77,6 +77,10 @@ impl Descriptor {
                  .map(|desc| desc.to_font(size, false))
                  .collect::<Vec<_>>();


### PR DESCRIPTION
#### Description

crossfont dependency was bumped to 0.7.0; reflect the change in nerdfont variant patch.

#### Test

Functionality of the patch can be tested with:

`curl https://gist.githubusercontent.com/ethan605/9046bcf894e972bef5d31eb2a8046bba/raw/510c857630c65dc3ed58f9a9a1d5e95db736bbc4/test-icons.js`