### PR TITLE
p5-spreadsheet-readsxc: new port

### DIFF
--- a/perl/p5-filter-signatures/Portfile
+++ b/perl/p5-filter-signatures/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Filter-signatures 0.19
+revision            0
+
+platforms           {darwin any}
+maintainers         nomaintainer
+license             {Artistic-1 GPL}
+
+supported_archs     noarch
+
+description         Very simplistic signatures for Perl < 5.20
+long_description    ${description}
+
+checksums           rmd160  4b8e3422862f93bc45061c0bddafc64befbe7b8b \
+                    sha256  00a1379249dffad428a54152a508f08c6195cb3a3d0691f3cb7c6fbf619f8426 \
+                    size    25795

--- a/perl/p5-spreadsheet-readsxc/Portfile
+++ b/perl/p5-spreadsheet-readsxc/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           perl5 1.0
+
+perl5.branches      5.28 5.30 5.32 5.34
+perl5.setup         Spreadsheet-ReadSXC 0.38
+revision            0
+platforms           {darwin any}
+maintainers         nomaintainer
+license             {Artistic-1 GPL}
+
+description         Extract OpenOffice spreadsheet data (SXC and ODS files)
+long_description    ${description}
+
+checksums           rmd160  017f249c182d3d634764e81d3e02c5a00904d25f \
+                    sha256  c2d902e241c6c42da43935d5124fe90178bdcae82920ec176df108dfcf659ef7 \
+                    size    711705
+
+if {${perl5.major} != ""} {
+    depends_lib-append \
+                    port:p${perl5.major}-perlx-maybe \
+                    port:p${perl5.major}-filter-signatures \
+                    port:p${perl5.major}-archive-zip \
+                    port:p${perl5.major}-perlio-gzip \
+                    port:p${perl5.major}-xml-twig \
+                    port:p${perl5.major}-xml-xpath \
+                    port:p${perl5.major}-xml-xpathengine \
+                    port:p${perl5.major}-storable \
+                    port:p${perl5.major}-moo \
+                    port:p${perl5.major}-scalar-list-utils
+
+    supported_archs noarch
+}


### PR DESCRIPTION
#### Description

Submitting p5-spreadsheet-readsxc and its dependency p5-filter-signatures.

This Perl 5 module allows one to read ODS spreadsheet files. It is maintained (whereas OpenOffice:OODoc wasn't maintained since 2010).

There is an old open submission for a similar module for XLSX files: https://trac.macports.org/ticket/58154 .

###### Type(s)

- [x] enhancement

###### Tested on

macOS 10.13.6 17G14042 x86_64
Xcode 9.1 9B55

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
