### PR TITLE
vigra: add py312 variant and make default

### DIFF
--- a/graphics/vigra/Portfile
+++ b/graphics/vigra/Portfile
@@ -107,7 +107,7 @@ if {[variant_isset valgrind]} {
     configure.args-append -DWITH_VALGRIND=NO
 }
 
-set py_vers [list 2.7 3.7 3.8 3.9 3.10 3.11]
+set py_vers [list 2.7 3.7 3.8 3.9 3.10 3.11 3.12]
 
 proc py_conflict_list {py_vers py_ver} {
     set py_conf_vers [lsearch -inline -all -not -exact $py_vers $py_ver]
@@ -139,7 +139,7 @@ foreach py_ver ${py_vers} {
 
 if { ${active_py} eq "" } {
     # default for boost
-    set active_py 3.11
+    set active_py 3.12
     set active_py_nodot [string map {. {}} ${active_py}]
     default_variants +python${active_py_nodot}
 }


### PR DESCRIPTION
Add python 3.12 support to vigra