### PR TITLE
bazel: Fix build failure due to deprecation warnings

### DIFF
--- a/devel/bazel/Portfile
+++ b/devel/bazel/Portfile
@@ -37,7 +37,7 @@ if { ${name} eq ${subport} } {
 
     # Main port
     github.setup    bazelbuild ${name} 6.4.0
-    revision        0
+    revision        1
     checksums       rmd160  8037f7fc0691fd1e4940782e7c945d807f4b66b6 \
                     sha256  bd88ff602c8bbb29ee82ba2a6b12ad092d51ec668c6577f9628f18e48ff4e51e \
                     size    206062629
@@ -45,6 +45,14 @@ if { ${name} eq ${subport} } {
     set bazel_min_xcode 10.3
     compiler.blacklist-append {clang < 1000}
     compiler.blacklist-append {macports-clang-[5-9].0}
+
+    # fix deprectation warnings causing build failure for xcode >= 15
+    # upstream issue: https://github.com/bazelbuild/bazel/issues/20076
+    # fixed in commit  https://github.com/meteorcloudy/bazel/commit/1297bacf2f4470c23e12c3d79e5984c4d2f307ea
+    # included in bazel since 7.0.0 RC5
+    if {[vercmp ${xcodeversion} 15] >= 0} {
+        set extra_args "--copt=-Wno-deprecated-builtins --host_copt=-Wno-deprecated-builtins ${extra_args}"
+    }
 } elseif { "bazel-3.7" eq ${subport} } {
     PortGroup       obsolete 1.0
 


### PR DESCRIPTION

#### Description

Fixes the build failure reported in https://trac.macports.org/ticket/68630.

This workaround was suggested in the corresponding [upstream issue](https://github.com/bazelbuild/bazel/issues/20076).  
It was fixed in Bazel version 7.0.0 RC5 and can/should hence be removed when the port is updated to a newer version.

###### Type(s)
- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.4 22G513 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

