### PR TITLE
haskell_cabal-based ports: updates and/or revbump to create binary with latest PG haskell_cabal

### DIFF
--- a/_resources/port1.0/group/haskell_cabal-1.0.tcl
+++ b/_resources/port1.0/group/haskell_cabal-1.0.tcl
@@ -166,7 +166,11 @@ options haskell_cabal.bin \
         haskell_cabal.installdir_args \
         haskell_cabal.bindirs
 
-default master_sites    {https://hackage.haskell.org/package/${subport}-${version}}
+# default master_sites for non-GitHub ports
+if {![info exists github.master_sites]} {
+    default master_sites \
+        {https://hackage.haskell.org/package/${subport}-${version}}
+}
 
 default haskell_cabal.bin {[haskell_cabal.getcabalbin]}
 
@@ -385,15 +389,15 @@ post-destroot {
                     && ([exec openssl dgst -ripemd160 ${binfile}.slash_hack] \
                             ne [exec openssl dgst -ripemd160 ${binfile}])} {
                     # gsed created a different file of the same size
-                    delete  ${binfile}
+                    delete ${binfile}
                     xinstall -m 0755 \
                         ${binfile}.slash_hack \
                         ${binfile}
+                    if {${configure.build_arch} eq {arm64}} {
+                        system "codesign -f -s - ${binfile}"
+                    }
                 }
-                delete  ${binfile}.slash_hack
-                if {${configure.build_arch} eq {arm64}} {
-                    system "codesign -f -s - ${binfile}"
-                }
+                delete ${binfile}.slash_hack
             }
         }
     }

--- a/devel/HaXml/Portfile
+++ b/devel/HaXml/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                HaXml
-version             1.25.12
+version             1.25.13
 revision            0
 categories          devel
 license             LGPL-2.1
@@ -17,13 +17,13 @@ long_description    HaXml is a collection of utilities for parsing, \
                     error-correcting parser for HTML, an XML \
                     validator, and pretty-printers for XML and HTML.
 
-homepage            https://projects.haskell.org/${name}
+homepage            https://github.com/HaXml/HaXml
 
-master_sites        https://hackage.haskell.org/package/${name}-${version}
+checksums           rmd160  370429d09761915339f196115ffbacfc9926a04c \
+                    sha256  5d855449bddef93703d2759626558c3202fbedb4a6deaa7f9659da6557bab373 \
+                    size    147978
 
-checksums           rmd160  0115096257804f72d9684e35f0317548f1510f96 \
-                    sha256  ec61ac2b33cf5032082ebaa109daea1ffa03baae090c0cc04624f19642b958f5 \
-                    size    147917
+installs_libs       no
 
 variant stack \
     description {Use stack to build.} {}

--- a/devel/aeson-pretty/Portfile
+++ b/devel/aeson-pretty/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                aeson-pretty
 version             0.8.10
-revision            0
+revision            1
 categories          devel haskell
 maintainers         nomaintainer
 license             GPL-3
@@ -24,11 +24,11 @@ long_description    A JSON pretty-printing library compatible with \
                     also offers a complementary \"compact\"-mode, \
                     essentially the opposite of pretty-printing.
 
-master_sites        https://hackage.haskell.org/package/${name}-${version}
-
 checksums           rmd160  82d41419da3a4f599df7dfe6d23e86f2e33db53f \
                     sha256  2a21f2cd78adcb149ceba770239ed664519552911e7680172b18ff695cfa7ae5 \
                     size    5894
+
+installs_libs       no
 
 variant stack \
     description {Use stack to build.} {}
@@ -38,6 +38,5 @@ if { [variant_isset "stack"] } {
 } else {
     PortGroup       haskell_cabal 1.0
 
-    build.target    exe:${name} \
-                    --allow-newer
+    build.target    exe:${name}
 }

--- a/devel/cpphs/Portfile
+++ b/devel/cpphs/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                cpphs
 version             1.20.9.1
-revision            4
+revision            5
 categories          devel haskell
 maintainers         nomaintainer
 license             GPL-3
@@ -18,11 +18,11 @@ long_description    Cpphs is a re-implementation of the C \
 
 homepage            http://projects.haskell.org/cpphs/
 
-master_sites        https://hackage.haskell.org/package/${name}-${version}
-
 checksums           rmd160  96be359b6b9e8572124d137dcab90ee04632a0c7 \
                     sha256  7f59b10bc3374004cee3c04fa4ee4a1b90d0dca84a3d0e436d5861a1aa3b919f \
                     size    45496
+
+installs_libs       no
 
 variant stack \
     description {Use stack to build.} {}

