### PR TITLE
db48: Fix implicit int, implicit function errors

### DIFF
--- a/databases/db48/files/patch-dist_configure.diff
+++ b/databases/db48/files/patch-dist_configure.diff
@@ -1,5 +1,5 @@
---- dist/configure.orig	2020-06-24 14:58:52.000000000 -0700
-+++ dist/configure	2020-06-24 15:09:30.000000000 -0700
+--- dist/configure.orig	2010-04-12 15:25:23.000000000 -0500
++++ dist/configure	2024-03-19 16:19:34.000000000 -0500
 @@ -18756,6 +18756,7 @@
  /* end confdefs.h.  */
  
@@ -8,15 +8,91 @@
  int
  main ()
  {
-@@ -18792,6 +18793,7 @@
+@@ -18792,6 +18793,8 @@
  /* end confdefs.h.  */
  
  #include <pthread.h>
 +#include <stdlib.h>
++int
  main() {
  	pthread_cond_t cond;
  	pthread_mutex_t mutex;
-@@ -19159,6 +19161,7 @@
+@@ -18828,6 +18831,7 @@
+ /* end confdefs.h.  */
+ 
+ #include <pthread.h>
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -18864,6 +18868,8 @@
+ /* end confdefs.h.  */
+ 
+ #include <pthread.h>
++#include <stdlib.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -18899,6 +18905,7 @@
+ /* end confdefs.h.  */
+ 
+ #include <pthread.h>
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -18933,6 +18940,8 @@
+ /* end confdefs.h.  */
+ 
+ #include <pthread.h>
++#include <stdlib.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -18967,6 +18976,7 @@
+ /* end confdefs.h.  */
+ 
+ #include <pthread.h>
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19001,6 +19011,8 @@
+ /* end confdefs.h.  */
+ 
+ #include <pthread.h>
++#include <stdlib.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -19037,6 +19049,7 @@
+ 	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++	#include <stdlib.h>
+ 	#include <synch.h>
+ int
+ main ()
+@@ -19068,6 +19081,7 @@
+ /* end confdefs.h.  */
+ 
+ 	#include <thread.h>
++	#include <stdlib.h>
+ 	#include <synch.h>
+ int
+ main ()
+@@ -19098,6 +19112,7 @@
+ /* end confdefs.h.  */
+ 
+ 	#include <thread.h>
++	#include <stdlib.h>
+ 	#include <synch.h>
+ int
+ main ()
+@@ -19136,6 +19151,7 @@
  	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
  
@@ -24,7 +100,7 @@
  int
  main ()
  {
-@@ -20198,6 +20201,7 @@
+@@ -19159,6 +19175,7 @@
  	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
  
@@ -32,7 +108,151 @@
  int
  main ()
  {
-@@ -21600,6 +21604,8 @@
+@@ -19210,6 +19227,7 @@
+ 	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19276,6 +19294,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <sys/mman.h>
+ int
+ main ()
+@@ -19308,6 +19327,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <sys/types.h>
+ #include <sys/mman.h>
+ int
+@@ -19366,6 +19386,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19497,6 +19518,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19522,6 +19544,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19547,6 +19570,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19572,6 +19596,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19597,6 +19622,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19622,6 +19648,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19647,6 +19674,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19672,6 +19700,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19697,6 +19726,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19722,6 +19752,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -19747,6 +19778,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -20198,6 +20230,7 @@
+ 	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -20224,6 +20257,7 @@
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++#include <stdlib.h>
+ #include <sys/atomic.h>
+ int
+ main ()
+@@ -20743,6 +20777,7 @@
+ /* end confdefs.h.  */
+ 
+ #include <sys/time.h>
++int
+ main() {
+ 	struct timespec t;
+ 	return (clock_gettime(CLOCK_MONOTONIC, &t) != 0);
+@@ -21600,6 +21635,8 @@
    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
  
@@ -41,12 +261,13 @@
  int
  main ()
  {
-@@ -21634,6 +21640,8 @@
+@@ -21634,6 +21671,9 @@
    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
  
-+#include <stdio.h>
-+#include <string.h>
++		#include <stdio.h>
++		#include <string.h>
++		int
  		main() {
  			$db_cv_seq_type l;
  			unsigned $db_cv_seq_type u;


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/69543

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.2 21G1974 x86_64
Xcode 14.2 14C18

with macports-clang-17

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
