### PR TITLE
transmission-x11: allow build with gcc7

### DIFF
--- a/net/transmission-x11/Portfile
+++ b/net/transmission-x11/Portfile
@@ -71,6 +71,22 @@ default_variants +gtk
 # transmission-gtk(47187) malloc: *** error for object 0x33480a4: Non-aligned pointer being freed
 legacysupport.redirect_bins transmission-cli transmission-create transmission-daemon transmission-edit transmission-gtk transmission-remote transmission-show
 
+if [string match macports-gcc-7 ${configure.compiler}] {
+
+    # two patches that I believe are only needed to build with gcc7
+
+    # work around std::tolower not being a constexpr. I am not sure how this
+    # works on other compilers, as it seems it should not
+    patchfiles-append   patch-transmission-x11-gcc7-crypto-utils-constexpr.diff
+
+    # work around std::ios_base::failure not deriving from std:system_error as
+    # it should. This may be related to the way we force the CXX11_ABI off in
+    # MacPorts. At any rate, the code has to be adjusted as std::ios_base::failure
+    # derives from std::exception when building with gcc7 on older Darwin, even if
+    # the c++ standard is set to c++11 or newer
+    patchfiles-append   patch-transmission-x11-gcc7-messagelogwindow-errorcode-fix.diff
+}
+
 variant aqua description {Build Aqua front-end} {
     configure.args-replace -DENABLE_QT=OFF -DENABLE_QT=ON \
                            -DENABLE_MAC=OFF -DENABLE_MAC=ON

--- a/net/transmission-x11/files/patch-transmission-x11-gcc7-crypto-utils-constexpr.diff
+++ b/net/transmission-x11/files/patch-transmission-x11-gcc7-crypto-utils-constexpr.diff
@@ -1,0 +1,29 @@
+diff --git libtransmission/crypto-utils.cc libtransmission/crypto-utils.cc
+index a77e2c9..aaea1f1 100644
+--- libtransmission/crypto-utils.cc
++++ libtransmission/crypto-utils.cc
+@@ -171,6 +171,11 @@ constexpr void tr_binary_to_hex(void const* vinput, void* voutput, size_t byte_l
+     }
+ }
+ 
++// Custom constexpr function to convert a character to lowercase
++constexpr char toLower(char c) {
++    return (c >= 'A' && c <= 'Z') ? (c - 'A' + 'a') : c;
++}
++
+ constexpr void tr_hex_to_binary(char const* input, void* voutput, size_t byte_length)
+ {
+     auto constexpr Hex = "0123456789abcdef"sv;
+@@ -179,9 +184,9 @@ constexpr void tr_hex_to_binary(char const* input, void* voutput, size_t byte_le
+ 
+     for (size_t i = 0; i < byte_length; ++i)
+     {
+-        auto const upper_nibble = Hex.find(std::tolower(*input++));
+-        auto const lower_nibble = Hex.find(std::tolower(*input++));
+-        *output++ = (uint8_t)((upper_nibble << 4) | lower_nibble);
++        auto const upper_nibble = Hex.find(toLower(*input++));
++        auto const lower_nibble = Hex.find(toLower(*input++));
++        *output++ = static_cast<uint8_t>((upper_nibble << 4) | lower_nibble);
+     }
+ }
+ 

--- a/net/transmission-x11/files/patch-transmission-x11-gcc7-messagelogwindow-errorcode-fix.diff
+++ b/net/transmission-x11/files/patch-transmission-x11-gcc7-messagelogwindow-errorcode-fix.diff
@@ -1,0 +1,20 @@
+diff --git gtk/MessageLogWindow.cc gtk/MessageLogWindow.cc
+index 05ca819..6abdab7 100644
+--- gtk/MessageLogWindow.cc
++++ gtk/MessageLogWindow.cc
+@@ -227,12 +227,12 @@ void MessageLogWindow::Impl::doSave(Gtk::Window& parent, Glib::ustring const& fi
+             fmt::format(
+                 _("Couldn't save '{path}': {error} ({error_code})"),
+                 fmt::arg("path", filename),
+-                fmt::arg("error", e.code().message()),
+-                fmt::arg("error_code", e.code().value())),
++                fmt::arg("error", e.what()),
++                fmt::arg("error_code", e.what())),
+             false,
+             TR_GTK_MESSAGE_TYPE(ERROR),
+             TR_GTK_BUTTONS_TYPE(CLOSE));
+-        w->set_secondary_text(e.code().message());
++        w->set_secondary_text(e.what());
+         w->signal_response().connect([w](int /*response*/) mutable { w.reset(); });
+         w->show();
+     }


### PR DESCRIPTION
adds two small patches to work around gcc7 issues
when building this port

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5 PPC

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
