### PR TITLE
uv: Update to 0.1.13

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,12 +4,12 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.1.11
+github.setup            astral-sh uv 0.1.13
 github.tarball_from     archive
 revision                0
 categories              devel python
 license                 Apache-2 MIT
-platforms               {darwin >= 15}
+platforms               {darwin >= 16}
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
 description             Extremely fast Python package installer and resolver
@@ -17,9 +17,9 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for pip and pip-compile.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  5881df0318b9060c4e01825c2b6b45eae3e97cad \
-                        sha256  22237f7f74ff2bb215a019dd61b86e3829dd83341104dc779a3263d2105eb0ea \
-                        size    1861771
+                        rmd160  1a6a3a73371565d88a60d181eec0ea33d67405a6 \
+                        sha256  bbd9abb6d735400e3c142e863bc7d69ad539c422a013601f550dd8fd2312ae4f \
+                        size    1860446
 
 depends_build-append    port:pkgconfig
 depends_lib-append      port:libgit2
@@ -68,7 +68,7 @@ cargo.crates \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
-    anstream                        0.6.11  6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5 \
+    anstream                        0.6.12  96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540 \
     anstyle                          1.0.6  8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc \
     anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
     anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
@@ -77,7 +77,7 @@ cargo.crates \
     arc-swap                         1.6.0  bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6 \
     arrayref                         0.3.7  6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545 \
     arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
-    assert_cmd                      2.0.13  00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467 \
+    assert_cmd                      2.0.14  ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8 \
     assert_fs                        1.1.1  2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec \
     async-compression                0.4.6  a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c \
     async-trait                     0.1.77  c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9 \
@@ -278,6 +278,7 @@ cargo.crates \
     parking_lot_core                 0.8.6  60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc \
     parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
     paste                           1.0.14  de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c \
+    pathdiff                         0.2.1  8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
     petgraph                         0.6.4  e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9 \
     pico-args                        0.5.0  5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315 \
@@ -362,9 +363,9 @@ cargo.crates \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
     security-framework               2.9.2  05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de \
     security-framework-sys           2.9.1  e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a \
-    serde                          1.0.196  870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32 \
-    serde_derive                   1.0.196  33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67 \
-    serde_json                     1.0.113  69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79 \
+    serde                          1.0.197  3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2 \
+    serde_derive                   1.0.197  7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b \
+    serde_json                     1.0.114  c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0 \
     serde_spanned                    0.6.5  eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
     sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
@@ -399,7 +400,7 @@ cargo.crates \
     system-configuration-sys         0.5.0  a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9 \
     tagu                             0.1.6  eddb6b06d20fba9ed21fca3d696ee1b6e870bca0bcf9fa2971f6ae2436de576a \
     tap                              1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
-    target-lexicon                 0.12.13  69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae \
+    target-lexicon                 0.12.14  e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f \
     task-local-extensions            0.1.4  ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8 \
     tempfile                        3.10.0  a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67 \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \


### PR DESCRIPTION
#### Description

Update `uv` to its latest release, 0.1.13.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
