### PR TITLE
ghc: Fix dependency loop; revbump ports required to bootstrap ghc

### DIFF
--- a/devel/alex/Portfile
+++ b/devel/alex/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                alex
 version             3.5.0.0
-revision            0
+revision            1
 categories          devel haskell
 maintainers         nomaintainer
 license             GPL-3
@@ -18,8 +18,6 @@ long_description    Alex is a tool for generating lexical analysers in \
                     module containing code for scanning text \
                     efficiently. It is similar to the tool lex or flex \
                     for C/C++.
-
-master_sites        https://hackage.haskell.org/package/${name}-${version}
 
 checksums           rmd160  81108dde73298615b1d5385dee828b60b37d16de \
                     sha256  caed9f23b4bc1cdd6f8083b79a0bb86ba86ed81ab9a1238fe0e13ed544809fed \

--- a/devel/happy/Portfile
+++ b/devel/happy/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                happy
 version             1.20.1.1
-revision            0
+revision            1
 categories          devel haskell
 maintainers         nomaintainer
 license             GPL-3
@@ -16,8 +16,6 @@ long_description    Happy is a parser generator for Haskell. Given a\
                     grammar specification in BNF, Happy generates\
                     Haskell code to parse the grammar. Happy works in\
                     a similar way to the yacc tool for C.
-
-master_sites        https://hackage.haskell.org/package/${name}-${version}
 
 checksums           rmd160  bccf9d0c8ef3028e25ff196f18349f1bac0bfd5e \
                     sha256  8b4e7dc5a6c5fd666f8f7163232931ab28746d0d17da8fa1cbd68be9e878881b \

--- a/devel/hscolour/Portfile
+++ b/devel/hscolour/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                hscolour
 version             1.25
-revision            0
+revision            1
 categories          devel haskell
 maintainers         nomaintainer
 license             GPL-3
@@ -19,8 +19,6 @@ long_description    {*}${description}. It currently has six output \
                     HTML 4.01 with CSS, HTML 4.01 with CSS and \
                     mouseover annotations, XHTML 1.0 with inline CSS \
                     styling, LaTeX, and mIRC chat codes.
-
-master_sites        https://hackage.haskell.org/package/${name}-${version}
 
 checksums           rmd160  1ed500fab6a2dc25421c401a2cd0824816ffd1cf \
                     sha256  54ce30da55599e872fd38d927aa518369e2971b284acc67ed0caac6ae14cc77c \

--- a/lang/ghc/Portfile
+++ b/lang/ghc/Portfile
@@ -193,7 +193,7 @@ if {${name} eq ${subport}} {
 
     # use these to specify python versions, python3 required
     # use ${prefix}/var/macports/sources/rsync.macports.org/macports/release/tarballs/ports/_resources/port1.0/group/python-1.0.tcl
-    set python3_version 311
+    set python3_version 312
     set python3_branch  [string index ${python3_version} 0].[string range ${python3_version} 1 end]
     set python3_prefix  ${frameworks_dir}/Python.framework/Versions/${python3_branch}
     set python3_bin     ${python3_prefix}/bin/python${python3_branch}
@@ -211,10 +211,10 @@ if {${name} eq ${subport}} {
                     port:HsColour \
                     port:python${python3_version} \
                     port:py${python3_version}-sphinx \
-                    port:texlive \
                     port:texlive-fonts-extra \
                     port:texlive-fonts-recommended \
                     port:texlive-latex-extra \
+                    port:texlive-xetex \
                     port:xz
 
     depends_lib-append  \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
