### PR TITLE
morshutalk: new portfile

### DIFF
--- a/python/morshutalk/Portfile
+++ b/python/morshutalk/Portfile
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+name                morshutalk
+github.setup        n0spaces MorshuTalk 993fa2bff4f389cc43363aefb419eb9d5de8bc46
+version             0.0.2
+revision            0
+
+categories-append   games
+license             MIT
+maintainers         nomaintainer
+
+description         Morshu text-to-speech
+long_description    {*}${description}
+
+checksums           rmd160  cccad335aa19050c25d02a8c26835328425b586e \
+                    sha256  01e1e9731ddbe0898e479536a269fc9b732421c7a585b36aef4ee1dc2d68ca63 \
+                    size    1879024
+
+python.versions     38 39 310 311 312
+python.default_version 312
+
+
+depends_lib-append \
+                port:py${python.version}-g2p-en \
+                port:py${python.version}-numpy \
+                port:py${python.version}-pydub \
+                port:py${python.version}-sounddevice \
+                port:py${python.version}-tqdm

--- a/python/py-g2p-en/Portfile
+++ b/python/py-g2p-en/Portfile
@@ -18,7 +18,7 @@ checksums           rmd160  7e9f0675a905bab747c7067016dfb9a3084eaf31 \
                     sha256 32ecb119827a3b10ea8c1197276f4ea4f44070ae56cbbd01f0f261875f556a58 \
                     size    3116166
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append \

--- a/python/py-nltk/Portfile
+++ b/python/py-nltk/Portfile
@@ -23,7 +23,7 @@ checksums           rmd160  a4b7e32caccd368487f6a67176a0971575022a46 \
                     sha256  676970e2b7aa0a7184e68f76e0c4f2756fd1b82559a509d5656a23117faeb658 \
                     size    2867926
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 github.livecheck.regex  {([\d.]+)}
 

--- a/python/py-pydub/Portfile
+++ b/python/py-pydub/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  e858da63838aad9dd2ee5840a45101e9e5ecaf98 \
                     sha256  980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f \
                     size    38326
 
-python.versions     38 39 310
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     post-destroot {


### PR DESCRIPTION
* Pull from github commit for untagged 0.0.2 release
* GUI unsupported due to current lack of pyside6
* Use 310 due to pydub dependency

Currently pydub gives a warning about missing ffmpeg or avconv when running the app, but functionally it works just fine without it. Not sure if worth adding a dependency for the purpose of quieting it
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
