### PR TITLE
openjdk22-oracle: new submission

### DIFF
--- a/java/openjdk22-oracle/Portfile
+++ b/java/openjdk22-oracle/Portfile
@@ -1,0 +1,93 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk22-oracle
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://jdk.java.net/22/
+version      22
+revision     0
+
+description  Oracle OpenJDK 22
+long_description Open-source Oracle build of OpenJDK 22, the Java Development Kit, an implementation of the Java SE Platform.
+
+master_sites https://download.java.net/java/GA/jdk${version}/830ec9fcccef480bb3e73fb7ecafe059/36/GPL/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     openjdk-${version}_macos-x64_bin
+    checksums    rmd160  8d2bd2aa6a4a9f2d617e1575c6bf043bd5e43c00 \
+                 sha256  ae31fe10916429e3fe284266095067a5ce9fecbdc03ff1a079d20459f731ca36 \
+                 size    198170569
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     openjdk-${version}_macos-aarch64_bin
+    checksums    rmd160  b753e92d0321fac0875daafb4ab9937a139b1107 \
+                 sha256  d10f82429d01047968c52c7975c326388cb5d212791e14c1de21c987463a4b53 \
+                 size    195890696
+}
+
+worksrcdir   jdk-${version}.jdk
+
+homepage     https://jdk.java.net/22/
+
+livecheck.type      regex
+livecheck.url       ${homepage}
+livecheck.regex     OpenJDK JDK (22\.\[0-9\.\]+)
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-22-oracle-openjdk.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New submission for Oracle OpenJDK 22.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?