### PR TITLE
python portgroup: Support prefix with sym links

### DIFF
--- a/_resources/port1.0/group/python-1.0.tcl
+++ b/_resources/port1.0/group/python-1.0.tcl
@@ -304,8 +304,14 @@ proc python_set_versions {option action args} {
         }
         post-destroot {
             if {${python.link_binaries}} {
-                foreach bin [glob -nocomplain -tails -directory "${destroot}${python.prefix}/bin" *] {
+                ui_msg "Do python.link_binaries:"
+                ui_msg "  \$destroot         = ${destroot}"
+                ui_msg "  \$python.prefix    = ${python.prefix}"
+                ui_msg "  \$python.absprefix = ${python.absprefix}"
+                foreach bin [glob -nocomplain -tails -directory "${destroot}${python.absprefix}/bin" *] {
+                    ui_msg "    \$bin = ${bin}"
                     if {[catch {file type "${destroot}${prefix}/bin/${bin}${python.link_binaries_suffix}"}]} {
+                        ui_msg "      Creating link: ${destroot}${prefix}/bin/${bin}${python.link_binaries_suffix}"
                         ln -s "${python.prefix}/bin/${bin}" "${destroot}${prefix}/bin/${bin}${python.link_binaries_suffix}"
                     }
                 }
@@ -337,7 +343,12 @@ options python.branch python.prefix python.bin python.lib python.libdir \
         python.test_framework python.add_dependencies
 # for pythonXY, python.branch is X.Y, for pythonXYZ, it's X.YZ
 default python.branch   {[string index ${python.version} 0].[string range ${python.version} 1 end]}
-default python.prefix   {${frameworks_dir}/Python.framework/Versions/${python.branch}}
+
+# Need a normalized python.prefix, in case frameworks_dir has a sym link.
+set     frameworks_abs   [file normalize ${frameworks_dir}]
+default python.prefix    {${frameworks_dir}/Python.framework/Versions/${python.branch}}
+default python.absprefix {${frameworks_abs}/Python.framework/Versions/${python.branch}}
+
 default python.bin      {${python.prefix}/bin/python${python.branch}}
 default python.lib      {${python.prefix}/Python}
 default python.pkgd     {${python.prefix}/lib/python${python.branch}/site-packages}


### PR DESCRIPTION
#### Description

* Python portgroup:  Fix python port builds when custom prefix contains sym links.
* Specifically, fix operational sym links in $prefix/bin.
* Print diagnostics for created sym links.
* Closes https://trac.macports.org/ticket/69327

###### Type(s)

- [x] bugfix

###### Tested on

macOS 12.7.3 21H1015 x86_64
Xcode 14.2 / Command Line Tools 14.2.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] tried a full install of a sample port with many python dependencies, with port -vs install?
- [x] tested basic functionality of newly provided operational sym links?
