### PR TITLE
jdk22-graalvm: new submission

### DIFF
--- a/java/jdk22-graalvm/Portfile
+++ b/java/jdk22-graalvm/Portfile
@@ -1,0 +1,94 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             jdk22-graalvm
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+# GraalVM Free Terms and Conditions: https://www.oracle.com/downloads/licenses/graal-free-license.html
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GFTC NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://www.oracle.com/java/technologies/downloads/#graalvmjava22-mac
+supported_archs  x86_64 arm64
+
+version     22
+revision    0
+
+master_sites https://download.oracle.com/graalvm/22/archive/
+
+homepage     https://www.oracle.com/java/graalvm/
+
+livecheck.type  none
+
+use_configure    no
+build {}
+
+description  Oracle GraalVM for JDK 22
+long_description Oracle GraalVM for JDK 22 compiles your Java applications ahead of time into standalone \
+    binaries that start instantly, provide peak performance with no warmup, and use fewer cloud resources.
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     graalvm-jdk-${version}_macos-x64_bin
+    checksums    rmd160  dfb3f3a561f67169b29231f82429e0b4654dbea1 \
+                 sha256  5b83f20dbc4c636ed41f19c3309f09839d4f5c6442dba986f460589c494a476c \
+                 size    324973526
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     graalvm-jdk-${version}_macos-aarch64_bin
+    checksums    rmd160  ceaf240f6e9afd7384dffaffc3f6bb4ee6a2942a \
+                 sha256  61632065cfcdc4e121362f1fd25a543955836bbacd6c1aadbcbe0d469d5ab8a3 \
+                 size    337590077
+}
+
+worksrcdir   graalvm-jdk-${version}+36.1
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-22-oracle-graalvm.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"
+


### PR DESCRIPTION
#### Description

New submission for Oracle GraalVM for JDK 22.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?