### PR TITLE
jsoncons: skip a few tests with libstdc++, fix 32-bit

### DIFF
--- a/devel/jsoncons/Portfile
+++ b/devel/jsoncons/Portfile
@@ -19,4 +19,15 @@ checksums               rmd160  4861f8442599537fe6b001673474250366ae8043 \
                         sha256  3e3525325c88b33f15af2e1f3cf7a1893a49e47aa787a2df723a098b3a4b20b1 \
                         size    1422526
 
+compiler.cxx_standard   2011
+
+# https://github.com/danielaparker/jsoncons/issues/488
+if {${configure.cxx_stdlib} ne "libc++"} {
+    patchfiles-append   patch-disable-broken-tests.diff
+}
+# Should be build_arch here, not configure.build_arch:
+if {${build_arch} in [list arm i386 ppc]} {
+    patchfiles-append   patch-32-bit.diff
+}
+
 test.run                yes

--- a/devel/jsoncons/files/patch-32-bit.diff
+++ b/devel/jsoncons/files/patch-32-bit.diff
@@ -1,0 +1,11 @@
+--- test/CMakeLists.txt	2024-02-05 05:59:37.000000000 +0800
++++ test/CMakeLists.txt	2024-02-20 08:26:06.000000000 +0800
+@@ -199,7 +198,7 @@
+     message(STATUS Version " ${CMAKE_CXX_COMPILER_VERSION}")
+     # older GCC versions don't support 
+    target_compile_options(unit_tests PRIVATE
+-       $<$<CXX_COMPILER_ID:GNU>:-Wnon-virtual-dtor -Werror=stringop-overflow -Werror -Wall -Wextra -Wcast-align -Wcast-qual -Wimplicit-fallthrough -Wsign-compare -pedantic -Wnonnull -Werror=nonnull>
++       $<$<CXX_COMPILER_ID:GNU>:-Wnon-virtual-dtor -Werror=stringop-overflow -Wall -Wextra -Wcast-align -Wcast-qual -Wimplicit-fallthrough -Wsign-compare -pedantic -Wnonnull -Werror=nonnull>
+    )
+ endif()
+ 

--- a/devel/jsoncons/files/patch-disable-broken-tests.diff
+++ b/devel/jsoncons/files/patch-disable-broken-tests.diff
@@ -1,0 +1,73 @@
+--- test/CMakeLists.txt	2024-02-05 05:59:37.000000000 +0800
++++ test/CMakeLists.txt	2024-02-20 09:25:47.000000000 +0800
+@@ -65,7 +65,6 @@
+                bson/src/bson_decimal128_tests.cpp
+                bson/src/bson_oid_tests.cpp
+                bson/src/bson_test_suite.cpp
+-               bson/src/encode_decode_bson_tests.cpp
+                cbor/src/cbor_bitset_traits_tests.cpp
+                cbor/src/cbor_cursor_tests.cpp
+                cbor/src/cbor_event_reader_tests.cpp
+@@ -75,7 +74,6 @@
+                cbor/src/cbor_tests.cpp
+                cbor/src/cbor_typed_array_tests.cpp
+                cbor/src/decode_cbor_tests.cpp
+-               cbor/src/encode_cbor_tests.cpp
+                csv/src/csv_cursor_tests.cpp
+                csv/src/csv_subfield_tests.cpp
+                csv/src/csv_tests.cpp
+@@ -96,16 +94,13 @@
+                jsonpath/src/jsonpath_json_replace_tests.cpp
+                jsonpath/src/jsonpath_select_paths_tests.cpp
+                jsonpath/src/jsonpath_test_suite.cpp
+-               jsonpath/src/jsonpath_stateful_allocator_tests.cpp
+                jsonpointer/src/jsonpointer_flatten_tests.cpp
+-               jsonpointer/src/jsonpointer_tests.cpp
+                jsonschema/src/format_validator_tests.cpp
+                jsonschema/src/jsonschema_defaults_tests.cpp
+                jsonschema/src/jsonschema_output_format_tests.cpp
+                jsonschema/src/jsonschema_draft7_tests.cpp
+                jsonschema/src/schema_version_tests.cpp
+                msgpack/src/decode_msgpack_tests.cpp
+-               msgpack/src/encode_msgpack_tests.cpp
+                msgpack/src/msgpack_bitset_traits_tests.cpp
+                msgpack/src/msgpack_cursor_tests.cpp
+                msgpack/src/msgpack_event_reader_tests.cpp
+@@ -125,7 +120,6 @@
+                corelib/src/double_round_trip_tests.cpp
+                corelib/src/double_to_string_tests.cpp
+                corelib/src/dtoa_tests.cpp
+-               corelib/src/encode_decode_json_tests.cpp
+                corelib/src/encode_traits_tests.cpp
+                corelib/src/error_recovery_tests.cpp
+                corelib/src/json_array_tests.cpp
+@@ -145,7 +139,6 @@
+                corelib/src/json_line_split_tests.cpp
+                corelib/src/json_literal_operator_tests.cpp
+                corelib/src/json_object_tests.cpp
+-               corelib/src/ojson_object_tests.cpp
+                corelib/src/json_options_tests.cpp
+                corelib/src/json_parse_error_tests.cpp
+                corelib/src/json_parser_position_tests.cpp
+@@ -153,7 +146,6 @@
+                corelib/src/json_proxy_tests.cpp
+                corelib/src/json_push_back_tests.cpp
+                corelib/src/json_reader_exception_tests.cpp
+-               corelib/src/json_reader_tests.cpp
+                corelib/src/json_storage_tests.cpp
+                corelib/src/json_swap_tests.cpp
+                corelib/src/json_traits_macro_functional_tests.cpp
+@@ -173,13 +165,10 @@
+                corelib/src/source_tests.cpp
+                corelib/src/staj_iterator_tests.cpp
+                corelib/src/extension_traits_tests.cpp
+-               corelib/src/polymorphic_allocator_tests.cpp
+-               corelib/src/scoped_allocator_adaptor_tests.cpp
+                corelib/src/string_to_double_tests.cpp
+                corelib/src/unicode_conv_tests.cpp
+                corelib/src/wjson_tests.cpp
+                ubjson/src/decode_ubjson_tests.cpp
+-               ubjson/src/encode_ubjson_tests.cpp
+                ubjson/src/ubjson_cursor_tests.cpp
+                ubjson/src/ubjson_encoder_tests.cpp
+                corelib/src/testmain.cpp


### PR DESCRIPTION
#### Description

This is a header-only port, but it is set to build tests by default. A number of tests are broken on systems using `libstdc++`.
Also `-Werror` breaks 32-bit build.
Fix both issues.

There is no change to the headers, only conditional skipping of broken tests and dropping of `-Werror` on 32-bit archs.

Remaining tests appear to pass.

Discussion with upstream: https://github.com/danielaparker/jsoncons/issues/488

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
