### PR TITLE
openjdk21: set boot JDK to noconflict

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -6,7 +6,7 @@ name                openjdk21
 # See https://github.com/openjdk/jdk21u/tags for the version and build number that matches the latest tag that ends with '-ga'
 version             21.0.2
 set build 13
-revision            1
+revision            2
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -23,12 +23,17 @@ checksums           rmd160  840b44086b26c773b28e9a6f3333c6769e5bc41f \
                     sha256  17eda717843ffbbacc7de4bdcd934f404a23a57ebb3cda3cec630a668651531f \
                     size    112252812
 
+set bootjdk_port    openjdk21-zulu
+
 depends_lib         port:freetype \
                     port:libiconv
-depends_build       port:openjdk21-zulu \
+depends_build       port:${bootjdk_port} \
                     port:autoconf \
                     port:gmake \
                     port:bash
+
+# Boot JDK license/redistributability should not affect license/redistributability of this port
+license_noconflict  ${bootjdk_port}
 
 pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4


### PR DESCRIPTION
#### Description

Set boot JDK to noconflict, to not affect redistributability.

###### Tested on

macOS 14.3.1 23D60 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?