### PR TITLE
osxphotos: update to 0.67.6

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.67.4
+version                 0.67.6
 revision                0
 
 categories              graphics python
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  ac4f6516336514da2b9aaf90943bcc1c3d245e48 \
-                        sha256  3bfebe866f26554df74cff3c81d34c9b01a0024e609b655f3a8c401797c9ec78 \
-                        size    2090024
+checksums               rmd160  a15e2475633eb6108957e9a797153f900421687d \
+                        sha256  0720392a02639c2b9170564547305ae639ea9c912d775f37d4bb7b04905c3fae \
+                        size    2098571
 
 python.default_version  311
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.67.6.

###### Tested on

macOS 14.3.1 23D60 arm64
Xcode 15.3 15E204a

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?