### PR TITLE
octave-gsl: Add missing patchfile

### DIFF
--- a/octave/octave-gsl/Portfile
+++ b/octave/octave-gsl/Portfile
@@ -5,7 +5,6 @@ PortGroup           octave 1.0
 
 octave.setup        sourceforge octave gsl 2.1.1
 revision            8
-platforms           darwin
 license             GPL-2+
 maintainers         {mps @Schamschula} openmaintainer
 description         Octave bindings to the GNU Scientific Library.
@@ -15,7 +14,25 @@ checksums           rmd160  8c434c0a811efd885eac78b91f328f49b3eb668d \
                     sha256  d028c52579e251c3f21ebfdf065dffab3ad7893434efda33b501225ef1ea6ed3 \
                     size    122003
 
+# We patch configure.ac.in.
+use_autoreconf      yes
+autoreconf.dir      ${worksrcpath}/src
+autoreconf.cmd      ./bootstrap
+autoreconf.args
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
+
 depends_lib-append  port:gsl
 
-patchfiles          of-gsl-1-cross-fixes.patch \
+patchfiles          configure.ac.in-return-type.patch \
+                    configure.ac.in-octave_include_dir.patch \
                     patch-src-gsl_sf.cc.diff
+
+platform darwin {
+    # Only needed because we run bootstrap.
+    patchfiles-append \
+                    replace_template.sh-sed.patch
+}

