### PR TITLE
ImageMagick7: Update to 7.1.1-29

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -1,193 +1,77 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           conflicts_build 1.0
-PortGroup           github 1.0
+PortGroup           meson 1.0
+PortGroup           gobject_introspection 1.0
+PortGroup           gitlab 1.0
 
-###### OBSOLETE NOTE FROM IM6:
-# Keep relevant lines in sync between ImageMagick and p5-perlmagick.
-
-###### OBSOLETE NOTE FROM IM6:
-# Before updating to a newer version, install phpNN-imagick.
-# After updating, run `phpNN -v`.
-# If the following warning appears, revbump php-imagick.
-# PHP Warning:  Version warning: Imagick was compiled against
-# Image Magick version XXXX but version YYYY is loaded.
-# Imagick will run but may behave surprisingly in Unknown on line 0.
-
-name                ImageMagick7
-github.setup        ImageMagick ImageMagick 7.1.1-28
+gitlab.instance     https://gitlab.gnome.org
+gitlab.setup        GNOME gjs 1.78.4
 revision            0
 
-checksums           rmd160  369ac03cf595c27810b4c5553cdd99f255c21a80 \
-                    sha256  8c06d298b0c85c4de971fc12d083dcba69ceb3823c1f96bcf6c2caa95f2ad954 \
-                    size    15399784
+checksums           rmd160  dad53f8fad8ea45ec1077f31c1d4449bbbae68fe \
+                    sha256  dc635cb481047dbdee3395f3ff3ac121e8449d5fce71682ad0a21df503237a3b \
+                    size    691601
+ 
+conflicts           gjs-devel
+set my_name         gjs
 
-categories          graphics devel
-maintainers         {@Dave-Allured noaa.gov:dave.allured} \
-                    openmaintainer
-license             Apache-2
-platforms           darwin
-use_parallel_build  yes
+categories          gnome
+license             LGPL-2.1+
+maintainers         {devans @dbevans} {mascguy @mascguy} openmaintainer
 
-description         Tools and libraries to manipulate images in many formats
+description         GNOME JavaScript/Spidermonkey bindings
+long_description    ${description}
+homepage            https://gitlab.gnome.org/GNOME/gjs/-/blob/master/doc/README.md \
+                    https://gjs-docs.gnome.org/gjs
 
-long_description    ImageMagick is a robust collection of tools and \
-                    libraries to create, edit and compose bitmap images \
-                    in a wide variety of formats. You can crop, resize, \
-                    rotate, sharpen, color reduce or add effects or text \
-                    or straight or curved lines to an image or image \
-                    sequence and save your completed work in the same or \
-                    differing image format. You can even create images \
-                    from scratch. Image processing operations are \
-                    available from the command line as well as through \
-                    C, Ch, C++, Java, Perl, PHP, Python, Ruby and Tcl/Tk \
-                    programming interfaces. Over 90 image formats are \
-                    supported, including GIF, JPEG, JPEG 2000, PNG, PDF, \
-                    PhotoCD and TIFF.
+set py_ver          3.12
+set py_ver_nodot    [string map {. {}} ${py_ver}]
 
-homepage            https://imagemagick.org
+depends_build-append \
+                    port:pkgconfig \
+                    port:python${py_ver_nodot}
 
-##master_sites        https://download.imagemagick.org/ImageMagick/download/releases/ \
-##                    https://github.com/ImageMagick/ImageMagick \
-##                    http://mirror.checkdomain.de/imagemagick/releases/ \
-##                    ftp://ftp.u-aizu.ac.jp/pub/graphics/image/ImageMagick/imagemagick.org/releases/ \
-##                    ftp://sunsite.icm.edu.pl/packages/ImageMagick/releases/
+depends_lib-append \
+                    path:lib/pkgconfig/cairo.pc:cairo \
+                    port:dbus \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                    port:libffi \
+                    port:mozjs115 \
+                    port:readline
 
-depends_lib         port:bzip2 \
-                    port:djvulibre \
-                    port:xz \
-                    port:jbigkit \
-                    path:include/turbojpeg.h:libjpeg-turbo \
-                    port:lcms2 \
-                    port:libpng \
-                    port:libraw \
-                    port:tiff \
-                    port:webp \
-                    port:zlib \
-                    port:fftw-3 \
-                    port:freetype \
-                    port:fontconfig \
-                    port:ghostscript \
-                    port:libiconv \
-                    port:libtool \
-                    port:openjpeg \
-                    port:openexr \
-                    port:expat \
-                    port:libxml2 \
-                    port:libheif
+compiler.cxx_standard \
+                    2017
 
-# Magick-config etc. use pkg-config
-depends_lib-append  port:pkgconfig
+# LD_LIBRARY_PATH => DYLD_LIBRARY_PATH
+patchfiles-append   patch-gjs-test.diff
 
-depends_run         port:urw-fonts
+# The gobject_introspection PG needs an 'introspection' option
+patchfiles-append   patch-gjs-meson_options.diff
 
