### PR TITLE
libjxl: backport a new patch from upstream for `__STDC_FORMAT_MACROS`

### DIFF
--- a/graphics/libjxl/Portfile
+++ b/graphics/libjxl/Portfile
@@ -53,6 +53,9 @@ if {${os.platform} eq "darwin" && ${os.major} <= 15} {
     patchfiles-append   sized-deallocation.patch
 }
 
+# https://github.com/libjxl/libjxl/pull/3426
+patchfiles-append   decode_progressive.cc-__STDC_FORMAT_MACROS.patch
+
 cmake.out_of_source yes
 configure.args-append \
                     -DBUILD_TESTING=NO \

--- a/graphics/libjxl/files/decode_progressive.cc-__STDC_FORMAT_MACROS.patch
+++ b/graphics/libjxl/files/decode_progressive.cc-__STDC_FORMAT_MACROS.patch
@@ -1,0 +1,25 @@
+From e07d25a72d2df2d79eecb876595de3785404de63 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Thu, 14 Mar 2024 23:20:16 +0800
+Subject: [PATCH] decode_progressive.cc: define __STDC_FORMAT_MACROS if
+ undefined
+
+---
+ examples/decode_progressive.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git examples/decode_progressive.cc examples/decode_progressive.cc
+index 792ed1d2..2cdc175e 100644
+--- examples/decode_progressive.cc
++++ examples/decode_progressive.cc
+@@ -6,6 +6,10 @@
+ // This C++ example decodes a JPEG XL image progressively (input bytes are
+ // passed in chunks). The example outputs the intermediate steps to PAM files.
+ 
++#ifndef __STDC_FORMAT_MACROS
++#define __STDC_FORMAT_MACROS
++#endif
++
+ #include <inttypes.h>
+ #include <jxl/decode.h>
+ #include <jxl/decode_cxx.h>


### PR DESCRIPTION
#### Description

Fix the build on systems which need `__STDC_FORMAT_MACROS` define.

UPD. Merged into upstream in https://github.com/libjxl/libjxl/commit/c8451c52d3f1e2d214e39a45e722c5bd10ed3db3

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
