### PR TITLE
xcode-build-server: Update to v1.0.1

### DIFF
--- a/devel/xcode-build-server/Portfile
+++ b/devel/xcode-build-server/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        SolaWing xcode-build-server 1.0.0 v
-version             1.0.0
+github.setup        SolaWing xcode-build-server 1.0.1 v
+version             1.0.1
 revision            0
 platforms           {macosx any}
 license             MIT
@@ -23,9 +23,9 @@ long_description    ${name} integrates Xcode with Apple's sourcekit-lsp. \
                     server to provide sourcekit-lsp with the build \
                     information it needs for an Xcode project.
 
-checksums           rmd160  fd21bf312b47c15fc28d03b80de1ec39d76140a2 \
-                    sha256  08ea2b9a892670bb7c2f8ff90a97ae0be519744f42ba713bb1a56e247c77e885 \
-                    size    18673
+checksums           rmd160  794378403a9616e785dfcdf0ed69c5bfe408a39e \
+                    sha256  11c87b7f300abc25db84eb6bddcc1a6e56c0c0a39f2547bd1c75ca2833d6073d \
+                    size    19087
 
 build {}
 


### PR DESCRIPTION
#### Description

Update the xcode-build-server tool to version 1.0.1

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.6.3 22G436 arm64
Xcode 15.2 15C500b

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
