### PR TITLE
jemalloc-devel: update to 2024.02.16

### DIFF
--- a/devel/jemalloc/Portfile
+++ b/devel/jemalloc/Portfile
@@ -33,20 +33,20 @@ if {${subport} eq ${name}} {
 }
 
 subport jemalloc-devel {
-    github.setup        jemalloc jemalloc f96010b7fa8ce5f83802144bdebf2bb7a6679649
-    version             2024.01.24
+    github.setup        jemalloc jemalloc 1aba4f41a3fef53fa913e655444dbba53a0c82df
+    version             2024.02.16
     conflicts           jemalloc
-    checksums           rmd160  803128a4cd13f06e708023b832dff33c2c014f11 \
-                        sha256  876c695ce41da086461b6a4585d3788edcec890a8ce355a832a4f4ee7fae2583 \
-                        size    834513
+    checksums           rmd160  07d83abdd0a3985f77458d4d6f7d10c1dacb1ad4 \
+                        sha256  172be6ff5538281b8073057c579f7182e698691da1d7fd65e5aee3a0df1da1a5 \
+                        size    834502
     github.tarball_from archive
 
     use_autoreconf      yes
 }
 
-compiler.cxx_standard 2014
+compiler.cxx_standard   2014
 
-configure.args-append --with-jemalloc-prefix=
+configure.args-append   --with-jemalloc-prefix=
 
 # provide a compatibility symlink with the older name
 post-destroot {


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
