### PR TITLE
py-notebook: patch for traitlets >5.9.0

### DIFF
--- a/python/py-notebook/Portfile
+++ b/python/py-notebook/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 
 name                py-notebook
 version             6.4.11
-revision            0
+revision            1
 categories-append   devel science
 license             BSD
 supported_archs     noarch
@@ -23,6 +23,9 @@ homepage            https://jupyter.org
 checksums           rmd160  cf55b90f08ca88013ab60b4b39931a9d6535b55f \
                     sha256  709b1856a564fe53054796c80e17a67262071c86bfbdfa6b96aaa346113c555a \
                     size    14373938
+
+patchfiles          traittypes.py.diff
+patch.dir           ${worksrcpath}/notebook
 
 if {${name} ne ${subport}} {
     depends_build-append \

--- a/python/py-notebook/files/traittypes.py.diff
+++ b/python/py-notebook/files/traittypes.py.diff
@@ -1,0 +1,10 @@
+--- traittypes.py.orig~	2024-02-29 21:00:44.071931000 -0600
++++ traittypes.py	2024-02-29 21:01:05.518299672 -0600
+@@ -1,5 +1,6 @@
+ import inspect
+-from traitlets import ClassBasedTraitType, Undefined, warn
++from warnings import warn
++from traitlets import ClassBasedTraitType, Undefined
+ 
+ # Traitlet's 5.x includes a set of utilities for building
+ # description strings for objects. Traitlets 5.x does not


### PR DESCRIPTION
* patch to workaround moving of warn submodule

Closes: https://trac.macports.org/ticket/69419
Closes https://trac.macports.org/ticket/69244

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1 23D60 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
