### PR TITLE
ffmpeg6: fix build with older librsvg

### DIFF
--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -105,6 +105,10 @@ patchfiles-append   patch-avutil-builtin-available.diff
 # TODO: Submit patches to upstream
 patchfiles-append   patch-libavcodec-profvidworkflow.diff
 
+# https://trac.macports.org/ticket/68973
+# TODO: Raise the issue to upstream
+patchfiles-append   patch-libavcodec-librsvgdec.diff
+
 # enable auto configure of asm optimizations
 # requires Xcode 3.1 or better on Leopard
 minimum_xcodeversions {9 3.1}

--- a/multimedia/ffmpeg6/files/patch-libavcodec-librsvgdec.diff
+++ b/multimedia/ffmpeg6/files/patch-libavcodec-librsvgdec.diff
@@ -1,0 +1,26 @@
+From a7bbfb137bbcf7ae37c72ace4b68b3ff6fb38a70 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Fri, 15 Mar 2024 23:13:19 +0800
+Subject: [PATCH] librsvgdec.c: unbreak compilation
+
+Commit 86ed68420d3b60439d0b7767c53d0fdc1deb7277 introduced a bug which has broken ffmpeg build. Allow it to compile.
+See: https://trac.macports.org/ticket/68973
+---
+ libavcodec/librsvgdec.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git libavcodec/librsvgdec.c libavcodec/librsvgdec.c
+index c328fbc774..756c26d868 100644
+--- libavcodec/librsvgdec.c
++++ libavcodec/librsvgdec.c
+@@ -90,8 +90,10 @@ static int librsvg_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+         goto end;
+ 
+     avctx->pix_fmt = AV_PIX_FMT_RGB32;
++#if LIBRSVG_MAJOR_VERSION > 2 || LIBRSVG_MAJOR_VERSION == 2 && LIBRSVG_MINOR_VERSION >= 52
+     viewport.width = dimensions.width;
+     viewport.height = dimensions.height;
++#endif
+ 
+     ret = ff_get_buffer(avctx, frame, 0);
+     if (ret < 0)


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/68973

#### Description

Fix the build failure

P. S. For the reference, this commit introduced the bug: https://github.com/FFmpeg/FFmpeg/commit/86ed68420d3b60439d0b7767c53d0fdc1deb7277

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
