### PR TITLE
micronaut: update to 4.3.6

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.3.5 v
+github.setup    micronaut-projects micronaut-starter 4.3.6 v
 revision        0
 name            micronaut
 categories      java
@@ -53,9 +53,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  97bfbba6b44f7a794a4720f880fb7f5fe342a668 \
-                sha256  6c4faa6873c79a1ed48506618dafb6db662a8cf0d3513fa5dbe18671cd8a53ce \
-                size    22368561
+checksums       rmd160  2daf682cb13514ae9e4d0a1b78a1328a58278cf8 \
+                sha256  817cc0fd024b420898646bde59e05e35651e966c8d3ddb26f3a05c5ae57de7e4 \
+                size    22294722
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.3.6.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?