### PR TITLE
weechat: update to 4.2.1

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -9,11 +9,11 @@ PortGroup           legacysupport 1.0
 legacysupport.newest_darwin_requires_legacy 10
 
 name                weechat
-version             4.1.2
+version             4.2.1
 revision            0
-checksums           rmd160  a9f09efe4f87789e1c394a2ecf4668a640078d86 \
-                    sha256  9a9b910fbe768bb9de7c7ac944f5db8f233833f345b2e505e16ec6ef35effbb5 \
-                    size    2635776
+checksums           rmd160  9501191a3c075916d223dfd4ba3182a330332ef2 \
+                    sha256  253ddf086f6c845031a2dd294b1552851d6b04cc08a2f9da4aedfb3e2f91bdcd \
+                    size    2594044
 
 master_sites        https://weechat.org/files/src/
 use_xz              yes


### PR DESCRIPTION
#### Description
weechat: update to 4.2.1

###### Tested on
macOS 12.7.2 21G1974 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
