### PR TITLE
docker-credential-helper-osxkeychain: update to 0.8.1

### DIFF
--- a/devel/docker-credential-helper-osxkeychain/Portfile
+++ b/devel/docker-credential-helper-osxkeychain/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/docker/docker-credential-helpers 0.6.4 v
+go.setup            github.com/docker/docker-credential-helpers 0.8.1 v
 revision            0
 name                docker-credential-helper-osxkeychain
 categories          devel
@@ -16,13 +16,18 @@ long_description    docker-credential-helpers is a suite of programs to use \
                     native stores to keep Docker credentials safe.  This \
                     port installs the macOS keychain credential helper.
 
-checksums           rmd160  53f9fc31d4f31c219c3226abe6cac9f2a79a02ce \
-                    sha256  a3a3e785931533b3cd868d555d251d3ee185dc63671bfb71cd790f12bfd40796 \
-                    size    35654
+checksums           rmd160  0ca627cc79392ab308fc4cc59bcda7490929721f \
+                    sha256  2fee67bc915b9fd9f0fb4b6d85b480516a64623a905a7d188ea7db6431fb6a5e \
+                    size    282857
 
 set docker.helper   docker-credential-osxkeychain
-build.pre_args      -ldflags -s -o bin/${docker.helper}
-build.args           osxkeychain/cmd/main_darwin.go
+set credentials.Version ${version}
+set credentials.Package ${go.package}
+
+build.pre_args      -o bin/${docker.helper} -trimpath -ldflags \
+                    "\"-s -w -X '${go.package}/credentials.Version=${credentials.Version}' \
+                    -X '${go.package}/credentials.Package=${go.package}'\""
+build.args          ./osxkeychain/cmd/
 
 destroot {
     xinstall -m 755 ${worksrcpath}/bin/${docker.helper} ${destroot}${prefix}/bin/


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1 23D60 x86_64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
