### PR TITLE
photoqt: allow qtlocation on arm64, add comment re updating, revbump

### DIFF
--- a/graphics/photoqt/Portfile
+++ b/graphics/photoqt/Portfile
@@ -5,8 +5,11 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 name                photoqt
+# 4.x requires Qt6, poppler-qt6 and fails with our exiv2:
+# https://trac.macports.org/ticket/69366
+# https://github.com/luspi/photoqt/issues/22
 github.setup        luspi photoqt 3.4 v
-revision            0
+revision            1
 categories          graphics
 license             GPL-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -61,17 +64,8 @@ if {${subport} eq "${name}"} {
                     -DVIDEO_MPV=OFF \
                     -DVIDEO_QT=OFF
 
-    if {${configure.build_arch} eq "arm64"} {
-        # qtlocation broken on aarch64: https://trac.macports.org/ticket/68508
-        qt5.depends_component \
-                    qtmultimedia qtsvg qttools qttranslations sqlite-plugin
-
-        configure.args-append \
-                    -DLOCATION=OFF
-    } else {
-        qt5.depends_component \
+    qt5.depends_component \
                     qtlocation qtmultimedia qtsvg qttools qttranslations sqlite-plugin
-    }
 
     # Without this the build cannot find QtPlatformHeaders:
     configure.cxxflags-append \


### PR DESCRIPTION
#### Description

Minor improvements. Also fixes pre-built binaries after recent `poppler` update (I postponed revbumping a bit, since wanted to do a few changes at once).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