-configure.ccache    no
+# https://gitlab.gnome.org/GNOME/gjs/-/issues/532
+patchfiles-append   patch-gjs-skip-gtk-tests.diff
 
-configure.pre_args  --prefix=${prefix}/lib/ImageMagick7
-configure.args      --mandir=${prefix}/lib/ImageMagick7/share/man
+post-patch {
+    reinplace "s|^#!/usr/bin/env python3|#!${configure.python}|" \
+        build/compile-gschemas.py \
+        build/symlink-gjs.py
+}
 
+configure.python    ${prefix}/bin/python${py_ver}
+
+# profiler currently only supported on Linux
 configure.args-append \
-                    --enable-shared \
-                    --enable-static \
-                    --disable-silent-rules \
-                    --with-frozenpaths \
-                    --with-openexr \
-                    --disable-hdri \
-                    --with-dps \
-                    --with-bzlib \
-                    --with-djvu \
-                    --with-fontconfig \
-                    --with-gslib \
-                    --with-jbig \
-                    --with-jpeg \
-                    --with-lcms \
-                    --with-openjp2 \
-                    --with-png \
-                    --with-tiff \
-                    --with-webp \
-                    --with-zlib \
-                    --with-modules \
-                    --with-xml \
-                    --with-heic \
-                    --without-gcc-arch \
-                    --without-perl \
-                    --without-fpx \
-                    --without-wmf \
-                    --without-gvc \
-                    --without-rsvg \
-                    --without-lqr \
-                    --without-pango \
-                    --without-x \
-                    --without-zstd \
-                    --with-gs-font-dir=${prefix}/share/fonts/urw-fonts \
-                    --disable-openmp
+                    -Dprofiler=disabled \
+                    -Dskip_dbus_tests=true \
+                    -Dskip_gtk_tests=true \
+                    -Dbsymbolic_functions=false
 
-if {${os.platform} eq "darwin" && ${os.major} < 11} {
-    configure.args-append   --disable-opencl
-} else {
-    configure.args-append   --disable-opencl
-    # On case-insensitive filesystems, ImageMagick finds cryptlib's libcl and
-    # tries to use it as if it were Apple's OpenCL, which fails; see #23354.
-    if {[file exists ${prefix}/lib/libCL.dylib]} {
-        conflicts_build         cryptlib
-    }
-}
+gobject_introspection yes
 
+# Note that a few tests in the "Scripts / CommandLine" category may fail as the
+# typelib (gobject-introspection) expects libgjs.0.dylib to be installed at the
+# system level during testing
 test.run            yes
-test.target         check
-test.env            DYLD_LIBRARY_PATH=${worksrcpath}/magick/.libs
-
-# ImageMagick uses .la files at runtime to find its coder modules.
-destroot.delete_la_files    no
-
-variant graphviz description {Support Graphviz} {
-    depends_lib-append      path:bin/dot:graphviz
-    configure.args-replace  --without-gvc --with-gvc
-}
-
-variant lqr description {Support Liquid Rescale (experimental)} {
-    depends_lib-append      port:liblqr
-    configure.args-replace  --without-lqr --with-lqr
-}
-
-variant pango description {Support Pango} {
-    depends_lib-append      path:lib/pkgconfig/pango.pc:pango
-    configure.args-replace  --without-pango --with-pango
-}
-
-variant rsvg description {Support SVG using librsvg} {
-    depends_lib-append      path:lib/pkgconfig/librsvg-2.0.pc:librsvg
-    configure.args-replace  --without-rsvg --with-rsvg
-}
-
-variant wmf description {Support the Windows Metafile Format} {
-    depends_lib-append      port:libwmf
-    configure.args-replace  --without-wmf --with-wmf
-}
-
-variant x11 {
-    depends_lib-append      port:xorg-libX11 \
-                            port:xorg-libXext \
-                            port:xorg-libXt
-    configure.args-replace  --without-x --with-x
-}
-
-default_variants    +x11
-
-## Livecheck is now provided by github portgroup.
-## livecheck.type      regex
-## livecheck.url       [lindex ${master_sites} 0]
-## livecheck.regex     ImageMagick-(7(?:\\.\\d+)+(?:-\\d+)?)\.tar
-
-notes-append {
---------
-To use the ImageMagic-7 command-line interface, add
-${prefix}/lib/ImageMagick7/bin to your $PATH,
-in front of the normal ${prefix}; or else use full paths.
---------
-To compile and link with ImageMagic-7, add
--I${prefix}/lib/ImageMagick7/include and
--L${prefix}/lib/ImageMagick7/lib to your compile command.
---------
-}
+test.target         test


### PR DESCRIPTION
#### Description

* Update 7.1.1-28 --> 7.1.1-29
* Add legacy support portgroup.
* Maybe fixes 10.6 builds.  We will find out on 10.6 builders after merge.
* Add pointer to previous ImageMagick (version 6) port in long_description.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.6.4 22G513 x86_64
Xcode 15.2 / Command Line Tools 15.1.0.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
- [x] tested basic functionality of ONE binary file?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
