### PR TITLE
corsixth: new port (version 0.67)

### DIFF
--- a/games/corsixth/Portfile
+++ b/games/corsixth/Portfile
@@ -1,0 +1,50 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake   1.1
+PortGroup           github  1.0
+
+github.setup        CorsixTH CorsixTH 0.67 v
+github.tarball_from archive
+name                corsixth
+revision            0
+
+description         Open source clone of Theme Hospital
+
+long_description    \
+    A reimplementation of the 1997 Bullfrog business sim Theme Hospital. As \
+    well as faithfully recreating the original, CorsixTH adds support for \
+    modern operating systems, high resolutions and much more.
+
+categories          games
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  e2fae0dae75d3a9103e5be64372d50fe050c54e5 \
+                    sha256  4e88cf1916bf4d7c304b551ddb91fb9194f110bad4663038ca73d31b939d69e3 \
+                    size    4127698
+
+patchfiles-append   patch-cmakelists.txt.diff
+
+cmake.install_prefix \
+                    ${applications_dir}
+
+depends_lib-append  \
+                    path:lib/freetype.dylib:freetype \
+                    path:lib/libiconv.2.dylib:libiconv \
+                    path:lib/libavcodec.dylib:ffmpeg \
+                    port:bzip2 \
+                    port:libsdl2 \
+                    port:libsdl2_mixer \
+                    port:lua53 \
+                    port:lua53-luafilesystem \
+                    port:lua53-lpeg \
+                    port:zlib
+
+notes "
+    CorixTH is now available in your Applications/MacPorts directory (${applications_dir})
+
+    You will also need a copy of the game data from the original Theme Hospital game.
+"

--- a/games/corsixth/files/patch-cmakelists.txt.diff
+++ b/games/corsixth/files/patch-cmakelists.txt.diff
@@ -1,0 +1,10 @@
+--- CorsixTH/CMakeLists.txt	2024-02-19 15:05:06
++++ CorsixTH/CMakeLists.txt	2024-02-19 15:05:35
+@@ -293,7 +293,6 @@
+     install(CODE "
+       INCLUDE(BundleUtilities)
+       SET(BU_CHMOD_BUNDLE_ITEMS ON)
+-      FIXUP_BUNDLE(\"${CMAKE_INSTALL_PREFIX}/CorsixTH.app\" \"\" \"\")
+       ")
+     if(WITH_LUAROCKS)
+       install(CODE "execute_process(


### PR DESCRIPTION
Open source clone of the Bullfrog Theme Hospital Game (1997)
https://github.com/CorsixTH/CorsixTH

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
