### PR TITLE
g-ls: new port (0.26.0)

### DIFF
--- a/sysutils/g-ls/Portfile
+++ b/sysutils/g-ls/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               golang 1.0
+
+go.setup                github.com/Equationzhao/g 0.26.0 v
+revision                0
+categories              sysutils
+license                 MIT
+platforms               {darwin >= 14}
+installs_libs           no
+maintainers             {@therealketo gmail.com:therealketo} openmaintainer
+
+description             Powerful and cross-platform ls
+long_description        {*}${description}. Built for the modern terminal.
+
+homepage                https://g.equationzhao.space
+
+checksums               rmd160  1645d8d4cbcd49db13bf984f799b8afabe122e47 \
+                        sha256  1cb9e0e0334635e67766986981b7fc6acc326a92c390a45ac782109e81edd61a \
+                        size    407263
+
+# Vendored libraries cause failure, fetch them at build time
+go.offline_build        no
+
+build.args-append       -ldflags="-s -w"
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0644 ${worksrcpath}/completions/zsh/_${name} \
+        ${destroot}${prefix}/share/zsh/site-functions
+}


### PR DESCRIPTION
#### Description

Add `g-ls`, an `ls` alternative written in Go. 

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
