### PR TITLE
pipexec: new port (v2.6.1)

### DIFF
--- a/sysutils/pipexec/Portfile
+++ b/sysutils/pipexec/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github  1.0
+
+github.setup        flonatel pipexec 2.6.1
+github.tarball_from releases
+revision            0
+
+description         Handling pipe of commands like a single command
+
+long_description    \
+    {*}${description}. ${name} allows you to build a network of processes and \
+    connecting pipes, and have them act like a single process.
+
+categories          sysutils
+installs_libs       no
+license             GPL-2
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  5d15030a5bee2d1463e5059294d2eb0bf642a562 \
+                    sha256  de8237eb45224c04c1bd41cc8dc5dfb9c78ceff3b02202a49981396e55602e29 \
+                    size    352352
+
+use_xz              yes
+
+configure.args-append \
+                    --disable-silent-rules
+
+post-destroot {
+    file delete ${destroot}${prefix}/bin/ptest
+
+    xinstall -d ${destroot}${prefix}/share/man/man1
+
+    xinstall -m 0444 \
+        {*}[glob ${worksrcpath}/doc/man/*.1] \
+        ${destroot}${prefix}/share/man/man1/
+}


### PR DESCRIPTION
https://github.com/flonatel/pipexec

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
