### PR TITLE
bpytop: fix issue where Enter key doesn't register on some systems

### DIFF
--- a/sysutils/bpytop/Portfile
+++ b/sysutils/bpytop/Portfile
@@ -6,7 +6,7 @@ PortGroup           makefile    1.0
 
 github.setup        aristocratos bpytop 1.0.68 v
 github.tarball_from archive
-revision            1
+revision            2
 
 description         \
     Linux/macOS/FreeBSD resource monitor
@@ -34,6 +34,8 @@ depends_run-append  port:python${python_version} \
                     port:py${python_version}-psutil
 
 makefile.has_destdir yes
+
+patchfiles-append   patch-pr413.diff
 
 post-patch {
     reinplace "s|/usr/bin/env python3|${python_bin}|" ${worksrcpath}/bpytop.py

--- a/sysutils/bpytop/files/patch-pr413.diff
+++ b/sysutils/bpytop/files/patch-pr413.diff
@@ -1,0 +1,12 @@
+# https://github.com/aristocratos/bpytop/pull/413
+--- bpytop.py	2021-12-22 14:22:48
++++ bpytop.py	2024-03-14 02:13:56
+@@ -840,7 +840,7 @@
+ 	mouse: Dict[str, List[List[int]]] = {}
+ 	mouse_pos: Tuple[int, int] = (0, 0)
+ 	escape: Dict[Union[str, Tuple[str, str]], str] = {
+-		"\n" :					"enter",
++		("\n", "\r") :			"enter",
+ 		("\x7f", "\x08") :		"backspace",
+ 		("[A", "OA") :			"up",
+ 		("[B", "OB") :			"down",


### PR DESCRIPTION
See: https://github.com/aristocratos/bpytop/issues/410

Fixes: https://trac.macports.org/ticket/69284

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
