### PR TITLE
ldns, drill: Add mutual conflicts

### DIFF
--- a/net/drill/Portfile
+++ b/net/drill/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl     1.0
 
 github.setup        fcsonline drill 0.8.3
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Drill is an HTTP load testing application written in Rust \
                     inspired by Ansible syntax
@@ -23,6 +23,8 @@ installs_libs       no
 license             GPL-3
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
+
+conflicts           ldns
 
 checksums           ${distname}${extract.suffix} \
                     rmd160  4c194ae9e1a93cb5daf39cb18f77f6539e1571d2 \

--- a/net/ldns/Portfile
+++ b/net/ldns/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                ldns
 
 version             1.8.3
-revision            0
+revision            1
 categories          net devel
 platforms           darwin
 license             BSD
@@ -20,6 +20,8 @@ if {${subport} eq ${name}} {
 
 homepage            https://www.nlnetlabs.nl/projects/ldns/about/
 master_sites        https://www.nlnetlabs.nl/downloads/ldns/
+
+conflicts           drill
 
 checksums           rmd160  0951e40118dc7c48997e157f5ecd20095f6c1f40 \
                     sha256  c3f72dd1036b2907e3a56e6acf9dfb2e551256b3c1bbd9787942deeeb70e7860 \


### PR DESCRIPTION
#### Description

Both `ldns` and `drill` install a command-line utility `drill`.

##### Tested on

macOS 14.3.1 23D60 arm64
Xcode 15.1 15C65

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
