### PR TITLE
uv: Update to 0.1.11

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,22 +4,22 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.1.10
+github.setup            astral-sh uv 0.1.11
 github.tarball_from     archive
 revision                0
 categories              devel python
 license                 Apache-2 MIT
 platforms               {darwin >= 15}
-maintainers             {@therealketo gmail.com:therealketo} openmaintainer
+maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
 description             Extremely fast Python package installer and resolver
 long_description        {*}${description}, written in Rust. Designed as a drop-in \
                         replacement for pip and pip-compile.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  82916cb087d66edf914eed868f61b5396b26b5da \
-                        sha256  2c31cb4b0d8c9e38f456bb813e40acb369cccf169043e9642b9879bd144f05b6 \
-                        size    1850973
+                        rmd160  5881df0318b9060c4e01825c2b6b45eae3e97cad \
+                        sha256  22237f7f74ff2bb215a019dd61b86e3829dd83341104dc779a3263d2105eb0ea \
+                        size    1861771
 
 depends_build-append    port:pkgconfig
 depends_lib-append      port:libgit2
@@ -73,7 +73,7 @@ cargo.crates \
     anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
     anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
     anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
-    anyhow                          1.0.79  080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca \
+    anyhow                          1.0.80  5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1 \
     arc-swap                         1.6.0  bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6 \
     arrayref                         0.3.7  6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545 \
     arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
@@ -213,7 +213,7 @@ cargo.crates \
     indexmap                         2.2.3  233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177 \
     indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
     indoc                            2.0.4  1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8 \
-    insta                           1.34.0  5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc \
+    insta                           1.35.1  7c985c1bef99cf13c58fade470483d81a2bfe846ebde60ed28cc2dddec2df9e2 \
     instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
     ipnet                            2.9.0  8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3 \
     is-terminal                     0.4.12  f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b \
@@ -229,7 +229,7 @@ cargo.crates \
     kurbo                            0.9.5  bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
-    libgit2-sys                   0.16.2+1.7.2  ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8 \
+    libgit2-sys               0.16.2+1.7.2  ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8 \
     libmimalloc-sys                 0.1.35  3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664 \
     libredox                         0.0.1  85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8 \
     libssh2-sys                      0.3.0  2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee \
@@ -267,7 +267,7 @@ cargo.crates \
     once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
     oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
-    openssl-src                   300.2.3+3.2.1  5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843 \
+    openssl-src              300.2.3+3.2.1  5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843 \
     openssl-sys                     0.9.99  22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
@@ -301,12 +301,12 @@ cargo.crates \
     proc-macro2                     1.0.78  e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae \
     ptr_meta                         0.1.4  0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1 \
     ptr_meta_derive                  0.1.4  16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac \
-    pyo3                            0.20.2  9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0 \
-    pyo3-build-config               0.20.2  07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be \
-    pyo3-ffi                        0.20.2  dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1 \
+    pyo3                            0.20.3  53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233 \
+    pyo3-build-config               0.20.3  deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7 \
+    pyo3-ffi                        0.20.3  62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa \
     pyo3-log                         0.9.0  4c10808ee7250403bedb24bc30c32493e93875fef7ba3e4292226fe924f398bd \
-    pyo3-macros                     0.20.2  05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3 \
-    pyo3-macros-backend             0.20.2  0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f \
+    pyo3-macros                     0.20.3  7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158 \
+    pyo3-macros-backend             0.20.3  7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185 \
     pyproject-toml                  0.10.0  3b80f889b6d413c3f8963a2c7db03f95dd6e1d85e1074137cb2013ea2faa8898 \
     quick-xml                       0.31.0  1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33 \
     quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
@@ -408,11 +408,11 @@ cargo.crates \
     test-case-core                   3.3.1  adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f \
     test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
     testing_logger                   0.1.1  6d92b727cb45d33ae956f7f46b966b25f1bc712092aeef9dba5ac798fc89f720 \
-    textwrap                        0.16.0  222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d \
+    textwrap                        0.16.1  23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9 \
     thiserror                       1.0.57  1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b \
     thiserror-impl                  1.0.57  a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81 \
     thread_local                     1.1.7  3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152 \
-    tikv-jemalloc-sys             0.5.4+5.3.0-patched  9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1 \
+    tikv-jemalloc-sys  0.5.4+5.3.0-patched  9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1 \
     tikv-jemallocator                0.5.4  965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca \
     time                            0.3.34  c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749 \
     time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
@@ -474,7 +474,7 @@ cargo.crates \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
     walkdir                          2.4.0  d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee \
     want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
-    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
     wasm-bindgen                    0.2.91  c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f \
     wasm-bindgen-backend            0.2.91  c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b \
     wasm-bindgen-futures            0.4.41  877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97 \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.1.11.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
