### PR TITLE
libucl: update to 0.9.0

### DIFF
--- a/devel/libucl/Portfile
+++ b/devel/libucl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        vstakhov libucl 0.8.2
+github.setup        vstakhov libucl 0.9.0
 license             BSD
 description         Universal configuration library parser
 
@@ -12,9 +12,9 @@ maintainers         {grimreaper @grimreaper}
 categories          devel
 platforms           darwin freebsd
 
-checksums           rmd160  fd1bc15643aa4c39ea5554bce6ed98e2fba737ce \
-                    sha256  e3b29f778fe306bdd42f90f3b62890d07bf9a54f2d91781e8e4592fc5768fc9d \
-                    size    2040138
+checksums           rmd160  10c9715f0b35bd4e2d4ad1e25b7cc9f15bb493f8 \
+                    sha256  ee44d2eaaf1676e934e43ebf02a69d6c784345d583405b3b297da743f1e9925f \
+                    size    2043739
 
 depends_build       port:pkgconfig
 use_autoreconf      yes


### PR DESCRIPTION
Is there any reason why this shouldn't also be `openmaintainer`?

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
