### PR TITLE
scribus-devel: unbreak after poppler update

### DIFF
--- a/print/scribus-devel/Portfile
+++ b/print/scribus-devel/Portfile
@@ -13,7 +13,7 @@ qt5.min_version     5.14.0
 name                scribus-devel
 epoch               1
 version             1.5.8
-revision            7
+revision            8
 checksums           rmd160  74aa3579efa5bc8733a95a47be6cf341b0bbdcec \
                     sha256  47816e8fcf6d05788ff16aa4499f97ff22431c777a7789149b0a88b451e16b74 \
                     size    74543476

--- a/print/scribus-devel/Portfile
+++ b/print/scribus-devel/Portfile
@@ -20,7 +20,7 @@ checksums           rmd160  74aa3579efa5bc8733a95a47be6cf341b0bbdcec \
 
 categories          print
 license             LGPL-2+ BSD MIT
-maintainers         nomaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 set branch          [join [lrange [split ${version} .] 0 1] .]
 
 description         qt5-based WYSIWYG desktop publishing application

--- a/print/scribus-devel/files/poppler.patch
+++ b/print/scribus-devel/files/poppler.patch
@@ -20,6 +20,10 @@ https://github.com/scribusproject/scribus/commit/f2237b8f0b5cf7690e864a22ef7a63a
 
 r25140: Fix build with poppler 22.09.0
 https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fac65819ed7
+
+r26042: Fix build failure with poppler 24.03.0
+https://github.com/scribusproject/scribus/commit/c57362c4f7bdef67904bf2f3d8126073792bdcf9
+
 --- cmake/modules/Findpoppler.cmake.orig	2022-01-23 10:16:42.000000000 -0600
 +++ cmake/modules/Findpoppler.cmake	2023-06-30 03:49:11.000000000 -0500
 @@ -1,8 +1,8 @@
@@ -215,7 +219,7 @@ https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fa
  //	qDebug() << "converting finished";
  //	qDebug() << "Imported" << m_elements.count() << "Elements";
 --- scribus/plugins/import/pdf/slaoutput.cpp.orig	2023-06-30 03:49:02.000000000 -0500
-+++ scribus/plugins/import/pdf/slaoutput.cpp	2023-06-30 03:49:11.000000000 -0500
++++ scribus/plugins/import/pdf/slaoutput.cpp	2024-03-08 15:23:01
 @@ -7,6 +7,11 @@
  
  #include "slaoutput.h"
@@ -593,7 +597,55 @@ https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fa
  }
  
  void SlaOutputDev::startPage(int pageNum, GfxState *, XRef *)
