### PR TITLE
micronaut: update to 4.3.5

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.3.4 v
+github.setup    micronaut-projects micronaut-starter 4.3.5 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  05b08cabafa43b8c5737085181f75b810384869f \
-                sha256  977a54a322d7059e25ddee708aaff276c7eed1097b5548ac4038b42e093880ea \
-                size    22371495
+checksums       rmd160  97bfbba6b44f7a794a4720f880fb7f5fe342a668 \
+                sha256  6c4faa6873c79a1ed48506618dafb6db662a8cf0d3513fa5dbe18671cd8a53ce \
+                size    22368561
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.3.5.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?