### PR TITLE
libhsts: new port (v0.1.0)

### DIFF
--- a/www/libhsts/Portfile
+++ b/www/libhsts/Portfile
@@ -1,0 +1,69 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+PortGroup       gitlab 1.0
+
+gitlab.setup    rockdaboot libhsts 0.1.0 libhsts-
+revision        0
+
+description     \
+    Library to easily check a domain against the Chromium HSTS Preload list.
+
+long_description \
+    {*}${description} The HSTS preload list is a list of domains that support \
+    HTTPS. The list is compiled by Google and is utilised by Chrome, Firefox \
+    and others. With this information, a HTTP client may contact a website \
+    without trying a plain-text HTTP connection first. It prevents \
+    interception with redirects that take place over HTTP. None of the sent \
+    data will ever be unencrypted.
+
+
+categories      www devel
+license         MIT
+maintainers     {gmail.com:herby.gillot @herbygillot} \
+                openmaintainer
+
+set python_ver  312
+
+set python_branch \
+    [string index ${python_ver} 0].[string range ${python_ver} 1 end]
+
+set python_bin  ${prefix}/bin/python${python_branch}
+
+checksums       rmd160  9c53ed69320201d625f832cbf1241dc167fcc531 \
+                sha256  3f9eb7ca48189d9ebfe3386e21a3ad393fc90f9bb2674f719daa451b765d2668 \
+                size    47304
+
+post-patch {
+    reinplace -E "s/@@PYVER@@/${python_branch}/" \
+        ${worksrcpath}/configure.ac
+    reinplace -E "s|#!/usr/bin/env python|#!${python_bin}|" \
+        ${worksrcpath}/src/hsts-make-dafsa
+}
+
+post-destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/src/hsts-make-dafsa ${destroot}${prefix}/bin/
+}
+
+patchfiles-append \
+                patch-configure.ac.diff \
+                patch-tests-Makefile.am.diff
+
+depends_build-append \
+                port:autoconf-archive \
+                port:gsed \
+                port:pkgconfig \
+                port:python${python_ver} \
+                port:wget
+
+depends_run-append \
+                port:python${python_ver}
+
+use_autoreconf  yes
+autoreconf.args -fvi
+
+configure.env-append \
+                PYTHON=${python_bin}
+configure.args-append \
+                --disable-silent-rules

--- a/www/libhsts/files/patch-configure.ac.diff
+++ b/www/libhsts/files/patch-configure.ac.diff
@@ -1,0 +1,11 @@
+--- ./configure.ac	2024-03-06 02:57:43
++++ ./configure.ac	2024-03-06 02:58:01
+@@ -83,7 +83,7 @@
+ #AM_CONDITIONAL(ENABLE_MAN, test x$enable_man = xyes)
+ 
+ # src/hsts-make-dafsa needs python 2.7+
+-AM_PATH_PYTHON([2.7])
++AM_PATH_PYTHON([@@PYVER@@])
+ 
+ PKG_PROG_PKG_CONFIG
+ 

--- a/www/libhsts/files/patch-tests-Makefile.am.diff
+++ b/www/libhsts/files/patch-tests-Makefile.am.diff
@@ -1,0 +1,11 @@
+--- ./tests/Makefile.am	2024-03-06 07:40:36
++++ ./tests/Makefile.am	2024-03-06 07:40:43
+@@ -24,7 +24,7 @@
+ $(HSTS_FILE):
+ 	if ! test -f $(HSTS_FILE); then \
+ 	  wget -O$(HSTS_FILE) https://raw.github.com/chromium/chromium/master/net/http/transport_security_state_static.json && \
+-	  sed -i 's/^ *\/\/.*$$//g' $(HSTS_FILE); \
++	  gsed -i 's/^ *\/\/.*$$//g' $(HSTS_FILE); \
+ 	fi
+ 
+ EXTRA_DIST = $(HSTS_FILE) hsts.dafsa hsts_ascii.dafsa


### PR DESCRIPTION
https://gitlab.com/rockdaboot/libhsts

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
