### PR TITLE
lapack: Fix builds with +accelerate +openblas

### DIFF
--- a/math/lapack/Portfile
+++ b/math/lapack/Portfile
@@ -3,6 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           compilers 1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           cmake 1.1
 
 github.setup        Reference-LAPACK lapack 3.12.0 v
@@ -11,7 +12,7 @@ if {${subport} eq ${name}} {
     compilers.setup     require_fortran -clang
     compilers.add_gcc_rpath_support no
 }
-revision            0
+revision            1
 categories          math devel science
 license             BSD
 maintainers         {takeshi @tenomoto} \
@@ -29,6 +30,12 @@ long_description \
     least-squares solutions of linear systems of equations, \
     eigenvalue problems, and singular value problems.
 homepage            http://www.netlib.org/${name}/
+
+# Fix 10.7 build for "invalid instruction mnemonic 'cvtsi2ssl'"
+# Copied from https://github.com/macports/macports-ports/pull/17193
+# https://github.com/william-dawson/NTPoly/issues/192
+compiler.blacklist-append \
+                    {clang < 500}
 
 configure.cppflags-append \
                     -DADD_
@@ -69,6 +76,19 @@ if {${subport} eq ${name}} {
         file delete -force ${destroot}${cmake_share_module_dir}
         move ${destroot}${prefix}/lib/${name}/cmake \
             ${destroot}${cmake_share_module_dir}
+    }
+}
+
+# Disable extended Index-64 API with _64 suffix.
+# Was introduced in LAPACK 3.12.0.
+# To be re-enabled when corresponding extended API becomes available
+#   for +openblas or +accelerate.
+# Ref. CMakeLists.txt
+# Fixes https://trac.macports.org/ticket/69295
+
+if {${subport} eq ${name}} {
+    if {[variant_isset accelerate] || [variant_isset openblas]} {
+       configure.args-append       -DBUILD_INDEX64_EXT_API=OFF
     }
 }
 


### PR DESCRIPTION
* Disable new extended Index-64 API, only when +accelerate or +openblas variants are used.
* The new API was introduced in LAPACK current version 3.12.0.
* Fixes https://trac.macports.org/ticket/69295
* Maybe also fix 10.7 build, unrelated problem.

The extended Index-64 API can be added back later, when the necessary support API's are added and functional in CBLAS library ports (+accelerate or +openblas).

###### Type(s)

- [x] bugfix

###### Tested on

macOS 12.7.3 21H1015 x86_64
Xcode 14.2 / Command Line Tools 14.2.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?