### PR TITLE
py-pylint: update to 3.1.0

### DIFF
--- a/python/py-pylint/Portfile
+++ b/python/py-pylint/Portfile
@@ -5,8 +5,8 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-pylint
-version             3.0.3
-revision            1
+version             3.1.0
+revision            0
 
 categories-append   devel
 platforms           {darwin any}
@@ -29,9 +29,9 @@ long_description    Pylint is a tool that checks for errors in python code, \
 
 homepage            https://pylint.org
 
-checksums           rmd160  0e60dfc7503484315f0f73cc78101c5f11bcec3d \
-                    sha256  58c2398b0301e049609a8429789ec6edf3aabe9b6c5fec916acd18639c16de8b \
-                    size    441807
+checksums           rmd160  2fe5ec392e136afdb444c2a99ab1af078c4b9f74 \
+                    sha256  6a69beb4a6f63debebaab0a3477ecd0f559aa726af4954fc948c51f7a2549e23 \
+                    size    1494465
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-dill \
@@ -52,11 +52,6 @@ if {${name} ne ${subport}} {
     }
 
     depends_run-append  port:pylint_select
-
-    post-patch {
-        reinplace "s|setuptools~=62.6|setuptools|g" ${worksrcpath}/pyproject.toml
-        reinplace "s|wheel~=0.37.1|wheel|g" ${worksrcpath}/pyproject.toml
-    }
 
     post-destroot {
         xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${subport}


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69533

Thank you for MacPorts!

#### Description

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 13.6.5 22G621 arm64
Xcode 15.2 15C500b


###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

I think tracing is still busted on Ventura, so I dropped the `-t` from `sudo port -vst install`.