### PR TITLE
jsoncons: new port

### DIFF
--- a/devel/jsoncons/Portfile
+++ b/devel/jsoncons/Portfile
@@ -1,0 +1,22 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               cmake 1.1
+
+github.setup            danielaparker jsoncons 0.173.4 v
+github.tarball_from     archive
+revision                0
+categories              devel
+platforms               any
+supported_archs         noarch
+license                 Boost-1
+maintainers             {@sikmir disroot.org:sikmir} openmaintainer
+description             A C++, header-only library for constructing JSON and JSON-like data formats
+long_description        {*}${description}
+
+checksums               rmd160  4861f8442599537fe6b001673474250366ae8043 \
+                        sha256  3e3525325c88b33f15af2e1f3cf7a1893a49e47aa787a2df723a098b3a4b20b1 \
+                        size    1422526
+
+test.run                yes


### PR DESCRIPTION
#### Description
https://github.com/danielaparker/jsoncons - A C++, header-only library for constructing JSON and JSON-like data formats.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
