### PR TITLE
maildrop: update to 3.1.6

### DIFF
--- a/mail/maildrop/Portfile
+++ b/mail/maildrop/Portfile
@@ -3,26 +3,27 @@
 PortSystem          1.0
 
 name                maildrop
-version             3.0.8
+version             3.1.6
 revision            0
-checksums           rmd160  982e4b64ab58ab2058c3b6f62fcdfa6ec7d68907 \
-                    sha256  b8855e280b8922d18fb37b3e49375272782c8fe6b9190aa1096b97e500010cb5 \
-                    size    2142001
+checksums           rmd160  bd753fb9cfb12c5c75382ebc55d0345c869cfd62 \
+                    sha256  e78b04041b7c1d46fd9b248323877f80dc1e4223d9f06f3dc77f0a8f0cd3adfd \
+                    size    2156136
 
 categories          mail
 license             {GPL-3 OpenSSLException}
 maintainers         nomaintainer
 description         Mail delivery agent (MDA) with filtering abilities
-long_description    ${description}
-homepage            http://www.courier-mta.org/maildrop/
+long_description    {*}${description}
+homepage            https://www.courier-mta.org/maildrop/
 master_sites        sourceforge:project/courier/maildrop/${version}/
 use_bzip2           yes
 
-depends_build       port:pkgconfig
+depends_build-append \
+                    port:pkgconfig
 
-depends_lib         port:courier-unicode \
+depends_lib-append  port:courier-unicode \
                     port:gdbm \
-                    port:libidn \
+                    port:libidn2 \
                     port:pcre2
 
 # courier-unicode needs C++11 or later
@@ -52,4 +53,4 @@ notes "
 The default maildrop mailfilter is in the ${etcdir} directory.
 "
 
-livecheck.distname  maildrop
+livecheck.regex     {maildrop-([0-9]+\.[0-9]+\.[0-9]+)\.tar\.bz2}


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
