### PR TITLE
totp-cli: update to 1.8.7

### DIFF
--- a/security/totp-cli/Portfile
+++ b/security/totp-cli/Portfile
@@ -4,11 +4,12 @@ PortSystem          1.0
 PortGroup           golang 1.0
 PortGroup           legacysupport 1.1
 
-go.setup            github.com/yitsushi/totp-cli 1.8.3 v
+go.setup            github.com/yitsushi/totp-cli 1.8.7 v
 revision            0
 
 categories          security
 maintainers         {gmail.com:smanojkarthick @manojkarthick} \
+                    {gmail.com:herby.gillot @herbygillot} \
                     {hotmail.com:amtor @RobK88} \
                     openmaintainer
 
@@ -21,64 +22,79 @@ long_description    A simple TOTP (Time-based One-time Password) CLI tool. \
                     You can manage and organize your accounts with namespaces and protect your data with a password.
 
 checksums           ${distname}${extract.suffix} \
-                        rmd160  01b345a8196f547fe117caacc2bc2273f33ec404 \
-                        sha256  0d3a01aee6101750375e3da70e3fe26455dd99476ebf9ca08b3eee83c94a3f25 \
-                        size    20089
+                        rmd160  71bba4a66211a9961b5c7de288608fa5862888de \
+                        sha256  0e186a4c0005000f6f5fbe4e41783c4b8e4f6d6481b15005b61376f9a2e9de93 \
+                        size    20672
 
 go.vendors          gopkg.in/yaml.v3 \
                         lock    v3.0.1 \
                         rmd160  e85ac1368fb7f9ef945b7fd7bd608a1f0d261c12 \
                         sha256  f3ea6be3f405ec25f8799773355aba54f8831d11f5315a01155bdc69b92eca7b \
                         size    91208 \
+                    gopkg.in/check.v1 \
+                        lock    20d25e280405 \
+                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
+                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
+                        size    30360 \
                     golang.org/x/term \
-                        lock    v0.14.0 \
-                        rmd160  c0fc38b7b1173e7ee521d528eafd3b597a53ff7b \
-                        sha256  f903d4d9d0aa62c6cfde13716a7481134ab8b12b117d01c71aa8674e1d201192 \
-                        size    14749 \
+                        lock    v0.16.0 \
+                        rmd160  bd756f55b20d8afea67740e01a2cc13d9c03f2da \
+                        sha256  0619c31c8e802b7380b4bc4ed21dbadab3938e88861829deda723aded067f90f \
+                        size    14741 \
                     golang.org/x/sys \
-                        lock    v0.14.0 \
-                        rmd160  d36195a767e48169c413eb77843e71fa014e7ac2 \
-                        sha256  9407ff6fbe0423f2559a99f7ad55479e1eb20201c5dfb9e885abb83c7b44bfc4 \
-                        size    1442384 \
+                        lock    v0.16.0 \
+                        rmd160  10e97b22e4ee6cb4210dc4a3939eff7029c76733 \
+                        sha256  1736d810e783163472b5653ec5eb4272b9f7d570f4e212c5d55d6491be694cf7 \
+                        size    1444408 \
                     golang.org/x/crypto \
-                        lock    v0.15.0 \
-                        rmd160  08e93131b3d22ceacee5f50d56f88ff2bb591df5 \
-                        sha256  bc663378acfc6d12da33eb2a58fccd7c8c3e254e86bcff44fe714088c05bff93 \
-                        size    1801178 \
+                        lock    v0.17.0 \
+                        rmd160  b42d588c4aa930e1d70d67b75a9a3f20a613536e \
+                        sha256  a559bc5b604090ff2ad6040e8207d79a969ff3017f9e61d2eb0df774ae3b47f4 \
+                        size    1809435 \
+                    github.com/xrash/smetrics \
+                        lock    1d8dd44e695e \
+                        rmd160  1d4694c12438fe017b12295d85d9f48073115c84 \
+                        sha256  9b27416730ef4c8884569e4afb51afa20d95e79bed55d7d5e08ee7a9ca47fe6a \
+                        size    1823507 \
                     github.com/urfave/cli \
