### PR TITLE
jenv: update to 0.5.7

### DIFF
--- a/java/jenv/Portfile
+++ b/java/jenv/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    jenv jenv 0.5.6
+github.setup    jenv jenv 0.5.7
 revision        0
 
 categories      java
@@ -19,9 +19,9 @@ long_description jEnv is a command line tool to help you forget how to set the J
 homepage        https://www.jenv.be
 github.tarball_from archive
 
-checksums       rmd160  791f26b1d0e1bfe44810a6f3c22c3c4cab003031 \
-                sha256  1afac0386ab4459b8523fb45937eb3111f3ce2b83f5b0da11327f5dd200e0672 \
-                size    22667
+checksums       rmd160  8acc65ef031a935ffa40bd64bda82157a0c4aaf9 \
+                sha256  5865f7839eda303467fb1ad3dfb606b31566001beeb05360f653905346c2624f \
+                size    22717
 
 use_configure   no
 


### PR DESCRIPTION
#### Description

Update to jEnv 0.5.7.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?