### PR TITLE
lighttpd: Update to 1.4.74

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -5,11 +5,11 @@ PortGroup                   legacysupport 1.0
 PortGroup                   lua 1.0
 
 name                        lighttpd
-version                     1.4.73
+version                     1.4.74
 revision                    0
-checksums                   rmd160  7524652b92a75f2f536191f6acea1aecf5c05162 \
-                            sha256  818816d0b314b0aa8728a7076513435f6d5eb227f3b61323468e1f10dbe84ca8 \
-                            size    1086680
+checksums                   rmd160  7446348be0f88bfbe9d952cc45e1bb5d7fd4adf6 \
+                            sha256  5c08736e83088f7e019797159f306e88ec729abe976dc98fb3bed71b9d3e53b5 \
+                            size    1098796
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  www
@@ -58,7 +58,7 @@ configure.args-append       CC_FOR_BUILD="${configure.cc}" \
                             ac_cv_prog_AWK=/usr/bin/awk
 
 platform darwin {
-    patchfiles-append       patch-conf-darwin.diff
+    patchfiles-append       patch-conf-darwin.diff patch-build.diff
 
     post-patch {
         if {${os.major} <= 8} {

--- a/www/lighttpd/files/patch-build.diff
+++ b/www/lighttpd/files/patch-build.diff
@@ -1,0 +1,20 @@
+--- src/ls-hpack/lshpack.h.orig
++++ src/ls-hpack/lshpack.h
+@@ -225,6 +225,8 @@ lshpack_dec_set_max_capacity (struct lshpack_dec *, unsigned);
+ #endif
+ #endif
+ 
++#ifndef STAILQ_FOREACH
++
+ #ifndef SIMPLEQ_FOREACH
+ #include "../compat/sys/queue.h"
+ #endif
+@@ -243,6 +245,8 @@ lshpack_dec_set_max_capacity (struct lshpack_dec *, unsigned);
+ #define STAILQ_FOREACH          SIMPLEQ_FOREACH
+ #endif
+ 
++#endif
++
+ #if defined(STAILQ_FIRST) && defined(STAILQ_NEXT) && !defined(STAILQ_FOREACH)
+ #define STAILQ_FOREACH(var, head, field)                                \
+         for((var) = STAILQ_FIRST((head));                               \

--- a/www/lighttpd/files/patch-conf.diff
+++ b/www/lighttpd/files/patch-conf.diff
@@ -90,7 +90,7 @@
  ## -> ..../status-404.html for 'File not found'
  ##
 -#server.errorfile-prefix    = server_root + "/htdocs/errors/status-"
-+#server.errorfile-prefix    = server.document-root + /errors/status-"
++#server.errorfile-prefix    = server.document-root + "/errors/status-"
  
  ##
  ## mimetype mapping


### PR DESCRIPTION
#### Description

lighttpd: Update to 1.4.74

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 11.7

(might need small patch to find ../compat/sys/queue.h)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?