### PR TITLE
ruff: Update to 0.3.1

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.2.2 v
+github.setup        astral-sh ruff 0.3.1 v
 github.tarball_from archive
 revision            0
 
@@ -25,12 +25,13 @@ categories          devel python
 installs_libs       no
 license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    {gmail.com:therealketo @TheRealKeto} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  7f7c33b15ead43876a30a78ff2b3b054c90c757d \
-                    sha256  12dd075410eb8c73865048817d851fed617e0d8baa30d06707b8b67ff25e247e \
-                    size    3764556
+                    rmd160  2fd7b7b641fe651b45c6b2720dc23290d4a272ce \
+                    sha256  0102df567ac89bc4e1517ef922de363e1604e60309e4d62c9b2b977847ca1ea6 \
+                    size    3811954
 
 destroot {
     xinstall -m 0755 \
@@ -41,23 +42,23 @@ destroot {
 cargo.crates \
     Inflector                       0.11.4  fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3 \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
-    ahash                            0.8.7  77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01 \
+    ahash                           0.8.10  8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b \
     aho-corasick                     1.1.2  b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0 \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
     annotate-snippets                0.6.1  c7021ce4924a3f25f802b2cccd1af585e39ea1a363a1aa2e72afe54b67a3a7a7 \
     annotate-snippets                0.9.2  ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e \
-    anstream                        0.6.11  6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5 \
+    anstream                        0.6.13  d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb \
     anstyle                          1.0.6  8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc \
     anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
     anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
     anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
-    anyhow                          1.0.79  080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca \
+    anyhow                          1.0.80  5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1 \
     argfile                          0.1.6  1287c4f82a41c5085e65ee337c7934d71ab43d5187740a81fb69129013f6a5f6 \
     arrayvec                         0.7.4  96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711 \
     ascii-canvas                     3.0.0  8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6 \
-    assert_cmd                      2.0.13  00ad3f3a942eee60335ab4342358c161ee296829e0d16ff42fc1d6cb07815467 \
+    assert_cmd                      2.0.14  ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8 \
     autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
     base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
     bincode                          1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
@@ -65,28 +66,28 @@ cargo.crates \
     bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
     bitflags                         2.4.2  ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf \
-    bstr                             1.9.0  c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc \
-    bumpalo                         3.14.0  7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec \
+    bstr                             1.9.1  05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706 \
+    bumpalo                         3.15.3  8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
-    cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
+    cc                              1.0.88  02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
     chic                             1.2.2  a5b5db619f3556839cb2223ae86ff3f9a09da2c5013be42bc9af08c9589bf70c \
     chrono                          0.4.34  5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                             4.5.0  80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f \
-    clap_builder                     4.5.0  458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99 \
-    clap_complete                    4.5.0  299353be8209bd133b049bf1c63582d184a8b39fd9c04f15fe65f50f88bdfe6c \
+    clap                             4.5.1  c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da \
+    clap_builder                     4.5.1  9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb \
+    clap_complete                    4.5.1  885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c \
     clap_complete_command            0.5.1  183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d \
     clap_complete_fig                4.5.0  54b3e65f91fabdd23cac3d57d39d5d938b4daabd070c335c006dccb866a61110 \
     clap_complete_nushell           0.1.11  5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e \
     clap_derive                      4.5.0  307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47 \
     clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
     clearscreen                      2.0.1  72f3f22f1a586604e62efd23f78218f3ccdecf7a33c4500db2d37d85a24fe994 \
-    codspeed                         2.3.3  0eb4ab4dcb6554eb4f590fb16f99d3b102ab76f5f56554c9a5340518b32c499b \
-    codspeed-criterion-compat        2.3.3  cc07a3d3f7e0c8961d0ffdee149d39b231bafdcdc3d978dc5ad790c615f55f3f \
+    codspeed                         2.4.0  4b85b056aa0541d1975ebc524149dde72803a5d7352b6aebf9eabc44f9017246 \
+    codspeed-criterion-compat        2.4.0  02ae9de916d6315a5129bca2fc7957285f0b9f77a2f6a8734a0a146caee2b0b6 \
     colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
     colored                          2.1.0  cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8 \
     console                         0.15.8  0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb \
@@ -94,17 +95,17 @@ cargo.crates \
     console_log                      1.0.0  be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f \
     core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
     countme                          3.0.1  7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636 \
-    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
+    crc32fast                        1.4.0  b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa \
     criterion                        0.5.1  f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f \
     criterion-plot                   0.5.0  6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1 \
-    crossbeam-channel               0.5.11  176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b \
+    crossbeam-channel               0.5.12  ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95 \
     crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
     crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
     crossbeam-utils                 0.8.19  248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345 \
     crunchy                          0.2.2  7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7 \
-    darling                         0.20.5  fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8 \
-    darling_core                    0.20.5  04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3 \
-    darling_macro                   0.20.5  1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77 \
+    darling                         0.20.8  54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391 \
+    darling_core                    0.20.8  9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f \
+    darling_macro                   0.20.8  a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
     difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     dirs                             4.0.0  ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059 \
@@ -115,8 +116,8 @@ cargo.crates \
     dirs-sys-next                    0.1.2  4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d \
     doc-comment                      0.3.3  fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10 \
     drop_bomb                        0.1.5  9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1 \
-    dyn-clone                       1.0.16  545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d \
-    either                           1.9.0  a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07 \
+    dyn-clone                       1.0.17  0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125 \
+    either                          1.10.0  11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a \
     ena                             0.14.2  c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1 \
     encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
     env_logger                      0.10.2  4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580 \
@@ -135,16 +136,13 @@ cargo.crates \
     getrandom                       0.2.12  190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5 \
     glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
     globset                         0.4.14  57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1 \
-    half                             2.3.1  bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872 \
+    half                             2.4.0  b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
-    hermit-abi                       0.3.5  d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3 \
+    hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hexf-parse                       0.2.1  dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
-    hoot                             0.1.3  df22a4d90f1b0e65fe3e0d6ee6a4608cc4d81f4b2eb3e670f44bb6bde711e452 \
-    hootbin                          0.1.1  354e60868e49ea1a39c44b9562ad207c4259dc6eabf9863bf3b0f058c55cfdb2 \
-    httparse                         1.8.0  d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904 \
     humantime                        2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
     iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
@@ -153,46 +151,47 @@ cargo.crates \
     ignore                          0.4.22  b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1 \
     imara-diff                       0.1.5  e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8 \
     imperative                       1.0.5  8b70798296d538cdaa6d652941fcc795963f8b9878b9e300c9fab7a522bd2fc0 \
-    indexmap                         2.2.2  824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520 \
+    indexmap                         2.2.5  7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4 \
     indicatif                       0.17.8  763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3 \
     indoc                            2.0.4  1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8 \
     inotify                          0.9.6  f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff \
     inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
-    insta                           1.34.0  5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc \
+    insta                           1.35.1  7c985c1bef99cf13c58fade470483d81a2bfe846ebde60ed28cc2dddec2df9e2 \
     insta-cmd                        0.4.0  809d3023d1d6e8d5c2206f199251f75cb26180e41f18cb0f22dd119161cb5127 \
     instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
     is-docker                        0.2.0  928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3 \
     is-macro                         0.3.5  59a85abdc13717906baccb5a1e435556ce0df215f242892f721dff62bf25288f \
-    is-terminal                     0.4.11  fe8f25ce1159c7740ff0b9b2f5cdf4a8428742ba7c112b9f20f22cd5219c7dab \
+    is-terminal                     0.4.12  f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b \
     is-wsl                           0.4.0  173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5 \
     itertools                       0.10.5  b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473 \
+    itertools                       0.11.0  b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57 \
     itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
     itoa                            1.0.10  b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c \
     js-sys                          0.3.68  406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee \
     kqueue                           1.0.8  7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c \
     kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
-    lalrpop                         0.20.0  da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8 \
-    lalrpop-util                    0.20.0  3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d \
+    lalrpop                         0.20.2  55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca \
+    lalrpop-util                    0.20.2  507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553 \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     lexical-parse-float              0.8.5  683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f \
     lexical-parse-integer            0.8.6  6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9 \
     lexical-util                     0.8.5  5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc \
     libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
-    libcst                           1.1.0  bd5c2ff400caac657bf794181d885491bb97cc37c376f8cb4fa3a0cc2176a053 \
-    libcst_derive                    1.1.0  6d7f252282b20bfec6fae65d351ab1df7e4552a6270dd7bb779ca9d6135aabe9 \
+    libcst                           1.2.0  890ee958b936e712c6f1c184f208176973e73c2e4f8d3cf499f94eb112f647f9 \
+    libcst_derive                    1.2.0  1dbd2f3cd9346422ebdc3a614aed6969d4e0b3e9c10517f33b30326acf894c11 \
     libmimalloc-sys                 0.1.35  3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664 \
     libredox                         0.0.1  85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8 \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
     lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
-    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
     matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
     matches                         0.1.10  2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5 \
     memchr                           2.7.1  523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149 \
     mimalloc                        0.1.39  fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c \
     minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
     miniz_oxide                      0.7.2  9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7 \
-    mio                             0.8.10  8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09 \
+    mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
     natord                           1.0.9  308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c \
     new_debug_unreachable            1.0.4  e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54 \
     nextest-workspace-hack           0.1.0  d906846a98739ed9d73d66e62c2641eef8321f1734b7a1156ab045a0248fb2b3 \
@@ -242,7 +241,7 @@ cargo.crates \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
-    rayon                            1.8.1  fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051 \
+    rayon                            1.9.0  e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
     redox_users                      0.4.4  a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4 \
@@ -250,31 +249,29 @@ cargo.crates \
     regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
     regex-automata                   0.4.5  5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd \
     regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
-    regex-syntax                     0.7.5  dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da \
     regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
     result-like                      0.5.0  abf7172fef6a7d056b5c26bf6c826570267562d51697f4982ff3ba4aec68a9df \
     result-like-derive               0.5.0  a8d6574c02e894d66370cfc681e5d68fedbc9a548fb55b30a96b3f0ae22d0fe5 \
-    ring                            0.17.7  688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74 \
+    ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
     rust-stemmers                    1.2.0  e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54 \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustix                         0.38.31  6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949 \
     rustls                          0.22.2  e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41 \
-    rustls-pki-types                 1.2.0  0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf \
+    rustls-pki-types                 1.3.1  5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8 \
     rustls-webpki                  0.102.2  faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610 \
     rustversion                     1.0.14  7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4 \
-    ryu                             1.0.16  f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c \
+    ryu                             1.0.17  e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schemars                        0.8.16  45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29 \
     schemars_derive                 0.8.16  c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967 \
     scoped-tls                       1.0.1  e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
-    semver                          1.0.21  b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0 \
-    serde                          1.0.196  870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32 \
-    serde-wasm-bindgen               0.6.3  b9b713f70513ae1f8d92665bbbbda5c295c2cf1da5542881ae5eefe20c9af132 \
-    serde_derive                   1.0.196  33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67 \
+    serde                          1.0.197  3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2 \
+    serde-wasm-bindgen               0.6.5  8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b \
+    serde_derive                   1.0.197  7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b \
     serde_derive_internals          0.26.0  85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c \
-    serde_json                     1.0.113  69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79 \
+    serde_json                     1.0.114  c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0 \
     serde_spanned                    0.6.5  eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1 \
     serde_test                     1.0.176  5a2f49ace1498612d14f7e0b8245519584db8299541dfe31a06374a828d620ab \
     serde_with                       3.6.1  15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270 \
@@ -295,8 +292,8 @@ cargo.crates \
     strum_macros                    0.25.3  23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0 \
     subtle                           2.5.0  81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc \
     syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
-    syn                             2.0.48  0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f \
-    tempfile                        3.10.0  a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67 \
+    syn                             2.0.52  b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07 \
+    tempfile                        3.10.1  85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1 \
     term                             0.7.0  c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f \
     termcolor                        1.4.1  06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755 \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
@@ -307,7 +304,7 @@ cargo.crates \
     test-case-macros                 3.3.1  5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb \
     thiserror                       1.0.57  1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b \
     thiserror-impl                  1.0.57  a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81 \
-    thread_local                     1.1.7  3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152 \
+    thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     tikv-jemalloc-sys  0.5.4+5.3.0-patched  9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1 \
     tikv-jemallocator                0.5.4  965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca \
     time                            0.3.20  cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890 \
@@ -318,7 +315,7 @@ cargo.crates \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     toml                            0.8.10  9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290 \
     toml_datetime                    0.6.5  3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1 \
-    toml_edit                       0.22.4  0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951 \
+    toml_edit                       0.22.6  2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6 \
     tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
     tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
     tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
@@ -333,13 +330,13 @@ cargo.crates \
     unic-ucd-version                 0.9.0  96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4 \
     unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
     unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
-    unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
+    unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
     unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
     unicode-xid                      0.2.4  f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c \
     unicode_names2                   1.2.1  ac64ef2f016dc69dfa8283394a70b057066eb054d5fcb6b9eb17bd2ec5097211 \
     unicode_names2_generator         1.2.1  013f6a731e80f3930de580e55ba41dfa846de4e0fdee4a701f97989cb1597d6a \
     untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
-    ureq                             2.9.5  0b52731d03d6bb2fd18289d4028aee361d6c28d44977846793b994b13cdcc64d \
+    ureq                             2.9.6  11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35 \
     url                              2.5.0  31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633 \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
     uuid                             1.7.0  f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a \
@@ -350,7 +347,7 @@ cargo.crates \
     vte                             0.11.1  f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197 \
     vte_generate_state_changes       0.1.1  d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
-    walkdir                          2.4.0  d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee \
+    walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
     wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
     wasm-bindgen                    0.2.91  c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f \
     wasm-bindgen-backend            0.2.91  c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b \
@@ -372,22 +369,22 @@ cargo.crates \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
     windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
-    windows-targets                 0.52.0  8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd \
+    windows-targets                 0.52.4  7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b \
     windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
-    windows_aarch64_gnullvm         0.52.0  cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea \
+    windows_aarch64_gnullvm         0.52.4  bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9 \
     windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
-    windows_aarch64_msvc            0.52.0  bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef \
+    windows_aarch64_msvc            0.52.4  da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675 \
     windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
-    windows_i686_gnu                0.52.0  a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313 \
+    windows_i686_gnu                0.52.4  b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3 \
     windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
-    windows_i686_msvc               0.52.0  ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a \
+    windows_i686_msvc               0.52.4  1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02 \
     windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
-    windows_x86_64_gnu              0.52.0  3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd \
+    windows_x86_64_gnu              0.52.4  5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03 \
     windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
-    windows_x86_64_gnullvm          0.52.0  1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e \
+    windows_x86_64_gnullvm          0.52.4  77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177 \
     windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
-    windows_x86_64_msvc             0.52.0  dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04 \
-    winnow                          0.5.39  5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29 \
+    windows_x86_64_msvc             0.52.4  32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8 \
+    winnow                           0.6.5  dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8 \
     yaml-rust                        0.4.5  56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85 \
     yansi                            0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec \
     yansi-term                       0.1.2  fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1 \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.3.1, adding myself as co-maintainer.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
