### PR TITLE
esmf: Rev bump and maintainer

### DIFF
--- a/science/esmf/Portfile
+++ b/science/esmf/Portfile
@@ -13,7 +13,7 @@ mpi.setup
 mpi.enforce_variant netcdf-fortran
 
 github.setup        esmf-org esmf 8.5.0 v
-revision            0
+revision            1
 checksums           rmd160  3d1edb514d5b09b46f1f60047e3f5cd3c0bf7b43 \
                     sha256  acd0b2641587007cc3ca318427f47b9cae5bfd2da8d2a16ea778f637107c29c4 \
                     size    14091400
@@ -21,7 +21,9 @@ checksums           rmd160  3d1edb514d5b09b46f1f60047e3f5cd3c0bf7b43 \
 version             [string map {_ .} ${github.version}]
 categories          science devel
 license             NCSA
-maintainers         {takeshi @tenomoto} openmaintainer
+maintainers         {takeshi @tenomoto} \
+                    {@Dave-Allured noaa.gov:dave.allured} \
+                    openmaintainer
 description         software for building and coupling weather, climate, and related models
 long_description    The ESMF defines an architecture for composing complex, coupled \
                     modeling systems and includes data structures \


### PR DESCRIPTION
#### Description

* Rev bump to fix broken builds with old LC_RPATH errors.
* Add myself as co-maintainer.
* Dependency problem was fixed by: https://github.com/macports/macports-ports/pull/21835
* Fixes https://trac.macports.org/ticket/68400

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 11, 12, 13-x86.  OS 14-arm.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?