### PR TITLE
LaTeXML: update to upstream version 0.8.8

### DIFF
--- a/tex/LaTeXML/Portfile
+++ b/tex/LaTeXML/Portfile
@@ -4,11 +4,11 @@ PortSystem          1.0
 PortGroup           texlive 1.0
 
 name                LaTeXML
-version             0.8.7
+version             0.8.8
 revision            0
-checksums           rmd160  1bd87b8f5057de6db1c6a76c95a9dae227bd2559 \
-                    sha256  25da9d9440779dec0dadd4cc2d4227e8eab87437c0719877274dcfb906a4cc79 \
-                    size    14339344
+checksums           rmd160  4f6aee98474e58905fe89327b55be42e3d5138f0 \
+                    sha256  7d2bbe2ce252baf86ba3f388cd0dec3aa4838f49d612b9ec7cc4ff88105badcc \
+                    size    15310900
 license             public-domain
 maintainers         {nist.gov:bruce.miller @brucemiller}
 description         LaTeXML converts TeX to XML/HTML/MathML


### PR DESCRIPTION
#### Description

Update LaTeXML to version 0.8.8

###### Type(s)

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on

macOS 14.3.1 23D60 x86_64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [X] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
