### PR TITLE
xapian-bindings: add Ruby 3.3

### DIFF
--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -182,7 +182,7 @@ foreach v {8.0 8.1 8.2} {
 }
 
 # Python
-foreach v {2.7 3.6 3.7 3.8 3.9 3.10 3.11} {
+foreach v {2.7 3.7 3.8 3.9 3.10 3.11} {
     set v_no_dot [string map {. {}} ${v}]
     if {[vercmp ${v} 3] >= 0} {
         set suffix 3

--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -206,7 +206,7 @@ foreach v {2.7 3.6 3.7 3.8 3.9 3.10 3.11} {
 }
 
 # Ruby
-foreach v {2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2} {
+foreach v {2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3} {
     set v_no_dot [string map {. {}} ${v}]
     subport xapian-bindings-ruby${v_no_dot} "
         revision                0

--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -182,7 +182,7 @@ foreach v {8.0 8.1 8.2} {
 }
 
 # Python
-foreach v {3.7 3.8 3.9 3.10 3.11} {
+foreach v {3.8 3.9 3.10 3.11} {
     set v_no_dot [string map {. {}} ${v}]
     if {[vercmp ${v} 3] >= 0} {
         set suffix 3

--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -35,6 +35,9 @@ if {${subport} eq ${name}} {
                                 sha256  eda5ae6dcf6b0553a8676af64b1fd304e998cd20f779031ccaaf7ab9a373531a \
                                 size    3194164
 
+    # https://github.com/xapian/xapian/pull/332
+    patchfiles-append           resolver.h-use-AI_NUMERICSERV-only-when-defined.patch
+
     # TODO: Fix xapian-config to not require the .la file
     # /opt/local/bin/xapian-config --ltlibs --cxxflags
     # /opt/local/bin/xapian-config: Can't find libxapian.la to link against.

--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -182,7 +182,7 @@ foreach v {8.0 8.1 8.2} {
 }
 
 # Python
-foreach v {2.7 3.7 3.8 3.9 3.10 3.11} {
+foreach v {3.7 3.8 3.9 3.10 3.11} {
     set v_no_dot [string map {. {}} ${v}]
     if {[vercmp ${v} 3] >= 0} {
         set suffix 3

--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -209,7 +209,7 @@ foreach v {3.8 3.9 3.10 3.11} {
 }
 
 # Ruby
-foreach v {2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3} {
+foreach v {2.7 3.0 3.1 3.2 3.3} {
     set v_no_dot [string map {. {}} ${v}]
     subport xapian-bindings-ruby${v_no_dot} "
         revision                0

--- a/devel/xapian-core/files/resolver.h-use-AI_NUMERICSERV-only-when-defined.patch
+++ b/devel/xapian-core/files/resolver.h-use-AI_NUMERICSERV-only-when-defined.patch
@@ -1,0 +1,23 @@
+From 90ed0e3153cdd145fe0831c73c1a0c7d74cb7e9c Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Wed, 28 Feb 2024 17:36:13 +0700
+Subject: [PATCH] resolver.h: use AI_NUMERICSERV only when defined
+
+---
+ xapian-core/net/resolver.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git xapian-core/net/resolver.h xapian-core/net/resolver.h
+index 401cf308d..3436227ee 100644
+--- net/resolver.h
++++ net/resolver.h
+@@ -143,7 +143,9 @@ class Resolver {
+ 	if (host != "::1" && host != "127.0.0.1" && host != "localhost") {
+ 	    flags |= AI_ADDRCONFIG;
+ 	}
++#ifdef AI_NUMERICSERV
+ 	flags |= AI_NUMERICSERV;
++#endif
+ 
+ 	struct addrinfo hints;
+ 	std::memset(&hints, 0, sizeof(struct addrinfo));


### PR DESCRIPTION
#### Description

1. Add support for Ruby 3.3, which is the current version.
2. Fix `xapian-core` build on old systems where `AI_NUMERICSERV` is not defined.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1
Xcode 15.2

macOS 10.5.8 (for `xapian-core`, to confirm the fix works as supposed)
Xcode 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
