### PR TITLE
cpp-argparse-dev: update to v1.9.1

### DIFF
--- a/devel/cpp-argparse-dev/Portfile
+++ b/devel/cpp-argparse-dev/Portfile
@@ -5,7 +5,7 @@ PortSystem              1.0
 PortGroup               github 1.0
 PortGroup               cmake 1.1
 
-github.setup            rue-ryuzaki argparse 1.9.0 v
+github.setup            rue-ryuzaki argparse 1.9.1 v
 github.tarball_from     archive
 revision                0
 name                    cpp-argparse-dev
@@ -18,9 +18,9 @@ maintainers             {gmail.com:golubchikov.mihail @rue-ryuzaki} \
 description             C++ argument parser.
 long_description        Python-like header-only argument parser for C++ projects.
 
-checksums               rmd160  d61fc151c8cc4ccde2f46332779e7b705af923b5 \
-                        sha256  bb507dd4f93b37a85343cb6df962fe136cb79d1463873c0822779ca39544ba1b \
-                        size    435731
+checksums               rmd160  130d5fbaa18699b0a4a26e532efa8e50f98c7c5c \
+                        sha256  d66b1e8a745c6926ff8f14f6e3097194dc8575e116e3124489ccf2669ec65e76 \
+                        size    442674
 
 compiler.cxx_standard   2011
 


### PR DESCRIPTION
#### Description

  * Remove: include `<algorithm>`, `<map>`, `<numeric>`, `<queue>`, `<set>`, `<stack>`
  * Move to impl: include `<fstream>`, `<regex>`
  * Update: std containers support for Namespace::get<>
  * Add: examples

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Xcode 12.1 12A7403

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
