### PR TITLE
QMPlay2: update to 24.03.16

### DIFF
--- a/multimedia/QMPlay2/Portfile
+++ b/multimedia/QMPlay2/Portfile
@@ -1,13 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           cmake 1.1
+PortGroup           github 1.0
 
 name                QMPlay2
 
-# Currently Qt5 is broken on 10.7.
-if {${os.platform} eq "darwin" && ${os.major} < 12} {
+# Does not build with Qt5 on 10.10 and below.
+if {${os.platform} eq "darwin" && ${os.major} < 15} {
     PortGroup       qt4 1.0
 
     github.setup    zaps166 QMPlay2 b76e6ea46b4a32bb2becc9444ddc6f5fdff699cd
@@ -76,16 +76,19 @@ if {${os.platform} eq "darwin" && ${os.major} < 12} {
         patchfiles-append \
                         1001-Fix-Qt-paths.patch
      } else {
-        github.setup    zaps166 QMPlay2 23.10.22
-        revision        1
-        checksums       rmd160  8a4c9db6811e577ebeae5c40c279fd64f550ece2 \
-                        sha256  d81c5a81a8839ac441eb7466eb16931aab92f71fd784a3b3e1d709272c4237cf \
-                        size    1442072
+        github.setup    zaps166 QMPlay2 24.03.16
+        revision        0
+        checksums       rmd160  316c8770abbfeffd1eb71fc145592e16cb9f3ce5 \
+                        sha256  88eea02d72df6af60e45cb2d3e4b0ade717b8cca2cf2999868c482a89c856e3c \
+                        size    2013280
         github.tarball_from releases
         distname        ${name}-src-${version}
 
         patchfiles-append \
                         2001-Fix-Qt-paths.patch
+
+        configure.args-append \
+                        -DBUILD_WITH_QT6=OFF
     }
 
     use_xz          yes

--- a/multimedia/QMPlay2/files/2001-Fix-Qt-paths.patch
+++ b/multimedia/QMPlay2/files/2001-Fix-Qt-paths.patch
@@ -7,7 +7,7 @@ diff --git src/gui/CMakeLists.txt src/gui/CMakeLists.txt
 index 33a67ac1..6bac8fa0 100644
 --- src/gui/CMakeLists.txt
 +++ src/gui/CMakeLists.txt
-@@ -237,8 +237,8 @@
+@@ -253,8 +253,8 @@
  elseif(APPLE)
      install(TARGETS ${PROJECT_NAME} BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
  
@@ -18,7 +18,7 @@ index 33a67ac1..6bac8fa0 100644
      install(FILES
          "${QT_PLUGINS_DIR}/platforms/libqcocoa.dylib"
          DESTINATION "${MAC_BUNDLE_PATH}/Contents/plugins/platforms")
-@@ -259,23 +259,7 @@
+@@ -275,23 +275,7 @@
          DESTINATION "${MAC_BUNDLE_PATH}/Contents"
          FILES_MATCHING
          PATTERN "qtbase_*.qm")
@@ -40,6 +40,6 @@ index 33a67ac1..6bac8fa0 100644
 -        fixup_bundle(${MAC_BUNDLE_PATH} \"\${QMPLAY2_MODULES_AND_QT_PLUGINS}\" \"\${DIRS}\")
 -    ")
 +    file(WRITE \"@destroot@${MAC_BUNDLE_PATH}/Contents/Resources/qt.conf\")
- else()
+ elseif(NOT ANDROID)
      # executable
      install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
#### Description

Update.
Also fix builds on some older systems where needed Qt5 does not build.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4
Xcode 15.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
