### PR TITLE
libcommuni: update to 3.7.0 and Qt5 for newer systems; communi-desktop: new port in IRC

### DIFF
--- a/devel/libcommuni/Portfile
+++ b/devel/libcommuni/Portfile
@@ -2,41 +2,81 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
-PortGroup           qmake 1.0
 
-# Please do not upgrade unless these are fixed:
-# https://github.com/communi/libcommuni/issues/117
-# https://github.com/communi/libcommuni/issues/118
-github.setup        communi libcommuni 3.6.0 v
-revision            0
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    PortGroup       qmake 1.0
+
+    # Please do not upgrade unless these are fixed:
+    # https://github.com/communi/libcommuni/issues/117
+    # https://github.com/communi/libcommuni/issues/118
+    github.setup    communi libcommuni 3.6.0 v
+    revision        1
+    checksums       rmd160  e689974400c25446a94280e5805f14f88a49c37e \
+                    sha256  c598e4ec23211f58bcb8dd3a9905a45d38c02f4c5c17cfc27cf724cd7b3edb9c \
+                    size    472634
+
+    # For w/e reason, clang pre-processor cannot handle this:
+    if {[string match *clang* ${configure.compiler}]} {
+        patchfiles-append patch-irccore_p.h.diff
+    }
+
+    pre-configure {
+        system -W ${worksrcpath} "${qt_lrelease_cmd} ${name}.pro"
+    }
+
+    set communiplugin_dir   ${qt_imports_dir}
+
+} else {
+    PortGroup       qmake5 1.0
+
+    github.setup    communi libcommuni 3.7.0 v
+    revision        0
+    checksums       rmd160  26a03135c661d05a31737788586c42271c7974fa \
+                    sha256  28f315992d90c2f915d7a41da313050d1f74fc7a98cce265ee2722e3775e3675 \
+                    size    475364
+
+    qt5.depends_component   qtdeclarative
+
+    set communiplugin_dir   ${qt_qml_dir}
+}
 
 categories          devel net irc
 license             BSD
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 
-description         Cross-platform IRC framework for Qt 
+description         Cross-platform IRC framework for Qt
 long_description    {*}${description}
 homepage            https://communi.github.io
 
 github.tarball_from archive
-checksums           rmd160  e689974400c25446a94280e5805f14f88a49c37e \
-                    sha256  c598e4ec23211f58bcb8dd3a9905a45d38c02f4c5c17cfc27cf724cd7b3edb9c \
-                    size    472634
 
-depends_lib-append  port:qt4-mac \
-                    port:uchardet
-
-# For w/e reason, clang pre-processor cannot handle this:
-if {[string match *clang* ${configure.compiler}]} {
-    patchfiles-append patch-irccore_p.h.diff
-}
-
-pre-configure {
-    system -W ${worksrcpath} "${qt_lrelease_cmd} ${name}.pro"
-}
+depends_lib-append  port:uchardet
 
 # Install normal dylibs:
 configure.args-append \
                     -config qt_no_framework
 
 compiler.cxx_standard 2011
+
+post-destroot {
+    # Fix libs:
+    foreach dylib [exec find ${destroot}${qt_libs_dir} -name "\*.dylib"] {
+        regsub ":$" ${dylib} "" destroot_dylib_path
+        regsub ${destroot} ${destroot_dylib_path} "" dylib_path
+        system "install_name_tool -id ${dylib_path} ${destroot_dylib_path}"
+        system "install_name_tool -change libIrcCore.3.dylib ${qt_libs_dir}/libIrcCore.3.dylib \
+            ${destroot_dylib_path}"
+        system "install_name_tool -change libIrcModel.3.dylib ${qt_libs_dir}/libIrcModel.3.dylib \
+            ${destroot_dylib_path}"
+        system "install_name_tool -change libIrcUtil.3.dylib ${qt_libs_dir}/libIrcUtil.3.dylib \
+            ${destroot_dylib_path}"
+    }
+
+    # Fix the plugin:
+    system "install_name_tool -id ${communiplugin_dir}/Communi/libcommuniplugin.dylib \
+            ${destroot}${communiplugin_dir}/Communi/libcommuniplugin.dylib"
+    foreach irclib [list libIrcCore.3.dylib libIrcModel.3.dylib libIrcUtil.3.dylib] {
+        system "install_name_tool -change ${irclib} ${qt_libs_dir}/${irclib} \
+            ${destroot}${communiplugin_dir}/Communi/libcommuniplugin.dylib"
+    }
+}

