### PR TITLE
re-flex: add variant to address conflict with pre-existing port

### DIFF
--- a/devel/re-flex/Portfile
+++ b/devel/re-flex/Portfile
@@ -26,7 +26,7 @@ long_description    RE/flex is a regex-centric, fast lexical analyzer generator 
 
 homepage            https://www.genivia.com/doc/reflex/html/
 
-notes               "The executable and manpage are renamed to avoid conflict with the pre-existing \"reflex\" port."
+notes               "The executable and manpage are renamed to \"re-flex\" (consistent with the port name), avoiding conflict with the pre-existing \"reflex\" port."
 
 configure.args-append --program-transform-name=s,reflex,re-flex,g
 

--- a/devel/re-flex/Portfile
+++ b/devel/re-flex/Portfile
@@ -26,8 +26,10 @@ long_description    RE/flex is a regex-centric, fast lexical analyzer generator 
 
 homepage            https://www.genivia.com/doc/reflex/html/
 
-# identical executable name
-conflicts           reflex
+# rename to avoid conflict identical executable name
+variant noconflict description {install as "re-flex" to address conflict} {
+    configure.args-append --program-transform-name=s,reflex,re-flex,g
+}
 
 compiler.cxx_standard 2011
 

--- a/devel/re-flex/Portfile
+++ b/devel/re-flex/Portfile
@@ -26,12 +26,9 @@ long_description    RE/flex is a regex-centric, fast lexical analyzer generator 
 
 homepage            https://www.genivia.com/doc/reflex/html/
 
-# rename to avoid conflict identical executable name
-variant noconflict description {install as "re-flex" to address conflict} {
-    configure.args-append --program-transform-name=s,reflex,re-flex,g
-}
-
-default_variants +noconflict
+# rename to avoid conflict (identical executable name) with pre-existing
+# "reflex" port, using the expected name given this port's name.
+configure.args-append --program-transform-name=s,reflex,re-flex,g
 
 compiler.cxx_standard 2011
 

--- a/devel/re-flex/Portfile
+++ b/devel/re-flex/Portfile
@@ -26,8 +26,8 @@ long_description    RE/flex is a regex-centric, fast lexical analyzer generator 
 
 homepage            https://www.genivia.com/doc/reflex/html/
 
-# rename to avoid conflict (identical executable name) with pre-existing
-# "reflex" port, using the expected name given this port's name.
+notes               "The executable and manpage are renamed to avoid conflict with the pre-existing \"reflex\" port."
+
 configure.args-append --program-transform-name=s,reflex,re-flex,g
 
 compiler.cxx_standard 2011

--- a/devel/re-flex/Portfile
+++ b/devel/re-flex/Portfile
@@ -31,6 +31,8 @@ variant noconflict description {install as "re-flex" to address conflict} {
     configure.args-append --program-transform-name=s,reflex,re-flex,g
 }
 
+default_variants +noconflict
+
 compiler.cxx_standard 2011
 
 test.run            yes


### PR DESCRIPTION
#### Description

The re-flex port installs an incompatible program conflicting with the pre-existing port reflex.
This commit adds a variant which can be used to provide for installing both ports.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.3 22G436 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
