### PR TITLE
idevicerestore-devel: Update to 20231126

### DIFF
--- a/devel/idevicerestore/Portfile
+++ b/devel/idevicerestore/Portfile
@@ -2,12 +2,12 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           openssl 1.0
 
 github.setup        libimobiledevice idevicerestore 1.0.0
 revision            1
 
 categories          devel
-platforms           darwin
 
 license             LGPL-3
 maintainers         {i0ntempest @i0ntempest} openmaintainer
@@ -47,8 +47,7 @@ depends_build-append \
                     port:libtool \
                     port:pkgconfig
 
-depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb \
-                    path:lib/libssl.dylib:openssl \
+depends_lib-append  path:lib/pkgconfig/libusb-1.0.pc:libusb \
                     port:curl \
                     port:libimobiledevice \
                     port:libirecovery \
@@ -60,13 +59,13 @@ depends_lib         path:lib/pkgconfig/libusb-1.0.pc:libusb \
 configure.cmd       ./autogen.sh
 
 subport idevicerestore-devel {
-    github.setup    libimobiledevice idevicerestore 8ebee55718190c5bec5fb24128f2e3b986174397
-    version         20200709
-    revision        1
+    github.setup    libimobiledevice idevicerestore 8a5abb99170b324b0fc5a00928ba2ac78a7afc98
+    version         20231126
+    revision        0
 
-    checksums       rmd160  6a9819ea4cbf4385bcbf3b776728983c57f21838 \
-                    sha256  ff7a74581c55f2348c1f5d4ef7190962173017f21bf92c030db4e6717ee90a19 \
-                    size    107556
+    checksums       rmd160  64a472b9a29358e5f0b80eff6c53bc2709589d1c \
+                    sha256  ea2732b521c368cb1b6a3d83680cfacfd964ad67a53cb1ea43039aad64534550 \
+                    size    119655
 
     depends_lib-replace port:libimobiledevice \
                         port:libimobiledevice-devel
@@ -74,6 +73,10 @@ subport idevicerestore-devel {
     depends_lib-replace port:libirecovery port:libirecovery-devel
 
     conflicts       idevicerestore
+
+    post-extract {
+        system -W ${worksrcpath} "echo ${version} > .tarball-version"
+    }
 
     livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
 }


### PR DESCRIPTION
#### Description

Update `idevicerestore-devel` to its latest commit, as the current commit is from 3 years ago. The port has also been migrated to use the `openssl` PortGroup.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
