### PR TITLE
py-numpy: prevent opportunistic linking to random BLAS implementations

### DIFF
--- a/python/py-numpy/Portfile
+++ b/python/py-numpy/Portfile
@@ -14,7 +14,7 @@ description             The core utilities for the scientific library scipy for 
 long_description        {*}${description}
 
 github.setup            numpy numpy 1.26.4 v
-revision                0
+revision                1
 
 checksums               rmd160  7f094022d62015d8ea78da78b37fd6f4f4e3076b \
                         sha256  2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010 \
@@ -48,6 +48,16 @@ compiler.cxx_standard 2011
 github.livecheck.regex {(\d+(?:\.\d+)+)}
 
 if {${name} ne ${subport}} {
+    PortGroup               conflicts_build 1.0
+
+    # If blis is available in PATH, numpy opportunistically links to it,
+    # ignoring a chosen variant. Resulting library is broken:
+    # https://trac.macports.org/ticket/67490
+    # https://trac.macports.org/ticket/69538
+    # TODO: add variants for blis and flexiblas, however blis
+    # can be enabled only after lapack support added into it.
+    conflicts_build         blis flexiblas
+
     set PATCH_PY_EXT ""
     if {${python.version} == 27} {
         github.setup        numpy numpy 1.16.6 v


### PR DESCRIPTION
#### Description

Prevent numpy opportunistically picking a BLAS implementation.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
