### PR TITLE
gh: update to 2.44.0

### DIFF
--- a/devel/gh/Portfile
+++ b/devel/gh/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             2.43.1
+version             2.44.0
 revision            0
 
 # Github CLI is failing to build on 10.12 and below.
@@ -54,9 +54,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  c738b8f7fc1dd262e0ca51c1c31da1fc4e8fa8ad \
-                        sha256  1ea3f451fb7002c1fb95a7fab21e9ab16591058492628fe264c5878e79ec7c90 \
-                        size    827993
+    checksums           rmd160  a1efe71a6ae85880649541c77d5a77e2d912d795 \
+                        sha256  babaa83c9662d0bb1b500f76b878b11a0b83342ced30ac5232cf811762310ffa \
+                        size    830602
 
     github.tarball_from archive
 
@@ -76,9 +76,9 @@ if ${source_build} {
 
     distname        gh_${version}_macOS_amd64
 
-    checksums       rmd160  3101d905749c0bd6650625159fb6ea5e84197428 \
-                    sha256  53f58c94324fcae7e424e3cf7662d68025bf148350b83911846b330920083e56 \
-                    size    11426127
+    checksums       rmd160  a150637755440650177a107f580754ef503b3b7d \
+                    sha256  14ad2446095e5a18c49c7d3530f3f50cc042f489bc1fd926870f6d9fe2cdb357 \
+                    size    11429022
 
     use_configure   no
     use_zip         yes


### PR DESCRIPTION

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
