### PR TITLE
Update to openjpeg @2.5.2

### DIFF
--- a/graphics/openjpeg/Portfile
+++ b/graphics/openjpeg/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        uclouvain openjpeg 2.5.1 v
+github.setup        uclouvain openjpeg 2.5.2 v
 revision            0
 
-checksums           rmd160  14212ce2a3e037bd2c49f05265a4b0169f3ff8fa \
-                    sha256  27b70673de22f42552e4455d206219518b584ab5fd67de0a53651a52effc5a33 \
-                    size    1872330
+checksums           rmd160  d88599b2ed6c3cc4af5bdf2711719f9af529c9fc \
+                    sha256  383857954a37e999df72f9cf584d8826b4365185a8eabdecd13ff491807d7458 \
+                    size    1873575
 
 categories          graphics
 license             BSD


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/69431

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1 23D60 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

I've verified that `ghostscript` now builds.