### PR TITLE
poppler,poppler-devel: use MP libc++ on legacy

### DIFF
--- a/graphics/poppler-devel/Portfile
+++ b/graphics/poppler-devel/Portfile
@@ -69,6 +69,9 @@ compiler.cxx_standard 2017
 compiler.c_standard   2011
 compiler.thread_local_storage yes
 
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx yes
+
 # match clang, not strequal
 patchfiles-append   patch-cmake_modules_PopplerMacros.cmake.diff
 

--- a/graphics/poppler/Portfile
+++ b/graphics/poppler/Portfile
@@ -69,6 +69,9 @@ compiler.cxx_standard 2017
 compiler.c_standard   2011
 compiler.thread_local_storage yes
 
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx yes
+
 # match clang, not strequal
 patchfiles-append   patch-cmake_modules_PopplerMacros.cmake.diff
 


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/69455

#### Description

Fix liking on older Mac OS X versions by linking against MacPorts libc++ on platforms that use the MacPorts legacy-support library

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
