### PR TITLE
google-cloud-sdk: update to 469.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             468.0.0
+version             469.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  b69649517e6fbdd90d08d237e274608fb5908277 \
-                    sha256  6db8f754afd5f2c7a1ae74e8b534532cf04b68d2c1c528ba3802f033faac0667 \
-                    size    128323193
+    checksums       rmd160  020c51234240613befa16472c63ba0f439934530 \
+                    sha256  0bbd953a0822299ce465306c4170841b2495a7d187a8d21d8007746271864600 \
+                    size    128538664
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  95bcd7627cab256a7e735c0ee931a697a5ae267d \
-                    sha256  e9f32a8107e5f4fe463e726dcc64ec1fdbd77820c2eb72d27262e4eaf73d9606 \
-                    size    129607382
+    checksums       rmd160  ad5bc84c226a001e7ba90660a7ecee519b4e60bf \
+                    sha256  90a20a2faaa1d069c99d3fa52f7d4d2f52235299784ccd0f1a1c63ecc0d0a37d \
+                    size    129822186
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  a979064de58c7f8642c81b3a672792cd6cbf3355 \
-                    sha256  1ebe530595c4b0ca02ae6ca5ff31635cefeb18f818b1c18f97c20c9bdff93dba \
-                    size    126679613
+    checksums       rmd160  a37def9a190bb71549bad31bb27792d50a2ee35e \
+                    sha256  ee2f100d75ec4f9ec85f1244db302115de937d71f65155cb247a8c33e0492a05 \
+                    size    126894412
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 469.0.0.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?