### PR TITLE
wget2: new port (v2.1.0)

### DIFF
--- a/net/wget2/Portfile
+++ b/net/wget2/Portfile
@@ -1,0 +1,80 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                wget2
+version             2.1.0
+revision            0
+
+homepage            https://gitlab.com/gnuwget/wget2
+
+description         \
+    GNU Wget2 is the successor of GNU Wget, a file and recursive website \
+    downloader.
+
+long_description    {*}${description}.
+
+categories          net www
+license             GPL-3+
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+master_sites        gnu:wget
+use_lzip            yes
+
+checksums           rmd160  c078e8d02bd9b0d741f53f23cb01d3bd9c687df6 \
+                    sha256  bc034194b512bb83ce0171d15a8db33e1c5c3ab8b3e343e1e6f2cf48f9154fad \
+                    size    2122122
+
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append  path:lib/pkgconfig/gnutls.pc:gnutls \
+                    port:brotli \
+                    port:bzip2 \
+                    port:gpgme \
+                    port:libhsts \
+                    port:libidn2 \
+                    port:libmicrohttpd \
+                    port:libpsl \
+                    port:lzlib \
+                    port:lzma \
+                    port:nghttp2 \
+                    port:pcre2 \
+                    port:zlib \
+                    port:zstd
+
+# https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr
+configure.checks.implicit_function_declaration.whitelist-append strchr
+
+configure.args-append \
+                    --disable-doc \
+                    --disable-silent-rules \
+                    --with-plugin-support
+
+configure.args-append \
+                    --with-brotlidec \
+                    --with-bzip2 \
+                    --with-gpgme \
+                    --with-gpgme-prefix=${prefix} \
+                    --with-libhsts \
+                    --with-libidn2 \
+                    --with-libmicrohttpd \
+                    --with-libnghttp2 \
+                    --with-libpcre2 \
+                    --with-libpsl \
+                    --with-lzip \
+                    --with-lzma \
+                    --with-ssl=gnutls \
+                    --with-zlib \
+                    --with-zstd
+
+compiler.blacklist-append \
+                    {*gcc-[34].*}
+
+post-destroot {
+    xinstall -m 0444 ${worksrcpath}/docs/man/man1/${name}.1 \
+        ${destroot}${prefix}/share/man/man1/
+}
+
+livecheck.distname  ${name}


### PR DESCRIPTION
New port for GNU Wget2: https://gitlab.com/gnuwget/wget2

Fixes: https://trac.macports.org/ticket/62922

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
