### PR TITLE
osxphotos: update to 0.67.7

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,8 +4,8 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.67.6
-revision                1
+version                 0.67.7
+revision                0
 
 categories              graphics python
 
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  a15e2475633eb6108957e9a797153f900421687d \
-                        sha256  0720392a02639c2b9170564547305ae639ea9c912d775f37d4bb7b04905c3fae \
-                        size    2098571
+checksums               rmd160  d01c78f22be6e972580ae96c011f7ad9f3303eca \
+                        sha256  cb4ca009f62b355c661104508a653c6bc3cb6237b4415c06ced4cc0dcfbff782 \
+                        size    2098823
 
 python.default_version  312
 
@@ -65,3 +65,8 @@ post-destroot {
     xinstall -m 644 -W ${worksrcpath} LICENSE README.md README.rst \
        ${destroot}${prefix}/share/doc/${subport}
 }
+
+test.run    yes
+test.cmd    osxphotos
+test.target
+test.args   version


### PR DESCRIPTION
#### Description

Update to osxphotos 0.67.7.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?