### PR TITLE
osm2pgsql: update to 1.11.0

### DIFF
--- a/gis/osm2pgsql/Portfile
+++ b/gis/osm2pgsql/Portfile
@@ -7,7 +7,7 @@ PortGroup           active_variants 1.1
 PortGroup           boost 1.0
 PortGroup           legacysupport 1.1
 
-github.setup        osm2pgsql-dev osm2pgsql 1.10.0
+github.setup        osm2pgsql-dev osm2pgsql 1.11.0
 
 categories          gis
 maintainers         {vince @Veence} openmaintainer
@@ -20,9 +20,9 @@ license             GPL-2+
 
 homepage            https://osm2pgsql.org
 
-checksums           rmd160  60f84c2353f85da7fd2faa00280d53caeadc4feb \
-                    sha256  cdcd15706e0f42cc93b1330e0a58061e6cbb91f19de878e9b94c1a9d41e10bad \
-                    size    2599718
+checksums           rmd160  196febf9742de2424851355145691906277c10ae \
+                    sha256  2033bd397965ff9b77ed300eb7184d9dc08c9baa3d9e9ce73685396a53558bc8 \
+                    size    2722128
 
 # It uses include variant
 compiler.cxx_standard 2017
@@ -32,18 +32,21 @@ legacysupport.newest_darwin_requires_legacy 17
 legacysupport.use_mp_libcxx yes
 
 set port_libfmt     libfmt8
+set opencv          opencv4
 
 cmake.module_path-append \
                     ${prefix}/lib/${port_libfmt}/cmake
 configure.args-append \
-                    -DFMT_INCLUDE_DIR=${prefix}/include/${port_libfmt}
+                    -DFMT_INCLUDE_DIR=${prefix}/include/${port_libfmt} \
+                    -DOpenCV_DIR="${prefix}/libexec/${opencv}/cmake"
 
 depends_lib-append  port:bzip2 \
-                    port:CImg \
+                    port:CLI11 \
                     port:expat \
                     port:libosmium \
                     port:nlohmann-json \
                     port:${port_libfmt} \
+                    port:${opencv} \
                     port:postgis3 \
                     port:potrace \
                     port:proj8 \
@@ -126,6 +129,9 @@ subport ${name}-lua {
 
     long_description    ${long_description} \
                         This sub-port includes support for Lua scripts.
+
+    destroot.target-append \
+                        install-gen
 
     post-destroot {
         file rename ${destroot}${prefix}/bin/${name} ${destroot}${prefix}/bin/${subport}


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/openstreetmap/osm2pgsql/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
