### PR TITLE
py-sphinxnotes-strike: Update to version 1.2.1; Add Python 311, 312, Remove Python 37

### DIFF
--- a/python/py-sphinxnotes-strike/Portfile
+++ b/python/py-sphinxnotes-strike/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-sphinxnotes-strike
-version             1.1
+version             1.2.1
 revision            0
 
 supported_archs     noarch
@@ -17,15 +17,15 @@ long_description    {*}${description}
 
 homepage            https://sphinx-notes.github.io/strike
 
-checksums           sha256  68f3e1cd152476421f17d85568aeea67f3c0eac7271ae33d27f1194c3841e2b0 \
-                    rmd160  206733513d3b92efa42340ad49bd9dff6916a368 \
-                    size    3723
+checksums           sha256  d51b5b8b60c62ba647abe9d5f32e78a9a4feddb48bf76aa77bbc4b6d5d968e70 \
+                    rmd160  b511db430f75354e5657520d23dd3d5bdbf2c4bb \
+                    size    29117
 
-python.versions     37 38 39 310
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-setuptools
+                    port:py${python.version}-setuptools_scm
 
     depends_run-append \
                     port:py${python.version}-sphinx


### PR DESCRIPTION

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
