### PR TITLE
legacy-support: update to v1.2.1

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -22,9 +22,7 @@ long_description    {*}${description}
 epoch               1
 
 # Primary release version
-# NOTE: At present, v1.2.0 has a compatibility issue.
-# Do not update until this is resolved.
-set release_ver     1.1.1
+set release_ver     1.2.1
 
 # Binary compatibility version
 set compat_ver      1.0.0
@@ -33,19 +31,9 @@ subport ${name} {
     conflicts           ${name}-devel
     github.setup        macports macports-legacy-support ${release_ver} v
     revision            0
-    checksums           rmd160  e4b78b21c8bfd7fbb3aa8003da90932e83d53dc4 \
-                        sha256  cbd73bdd6261368a521c24f73fbd20e2f96ff3d49b3d1e1291a9de77e4914ba8 \
-                        size    72245
-
-    # Remove this once the above release_ver works on 10.4
-    if {${os.platform} eq "darwin" && ${os.major} < 9} {
-        set release_ver     1.0.13
-        github.setup        macports macports-legacy-support ${release_ver} v
-        revision            0
-        checksums           rmd160  1afccf82bccb721d31ed63c1dfddbb36436af004 \
-                        sha256  56dfbbca8b82f941856cdac38354b4fd504d4b7bed2c7b9b6b14a784cc59c6aa \
-                        size    65296
-    }
+    checksums           rmd160  e25e45cc5d747c6a710aa085ffbcfbaffb547935 \
+                        sha256  971ed22e77f1b3ab34eb3f306a9a792f5b2f912534976b6c3e261dcc8f9512e2 \
+                        size    72500
 }
 
 subport ${name}-devel {


### PR DESCRIPTION
Also removes the now-unnecessary version holdback for OS 10.4.

Retains the -devel subport, since it's likely to be needed again in the not-too-distant future.  At this time, the -devel and non-devel versions are identical, but the -devel version is still referenced to the commit ID rather than the version, for easier future editing.

Closes: https://trac.macports.org/ticket/68314

TESTED:
Tested both normal and -devel versions (currently identical) on 10.4-10.5 ppc, 10.5-10.6 ppc (x86_64 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-14.x arm64.
Builds on all tested platforms except 10.5 ppc +universal. Passes all -universal tests.
Buildable +universal cases pass all tests, except for expected failures on 10.11-10.13 x86_64 +universal (i386).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (x86_64 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, PPC (x86_64 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.3 21H1015, x86_64, Xcode 14.2 14C18
macOS 12.7.3 21H1015, arm64, Xcode 14.2 14C18
macOS 13.6.4 22G513, arm64, Xcode 15.2 15C500b
macOS 14.3.1 23D60, arm64, Xcode 15.2 15C500b
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
