### PR TITLE
eza: update dependencies

### DIFF
--- a/sysutils/eza/Portfile
+++ b/sysutils/eza/Portfile
@@ -103,6 +103,7 @@ cargo.crates \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
     anes                             0.1.6  4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299 \
+    ansi-width                       0.1.0  219e3ce6f2611d83b51ec2098a12702112c29e57203a6b0a0929b2cddb486608 \
     ansi_colours                     1.2.2  6a1558bd2075d341b9ca698ec8eb6fcc55a746b1fc4255585aad5b141d918a80 \
     ansiterm                        0.12.2  4ab587f5395da16dd2e6939adf53dede583221b320cadfb94e02b5b7b9bf24cc \
     anstream                        0.6.11  6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5 \
@@ -168,7 +169,7 @@ cargo.crates \
     line-wrap                        0.1.1  f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9 \
     linux-raw-sys                   0.4.11  969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829 \
     locale                           0.2.2  5fdbe492a9c0238da900a1165c42fc5067161ce292678a6fe80921f30fe307fd \
-    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
     matches                          0.1.8  7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08 \
     memchr                           2.6.3  8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c \
     memoffset                        0.9.0  5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
@@ -184,6 +185,7 @@ cargo.crates \
     palette                          0.7.5  ebfc23a4b76642983d57e4ad00bb4504eb30a8ce3c70f4aee1f725610e36d97a \
     palette_derive                   0.7.5  e8890702dbec0bad9116041ae586f84805b13eecd1d8b1df27c29998a9969d6d \
     partition-identity               0.3.0  9fa925f9becb532d758b0014b472c576869910929cf4c3f8054b386f19ab9e21 \
+    path-clean                       1.0.1  17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef \
     percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
     phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
     phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
@@ -201,7 +203,7 @@ cargo.crates \
     quote                           1.0.33  5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
-    rayon                            1.8.1  fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051 \
+    rayon                            1.9.0  e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
     redox_syscall                    0.3.5  567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29 \
@@ -243,7 +245,7 @@ cargo.crates \
     unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
     url                              2.2.1  9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
-    uutils_term_grid                 0.3.0  b389452a568698688dda38802068378a16c15c4af9b153cdd99b65391292bbc7 \
+    uutils_term_grid                 0.6.0  f89defb4adb4ba5703a57abc879f96ddd6263a444cacc446db90bf2617f141fb \
     uzers                           0.11.3  76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63 \
     vcpkg                           0.2.12  cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \


### PR DESCRIPTION
#### Description

update eza dependencies according to the upstream's Cargo.lock file

Fixes https://trac.macports.org/ticket/69457
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
