### PR TITLE
py-setuptools_scm: fix py38–39 subports

### DIFF
--- a/python/py-setuptools_scm/Portfile
+++ b/python/py-setuptools_scm/Portfile
@@ -58,6 +58,14 @@ if {${name} ne ${subport}} {
         depends_lib-append  port:py${python.version}-packaging \
                             port:py${python.version}-typing_extensions
 
+        if {${python.version} < 310} {
+            # https://trac.macports.org/ticket/69106
+            # https://github.com/pypa/setuptools_scm/issues/1013
+            PortGroup       conflicts_build 1.0
+
+            conflicts_build py${python.version}-setuptools_scm
+        }
+
         if {${python.version} < 311} {
             depends_lib-append  port:py${python.version}-tomli
         }


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/69106

#### Description

Build fails when earlier versions are installed, but only for Python 3.8–3.9, AFAICT.
See upstream response in: https://github.com/pypa/setuptools_scm/issues/1013

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
