### PR TITLE
symfony-cli: update to 5.8.12

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.11
+version             5.8.12
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  ec79621981d0e1e84fef34649d7d9d23f563d004 \
-                        sha256  56aec8dc71499523f8e99d511b0acde809473024466b9b52b2a03353aa663da6 \
-                        size    265335
+    checksums           rmd160  e6a363d2254bccd2175d342318912569aae6d377 \
+                        sha256  13a8b37bc48d49093f5b2e3658e168d0329797f93d63e3d0fab1693085d00b43 \
+                        size    265603
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  5e347adf8268c4af34e8747c3132d4b3dbb83cf0 \
-                        sha256  7114fecb490703b7fed8b9b0e6361e7ca1613525e5815f633972cd366cad7e74 \
-                        size    11096462
+    checksums           rmd160  66c30037f04b136957d5c356604b17c31e6d3f7a \
+                        sha256  eaf147e18e6f3b7ccede5c2397f2b6aba346f0e1eeca2489eef85ff3828f6b0e \
+                        size    11100371
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.12

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
