### PR TITLE
xcode-build-server: new port

### DIFF
--- a/devel/xcode-build-server/Portfile
+++ b/devel/xcode-build-server/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           python 1.0
+
+github.setup        SolaWing xcode-build-server 1.0.0 v
+version             1.0.0
+revision            0
+platforms           {macosx any}
+license             MIT
+categories          devel python
+maintainers         {woolsweater.net:macports @woolsweater} \
+                    openmaintainer
+supported_archs     noarch
+
+description         Build Server Protocol implementation for Xcode projects
+
+long_description    ${name} integrates Xcode with Apple's sourcekit-lsp. \
+                    sourcekit-lsp doesn't itself support Xcode projects, but it does \
+                    provide a Build Server Protocol client to work with other \
+                    build systems. xcode-build-server implements a build \
+                    server to provide sourcekit-lsp with the build \
+                    information it needs for an Xcode project.
+
+checksums           rmd160  fd21bf312b47c15fc28d03b80de1ec39d76140a2 \
+                    sha256  08ea2b9a892670bb7c2f8ff90a97ae0be519744f42ba713bb1a56e247c77e885 \
+                    size    18673
+
+build {}
+
+post-patch {
+    reinplace "s|/usr/bin/env python3|${python.bin}|" \
+        ${worksrcpath}/${name}
+}
+
+destroot {
+    xinstall -d ${destroot}/${python.pkgd}/${name}
+    xinstall -m 0755 {*}[glob ${worksrcpath}/*.py] ${destroot}/${python.pkgd}/${name}
+    xinstall -m 0755 -W ${worksrcpath} ${name} ${destroot}/${python.pkgd}/${name}
+    ln -s ${python.pkgd}/${name}/${name} ${destroot}${prefix}/bin/${name}
+}


### PR DESCRIPTION
#### Description

`xcode-build-server` provides a Build Server Protocol implementation that allows `sourcekit-lsp` to be used with Xcode projects. It recently published a v1.0.0 release.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.6.1 22G313 arm64
Xcode 15.0.1 15A507

macOS 13.6.3 22G436 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
