### PR TITLE
catgirl: update to 2.2

### DIFF
--- a/net/catgirl/Portfile
+++ b/net/catgirl/Portfile
@@ -1,15 +1,15 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 name                catgirl
-version             2.1
-revision            1
+version             2.2
+revision            0
 categories          net
 license             GPL-3+
 license_noconflict  openssl libressl
-platforms           darwin
 maintainers         {@ryanakca debian.org:rak} \
                     {causal.agency:june @causal-agent} \
                     openmaintainer
@@ -23,30 +23,29 @@ long_description    catgirl is a TLS-only terminal IRC client. Its features \
 homepage            https://git.causal.agency/catgirl/
 master_sites        ${homepage}snapshot/
 
-checksums           rmd160  4572a61899ef8d9ea2eed03ed2c4a014570fd03b \
-                    sha256  a68bfb82f625bcdf7bc5b7a6e1528fe3559bcded41f0d3c972f8b7e918bcee8e \
-                    size    68822
+checksums           rmd160  b546d4a2aa4ce62b77f558350d26a54d4ed57e9a \
+                    sha256  fb6d04a099303af05d278c705c1542e7ee61643c030d6a0b68dec5371080a3c7 \
+                    size    69835
 
 depends_build       port:pkgconfig
 
 depends_lib         path:lib/libtls.dylib:libretls \
                     port:ncurses
 
+compiler.c_standard 2011
+
 use_configure       yes
-configure.post_args --prefix=${prefix} \
+configure.post_args --enable-sandman \
+                    --prefix=${prefix} \
                     --mandir=${prefix}/share/man
 
-post-build {
-    system -W "${worksrcpath}" "${build.cmd} -C scripts sandman"
-}
+# FIXME: needs an implementation of memset_s:
+# https://trac.macports.org/ticket/67214
+# See also:
+# https://trac.macports.org/ticket/66087
 
 test.run            yes
 test.target         check
-
-post-destroot {
-    system -W "${worksrcpath}" \
-        "${destroot.cmd} -C scripts install ${destroot.destdir}"
-}
 
 livecheck.type      regex
 livecheck.regex     ${name}-(\\d+\.\\d+\[a-z\]?).tar.gz


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
