### PR TITLE
sane-frontends: update to latest git revision

### DIFF
--- a/graphics/sane-frontends/Portfile
+++ b/graphics/sane-frontends/Portfile
@@ -2,6 +2,7 @@ PortSystem                  1.0
 
 name                        sane-frontends
 version                     1.0.15git
+revision                    1
 categories                  graphics
 platforms                   darwin
 # Some content is LGPL-2+ or public-domain, but the package as a whole is GPL-2+
@@ -22,10 +23,12 @@ long_description            These are the frontends for the Scanner Access Now \
 # sane-frontends from the official git repository is the
 # best bet for getting a compilable sane-frontends
 fetch.type                  git
-git.url                     https://gitlab.com/sane-project/frontends.git
-git.branch                  1928f945eefa3b97b5c76d586082435bb23c2969
+git.url                     https://gitlab.com/mklein-de/frontends.git
+git.branch                  141ef6bdcb8d1ccfff46e9981ff9f9f1fbfcfe1c
 
 depends_lib                 port:sane-backends
+
+depends_build-append        path:bin/pkg-config:pkgconfig
 
 configure.cppflags-append   -fno-common
 


### PR DESCRIPTION
- contains build fixes for macOS 10.15

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
