### PR TITLE
bind9: fix on Leopard and PowerPC

### DIFF
--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -57,7 +57,8 @@ compiler.blacklist \
                 {clang >= 1500.0.40.1 < 1500.1.0.2.5 }
 
 patchfiles      atomics.patch \
-                lib_dns_Makefile.in.patch
+                lib_dns_Makefile.in.patch \
+                patch-fix-rwlock.diff
 
 # tests require `sudo bin/tests/system/ifconfig.sh up`
 test.run        yes

--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -92,6 +92,13 @@ platform darwin 9 {
     configure.args-append --with-dlopen=no
 }
 
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    # Until this is fixed: https://trac.macports.org/ticket/65945
+    depends_lib-delete \
+                path:lib/pkgconfig/jemalloc.pc:jemalloc
+    configure.args-append --with-jemalloc=no
+}
+
 post-destroot    {
     # Ensure needed directories
     xinstall -o named -g named -m 755 -d \

--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -52,7 +52,7 @@ universal_variant \
 # Needs working __atomic_* builtins
 # Apple clang 15.0.0 from Xcode before 15.2 has a codgen bug that causes
 compiler.blacklist \
-                gcc-4.2 \
+                *gcc-4.0 *gcc-4.2 \
                 {clang < 500} \
                 {clang >= 1500.0.40.1 < 1500.1.0.2.5 }
 

--- a/net/bind9/Portfile
+++ b/net/bind9/Portfile
@@ -38,10 +38,10 @@ use_xz          yes
 depends_build   port:pkgconfig
 
 depends_lib     path:lib/libssl.dylib:openssl  \
-                port:libuv \
+                path:lib/pkgconfig/libuv.pc:libuv \
                 port:libxml2 \
                 port:nghttp2 \
-                port:jemalloc \
+                path:lib/pkgconfig/jemalloc.pc:jemalloc \
                 port:json-c \
                 port:libidn2 \
                 port:lmdb

--- a/net/bind9/files/patch-fix-rwlock.diff
+++ b/net/bind9/files/patch-fix-rwlock.diff
@@ -1,0 +1,18 @@
+Fix PowerPC assembler syntax.
+
+--- lib/isc/rwlock.c.orig	2023-12-08 20:09:37.000000000 +0800
++++ lib/isc/rwlock.c	2024-02-11 15:55:13.000000000 +0800
+@@ -160,8 +160,12 @@
+ #elif (defined(__sparc) || defined(__sparc__)) && HAVE_SPARC_PAUSE
+ #define isc_rwlock_pause() __asm__ __volatile__("pause")
+ #elif defined(__ppc__) || defined(_ARCH_PPC) || defined(_ARCH_PWR) || \
+-	defined(_ARCH_PWR2) || defined(_POWER)
++	defined(_ARCH_PWR2) || defined(_POWER) || defined(__POWERPC__)
++#ifdef __APPLE__
++#define isc_rwlock_pause() __asm__ volatile("or r27,r27,r27")
++#else
+ #define isc_rwlock_pause() __asm__ volatile("or 27,27,27")
++#endif
+ #else /* if defined(_MSC_VER) */
+ #define isc_rwlock_pause()
+ #endif /* if defined(_MSC_VER) */


### PR DESCRIPTION
#### Description

1. Fix compiler blacklist to avoid gcc-4.0.
2. Fix broken PowerPC assembler code in rwlock.
3. Do not depend on `jemalloc` on Leopard and Tiger, it does not build there, as of now.
4. Use path-style dependencies, where appropriate.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
