### PR TITLE
graphviz-devel: remove Clang '_Nullable' work around

### DIFF
--- a/graphics/graphviz-devel/Portfile
+++ b/graphics/graphviz-devel/Portfile
@@ -38,18 +38,6 @@ long_description                Graphviz is ${description}. Graph visualization 
 # graphviz-gui needs Xcode 3.1.2+; see #18811
 minimum_xcodeversions           {9 3.1.2}
 
-# Fix compilation errors:
-#   ../../lib/cgraph/sprint.h:54:15: error: expected ';' after top level declarator
-#   char *NULLABLE gv_sprint(const char *NONNULL format, ...);
-#   ../../lib/cgraph/sprint.h:67:14: error: expected ';' after top level declarator
-#   char *NONNULL gv_sprint_or_exit(const char *NONNULL format, ...);
-#   sprint.c:15:14: error: static declaration of '_Nullable' follows non-static declaration
-#   static char *NULLABLE print(const char *NONNULL format, va_list ap) {
-#   sprint.c:15:22: error: expected ';' after top level declarator
-#   static char *NULLABLE print(const char *NONNULL format, va_list ap) {
-compiler.blacklist-append       \
-                                {clang < 900}
-
 compiler.cxx_standard           2011
 
 if {${name} eq ${subport}} {

--- a/graphics/graphviz-devel/Portfile
+++ b/graphics/graphviz-devel/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem                      1.0
 PortGroup                       xcodeversion 1.0
-PortGroup                       compiler_blacklist_versions 1.0
 
 # Please keep the graphviz and graphviz-devel ports as similar as possible.
 

--- a/graphics/graphviz/Portfile
+++ b/graphics/graphviz/Portfile
@@ -38,18 +38,6 @@ long_description                Graphviz is ${description}. Graph visualization 
 # graphviz-gui needs Xcode 3.1.2+; see #18811
 minimum_xcodeversions           {9 3.1.2}
 
-# Fix compilation errors:
-#   ../../lib/cgraph/sprint.h:54:15: error: expected ';' after top level declarator
-#   char *NULLABLE gv_sprint(const char *NONNULL format, ...);
-#   ../../lib/cgraph/sprint.h:67:14: error: expected ';' after top level declarator
-#   char *NONNULL gv_sprint_or_exit(const char *NONNULL format, ...);
-#   sprint.c:15:14: error: static declaration of '_Nullable' follows non-static declaration
-#   static char *NULLABLE print(const char *NONNULL format, va_list ap) {
-#   sprint.c:15:22: error: expected ';' after top level declarator
-#   static char *NULLABLE print(const char *NONNULL format, va_list ap) {
-compiler.blacklist-append       \
-                                {clang < 900}
-
 compiler.cxx_standard           2011
 
 if {${name} eq ${subport}} {

--- a/graphics/graphviz/Portfile
+++ b/graphics/graphviz/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem                      1.0
 PortGroup                       xcodeversion 1.0
-PortGroup                       compiler_blacklist_versions 1.0
 
 # Please keep the graphviz and graphviz-devel ports as similar as possible.
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
Graphviz commit b517af6738b5900b10dd5397a918760d6c14f76f removed the offending file quoted in the comment here. This commit made it into Graphviz 4.0.0, so this suppression should no longer be required.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

I do not have a macOS environment in which to test this. I am just one of the upstream Graphviz maintainers who noticed this in driving by.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
