### PR TITLE
symfony-cli: update to 5.8.11

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.7
+version             5.8.11
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  2db39c9b944f412cbc416f60e0fe0ff28baf62eb \
-                        sha256  4a5a00570678e02336a6617b7f923a66c2a5b948d6e82efa80de8127054ad17b \
-                        size    263653
+    checksums           rmd160  ec79621981d0e1e84fef34649d7d9d23f563d004 \
+                        sha256  56aec8dc71499523f8e99d511b0acde809473024466b9b52b2a03353aa663da6 \
+                        size    265335
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  25639f0e3e2bea3d99c7299db69e69220e0dd03d \
-                        sha256  828d4c17369cad65a1805e0fced81fc2a73ec86240c0e25a73770c0b9ecb93ba \
-                        size    11153849
+    checksums           rmd160  5e347adf8268c4af34e8747c3132d4b3dbb83cf0 \
+                        sha256  7114fecb490703b7fed8b9b0e6361e7ca1613525e5815f633972cd366cad7e74 \
+                        size    11096462
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.11

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
