### PR TITLE
galaxis: Update to 1.11

### DIFF
--- a/games/galaxis/Portfile
+++ b/games/galaxis/Portfile
@@ -1,24 +1,31 @@
-PortSystem       1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name             galaxis
-version          1.7
-categories       games
-license          GPL-2
-maintainers      nomaintainer
-description      UNIX clone of the Mac game Galaxis
-long_description \
-    UNIX-hosted, curses-based clone of the nifty little Macintosh \
-    freeware game Galaxis. The code is POSIX-conforming and was \
-    written under Linux using the ncurses library\; it should part \
-    readily to any System V. BSD sites using the inferior native \
-    BSD curses will lose some features (no color, nor arrow-key \
-    support).
-homepage         http://www.catb.org/~esr/galaxis/
-platforms        darwin
-master_sites     sunsite:games/strategy
-checksums        md5 5251b71f7e7cf0bb57b3f6c2cfc887e3
-patch {
-    reinplace s|\$.ROOT./usr|\$\{DESTDIR\}${prefix}|g $worksrcpath/Makefile
-}
-use_configure    no
-build.target     ${name}
+PortSystem              1.0
+PortGroup               makefile 1.0
+
+name                    galaxis
+version                 1.11
+revision                0
+categories              games
+license                 BSD
+maintainers             nomaintainer
+
+description             UNIX clone of the Mac game Galaxis
+long_description        UNIX-hosted, curses-based clone of the nifty little Macintosh \
+                        freeware game Galaxis. The code is POSIX-conforming and was \
+                        written under Linux using the ncurses library\; it should part \
+                        readily to any System V. BSD sites using the inferior native \
+                        BSD curses will lose some features (no color, nor arrow-key \
+                        support).
+
+homepage                http://catb.org/~esr/galaxis/
+master_sites            ${homepage}
+
+checksums               rmd160  98b064f5dfce4688c122153bc1a2f9b5390f870b \
+                        sha256  94059ba4f09985033a7d5f57a307063edbb0cdecc2d02898dc6ce4ce496b6856 \
+                        size    10931
+
+patch.pre_args          -p1
+patchfiles              patch-makefile.diff
+
+depends_lib-append      port:ncurses

--- a/games/galaxis/files/patch-makefile.diff
+++ b/games/galaxis/files/patch-makefile.diff
@@ -1,0 +1,36 @@
+diff -urN a/Makefile b/Makefile
+--- a/Makefile	2024-02-08 11:25:35.000000000 +0000
++++ b/Makefile	2024-03-02 20:26:12.000000000 +0000
+@@ -8,7 +8,12 @@
+ # Flags for use with the Linux ncurses package (recommended)
+ CFLAGS = -g -DNDEBUG
+ TERMLIB = -lncurses
+-CC = gcc
++
++PREFIX ?= /usr
++BINDIR := $(PREFIX)/bin
++MANDIR := $(PREFIX)/share/man/man6
++
++all: galaxis
+ 
+ galaxis: galaxis.c
+ 	$(CC) $(CFLAGS) -o galaxis galaxis.c $(TERMLIB)
+@@ -25,13 +30,13 @@
+ 	asciidoctor -D. -a nofooter -a webfonts! $<
+ 
+ install: galaxis.6 uninstall
+-	install -m 755 -o 0 -g 0 -d $(ROOT)/usr/bin/
+-	install -m 755 -o 0 -g 0 galaxis $(ROOT)/usr/bin/galaxis
+-	install -m 755 -o 0 -g 0 -d $(ROOT)/usr/share/man/man6/
+-	install -m 755 -o 0 -g 0 galaxis.6 $(ROOT)/usr/share/man/man6/galaxis.6
++	install -m 755 -d $(DESTDIR)$(BINDIR)
++	install -m 755 galaxis $(DESTDIR)$(BINDIR)
++	install -m 755 -d $(DESTDIR)$(MANDIR)
++	install -m 755 galaxis.6 $(DESTDIR)$(MANDIR)
+ 
+ uninstall:
+-	rm -f ${ROOT}/usr/bin/galaxis ${ROOT}/usr/share/man/man6/galaxis.6
++	rm -f $(DESTDIR)$(BINDIR)/galaxis $(DESTDIR)$(MANDIR)/galaxis.6
+ 
+ clean:
+ 	rm -f galaxis galaxis.6 galaxis-*.tar.gz *~ *.html


### PR DESCRIPTION
#### Description

Update `galaxis` to its latest released version, 1.11. Additionally, the Portfile was changed to reflect the following changes:

- Use a patch to adapt the `makefile` PG
- Correctly declare `ncurses` as a dependency
- Showcase license change; use indentation based on modline

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
