### PR TITLE
watchexec: new port (v1.25.1)

### DIFF
--- a/sysutils/watchexec/Portfile
+++ b/sysutils/watchexec/Portfile
@@ -1,0 +1,493 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cargo   1.0
+PortGroup           github  1.0
+
+github.setup        watchexec watchexec 1.25.1 v
+github.tarball_from archive
+revision            0
+
+homepage            https://watchexec.github.io/
+
+description         Executes commands in response to file modifications
+
+long_description    \
+    Software development often involves running the same commands over and \
+    over. Boring\!  watchexec is a simple, standalone tool that watches a \
+    path and runs a command whenever it detects modifications. Example use \
+    cases\: automatically run unit tests, run linters\/syntax checkers, \
+    rebuild artifacts
+
+categories          sysutils
+installs_libs       no
+license             Apache-2
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  5360b98a81203c922b2cd31f82725c5957aeee7e \
+                    sha256  9609163c14cd49ec651562838f38b88ed2d370e354af312ddc78c2be76c08d37 \
+                    size    363708
+
+set target_bin      ${worksrcpath}/target/[cargo.rust_platform]/release/${name}
+
+post-build {
+    # regenerate man page
+    system -W ${worksrcpath} "${target_bin} --manual > ./doc/${name}.1"
+
+    # regenerate shell completions
+    foreach _shell {bash fish zsh} {
+        system -W ${worksrcpath} \
+            "${target_bin} --completions ${_shell} > ./completions/${_shell}"
+    }
+}
+
+destroot {
+    xinstall -m 0755 ${target_bin} ${destroot}${prefix}/bin/
+
+    # install man page
+    xinstall -d ${destroot}${prefix}/share/man/man1
+    xinstall -m 0644 ${worksrcpath}/doc/${name}.1 \
+        ${destroot}${prefix}/share/man/man1/
+
+    # install shell completions
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 0644 ${worksrcpath}/completions/bash \
+        ${destroot}${prefix}/share/bash-completion/completions/${name}
+
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completions.d
+    xinstall -m 0644 ${worksrcpath}/completions/fish \
+        ${destroot}${prefix}/share/fish/vendor_completions.d/${name}.fish
+
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 0644 ${worksrcpath}/completions/zsh \
+        ${destroot}${prefix}/share/zsh/site-functions/_${name}
+}
+
+cargo.crates \
+    addr2line                       0.21.0  8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    aho-corasick                     1.1.2  b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0 \
+    android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
+    android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
+    ansi_term                       0.12.1  d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2 \
+    anstream                         0.6.5  d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6 \
+    anstyle                          1.0.4  7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87 \
+    anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
+    anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
+    anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
+    anyhow                          1.0.79  080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca \
+    arc-swap                         1.6.0  bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6 \
+    argfile                          0.1.6  1287c4f82a41c5085e65ee337c7934d71ab43d5187740a81fb69129013f6a5f6 \
+    async-broadcast                  0.5.1  7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b \
+    async-channel                    2.1.1  1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c \
+    async-executor                   1.8.0  17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c \
+    async-fs                         1.6.0  279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06 \
+    async-io                        1.13.0  0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af \
+    async-io                         2.2.2  6afaa937395a620e33dc6a742c593c01aced20aa376ffb0f628121198578ccc7 \
+    async-lock                       2.8.0  287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b \
+    async-lock                       3.2.0  7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c \
+    async-priority-channel           0.2.0  acde96f444d31031f760c5c43dc786b97d3e1cb2ee49dd06898383fe9a999758 \
+    async-process                    1.8.1  ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88 \
+    async-recursion                  1.0.5  5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0 \
+    async-signal                     0.2.5  9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5 \
+    async-stream                     0.3.5  cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51 \
+    async-stream-impl                0.3.5  16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193 \
+    async-task                       4.7.0  fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799 \
+    async-trait                     0.1.77  c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9 \
+    atomic-take                      1.1.0  a8ab6b55fe97976e46f91ddbed8d147d966475dc29b2032757ba47e02376fbc3 \
+    atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
+    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    axum                            0.6.20  3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf \
+    axum-core                        0.3.4  759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c \
+    backtrace                       0.3.69  2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837 \
+    backtrace-ext                    0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
+    base64                          0.21.5  35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9 \
+    bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                         2.4.1  327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07 \
+    block                            0.1.6  0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a \
+    block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
+    blocking                         1.5.1  6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118 \
+    boxcar                           0.2.4  e516014975db8769c0dcd1aba681c21079475fcddf77118bf54f9e2e013f6b29 \
+    bstr                             1.9.0  c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc \
+    btoi                             0.4.3  9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad \
+    bumpalo                         3.14.0  7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec \
+    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
+    bytes                            1.5.0  a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223 \
+    c-gull                         0.15.40  aea6f945c316611372195edc506dfabc3fbc2b0811d4bdeb5700e5739150c746 \
+    c-scape                        0.15.40  2da8e03739ea180db9ac1c153c152f3672adf95faf474b766f28caa6ffc93985 \
+    cc                              1.0.83  f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0 \
+    cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
+    chrono                          0.4.31  7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38 \
+    clap                            4.4.12  dcfab8ba68f3668e89f6ff60f5b205cea56aa7b769451a59f34b8682f51c056d \
+    clap_builder                    4.4.12  fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9 \
+    clap_complete                    4.4.6  97aeaa95557bd02f23fbb662f981670c3d20c5a26e69f7354b28f57092437fcd \
+    clap_complete_nushell            4.4.2  948bf70d7e1f179635d3ef819ce8baa2d3074d0d57816ac37387cd6f9eed0c31 \
+    clap_derive                      4.4.7  cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442 \
+    clap_lex                         0.6.0  702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1 \
+    clap_mangen                     0.2.16  10b5db60b3310cdb376fbeb8826e875a38080d0c61bdec0a91a3da8338948736 \
+    clearscreen                      2.0.1  72f3f22f1a586604e62efd23f78218f3ccdecf7a33c4500db2d37d85a24fe994 \
+    clru                             0.6.1  b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807 \
+    colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
+    command-group                    2.1.0  5080df6b0f0ecb76cab30808f00d937ba725cebe266a3da8cd89dff92f2a9916 \
+    command-group                    5.0.1  a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409 \
+    concurrent-queue                 2.4.0  d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363 \
+    console-api                      0.6.0  fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787 \
+    console-subscriber               0.2.0  7481d4c57092cd1c19dd541b92bdce883de840df30aa5d03fd48a3935c01842e \
+    core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
+    cpufeatures                     0.2.11  ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0 \
+    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
+    crossbeam-channel               0.5.10  82a9b73a36529d9c47029b9fb3a6f0ea3cc916a261195352ba19e770fc1748b2 \
+    crossbeam-deque                  0.8.4  fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751 \
+    crossbeam-epoch                 0.9.17  0e3681d554572a651dda4186cd47240627c3d0114d45a95f6ad27f2f22e7548d \
+    crossbeam-utils                 0.8.18  c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c \
+    crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
+    cstr_core                        0.2.6  dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956 \
+    cty                              0.2.2  b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35 \
+    deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
+    derivative                       2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
+    digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
+    dirs                             4.0.0  ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059 \
+    dirs                             5.0.1  44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225 \
+    dirs-next                        2.0.0  b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1 \
+    dirs-sys                         0.3.7  1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6 \
+    dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
+    dirs-sys-next                    0.1.2  4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d \
+    dunce                            1.0.4  56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b \
+    either                           1.9.0  a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07 \
+    embed-resource                   2.4.0  f54cc3e827ee1c3812239a9a41dede7b4d7d5d5464faa32d71bd7cba28ce2cb2 \
+    endian-type                      0.1.2  c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d \
+    enumflags2                       0.7.8  5998b4f30320c9d93aed72f63af821bfdac50465b75428fce77b48ec482c3939 \
+    enumflags2_derive                0.7.8  f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246 \
+    env_logger                      0.10.1  95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece \
+    equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
+    errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
+    event-listener                   2.5.3  0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0 \
+    event-listener                   3.1.0  d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2 \
+    event-listener                   4.0.2  218a870470cce1469024e9fb66b901aa983929d81304a1cdb299f28118e550d5 \
+    event-listener-strategy          0.4.0  958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3 \
+    eyra                            0.16.9  db384ddd5420abd490da5ac8f52ab60983661315eed82d866ae4a72cdadc7e1a \
+    faster-hex                       0.9.0  a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183 \
+    fastrand                         1.9.0  e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be \
+    fastrand                         2.0.1  25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5 \
+    filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
+    flate2                          1.0.28  46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e \
+    fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
+    form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
+    fs-err                          2.11.0  88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41 \
+    fsevent-sys                      4.1.0  76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2 \
+    futures                         0.3.30  645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0 \
+    futures-channel                 0.3.30  eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78 \
+    futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
+    futures-executor                0.3.30  a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d \
+    futures-io                      0.3.30  a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1 \
+    futures-lite                    1.13.0  49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce \
+    futures-lite                     2.1.0  aeee267a1883f7ebef3700f262d2d54de95dfaf38189015a74fdc4e0c7ad8143 \
+    futures-macro                   0.3.30  87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac \
+    futures-sink                    0.3.30  9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5 \
+    futures-task                    0.3.30  38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004 \
+    futures-util                    0.3.30  3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48 \
+    generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
+    getrandom                       0.2.11  fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f \
+    gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
+    gix                             0.55.2  002667cd1ebb789313d0d0afe3d23b2821cf3b0e91605095f0e6d8751f0ceeea \
+    gix-actor                       0.28.1  2eadca029ef716b4378f7afb19f7ee101fde9e58ba1f1445971315ac866db417 \
+    gix-chunk                        0.4.7  003ec6deacf68076a0c157271a127e0bb2c031c1a41f7168cbe5d248d9b85c78 \
+    gix-commitgraph                 0.22.1  85a7007ba021f059803afaf6f8a48872422abc20550ac12ede6ddea2936cec36 \
+    gix-config                      0.31.0  5cae98c6b4c66c09379bc35274b172587d6b0ac369a416c39128ad8c6454f9bb \
+    gix-config-value                0.14.3  52e0be46f4cf1f8f9e88d0e3eb7b29718aff23889563249f379119bd1ab6910e \
+    gix-date                         0.8.3  fb7f3dfb72bebe3449b5e642be64e3c6ccbe9821c8b8f19f487cf5bfbbf4067e \
+    gix-diff                        0.37.0  931394f69fb8c9ed6afc0aae3487bd869e936339bcc13ed8884472af072e0554 \
+    gix-discover                    0.26.0  a45d5cf0321178883e38705ab2b098f625d609a7d4c391b33ac952eff2c490f2 \
+    gix-features                    0.36.1  4d46a4a5c6bb5bebec9c0d18b65ada20e6517dbd7cf855b87dd4bbdce3a771b2 \
+    gix-fs                           0.8.1  20e86eb040f5776a5ade092282e51cdcad398adb77d948b88d17583c2ae4e107 \
+    gix-glob                        0.14.1  5db19298c5eeea2961e5b3bf190767a2d1f09b8802aeb5f258e42276350aff19 \
+    gix-hash                        0.13.3  1f8cf8c2266f63e582b7eb206799b63aa5fa68ee510ad349f637dfe2d0653de0 \
+    gix-hashtable                    0.4.1  feb61880816d7ec4f0b20606b498147d480860ddd9133ba542628df2f548d3ca \
+    gix-lock                        11.0.1  7e5c65e6a29830a435664891ced3f3c1af010f14900226019590ee0971a22f37 \
+    gix-macros                       0.1.3  d75e7ab728059f595f6ddc1ad8771b8d6a231971ae493d9d5948ecad366ee8bb \
+    gix-object                      0.38.0  740f2a44267f58770a1cb3a3d01d14e67b089c7136c48d4bddbb3cfd2bf86a51 \
+    gix-odb                         0.54.0  8630b56cb80d8fa684d383dad006a66401ee8314e12fbf0e566ddad8c115143b \
+    gix-pack                        0.44.0  1431ba2e30deff1405920693d54ab231c88d7c240dd6ccc936ee223d8f8697c3 \
+    gix-path                        0.10.3  b8dd0998ab245f33d40ca2267e58d542fe54185ebd1dc41923346cf28d179fb6 \
+    gix-quote                       0.4.10  9f7dc10303d73a960d10fb82f81188b036ac3e6b11b5795b20b1a60b51d1321f \
+    gix-ref                         0.38.0  0ec2f6d07ac88d2fb8007ee3fa3e801856fb9d82e7366ec0ca332eb2c9d74a52 \
+    gix-refspec                     0.19.0  ccb0974cc41dbdb43a180c7f67aa481e1c1e160fcfa8f4a55291fd1126c1a6e7 \
+    gix-revision                    0.23.0  2ca97ac73459a7f3766aa4a5638a6e37d56d4c7962bc1986fbaf4883d0772588 \
+    gix-revwalk                      0.9.0  a16d8c892e4cd676d86f0265bf9d40cefd73d8d94f86b213b8b77d50e77efae0 \
+    gix-sec                         0.10.3  78f6dce0c6683e2219e8169aac4b1c29e89540a8262fef7056b31d80d969408c \
+    gix-tempfile                    11.0.1  388dd29114a86ec69b28d1e26d6d63a662300ecf61ab3f4cc578f7d7dc9e7e23 \
+    gix-trace                        0.1.6  e8e1127ede0475b58f4fe9c0aaa0d9bb0bad2af90bbd93ccd307c8632b863d89 \
+    gix-traverse                    0.34.0  14d050ec7d4e1bb76abf0636cf4104fb915b70e54e3ced9a4427c999100ff38a \
+    gix-url                         0.25.2  0c427a1a11ccfa53a4a2da47d9442c2241deee63a154bc15cc14b8312fbc4005 \
+    gix-utils                        0.1.8  de6225e2de30b6e9bca2d9f1cc4731640fcef0fb3cabddceee366e7e85d3e94f \
+    gix-validate                     0.8.3  ac7cc36f496bd5d96cdca0f9289bb684480725d40db60f48194aa7723b883854 \
+    globset                         0.4.14  57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1 \
+    h2                              0.3.22  4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178 \
+    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
+    hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
+    hdrhistogram                     7.5.4  765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d \
+    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    hermit-abi                       0.3.3  d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7 \
+    hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
+    home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
+    http                            0.2.11  8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb \
+    http-body                        0.4.6  7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2 \
+    httparse                         1.8.0  d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904 \
+    httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
+    humantime                        2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
+    hyper                          0.14.28  bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80 \
+    hyper-timeout                    0.4.1  bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1 \
+    iana-time-zone                  0.1.59  b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539 \
+    iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
+    idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
+    ignore                          0.4.21  747ad1b4ae841a78e8aba0d63adbfbeaea26b517b63705d47856b73015d27060 \
+    indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
+    indexmap                         2.1.0  d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f \
+    inotify                          0.9.6  f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff \
+    inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
+    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
+    io-lifetimes                    1.0.11  eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2 \
+    is-terminal                     0.4.10  0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455 \
+    is_ci                            1.1.1  616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb \
+    itertools                        0.9.0  284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b \
+    itertools                       0.11.0  b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57 \
+    itoa                            1.0.10  b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c \
+    js-sys                          0.3.66  cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca \
+    kqueue                           1.0.8  7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c \
+    kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
+    lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
+    libc                           0.2.151  302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4 \
+    libm                             0.2.8  4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058 \
+    libmimalloc-sys                 0.1.35  3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664 \
+    libredox                         0.0.1  85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8 \
+    linux-raw-sys                    0.3.8  ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519 \
+    linux-raw-sys                   0.4.12  c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456 \
+    lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
+    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
+    mac-notification-sys             0.6.1  51fca4d74ff9dbaac16a01b924bc3693fa2bba0862c2c633abc73f9a8ea21f64 \
+    malloc_buf                       0.0.6  62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb \
+    matchers                         0.0.1  f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1 \
+    matchers                         0.1.0  8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558 \
+    matchit                          0.7.3  0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94 \
+    memchr                           2.7.1  523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149 \
+    memmap2                          0.7.1  f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6 \
+    memmap2                          0.9.3  45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92 \
+    memoffset                        0.7.1  5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4 \
+    memoffset                        0.9.0  5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
+    miette                          5.10.0  59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e \
+    miette-derive                   5.10.0  49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c \
+    mimalloc                        0.1.39  fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c \
+    mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
+    minimal-lexical                  0.2.1  68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a \
+    miniz_oxide                      0.7.1  e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7 \
+    mio                             0.8.10  8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09 \
+    nibble_vec                       0.1.0  77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43 \
+    nix                             0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
+    nix                             0.27.1  2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053 \
+    nom                              7.1.3  d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a \
+    normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
+    normalize-path                   0.2.1  f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d \
+    notify                           6.1.1  6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d \
+    notify-rust                     4.10.0  827c5edfa80235ded4ab3fe8e9dc619b4f866ef16fe9b1c6b8a7f8692c0f2226 \
+    nu-ansi-term                    0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
+    num-complex                      0.4.4  1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214 \
+    num-traits                      0.2.17  39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c \
+    num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
+    num_threads                      0.1.6  2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44 \
+    objc                             0.2.7  915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1 \
+    objc-foundation                  0.1.1  1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9 \
+    objc_id                          0.1.1  c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b \
+    object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
+    once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
+    option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
+    ordered-stream                   0.2.0  9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50 \
+    origin                          0.17.0  29694778a0a2a6fa799f26926fd5537c120636f317b69dbfc4e6414dfc71ec99 \
+    os_str_bytes                     6.6.1  e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1 \
+    overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
+    owo-colors                       3.5.0  c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f \
+    parking                          2.2.0  bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae \
+    parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
+    parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
+    percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
+    phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
+    phf_codegen                     0.11.2  e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a \
+    phf_generator                   0.11.2  48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0 \
+    phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
+    pid1                             0.1.1  d44f4ae25e184abe89b03033470ffe3b15fca221bf3feb090044fe16fff81474 \
+    pin-project                      1.1.3  fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422 \
+    pin-project-internal             1.1.3  4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405 \
+    pin-project-lite                0.2.13  8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58 \
+    pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
+    piper                            0.2.1  668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4 \
+    polling                          2.8.0  4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce \
+    polling                          3.3.1  cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e \
+    posix-regex                      0.1.1  0df8665cbe91ba9b18af9b0e7a36f02d00ce1123cf8d4b8a3a1104e932cdd341 \
+    powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
+    ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
+    printf-compat                    0.1.1  3b002af28ffe3d3d67202ae717810a28125a494d5396debc43de01ee136ac404 \
+    proc-macro-crate                 1.3.1  7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919 \
+    proc-macro2                     1.0.75  907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708 \
+    prodash                         26.2.2  794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf \
+    prost                           0.12.3  146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a \
+    prost-derive                    0.12.3  efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e \
+    prost-types                     0.12.3  193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e \
+    quick-xml                       0.30.0  eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956 \
+    quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
+    radix_trie                       0.2.1  c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+    rand_pcg                         0.3.1  59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e \
+    realpath-ext                     0.1.3  692f72862a0d532b44a0f4965fb10f17e7659eaedf24d2ce3c989ca778bd092f \
+    redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
+    redox_users                      0.4.4  a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4 \
+    regex                           1.10.2  380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343 \
+    regex-automata                  0.1.10  6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132 \
+    regex-automata                   0.4.3  5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f \
+    regex-syntax                    0.6.29  f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1 \
+    regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+    roff                             0.2.1  b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316 \
+    rustc-demangle                  0.1.23  d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76 \
+    rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
+    rustix                         0.37.27  fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2 \
+    rustix                         0.38.28  72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316 \
+    rustix-dlmalloc                  0.1.2  a0fab868d3bd1ac5de1f1507e58fab624339e5bb201049e3329767974ba219ec \
+    rustix-futex-sync                0.2.1  fbf5fb8d04cb2409733689b671078896d4a79ebb34cee0b9067fa4e82e072484 \
+    rustix-openpty                   0.1.1  a25c3aad9fc1424eb82c88087789a7d938e1829724f3e4043163baf0d13cfc12 \
+    rustversion                     1.0.14  7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4 \
+    ryu                             1.0.16  f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c \
+    same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    semver                          1.0.21  b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0 \
+    serde                          1.0.194  0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773 \
+    serde_derive                   1.0.194  a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0 \
+    serde_json                     1.0.111  176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4 \
+    serde_repr                      0.1.18  0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb \
+    serde_spanned                    0.6.5  eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1 \
+    sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    sha1_smol                        1.0.0  ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012 \
+    sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
+    signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
+    signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
+    similar                          2.4.0  32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21 \
+    siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
+    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
+    smallvec                        1.11.2  4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970 \
+    smawk                            0.3.2  b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c \
+    snapbox                         0.4.15  c4f1976ee8fd1be27d5f72c98be0aac4397a882a4736935d47418a5fbbd12042 \
+    snapbox-macros                   0.3.6  ed1559baff8a696add3322b9be3e940d433e7bb4e38d79017205fd37ff28b28e \
+    socket2                         0.4.10  9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d \
+    socket2                          0.5.5  7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9 \
+    static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
+    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
+    supports-color                   2.1.0  d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89 \
+    supports-hyperlinks              2.1.0  f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d \
+    supports-unicode                 2.0.0  4b6c2cb240ab5dd21ed4906895ee23fe5a48acdbd15a3ce388e7b62a9b66baf7 \
+    syn                            1.0.109  72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237 \
+    syn                             2.0.47  1726efe18f42ae774cc644f330953a5e7b3c3003d3edcecf18850fe9d4dd9afb \
+    sync_wrapper                     0.1.2  2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160 \
+    tauri-winrt-notification         0.1.3  006851c9ccefa3c38a7646b8cec804bb429def3da10497bfa977179869c3e8e2 \
+    tempfile                         3.9.0  01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa \
+    termcolor                        1.4.0  ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449 \
+    terminal_size                   0.1.17  633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df \
+    terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
+    terminfo                         0.8.0  666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f \
+    textwrap                        0.15.2  b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d \
+    thiserror                       1.0.56  d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad \
+    thiserror-impl                  1.0.56  fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471 \
+    thread_local                     1.1.7  3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152 \
+    time                            0.3.31  f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e \
+    time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
+    time-macros                     0.2.16  26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f \
+    tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
+    tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
+    tokio                           1.35.1  c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104 \
+    tokio-io-timeout                 1.2.0  30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf \
+    tokio-macros                     2.2.0  5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b \
+    tokio-stream                    0.1.14  397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842 \
+    tokio-util                      0.7.10  5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15 \
+    toml                             0.8.8  a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35 \
+    toml_datetime                    0.6.5  3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1 \
+    toml_edit                      0.19.15  1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421 \
+    toml_edit                       0.21.0  d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03 \
+    tonic                           0.10.2  d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e \
+    tower                           0.4.13  b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c \
+    tower-layer                      0.3.2  c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0 \
+    tower-service                    0.3.2  b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52 \
+    tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
+    tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
+    tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
+    tracing-log                      0.1.4  f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2 \
+    tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
+    tracing-serde                    0.1.3  bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1 \
+    tracing-subscriber              0.2.25  0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71 \
+    tracing-subscriber              0.3.18  ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b \
+    tracing-test                     0.1.0  a3b48778c2d401c6a7fcf38a0e3c55dc8e8e753cbd381044a8cdb6fd69a29f53 \
+    tracing-test-macro               0.1.0  c49adbab879d2e0dd7f75edace5f0ac2156939ecb7e6a1e8fa14e53728328c48 \
+    try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
+    typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
+    tz-rs                           0.6.14  33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4 \
+    uds_windows                      1.1.0  89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9 \
+    unicase                          2.7.0  f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89 \
+    unicode-bidi                    0.3.14  6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416 \
+    unicode-bom                      2.0.3  7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217 \
+    unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
+    unicode-linebreak                0.1.5  3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f \
+    unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
+    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
+    unwinding                        0.2.1  37a19a21a537f635c16c7576f22d0f2f7d63353c1337ad4ce0d8001c7952a25b \
+    url                              2.5.0  31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633 \
+    utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
+    uuid                             1.6.1  5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560 \
+    valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \
+    version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
+    vswhom                           0.1.0  be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b \
+    vswhom-sys                       0.1.2  d3b17ae1f6c8a2b28506cd96d412eebf83b4a0ff2cbefeeb952f2f9dfa44ba18 \
+    waker-fn                         1.1.1  f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690 \
+    walkdir                          2.4.0  d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee \
+    want                             0.3.1  bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e \
+    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasm-bindgen                    0.2.89  0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e \
+    wasm-bindgen-backend            0.2.89  1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826 \
+    wasm-bindgen-macro              0.2.89  0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2 \
+    wasm-bindgen-macro-support      0.2.89  f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283 \
+    wasm-bindgen-shared             0.2.89  7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f \
+    which                            4.4.2  87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7 \
+    which                            5.0.0  9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14 \
+    winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
+    winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
+    winapi-util                      0.1.6  f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596 \
+    winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows                         0.51.1  ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9 \
+    windows                         0.52.0  e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be \
+    windows-core                    0.51.1  f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64 \
+    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
+    windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
+    windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows-targets                 0.52.0  8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_gnullvm         0.52.0  cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_aarch64_msvc            0.52.0  bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_gnu                0.52.0  a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313 \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_i686_msvc               0.52.0  ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnu              0.52.0  3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_gnullvm          0.52.0  1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
+    windows_x86_64_msvc             0.52.0  dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04 \
+    winnow                          0.5.32  8434aeec7b290e8da5c3f0d628cb0eac6cabcb31d14bb74f779a08109a5914d6 \
+    winreg                          0.51.0  937f3df7948156640f46aacef17a70db0de5917bda9c92b0f751f3a955b588fc \
+    xdg-home                         1.0.0  2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd \
+    zbus                            3.14.1  31de390a2d872e4cd04edd71b425e29853f786dc99317ed72d73d6fcf5ebb948 \
+    zbus_macros                     3.14.1  41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d \
+    zbus_names                       2.6.0  fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9 \
+    zvariant                        3.15.0  44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c \
+    zvariant_derive                 3.15.0  934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd \
+    zvariant_utils                   1.0.1  7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200


### PR DESCRIPTION
https://watchexec.github.io/

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
