### PR TITLE
uv: new port (0.1.10)

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -1,0 +1,519 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               cargo 1.0
+PortGroup               github 1.0
+
+github.setup            astral-sh uv 0.1.10
+github.tarball_from     archive
+revision                0
+categories              devel python
+license                 Apache-2 MIT
+platforms               {darwin >= 15}
+maintainers             {@therealketo gmail.com:therealketo} openmaintainer
+
+description             Extremely fast Python package installer and resolver
+long_description        {*}${description}, written in Rust. Designed as a drop-in \
+                        replacement for pip and pip-compile.
+
+checksums               ${distname}${extract.suffix} \
+                        rmd160  82916cb087d66edf914eed868f61b5396b26b5da \
+                        sha256  2c31cb4b0d8c9e38f456bb813e40acb369cccf169043e9642b9879bd144f05b6 \
+                        size    1850973
+
+depends_build-append    port:pkgconfig
+depends_lib-append      port:libgit2
+
+# Disable --frozen to workaround some dependencies
+cargo.offline_cmd
+
+build.env-append        LIBGIT2_NO_VENDOR=1 \
+                        OPENSSL_NO_VENDOR=1
+
+build.args-append       --no-default-features
+
+post-build {
+    # Generate shell completions for supported shells
+    set uv_bin ${worksrcpath}/target/[cargo.rust_platform]/release/${name}
+    foreach shell {zsh bash fish} {
+        system -W ${worksrcpath} \
+            "${uv_bin} generate-shell-completion ${shell} > uv.${shell}"
+    }
+}
+
+destroot {
+    set bindir ${worksrcpath}/target/[cargo.rust_platform]/release
+    xinstall -m 0755 -W ${bindir} ${name} ${destroot}${prefix}/bin/${name}
+
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_comp_path}
+    xinstall -m 0644 ${worksrcpath}/${name}.zsh ${zsh_comp_path}/_${name}
+
+    set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${bash_comp_path}
+    xinstall -m 0644 ${worksrcpath}/${name}.bash ${bash_comp_path}/${name}
+
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completion.d
+    xinstall -d ${fish_comp_path}
+    xinstall -m 0644 ${worksrcpath}/${name}.fish ${fish_comp_path}
+}
+
+cargo.crates \
+    addr2line                       0.21.0  8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    ahash                            0.7.8  891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9 \
+    aho-corasick                     1.1.2  b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0 \
+    alloc-no-stdlib                  2.0.4  cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3 \
+    alloc-stdlib                     0.2.2  94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece \
+    android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
+    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
+    anstream                        0.6.11  6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5 \
+    anstyle                          1.0.6  8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc \
+    anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
+    anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
+    anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
+    anyhow                          1.0.79  080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca \
+    arc-swap                         1.6.0  bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6 \
+    arrayref                         0.3.7  6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545 \
+    arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
+    assert_cmd                      2.0.13  00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467 \
+    assert_fs                        1.1.1  2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec \
+    async-compression                0.4.6  a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c \
+    async-trait                     0.1.77  c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9 \
+    async_http_range_reader          0.7.0  cf8eeab30c68da4dc2c51f3afc4327ab06fe0f3f028ca423f7ca398c7ed8c5e7 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    backtrace                       0.3.69  2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837 \
+    backtrace-ext                    0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
+    base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
+    base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
+    bisection                        0.1.0  021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3 \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                         2.4.2  ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf \
+    bitvec                           1.0.1  1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c \
+    block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
+    brotli                           3.4.0  516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f \
+    brotli-decompressor              2.5.1  4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f \
+    bstr                             1.9.0  c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc \
+    bumpalo                         3.14.0  7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec \
+    bytecheck                       0.6.12  23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2 \
+    bytecheck_derive                0.6.12  3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659 \
+    bytemuck                        1.14.3  a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f \
+    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
+    bytes                            1.5.0  a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223 \
+    cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
+    camino                           1.1.6  c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c \
+    cargo-util                       0.2.9  74862c3c6e53a1c1f8f0178f9d38ab41e49746cd3a7cafc239b3d0248fd4e342 \
+    cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
+    cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    charset                          0.1.3  18e9079d1a12a2cc2bffb5db039c43661836ead4082120d5844f02555aca2d46 \
+    chrono                          0.4.34  5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b \
+    ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
+    ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
+    ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
+    clap                             4.5.0  80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f \
+    clap_builder                     4.5.0  458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99 \
+    clap_complete                    4.5.1  885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c \
+    clap_complete_command            0.5.1  183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d \
+    clap_complete_fig                4.5.0  54b3e65f91fabdd23cac3d57d39d5d938b4daabd070c335c006dccb866a61110 \
+    clap_complete_nushell           0.1.11  5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e \
+    clap_derive                      4.5.0  307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47 \
+    clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
+    cmake                           0.1.50  a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130 \
+    color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
+    colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
+    configparser                     3.0.4  4ec6d3da8e550377a85339063af6e3735f4b1d9392108da4e083a1b3b9820288 \
+    console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
+    core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
+    core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
+    cpufeatures                     0.2.12  53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504 \
+    crc32fast                        1.4.0  b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa \
+    criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
+    criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
+    crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
+    crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
+    crossbeam-utils                 0.8.19  248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345 \
+    crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
+    crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
+    csv                              1.3.0  ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe \
+    csv-core                        0.1.11  5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70 \
+    ctrlc                            3.4.2  b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b \
+    dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
+    data-encoding                    2.5.0  7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5 \
+    data-url                         0.2.0  8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5 \
+    deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
+    derivative                       2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
+    difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
+    digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    directories                      5.0.1  9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35 \
+    dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
+    doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
+    dunce                            1.0.4  56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b \
+    either                          1.10.0  11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a \
+    encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
+    encoding_rs                     0.8.33  7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1 \
+    equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
+    errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
+    fastrand                         2.0.1  25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5 \
+    fdeflate                         0.3.4  4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645 \
+    filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
+    fixedbitset                      0.4.2  0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80 \
+    flate2                          1.0.28  46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e \
+    float-cmp                        0.9.0  98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4 \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    fontconfig-parser                0.5.6  6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d \
+    fontdb                          0.12.0  ff20bef7942a72af07104346154a70a70b089c572e454b41bef6eb6cb10e9c06 \
+    form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
+    fs-err                          2.11.0  88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41 \
+    fs2                              0.4.3  9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213 \
+    funty                            2.0.0  e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c \
+    futures                         0.3.30  645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0 \
+    futures-channel                 0.3.30  eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78 \
+    futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
+    futures-executor                0.3.30  a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d \
+    futures-io                      0.3.30  a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1 \
+    futures-lite                     2.2.0  445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba \
+    futures-macro                   0.3.30  87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac \
+    futures-sink                    0.3.30  9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5 \
+    futures-task                    0.3.30  38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004 \
+    futures-util                    0.3.30  3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48 \
+    generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
+    getrandom                       0.2.12  190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5 \
+    gif                             0.12.0  80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045 \
+    gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
+    git2                            0.18.2  1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd \
+    glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
+    globset                         0.4.14  57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1 \
+    globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
+    goblin                           0.8.0  bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887 \
+    h2                              0.3.24  bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9 \
+    half                             2.3.1  bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872 \
+    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+    hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
+    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    hermit-abi                       0.3.6  bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd \
+    hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
+    hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
+    home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
+    html-escape                     0.2.13  6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476 \
+    http                            0.2.11  8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb \
+    http-body                        0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
+    http-content-range               0.1.2  9f0d1a8ef218a86416107794b34cc446958d9203556c312bb41eab4c924c1d2e \
+    httparse                         1.8.0  d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904 \
+    httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
+    hyper                          0.14.28  bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80 \
+    hyper-rustls                    0.24.2  ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590 \
+    iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
+    iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
+    idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
+    ignore                          0.4.22  b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1 \
+    imagesize                       0.11.0  b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf \
+    indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
+    indexmap                         2.2.3  233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177 \
+    indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
+    indoc                            2.0.4  1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8 \
+    insta                           1.34.0  5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc \
+    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
+    ipnet                            2.9.0  8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3 \
+    is-terminal                     0.4.12  f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b \
+    is_ci                            1.2.0  7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45 \
+    itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
+    itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
+    itoa                            1.0.10  b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c \
+    jobserver                       0.1.28  ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6 \
+    jpeg-decoder                     0.3.1  f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0 \
+    js-sys                          0.3.68  406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee \
+    junction                         1.0.0  ca39ef0d69b18e6a2fd14c2f0a1d593200f4a4ed949b240b5917ab51fac754cb \
+    kurbo                            0.8.3  7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449 \
+    kurbo                            0.9.5  bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
+    libgit2-sys                   0.16.2+1.7.2  ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8 \
+    libmimalloc-sys                 0.1.35  3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664 \
+    libredox                         0.0.1  85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8 \
+    libssh2-sys                      0.3.0  2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee \
+    libz-ng-sys                     1.1.15  c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5 \
+    libz-sys                        1.1.15  037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6 \
+    line-wrap                        0.1.1  f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9 \
+    linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
+    linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
+    lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
+    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    mailparse                       0.14.1  2d096594926cab442e054e047eb8c1402f7d5b2272573b97ba68aa40629f9757 \
+    matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
+    memchr                           2.7.1  523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149 \
+    memmap2                         0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
+    memmap2                          0.9.4  fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322 \
+    memoffset                        0.9.0  5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
+    miette                           6.0.1  337e1043bbc086dac9d9674983bef52ac991ce150e09b5b8e35c5a73dd83f66c \
+    miette-derive                    6.0.1  71e622f2a0dd84cbca79bc6c3c33f4fd7dc69faf992216516aacc1d136102800 \
+    mimalloc                        0.1.39  fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c \
+    mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
+    mime_guess                       2.0.4  4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef \
+    miniz_oxide                      0.7.2  9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7 \
+    mio                             0.8.10  8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09 \
+    miow                             0.6.0  359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044 \
+    nanoid                           0.4.0  3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8 \
+    nix                             0.27.1  2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053 \
+    normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
+    nu-ansi-term                    0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
+    nu-ansi-term                    0.49.0  c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68 \
+    num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
+    num-traits                      0.2.18  da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a \
+    num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
+    number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
+    object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
+    once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
+    oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
+    openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
+    openssl-src                   300.2.3+3.2.1  5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843 \
+    openssl-sys                     0.9.99  22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae \
+    option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
+    overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
+    owo-colors                       3.5.0  c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f \
+    owo-colors                       4.0.0  caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f \
+    parking                          2.2.0  bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae \
+    parking_lot                     0.11.2  7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99 \
+    parking_lot_core                 0.8.6  60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc \
+    parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
+    paste                           1.0.14  de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c \
+    percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
+    petgraph                         0.6.4  e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9 \
+    pico-args                        0.5.0  5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315 \
+    pin-project                      1.1.4  0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0 \
+    pin-project-internal             1.1.4  266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690 \
+    pin-project-lite                0.2.13  8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58 \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    pkg-config                      0.3.30  d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec \
+    plain                            0.2.3  b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6 \
+    platform-info                    2.0.2  d6259c4860e53bf665016f1b2f46a8859cadfa717581dc9d597ae4069de6300f \
+    plist                            1.6.0  e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef \
+    png                            0.17.11  1f6c3c3e617595665b8ea2ff95a86066be38fb121ff920a9c0eb282abcd1da5a \
+    poloto                          19.1.2  164dbd541c9832e92fa34452e9c2e98b515a548a3f8549fb2402fe1cd5e46b96 \
+    portable-atomic                  1.6.0  7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0 \
+    powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
+    ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
+    predicates                       3.1.0  68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8 \
+    predicates-core                  1.0.6  b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174 \
+    predicates-tree                  1.0.9  368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf \
+    priority-queue                   1.4.0  a0bda9164fe05bc9225752d54aae413343c36f684380005398a6a8fde95fe785 \
+    proc-macro2                     1.0.78  e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae \
+    ptr_meta                         0.1.4  0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1 \
+    ptr_meta_derive                  0.1.4  16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac \
+    pyo3                            0.20.2  9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0 \
+    pyo3-build-config               0.20.2  07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be \
+    pyo3-ffi                        0.20.2  dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1 \
+    pyo3-log                         0.9.0  4c10808ee7250403bedb24bc30c32493e93875fef7ba3e4292226fe924f398bd \
+    pyo3-macros                     0.20.2  05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3 \
+    pyo3-macros-backend             0.20.2  0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f \
+    pyproject-toml                  0.10.0  3b80f889b6d413c3f8963a2c7db03f95dd6e1d85e1074137cb2013ea2faa8898 \
+    quick-xml                       0.31.0  1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33 \
+    quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
+    quoted_printable                 0.5.0  79ec282e887b434b68c18fe5c121d38e72a5cf35119b59e54ec5b992ea9c8eb0 \
+    radium                           0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+    rayon                            1.8.1  fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051 \
+    rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
+    rctree                           0.5.0  3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f \
+    redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
+    redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
+    redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
+    redox_users                      0.4.4  a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4 \
+    reflink-copy                    0.1.14  767be24c0da52e7448d495b8d162506a9aa125426651d547d545d6c2b4b65b62 \
+    regex                           1.10.3  b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15 \
+    regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
+    regex-automata                   0.4.5  5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd \
+    regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
+    regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+    rend                             0.4.2  71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c \
+    reqwest                        0.11.24  c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251 \
+    reqwest-middleware               0.2.4  88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690 \
+    reqwest-retry                    0.3.0  9af20b65c2ee9746cc575acb6bd28a05ffc0d15e25c992a8f4462d8686aacb4f \
+    resvg                           0.29.0  76888219c0881e22b0ceab06fddcfe83163cd81642bd60c7842387f9c968a72e \
+    retry-policies                   0.2.1  17dd00bff1d737c40dbcd47d4375281bf4c17933f9eef0a185fc7bacca23ecbd \
+    rgb                             0.8.37  05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8 \
+    ring                            0.17.7  688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74 \
+    rkyv                            0.7.44  5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0 \
+    rkyv_derive                     0.7.44  a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65 \
+    rmp                             0.8.12  7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20 \
+    rmp-serde                        1.1.2  bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a \
+    rosvgtree                        0.1.0  bdc23d1ace03d6b8153c7d16f0708cd80b61ee8e80304954803354e67e40d150 \
+    roxmltree                       0.18.1  862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302 \
+    roxmltree                       0.19.0  3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f \
+    rustc-demangle                  0.1.23  d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76 \
+    rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
+    rustix                         0.38.31  6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949 \
+    rustls                         0.21.10  f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba \
+    rustls-native-certs              0.6.3  a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00 \
+    rustls-pemfile                   1.0.4  1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c \
+    rustls-webpki                  0.101.7  8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765 \
+    rustybuzz                        0.7.0  162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a \
+    ryu                             1.0.16  f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c \
+    safemem                          0.3.3  ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072 \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    schannel                        0.1.23  fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534 \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    scroll                          0.12.0  6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6 \
+    scroll_derive                   0.12.0  7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932 \
+    sct                              0.7.1  da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414 \
+    seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
+    security-framework               2.9.2  05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de \
+    security-framework-sys           2.9.1  e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a \
+    serde                          1.0.196  870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32 \
+    serde_derive                   1.0.196  33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67 \
+    serde_json                     1.0.113  69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79 \
+    serde_spanned                    0.6.5  eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1 \
+    serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
+    sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
+    sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
+    shell-escape                     0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
+    signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
+    simd-adler32                     0.3.7  d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe \
+    simdutf8                         0.1.4  f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a \
+    similar                          2.4.0  32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21 \
+    simplecss                        0.2.1  a11be7c62927d9427e9f40f3444d5499d868648e2edbc4e2116de69e7ec0e89d \
+    siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
+    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
+    smallvec                        1.13.1  e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7 \
+    smawk                            0.3.2  b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c \
+    socket2                          0.5.5  7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9 \
+    spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
+    strict-num                       0.1.1  6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731 \
+    strsim                          0.11.0  5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01 \
+    subtle                           2.5.0  81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc \
+    supports-color                   3.0.0  9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f \
+    supports-hyperlinks              3.0.0  2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee \
+    supports-unicode                 3.0.0  b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2 \
+    svg                             0.15.0  2198f991cd549041203080de947415bae45220eab7253c220b87e3188d19f21a \
+    svgfilters                       0.4.0  639abcebc15fdc2df179f37d6f5463d660c1c79cd552c12343a4600827a04bce \
+    svgtypes                         0.9.0  c9ee29c1407a5b18ccfe5f6ac82ac11bab3b14407e09c209a6c1a32098b19734 \
+    svgtypes                        0.10.0  98ffacedcdcf1da6579c907279b4f3c5492fbce99fbbf227f5ed270a589c2765 \
+    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+    syn                             2.0.48  0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f \
+    sync_wrapper                     0.1.2  2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160 \
+    system-configuration             0.5.1  ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7 \
+    system-configuration-sys         0.5.0  a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9 \
+    tagu                             0.1.6  eddb6b06d20fba9ed21fca3d696ee1b6e870bca0bcf9fa2971f6ae2436de576a \
+    tap                              1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
+    target-lexicon                 0.12.13  69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae \
+    task-local-extensions            0.1.4  ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8 \
+    tempfile                        3.10.0  a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67 \
+    terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
+    termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
+    test-case                        3.3.1  eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8 \
+    test-case-core                   3.3.1  adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f \
+    test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
+    testing_logger                   0.1.1  6d92b727cb45d33ae956f7f46b966b25f1bc712092aeef9dba5ac798fc89f720 \
+    textwrap                        0.16.0  222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d \
+    thiserror                       1.0.57  1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b \
+    thiserror-impl                  1.0.57  a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81 \
+    thread_local                     1.1.7  3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152 \
+    tikv-jemalloc-sys             0.5.4+5.3.0-patched  9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1 \
+    tikv-jemallocator                0.5.4  965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca \
+    time                            0.3.34  c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749 \
+    time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
+    time-macros                     0.2.17  7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774 \
+    tiny-skia                        0.8.4  df8493a203431061e901613751931f047d1971337153f96d0e5e363d6dbf6a67 \
+    tiny-skia-path                   0.8.4  adbfb5d3f3dd57a0e11d12f4f13d4ebbbc1b5c15b7ab0a156d030b21da5f677c \
+    tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
+    tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+    tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
+    tl                               0.7.8  b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7 \
+    tokio                           1.36.0  61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931 \
+    tokio-macros                     2.2.0  5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b \
+    tokio-rustls                    0.24.1  c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081 \
+    tokio-stream                    0.1.14  397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842 \
+    tokio-tar                        0.3.1  9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75 \
+    tokio-util                      0.7.10  5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15 \
+    toml                            0.8.10  9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290 \
+    toml_datetime                    0.6.5  3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1 \
+    toml_edit                       0.22.5  99e68c159e8f5ba8a28c4eb7b0c0c190d77bb479047ca713270048145a9ad28a \
+    tower-service                    0.3.2  b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52 \
+    tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
+    tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
+    tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
+    tracing-durations-export         0.2.0  35b910b25a6c8e0fefcfff912bad6c4f4849d37e5945c3861d15e550d819da53 \
+    tracing-indicatif                0.3.6  069580424efe11d97c3fef4197fa98c004fa26672cc71ad8770d224e23b1951d \
+    tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
+    tracing-subscriber              0.3.18  ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b \
+    tracing-tree                     0.3.0  65139ecd2c3f6484c3b99bc01c77afe21e95473630747c7aca525e78b0666675 \
+    try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
+    ttf-parser                      0.18.1  0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633 \
+    typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
+    unicase                          2.7.0  f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89 \
+    unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
+    unicode-bidi-mirroring           0.1.0  56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694 \
+    unicode-ccc                      0.1.2  cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1 \
+    unicode-general-category         0.6.0  2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7 \
+    unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
+    unicode-linebreak                0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
+    unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
+    unicode-script                   0.5.5  7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc \
+    unicode-vo                       0.1.0  b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94 \
+    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
+    unindent                         0.2.3  c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce \
+    unscanny                         0.1.0  e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47 \
+    untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
+    url                              2.5.0  31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633 \
+    urlencoding                      2.1.3  daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da \
+    usvg                            0.29.0  63b6bb4e62619d9f68aa2d8a823fea2bff302340a1f2d45c264d5b0be170832e \
+    usvg-text-layout                0.29.0  195386e01bc35f860db024de275a76e7a31afdf975d18beb6d0e44764118b4db \
+    utf8-width                       0.1.7  86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3 \
+    utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
+    uuid                             1.7.0  f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a \
+    valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \
+    vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    vt100                           0.15.2  84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de \
+    vte                             0.11.1  f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197 \
+    vte_generate_state_changes       0.1.1  d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff \
+    wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
+    walkdir                          2.4.0  d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee \
+    want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
+    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasm-bindgen                    0.2.91  c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f \
+    wasm-bindgen-backend            0.2.91  c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b \
+    wasm-bindgen-futures            0.4.41  877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97 \
+    wasm-bindgen-macro              0.2.91  b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed \
+    wasm-bindgen-macro-support      0.2.91  642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66 \
+    wasm-bindgen-shared             0.2.91  4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838 \
+    wasm-streams                     0.4.0  b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129 \
+    wasm-timer                       0.2.5  be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f \
+    web-sys                         0.3.68  96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446 \
+    weezl                            0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \
+    which                            6.0.0  7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.6  f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows                         0.52.0  e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be \
+    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows-targets                 0.52.0  8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_gnullvm         0.52.0  cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_aarch64_msvc            0.52.0  bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_gnu                0.52.0  a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313 \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_i686_msvc               0.52.0  ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnu              0.52.0  3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_gnullvm          0.52.0  1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
+    windows_x86_64_msvc             0.52.0  dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04 \
+    winnow                           0.6.1  d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401 \
+    winreg                          0.50.0  524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1 \
+    wyz                              0.5.1  05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed \
+    xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
+    xmlparser                       0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \
+    yaml-rust                        0.4.5  56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85 \
+    zip                              0.6.6  760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261


### PR DESCRIPTION
#### Description

Add `uv`, a fast Python dependency installer and resolver written in Rust.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
