### PR TITLE
g-ls: Use different name to avoid re-indexing

### DIFF
--- a/sysutils/g-ls/Portfile
+++ b/sysutils/g-ls/Portfile
@@ -4,6 +4,7 @@ PortSystem              1.0
 PortGroup               golang 1.0
 
 go.setup                github.com/Equationzhao/g 0.26.0 v
+name                    g-ls
 revision                0
 categories              sysutils
 license                 MIT
@@ -26,8 +27,8 @@ go.offline_build        no
 build.args-append       -ldflags="-s -w"
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+    xinstall -m 0755 ${worksrcpath}/g ${destroot}${prefix}/bin/g
     xinstall -d ${destroot}${prefix}/share/zsh/site-functions
-    xinstall -m 0644 ${worksrcpath}/completions/zsh/_${name} \
+    xinstall -m 0644 ${worksrcpath}/completions/zsh/_g \
         ${destroot}${prefix}/share/zsh/site-functions
 }


### PR DESCRIPTION
#### Description

With the introduction of this port in #22620, a small issue involved with port indexing allowed this port to be reindexed every time. This is ultimately better, since other package managers adopt this name as well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
