### PR TITLE
coinor-(cbc,cgl,clp,coinutils,osi): new ports

### DIFF
--- a/math/coinor-cbc/Portfile
+++ b/math/coinor-cbc/Portfile
@@ -1,0 +1,47 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+name                    coinor-cbc
+version                 2.10.11
+revision                0
+categories              math
+
+github.setup            coin-or cbc ${version} releases/
+
+checksums               rmd160  98972ddd7a1d7a24ba3c591592e7411104fc88aa \
+                        sha256  ea47ca1b87597e6099166a386112737f2ae545baf763efc29f4097d0bbcd9a8e \
+                        size    1680448
+
+maintainers             {@flyingsamson tuxcad.de:flyingsamson} openmaintainer
+description             An LP-based branch-and-cut library
+long_description        CBC is an open-source MILP solver. It uses many of the COIN-OR components \
+                        and is designed to be used with CLP. It is available as a library and \
+                        as a standalone solver.
+license                 EPL-2
+
+homepage                https://github.com/coin-or/cbc
+
+depends_build-append    port:pkgconfig
+depends_lib-append      port:asl \
+                        port:coinor-coinutils \
+                        port:coinor-osi \
+                        port:coinor-clp \
+                        port:coinor-cgl \
+                        port:glpk \
+                        port:mumps \
+                        port:readline
+
+patchfiles              wimplicit-function-declaration.diff
+
+configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig \
+                        PKG_CONFIG=${prefix}/bin/pkg-config
+
+variant openblas description {compile with OpenBLAS support} {
+    depends_lib-append          path:lib/libopenblas.dylib:OpenBLAS
+    pre-configure {
+        configure.args-append   --with-blas-lib="-L${prefix}/lib -lopenblas -llapack"
+    }
+}
+default_variants        +openblas

--- a/math/coinor-cbc/files/wimplicit-function-declaration.diff
+++ b/math/coinor-cbc/files/wimplicit-function-declaration.diff
@@ -1,0 +1,10 @@
+--- configure.orig	2024-03-18 17:49:45
++++ configure	2024-03-18 17:50:08
+@@ -6933,6 +6933,7 @@
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ #include <ctype.h>
++#include <stdlib.h>
+ #if ((' ' & 0x0FF) == 0x020)
+ # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+ # define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))

