### PR TITLE
openjdk11-openj9: update to 11.0.22

### DIFF
--- a/java/openjdk11-openj9/Portfile
+++ b/java/openjdk11-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      11.0.21
+version      11.0.22
 revision     0
 
-set build    9
-set openj9_version 0.41.0
+set build    7
+set openj9_version 0.43.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 11
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru11-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  ce894f346f5a531da39a78511684ebf5f5d4837e \
-                 sha256  195800cd1783626659c5b70355ecf19072f849eeabcf1f652d45d76e22ec31af \
-                 size    206685231
+    checksums    rmd160  04504aa273af70c196a66f52411e68bd8fe06315 \
+                 sha256  16dbe2be761ae7c48a1338398c6cad748014137e59509aa2b84223049d385bbc \
+                 size    206769212
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  6fa276d4b7adc68778055c5c1e6b92249c99342b \
-                 sha256  108e8ac9e738ca0c19ca3c5ba3e89ee807e4c4d78ffd5692ce04abe1bb5a07c4 \
-                 size    200954634
+    checksums    rmd160  4f4f2d2120bb8fe554b5734fbf283e3f9c7083e1 \
+                 sha256  b5039b79a601c07dcba819f29e111871662218d042d2ee2b246b6beaccf09342 \
+                 size    201040571
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 11.0.22 with OpenJ9 0.43.0.

###### Tested on

macOS 14.3.1 23D60 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?