### PR TITLE
micronaut: update to 4.3.4

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.3.3 v
+github.setup    micronaut-projects micronaut-starter 4.3.4 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  f33b49a935c27a24e48ba75201f94a0b8ddb5adf \
-                sha256  720fa422dc634158724ee135232821b8b89dbade4d5ac1d7badf5d975d6d066b \
-                size    22370679
+checksums       rmd160  05b08cabafa43b8c5737085181f75b810384869f \
+                sha256  977a54a322d7059e25ddee708aaff276c7eed1097b5548ac4038b42e093880ea \
+                size    22371495
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Miconaut Starter 4.3.4.

###### Tested on

macOS 14.3.1 23D60 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?