### PR TITLE
libtool: Use MacPorts m4

### DIFF
--- a/devel/libtool/Portfile
+++ b/devel/libtool/Portfile
@@ -5,7 +5,7 @@ PortGroup           clang_dependency 1.0
 
 name                libtool
 version             2.4.7
-revision            1
+revision            2
 categories          devel sysutils
 platforms           darwin freebsd
 # Scripts are GPL-2+, libltdl is LGPL-2+, but all parts that tend to be
@@ -38,15 +38,12 @@ post-patch {
     touch ${worksrcpath}/configure ${worksrcpath}/libltdl/configure
 }
 
-# Leopard and later provide GNU M4 1.4.6, which works fine. Tiger's
-# 1.4.2 does not (#47545).
-#   - https://lists.gnu.org/archive/html/libtool/2014-12/msg00002.html
-#   - https://lists.gnu.org/archive/html/libtool/2015-01/msg00004.html
-if {${os.platform} eq "darwin" && ${os.major} >= 9} {
-    configure.env   M4=/usr/bin/m4
-} else {
-    depends_lib     port:m4
-}
+# m4 1.4.2 which comes with Mac OS X 10.4 is too old:
+# https://trac.macports.org/ticket/47545
+# And m4 wasn't included in the Xcode 15.3 version of the command line tools:
+# https://trac.macports.org/ticket/69467#comment:6
+depends_lib-append      port:m4
+configure.env           M4=${prefix}/bin/gm4
 
 # Don't let configure detect MacPorts' grep or gsed (#19237).
 if {${os.platform} eq "darwin"} {


### PR DESCRIPTION
#### Description

Fixes build of many ports that use libtool when using Xcode 15.3 in which m4 is not included.

Closes: https://trac.macports.org/ticket/69467
Closes: https://trac.macports.org/ticket/69481
Closes: https://trac.macports.org/ticket/69493
See: https://trac.macports.org/ticket/69471

Reverses a previous decision not to use MacPorts m4 except on Tiger:

See: https://trac.macports.org/ticket/47545

as it was already reversed in autoconf:

See: https://trac.macports.org/ticket/62411

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 21G1974 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
