### PR TITLE
legacy-support-devel: update to latest master

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -10,7 +10,9 @@ name                legacy-support
 categories          devel
 platforms           darwin
 
-maintainers         {jonesc @cjones051073} openmaintainer
+maintainers         {mascguy @mascguy} \
+                    {fwright.net:fw @fhgwright} \
+                    openmaintainer
 license             MIT BSD APSL-2
 
 description         Installs wrapper headers to add missing functionality to legacy OSX versions.
@@ -20,6 +22,8 @@ long_description    {*}${description}
 epoch               1
 
 # Primary release version
+# NOTE: At present, v1.2.0 has a compatibility issue.
+# Do not update until this is resolved.
 set release_ver     1.1.1
 
 # Binary compatibility version
@@ -46,13 +50,13 @@ subport ${name} {
 
 subport ${name}-devel {
     conflicts           ${name}
-    github.setup        macports macports-legacy-support 3631c1f36ff8f9e7f284ce4e15be7ea659e8cc1a
-    version             20240220
+    github.setup        macports macports-legacy-support ae88daa43c2b0dddb855bb0bf1e6ef4a0f9e8c53
+    version             20240303
     revision            0
     livecheck.type      none
-    checksums           rmd160  2417714d15221eaaaa04ab5f3721eb6fcd83bd12 \
-                        sha256  9c9a394b9e23bb256103cf2a343be4e0d227174b14966125cc9fbf7395687b49 \
-                        size    71438
+    checksums           rmd160  e25e45cc5d747c6a710aa085ffbcfbaffb547935 \
+                        sha256  971ed22e77f1b3ab34eb3f306a9a792f5b2f912534976b6c3e261dcc8f9512e2 \
+                        size    72500
     set v_split         [split ${release_ver} .]
     set release_ver     [lindex ${v_split} 0].[lindex ${v_split} 1].99
 }


### PR DESCRIPTION
Adds new maintainers, and removes jonesc as requested.

Adds a comment to discourage updating to the problematic current release version.

TESTED:
Tested on 10.4-10.5 ppc, 10.5-10.6 ppc (x86_64 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-14.x arm64.
Builds on all tested platforms except 10.5 ppc +universal. Passes all -universal tests.
Buildable +universal cases pass all tests, except for expected failures on 10.11-10.13 x86_64 +universal (i386), and unexpected failure on 12.x arm64 +universal, which clearly doesn't matter in practice.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (x86_64 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (x86_64 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.3 21H1015, x86_64, Xcode 14.2 14C18
macOS 12.7.3 21H1015, arm64, Xcode 14.2 14C18
macOS 13.6.4 22G513, arm64, Xcode 15.2 15C500b
macOS 14.3.1 23D60, arm64, Xcode 15.2 15C500b
```
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
