### PR TITLE
spring-boot-cli: update to 3.2.3

### DIFF
--- a/java/spring-boot-cli/Portfile
+++ b/java/spring-boot-cli/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            spring-boot-cli
-version         3.2.2
+version         3.2.3
 revision        0
 
 categories      java
@@ -30,9 +30,9 @@ master_sites    https://repo.maven.apache.org/maven2/org/springframework/boot/${
 
 distname        ${name}-${version}-bin
 
-checksums       rmd160  47dc76ae47cf054084c1ab1cfcf3845aa8a9527c \
-                sha256  4fa7458879f9af01a5d2090f0e01d9ea0dd1899d12be3e205fcf6e9a59be0de9 \
-                size    5429260
+checksums       rmd160  02a4def70c171c3292aa076954aee5a4a82a999e \
+                sha256  9758b284a63f555e0ea4750b11b1a09b450fe5d6834c3b59eb966ca5452ecf7f \
+                size    5393064
 
 worksrcdir      spring-${version}
 


### PR DESCRIPTION
#### Description

Update to Spring Boot CLI 3.2.3.

###### Tested on

macOS 14.3.1 23D60 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?