### PR TITLE
x86_64-binutils: new package

### DIFF
--- a/cross/x86_64-binutils/Portfile
+++ b/cross/x86_64-binutils/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           crossbinutils 1.0
+
+name                x86_64-binutils
+version             2.41
+revision            0
+maintainers         {@kamischi web.de:karl-michael.schindler} \
+                    openmaintainer
+
+if {$subport eq $name} {
+    # sort of a dummy package. Download sources and install docs only
+    crossbinutils.setup x86_64 ${version}
+    depends_build
+    depends_lib
+    platforms           any
+    supported_archs     noarch
+    use_configure       no
+    build               {}
+    destroot            {}
+}
+
+foreach ostarget {linux dragonfly freebsd netbsd openbsd} {
+    subport x86_64-${ostarget}-binutils {
+        crossbinutils.setup     x86_64-${ostarget} ${version}
+        configure.args-append   --disable-werror
+        if {${ostarget} eq "linux"} {
+            depends_build-append    port:bison
+        }
+    }
+}
+
+subport x86_64-embedded-binutils {
+    crossbinutils.setup x86_64-embedded ${version}
+    configure.args-append \
+        --target=x86_64-unknown-elf \
+        --disable-werror
+
+    post-destroot {
+        file rename ${destroot}${prefix}/x86_64-unknown-elf/bin \
+                    ${destroot}${prefix}/x86_64-embedded
+        file rename ${destroot}${prefix}/x86_64-unknown-elf/lib \
+                    ${destroot}${prefix}/x86_64-embedded
+        file delete ${destroot}${prefix}/x86_64-unknown-elf
+    }
+}


### PR DESCRIPTION
Builds cross binutils for linux dragonfly embedded freebsd netbsd and openbsd.#### Description

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.6.4 22G513 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
