### PR TITLE
p5-dbd-mysql: cleanup variant listing and fix mariadb/percona

### DIFF
--- a/perl/p5-dbd-mysql/Portfile
+++ b/perl/p5-dbd-mysql/Portfile
@@ -2,10 +2,9 @@
 
 PortSystem          1.0
 PortGroup           perl5 1.0
+PortGroup           active_variants 1.1
 
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         DBD-mysql 5.003 ../../authors/id/D/DV/DVEEDEN
-revision            1
 license             {Artistic-1 GPL}
 maintainers         nomaintainer
 description         Perl5 Database Interface to the MySQL database
@@ -13,9 +12,86 @@ long_description    {*}${description}
 
 platforms           darwin
 
-checksums           rmd160  750b4a31d358a7c5ae5a3f9905df80357dbc1f3b \
-                    sha256  21554443d60e294cc0ac00adaef53ccb7de55d4fae66a38372a5adf0a0f1edda \
-                    size    154242
+###############################################################################
+# Create an array of DBD:MYSQL versions
+###############################################################################
+# "DBD:MYSQL Major Verion" {
+#     version    DBD:MYSQL version
+#     rmd160     value
+#     sha256     value
+#     size.      value
+# }
+###############################################################################
+array set version_current {
+    version     5.003
+    rmd160      750b4a31d358a7c5ae5a3f9905df80357dbc1f3b
+    sha256      21554443d60e294cc0ac00adaef53ccb7de55d4fae66a38372a5adf0a0f1edda
+    size        154242
+}
+array set version_4 {
+    version     4.052
+    rmd160      2e614009d863d4a67bb225a3a0ac329209b1910e
+    sha256      a83f57af7817787de0ef56fb15fdfaf4f1c952c8f32ff907153b66d2da78ff5b
+    size        162074
+}
+
+###############################################################################
+# Create an array of mysql variants.  This is an attempt to make adding new
+# variant easier as they emerge.
+###############################################################################
+# Variant list
+# {
+#   sql variant name     port name (if different)
+# }
+###############################################################################
+array set db_variants {
+    mysql82         ""
+    mysql81         ""
+    mysql8          ""
+    mariadb10_11    mariadb-10.11
+    mariadb10_10    mariadb-10.10
+    mariadb10_6     mariadb-10.6
+    mariadb10_5     mariadb-10.5
+    mariadb10_4     mariadb-10.4
+    percona         ""
+}
+
+# check to see if a variant was set by the user
+set any_sql no
+foreach variant_name [array names db_variants] {
+    if {[variant_isset ${variant_name}]} {
+        set any_sql yes
+        switch -glob -- $variant_name {
+            "*mysql*" {
+                set install_version "version_current"
+            }
+            default {
+                set install_version "version_4"
+            }
+        }
+        break
+    }
+}
+# set the default variant if no variant is set by the user
+# NOTE: if the user passes in a bad variant, these defaults will
+# be installed instead of throwing an error
+if { !${any_sql}} {
+    if {${os.major} > 12} {
+        default_variants +mysql8
+        set install_version "version_current"
+    } else {
+        default_variants +mariadb10_6
+        set install_version "version_4"
+    }
+}
+# setup perl and checksums based the requested variant version
+perl5.setup                 DBD-mysql [lindex [array get $install_version version] 1] ../../authors/id/D/DV/DVEEDEN
+checksums                   rmd160  [lindex [array get $install_version rmd160] 1] \
+                                    sha256  [lindex [array get $install_version sha256] 1] \
+                                    size    [lindex [array get $install_version size] 1]
+# version gets set to the "current version" values to prevenet constant upgraing by port upgrade
+version                     [perl5_convert_version [lindex [array get version_current version] 1]]
+revision                    1
 
 if {${perl5.major} != ""} {
     depends_build-append \
@@ -26,74 +102,44 @@ if {${perl5.major} != ""} {
     depends_lib-append \
                     port:p${perl5.major}-dbi
 
-    variant mysql8 conflicts mysql81 mysql82 mariadb10_4 mariadb10_5 mariadb10_6 mariadb10_10 mariadb10_11 \
-        description {build with mysql8 port} {
-        depends_lib-append      port:mysql8
-        configure.args-append   --mysql_config=${prefix}/lib/mysql8/bin/mysql_config
-    }
-
-    variant mysql81 conflicts mysql8 mysql82 mariadb10_4 mariadb10_5 mariadb10_6 mariadb10_10 mariadb10_11 \
-        description {build with mysql81 port} {
-        depends_lib-append      port:mysql81
-        configure.args-append   --mysql_config=${prefix}/lib/mysql81/bin/mysql_config
-    }
-
-    variant mysql82 conflicts mysql8 mysql81 mariadb10_4 mariadb10_5 mariadb10_6  mariadb10_10 mariadb10_11 \
-        description {build with mysql82 port} {
-        depends_lib-append      port:mysql82
-        configure.args-append   --mysql_config=${prefix}/lib/mysql82/bin/mysql_config
-    }
-
-    variant mariadb10_4 conflicts mysql8 mysql81 mysql82 mariadb10_5 mariadb10_6 mariadb10_10 mariadb10_11 \
-        description {build with mariadb-10.4 port} {
-        depends_lib-append      port:mariadb-10.4
-        configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.4/bin/mysql_config
-    }
-
-    variant mariadb10_5 conflicts mysql8 mysql81 mysql82 mariadb10_4 mariadb10_6 mariadb10_10 mariadb10_11 \
-        description {build with mariadb-10.5 port} {
-        depends_lib-append      port:mariadb-10.5
-        configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.5/bin/mysql_config
-    }
-
-    variant mariadb10_6 conflicts mysql8 mysql81 mysql82 mariadb10_4 mariadb10_5 mariadb10_10 mariadb10_11 \
-        description {build with mariadb-10.6 port} {
-        depends_lib-append      port:mariadb-10.6
-        configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.6/bin/mysql_config
-    }
-
-    variant mariadb10_10 conflicts mysql8 mysql81 mysql82 mariadb10_4 mariadb10_5 mariadb10_6 mariadb10_11 \
-        description {build with mariadb-10.10 port} {
-        depends_lib-append      port:mariadb-10.10
-        configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.10/bin/mysql_config
-    }
-
-    variant mariadb10_11 conflicts mysql8 mysql81 mysql82 mariadb10_4 mariadb10_5 mariadb10_6 mariadb10_10 \
-        description {build with mariadb-10.11 port} {
-        depends_lib-append      port:mariadb-10.11
-        configure.args-append   --mysql_config=${prefix}/lib/mariadb-10.11/bin/mysql_config
-    }
-
-    variant percona conflicts mysql8 mysql81 mysql82 mariadb10_4 mariadb10_5 mariadb10_6 mariadb10_10 mariadb10_11 \
-        description {build with percona port} {
-        depends_lib-append      port:percona
-        configure.args-append   --mysql_config=${prefix}/lib/percona/bin/mysql_config
-    }
-
-    if {   ![variant_isset mysql8]
-        && ![variant_isset mysql81]
-        && ![variant_isset mysql82]
-        && ![variant_isset mariadb10_4]
-        && ![variant_isset mariadb10_5]
-        && ![variant_isset mariadb10_6]
-        && ![variant_isset mariadb10_10]
-        && ![variant_isset mariadb10_11]
-        && ![variant_isset percona]
-    } {
-        if {${os.major} > 12} {
-            default_variants +mysql8
-        } else {
-            default_variants +mariadb10_6
+    # loop over the array creating the specified variants
+    # with the multiple versioning change, the conflicts lists no longer apepears
+    # to be enforced, so this will be handled later in the pre-fetch stage with
+    # active_vaiants.  The conflicts list is left here so the user gets the approprate
+    # warning when running port variant
+    foreach variant_name [array names db_variants] {
+        set idx [lsearch [array names db_variants] $variant_name]
+        set conflict_list [lreplace [array names db_variants] $idx $idx]
+        variant $variant_name conflicts $conflict_list description "build with $variant_name" {}
+        if {[variant_isset $variant_name]} {
+            set active_conflicts $conflict_list
         }
+    }
+
+    # add the build dependencies, this must be done outside the variant call to work
+    foreach variant_name [array names db_variants] {
+        set reqPort            [lindex [array get db_variants $variant_name] 1]
+
+        if {$reqPort eq ""} {set reqPort $variant_name}
+
+        if { ([variant_exists $variant_name] && [variant_isset $variant_name])} {
+            depends_lib-append      port:$reqPort
+            configure.args-append   --mysql_config=${prefix}/lib/$reqPort/bin/mysql_config
+        }
+    }
+}
+
+# Use active_variants to enforce that only one variant can be installed at any given time
+pre-fetch {
+    if {![catch {set result [active_variants p${perl5.major}-dbd-mysql $active_conflicts ""]}]} {
+        ui_error "
+            ****
+            **** p${perl5.major}-dbd-mysql can only have one active variant installed
+            **** If you need this vaiant, deactivate the previously installed one with
+            ****     port deactivate p${perl5.major}-dbd-mysql
+            **** or uninstall is with
+            ****     sudo port uninstall p${perl5.major}-dbd-mysql
+            ****"
+        error "Error: p${perl5.major}-dbd-mysql variant already installed"
     }
 }


### PR DESCRIPTION
  Update the Portfile to reduce the redundant work needed to update
  variants.

  Additionally, in version >5 support for databases other than the
  mysql8x was dropped.  Fix broken mariadb and percona variants by
  pointing them to an older version (4). These versions will need to
  be pruned when they go EOL.  Mariadb based ports should start to
  migrate to using p5-dbd-mariadb

#### Description

Basically, the old portfile was very manually intensive to update leading to lots of place where a small detail could be missed causing errors.  This update automates many of those issues.

Additionally, DBD:mysql versions greater than 5 no longer support SQL variants other than mysql8+.  As such, have the portfile install v5+ for mysql8+ variants and install the older v4 for mariadb / percona.

When those versions of mariadb/percona retire, this workaround should be removed from the portfile.

Users need to suggest to their upstream counterparts to move away from DBD:mysql for mariadb and percona based installs.

Reference [Trac ticket 69359](https://trac.macports.org/ticket/69359) for additional details on how we got here.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.3.1 23D60 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
