### PR TITLE
poetry: update to 1.8.1

### DIFF
--- a/python/poetry/Portfile
+++ b/python/poetry/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    poetry
-version                 1.7.1
+version                 1.8.1
 revision                0
 categories-append       devel
 platforms               {darwin any}
@@ -23,20 +23,21 @@ long_description        Poetry: Dependency Management for Python. \
 
 homepage                https://python-poetry.org/
 
-checksums               rmd160  6d56dc5325dfd2dc9dbb0191763b0785e616124a \
-                        sha256  b348a70e7d67ad9c0bd3d0ea255bc6df84c24cf4b16f8d104adb30b425d6ff32 \
-                        size    1483927
+checksums               rmd160  ba5ebd7411fb53f3d36b33a951a6910db3212023 \
+                        sha256  23519cc45eb3cf48e899145bc762425a141e3afd52ecc53ec443ca635122327f \
+                        size    1514978
 
 variant python38 conflicts python39 python310 python311 description {Use Python 3.8} {}
 variant python39 conflicts python38 python310 python311 description {Use Python 3.9} {}
 variant python310 conflicts python38 python39 python311 description {Use Python 3.10} {}
 variant python311 conflicts python38 python39 python310 description {Use Python 3.11} {}
+variant python312 conflicts python38 python39 python310 description {Use Python 3.12} {}
 
-if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310]} {
-    default_variants +python311
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
+    default_variants +python312
 }
 
-foreach pv {311 310 39 38} {
+foreach pv {312 311 310 39 38} {
     if {[variant_isset python${pv}]} {
         python.default_version  ${pv}
         break

--- a/python/py-poetry-core/Portfile
+++ b/python/py-poetry-core/Portfile
@@ -8,14 +8,14 @@ PortGroup           select 1.0
 # compatible with this port. py-poetry-core is closely coupled to poetry,
 # both in terms of APIs but also the version pinning.
 name                py-poetry-core
-version             1.8.1
+version             1.9.0
 revision            0
 
 distname            poetry_core-${version}
 
-checksums           rmd160  c5acd6c31abe6d4bb8c7c14c3a19e1620edf54fa \
-                    sha256  67a76c671da2a70e55047cddda83566035b701f7e463b32a2abfeac6e2a16376 \
-                    size    333719
+checksums           rmd160  c42f182a805e3874558f927fcd0114dd0b1a99f0 \
+                    sha256  fa7a4001eae8aa572ee84f35feb510b321bd652e5cf9293249d62853e1f935a2 \
+                    size    337190
 
 categories-append   devel
 supported_archs     noarch


### PR DESCRIPTION
#### Description

This is blocked on #22813

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.4 22G513 x86_64
Command Line Tools 15.1.0.0.1.1700200546


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
