### PR TITLE
kubectl: update 1.29, 1.28, 1.27 & 1.26

### DIFF
--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -57,11 +57,11 @@ subport kubectl-1.27 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     10
+    set patchNumber     11
     revision            0
-    checksums           rmd160  f4c96f9736d7d0b64a0e62162cdb6e9565bdc511 \
-                        sha256  f29c6f1f82b7c71114753655ccc3108651ab3d2235fed8bb2c676475b326bc5c \
-                        size    39183865
+    checksums           rmd160  dc9a4b1b1068a626a82fbb465c6bf567b81add19 \
+                        sha256  2dafbfd80b1efd40ac059bfac468be746cefad0c52462d77dc89bf03c5ba1bf0 \
+                        size    39184562
 }
 
 subport kubectl-1.26 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -69,11 +69,11 @@ subport kubectl-1.26 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     13
+    set patchNumber     14
     revision            0
-    checksums           rmd160  1579d3c7d2d13f8ddbcd55934bf94680e96e51ce \
-                        sha256  70d383fc6344c5f59fa67026c191c7e7c40580888c93803f79752bcac6e66ff6 \
-                        size    39454349
+    checksums           rmd160  f06d9816dd6f4b8133940eea5e2460af4d1f6af4 \
+                        sha256  81c974206b9e40ad051de1e0be2a61a8fe4fa340c0ab76aa60a871a01282e25c \
+                        size    39454535
 }
 
 subport kubectl-1.25 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -45,11 +45,11 @@ subport kubectl-1.28 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     6
+    set patchNumber     7
     revision            0
-    checksums           rmd160  c01aef65a8345627dd514b448bd7d6c9243c6038 \
-                        sha256  6f98d87a297ec3551e169274fa9a7989172d613cd9ae35d49ca3a7d6b1d9aa0f \
-                        size    39955920
+    checksums           rmd160  0760bde60aa8165a9695e44dd0a428ca1965fa8e \
+                        sha256  bd7b2c457c91479ee4233d717f0740bc16a43bc51c270c21a1b63d703bef9329 \
+                        size    39959046
 }
 
 subport kubectl-1.27 {

--- a/sysutils/kubectl/Portfile
+++ b/sysutils/kubectl/Portfile
@@ -32,11 +32,11 @@ subport kubectl-1.29 {
     supported_archs     x86_64 arm64
     platforms           {darwin >= 17}
 
-    set patchNumber     1
+    set patchNumber     2
     revision            0
-    checksums           rmd160  b8e529d0ef19a342d3109391d2b2db37aebdd5ca \
-                        sha256  63fd3a82639c5d2a76ad0345930dd672fa1affc958d28975e6809300683132e8 \
-                        size    41130463
+    checksums           rmd160  e03da5dbd960f99f8b5ff5757444f28883539cd4 \
+                        sha256  da261f3d82e1b534dbc585bdf961b1eb9d073501fa0ecf406317e95238d0867b \
+                        size    41132583
 }
 
 subport kubectl-1.28 {
@@ -235,7 +235,7 @@ if {${subport} == ${name}} {
     PortGroup           obsolete 1.0
 
     replaced_by         ${latestVersion}
-    version             1.29.0
+    version             1.29.2
     revision            0
 
 } elseif {${subport} == "kubectl_select"} {


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
