### PR TITLE
legacy-support: update -devel subport and fix some build/test issues

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -46,13 +46,13 @@ subport ${name} {
 
 subport ${name}-devel {
     conflicts           ${name}
-    github.setup        macports macports-legacy-support 440e79a1235dfe7f8b9ebdc62e20e639bf457006
-    version             20240212
+    github.setup        macports macports-legacy-support 3631c1f36ff8f9e7f284ce4e15be7ea659e8cc1a
+    version             20240220
     revision            0
     livecheck.type      none
-    checksums           rmd160  ddcd35a7ff87c705d45cda3b4d11b19f94a2489d \
-                        sha256  b27c01cd711f8b3bf7d95d0552264d729632a20449f9faabbc6977384bc47fdd \
-                        size    71173
+    checksums           rmd160  2417714d15221eaaaa04ab5f3721eb6fcd83bd12 \
+                        sha256  9c9a394b9e23bb256103cf2a343be4e0d227174b14966125cc9fbf7395687b49 \
+                        size    71438
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
 }

--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -61,6 +61,14 @@ subport ${name}-devel {
 # https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/141962/steps/install-port/logs/stdio
 use_parallel_build  no
 
+# This port doesn't use C++ at all, except for a couple of tests which may
+# fail to build with an non-OS-default stdlib setting.  Since the cxx_stdlib
+# selection is unimportant for the tests (which are actually only testing
+# the C-only interface to the library), we disable the cxx_stlib setting.
+# This also avoids depending on a MacPorts compiler in some OS versions.
+
+configure.cxx_stdlib
+
 post-extract {
     # until upstream can be fixed, do not include atexit symbols
     # under certain circumstances, infinite recursive loops can form

--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -111,20 +111,41 @@ proc tiger_copy {from to} {
     }
 }
 
-# The legacy-support build cannot create the LegacySupportSystem library directly
-# on newer systems as the reexport link option to /usr/lib/libSystem.B.dylib
-# does not work, due to the file system library cache added in macOS11.
-# Fallback to using optool here. Optool also currently not working on arm.
-if { ${build_arch} ne "arm64" && ${os.major} > ${max_darwin_reexport} && ${os.major} <= ${max_darwin_optool} } {
-    depends_build-append port:optool
+# The legacy-support build cannot create the LegacySupportSystem library
+# directly on newer systems as the reexport link option to
+# /usr/lib/libSystem.B.dylib does not work, due to the file system
+# library cache added in macOS11.
+#
+# Fall back to using optool here. Optool does not currently work on arm64.
+# This means that LegacySupportSystem will be missing on arm64, and that
+# universal builds of LegacySupportSystem will lack the arm64 slice
+# (which will produce a warning).
+
+if { ${os.major} > ${max_darwin_reexport}
+     && ${os.major} <= ${max_darwin_optool} } {
+     # First determine whether any non-arm64 slice will be built
+    set optool_needed no
+    foreach arch ${muniversal.architectures} {
+        if { ${arch} ne "arm64"} {
+            set optool_needed yes
+        }
+    }
+    # If any non-arm64, add optool dependency
+    if { ${optool_needed} } {
+        depends_build-append port:optool
+        depends_skip_archcheck-append optool
+    }
+    # After destroot, apply optool to any non-arm64 slice
     post-destroot {
-        set legSupp   ${prefix}/lib/libMacportsLegacySupport.dylib
-        set legSystem ${prefix}/lib/libMacportsLegacySystem.B.dylib
-        if {![file exists ${destroot}${legSystem}]} {
-            copy ${destroot}${legSupp} ${destroot}${legSystem}
-            system "${prefix}/bin/optool install -c reexport -p /usr/lib/libSystem.B.dylib -t ${destroot}${legSystem}"
-        } else {
-            ui_warn "${destroot}${legSystem} already exists."
+        if { ${muniversal.build_arch} ne "arm64" } {
+            set legSupp   ${prefix}/lib/libMacportsLegacySupport.dylib
+            set legSystem ${prefix}/lib/libMacportsLegacySystem.B.dylib
+            if {![file exists ${destroot}${legSystem}]} {
+                copy ${destroot}${legSupp} ${destroot}${legSystem}
+                system "${prefix}/bin/optool install -c reexport -p /usr/lib/libSystem.B.dylib -t ${destroot}${legSystem}"
+            } else {
+                ui_warn "${destroot}${legSystem} already exists."
+            }
         }
     }
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

This has three commits - one to fix the 11.x +universal build, one to fix the 10.6-10.8 test build failures, and one to update the -devel subport to the latest master.  See the individual commit messages for more details.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.3 21H1015, x86_64, Xcode 14.2 14C18
macOS 12.7.3 21H1015, arm64, Xcode 14.2 14C18
macOS 13.6.4 22G513, arm64, Xcode 15.2 15C500b
macOS 14.3.1 23D60, arm64, Xcode 15.2 15C500b
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
