### PR TITLE
openjdk21-openj9: update to 21.0.2

### DIFF
--- a/java/openjdk21-openj9/Portfile
+++ b/java/openjdk21-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      21.0.1
+version      21.0.2
 revision     0
 
-set build    12
-set openj9_version 0.42.0
+set build    13
+set openj9_version 0.43.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 21
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru21-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  060afc025cf482de9309f6ffa1d5844af9cad842 \
-                 sha256  6ea3a8c1ddb22dea74530e145b3c1b96e94aa044a584bd9bfa4f5fff2cc21f73 \
-                 size    224190216
+    checksums    rmd160  fcfc7ce7d083476330636079191a6f21ada8dc86 \
+                 sha256  d4918284a06a921dcadeec700d2a22c7e3d9bf09f28b30423563daecececb8f4 \
+                 size    224362362
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  633f5ceeafe3147b68f93c82a72e205b901da7aa \
-                 sha256  def95faa925d691d1d2ac1a3b5971b534b3f5b7af532424713bb66575bc49ea0 \
-                 size    217410945
+    checksums    rmd160  51f01ced65cca7db7282323c07a31657289ef5db \
+                 sha256  78d3e37d57f7b1ab37bba82a65a0d575939cbb06c10e0ddc6a3a1c5576d185d3 \
+                 size    217579545
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 21.0.2 with OpenJ9 0.43.0.

###### Tested on

macOS 14.3.1 23D60 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?