### PR TITLE
bitchx: fix build on macOS 10.6

### DIFF
--- a/irc/bitchx/Portfile
+++ b/irc/bitchx/Portfile
@@ -2,7 +2,7 @@ PortSystem          1.0
 
 name                bitchx
 version             1.2.1
-revision            3
+revision            4
 
 categories          irc
 license             BSD
@@ -15,7 +15,7 @@ long_description    BitchX is an IRC (Internet Relay Chat) client by Colten Edwa
                     for the popular UNIX IRC client ircII. Around Christmas of 1994 the \
                     script was patched directly into the client by panasync.
 
-homepage            http://www.bitchx.org/
+homepage            https://sourceforge.net/projects/bitchx/
 master_sites        sourceforge:project/${name}/ircii-pana/${name}-${version}
 
 checksums           rmd160  0bf85169f26297fe517b2886f8b9693c360f32f7 \
@@ -24,9 +24,11 @@ checksums           rmd160  0bf85169f26297fe517b2886f8b9693c360f32f7 \
 
 depends_lib         path:lib/libssl.dylib:openssl
 
+# backported from https://sourceforge.net/p/bitchx/git/ci/4f63d4892995eec6707f194b462c9fc3184ee85d/
 # backported from https://github.com/freebsd/freebsd-ports/commit/7075120b4d50ebba264775ce8a5bcbcafd1d99a2
 # backported from https://sourceforge.net/p/bitchx/git/ci/184af728c73c379d1eee57a387b6012572794fa8/
-patchfiles          patch-expr2.diff \
+patchfiles          patch-duplicate-definitions.diff \
+                    patch-expr2.diff \
                     patch-openssl11.diff
 
 # the patch above modifies configure.in

--- a/irc/bitchx/files/patch-duplicate-definitions.diff
+++ b/irc/bitchx/files/patch-duplicate-definitions.diff
@@ -1,0 +1,40 @@
+From 4f63d4892995eec6707f194b462c9fc3184ee85d Mon Sep 17 00:00:00 2001
+From: Kevin Easton <caf@bitchx.org>
+Date: Sat, 28 Dec 2019 17:07:58 +1100
+Subject: [PATCH] Remove duplicate global definitions
+
+This fixes compiling with gcc-10.
+
+Reported by ixz.
+
+--- source/commands.c
++++ source/commands.c
+@@ -118,7 +118,6 @@ extern	int	doing_notice;
+ 
+ static	void	oper_password_received (char *, char *);
+ 
+-int	no_hook_notify = 0;
+ int	load_depth = -1;
+ 
+ extern char	cx_function[];
+--- source/modules.c
++++ source/modules.c
+@@ -77,7 +77,7 @@ extern int BX_read_sockets();
+ extern int identd;
+ extern int doing_notice;
+ 
+-int (*serv_open_func) (int, unsigned long, int);
++extern int (*serv_open_func) (int, unsigned long, int);
+ extern int (*serv_output_func) (int, int, char *, int);
+ extern int (*serv_input_func)  (int, char *, int, int, int);
+ extern int (*serv_close_func) (int, unsigned long, int);
+--- source/numbers.c
++++ source/numbers.c
+@@ -66,7 +66,6 @@ void	show_server_map		(void);
+ int	stats_k_grep		(char **);
+ void	who_handlekill		(char *, char *, char *);
+ void	handle_tracekill	(int, char *, char *, char *);
+-int	no_hook_notify;
+ extern  AJoinList *ajoin_list;
+ void	remove_from_server_list (int);
+ 


### PR DESCRIPTION
https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/190161/steps/install-port/logs/stdio

* update homepage

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
