### PR TITLE
duckdb: unbreak 0.10.0 for < 10.7

### DIFF
--- a/databases/duckdb/Portfile
+++ b/databases/duckdb/Portfile
@@ -32,7 +32,8 @@ checksums           rmd160  692c7857b78c53486dc06d1327c5a00b9ea44dbb \
                     size    79037968
 
 patchfiles-append   no-ccache.patch \
-                    no-default-tarball-version.patch
+                    no-default-tarball-version.patch \
+                    fix-libproc-for-older-macOS.patch
 
 configure.args-append \
                     -DBUILD_PARQUET_EXTENSION=TRUE \

--- a/databases/duckdb/files/fix-libproc-for-older-macOS.patch
+++ b/databases/duckdb/files/fix-libproc-for-older-macOS.patch
@@ -1,0 +1,48 @@
+From 16acae07aebc8259dd21551f19d355f15c61dd99 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 20 Feb 2024 06:50:32 +0800
+Subject: [PATCH] local_file_system.cpp: minor fix for macOS libproc code
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Recent commit has broken duckdb build on macOS < 10.7: https://github.com/duckdb/duckdb/commit/23112e9aa344905c2d2a0d1cb696c5f73c329534
+Add a fallback to fix it.
+See also get_ppid_of.c in gettext’s libtextstyle.
+---
+ src/common/local_file_system.cpp | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git src/common/local_file_system.cpp src/common/local_file_system.cpp
+index bbca902a28..14903303e6 100644
+--- src/common/local_file_system.cpp
++++ src/common/local_file_system.cpp
+@@ -188,6 +188,8 @@ static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
+ 	}
+ 
+ 	string process_name, process_owner;
++// macOS >= 10.7 has PROC_PIDT_SHORTBSDINFO
++#if defined PROC_PIDT_SHORTBSDINFO
+ 	// try to find out more about the process holding the lock
+ 	struct proc_bsdshortinfo proc;
+ 	if (proc_pidinfo(pid, PROC_PIDT_SHORTBSDINFO, 0, &proc, PROC_PIDT_SHORTBSDINFO_SIZE) ==
+@@ -199,6 +201,19 @@ static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
+ 			process_owner = pw->pw_name;
+ 		}
+ 	}
++#else
++// Fallback code for older versions
++	// try to find out more about the process holding the lock
++	struct proc_bsdinfo proc;
++	if (proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &proc, 128) == 128) {
++		process_name = proc.pbi_comm; // only a short version however, let's take it in case proc_pidpath() below fails
++		// try to get actual name of conflicting process owner
++		auto pw = getpwuid(proc.pbi_uid);
++		if (pw) {
++			process_owner = pw->pw_name;
++		}
++	}
++#endif
+ 	// try to get a better process name (full path)
+ 	char full_exec_path[PROC_PIDPATHINFO_MAXSIZE];
+ 	if (proc_pidpath(pid, full_exec_path, PROC_PIDPATHINFO_MAXSIZE) > 0) {


### PR DESCRIPTION
#### Description

Recent version has been broken by https://github.com/duckdb/duckdb/commit/23112e9aa344905c2d2a0d1cb696c5f73c329534
Add a fallback.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

macOS 14.3.1 (just to make sure nothing got broken)
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