--- a/devel/shellcheck/Portfile
+++ b/devel/shellcheck/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        koalaman shellcheck 0.9.0 v
-revision            4
+revision            5
 categories          devel haskell
 
 license             GPL-3+
-maintainers         {cal @neverpanic} openmaintainer
+maintainers         nomaintainer
 platforms           darwin
 
 description         ShellCheck, a static analysis tool for shell scripts
@@ -29,6 +29,8 @@ checksums           rmd160  d553c8251fa8f3d28f262b0069d87c481a6764d0 \
                     size    456737
 
 livecheck.url       https://hackage.haskell.org/package/ShellCheck
+
+installs_libs       no
 
 variant stack \
     description {Use stack to build.} {}

--- a/lang/cabal/Portfile
+++ b/lang/cabal/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                cabal
 version             3.10.2.0
-revision            1
+revision            2
 categories          lang haskell devel
 platforms           darwin
 license             BSD
@@ -24,6 +24,8 @@ long_description    Cabal is a system for building and packaging \
 homepage            https://www.haskell.org/cabal
 
 master_sites        https://downloads.haskell.org/~${name}/${name}-install-${version}/:haskell
+
+installs_libs       no
 
 platform arm {
     set cabal_build_arch    aarch64

--- a/textproc/lhs2tex/Portfile
+++ b/textproc/lhs2tex/Portfile
@@ -3,23 +3,23 @@
 PortSystem          1.0
 
 name                lhs2tex
-version             1.24
-revision            3
+version             1.25
+revision            0
 license             GPL-2+
-maintainers         {cal @neverpanic} openmaintainer
+maintainers         nomaintainer
 platforms           darwin
 categories          textproc tex haskell
 
 description         Preprocessor for typesetting Haskell sources with LaTeX
 long_description    {*}${description}
 
-homepage            https://hackage.haskell.org/package/${name}
+homepage            https://github.com/kosmikus/lhs2tex
 
-master_sites        ${homepage}-${version}
+checksums           rmd160  320a89b507e4328d071c32b384d3daba9b507d1a \
+                    sha256  d263232264f1d8ab62e39f15a6dd7a7ce644117f6615dd43c3afa957cd37c631 \
+                    size    891949
 
-checksums           rmd160  aea7b5da594d1b5d6a3d8749b18663fe50c540f1 \
-                    sha256  ecd7059967d23d1e6453d6023f8b23d0d7d2c947beb2c63bb13daa54e964b326 \
-                    size    775885
+installs_libs       no
 
 variant stack \
     description {Use stack to build.} {}

--- a/textproc/pandoc/Portfile
+++ b/textproc/pandoc/Portfile
@@ -3,8 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jgm pandoc 3.1.11.1
-revision            1
+github.setup        jgm pandoc 3.1.12
+revision            0
 categories          textproc haskell
 license             GPL-3
 maintainers         {judaew @judaew} openmaintainer
@@ -27,24 +27,23 @@ homepage            https://pandoc.org
 
 installs_libs       no
 
+checksums           rmd160  941a905dafbc79f959c218ff65508100b5fe15a2 \
+                    sha256  709629f264455f73da7afbcae1138e97cb375a7563cf9c251c059f54bb777259 \
+                    size    7651793
+
 # See https://trac.macports.org/ticket/48971
 notes-append       "For PDF support, please install the texlive-latex and texlive-fonts-recommended packages."
 
-set minimum_major_version_for_source 21
+set minimum_major_version_for_source 20
 
 # set build_arch/os.arch/os.major by hand to get binary x86_64/arm64 checksums
-# sudo port -d checksum pandoc os.arch=arm os.major=20 build_arch=arm64
-# sudo port -d checksum pandoc os.arch=i386 os.major=20 build_arch=x86_64
+# sudo port -d checksum pandoc os.arch=arm os.major=19 build_arch=arm64
+# sudo port -d checksum pandoc os.arch=i386 os.major=19 build_arch=x86_64
 # run `sudo port clean --all pandoc` afterwards
 
 if {(${os.platform} eq {darwin}
-     && ${os.major} >= ${minimum_major_version_for_source})
-    || ${os.platform} ne {darwin}} {
-
-    checksums       rmd160  db179bb241ff7a7c017dbb638b49411f2cc19889 \
-                    sha256  a486bc7eb78f32ea080e033d29a78659bdbe5fcb77e9277e0af5944f29196d90 \
-                    size    7626371
-
+        && ${os.major} >= ${minimum_major_version_for_source})
+        || ${os.platform} ne {darwin}} {
     compiler.blacklist-append \
                    {clang < 900}
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
