### PR TITLE
matterhorn: update to 90000.0.0

### DIFF
--- a/net/matterhorn/Portfile
+++ b/net/matterhorn/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           haskell_cabal 1.0
 
 name                matterhorn
-version             50200.15.0
-revision            1
-checksums           rmd160  73d6e5a5fcb12916c2745bbcf5229779f762bf05 \
-                    sha256  aad5d0d5b7d89bd39814f9be080c060f767edc825b43a048389a7e175d68c342 \
-                    size    964876
+version             90000.0.0
+revision            0
+checksums           rmd160  b5a2eaf4f0bf466e665ac1f81f8b1c49f6c42ebf \
+                    sha256  57838f85c6740e8fb17c6e96c716c657931e163546658e1043a73cd6031c866d \
+                    size    1057207
 
 master_sites        https://hackage.haskell.org/package/${name}-${version}
 
@@ -23,5 +23,7 @@ platforms           darwin
 supported_archs     noarch
 maintainers         {isi.edu:calvin @cardi} openmaintainer
 license             BSD
+
+build.target        exe:matterhorn
 
 test.run            yes


### PR DESCRIPTION
#### Description
matterhorn: update to 90000.0.0
* explicitly set build target to matterhorn executable

###### Tested on
macOS 12.7.2 21G1974 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
