### PR TITLE
qt5: Add Vulkan support, fix qtwebengine with clang 16

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -193,13 +193,13 @@ array set modules {
             d058c53e72dd7caa92e6c1a4a2ed301aee55a9bd92828136752f0a1299fe694b
             118298584
         }
-        ""
+        "port:vulkan-headers "
         "port:assimp"
         "qtbase qtdeclarative qtimageformats qtgamepad"
         {"Qt 3D"}
         ""
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtbase {
@@ -208,13 +208,13 @@ array set modules {
             4c01b7b0f1f3c1e05ae6bf53c66e49c65c6b3872475bac26b0fb228136914af0
             50840192
         }
-        ""
-        "port:zlib port:libpng path:include/turbojpeg.h:libjpeg-turbo port:freetype path:bin/dbus-daemon:dbus path:lib/pkgconfig/glib-2.0.pc:glib2 path:lib/pkgconfig/icu-uc.pc:icu port:pcre2 path:lib/pkgconfig/harfbuzz.pc:harfbuzz port:double-conversion port:zstd"
+        "port:vulkan-headers "
+        "port:zlib port:libpng path:include/turbojpeg.h:libjpeg-turbo port:freetype path:bin/dbus-daemon:dbus path:lib/pkgconfig/glib-2.0.pc:glib2 path:lib/pkgconfig/icu-uc.pc:icu port:pcre2 path:lib/pkgconfig/harfbuzz.pc:harfbuzz port:double-conversion port:zstd port:vulkan-loader port:vulkan-tools port:MoltenVK"
         ""
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtcharts {
@@ -259,7 +259,7 @@ array set modules {
         {"Qt Data Visualization"}
         "GPLv3 license only"
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: {GPL-3 OpenSSLException}"
     }
     qtdeclarative {
@@ -268,13 +268,13 @@ array set modules {
             03b920dfba5ad8b741d7610ad2e37336b4d669c6613fca64426244b7e7f9df9e
             21602960
         }
-        "port:python311"
+        "port:python311 port:vulkan-headers"
         ""
         "qtbase qtsvg"
         {"Qt QML" "Qt Quick" "Qt Quick Layouts" "Qt Quick Widgets"}
         ""
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtdoc {
@@ -283,13 +283,13 @@ array set modules {
             f0bd34f8d92f807a50118d353e1c8e6ce987a70c8a33bb7233723a3f2bb5cc44
             5751304
         }
-        ""
+        "port:vulkan-headers"
         ""
         "qtdeclarative qttools qtmultimedia qtquickcontrols qtquickcontrols2 sqlite-plugin"
         {"Qt Reference Documentation"}
         "requires all documentation"
         "variant overrides: ~examples ~tests ~debug noarch ~docs"
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtgamepad {
@@ -433,13 +433,13 @@ array set modules {
             df71f11bf032e3ddbba777ecedf159a5b7cccc48147801f22e64ecb224447af3
             55764980
         }
-        ""
+        "port:vulkan-headers"
         "port:assimp"
         "qtbase qtdeclarative"
         {"Provides a high-level API for creating 3D content or UIs based on Qt Quick."}
         "technology preview module; GPLv3 license only"
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: {GPL-3 OpenSSLException}"
     }
     qtquickcontrols {
@@ -613,13 +613,13 @@ array set modules {
             9a4084fee80a2acebb6415efa5a28dd666960129895a0bb7d97468a9f0c66506
             8900672
         }
-        ""
+        "port:vulkan-headers"
         "port:clang-${llvm_version}"
         "qtbase qtdeclarative"
         {"Qt Designer" "Qt Help" "Qt UI Tools"}
         ""
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qttranslations {
@@ -669,13 +669,13 @@ array set modules {
     }
     qtwebengine {
         {}
-        "port:python27 port:py27-ply path:bin/ninja:ninja port:gperf port:bison port:flex port:qt5-qtwebengine-gn"
+        "port:python27 port:py27-ply path:bin/ninja:ninja port:gperf port:bison port:flex port:qt5-qtwebengine-gn port:vulkan-headers"
         "port:fontconfig port:dbus path:lib/pkgconfig/harfbuzz.pc:harfbuzz path:lib/pkgconfig/glib-2.0.pc:glib2 port:zlib port:minizip port:libevent port:libxml2 path:lib/pkgconfig/poppler.pc:poppler port:pulseaudio path:lib/pkgconfig/icu-uc.pc:icu path:lib/libavcodec.dylib:ffmpeg port:libopus port:webp port:libpng port:lcms2 port:freetype port:re2 port:snappy"
         "qtdeclarative qtquickcontrols qtquickcontrols2 qtlocation qtwebchannel qttools"
         {"Qt WebEngine"}
         "very large and relatively new"
         "variant overrides: "
-        "revision 2"
+        "revision 3"
         "License: "
     }
     qtwebglplugin {
@@ -750,7 +750,7 @@ array set modules {
         {"Qt WebView"}
         "new in 5.6.0; requires qtwebengine"
         "variant overrides: "
-        "revision 0"
+        "revision 1"
         "License: "
     }
     qtxmlpatterns {
@@ -1398,12 +1398,6 @@ foreach {module module_info} [array get modules] {
                 -no-xkbcommon           \
                 -no-system-proxies
 
-            # do not opportunistically enable Vulkan support
-            # (TODO: is Vulkan support desirable?)
-            # see https://trac.macports.org/ticket/62104
-            configure.args-append \
-                -no-feature-vulkan
-
             # MacOS/iOS options:
             configure.args-append    \
                 -framework           \
@@ -1804,6 +1798,10 @@ foreach {module module_info} [array get modules] {
 
                 # do not opportunistically find MacPorts libraries (e.g. X11 libraries)
                 patchfiles-append patch-qtwebengine_tests.diff
+
+                # workaraound for a clang error where an integer exceeds an enueration value
+                # this should be removed as future versions as this error may no longer be convertable to a warning.
+                patchfiles-append patch-qtwebengine_clang.diff
 
                 # run syncqt.pl to generate headers needed to build from git snapshot (rather than release tarball)
                 # system Perl is sufficient, since syncqt.pl only uses standard core modules

--- a/aqua/qt5/files/patch-qtwebengine_clang.diff
+++ b/aqua/qt5/files/patch-qtwebengine_clang.diff
@@ -1,0 +1,22 @@
+clang-16 complains about casting an integer value that exceeds an
+enumeration capacity in the class base::BitField
+to not modify chromium code we just cancel warning about this
+circumstance to prevent it from being converted to an error that fails
+compilation
+
+[sam: Note that this is a bandaid and won't work with Clang 17.]
+
+--- src/3rdparty/chromium/v8/src/base/bit-field.h
++++ src/3rdparty/chromium/v8/src/base/bit-field.h
+@@ -39,8 +39,11 @@
+   static constexpr int kLastUsedBit = kShift + kSize - 1;
+   static constexpr U kNumValues = U{1} << kSize;
+ 
++  #pragma clang diagnostic push
++  #pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
+   // Value for the field with all bits set.
+   static constexpr T kMax = static_cast<T>(kNumValues - 1);
++  #pragma clang diagnostic pop
+ 
+   template <class T2, int size2>
+   using Next = BitField<T2, kShift + kSize, size2, U>;


### PR DESCRIPTION
#### Description

Add missing support for Vulkan now that everything required is in the ports tree. Also, let's hope the openssl 1.1/3.0 from 2 years ago are behind us.

Additionally fix qtwebengine with the latest clang

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.3.1 23D60 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
