### PR TITLE
libcdio: fix crash reading CD TOC on macOS Ventura

### DIFF
--- a/devel/libcdio/Portfile
+++ b/devel/libcdio/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                libcdio
 version             2.1.0
+revision            1
 
 categories          devel
 license             GPL-3+
@@ -32,6 +33,9 @@ checksums           rmd160 6b0e4917cd2dd5cac0b7afdb70789bf0ad2aed79 \
 # using newer gcc versions on Tiger in these files doesn't work as FSF gcc
 # doesn't understand the pramga usage in the Tiger headers - gcc bug 50909
 patchfiles          patch-libcdio-lib-iso9660-move-pragma.diff
+
+# Remove the unecessary addtional byte added to the TOC buffer
+patchfiles-append      remove-additional-byte-TOC-buffer.diff
 
 configure.args      --disable-rpath \
                     --disable-silent-rules

--- a/devel/libcdio/files/remove-additional-byte-TOC-buffer.diff
+++ b/devel/libcdio/files/remove-additional-byte-TOC-buffer.diff
@@ -1,0 +1,12 @@
+Upstream patch: https://git.savannah.gnu.org/cgit/libcdio.git/commit/?id=6f2426e8bf4dc5269ccbd9fbfa94340895f8be6e
+--- lib/driver/osx.c.orig
++++ lib/driver/osx.c
+@@ -1232,7 +1232,7 @@
+     CFRange range;
+     CFIndex buf_len;
+ 
+-    buf_len = CFDataGetLength( data ) + 1;
++    buf_len = CFDataGetLength( data );
+     range = CFRangeMake( 0, buf_len );
+ 
+     if( ( p_env->pTOC = (CDTOC *)malloc( buf_len ) ) != NULL ) {


### PR DESCRIPTION
Remove the unnecessary byte added to the TOC buffer. See the upstream patch: https://git.savannah.gnu.org/cgit/libcdio.git/commit/?id=6f2426e8bf4dc5269ccbd9fbfa94340895f8be6e

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

The test is rudimentary. I'm using the library only through [freac](https://www.freac.org) which was crashing because of this bug, see for example [this ticket](https://github.com/enzo1982/freac/issues/587). After the fix, it works.

This is my first contribution to macports, and I'd be happy to contribute more. Please feel free to add any "pedagogical comment"/recommendation.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1 23D60 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
