### PR TITLE
kotlin: update to 1.9.23

### DIFF
--- a/lang/kotlin/Portfile
+++ b/lang/kotlin/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           java 1.0
 
-github.setup        JetBrains kotlin 1.9.22 v
+github.setup        JetBrains kotlin 1.9.23 v
 revision            0
 github.tarball_from releases
 distname            ${name}-compiler-${version}
@@ -24,9 +24,9 @@ long_description    Kotlin is a modern but already mature programming \
 
 homepage            https://kotlinlang.org/
 
-checksums           rmd160  9724108d0fe5b1285949b6dce93d34de6e4f37ce \
-                    sha256  88b39213506532c816ff56348c07bbeefe0c8d18943bffbad11063cf97cac3e6 \
-                    size    91026092
+checksums           rmd160  8a7fdfd01aae1da22df5e71a3d7789ef3391ce45 \
+                    sha256  93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88 \
+                    size    91045770
 
 java.version        1.8+
 java.fallback       openjdk21


### PR DESCRIPTION
#### Description

Update to Kotlin 1.9.23.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?