### PR TITLE
dog: Build from source to support more archs

### DIFF
--- a/net/dog/Portfile
+++ b/net/dog/Portfile
@@ -1,60 +1,134 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem          1.0
-PortGroup           github 1.0
+PortSystem              1.0
+PortGroup               cargo 1.0
+PortGroup               github 1.0
 
-github.setup        ogham dog 0.1.0 v
-revision            2
+github.setup            ogham dog 0.1.0 v
+github.tarball_from     archive
+revision                3
+categories              net sysutils
+license                 MIT
+maintainers             {gmail.com:herby.gillot @herbygillot} openmaintainer
 
-homepage            https://dns.lookup.dog
+description             ${name} is a command-line DNS client
+long_description        Dogs can look up! ${name} is a command-line DNS client, \
+                        like dig. IT has colourful output, understands normal \
+                        command-line argument syntax, supports the DNS-over-TLS \
+                        and DNS-over-HTTPS protocols, and can emit JSON.
 
-description         ${name} is a command-line DNS client
+homepage                https://dns.lookup.dog/
 
-long_description    Dogs can look up! dog is a command-line DNS client, \
-                    like dig. It has colourful output, understands normal \
-                    command-line argument syntax, supports the DNS-over-TLS \
-                    and DNS-over-HTTPS protocols, and can emit JSON.
+checksums               ${distname}${extract.suffix} \
+                        rmd160  469b64b3e07c758e0aff37fe60250f96ed21346c \
+                        sha256  82387d38727bac7fcdb080970e84b36de80bfe7923ce83f993a77d9ac7847858 \
+                        size    449366
 
-categories          net sysutils
-platforms           darwin
-supported_archs     x86_64
-license             MIT
+depends_build-append    port:just \
+                        port:pandoc
 
-checksums           rmd160  712de148301083163d46a9849316c5adf99c8070 \
-                    sha256  97b749124e3bdcb1c3a97076a2fb3dee29dfc16a29c9f638bdae1060ad4e3d89 \
-                    size    271723
+# Disable --frozen to workaround dependencies from Git
+cargo.offline_cmd
 
-maintainers         {gmail.com:herby.gillot @herbygillot} \
-                    openmaintainer
+# dog doesn't work with OpenSSL3
+openssl.branch          1.1
 
-github.tarball_from releases
-distname            ${name}-v${version}-x86_64-apple-darwin
-use_zip             yes
-
-worksrcdir
-
-use_configure       no
-
-build {}
+post-build {
+    system -W ${worksrcpath} "${prefix}/bin/just man"
+}
 
 destroot {
-    # Install binary
-    move ${workpath}/bin/dog ${destroot}${prefix}/bin/
-    
-    # Install man page
-    xinstall -d ${destroot}${prefix}/share/man/man1
-    move ${workpath}/man/dog.1 ${destroot}${prefix}/share/man/man1/
+    set bindir ${worksrcpath}/target/[cargo.rust_platform]/release
+    xinstall -m 0755 ${bindir}/${name} ${destroot}${prefix}/bin/${name}
 
-    # Install completions
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 ${worksrcpath}/target/man/${name}.1 \
+        ${destroot}${prefix}/share/man/man1/${name}.1
+
     xinstall -d ${destroot}${prefix}/share/bash-completion/completions
-    xinstall -m 0644 ${workpath}/completions/${name}.bash \
+    xinstall -m 0644 ${worksrcpath}/completions/${name}.bash \
         ${destroot}${prefix}/share/bash-completion/completions/${name}
 
     xinstall -d ${destroot}${prefix}/share/zsh/site-functions
-    xinstall -m 0644 ${workpath}/completions/${name}.zsh \
+    xinstall -m 0644 ${worksrcpath}/completions/${name}.zsh \
         ${destroot}${prefix}/share/zsh/site-functions/_${name}
 
     xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
-    xinstall -m 0644 ${workpath}/completions/${name}.fish \
+    xinstall -m 0644 ${worksrcpath}/completions/${name}.fish \
         ${destroot}${prefix}/share/fish/vendor_completions.d/
 }
+
+cargo.crates \
+    addr2line                       0.14.0  7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423 \
+    adler                            0.2.3  ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e \
+    ansi_term                       0.11.0  ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    atty                            0.2.14  d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8 \
+    autocfg                          1.0.1  cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a \
+    backtrace                       0.3.54  2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28 \
+    bitflags                         1.2.1  cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693 \
+    byteorder                        1.3.4  08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de \
+    cc                              1.0.61  ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d \
+    cfg-if                          0.1.10  4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    core-foundation                  0.7.0  57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171 \
+    core-foundation-sys              0.7.0  b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac \
+    ctor                            0.1.16  7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484 \
+    datetime                         0.5.1  d0fcb4df22ae812fa2f6d5e3b577247584cc67fce06ad0779168d1dd41cbcce3 \
+    difference                       2.0.0  524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198 \
+    failure                          0.1.8  d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86 \
+    failure_derive                   0.1.8  aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4 \
+    foreign-types                    0.3.2  f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1 \
+    foreign-types-shared             0.1.1  00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b \
+    getopts                         0.2.21  14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5 \
+    getrandom                       0.1.15  fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6 \
+    gimli                           0.23.0  f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce \
+    hermit-abi                      0.1.17  5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8 \
+    httparse                         1.3.4  cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9 \
+    ipconfig                         0.2.2  f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7 \
+    itoa                             0.4.6  dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6 \
+    json                            0.12.4  078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                            0.2.80  4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614 \
+    log                             0.4.11  4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b \
+    miniz_oxide                      0.4.3  0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d \
+    native-tls                       0.2.4  2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d \
+    object                          0.22.0  8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397 \
+    openssl                        0.10.30  8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4 \
+    openssl-probe                    0.1.2  77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de \
+    openssl-sys                     0.9.58  a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de \
+    output_vt100                     0.1.2  53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9 \
+    pkg-config                      0.3.19  3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c \
+    ppv-lite86                      0.2.10  ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857 \
+    pretty_assertions                0.6.1  3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427 \
+    proc-macro2                     1.0.24  1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71 \
+    quote                            1.0.7  aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37 \
+    rand                             0.7.3  6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03 \
+    rand_chacha                      0.2.2  f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402 \
+    rand_core                        0.5.1  90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19 \
+    rand_hc                          0.2.0  ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c \
+    redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
+    regex                            1.4.2  38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c \
+    regex-syntax                    0.6.21  3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189 \
+    remove_dir_all                   0.5.3  3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7 \
+    rustc-demangle                  0.1.18  6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232 \
+    ryu                              1.0.5  71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e \
+    schannel                        0.1.19  8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75 \
+    security-framework               0.4.4  64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535 \
+    security-framework-sys           0.4.3  17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405 \
+    serde                          1.0.117  b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a \
+    serde_derive                   1.0.117  cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e \
+    serde_json                      1.0.59  dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95 \
+    socket2                         0.3.15  b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44 \
+    syn                             1.0.48  cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac \
+    synstructure                    0.12.4  b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701 \
+    tempfile                         3.1.0  7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9 \
+    unicode-width                    0.1.8  9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3 \
+    unicode-xid                      0.2.1  f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564 \
+    vcpkg                           0.2.10  6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c \
+    wasi      0.9.0+wasi-snapshot-preview1  cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519 \
+    widestring                       0.4.3  c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    winreg                           0.6.2  b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9


### PR DESCRIPTION
#### Description

By building `dog` from source, other "unsupported" architectures can be supported (such as arm64). This is possible by removing the `--frozen` flag from cargo when building (through clearing `cargo.offline_cmd`).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
