### PR TITLE
ruby-build: Update to 20240318

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20240221 v
+github.setup        rbenv ruby-build 20240318 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  d56a336fcf84c160a34ada7d1fc311c7836d6571 \
-                    sha256  7cc07a1fdfe0ec8ed941616ef8b76d8c33fbf84f9cbf8e80d7011f3361357bc7 \
-                    size    88074
+checksums           rmd160  fe3b638aeef767ac723fd3c1a3fa8b801c3a5e72 \
+                    sha256  3edc96e725afc6f6dcd06c74b0438058c4878434e67ab0fa7d82aeb486df07d5 \
+                    size    88256
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Update to 20240318

Switch to EA build from graalvm/graa-languages-ea-builds for
truffleruby+graalvm-dev

##### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
