### PR TITLE
golangci-lint: update to 1.56.1

### DIFF
--- a/devel/golangci-lint/Portfile
+++ b/devel/golangci-lint/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/golangci/golangci-lint 1.55.2 v
+go.setup            github.com/golangci/golangci-lint 1.56.1 v
 github.tarball_from archive
 revision            0
 
@@ -23,9 +23,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {@steenzout} \
                     openmaintainer
 
-checksums           rmd160  18dd6cfb1ef4dab7f1aa24d1e905653c53e493ec \
-                    sha256  708cec4950fa532ccf63509a05fb7b4d77fb5f2a3186900208f8bde68119e6ac \
-                    size    1687534
+checksums           rmd160  7672b8e988a2865d2257f67b1c94af1ed09eec62 \
+                    sha256  34e1fb90a34c96c6c131cdcb4b32727ed61137a737878633f21a8805f3b50342 \
+                    size    1695648
 
 build.args          ./cmd/golangci-lint
 


### PR DESCRIPTION
#### Description

* update [golangci-lint](https://github.com/golangci/golangci-lint) to [v1.56.1](https://github.com/golangci/golangci-lint/releases/tag/v1.56.1)


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.2.1
Xcode 15.2 / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?

```shell
port -vst install golangci-lint
--->  Cleaning golangci-lint
--->  Removing work directory for golangci-lint
--->  Scanning binaries for linking errors
--->  No broken files found.
--->  No broken ports found.
```

- [x] tested basic functionality of all binary files?

```shell
$ command -v golangci-lint
/opt/local/bin/golangci-lint
```

```shell
$ golangci-lint --help   
Smart, fast linters runner.

Usage:
  golangci-lint [flags]
  golangci-lint [command]

Available Commands:
  cache       Cache control and information
  completion  Generate the autocompletion script for the specified shell
  config      Config
  help        Help
  linters     List current linters configuration
  run         Run the linters
  version     Version

Flags:
      --color string              Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
  -j, --concurrency int           Concurrency (default NumCPU) (default 10)
      --cpu-profile-path string   Path to CPU profile output file
  -h, --help                      help for golangci-lint
      --mem-profile-path string   Path to memory profile output file
      --trace-path string         Path to trace output file
  -v, --verbose                   Verbose output
      --version                   Print version

Use "golangci-lint [command] --help" for more information about a command.
```

- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
