### PR TITLE
netcdf-fortran:  Whitespace only, push rebuilds

### DIFF
--- a/science/netcdf-fortran/Portfile
+++ b/science/netcdf-fortran/Portfile
@@ -82,7 +82,7 @@ test.run                    yes
 test.target                 check
 
 if {[mpi_variant_isset]} {
-    configure.args-append      --enable-parallel-tests
+    configure.args-append     --enable-parallel-tests
     pre-test {
         foreach script {nf_test4/run_f77_par_test.sh nf_test4/run_f77_par_test_03.sh nf03_test4/run_f90_par_test.sh examples/F90/run_f90_par_examples.sh} {
             reinplace -W ${worksrcpath} "s|mpiexec|${prefix}/bin/${mpi.exec}|" ${script}


### PR DESCRIPTION
* Whitespace, only to force rebuilds.
* Dependency netcdf had link problems that were breaking later builds.
* That was fixed.  Now need to fix broken netcdf-fortran builds.
* Also need to ensure that other netcdf-fortran builds are still working.

Maybe fixes:  https://trac.macports.org/ticket/68124

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?