### PR TITLE
contacts-cli: new port

### DIFF
--- a/sysutils/contacts-cli/Portfile
+++ b/sysutils/contacts-cli/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           xcodeversion 1.0
+
+github.setup        keith contacts-cli 45dd928cb3d17e61f87eced433ff9b3d389f9991
+github.tarball_from archive
+version             20210930
+revision            0
+
+description         Query macOS contacts from the command line
+
+long_description    {*}${description}
+
+categories          sysutils
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  29cd9cefc0e740a31853b72603b4e3c19eac8026 \
+                    sha256  571e57fbaa3e8f7e02335d8b1e4a1db242e78e6b8f1956b9fd4127a22f9fbdba \
+                    size    3105
+
+conflicts           contacts
+
+use_configure       no
+
+build.cmd           swift
+build.pre_args      build
+build.args          --configuration release --disable-sandbox
+
+use_xcode           yes
+
+destroot {
+    xinstall -m 0755 \
+        ${worksrcpath}/.build/release/contacts \
+        ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
https://github.com/keith/contacts-cli

Fixes: https://trac.macports.org/ticket/58472

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
