### PR TITLE
greed: Update to 4.3

### DIFF
--- a/games/greed/Portfile
+++ b/games/greed/Portfile
@@ -1,41 +1,37 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
+PortSystem              1.0
+PortGroup               makefile 1.0
 
-name                greed
-version             4.2
-categories          games
-license             GPL-2
-platforms           darwin
-maintainers         nomaintainer
+name                    greed
+version                 4.3
+revision                0
+categories              games
+license                 BSD
+maintainers             nomaintainer
 
-description         strategy game
-long_description \
-    The strategy game of Greed. Try to eat as much as possible \
-    of the board before munching yourself into a corner.
+description             The strategy game of Greed
+long_description        {*}${description}. Try to eat as much as possible of \
+                        the board before munching yourself into a corner.
 
-homepage            http://www.catb.org/~esr/greed/
-master_sites        http://www.catb.org/~esr/greed/
+homepage                http://www.catb.org/~esr/greed/
+master_sites            ${homepage}
 
-checksums           rmd160  710d211d2cffde25f3732c5a45f3df9fec3558d1 \
-                    sha256  702bc0314ddedb2ba17d4b55d873384a1606886e8d69f35ce67f6e3024a8d3fd
+checksums               rmd160  165629a6c2afcd62ec8d0b41441a60686566da14 \
+                        sha256  8ea3b9a22e9cf3789a9103d38ac0bf88fd6179763fffe36e3b607946b7449acf \
+                        size    15150
 
-use_configure       no
-build.target        ${name}
+patch.pre_args          -p1
+patchfiles              patch-makefile.diff
 
-patch {
-    reinplace s|/install|/greed| $worksrcpath/Makefile
-    reinplace "s|cp greed |cp greed \$\{DESTDIR\}|" $worksrcpath/Makefile
-    reinplace "s|cp greed.6 |cp greed.6 \$\{DESTDIR\}|" \
-        $worksrcpath/Makefile
-    reinplace s|BIN=/usr/games|BIN=${prefix}/bin| $worksrcpath/Makefile
-    reinplace s|SFILE=/usr/games/lib|SFILE=${prefix}/share/greed| \
-        $worksrcpath/Makefile
-    reinplace s|/usr/share|${prefix}/share| $worksrcpath/Makefile
+depends_lib-append      port:ncurses
+
+post-build {
+    reinplace "s|/usr/lib/games|${prefix}/share/${name}|g" ${worksrcpath}/${name}.6
 }
 
 post-destroot {
-    file mkdir ${destroot}${prefix}/share/greed
-    system "touch ${destroot}${prefix}/share/greed/greed.hs"
-    system "chmod 775 ${destroot}${prefix}/share/greed/greed.hs"
+    file mkdir ${destroot}${prefix}/share/${name}
+    system "touch ${destroot}${prefix}/share/${name}/${name}.hs"
+    system "chmod 644 ${destroot}${prefix}/share/${name}/${name}.hs"
 }

--- a/games/greed/files/patch-makefile.diff
+++ b/games/greed/files/patch-makefile.diff
@@ -1,0 +1,38 @@
+diff -urN a/Makefile b/Makefile
+--- a/Makefile	2024-03-02 02:24:04.000000000 +0000
++++ b/Makefile	2024-03-02 02:46:16.000000000 +0000
+@@ -2,12 +2,15 @@
+ 
+ VERS=$(shell sed -n <NEWS.adoc '/^[0-9]/s/:.*//p' | head -1)
+ 
+-SFILE=/usr/games/lib/greed.hs
+-# Location of game executable
+-BIN=/usr/games
++PREFIX ?= /usr/local
++BINDIR := $(PREFIX)/bin
++MANDIR := $(PREFIX)/share/man
++SFILE  ?= $(PREFIX)/share/greed/greed.hs
++
++all: greed greed.6
+ 
+ greed: greed.c
+-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -DSCOREFILE=\"$(SFILE)\" -DRELEASE=\"$(VERS)\" -o greed greed.c -O3 -lcurses
++	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -DSCOREFILE=\"$(SFILE)\" -DRELEASE=\"$(VERS)\" -o greed greed.c -O2 -lncurses
+ 
+ # Note: to suppress the footers with timestamps being generated in HTML,
+ # we use "-a nofooter".
+@@ -19,9 +22,11 @@
+ 	asciidoctor -D. -a nofooter -b manpage $<
+ .adoc.html:
+ 	asciidoctor -D. -a nofooter -a webfonts! $<
+-install: greed.6 uninstall
+-	cp greed $(BIN)
+-	cp greed.6 /usr/share/man/man6/greed.6
++install: greed.6
++	install -d $(DESTDIR)$(BINDIR)
++	install -d $(DESTDIR)$(MANDIR)
++	install -m 0755 greed $(DESTDIR)$(BINDIR)
++	install -m 0644 greed.6 $(DESTDIR)$(MANDIR)/man6/greed.6
+ 
+ uninstall:
+ 	rm -f $(BIN)/install /usr/share/man/man6/greed.6


### PR DESCRIPTION
#### Description

Update the game, `greed`, to its latest released version, 4.3. Rather than having constant `reinplace` calls for the Makefile, a patch was made to fit the `makefile` PG, which modernizes the Portfile.

Additionally, the Portfile now links with MacPorts's `ncurses` port, and reflects the license change of the project.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
