### PR TITLE
libsecret: update to 0.20.5

### DIFF
--- a/gnome/libsecret/Portfile
+++ b/gnome/libsecret/Portfile
@@ -1,18 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem      1.0
-PortGroup       gobject_introspection 1.0
+PortGroup       meson 1.0
 
 name            libsecret
-version         0.20.4
-revision        1
+version         0.20.5
+revision        0
 set branch      [join [lrange [split ${version} .] 0 1] .]
 maintainers     nomaintainer
-categories      gnome
-platforms       darwin
+categories      gnome security
 license         LGPL-2.1
-description     libsecret is a library for storing and retrieving passwords and other secrets
-
+description     ${name} is a library for storing and retrieving passwords \
+                and other secrets
 long_description \
     libsecrets is a client for the Secret Service DBus API. The Secret \
     Service allows storage of passwords in a common way on the desktop. \
@@ -22,21 +21,23 @@ homepage        https://wiki.gnome.org/Projects/Libsecret
 master_sites    gnome:sources/${name}/${branch}/
 use_xz          yes
 
-checksums       rmd160  afecef24d1d40d8402edf93b3e53eae22d4aeb0f \
-                sha256  325a4c54db320c406711bf2b55e5cb5b6c29823426aa82596a907595abb39d28 \
-                size    529916
+checksums       rmd160  c67c3cd7de11fe5e5001e0bdb6cb653af88087d3 \
+                sha256  3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d \
+                size    187340
 
-depends_build   port:pkgconfig \
+depends_build-append \
                 port:docbook-xsl-nons \
+                port:gsed \
                 port:libxslt \
-                port:gsed
+                port:pkgconfig
 
-depends_lib     path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                path:bin/vala:vala \
-                port:libgcrypt
+depends_lib-append \
+                path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
+                port:libgcrypt \
+                path:bin/vala:vala
 
-gobject_introspection yes
-
-configure.args  --disable-silent-rules
+configure.args-append \
+                -Dgtk_doc=false
 
 livecheck.type  gnome

--- a/gnome/libsecret/Portfile
+++ b/gnome/libsecret/Portfile
@@ -6,18 +6,23 @@ PortGroup       meson 1.0
 name            libsecret
 version         0.20.5
 revision        0
-set branch      [join [lrange [split ${version} .] 0 1] .]
-maintainers     nomaintainer
+
 categories      gnome security
 license         LGPL-2.1
+maintainers     nomaintainer
+
 description     ${name} is a library for storing and retrieving passwords \
                 and other secrets
 long_description \
-    libsecrets is a client for the Secret Service DBus API. The Secret \
-    Service allows storage of passwords in a common way on the desktop. \
-    Supported by gnome-keyring and ksecretservice.
-
+                libsecret is a client for the Secret Service DBus API. The Secret \
+                Service allows storage of passwords in a common way on the desktop. \
+                Supported by gnome-keyring and ksecretservice.
 homepage        https://wiki.gnome.org/Projects/Libsecret
+
+# Disable unexpected download of subprojects
+meson.wrap_mode nodownload
+
+set branch      [join [lrange [split ${version} .] 0 1] .]
 master_sites    gnome:sources/${name}/${branch}/
 use_xz          yes
 
@@ -26,12 +31,15 @@ checksums       rmd160  c67c3cd7de11fe5e5001e0bdb6cb653af88087d3 \
                 size    187340
 
 depends_build-append \
+                port:docbook-xml \
                 port:docbook-xsl-nons \
+                port:gettext \
                 port:gsed \
                 port:libxslt \
                 port:pkgconfig
 
 depends_lib-append \
+                port:gettext-runtime \
                 path:lib/pkgconfig/glib-2.0.pc:glib2 \
                 path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                 port:libgcrypt \

--- a/gnome/libsecret/Portfile
+++ b/gnome/libsecret/Portfile
@@ -30,6 +30,9 @@ checksums       rmd160  c67c3cd7de11fe5e5001e0bdb6cb653af88087d3 \
                 sha256  3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d \
                 size    187340
 
+patchfiles-append \
+                patch-meson-dylib-versions.diff
+
 depends_build-append \
                 port:docbook-xml \
                 port:docbook-xsl-nons \

--- a/gnome/libsecret/files/patch-meson-dylib-versions.diff
+++ b/gnome/libsecret/files/patch-meson-dylib-versions.diff
@@ -1,0 +1,30 @@
+#==================================================================================================
+# Upstream patch for dylib versioning. Expected to be included in next release.
+#
+# Author: Christopher Nielsen @ MacPorts
+# Date:   2024-03-27
+#==================================================================================================
+--- libsecret/meson.build.orig	2024-03-27 11:40:43.718979837 -0400
++++ libsecret/meson.build	2024-03-27 11:48:57.308550988 -0400
+@@ -48,6 +48,13 @@
+ version_major = version_numbers[0].to_int()
+ version_minor = version_numbers[1].to_int()
+ version_micro = version_numbers[2].to_int()
++
++dylib_ver_compat = api_version
++dylib_ver_current = api_version
++#message('dylib_ver_compat: ', dylib_ver_compat)
++#message('dylib_ver_current: ', dylib_ver_current)
++dylib_ver_array = [dylib_ver_compat, dylib_ver_current]
++
+ version_h_conf = configuration_data({
+   'SECRET_MAJOR_VERSION': version_major,
+   'SECRET_MINOR_VERSION': version_minor,
+@@ -87,6 +94,7 @@
+ libsecret = library('secret-@0@'.format(api_version_major),
+   [ libsecret_sources, _dbus_generated, _enums_generated ],
+   version: libtool_version,
++  darwin_versions: dylib_ver_array,
+   dependencies: libsecret_dependencies,
+   link_with: libegg,
+   c_args: libsecret_cflags,


### PR DESCRIPTION
#### Description

This will require revbumping dependents.

@mascguy How should we do this? CI for revbumping will fail, since there are several WebKit versions etc.

UPD. Well, we could just do a follow-up revbump for all dependents then.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
