### PR TITLE
bcprov: revert to 1.74 for now

### DIFF
--- a/java/bcprov/Portfile
+++ b/java/bcprov/Portfile
@@ -4,12 +4,17 @@ PortSystem          1.0
 PortGroup           java 1.0
 
 name                bcprov
-version             1.77
+# See https://trac.macports.org/ticket/68455
+# This port is currently only needed by pdftk-java.
+# Please wait until https://gitlab.com/pdftk-java/pdftk/-/issues/155
+# is resolved before updating to bcprov ≥ 1.75.
+version             1.74
+epoch               1
 revision            0
 
-checksums           rmd160  22b932e234bdce4a18b4ca034557e93e34f5ae8e \
-                    sha256  dabb98c24d72c9b9f585633d1df9c5cd58d9ad373d0cd681367e6a603a495d58 \
-                    size    8372360
+checksums           rmd160  d12042ab8de08b6913e816a46eccacedb4d9bbb7 \
+                    sha256  56ede1472d78dc47b8a16fc5e90c02b9eeb970b55d8b5b8bfe760311907821e9 \
+                    size    8353376
 
 categories          java devel security
 license             MIT


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68455

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
Untested

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
