### PR TITLE
picotls: fix build on <10.7; install headers, revbump

### DIFF
--- a/net/picotls/Portfile
+++ b/net/picotls/Portfile
@@ -12,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 github.setup        h2o picotls eb013f761bf1dc3da244322d8569f57b33a95178
 version             2024.01.11
-revision            0
+revision            1
 categories          net security
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -60,6 +60,8 @@ compiler.blacklist-append \
 
 destroot {
     move ${cmake.build_dir}/cli ${destroot}${prefix}/bin/picotls_cli
+    copy ${worksrcpath}/include/picotls ${destroot}${prefix}/include
+    copy ${worksrcpath}/include/picotls.h ${destroot}${prefix}/include
     foreach lib {libpicotls-core.a libpicotls-mbedtls.a libpicotls-minicrypto.a libpicotls-openssl.a} {
         copy ${cmake.build_dir}/${lib} ${destroot}${prefix}/lib
     }

--- a/net/picotls/Portfile
+++ b/net/picotls/Portfile
@@ -2,8 +2,13 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.1
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
+
+# Need O_CLOEXEC
+legacysupport.newest_darwin_requires_legacy 10
 
 github.setup        h2o picotls eb013f761bf1dc3da244322d8569f57b33a95178
 version             2024.01.11
@@ -48,6 +53,10 @@ configure.args-append \
                     -DWITH_AEGIS=OFF \
                     -DWITH_DTRACE=OFF \
                     -DWITH_MBEDTLS=ON
+
+# https://github.com/h2o/picotls/issues/505
+compiler.blacklist-append \
+                    *gcc-4.* {clang < 500}
 
 destroot {
     move ${cmake.build_dir}/cli ${destroot}${prefix}/bin/picotls_cli


### PR DESCRIPTION
#### Description

Somehow this was missed last time. Fix it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
