### PR TITLE
ruby: fix type conversion errors

### DIFF
--- a/lang/ruby/Portfile
+++ b/lang/ruby/Portfile
@@ -78,7 +78,8 @@ patchfiles      patch-vendordir.diff \
                 patch-ext_openssl_extconf_rb.diff \
                 patch-ext_openssl_ossl_ssl_c.diff \
                 patch-ext_openssl_ossl.h.diff \
-                implicit.patch
+                implicit.patch \
+                conversion.patch
 
 # ignore getcontext() and setcontext()
 # on 10.5 or later, these functions have some problems (SEGV on ppc, slower than 1.8.6)

--- a/lang/ruby/files/conversion.patch
+++ b/lang/ruby/files/conversion.patch
@@ -1,0 +1,107 @@
+--- eval.c.orig	2024-03-20 19:48:01
++++ eval.c	2024-03-20 19:49:33
+@@ -6809,12 +6809,12 @@ yield_under(under, self, args)
+     VALUE under, self, args;
+ {
+     if (args == Qundef) {
+-	return exec_under(yield_under_i, under, 0, self);
++	return exec_under(yield_under_i, under, 0, (void *)self);
+     }
+     else {
+ 	VALUE info[2] = { args, self };
+ 
+-	return exec_under(yield_args_under_i, under, 0, (VALUE)info);
++	return exec_under(yield_args_under_i, under, 0, info);
+     }
+ }
+ 
+@@ -12650,7 +12650,7 @@ rb_thread_initialize(thread, args)
+ 	rb_raise(rb_eThreadError, "already initialized thread - %s:%d",
+ 		 node->nd_file, nd_line(node));
+     }
+-    return rb_thread_start_0(rb_thread_yield, args, th);
++    return rb_thread_start_0(rb_thread_yield, (void *)args, th);
+ }
+ 
+ 
+@@ -12671,7 +12671,7 @@ rb_thread_start(klass, args)
+     if (!rb_block_given_p()) {
+ 	rb_raise(rb_eThreadError, "must be called with a block");
+     }
+-    return rb_thread_start_0(rb_thread_yield, args, rb_thread_alloc(klass));
++    return rb_thread_start_0(rb_thread_yield, (void *)args, rb_thread_alloc(klass));
+ }
+ 
+ 
+--- range.c.orig	2009-02-22 23:43:42
++++ range.c	2024-03-20 19:02:38
+@@ -390,7 +390,7 @@ range_step(argc, argv, range)
+ 	    }
+ 	    args[0] = INT2FIX(1);
+ 	    args[1] = step;
+-	    range_each_func(range, step_i, b, e, args);
++	    range_each_func(range, (void *)step_i, b, e, args);
+ 	}
+     }
+     return range;
+--- string.c.orig	2011-12-28 23:47:15
++++ string.c	2024-03-20 19:09:19
+@@ -1985,8 +1985,7 @@ get_arg_pat(pat, quote)
+ }
+ 
+ static VALUE
+-get_arg_pat(pat, quote)
+-     VALUE pat;
++get_arg_pat(VALUE pat)
+ {
+     return rb_rescue2(get_pat_quoted, pat,
+                       regcomp_failed, pat,
+--- ext/openssl/openssl_missing.h.orig	2010-05-25 09:58:49
++++ ext/openssl/openssl_missing.h	2024-03-20 19:22:17
+@@ -28,7 +28,7 @@ typedef int i2d_of_void();
+ 
+ #if !defined(PEM_read_bio_DSAPublicKey)
+ # define PEM_read_bio_DSAPublicKey(bp,x,cb,u) (DSA *)PEM_ASN1_read_bio( \
+-        (char *(*)())d2i_DSAPublicKey,PEM_STRING_DSA_PUBLIC,bp,(char **)x,cb,u)
++        (d2i_of_void *)d2i_DSAPublicKey,PEM_STRING_DSA_PUBLIC,bp,(char **)x,cb,u)
+ #endif
+ 
+ #if !defined(PEM_write_bio_DSAPublicKey)
+@@ -45,22 +45,22 @@ typedef int i2d_of_void();
+ 
+ #if !defined(DSAPublicKey_dup)
+ # define DSAPublicKey_dup(dsa) (DSA *)ASN1_dup((i2d_of_void *)i2d_DSAPublicKey, \
+-	(char *(*)())d2i_DSAPublicKey,(char *)dsa)
++	(d2i_of_void *)d2i_DSAPublicKey,(char *)dsa)
+ #endif
+ 
+ #if !defined(X509_REVOKED_dup)
+ # define X509_REVOKED_dup(rev) (X509_REVOKED *)ASN1_dup((i2d_of_void *)i2d_X509_REVOKED, \
+-	(char *(*)())d2i_X509_REVOKED, (char *)rev)
++	(d2i_of_void *)d2i_X509_REVOKED, (char *)rev)
+ #endif
+ 
+ #if !defined(PKCS7_SIGNER_INFO_dup)
+ #  define PKCS7_SIGNER_INFO_dup(si) (PKCS7_SIGNER_INFO *)ASN1_dup((i2d_of_void *)i2d_PKCS7_SIGNER_INFO, \
+-	(char *(*)())d2i_PKCS7_SIGNER_INFO, (char *)si)
++	(d2i_of_void *)d2i_PKCS7_SIGNER_INFO, (char *)si)
+ #endif
+ 
+ #if !defined(PKCS7_RECIP_INFO_dup)
+ #  define PKCS7_RECIP_INFO_dup(ri) (PKCS7_RECIP_INFO *)ASN1_dup((i2d_of_void *)i2d_PKCS7_RECIP_INFO, \
+-	(char *(*)())d2i_PKCS7_RECIP_INFO, (char *)ri)
++	(d2i_of_void *)d2i_PKCS7_RECIP_INFO, (char *)ri)
+ #endif
+ 
+ #if !defined(HAVE_EVP_MD_CTX_INIT)
+--- ext/openssl/ossl_ssl.c.orig	2012-02-08 17:09:40
++++ ext/openssl/ossl_ssl.c	2024-03-20 19:40:58
+@@ -95,7 +95,7 @@ struct {
+  */
+ struct {
+     const char *name;
+-    SSL_METHOD *(*func)(void);
++    const SSL_METHOD *(*func)(void);
+ } ossl_ssl_method_tab[] = {
+ #define OSSL_SSL_METHOD_ENTRY(name) { #name, name##_method }
+     OSSL_SSL_METHOD_ENTRY(TLSv1),


### PR DESCRIPTION
#### Description

These warnings have become errors as of Xcode 15.3.

###### Type(s)

- [x] bugfix

###### Tested on
macOS 14.4 23E214 x86_64
Xcode 15.3 15E204a
