### PR TITLE
openjdk22-corretto: new submission

### DIFF
--- a/java/openjdk22-corretto/Portfile
+++ b/java/openjdk22-corretto/Portfile
@@ -1,0 +1,98 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk22-corretto
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+
+# See https://aws.amazon.com/corretto/faqs/#Using_Amazon_Corretto
+# and https://trac.macports.org/wiki/PortfileRecipes#compare-osx-darwin-version
+platforms        {darwin any} {darwin >= 21}
+
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+supported_archs  x86_64 arm64
+
+# https://github.com/corretto/corretto-22/releases
+version      22.0.0.36.2
+revision     0
+
+description  Amazon Corretto OpenJDK 22 (Short Term Support)
+long_description No-cost, multiplatform, production-ready distribution of OpenJDK from Amazon.
+
+master_sites https://corretto.aws/downloads/resources/${version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     amazon-corretto-${version}-macosx-x64
+    checksums    rmd160  ff7bc1438055d45748547adec741a543d259254a \
+                 sha256  01ab8522d542b2338ac8055ba19d226286dc3710a0daa48a7569e5b98c0464d3 \
+                 size    201528918
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     amazon-corretto-${version}-macosx-aarch64
+    checksums    rmd160  fb1f40ab3e7a78025a358b015f145cd2c70cc7a6 \
+                 sha256  914b5747eac275b811830ed687605b8921729b82ff3a1e1c77834a97798c85c7 \
+                 size    199304730
+}
+
+worksrcdir   amazon-corretto-22.jdk
+
+homepage     https://aws.amazon.com/corretto/
+
+livecheck.type      regex
+livecheck.url       https://github.com/corretto/corretto-22/releases
+livecheck.regex     amazon-corretto-(22\.\[0-9\.\]+)-macosx-.*\.tar\.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-22-amazon-corretto.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New submission for Amazon Corretto based on OpenJDK 22.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?