### PR TITLE
miniflux: update to 2.1.0

### DIFF
--- a/net/miniflux/Portfile
+++ b/net/miniflux/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/miniflux/v2 2.0.51 v
+go.setup            github.com/miniflux/v2 2.1.0
 go.package          miniflux.app/v2
 go.offline_build    no
 name                miniflux
@@ -18,9 +18,9 @@ description         Minimalist and opinionated feed reader
 long_description    {*}${description}
 homepage            https://miniflux.app
 
-checksums           rmd160  5ce799c191c1df6b85445d2b834f462ba5f5dad5 \
-                    sha256  1ff67a55451994c0211c1e6c9a7a84ca62d23be30497cfabe16eda0703c8de18 \
-                    size    493360
+checksums           rmd160  af08dcb7ed0ad028170cdbe990858261dda0cf5d \
+                    sha256  ea16999d4bae2db59850fbb58299b1aa96100fd64d69ab2dd1745401962ee4ac \
+                    size    505799
 
 build.args-append   \
     -ldflags=\"-s -w -X \


### PR DESCRIPTION
#### Description
https://github.com/miniflux/v2/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.3 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