--- a/math/coinor-cgl/Portfile
+++ b/math/coinor-cgl/Portfile
@@ -1,0 +1,39 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+name                    coinor-cgl
+version                 0.60.8
+revision                0
+categories              math
+
+github.setup            coin-or cgl ${version} releases/
+
+checksums               rmd160  ae3c46eebb3416da0cef944e382b7045aa1476a3 \
+                        sha256  fb02f4d43ce234fb22e3aceaee092fcefb10619810e70c76c71c1b3f893eb7c5 \
+                        size    1285232
+
+maintainers             {@flyingsamson tuxcad.de:flyingsamson} openmaintainer
+description             A library of cutting-plane generators.
+long_description        The COIN-OR Cut Generation Library (Cgl) is an open collection \
+                        of cutting plane implementations (\"cut generators\") for use in \
+                        teaching, research, and applications. Cgl can be used with other \
+                        COIN-OR packages that make use of cuts, such as the mixed-integer \
+                        linear programming solver Cbc. Each cut generator has its own \
+                        maintainer who leads the development of its functionality, testing, \
+                        and documentation. See below for a listing of available generators. \
+                        All the generators are combined in one library when Cgl is compiled.
+license                 EPL-2
+
+homepage                https://github.com/coin-or/cgl
+
+depends_build-append    port:pkgconfig
+depends_lib-append      port:coinor-coinutils \
+                        port:coinor-osi \
+                        port:coinor-clp
+
+patchfiles              wimplicit-function-declaration.diff
+
+configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig \
+                        PKG_CONFIG=${prefix}/bin/pkg-config

--- a/math/coinor-cgl/files/wimplicit-function-declaration.diff
+++ b/math/coinor-cgl/files/wimplicit-function-declaration.diff
@@ -1,0 +1,10 @@
+--- configure.orig	2024-03-18 17:42:31
++++ configure	2024-03-18 17:42:58
+@@ -6893,6 +6893,7 @@
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ #include <ctype.h>
++#include <stdlib.h>
+ #if ((' ' & 0x0FF) == 0x020)
+ # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+ # define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))

--- a/math/coinor-clp/Portfile
+++ b/math/coinor-clp/Portfile
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+name                    coinor-clp
+version                 1.17.9
+revision                0
+categories              math
+
+github.setup            coin-or clp ${version} releases/
+
+checksums               rmd160  037253a6f0e117acb8af78aaa042215556bbecb9 \
+                        sha256  c553362b4fe82b9dc10e0cead782e39d9fbf734e63174eee1ab39c5f3b7b5bca \
+                        size    2176272
+
+maintainers             {@flyingsamson tuxcad.de:flyingsamson} openmaintainer
+description             A solver for linear programs
+long_description        Clp (Coin-or linear programming) is an open-source linear programming solver. \
+                        \nIt is primarily meant to be used as a callable library, but a basic, stand-alone executable \
+                        version is also available. It is designed to find solutions of mathematical optimization \
+                        problems of the form \
+                        \n\
+                        \nminimize   c\'x \
+                        \nsuch that  lhs <= Ax <= rhs \
+                        \nand        lb  <=  x <= ub \
+                        \n\
+                        \nCLP includes primal and dual Simplex solvers. \
+                        Both dual and primal algorithms can use matrix storage methods provided by the user (0-1 and \
+                        network matrices are already supported in addition to the default sparse matrix). \
+                        The dual algorithm has Dantzig and Steepest edge row pivot choices, new ones may be provided \
+                        by the user. The same is true for the column pivot choice of the primal algorithm. \
+                        The primal can also use a non linear cost which should work for piecewise linear convex \
+                        functions. CLP also includes a barrier method for solving LPs.
+license                 EPL-2
+
+homepage                https://github.com/coin-or/clp
+
+depends_build-append    port:pkgconfig
+depends_lib-append      port:asl \
+                        port:coinor-coinutils \
+                        port:coinor-osi \
+                        port:glpk \
+                        port:mumps \
+                        port:readline
+
+patchfiles              wimplicit-function-declaration.diff
+
+configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig \
+                        PKG_CONFIG=${prefix}/bin/pkg-config
+
+variant openblas description {compile with OpenBLAS support} {
+    depends_lib-append          path:lib/libopenblas.dylib:OpenBLAS
+    pre-configure {
+        configure.args-append   --with-blas-lib="-L${prefix}/lib -lopenblas -llapack"
+    }
+}
+default_variants        +openblas

--- a/math/coinor-clp/files/wimplicit-function-declaration.diff
+++ b/math/coinor-clp/files/wimplicit-function-declaration.diff
@@ -1,0 +1,10 @@
+--- configure.orig	2024-03-18 17:29:46
++++ configure	2024-03-18 17:30:14
+@@ -6913,6 +6913,7 @@
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ #include <ctype.h>
++#include <stdlib.h>
+ #if ((' ' & 0x0FF) == 0x020)
+ # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+ # define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))

--- a/math/coinor-coinutils/Portfile
+++ b/math/coinor-coinutils/Portfile
@@ -1,0 +1,46 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem                  1.0
+PortGroup                   github 1.0
+
+name                        coinor-coinutils
+version                     2.11.10
+revision                    0
+categories                  math
+
+github.setup                coin-or coinutils ${version} releases/
+
+checksums                   rmd160  92d48d43f7be67b4ff8c95c89fc6111452e9832d \
+                            sha256  fdf1a892e0ae6f4df00c6c10e8617ed7164347c8fce8ba9fd77fddd9bab8bca4 \
+                            size    1239046
+
+maintainers                 {@flyingsamson tuxcad.de:flyingsamson} openmaintainer
+description                 Utilities, data structures, and linear algebra methods for COIN-OR projects
+long_description            CoinUtils is an open-source collection of classes and helper functions \
+                            that are generally useful to multiple COIN-OR projects.\
+                            \nThese utilities include:\
+                            \n * classes for storing and manipulating sparse matrices and vectors,\
+                            \n * performing matrix factorization,\
+                            \n * parsing input files in standard formats, e.g. MPS,\
+                            \n * building representations of mathematical programs,\
+                            \n * performing simple presolve operations,\
+                            \n * warm starting algorithms for mathematical programs,\
+                            \n * comparing floating point numbers with a tolerance\
+                            \n * classes for storing and manipulating conflict graphs, and\
+                            \n * classes for searching and storing cliques and odd cycles in conflict graphs, among others.
+license                     EPL-2
+
+homepage                    https://github.com/coin-or/CoinUtils
+
+depends_build-append        port:pkgconfig
+depends_lib                 port:glpk
+
+patchfiles                  wimplicit-function-declaration.diff
+
+variant openblas description {compile with OpenBLAS support} {
+    depends_lib-append          path:lib/libopenblas.dylib:OpenBLAS
+    pre-configure {
+        configure.args-append   --with-blas-lib="-L${prefix}/lib -lopenblas -llapack"
+    }
+}
+default_variants            +openblas

--- a/math/coinor-coinutils/files/wimplicit-function-declaration.diff
+++ b/math/coinor-coinutils/files/wimplicit-function-declaration.diff
@@ -1,0 +1,10 @@
+--- configure.orig	2024-03-18 16:50:08
++++ configure	2024-03-18 16:51:22
+@@ -6893,6 +6893,7 @@
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ #include <ctype.h>
++#include <stdlib.h>
+ #if ((' ' & 0x0FF) == 0x020)
+ # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+ # define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))

--- a/math/coinor-osi/Portfile
+++ b/math/coinor-osi/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+
+name                    coinor-osi
+version                 0.108.9
+revision                0
+categories              math
+
+github.setup            coin-or osi ${version} releases/
+
+checksums               rmd160  438fa598ffb19741a6119fbe7cc257a5aae7ffc0 \
+                        sha256  a136cb21174c0ba0db74c18e5e6a4d80aebf59dcc7d361d5789097771eed6153 \
+                        size    1030741
+
+maintainers             {@flyingsamson tuxcad.de:flyingsamson} openmaintainer
+description             A uniform API for calling embedded linear and mixed-integer programming solvers.
+long_description        The COIN-OR Open Solver Interface is a uniform API for interacting with callable \
+                        solver libraries. It supports linear programming solvers as well as the ability \
+                        to \"finish off\" a mixed-integer problem calling the solver library\'s MIP solver.
+license                 EPL-2
+
+homepage                https://github.com/coin-or/osi
+
+depends_build-append    port:pkgconfig
+depends_lib-append      port:coinor-coinutils \
+                        port:glpk
+
+patchfiles              wimplicit-function-declaration.diff
+
+configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig \
+                        PKG_CONFIG=${prefix}/bin/pkg-config

--- a/math/coinor-osi/files/wimplicit-function-declaration.diff
+++ b/math/coinor-osi/files/wimplicit-function-declaration.diff
@@ -1,0 +1,10 @@
+--- configure.orig	2024-03-18 17:05:18
++++ configure	2024-03-18 17:06:08
+@@ -6901,6 +6901,7 @@
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ #include <ctype.h>
++#include <stdlib.h>
+ #if ((' ' & 0x0FF) == 0x020)
+ # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+ # define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))


### PR DESCRIPTION
#### Description

This adds the ports coinor-cbc, coinor-cgl, coinor-clp, coinor-coinutils, and coinor-osi, which are all packages for one or another optimisation problem.

I have two open questions:
- Is `math` the correct category or should it be science? I noticed there is a `science/coinor-liblemon` package, but all in all I see these `coinor` packages more in the direction of `eigen`, `lapack`, and `scip` who live in the `math` category. If you'd prefer them in `science`, however, I will of course move them there.
- There are some "optional" and "recommended" dependencies to those packages. What is the guideline here? Should these all be variants? If so, should the default variant be to include all capabilities, so that other ports can easily depend on them?

###### Tested on
macOS 13.6.4 22G513 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
