### PR TITLE
fdupes: update to 2.3.0

### DIFF
--- a/sysutils/fdupes/Portfile
+++ b/sysutils/fdupes/Portfile
@@ -4,10 +4,12 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 epoch               1
-github.setup        adrianlopezroche fdupes 2.2.1 v
+github.setup        adrianlopezroche fdupes 2.3.0 v
+github.tarball_from releases
 revision            0
 
 categories          sysutils
+installs_libs       no
 maintainers         {grimreaper @grimreaper}
 license             MIT zlib
 
@@ -16,15 +18,15 @@ long_description    ${name} identifies and/or deletes duplicate files in specifi
 
 platforms           darwin freebsd
 
-github.tarball_from releases
+checksums           rmd160  691bc9549e3038a1d86d83d44515029f6eb23ed5 \
+                    sha256  6170d64a7e565ee314cca4dd25a123e60aa1e3febb11e57078bebb9c1da7e019 \
+                    size    154700
 
-checksums           rmd160  dc0776b1de2b323fea8bd496ae65bf1cd531125d \
-                    sha256  846bb79ca3f0157856aa93ed50b49217feb68e1b35226193b6bc578be0c5698d \
-                    size    144719
+depends_build-append \
+                    port:pkgconfig
 
-depends_build       port:pkgconfig
-
-depends_lib         port:ncurses \
-                    port:pcre2
+depends_lib-append  port:ncurses \
+                    port:pcre2 \
+                    port:sqlite3
 
 use_autoreconf      yes


### PR DESCRIPTION
Should this also be marked `openmaintainer`?

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
