### PR TITLE
groovy: update to 4.0.20

### DIFF
--- a/lang/groovy/Portfile
+++ b/lang/groovy/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       java 1.0
 
 name            groovy
-version         4.0.19
+version         4.0.20
 revision        0
 
 categories      lang java
@@ -41,9 +41,9 @@ master_sites    https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zi
 distname        apache-${name}-binary-${version}
 use_zip         yes
 
-checksums       rmd160  e853722f2527da0f3439a3517fe02f2c6aeecc60 \
-                sha256  41b5ac00bd86e5beff108002cf328724ce533f0dfcb7d8f8073071385378fd22 \
-                size    34157577
+checksums       rmd160  24d1477dec54527d1b143ede44afd6986c6aaf1c \
+                sha256  fdf70cc57eff997f3fa5aee2b340d311593912e822ad810b3fd6ee403985eb75 \
+                size    29824179
 
 worksrcdir      ${name}-${version}
 
@@ -69,9 +69,6 @@ destroot {
     foreach f [glob -directory ${target}/bin *.bat] {
         delete ${f}
     }
-
-    # Remove groovy-raw to work around https://issues.apache.org/jira/browse/GROOVY-9432
-    delete ${target}/lib/groovy-raw-4.0.19-raw.jar
 
     # Add symlinks to the scripts
     foreach f { grape grape_completion groovy groovy_completion groovyConsole groovyConsole_completion groovyc groovyc_completion groovydoc groovydoc_completion groovysh groovysh_completion java2groovy startGroovy } {


### PR DESCRIPTION
#### Description

Update to Apache Groovy 4.0.20.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?