### PR TITLE
pandoc: Add texlive variant for LaTeX dependencies

### DIFF
--- a/textproc/pandoc/Portfile
+++ b/textproc/pandoc/Portfile
@@ -33,14 +33,20 @@ checksums           rmd160  48d25968949d35c50289889f53ab8657a0c90bfe \
 
 depends_lib-append  port:zlib
 
+depends_run-append  port:groff
+
 # https://github.com/jgm/pandoc/blob/main/tools/latex-package-dependencies.lua
 # comm -23 <(pandoc lua ${worksrcpath}/tools/latex-package-dependencies.lua | xargs -I{} find ${prefix}/share/texmf-texlive -name {} | sort -u | xargs -I{} find {} -depth 1 -type f | xargs port provides | awk '{print $NF}' | sort -u) <(port echo rdepof:texlive-xetex rdepends:texlive-fonts-recommended | grep texlive | sort -u)
-depends_run-append  port:groff \
+variant texlive \
+    description {Use TeXLive; see "port notes" for more information.} {
+    depends_run-append \
                     port:latexmk \
                     port:texlive-fonts-recommended \
                     port:texlive-xetex
+}
 
 variant full_latex_dependencies \
+    requires texlive \
     description {Install all LaTeX dependencies.} {
     depends_run-append \
                     port:texlive-bin-extra \
@@ -49,7 +55,11 @@ variant full_latex_dependencies \
                     port:texlive-luatex
 }
 
-notes-append       "For full LaTeX PDF support, please install the variant +full_latex_dependencies."
+notes-append       "${name} uses LaTeX to create PDFs.
+
+The (minimized) variant +texlive uses MacPorts TeXLive.
+
+For full LaTeX PDF support, please use the variant +full_latex_dependencies."
 
 set minimum_major_version_for_source 20
 


### PR DESCRIPTION
* Fixes: https://trac.macports.org/ticket/69529

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
