### PR TITLE
jimtcl: new port (version 0.82)

### DIFF
--- a/lang/jimtcl/Portfile
+++ b/lang/jimtcl/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+
+github.setup        msteveb jimtcl 0.82
+github.tarball_from archive
+revision            0
+
+homepage            https://jim.tcl.tk/
+
+description         \
+    Jim is a small footprint implementation of the Tcl programming language \
+    written from scratch.
+
+long_description    \
+    {*}${description} Currently Jim Tcl is very feature complete with an \
+    extensive test suite \(see the tests directory\).  There are some Tcl \
+    commands and features which are not implemented \(and likely never will \
+    be\), including traces and Tk. However, Jim Tcl offers a number of both \
+    Tcl8.5 and Tcl8.6 features \(\{\*\}, dict, lassign, tailcall and optional \
+    UTF-8 support\) and some unique features. These unique features include \
+    \[lambda\] with garbage collection, a general GC\/references system, \
+    arrays as syntax sugar for \[dict\]tionaries, object-based I/O and more. \
+    Other common features of the Tcl programming language are present, like \
+    the \"everything is a string\" behaviour, implemented internally as dual \
+    ported objects to ensure that the execution time does not reflect the \
+    semantic of the language
+
+categories          lang devel
+installs_libs       no
+license             Tcl/Tk
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  a26cfb6ff9be09aaa8e158d9df617d34ba7d6ab5 \
+                    sha256  e8af929b815e4d30e54ff116b2b933e56c00a02b9110529d1a58660b2469aea7 \
+                    size    4435258
+
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  path:lib/libssl.dylib:openssl \
+                    port:zlib
+
+configure.args-append \
+                    --docdir=${prefix}/share/doc/${name} \
+                    --shared
+
+variant static description {Build as static library} {
+    configure.args-delete --shared
+}


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
