### PR TITLE
offpunk: update to 2.2

### DIFF
--- a/net/offpunk/Portfile
+++ b/net/offpunk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           sourcehut 1.0
 
-sourcehut.setup     lioploum offpunk 2.0 v
+sourcehut.setup     lioploum offpunk 2.2 v
 revision            0
 categories          net gemini
 license             AGPL
@@ -13,9 +13,9 @@ description         Command-line and offline-first smolnet browser/feed reader f
 long_description    {*}${description}. The goal of Offpunk is to be able to synchronise your content once (a day, a week, a month) \
                     and then browse/organise it while staying disconnected.
 
-checksums           rmd160  052a1086191173b6b0b028648a675ace7e6b928f \
-                    sha256  3d5abb1882fdf6dfd8fce2bbd960f30fd9e49c0619432de883b4ea8e048db56c \
-                    size    228392
+checksums           rmd160  abf647146c681374ea3e2ced819dd6594fd49847 \
+                    sha256  c6afc11bcfc8624f2eb79e97b37987ee3a9b46fe0888a09d86310fd3a7ddb346 \
+                    size    231019
 
 python.default_version 311
 


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
