### PR TITLE
stellarium: fix ShowMySkyBuild against GLM 1.0.0

### DIFF
--- a/science/stellarium/Portfile
+++ b/science/stellarium/Portfile
@@ -59,6 +59,16 @@ depends_lib-append \
 # fix the install prefix for MP use only
 patchfiles-append patch-CMakeLists.txt.diff
 
+post-configure {
+    # ShowMySky with GLM 1.0.0 needs -DGLM_ENABLE_EXPERIMENTAL
+    # https://github.com/10110111/CalcMySky/pull/18
+    foreach file {ShowMySky/GLWidget.cpp common/EclipsedDoubleScatteringPrecomputer.cpp} {
+        system -W ${cmake.build_dir}/_deps/showmysky-qt5-src "grep -q GLM_ENABLE_EXPERIMENTAL ${file} ||
+        awk '/#include <glm\\/gtx\\/transform.hpp>/ { print \"#define GLM_ENABLE_EXPERIMENTAL\" } { print }'
+            < ${file} > ${file}.tmp && mv ${file}.tmp $file"
+    }
+}
+
 compiler.c_standard   2011
 compiler.cxx_standard 2017
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.15.7 19H2026 x86_64
Xcode 12.4 12D4e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
