### PR TITLE
Dependent upon DCMTK: Add missing bump for ABI compat.

### DIFF
--- a/graphics/InsightToolkit/Portfile
+++ b/graphics/InsightToolkit/Portfile
@@ -8,7 +8,7 @@ PortGroup           github 1.0
 
 name                InsightToolkit
 github.setup        InsightSoftwareConsortium ITK 5.3.0 v
-revision            0
+revision            1
 categories          graphics science devel
 license             Apache
 conflicts_build     InsightToolkit4

--- a/graphics/InsightToolkit4/Portfile
+++ b/graphics/InsightToolkit4/Portfile
@@ -8,7 +8,7 @@ PortGroup           github 1.0
 
 name                InsightToolkit4
 github.setup        InsightSoftwareConsortium ITK 4.13.3 v
-revision            0
+revision            1
 categories          graphics science devel
 license             Apache
 conflicts_build     InsightToolkit

--- a/graphics/h3dutil/Portfile
+++ b/graphics/h3dutil/Portfile
@@ -6,7 +6,7 @@ PortGroup           conflicts_build 1.0
 
 name                h3dutil
 version             1.4.0
-revision            2
+revision            3
 categories          graphics
 platforms           darwin
 maintainers         {@SenseGraphics sensegraphics.com:support}

--- a/graphics/openimageio/Portfile
+++ b/graphics/openimageio/Portfile
@@ -26,13 +26,13 @@ if {${os.platform} eq "darwin" && ${os.major} >= 20} {
 
 if {${port_latest}} {
     github.setup        OpenImageIO oiio 2.4.5.0 v
-    revision            8
+    revision            9
     checksums           rmd160  32b2b0f0b01268a91fc98cfca948a71e89d8e54b \
                         sha256  21177a9665021a99123885cd8383116d15013b6610b4b09bcf209612423fedc5 \
                         size    31938357
 } else {
     github.setup        OpenImageIO oiio 2.1.20.0 v
-    revision            13
+    revision            14
     checksums           rmd160  d10c488b93ab2335d53545d8a1b35ba4c1babb98 \
                         sha256  75222543286d3a12473aa03fdb4e6c9f98760c5ad1ad89d3cf82a5da41385ae0 \
                         size    29115990


### PR DESCRIPTION
Maintainer (of dcmtk) update.

Apologies for missing this initially.

Not bumping ports dependent on these; hopefully they advertise dcmtk if they directly link to it.