### PR TITLE
ssc: new port in www

### DIFF
--- a/www/ssc/Portfile
+++ b/www/ssc/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   github 1.0
+PortGroup                   cmake 1.1
+revision                    0
+
+github.setup                devongarde ssc 0.1.56 v
+github.tarball_from         releases
+categories                  www
+platforms                   {darwin >= 18} {openbsd >= 7.2}
+supported_archs             x86_64 arm64
+license                     GPL-3
+maintainers                 { @devongarde } openmaintainer
+description                 an opinionated static website nitpicker
+long_description            ${name}, the Static Site Checker, is an opinionated nitpicker for static \
+                            websites, analysing HTML, SVG, MathML, and more, including ontologies. \
+                            It can produce detailed reports, 'repaired' HTML with resolved server \
+                            side includes, site statistics, etc.. Consider it, at best, alpha.
+
+distname                    ${name}-v${version}
+distfiles                   ssc-v${version}.tgz
+extract.suffix              .tgz
+extract.post_args           "| tar -xzf -"
+
+homepage                    https://ssc.lu/
+master_sites                https://github.com/devongarde/ssc/releases/download/v${version}
+
+checksums                   rmd160  df2784a8d7671568cc3bd87b8a7f0ba9b0d9c809 \
+                            sha256  1ee28fec98d7910f87f7120cbaa517837259f4eced34491576c2b8e2834b2ce3 \
+                            size    23016387
+
+depends_lib                 port:boost \
+                            port:hunspell \
+                            port:icu \
+                            port:curl
+
+configure.cppflags-append   -DNO_GSL
+
+compiler.cxx_standard       2017


### PR DESCRIPTION
This is a revised pull request following some very helpful feedback from Herby Gillot, for which I give my humble thanks. All errors remain entirely mine.

ssc v0.1.55, a command line utility, is an opinionated static (web)site nitpicker, with a little more sweet linty depth than most alternatives. Please consider it alpha quality, but still useful.

This is a resubmission of my first pull request to macports, so please continue to expect beginner errors and embarrassing bloopers. Feedback most welcome.

I've tested both on an Intel iMac:
macOS 14.3.1 23D60 x86_64
Xcode 15.2 15C500b
plus various intel hosted VMs with macOSs 12 13 & 14, and an arm64 M2 with macOS 14. It also runs on OpenBSD, Windows, FreeBSD, and various Linux flavours.

Only relevant verification actions have been carried out, namely:

    I've tried to follow commit message guidelines
    your linter still seems happy
    existing tests pass, again
    the installer appears to install what should be installed, and what's installed appears to run as expected
    I've checked more than basic functionality (ssc has a test suite)
    there are no variants to validate

Possible gotchas:
    The build process is resource hungry. The smallest machine I've tested against is an 8G M2. I don't know what's the smallest resource set defined as suitable for building under macports.
     the dratted thing compiled and ran happily on my systems, but not on Herby's (see above) ... it seems I had an undeclared dependency that was anyway visible to my build. That's fixed (removed the dependency), and I don't think there are any other dependencies, but if there are I apologise deeply and I'll deal with them in a manner that involves a large hammer.

For more info on ssc:
https://ssc.lu/
https://github.com/devongarde/ssc/

For more info on me:
https://dylanharris.org/

Dylan Harris
