### PR TITLE
gk: update to version 1.6.0

### DIFF
--- a/devel/gk/Portfile
+++ b/devel/gk/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            gitkraken gk-cli 1.5.1 v
+github.setup            gitkraken gk-cli 1.6.0 v
 name                    gk
 github.tarball_from     releases
 
@@ -25,13 +25,13 @@ long_description        ${name} is GitKraken on the command line. It makes worki
                         to visualize git information when you need it.
 
 checksums               ${name}_${version}_macOS_arm64.zip \
-                            sha256  0d2191829d02bd435a48d16ef4e28408457aed1b56d10b6bffd88d79ed7a02d6 \
-                            rmd160  f4c8a220f73ab823682546ab9a2c282a045a22e9 \
-                            size    24097888 \
+                            sha256  eaa510e623a248535a800891fb01b731236d99b5835a4c2ffc74c5999e20e928 \
+                            rmd160  afa393afbf9c97cea3931d9f8af2e3ac7d3a5811 \
+                            size    23422668 \
                         ${name}_${version}_macOS_x86_64.zip \
-                            sha256  af59717e612fd120918b602f13f2c96cea4345c254a81c3e98dc0d7c0f5a9d77 \
-                            rmd160  eeae414ddcfee68d49eeb3d92ddc93796fa07b47 \
-                            size    25497196
+                            sha256  a5924468a3052a6f4cfa90fff5c0599fd3582a1bd6555a8c57feb34e2442124b \
+                            rmd160  12090747b71d0a1a112c239d5d3603f426d42f1a \
+                            size    25378744
 
 extract.mkdir           yes
 


### PR DESCRIPTION
#### Description

Update to version 1.6.0

###### Type(s)

- [x] update

###### Tested on
macOS 14.3.1 23D60 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

[skip notification]