--- a/octave/octave-gsl/files/configure.ac.in-octave_include_dir.patch
+++ b/octave/octave-gsl/files/configure.ac.in-octave_include_dir.patch
@@ -1,0 +1,83 @@
+Fix failure to find octave_include_dir.
+https://savannah.gnu.org/bugs/index.php?61668
+https://hg.octave.org/mxe-octave/file/25a0aca9bbad/src/of-gsl-1-cross-fixes.patch
+--- src/configure.ac.in.orig	2018-07-06 11:04:59.199071174 -0400
++++ src/configure.ac.in	2018-07-06 12:16:06.825679865 -0400
+@@ -28,24 +28,23 @@
+ AC_PATH_PROG([MKOCTFILE],[mkoctfile])
+ test -z "$MKOCTFILE" && AC_MSG_ERROR([mkoctfile not found])
+ 
+-dnl Check for octave (used to get cannical_host_type)
+-AC_PATH_PROG([OCTAVE],[octave])
+-test -z "$OCTAVE" && AC_MSG_ERROR([octave not found])
+-
++dnl Check for octave-config
++AC_PATH_PROG([OCTAVE_CONFIG],[octave-config])
++test -z "$OCTAVE_CONFIG" &&  AC_MSG_ERROR([octave-config not found])
++
++AC_DEFUN(OCTAVE_CONFIG_EVAL,
++[AC_MSG_CHECKING([for $1 in octave-config])
++$2=`$OCTAVE_CONFIG -p $1`
++AC_MSG_RESULT($$2)
++AC_SUBST($2)
++])
+ 
+ dnl *****************************
+ dnl *** System-specific stuff ***
+ dnl *****************************
+ 
+ dnl Grab canonical host type so we can write system specific install stuff
+-AC_MSG_CHECKING([for Octave's canonical_host_type])
+-canonical_host_type=`$OCTAVE -qf --eval "                   \
+-  if exist ('__octave_config_info__')                       \
+-    disp  (__octave_config_info__ ('canonical_host_type'))  \
+-  else                                                      \
+-    disp  (octave_config_info ('canonical_host_type'))      \
+-  end"`
+-AC_MSG_RESULT([${canonical_host_type}])
++OCTAVE_CONFIG_EVAL(CANONICAL_HOST_TYPE,canonical_host_type)
+ 
+ dnl GSL specific preprocessor flags
+ AC_SUBST([GSL_DEFINES])
+@@ -63,17 +62,23 @@
+ dnl *********************************
+ 
+ dnl Find Octave's include directory
+-AC_MSG_CHECKING([for Octave's include directory])
+-octave_include_dir=`$OCTAVE -qf --eval "              \
+-  if exist ('__octave_config_info__')                 \
+-    disp  (__octave_config_info__ ('octincludedir'))  \
+-  else                                                \
+-    disp  (octave_config_info ('octincludedir'))      \
+-  end"`
+-AC_MSG_RESULT([${octave_include_dir}])
++OCTAVE_CONFIG_EVAL(OCTINCLUDEDIR,octave_include_dir)
++
++# let configure get CC and CXX so we cant override for tests
++AC_PROG_CC
++AC_PROG_CXX
++
++# set compiler and flags to values octave will be using
++CC=`$MKOCTFILE -p CC`
++CXX=`$MKOCTFILE -p CXX`
++CFLAGS=`$MKOCTFILE -p CFLAGS`
++CPPFLAGS=`$MKOCTFILE -p CPPFLAGS`
++LDFLAGS=`$MKOCTFILE -p LDFLAGS`
++LIBS=`$MKOCTFILE -p LIBS`
++CXXFLAGS=`$MKOCTFILE -p CXXFLAGS`
+ 
+ dnl Save initial state
+-save_CPPFLAGS=${CPPFLAG}
++save_CPPFLAGS=${CPPFLAGS}
+ AC_LANG_PUSH([C++])
+ 
+ dnl Add octave include dir to CPPFLAGS
+@@ -120,7 +125,7 @@
+ )
+ 
+ dnl Restore initial state
+-AC_LANG_PUSH([C++])
++AC_LANG_POP([C++])
+ CPPFLAGS=${save_CPPFLAGS}
+ 
+ 

--- a/octave/octave-gsl/files/configure.ac.in-return-type.patch
+++ b/octave/octave-gsl/files/configure.ac.in-return-type.patch
@@ -1,16 +1,17 @@
+Specify function return types.
 https://savannah.gnu.org/bugs/?59159
---- src/configure.orig	2018-06-18 09:57:54.000000000 -0500
-+++ src/configure	2024-01-30 20:16:53.000000000 -0600
-@@ -3138,7 +3138,7 @@
- /* end confdefs.h.  */
- 
+--- src/configure.ac.in.orig	2018-06-18 09:57:53.000000000 -0500
++++ src/configure.ac.in	2024-02-23 00:31:00.000000000 -0600
+@@ -86,7 +86,7 @@
+   [AC_LANG_SOURCE(
+      [[
  #include "ov-scalar.h"
 -main()
 +int main()
  {
    octave_scalar x (1.234);
    bool y = x.isreal ();
-@@ -3162,7 +3162,7 @@
+@@ -106,7 +106,7 @@
  #include "ov-scalar.h"
  #include "ovl.h"
  #include "parse.h"

--- a/octave/octave-gsl/files/replace_template.sh-sed.patch
+++ b/octave/octave-gsl/files/replace_template.sh-sed.patch
@@ -1,0 +1,11 @@
+Fix path to sed for macOS
+--- src/replace_template.sh.orig	2018-06-18 09:57:53.000000000 -0500
++++ src/replace_template.sh	2024-02-23 00:57:35.000000000 -0600
+@@ -1,6 +1,6 @@
+ #!/bin/bash
+ 
+-SED=/bin/sed
++SED=/usr/bin/sed
+ 
+ capfuncname=`echo ${funcname}|tr a-z A-Z`
+ 


### PR DESCRIPTION
#### Description

Fixes "fatal error: 'ov-scalar.h' file not found" which occurred due to failure to locate Octave's include directory.

Closes: https://trac.macports.org/ticket/69246

Instead of adding the nearly 4000-line configure patch, I added the much smaller configure.ac.in patch and then made the port run bootstrap to regenerate configure.ac and configure.

This built for me on macOS 12 x86_64, but it also worked for me before this change, so we need to see if it works in CI and Marius you may want to test it on your system as well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 21G1974 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
