### PR TITLE
hugo: update to 0.123.6

### DIFF
--- a/www/hugo/Portfile
+++ b/www/hugo/Portfile
@@ -3,13 +3,13 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/gohugoio/hugo 0.123.4 v
+go.setup            github.com/gohugoio/hugo 0.123.6 v
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  c91429cc69d9b26bc6b3cba3070b71c5896a4e46 \
-                    sha256  3e681c0a3f5d1422e7b26cb996ec53f20481ab4bb24eaf9f1ba0cccf5dde20ac \
-                    size    21043942
+checksums           rmd160  45e69da87b179f58715bf5c0a9f6656980a0f571 \
+                    sha256  203ff012fb017cd8eba491804b469d1b202f19f7885e6c65fbcffb40a7742a2f \
+                    size    21044465
 
 categories          www
 installs_libs       no


### PR DESCRIPTION
#### Description
hugo: update to 0.123.6

###### Tested on
macOS 12.7.2 21G1974 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?