### PR TITLE
google-cloud-sdk: update to 464.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             463.0.0
+version             464.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  dd20866fe2dbe478bc814bde6824c4a707b91dee \
-                    sha256  6dc1b75d42ab14c5f8949ae9caa6f5167b18754a76b6d70271826ff512087b88 \
-                    size    127704735
+    checksums       rmd160  dd1f28a3f467798a7576077e13f56716ccb1c379 \
+                    sha256  355b895a85f96a15a6309351218550ca1f33ed2b88c73416d3a7d20550c0d8ac \
+                    size    127741709
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  a0770b74908654594afbdb9938794900cbec259f \
-                    sha256  98be2c530022c3cea5744a70bf37c6c9c1d9a05934d741f442ac5127a79c1734 \
-                    size    128990247
+    checksums       rmd160  e8c438b8350f40f16136e0ebe8083f770bc708ad \
+                    sha256  fa3f736952e282088bd7c607dc1f5b4fee0686e38ed529708c2f2d02821e5127 \
+                    size    129025644
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  8867e608b931c9fe0fca932e23bb1a952a48ffa5 \
-                    sha256  f9386574da1e6524a8c5f03b5f2945f85e5a312c5e0469ee82c2a72387b38a58 \
-                    size    126053298
+    checksums       rmd160  7ec7fd54e54599c6cef87de729c489f5a4257e22 \
+                    sha256  755882ed959ac79cb40fe8ed63020ef97d16f5dc5952f85626ea1d5fcaa64076 \
+                    size    126091065
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 464.0.0.

###### Tested on

macOS 14.3.1 23D60 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?