-                        lock    v2.25.7 \
-                        rmd160  54cb9b78d2762c931d2ec1f83015a8147158237e \
-                        sha256  a09c96d3722f1efdcba7677bc9ef9394947e22f7f1e235edf923607c3f8b942c \
-                        size    3482618 \
+                        lock    v2.27.1 \
+                        rmd160  5ed423283f063a24972ad7ba2dec285e244a25fa \
+                        sha256  ca879821f57d546acad456afaee27cb3d49e68068e37005e777acf3712d9458d \
+                        size    3484663 \
+                    github.com/stretchr/testify \
+                        lock    v1.7.1 \
+                        rmd160  9e07f7d6890b8598706260ece5db26a7b12b5b2a \
+                        sha256  27cabaf81344157a188083266cf8ccc19d04c43d9a34b6276b760514b9c880a3 \
+                        size    94020 \
+                    github.com/russross/blackfriday \
+                        lock    v2.1.0 \
+                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
+                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
+                        size    92950 \
+                    github.com/pmezard/go-difflib \
+                        lock    v1.0.0 \
+                        rmd160  fc879bfbdef9e3ff50844def58404e2b5a613ab8 \
+                        sha256  7cd492737641847266115f3060489a67f63581e521a8ec51efbc280c33fc991f \
+                        size    11409 \
+                    github.com/davecgh/go-spew \
+                        lock    v1.1.1 \
+                        rmd160  7c02883aa81f81aca14e13a27fdca9e7fbc136f7 \
+                        sha256  e85d6afa83e64962e0d63dd4812971eccf2b9b5445eda93f46a4406f0c177d5f \
+                        size    42171 \
                     github.com/cpuguy83/go-md2man \
                         lock    v2.0.3 \
                         rmd160  f44cb99228e4f418c00979bf850d568837755b76 \
                         sha256  712375b6a4472b6eff9225cdf3e01a4d33e1e0753f713874ecd67a0d0c74bfea \
                         size    64980 \
-                    github.com/xrash/smetrics \
-                        lock    039620a656736e6ad994090895784a7af15e0b80 \
-                        rmd160  55c9e9f554905046a0db05723db5a9d95c6b2d41 \
-                        sha256  996b007cfb8fd8308b8f1912bf3863a108edeb07e1e705b8294e13c7a3a662cb \
-                        size    1823438 \
-                    github.com/FiloSottile/age \
+                    filippo.io/age \
+                        repo    github.com/FiloSottile/age \
                         lock    v1.1.1 \
                         rmd160  5e09dc3b85d53c92b62c114355097f51a8f79690 \
                         sha256  007f2a349124a61c8357a8d34703f420248a4cd9c0c00892efab8186310baa8c \
-                        size    204319 \
-                    github.com/russross/blackfriday \
-                        lock    v2.1.0 \
-                        rmd160  c42a9332a2c2f3074c6f7e8d37a58d6148d2af08 \
-                        sha256  c4df56f2012a7d16471418245e78b5790569e27bbe8d72a860d7117a801a7fae \
-                        size    92950
+                        size    204319
 
-#
-# symlink for the "filippo.io/age" go package pointing to the "github.com/FiloSottile/age" go package
-# (since go-vendors cannot handle packages from filippo.io)
-#
-post-extract {
-    file mkdir ${workpath}/gopath/src/filippo.io
-    ln -s ${workpath}/gopath/src/github.com/FiloSottile/age ${workpath}/gopath/src/filippo.io/age
-}
+build.args-append   \
+    -ldflags \"-X ${go.package}/internal/info.Version=${github.tag_prefix}${version}\"
 
 pre-build {
 #   Sierra and earlier
@@ -91,4 +107,12 @@ pre-build {
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    file copy ${worksrcpath}/autocomplete/bash_autocomplete \
+        ${destroot}${prefix}/share/bash-completion/completions/${name}
+
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    file copy ${worksrcpath}/autocomplete/zsh_autocomplete \
+        ${destroot}${prefix}/share/zsh/site-functions/_${name}
 }


### PR DESCRIPTION
  - build with version info
  - remove workaround for filippo.io/age, no longer needed
  - install bash & zsh autocompletion files
  - add self as co-maintainer

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
