### PR TITLE
legacy-support: replace maintainer

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -10,7 +10,8 @@ name                legacy-support
 categories          devel
 platforms           darwin
 
-maintainers         {jonesc @cjones051073} openmaintainer
+maintainers         {mascguy @mascguy} \
+                    {fwright.net:fw @fhgwright}
 license             MIT BSD APSL-2
 
 description         Installs wrapper headers to add missing functionality to legacy OSX versions.
@@ -20,6 +21,8 @@ long_description    {*}${description}
 epoch               1
 
 # Primary release version
+# NOTE: At present, v1.2.0 has a compatibility issue.
+# Do not update until this is resolved.
 set release_ver     1.1.1
 
 # Binary compatibility version


### PR DESCRIPTION
Adds new maintainers, and removes jonesc as requested.

Temporarily removes openmaintainer, until compatibility issue in upcoming version is resolved.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

None of the above.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

###### Verification <!-- (delete not applicable items) -->
Have you


<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
