### PR TITLE
uv: Update to 0.1.15

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,11 +4,11 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.1.13
+github.setup            astral-sh uv 0.1.15
 github.tarball_from     archive
 revision                0
 categories              devel python
-license                 Apache-2 MIT
+license                 {Apache-2 MIT}
 platforms               {darwin >= 16}
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
@@ -17,14 +17,14 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for pip and pip-compile.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  1a6a3a73371565d88a60d181eec0ea33d67405a6 \
-                        sha256  bbd9abb6d735400e3c142e863bc7d69ad539c422a013601f550dd8fd2312ae4f \
-                        size    1860446
+                        rmd160  79d0361d8d064f9c139c868045991d3134dc8539 \
+                        sha256  0a44d1207a7e28e7a76878b79569370f9bbac6c3571527fbd7da94769fbbf3b8 \
+                        size    803628
 
 depends_build-append    port:pkgconfig
 depends_lib-append      port:libgit2
 
-# Disable --frozen to workaround some dependencies
+# Disable --frozen to workaround dependencies from Git
 cargo.offline_cmd
 
 build.env-append        LIBGIT2_NO_VENDOR=1 \
@@ -68,7 +68,7 @@ cargo.crates \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
-    anstream                        0.6.12  96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540 \
+    anstream                        0.6.13  d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb \
     anstyle                          1.0.6  8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc \
     anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
     anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
@@ -79,6 +79,7 @@ cargo.crates \
     arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
     assert_cmd                      2.0.14  ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8 \
     assert_fs                        1.1.1  2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec \
+    async-channel                    2.2.0  f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3 \
     async-compression                0.4.6  a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c \
     async-trait                     0.1.77  c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9 \
     async_http_range_reader          0.7.0  cf8eeab30c68da4dc2c51f3afc4327ab06fe0f3f028ca423f7ca398c7ed8c5e7 \
@@ -102,7 +103,6 @@ cargo.crates \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                            1.5.0  a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223 \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
-    camino                           1.1.6  c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c \
     cargo-util                       0.2.9  74862c3c6e53a1c1f8f0178f9d38ab41e49746cd3a7cafc239b3d0248fd4e342 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
@@ -123,6 +123,7 @@ cargo.crates \
     cmake                           0.1.50  a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130 \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
     colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
+    concurrent-queue                 2.4.0  d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363 \
     configparser                     3.0.4  4ec6d3da8e550377a85339063af6e3735f4b1d9392108da4e083a1b3b9820288 \
     console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
     core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
@@ -155,6 +156,8 @@ cargo.crates \
     encoding_rs                     0.8.33  7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1 \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
+    event-listener                   5.2.0  2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91 \
+    event-listener-strategy          0.5.0  feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291 \
     fastrand                         2.0.1  25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5 \
     fdeflate                         0.3.4  4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645 \
     filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
@@ -197,7 +200,7 @@ cargo.crates \
     hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
     html-escape                     0.2.13  6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476 \
-    http                            0.2.11  8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb \
+    http                            0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
     http-body                        0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
     http-content-range               0.1.2  9f0d1a8ef218a86416107794b34cc446958d9203556c312bb41eab4c924c1d2e \
     httparse                         1.8.0  d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904 \
@@ -213,7 +216,7 @@ cargo.crates \
     indexmap                         2.2.3  233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177 \
     indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
     indoc                            2.0.4  1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8 \
-    insta                           1.35.1  7c985c1bef99cf13c58fade470483d81a2bfe846ebde60ed28cc2dddec2df9e2 \
+    insta                           1.36.1  0a7c22c4d34ef4788c351e971c52bfdfe7ea2766f8c5466bc175dd46e52ac22e \
     instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
     ipnet                            2.9.0  8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3 \
     is-terminal                     0.4.12  f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b \
@@ -239,7 +242,7 @@ cargo.crates \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
     lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
-    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
     mailparse                       0.14.1  2d096594926cab442e054e047eb8c1402f7d5b2272573b97ba68aa40629f9757 \
     matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
     memchr                           2.7.1  523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149 \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.1.15.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
