### PR TITLE
py-xattr: update to 1.1.0

### DIFF
--- a/python/py-xattr/Portfile
+++ b/python/py-xattr/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-xattr
-version             0.10.1
+version             1.1.0
 license             {MIT PSF}
 platforms           darwin linux
 maintainers         {danchr @danchr} openmaintainer
@@ -20,9 +20,9 @@ long_description    xattr is a Python wrapper for Darwin, Linux, and FreeBSD \
 
 homepage            https://undefined.org/python/#xattr
 
-checksums           rmd160  cab64418aa447df02c5ba542bfd4ea9cc9962283 \
-                    sha256  c12e7d81ffaa0605b3ac8c22c2994a8e18a9cf1c59287a1b7722a2289c952ec5 \
-                    size    15868
+checksums           rmd160  560915916b2e80414f7172dae9cf04506f9ee49a \
+                    sha256  fecbf3b05043ed3487a28190dec3e4c4d879b2fcec0e30bafd8ec5d4b6043630 \
+                    size    16634
 
 python.versions     38 39 310 311 312
 


### PR DESCRIPTION
#### Description

The 1.x release didn't change any APIs.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.4 22G513 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
