### PR TITLE
gdal, py-gdal: update to version 3.8.4

### DIFF
--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -8,12 +8,12 @@ PortGroup           legacysupport 1.0
 PortGroup           muniversal 1.0
 
 name                gdal
-version             3.8.3
-revision            1
+version             3.8.4
+revision            0
 
-checksums           rmd160  55ef2f3940680fcbda1d3934b1e2b652610acaad \
-                    sha256  ae2d160f65016e208eca34ff14490ec4511f1fa03fd386ac130449d15e82929d \
-                    size    8865180
+checksums           rmd160  8a889ec98c01c2d58dea4b7c9804df3531edf6f2 \
+                    sha256  0c53ced95d29474236487202709b49015854f8e02e35e44ed0f4f4e12a7966ce \
+                    size    8867580
 
 categories          gis
 license             MIT BSD

--- a/python/py-gdal/Portfile
+++ b/python/py-gdal/Portfile
@@ -7,7 +7,7 @@ PortGroup           select 1.0
 name                py-gdal
 python.rootname     GDAL
 # keep version in sync with gdal; rebuilt after gdal update
-version             3.8.3
+version             3.8.4
 revision            0
 
 categories-append   gis
@@ -20,9 +20,9 @@ long_description    This Python package and extensions are a number of tools for
 
 homepage            https://www.gdal.org
 
-checksums           rmd160  93932cfdc77ab070d0f64060a035aa05d0b3bb26 \
-                    sha256  eae2587c581d6609289e44f30afe30edcc25fbc640b5d6aba2f3c3e81def55be \
-                    size    802458
+checksums           rmd160  38759f66de7b4043eb3283ca031eb3e7dba8d536 \
+                    sha256  7c51e0ae7a7ccf43ad9e4bf435176baa9276653dfa16fd167c3632f6e7275207 \
+                    size    802459
 
 python.versions     38 39 310 311 312
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

Update `gdal` and `py-gdal` to version 3.8.4.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