-@@ -3026,19 +2932,30 @@
+@@ -1821,7 +1727,11 @@
+ 	VGradient FillGradient = VGradient(VGradient::linear);
+ 	FillGradient.clearStops();
+ 	GfxColorSpace *color_space = shading->getColorSpace();
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 3, 0)
++	if (func->getType() == Function::Type::Stitching)
++#else
+ 	if (func->getType() == 3)
++#endif
+ 	{
+ 		StitchingFunction *stitchingFunc = (StitchingFunction*)func;
+ 		const double *bounds = stitchingFunc->getBounds();
+@@ -1843,7 +1753,11 @@
+ 			FillGradient.addStop( ScColorEngine::getShadeColor(m_doc->PageColors[stopColor], m_doc, shade), stopPoint, 0.5, 1.0, stopColor, shade );
+ 		}
+ 	}
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 3, 0)
++	else if ((func->getType() == Function::Type::Exponential) || (func->getType() == Function::Type::Identity))
++#else
+ 	else if ((func->getType() == 2) || (func->getType() == 0))
++#endif
+ 	{
+ 		GfxColor stop1;
+ 		shading->getColor(0.0, &stop1);
+@@ -1953,7 +1867,11 @@
+ 	VGradient FillGradient = VGradient(VGradient::linear);
+ 	FillGradient.clearStops();
+ 	GfxColorSpace *color_space = shading->getColorSpace();
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 3, 0)
++	if (func->getType() == Function::Type::Stitching)
++#else
+ 	if (func->getType() == 3)
++#endif
+ 	{
+ 		StitchingFunction *stitchingFunc = (StitchingFunction*)func;
+ 		const double *bounds = stitchingFunc->getBounds();
+@@ -1975,7 +1893,11 @@
+ 			FillGradient.addStop( ScColorEngine::getShadeColor(m_doc->PageColors[stopColor], m_doc, shade), stopPoint, 0.5, 1.0, stopColor, shade );
+ 		}
+ 	}
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 3, 0)
++	else if ((func->getType() == Function::Type::Exponential) || (func->getType() == Function::Type::Identity))
++#else
+ 	else if ((func->getType() == 2) || (func->getType() == 0))
++#endif
+ 	{
+ 		GfxColor stop1;
+ 		shading->getColor(0.0, &stop1);
+@@ -3026,19 +2948,30 @@
  
  void SlaOutputDev::updateFont(GfxState *state)
  {
@@ -631,7 +683,7 @@ https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fa
  	double m11, m12, m21, m22, fontSize;
  	SplashCoord mat[4];
  	int n = 0;
-@@ -3046,11 +2963,12 @@
+@@ -3046,11 +2979,12 @@
  	SplashCoord matrix[6];
  
  	m_font = nullptr;
@@ -648,7 +700,7 @@ https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fa
  	if (!gfxFont)
  		goto err1;
  
-@@ -3075,94 +2993,106 @@
+@@ -3075,94 +3009,106 @@
  		if (fontLoc->locType == gfxFontLocEmbedded)
  		{
  			// if there is an embedded font, read it to memory
@@ -668,11 +720,11 @@ https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fa
  		else
  		{ // gfxFontLocExternal
 +#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(22, 4, 0)
-+			fileName = fontLoc->path;
+ 			fileName = fontLoc->path;
 +#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(22, 2, 0)
 +			fileName = fontLoc->pathAsGooString();
 +#else
- 			fileName = fontLoc->path;
++			fileName = fontLoc->path;
 +#endif
  			fontType = fontLoc->fontType;
  		}
@@ -786,7 +838,7 @@ https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fa
  				goto err2;
  			}
  			break;
-@@ -3178,10 +3108,7 @@
+@@ -3178,10 +3124,7 @@
  				codeToGID = nullptr;
  				n = 0;
  			}
@@ -798,7 +850,7 @@ https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fa
  			{
  				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'",
  				gfxFont->getName() ? gfxFont->getName()->getCString() : "(unnamed)");
-@@ -3203,22 +3130,30 @@
+@@ -3203,22 +3146,30 @@
  			}
  			else
  			{
@@ -835,7 +887,7 @@ https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fa
  				goto err2;
  			}
  			break;
-@@ -3247,14 +3182,19 @@
+@@ -3247,14 +3198,19 @@
  	mat[3] = -m22;
  	m_font = m_fontEngine->getFont(fontFile, mat, matrix);
  
@@ -855,7 +907,7 @@ https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fa
  err1:
  	if (fontsrc && !fontsrc->isFile)
  		fontsrc->unref();
-@@ -3357,9 +3297,15 @@
+@@ -3357,9 +3313,15 @@
  GBool SlaOutputDev::beginType3Char(GfxState *state, double x, double y, double dx, double dy, CharCode code, POPPLER_CONST_082 Unicode *u, int uLen)
  {
  //	qDebug() << "beginType3Char";
@@ -871,7 +923,7 @@ https://github.com/scribusproject/scribus/commit/8acd29e97813b9132e3b51b2f05e8fa
  	if (gfxFont->getType() != fontType3)
  		return gTrue;
  	F3Entry f3e;
-@@ -3680,16 +3626,21 @@
+@@ -3680,16 +3642,21 @@
  			m_lineJoin = Qt::BevelJoin;
  			break;
  	}


### PR DESCRIPTION
#### Description

Revbumping was again forgotten when `poppler` was updated, which left dependents broken.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.3.1
Xcode 15.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
