### PR TITLE
ocaml-js_of_ocaml: update to 5.7.1

### DIFF
--- a/_resources/port1.0/group/ocaml-1.1.tcl
+++ b/_resources/port1.0/group/ocaml-1.1.tcl
@@ -579,7 +579,15 @@ destroot {
     }
 }
 
+# Most of our OCaml ports do not have test dependencies,
+# so disable tests by default.
+default test.run    no
+
 test {
+    if {![option test.run]} {
+        ui_info "Tests are disabled."
+        return
+    }
     switch -- ${ocaml.build_type} {
         dune {
             command_exec dune.test

--- a/ocaml/ocaml-js_of_ocaml/Portfile
+++ b/ocaml/ocaml-js_of_ocaml/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           ocaml 1.1
 
 name                ocaml-js_of_ocaml
-github.setup        ocsigen js_of_ocaml 5.4.0
+github.setup        ocsigen js_of_ocaml 5.7.1
 revision            0
 categories          ocaml devel lang
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -13,9 +13,9 @@ license             {GPL-2+ LGPL-2.1+}
 description         Compiler from OCaml bytecode to JavaScript
 long_description    {*}${description}
 
-checksums           rmd160  4eda89388d1fe9a4331d9deb58110bfb2b0d75fa \
-                    sha256  c7c230738828c0f93982653975c5ca1c574ba76d628599fac3018c2a45f75d42 \
-                    size    1944795
+checksums           rmd160  a52235e66e072f9febbb7a8e34d79b3a6e42774e \
+                    sha256  3176267c3579f4d298dde15c3dee3a8bf23b7b20d3810de9871731b7b1787244 \
+                    size    2191606
 github.tarball_from archive
 
 depends_lib-append  port:ocaml-ppxlib


### PR DESCRIPTION
#### Description

Also disable tests in ocaml PG by default, since most of OCaml ports do not have needed test dependencies (and adding those is non-trivial), so the new CI setup gonna break down.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
