### PR TITLE
py-cvskit: add support for py312 (also dependencies)

### DIFF
--- a/python/py-agate-dbf/Portfile
+++ b/python/py-agate-dbf/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  8dfd67b33db6ed8b9d474cb04abf2e30fbeb6cf7 \
                     sha256  589682b78c5c03f2dc8511e6e3edb659fb7336cd118e248896bb0b44c2f1917b \
                     size    2863
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-agate-excel/Portfile
+++ b/python/py-agate-excel/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  3afd4d0df268d1742b5248b105a9c206171aea35 \
                     sha256  62315708433108772f7f610ca769996b468a4ead380076dbaf6ffe262831b153 \
                     size    161131
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-agate-sql/Portfile
+++ b/python/py-agate-sql/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  11e6b3b8198585aa1b2e1bd8b023ef3ec9b8c013 \
                     sha256  581e062ae878cc087d3d0948670d46b16589df0790bf814524b0587a359f2ada \
                     size    15182
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-agate/Portfile
+++ b/python/py-agate/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  f217d911e0cdcf28fb3c90901cae1f1bb5e071ed \
                     sha256  e0f2f813f7e12311a4cdccc97d6ba0a6781e9c1aa8eca0ab00d5931c0113a308 \
                     size    202102
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-csvkit/Portfile
+++ b/python/py-csvkit/Portfile
@@ -26,7 +26,7 @@ checksums           rmd160  e5c6c9829f98ea9fac4b59057a8df8566c342083 \
                     sha256  beddb7b78f6b22adbed6ead5ad5de4bfb31dd2c55f3211b2a2b3b65529049223 \
                     size    3792699
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-agate \

--- a/python/py-csvkit/files/py312-csvkit
+++ b/python/py-csvkit/files/py312-csvkit
@@ -1,0 +1,11 @@
+bin/csvclean-3.12
+bin/csvcut-3.12
+bin/csvgrep-3.12
+bin/csvjoin-3.12
+bin/csvjson-3.12
+bin/csvlook-3.12
+bin/csvsort-3.12
+bin/csvsql-3.12
+bin/csvstack-3.12
+bin/csvstat-3.12
+bin/in2csv-3.12

--- a/python/py-dbfread/Portfile
+++ b/python/py-dbfread/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  6599d0c691b9047c46ec75842ed380880c595567 \
 
 homepage            https://dbfread.readthedocs.io/
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-leather/Portfile
+++ b/python/py-leather/Portfile
@@ -25,7 +25,7 @@ checksums           rmd160  cdcbef561aacd19bc5ba0d35ec70cf65a1704141 \
                     sha256  b43e21c8fa46b2679de8449f4d953c06418666dc058ce41055ee8a8d3bb40918 \
                     size    30605
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pytimeparse/Portfile
+++ b/python/py-pytimeparse/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  e56358a299e95b6593e39f2b57013a4157a412b0 \
                     sha256  e86136477be924d7e670646a98561957e8ca7308d44841e21f5ddea757556a0a \
                     size    9403
 
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-pytimeparse2/Portfile
+++ b/python/py-pytimeparse2/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  7ee2bc6aae54b69e634d51c37c60017d93ce1eb8 \
                     sha256  98668cdcba4890e1789e432e8ea0059ccf72402f13f5d52be15bdfaeb3a8b253 \
                     size    10431
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-xlrd/Portfile
+++ b/python/py-xlrd/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-xlrd
 version             2.0.1
-python.versions     37 38 39 310 311
+python.versions     37 38 39 310 311 312
 supported_archs     noarch
 platforms           {darwin any}
 maintainers         {snc @nerdling} openmaintainer


### PR DESCRIPTION
#### Description

Add support for Python 3.12 to py-cvskit as well as to its dependencies:
* py-agate
* py-agate-dbf
* py-agate-excel
* py-agate-sql
* py-dbfread
* py-leather
* py-pytimeparse
* py-pytimeparse2
* py-xlrd

No revision bump is needed since the py312-* variant was not available for any of these before, and nothing changes for the existing py*-* variants.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.3.1 23D60 x86_64
Command Line Tools 15.1.0.0.1.1700200546


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
