### PR TITLE
gmp: Use MacPorts m4

### DIFF
--- a/devel/gmp/Portfile
+++ b/devel/gmp/Portfile
@@ -30,6 +30,9 @@ checksums               rmd160  ce893dd234e66923adc879473b48ad0459d345cc \
 
 use_bzip2               yes
 
+depends_build-append    port:m4
+configure.env           M4=${prefix}/bin/gm4
+
 configure.args          --enable-cxx
 
 # Clear all options that affect CFLAGS and CXXFLAGS, since the configure


### PR DESCRIPTION
#### Description

Xcode 15.3 CLT doesn't include `m4`, possibly due to an oversight.

Closes: https://trac.macports.org/ticket/69464

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 21G1974 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
