### PR TITLE
include-what-you-use: update to 0.22

### DIFF
--- a/devel/include-what-you-use/Portfile
+++ b/devel/include-what-you-use/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        include-what-you-use include-what-you-use 0.21
+github.setup        include-what-you-use include-what-you-use 0.22
 github.tarball_from archive
-revision            1
+revision            0
 categories          devel
 license             NCSA
 maintainers         {outlook.com:mohd.akram @mohd-akram} openmaintainer
@@ -16,19 +16,21 @@ description         A tool for use with clang to analyze #includes in C and C++ 
 
 long_description    {*}${description}
 
-checksums           rmd160  70834a92aaed0d19e1c345191f48279b5d1f360c \
-                    sha256  a472fe8587376d041585c72e5643200f8929899f787725f0ba9e5b3d3820d401 \
-                    size    776263
+checksums           rmd160  1a86b5f12e8cc1f09c03784cfab4f51c57381191 \
+                    sha256  34c7636da2abe7b86580b53b762f5269e71efff460f24f17d5913c56eb99cb7c \
+                    size    796681
 
-set llvm_version    17
+set llvm_version    18
 set llvm_dir        ${prefix}/libexec/llvm-${llvm_version}
 
-depends_lib-append  port:clang-${llvm_version}
+depends_build-append    port:python312
+depends_lib-append      port:clang-${llvm_version}
 
 cmake.install_rpath-append  ${llvm_dir}/lib
 
 configure.args-append   -DLLVM_DIR=${llvm_dir}/lib/cmake/llvm \
-                        -DClang_DIR=${llvm_dir}/lib/cmake/clang
+                        -DClang_DIR=${llvm_dir}/lib/cmake/clang \
+                        -DPython3_EXECUTABLE=${prefix}/bin/python3.12
 
 post-destroot {
     # Move the binary next to clang so it picks up its include directory one


### PR DESCRIPTION
###### Tested on
macOS 14.4 23E214 x86_64
Xcode 15.3 15E204a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?