### PR TITLE
libimobiledevice-glue: Update to 1.1.0

### DIFF
--- a/devel/libimobiledevice-glue/Portfile
+++ b/devel/libimobiledevice-glue/Portfile
@@ -3,9 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        libimobiledevice libimobiledevice-glue 1.0.0
+github.setup        libimobiledevice libimobiledevice-glue 1.1.0
 revision            0
-github.tarball_from archive
 
 categories          devel
 
@@ -23,24 +22,14 @@ long_description    The main functionality provided by this library are socket h
 
 homepage            https://www.libimobiledevice.org/
 
-checksums           rmd160  ec1dc6bbed16a63917a4053ecaae4d2ecb98d932 \
-                    sha256  6be77b9b51a07fc89d41b29e2e65ada1bab72a7c9a0bebeb279030167decef4e \
-                    size    43281
+checksums           rmd160  69b652b1d7bd2b6a130d3eb5b771adfe69d67061 \
+                    sha256  e7f93c1e6ceacf617ed78bdca92749d15a9dac72443ccb62eb59e4d606d87737 \
+                    size    324600
 
 depends_build-append \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool \
                     port:pkgconfig
 
-depends_lib         port:libplist
-
-# See https://github.com/libimobiledevice/libimobiledevice-glue/commit/0e7b8b42ce4cbeb32eb3103b0ff97916cb273d78
-# remove after next release
-pre-configure {
-    system -W ${worksrcpath} "echo ${version} > .tarball-version"
-}
-configure.cmd       ./autogen.sh
+depends_lib-append  port:libplist
 
 configure.args      --disable-silent-rules
 
@@ -55,7 +44,25 @@ subport libimobiledevice-glue-devel {
 
     conflicts       libimobiledeviceglue
 
+    depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
+
     depends_lib-replace port:libplist port:libplist-devel
 
+    configure.cmd   ./autogen.sh
+
+    pre-configure {
+        system -W ${worksrcpath} "echo ${version} > .tarball-version"
+    }
+
     livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
+}
+
+if {${subport} eq ${name}} {
+    github.tarball_from     releases
+    use_bzip2               yes
+} else {
+    github.tarball_from     archive
 }


### PR DESCRIPTION
#### Description

Update `libimobiledevice-glue` to its latest released version, 1.1.0. [Changelog](https://github.com/libimobiledevice/libimobiledevice-glue/releases/tag/1.1.0).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
