### PR TITLE
ruff: Update to 0.3.2

### DIFF
--- a/devel/ruff/Portfile
+++ b/devel/ruff/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        astral-sh ruff 0.3.1 v
+github.setup        astral-sh ruff 0.3.2 v
 github.tarball_from archive
 revision            0
 
@@ -29,9 +29,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  2fd7b7b641fe651b45c6b2720dc23290d4a272ce \
-                    sha256  0102df567ac89bc4e1517ef922de363e1604e60309e4d62c9b2b977847ca1ea6 \
-                    size    3811954
+                    rmd160  96a767e9bdd513cc4575ac96a86adce287e0145b \
+                    sha256  f31d179ddc11297f33a509069f72efdc542350274d490c2be063287ef0290579 \
+                    size    3818987
 
 destroot {
     xinstall -m 0755 \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.3.2. There's apparently [another port referring to this project](https://github.com/macports/macports-ports/blob/master/python/py-ruff/Portfile), but I propose it (the linked port) should be declared as obsolete.

CC @catap

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
