### PR TITLE
py-ezdxf: new port

### DIFF
--- a/python/py-ezdxf/Portfile
+++ b/python/py-ezdxf/Portfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               python 1.0
+
+name                    py-ezdxf
+version                 1.2.0
+revision                0
+
+checksums               rmd160  1eae28a34810f8e975755b0180cd6756d2154fc8 \
+                        sha256  a34748ac31d414387dab72ecf819b1422b44d43b094045a5235f2ad268882942 \
+                        size    2178069
+
+maintainers             {@flyingsamson tuxcad.de:flyingsamson} openmaintainer
+description             Python interface to DXF
+long_description        This Python package is designed to facilitate the creation and manipulation \
+                        of DXF documents, with compatibility across various DXF versions. It empowers \
+                        users to seamlessly load and edit DXF files while preserving all content, \
+                        except for comments.
+license                 MIT
+
+homepage                https://ezdxf.mozman.at
+
+python.versions         38 39 310 311 312
+
+use_zip                 yes
+
+if {${name} ne ${subport}} {
+    depends_run         port:py${python.version}-typing_extensions \
+                        port:py${python.version}-parsing \
+                        port:py${python.version}-numpy \
+                        port:py${python.version}-fonttools
+
+    variant draw description {Include the drawing add-on} {
+        depends_run-append \
+                        port:py${python.version}-matplotlib \
+                        port:py${python.version}-pyqt5 \
+                        port:py${python.version}-mupdf \
+                        port:py${python.version}-Pillow
+    }
+}


### PR DESCRIPTION
#### Description

This adds the python package `ezdxf` which offers functionality to read, create, manipulate, and export dxf files.


###### Tested on
macOS 13.6.4 22G513 arm64
Xcode 15.2 15C500b

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?