### PR TITLE
tippecanoe: update to 2.49.0

### DIFF
--- a/gis/tippecanoe/Portfile
+++ b/gis/tippecanoe/Portfile
@@ -6,7 +6,8 @@ PortGroup               makefile 1.0
 PortGroup               legacysupport 1.0
 PortGroup               compiler_blacklist_versions 1.0
 
-github.setup            felt tippecanoe 2.45.0
+github.setup            felt tippecanoe 2.49.0
+github.tarball_from     archive
 revision                0
 categories              gis
 license                 BSD
@@ -14,9 +15,9 @@ maintainers             {@sikmir disroot.org:sikmir} openmaintainer
 description             Build vector tilesets from large collections of GeoJSON features
 long_description        {*}${description}
 
-checksums               rmd160  8662ecd2f075e5c80253b341b27d84a40f0537e2 \
-                        sha256  40c261e3b1b4217fdec4d04eff65d603cdd3c1ea302881983e519f449eb3bcdb \
-                        size    22542415
+checksums               rmd160  24e7985aa4251791a32839c8868ba5fe9e0d874a \
+                        sha256  6588fe5961d0cb279a8b75688bfe9f849e3f98a0823107a6af32a413d366c0c6 \
+                        size    22534473
 
 depends_lib-append      port:sqlite3 \
                         port:zlib


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/felt/tippecanoe/releases)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
