### PR TITLE
uv: Update to 0.1.16

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.1.15
+github.setup            astral-sh uv 0.1.16
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -17,9 +17,9 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for pip and pip-compile.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  79d0361d8d064f9c139c868045991d3134dc8539 \
-                        sha256  0a44d1207a7e28e7a76878b79569370f9bbac6c3571527fbd7da94769fbbf3b8 \
-                        size    803628
+                        rmd160  2765639fa97431c604a9a66f52d151b389e64925 \
+                        sha256  90f01d916c842a9ff229e2ddc6418210154b7e7ccf13f1ec145f3c8100b445f6 \
+                        size    823680
 
 depends_build-append    port:pkgconfig
 depends_lib-append      port:libgit2
@@ -81,6 +81,7 @@ cargo.crates \
     assert_fs                        1.1.1  2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec \
     async-channel                    2.2.0  f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3 \
     async-compression                0.4.6  a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c \
+    async-recursion                  1.0.5  5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0 \
     async-trait                     0.1.77  c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9 \
     async_http_range_reader          0.7.0  cf8eeab30c68da4dc2c51f3afc4327ab06fe0f3f028ca423f7ca398c7ed8c5e7 \
     autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
@@ -335,6 +336,7 @@ cargo.crates \
     rend                             0.4.2  71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c \
     reqwest                        0.11.24  c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251 \
     reqwest-middleware               0.2.4  88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690 \
+    reqwest-netrc                    0.1.1  eca0c58cd4b2978f9697dea94302e772399f559cd175356eb631cb6daaa0b6db \
     reqwest-retry                    0.3.0  9af20b65c2ee9746cc575acb6bd28a05ffc0d15e25c992a8f4462d8686aacb4f \
     resvg                           0.29.0  76888219c0881e22b0ceab06fddcfe83163cd81642bd60c7842387f9c968a72e \
     retry-policies                   0.2.1  17dd00bff1d737c40dbcd47d4375281bf4c17933f9eef0a185fc7bacca23ecbd \
@@ -347,6 +349,7 @@ cargo.crates \
     rosvgtree                        0.1.0  bdc23d1ace03d6b8153c7d16f0708cd80b61ee8e80304954803354e67e40d150 \
     roxmltree                       0.18.1  862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302 \
     roxmltree                       0.19.0  3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f \
+    rust-netrc                       0.1.1  32662f97cbfdbad9d5f78f1338116f06871e7dae4fd37e9f59a0f57cf2044868 \
     rustc-demangle                  0.1.23  d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76 \
     rustc-hash                       1.1.0  08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2 \
     rustix                         0.38.31  6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949 \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.1.16.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
