### PR TITLE
libuv dependents: switch to path-style dep spec to also be able to us…

### DIFF
--- a/devel/cmake-devel/Portfile
+++ b/devel/cmake-devel/Portfile
@@ -85,6 +85,7 @@ platform darwin 8 {
 }
 
 depends_lib-append \
+    path:lib/pkgconfig/libuv.pc:libuv \
     port:curl \
     port:expat \
     port:zlib \

--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -83,6 +83,7 @@ platform darwin 8 {
 }
 
 depends_lib-append \
+    path:lib/pkgconfig/libuv.pc:libuv \
     port:curl \
     port:expat \
     port:zlib \

--- a/devel/getdns/Portfile
+++ b/devel/getdns/Portfile
@@ -32,9 +32,9 @@ checksums           rmd160  9f526ba64162308ee963b206e36540101bbe9441 \
 depends_build-append        port:pkgconfig
 
 depends_lib                 path:lib/libssl.dylib:openssl \
+                            path:lib/pkgconfig/libuv.pc:libuv \
                             port:libevent \
-                            port:libidn2 \
-                            port:libuv
+                            port:libidn2
 
 configure.args-append       -DBUILD_TESTING=OFF \
                             -DENABLE_STUB_ONLY=ON \

--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -49,10 +49,10 @@ depends_build-append \
 
 depends_lib-append \
                     path:lib/libssl.dylib:openssl \
+                    path:lib/pkgconfig/libuv.pc:libuv \
                     port:abseil \
                     port:c-ares \
                     port:lbzip2 \
-                    port:libuv \
                     port:protobuf3-cpp \
                     port:re2 \
                     port:zlib

--- a/devel/libwebsockets/Portfile
+++ b/devel/libwebsockets/Portfile
@@ -29,9 +29,9 @@ checksums           rmd160  aed3594d639d46e926a4d445bee2ea44b7726a2c \
                     size    15618186
 
 depends_lib-append  path:lib/libssl.dylib:openssl \
+                    path:lib/pkgconfig/libuv.pc:libuv \
                     port:zlib \
-                    port:libev \
-                    port:libuv
+                    port:libev
 
 # https://trac.macports.org/ticket/65706
 compiler.blacklist-append *gcc-4.*

--- a/devel/luv/Portfile
+++ b/devel/luv/Portfile
@@ -21,7 +21,7 @@ checksums           rmd160  0ac20e8507492a548e1a87b7c80ba42ff9592efd \
                     sha256  fa6c46fb09f88320afa7f88017efd7b0d2b3a0158c5ba5b6851340b0332a2b81 \
                     size    1468792
 
-depends_lib         port:libuv \
+depends_lib         path:lib/pkgconfig/libuv.pc:libuv \
                     port:lua
 
 # If Lua engine is LuaJIT, prefer lua.h from LUAJIT_INCLUDE_DIR over

--- a/devel/uvw/Portfile
+++ b/devel/uvw/Portfile
@@ -65,7 +65,7 @@ configure.pre_args-replace \
 configure.args-append   -DBUILD_DOCS:BOOL=OFF
 
 if {${subport} eq ${name} || ${subport} eq "uvw2"} {
-    depends_lib-append  port:libuv
+    depends_lib-append  path:lib/pkgconfig/libuv.pc:libuv
     configure.args-append \
                         -DBUILD_TESTING:BOOL=ON \
                         -DBUILD_UVW_SHARED_LIB:BOOL=ON \

--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -31,7 +31,7 @@ checksums               rmd160  a573b99de81e23f37ba6114a7cd669d6e62a4c1a \
 depends_build-append    port:pkgconfig
 
 depends_lib             port:gettext \
-                        port:libuv \
+                        path:lib/pkgconfig/libuv.pc:libuv \
                         port:libvterm \
                         port:libtermkey \
                         port:unibilium \

--- a/net/aria2/Portfile
+++ b/net/aria2/Portfile
@@ -23,7 +23,7 @@ depends_build-append    port:pkgconfig \
 
 depends_lib-append      port:gettext-runtime \
                         port:libiconv \
-                        port:libuv \
+                        path:lib/pkgconfig/libuv.pc:libuv \
                         port:libxml2
 
 # use_* must be defined after depends_*, otherwise the automatic dependencies
@@ -120,6 +120,6 @@ if {${os.platform} eq "darwin" && ${os.major} <= 10} {
 
 # libuv presently not available on 10.4 or earlier
 if {${os.platform} eq "darwin" && ${os.major} <= 8} {
-        depends_lib-delete      port:libuv
+        depends_lib-delete      path:lib/pkgconfig/libuv.pc:libuv \
         configure.args-delete   --with-libuv
 }


### PR DESCRIPTION
…e libuv-devel

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
