### PR TITLE
ipsw: new port (3.1.456)

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -1,0 +1,65 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               golang 1.0
+
+go.setup                github.com/blacktop/ipsw 3.1.456 v
+github.tarball_from     archive
+revision                0
+categories              security devel
+license                 MIT
+platforms               {darwin >= 11}
+installs_libs           no
+maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
+
+description             iOS/macOS Research Swiss Army Knife
+long_description        {*}${description}. Everything you need to start \
+                        researching Apple security and internals.
+
+checksums               rmd160  4080714c4c112f4a959f0bd470e230eae8cf0fda \
+                        sha256  0e5a54d8e526186d8b904d1cdaec5930c6f92d89497754bb1aaefac43014bc58 \
+                        size    4028544
+
+patch.pre_args          -p1
+patchfiles              reproducible-build.diff
+
+# Vendored libraries cause failure, fetch them at build time
+go.offline_build        no
+
+build.args-append       -ldflags \"-s -w\" \
+                        -ldflags \"-X ${go.package}/cmd/ipsw/cmd.AppVersion=${version}\"
+
+build.post_args-append  ./cmd/${name}
+
+post-build {
+    # Generate shell completions for supported shells
+    foreach shell {zsh bash fish} {
+        system -W ${worksrcpath} "./${name} completion ${shell} > ipsw.${shell}"
+    }
+
+    # Generate individual command manpages
+    file mkdir ${worksrcpath}/man
+    system "${worksrcpath}/${name} man ${worksrcpath}/man"
+}
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/${name}
+    file copy {*}[glob ${worksrcpath}/man/*.1] \
+        ${destroot}${prefix}/share/man/man1/
+
+    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 644 ${worksrcpath}/${name}.zsh \
+        ${destroot}${prefix}/share/zsh/site-functions/_${name}
+
+    xinstall -d ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -m 644 ${worksrcpath}/${name}.bash \
+        ${destroot}${prefix}/share/bash-completion/completions/${name}
+
+    xinstall -d ${destroot}${prefix}/share/fish/vendor_completion.d
+    xinstall -m 644 ${worksrcpath}/${name}.fish \
+        ${destroot}${prefix}/share/fish/vendor_completion.d
+
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 644 -W ${worksrcpath} LICENSE README.md \
+        ${destroot}${prefix}/share/doc/${name}
+}

--- a/security/ipsw/files/reproducible-build.diff
+++ b/security/ipsw/files/reproducible-build.diff
@@ -1,0 +1,47 @@
+diff -urN a/cmd/ipsw/cmd/class_dump.go b/cmd/ipsw/cmd/class_dump.go
+--- a/cmd/ipsw/cmd/class_dump.go	2024-03-05 21:03:07.000000000 +0000
++++ b/cmd/ipsw/cmd/class_dump.go	2024-03-18 23:19:42.000000000 +0000
+@@ -132,7 +132,7 @@
+ 			Headers:     viper.GetBool("class-dump.headers"),
+ 			ObjcRefs:    viper.GetBool("class-dump.refs"),
+ 			Deps:        viper.GetBool("class-dump.deps"),
+-			IpswVersion: fmt.Sprintf("Version: %s, BuildTime: %s", strings.TrimSpace(AppVersion), strings.TrimSpace(AppBuildTime)),
++			IpswVersion: fmt.Sprintf("Version: %s", strings.TrimSpace(AppVersion)),
+ 			Color:       viper.GetBool("color") && !viper.GetBool("no-color"),
+ 			Theme:       viper.GetString("class-dump.theme"),
+ 			Output:      viper.GetString("class-dump.output"),
+diff -urN a/cmd/ipsw/cmd/root.go b/cmd/ipsw/cmd/root.go
+--- a/cmd/ipsw/cmd/root.go	2024-03-05 21:03:07.000000000 +0000
++++ b/cmd/ipsw/cmd/root.go	2024-03-18 23:07:10.000000000 +0000
+@@ -50,8 +50,6 @@
+ 	Verbose bool
+ 	// AppVersion stores the plugin's version
+ 	AppVersion string
+-	// AppBuildTime stores the plugin's build time
+-	AppBuildTime string
+ )
+ 
+ // rootCmd represents the base command when called without any subcommands
+diff -urN a/cmd/ipsw/cmd/swift_dump.go b/cmd/ipsw/cmd/swift_dump.go
+--- a/cmd/ipsw/cmd/swift_dump.go	2024-03-05 21:03:07.000000000 +0000
++++ b/cmd/ipsw/cmd/swift_dump.go	2024-03-18 23:14:01.000000000 +0000
+@@ -121,7 +121,7 @@
+ 			Interface:   viper.GetBool("swift-dump.interface"),
+ 			Deps:        viper.GetBool("swift-dump.deps"),
+ 			Demangle:    doDemangle,
+-			IpswVersion: fmt.Sprintf("Version: %s, BuildTime: %s", strings.TrimSpace(AppVersion), strings.TrimSpace(AppBuildTime)),
++			IpswVersion: fmt.Sprintf("Version: %s", strings.TrimSpace(AppVersion)),
+ 			Color:       viper.GetBool("color") && !viper.GetBool("no-color"),
+ 			Theme:       viper.GetString("swift-dump.theme"),
+ 			Output:      viper.GetString("swift-dump.output"),
+diff -urN a/cmd/ipsw/cmd/version.go b/cmd/ipsw/cmd/version.go
+--- a/cmd/ipsw/cmd/version.go	2024-03-05 21:03:07.000000000 +0000
++++ b/cmd/ipsw/cmd/version.go	2024-03-18 23:19:53.000000000 +0000
+@@ -38,6 +38,6 @@
+ 	Aliases: []string{"v"},
+ 	Short:   "Print the version number of ipsw",
+ 	Run: func(cmd *cobra.Command, args []string) {
+-		fmt.Printf("Version: %s, BuildTime: %s\n", strings.TrimSpace(AppVersion), strings.TrimSpace(AppBuildTime))
++		fmt.Printf("Version: %s\n", strings.TrimSpace(AppVersion))
+ 	},
+ }


### PR DESCRIPTION
#### Description

Add `ipsw`, the Swiss Army Knife for researching Apple internals.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
