### PR TITLE
homebank: Update to version 5.7.4

### DIFF
--- a/Portfile
+++ b/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                homebank
+version             5.7.4
+revision            0
+categories          x11 finance
+license             GPL-2+
+maintainers         {@jbarbey gmail.com:julien.barbey} openmaintainer
+description         Software to manage personal accounts, light and simple.
+long_description    HomeBank is the free software you have always wanted to \
+                    manage your personal accounts at home. The main concept \
+                    is to be light, simple and very easy to use. It brings \
+                    you many features that allow you to analyze your \
+                    finances in a detailed way instantly and dynamically \
+                    with powerful report tools based on filtering and \
+                    graphical charts.
+
+homepage            https://www.gethomebank.org/
+master_sites        ${homepage}public/sources/
+
+checksums           rmd160  c6eec6fa0d233e24aade8ae2c087ec29abb0ab00 \
+                    sha256  42ce7146c875ea0ca3c93391b6a9bf4714db4621c63f4a094dcc6f8985bb54e4 \
+                    size    3670067
+
+livecheck.type      regex
+livecheck.url       ${homepage}/ChangeLog
+livecheck.regex     "Made (\\d.\\d.\\d) release"
+
+depends_build       port:intltool \
+                    port:pkgconfig
+depends_lib         port:gettext \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                    port:libofx \
+                    path:lib/pkgconfig/librsvg-2.0.pc:librsvg \
+                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup
+
+# https://bugs.launchpad.net/intltool/+bug/1197875
+use_autoreconf      yes

--- a/x11/homebank/Portfile
+++ b/x11/homebank/Portfile
@@ -24,6 +24,10 @@ checksums           rmd160  5b8452b559e5f2d6e84e1089558fa37b918f7076 \
                     sha256  331d7ef88d90f3f34ca6610f7f18e89e935443b18b091a87d9b94bd7556399ef \
                     size    3651101
 
+livecheck.type      regex
+livecheck.url       ${homepage}/ChangeLog
+livecheck.regex     "Made (\\d.\\d.\\d) release"
+
 depends_build       port:intltool \
                     port:pkgconfig
 depends_lib         port:gettext \

--- a/x11/homebank/Portfile
+++ b/x11/homebank/Portfile
@@ -28,18 +28,6 @@ livecheck.type      regex
 livecheck.url       ${homepage}/ChangeLog
 livecheck.regex     "Made (\\d.\\d.\\d) release"
 
-livecheck.type      regex
-livecheck.url       ${homepage}/ChangeLog
-livecheck.regex     "Made (\\d.\\d.\\d) release"
-
-livecheck.type      regex
-livecheck.url       ${homepage}/ChangeLog
-livecheck.regex     "Made (\\d.\\d.\\d) release"
-
-livecheck.type      regex
-livecheck.url       ${homepage}/ChangeLog
-livecheck.regex     "Made (\\d.\\d.\\d) release"
-
 depends_build       port:intltool \
                     port:pkgconfig
 depends_lib         port:gettext \


### PR DESCRIPTION
#### Description

Update homebank with version 5.7.4

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
