### PR TITLE
nghttp2: update one patch

### DIFF
--- a/www/nghttp2/Portfile
+++ b/www/nghttp2/Portfile
@@ -27,6 +27,7 @@ depends_build       port:pkgconfig
 # See: https://trac.macports.org/ticket/57960
 # See: https://github.com/nghttp2/nghttp2/issues/1309
 # See: https://github.com/nghttp2/nghttp2/pull/1319
+# See: https://github.com/nghttp2/nghttp2/pull/2086
 patchfiles-append   patch-src-shrpx_client_handler.cc.diff \
                     patch-src-shrpx_downstream_connection_pool.cc.diff \
                     src-shrpx_config.diff

--- a/www/nghttp2/files/src-shrpx_config.diff
+++ b/www/nghttp2/files/src-shrpx_config.diff
@@ -1,24 +1,50 @@
---- src/shrpx_config.cc~	2017-07-02 10:46:31.000000000 +0200
-+++ src/shrpx_config.cc	2017-07-09 22:29:41.000000000 +0200
-@@ -43,6 +43,21 @@
- #endif // HAVE_UNISTD_H
- #include <dirent.h>
+From a42253a08e3686a90e676773819f0dccd2f98fb0 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Thu, 29 Feb 2024 02:26:33 +0700
+Subject: [PATCH 1/3] shrpx_config.cc: if undefined, define AI_NUMERICSERV to 0
+
+---
+ src/shrpx_config.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git src/shrpx_config.cc src/shrpx_config.cc
+index 8bc3a280..1e9cd4c5 100644
+--- src/shrpx_config.cc
++++ src/shrpx_config.cc
+@@ -66,6 +66,10 @@
+ #include "ssl_compat.h"
+ #include "xsi_strerror.h"
  
-+#ifdef __APPLE__                                                // this block only for Macs
-+# ifndef __MAC_OS_X_VERSION_MIN_REQUIRED                        // are AvailabilityMacros.h or Availability.h not yet included?
-+#  if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050     // then for Leopard and later…
-+#   include <Availability.h>                                    // …either include this…
-+#  else
-+#   include <AvailabilityMacros.h>                              // …or include that
-+#  endif
-+# endif
-+# if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060                     // and for some OS versions do this…
-+#  ifndef AI_NUMERICSERV
-+#   define AI_NUMERICSERV 0
-+#  endif
-+# endif                                                         // finish OS version discrimination
-+#endif                                                          // finish Apple case
++#ifndef AI_NUMERICSERV
++#define AI_NUMERICSERV 0
++#endif
 +
- #include <cstring>
- #include <cerrno>
- #include <limits>
+ namespace shrpx {
+ 
+ namespace {
+
+From 1942eb8ffeee28efb46a7472f002b6e0aeedb8d5 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Thu, 29 Feb 2024 02:29:36 +0700
+Subject: [PATCH 2/3] shrpx_tls_test.cc: use AI_NUMERICSERV when defined
+
+---
+ src/shrpx_tls_test.cc | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git src/shrpx_tls_test.cc src/shrpx_tls_test.cc
+index 7fe50dde..04d16daa 100644
+--- src/shrpx_tls_test.cc
++++ src/shrpx_tls_test.cc
+@@ -225,7 +225,10 @@ static Address parse_addr(const char *ipaddr) {
+   addrinfo hints{};
+ 
+   hints.ai_family = AF_UNSPEC;
+-  hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
++  hints.ai_flags = AI_NUMERICHOST;
++#ifdef AI_NUMERICSERV
++  hints.ai_flags |= AI_NUMERICSERV;
++#endif
+ 
+   addrinfo *res = nullptr;
+ 


### PR DESCRIPTION
#### Description

Update `AI_NUMERICSERV` to a simpler version.
(I also think that the existing patch is incorrect and works by accident.)

The effect is the same, however: it defines `AI_NUMERICSERV` to 0 if undefined otherwise.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1
Xcode 15.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
