### PR TITLE
netcdf-fortran:  Rev bump only, to fix broken builds

### DIFF
--- a/science/netcdf-fortran/Portfile
+++ b/science/netcdf-fortran/Portfile
@@ -21,7 +21,7 @@ PortGroup                   github 1.0
 mpi.enforce_variant         netcdf
 
 github.setup                Unidata netcdf-fortran 4.6.1 v
-revision                    3
+revision                    4
 maintainers                 {takeshi @tenomoto} \
                             {@Dave-Allured noaa.gov:dave.allured} \
                             openmaintainer


### PR DESCRIPTION
* Dependency port netcdf had hidden defects that caused downstream builds to break with obscure symptoms.
* Was fixed by #22502.
* Now pushing necessary rebuilds of netcdf-fortran, to follow.

Maybe fixes:  https://trac.macports.org/ticket/68124

###### Type(s)

- [x] bugfix

###### Tested on

CI only.  11.x86, 12.x86, 13.x86, 14.arm.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?