### PR TITLE
Vidalia: add miniupnpc variant, support aarch64, add tests

### DIFF
--- a/security/Vidalia/Portfile
+++ b/security/Vidalia/Portfile
@@ -2,11 +2,8 @@
 
 PortSystem          1.0
 PortGroup           cmake 1.0
-PortGroup           qt4 1.0
 
 name                Vidalia
-version             0.2.21
-revision            1
 categories          security net aqua
 maintainers         nomaintainer
 description         Vidalia is a controller GUI for the Tor software
@@ -16,20 +13,53 @@ long_description    Vidalia is a cross-platform controller GUI for the Tor softw
 
 license             {GPL-2+ OpenSSLException}
 homepage            https://www.torproject.org/projects/vidalia.html.en
-master_sites        https://www.torproject.org/dist/vidalia/ \
-                    https://archive.torproject.org/tor-package-archive/vidalia/
-distname            vidalia-${version}
 
-checksums           rmd160  a1086c98216fed09472d494c95033097ec57b43c \
+if {${os.arch} eq "arm"} {
+    PortGroup       github 1.0
+    PortGroup       qt5 1.0
+
+    qt5.depends_component   qtscript qttools
+    # No support for Qt5 in releases. Qt4 is broken on aarch64.
+    github.setup    a-ilin vidalia 8240540188062a168a66b25ca61b852cc89140ad
+    version         0.3.3-alpha
+    revision        0
+    github.tarball_from archive
+    checksums       rmd160  2107d50a7d72fd93ed75e613515ed33af4e191ca \
+                    sha256  e4c2138b43d32d9cd23282378074f94bc38065e2dc79da05a3f7fbfb61ecb2a0 \
+                    size    6116757
+
+    # https://github.com/a-ilin/vidalia/pull/3
+    patchfiles-append \
+                    0001-Vidalia.cpp-fix-linking.patch \
+                    0002-LogFilter.cpp-fix-includes.patch
+
+    configure.args-append \
+                    -DUSE_QT5=ON
+} else {
+    PortGroup       qt4 1.0
+
+    version         0.2.21
+    revision        1
+    master_sites    https://www.torproject.org/dist/vidalia/ \
+                    https://archive.torproject.org/tor-package-archive/vidalia/
+    distname        vidalia-${version}
+    checksums       rmd160  a1086c98216fed09472d494c95033097ec57b43c \
                     sha256  c4008e7e7781dddf4a8670a435da6496dc9309dbdbc6125ac6d2cc871bdc1be7 \
                     size    6360390
 
+    patchfiles      patch-TorSettings.h.diff
+
+    configure.args-append \
+                    ${qt_cmake_defines}
+
+    livecheck.type  regexm
+    livecheck.url   ${homepage}
+    livecheck.regex The most recent stable release is: (\[\\d\.\]+)
+}
+
 depends_lib-append  port:tor
 
-patchfiles          patch-TorSettings.h.diff
-
 configure.args-append \