--- a/irc/communi-desktop/Portfile
+++ b/irc/communi-desktop/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           qmake5 1.0
+
+# FIXME: support for Qt4 has been dropped in 3.2.0:
+# https://github.com/communi/communi-desktop/commit/1414cb8c8a0e6a60bee5e1b7bd808cff18fc549d
+# Find a version which works with Qt4.
+github.setup        communi communi-desktop 512df86ef749cd9f45fc9bbc264f52a5374941b5
+version             2022.08.14
+revision            0
+
+categories          irc
+license             BSD
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+
+description         IRC client for desktop environments
+long_description    {*}${description}
+homepage            https://communi.github.io
+
+fetch.type          git
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init"
+}
+
+patchfiles-append   0001-Fix-install-paths.patch
+
+post-patch {
+    reinplace "s|@APPDIR@|${applications_dir}|" ${worksrcpath}/features/communi_installs.prf
+    reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/features/communi_installs.prf
+}
+
+depends_lib-append  port:libcommuni
+
+compiler.cxx_standard 2011
+
+configure.args-append \
+                    -config qt_no_framework

--- a/irc/communi-desktop/files/0001-Fix-install-paths.patch
+++ b/irc/communi-desktop/files/0001-Fix-install-paths.patch
@@ -1,0 +1,44 @@
+From 15c942c8d5432b6804e5b6410dae2cfb483d84cc Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 23 Feb 2024 09:09:58 +0800
+Subject: [PATCH] Fix install paths
+
+---
+ features/communi_installs.prf | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git features/communi_installs.prf features/communi_installs.prf
+index a976ba3e..36fecb6a 100644
+--- features/communi_installs.prf
++++ features/communi_installs.prf
+@@ -21,8 +21,8 @@ isEmpty(COMMUNI_INSTALL_THEMES): \
+ isEmpty(COMMUNI_INSTALL_BINS) {
+     !isEmpty(COMMUNI_INSTALL_PREFIX):COMMUNI_INSTALL_BINS = $$COMMUNI_INSTALL_PREFIX/bin
+     else:win32:COMMUNI_INSTALL_BINS = $$[QT_INSTALL_BINS]
+-    else:mac:COMMUNI_INSTALL_BINS = /Applications
+-    else:COMMUNI_INSTALL_BINS = /usr/bin
++    else:mac:COMMUNI_INSTALL_BINS = @APPDIR@
++    else:COMMUNI_INSTALL_BINS = @PREFIX@/bin
+ }
+ 
+ isEmpty(COMMUNI_INSTALL_LIBS) {
+@@ -39,16 +39,16 @@ isEmpty(COMMUNI_INSTALL_PLUGINS) {
+ 
+ isEmpty(COMMUNI_INSTALL_ICONS) {
+     !isEmpty(COMMUNI_INSTALL_PREFIX):COMMUNI_INSTALL_ICONS = $$COMMUNI_INSTALL_PREFIX/icons
+-    else:COMMUNI_INSTALL_ICONS = /usr/share/icons/hicolor
++    else:COMMUNI_INSTALL_ICONS = @PREFIX@/share/icons/hicolor
+ }
+ 
+ isEmpty(COMMUNI_INSTALL_DESKTOP) {
+     !isEmpty(COMMUNI_INSTALL_PREFIX):COMMUNI_INSTALL_DESKTOP = $$COMMUNI_INSTALL_PREFIX
+-    else:COMMUNI_INSTALL_DESKTOP = /usr/share/applications
++    else:COMMUNI_INSTALL_DESKTOP = @PREFIX@/share/applications
+ }
+ 
+ isEmpty(COMMUNI_INSTALL_THEMES) {
+     !isEmpty(COMMUNI_INSTALL_PREFIX):COMMUNI_INSTALL_THEMES = $$COMMUNI_INSTALL_PREFIX/themes
+     else:win32:COMMUNI_INSTALL_THEMES = $$[QT_INSTALL_BINS]/themes
+-    else:COMMUNI_INSTALL_THEMES = /usr/share/themes/communi
++    else:COMMUNI_INSTALL_THEMES = @PREFIX@/share/themes/communi
+ }


### PR DESCRIPTION
#### Description

1. Update `libcommuni` for newer systems.
2. New port for IRC using `libcommuni`. This one is only for Qt5 now, since I cannot test Qt4 at the moment (and it may not be easily fixable for it too).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
