### PR TITLE
uv: Update to 0.1.17

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.1.16
+github.setup            astral-sh uv 0.1.17
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -17,9 +17,9 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for pip and pip-compile.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  2765639fa97431c604a9a66f52d151b389e64925 \
-                        sha256  90f01d916c842a9ff229e2ddc6418210154b7e7ccf13f1ec145f3c8100b445f6 \
-                        size    823680
+                        rmd160  5019b4954d2e8193459ad48bf63d4e14d4046c64 \
+                        sha256  f0b4b6dac4193247f317384ef6599662a4e8ce6556dd16f509e7967171d7a883 \
+                        size    833867
 
 depends_build-append    port:pkgconfig
 depends_lib-append      port:libgit2
@@ -155,6 +155,7 @@ cargo.crates \
     either                          1.10.0  11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a \
     encode_unicode                   0.3.6  a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f \
     encoding_rs                     0.8.33  7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1 \
+    encoding_rs_io                   0.1.7  1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83 \
     equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
     errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
     event-listener                   5.2.0  2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91 \
@@ -336,7 +337,6 @@ cargo.crates \
     rend                             0.4.2  71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c \
     reqwest                        0.11.24  c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251 \
     reqwest-middleware               0.2.4  88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690 \
-    reqwest-netrc                    0.1.1  eca0c58cd4b2978f9697dea94302e772399f559cd175356eb631cb6daaa0b6db \
     reqwest-retry                    0.3.0  9af20b65c2ee9746cc575acb6bd28a05ffc0d15e25c992a8f4462d8686aacb4f \
     resvg                           0.29.0  76888219c0881e22b0ceab06fddcfe83163cd81642bd60c7842387f9c968a72e \
     retry-policies                   0.2.1  17dd00bff1d737c40dbcd47d4375281bf4c17933f9eef0a185fc7bacca23ecbd \


### PR DESCRIPTION
#### Description

Update `ruff` to its latest released version, 0.1.17. [Changelog](https://github.com/astral-sh/uv/releases/tag/0.1.17).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