-                    ${qt_cmake_defines} \
                     -DUSE_MINIUPNPC=OFF
 
 destroot {
@@ -45,7 +75,3 @@ variant miniupnpc description "Enable miniupnpc support" {
 
 default_variants-append \
                     +miniupnpc
-
-livecheck.type      regexm
-livecheck.url       ${homepage}
-livecheck.regex     The most recent stable release is: (\[\\d\.\]+)

--- a/security/Vidalia/Portfile
+++ b/security/Vidalia/Portfile
@@ -5,11 +5,11 @@ PortGroup           cmake 1.0
 
 name                Vidalia
 categories          security net aqua
-maintainers         nomaintainer
-description         Vidalia is a controller GUI for the Tor software
-long_description    Vidalia is a cross-platform controller GUI for the Tor software, \
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         ${name} is a controller GUI for the Tor software
+long_description    ${name} is a cross-platform controller GUI for the Tor software, \
                     built using the Qt framework. Vidalia runs on most platforms \
-                    supported by Qt 4.2 or later
+                    supported by Qt 4.2 or later.
 
 license             {GPL-2+ OpenSSLException}
 homepage            https://www.torproject.org/projects/vidalia.html.en

--- a/security/Vidalia/Portfile
+++ b/security/Vidalia/Portfile
@@ -75,3 +75,23 @@ variant miniupnpc description "Enable miniupnpc support" {
 
 default_variants-append \
                     +miniupnpc
+
+variant tests description "Enable tests" {
+    depends_build-append \
+                    port:libiconv
+    configure.args-append \
+                    -DBUILD_TESTS=ON
+
+    test.run        yes
+
+    test.dir        ${worksrcpath}/src/tests
+    test.cmd        ./VidaliaTestSuite
+    test.target
+
+    # https://github.com/a-ilin/vidalia/issues/4
+    pre-test {
+        ui_warn "At the moment tests run correctly\
+            only under a regular user. You could run\
+            VidaliaTestSuite binary manually."
+    }
+}

--- a/security/Vidalia/Portfile
+++ b/security/Vidalia/Portfile
@@ -6,6 +6,7 @@ PortGroup           qt4 1.0
 
 name                Vidalia
 version             0.2.21
+revision            1
 categories          security net aqua
 maintainers         nomaintainer
 description         Vidalia is a controller GUI for the Tor software
@@ -27,11 +28,23 @@ depends_lib-append  port:tor
 
 patchfiles          patch-TorSettings.h.diff
 
-configure.args      ${qt_cmake_defines}
+configure.args-append \
+                    ${qt_cmake_defines} \
+                    -DUSE_MINIUPNPC=OFF
 
 destroot {
     file copy ${worksrcpath}/src/vidalia/Vidalia.app ${destroot}${applications_dir}/Vidalia.app
 }
+
+variant miniupnpc description "Enable miniupnpc support" {
+    depends_lib-append \
+                    port:miniupnpc
+    configure.args-replace \
+                    -DUSE_MINIUPNPC=OFF -DUSE_MINIUPNPC=ON
+}
+
+default_variants-append \
+                    +miniupnpc
 
 livecheck.type      regexm
 livecheck.url       ${homepage}

--- a/security/Vidalia/files/0001-Vidalia.cpp-fix-linking.patch
+++ b/security/Vidalia/files/0001-Vidalia.cpp-fix-linking.patch
@@ -1,0 +1,26 @@
+From 678cb733f92a43e762d73b2b53843fd08f138de9 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sat, 24 Feb 2024 12:15:49 +0700
+Subject: [PATCH] Vidalia.cpp: fix linking
+
+Fix suggested in https://github.com/a-ilin/vidalia/issues/1#issuecomment-936246083
+---
+ src/vidalia/Vidalia.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git src/vidalia/Vidalia.cpp src/vidalia/Vidalia.cpp
+index 2a34fc39..2497a33a 100644
+--- src/vidalia/Vidalia.cpp
++++ src/vidalia/Vidalia.cpp
+@@ -239,6 +239,11 @@ VidaliaNativeEventFilter::nativeEventFilter(const QByteArray& /*eventType*/, voi
+   return false;
+ #endif
+ }
++#else
++bool VidaliaNativeEventFilter::nativeEventFilter(const QByteArray& /*eventType*/, void* message, long* result)
++{
++    return false;
++}
+ #endif
+ 
+ /** Returns true if the user wants to see usage information. */

--- a/security/Vidalia/files/0002-LogFilter.cpp-fix-includes.patch
+++ b/security/Vidalia/files/0002-LogFilter.cpp-fix-includes.patch
@@ -1,0 +1,23 @@
+From e618901f539760e12ea8a107a4064fceba1d2f19 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sat, 24 Feb 2024 12:21:08 +0700
+Subject: [PATCH] LogFilter.cpp: fix includes
+
+Fixes: https://github.com/a-ilin/vidalia/issues/2
+---
+ src/vidalia/log/LogFilter.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git src/vidalia/log/LogFilter.cpp src/vidalia/log/LogFilter.cpp
+index d7b64d6b..35220131 100644
+--- src/vidalia/log/LogFilter.cpp
++++ src/vidalia/log/LogFilter.cpp
+@@ -15,6 +15,8 @@
+ 
+ #include "LogFilter.h"
+ #include <QStack>
++#include <QList>
++#include <QString>
+ 
+ /** Constructor taking severity as argument. */
+ LogFilter::LogFilter(uint filter)


### PR DESCRIPTION
#### Description

1. Support `miniupnpc` explicitly via a variant.
2. Use a version with Qt5 support on aarch64, where Qt4 is broken.
3. Support tests via a variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
