### PR TITLE
libpsl: update to 0.21.5

### DIFF
--- a/net/libpsl/Portfile
+++ b/net/libpsl/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           clang_dependency 1.0
 
-github.setup        rockdaboot libpsl 0.21.2
+github.setup        rockdaboot libpsl 0.21.5
 # when incrementing version or revision please check
 # that psl_data_commit and psl_data_date refer to latest
 # https://github.com/publicsuffix/list git master commit
@@ -18,8 +18,8 @@ categories          net
 github.tarball_from releases
 set main_distfile   ${distfiles}
 
-set psl_data_commit     19f2225196dcf2b8f624a279b448eee7894a92b1
-set psl_data_date       20230117
+set psl_data_commit     11e07e0f7233ab2d972709b777b69dd469536458
+set psl_data_date       20240303
 set psl_data_worksrcdir list-${psl_data_commit}
 set psl_data_distname   publicsuffix-list-[string range ${psl_data_commit} 0 6]
 set psl_data_distfile   ${psl_data_distname}${extract.suffix}
@@ -33,13 +33,13 @@ master_sites        ${github.master_sites}:main \
                     https://github.com/publicsuffix/list/archive/${psl_data_commit}:list
 
 checksums           ${main_distfile} \
-                    rmd160  4443bc056bebd11afa3a066a7509216d33ae447d \
-                    sha256  e35991b6e17001afa2c0ca3b10c357650602b92596209b7492802f3768a6285f \
-                    size    7617025 \
+                    rmd160  31dda77d700a85ef9249a97297191f73d73f0b28 \
+                    sha256  1dcc9ceae8b128f3c0b3f654decd0e1e891afc6ff81098f227ef260449dae208 \
+                    size    7624251 \
 ${psl_data_distfile} \
-                    rmd160  6c7a3c3284d3b07bb00f228d0d2677150db101a9 \
-                    sha256  c0c4532569c6f779ae439c08bb7079755e51b4a5766d02f8d9cfe45ed0af8016 \
-                    size    111898
+                    rmd160  f37a0e6d51fd852a0d390f30f98b2349b74c3678 \
+                    sha256  b9c938d4d90b4ba54a8f2abba74bfade568d4ed6343063a4a30355eafc95e216 \
+                    size    117951
 
 # Please note this port is (indirectly, via cmake) a dependency of the
 # various clang-X ports. When updating the port versions (e.g. python)
@@ -48,7 +48,7 @@ ${psl_data_distfile} \
 # See e.g. https://trac.macports.org/ticket/60419
 
 # DO NOT change this unless you have understood and acted on the above comment!
-set py_ver          3.10
+set py_ver          3.12
 set py_ver_nodot    [string map {. {}} ${py_ver}]
 
 depends_build-append \
@@ -77,7 +77,7 @@ post-patch {
 
 configure.python    ${prefix}/bin/python${py_ver}
 
-configure.args      --enable-builtin=libidn2 \
+configure.args      --enable-builtin \
                     --enable-runtime=libidn2 \
                     --disable-silent-rules
 


### PR DESCRIPTION
- use Python 3.12
- update public suffix lists

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
