### PR TITLE
google-cloud-sdk: update to 466.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             465.0.0
+version             466.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  72a62ebac872b224d0ab26e5c886e65a53a3875a \
-                    sha256  889314ca3d0bf52be8bb867e3b498a636449d808a4be1a92016987996cb2c9df \
-                    size    127813432
+    checksums       rmd160  067c1f70018949bfd56b712f5b5282f6d874c432 \
+                    sha256  8088054bb3b160ca7d0d3b70a51b4fb0b3d3a1be7e58aeb97d5c8523a62f3345 \
+                    size    127928837
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  9b8cb3a3b6a7aee8d82432da4a5a8c26ec8b84c0 \
-                    sha256  ec36018125da256181429d91fc9567e7756f6027b5f0edec1f0f521c0dad98f2 \
-                    size    129097757
+    checksums       rmd160  23ba504a789a8f6456820979cf00a75dd7faba8f \
+                    sha256  087e3678b802acc7326c8297f9b050aea005f1c7dce3e4d26542141e60964531 \
+                    size    129212806
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  c5a5cad5d3d1f666734479bf93d656dcde21c722 \
-                    sha256  37fb04743d5bfa3a21f3bee7359997e531fe5d21f141bc3d4a5b5d53f67c12eb \
-                    size    126166081
+    checksums       rmd160  81249e7b02fc1d9e0b8d0947a46885f1a68cbaf8 \
+                    sha256  525a93e2449ef5c7a9b94da845aadb936db334c47db4d6f72fe6cace846c483c \
+                    size    126282898
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 466.0.0.

###### Tested on

macOS 14.3.1 23D60 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?