### PR TITLE
py-inflect: new port

### DIFF
--- a/python/py-inflect/Portfile
+++ b/python/py-inflect/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-inflect
+version             7.0.0
+license             MIT
+maintainers         nomaintainer
+
+description         Correctly generate plurals, singular nouns, ordinals, \
+                    indefinite articles\; convert numbers to words
+long_description    {*}${description}
+
+homepage            https://github.com/jaraco/inflect
+checksums           rmd160  8ce769569c102155c3fe04a07b1ebabccd894d16 \
+                    sha256  63da9325ad29da81ec23e055b41225795ab793b4ecb483be5dc1fa363fd4717e \
+                    size    70963
+
+python.versions     38 39 310 311 312
+
+if {${name} ne ${subport}} {
+    depends_build-append \
+                    port:py${python.version}-setuptools_scm
+    depends_lib-append \
+                    port:py${python.version}-pydantic \
+                    port:py${python.version}-typing_extensions
+}


### PR DESCRIPTION
Created mostly using upt

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`? (testing is possible but I didn't add it to the portfile)
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? (only as a dependency for a currently unreleased port)
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
