### PR TITLE
uv: Update to 0.1.23

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.1.22
+github.setup            astral-sh uv 0.1.23
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -17,9 +17,9 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for common pip and pip-tools workflows.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  9644bd8dd4b9ca68ce147a2b5329066dda41c3e5 \
-                        sha256  8b2f938e6b937e75aa15e2228720d8204d235b9c09cad6ba97d15f8f42d4c05e \
-                        size    873654
+                        rmd160  a3d0afc3ec40f87e5f73a16a57c037047f69d9ed \
+                        sha256  7a491529c2aef1b2243ffc221f716303b1ec5d55896c055fd7b35a44e6973661 \
+                        size    885317
 
 depends_build-append    port:pkgconfig
 depends_lib-append      port:libgit2
@@ -83,9 +83,12 @@ cargo.crates \
     async-channel                    2.2.0  f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3 \
     async-compression                0.4.6  a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c \
     async-recursion                  1.0.5  5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0 \
-    async-trait                     0.1.77  c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9 \
+    async-trait                     0.1.78  461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85 \
     async_http_range_reader          0.7.0  cf8eeab30c68da4dc2c51f3afc4327ab06fe0f3f028ca423f7ca398c7ed8c5e7 \
     autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
+    axoasset                         0.9.0  7dce2f189800bafe8322ef3a4d361ee7373bfc2f8fe052afda404230166dc45f \
+    axoprocess                       0.2.0  4de46920588aef95658797996130bacd542436aee090084646521260a74bda7d \
+    axoupdater                       0.3.1  51b3130c1f3911eecdb1caf0412160c62758e314b644377796eb64917539ba8c \
     backoff                          0.4.0  b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1 \
     backtrace                       0.3.69  2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837 \
     backtrace-ext                    0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
@@ -106,6 +109,7 @@ cargo.crates \
     byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytes                            1.5.0  a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223 \
     cachedir                         0.3.1  4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873 \
+    camino                           1.1.6  c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c \
     cargo-util                       0.2.9  74862c3c6e53a1c1f8f0178f9d38ab41e49746cd3a7cafc239b3d0248fd4e342 \
     cast                             0.3.0  37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5 \
     cc                              1.0.90  8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5 \
@@ -116,13 +120,13 @@ cargo.crates \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
-    clap                             4.5.2  b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651 \
+    clap                             4.5.3  949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813 \
     clap_builder                     4.5.2  ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4 \
     clap_complete                    4.5.1  885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c \
     clap_complete_command            0.5.1  183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d \
     clap_complete_fig                4.5.0  54b3e65f91fabdd23cac3d57d39d5d938b4daabd070c335c006dccb866a61110 \
     clap_complete_nushell           0.1.11  5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e \
-    clap_derive                      4.5.0  307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47 \
+    clap_derive                      4.5.3  90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f \
     clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
     cmake                           0.1.50  a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130 \
     color_quant                      1.1.0  3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b \
@@ -149,7 +153,6 @@ cargo.crates \
     data-url                         0.2.0  8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5 \
     deadpool                        0.10.0  fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490 \
     deadpool-runtime                 0.1.3  63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49 \
-    deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     derivative                       2.2.0  fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b \
     difflib                          0.4.0  6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8 \
     digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
@@ -202,10 +205,12 @@ cargo.crates \
     hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
     hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
     hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
+    homedir                          0.2.1  22074da8bba2ef26fc1737ae6c777b5baab5524c2dc403b5c6a76166766ccda5 \
     html-escape                     0.2.13  6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476 \
     http                            0.2.12  601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1 \
     http                             1.1.0  21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258 \
@@ -223,6 +228,7 @@ cargo.crates \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
     ignore                          0.4.22  b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1 \
+    image                           0.24.9  5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d \
     imagesize                       0.11.0  b72ad49b554c1728b1e83254a1b1565aea4161e28dabbfa171fc15fe62299caf \
     indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
     indexmap                         2.2.5  7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4 \
@@ -250,7 +256,6 @@ cargo.crates \
     libssh2-sys                      0.3.0  2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee \
     libz-ng-sys                     1.1.15  c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5 \
     libz-sys                        1.1.15  037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6 \
-    line-wrap                        0.1.1  f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9 \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
     lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
@@ -260,9 +265,12 @@ cargo.crates \
     memchr                           2.7.1  523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149 \
     memmap2                         0.5.10  83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327 \
     memmap2                          0.9.4  fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322 \
+    memoffset                        0.7.1  5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4 \
     memoffset                        0.9.0  5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c \
     miette                           6.0.1  337e1043bbc086dac9d9674983bef52ac991ce150e09b5b8e35c5a73dd83f66c \
+    miette                           7.2.0  4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1 \
     miette-derive                    6.0.1  71e622f2a0dd84cbca79bc6c3c33f4fd7dc69faf992216516aacc1d136102800 \
+    miette-derive                    7.2.0  dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c \
     mimalloc                        0.1.39  fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     mime_guess                       2.0.4  4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef \
@@ -270,11 +278,11 @@ cargo.crates \
     mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
     miow                             0.6.0  359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044 \
     nanoid                           0.4.0  3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8 \
+    nix                             0.26.4  598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b \
     nix                             0.28.0  ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4 \
     normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
     nu-ansi-term                    0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
     nu-ansi-term                    0.49.0  c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68 \
-    num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
     num-traits                      0.2.18  da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a \
     num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
@@ -305,11 +313,9 @@ cargo.crates \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     pkg-config                      0.3.30  d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec \
     platform-info                    2.0.2  d6259c4860e53bf665016f1b2f46a8859cadfa717581dc9d597ae4069de6300f \
-    plist                            1.6.0  e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef \
     png                            0.17.13  06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1 \
     poloto                          19.1.2  164dbd541c9832e92fa34452e9c2e98b515a548a3f8549fb2402fe1cd5e46b96 \
     portable-atomic                  1.6.0  7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0 \
-    powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
     ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
     predicates                       3.1.0  68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8 \
     predicates-core                  1.0.6  b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174 \
@@ -325,7 +331,6 @@ cargo.crates \
     pyo3-macros                     0.20.3  7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158 \
     pyo3-macros-backend             0.20.3  7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185 \
     pyproject-toml                  0.10.0  3b80f889b6d413c3f8963a2c7db03f95dd6e1d85e1074137cb2013ea2faa8898 \
-    quick-xml                       0.31.0  1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33 \
     quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
     quoted_printable                 0.5.0  79ec282e887b434b68c18fe5c121d38e72a5cf35119b59e54ec5b992ea9c8eb0 \
     radium                           0.7.0  dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09 \
@@ -370,7 +375,6 @@ cargo.crates \
     rustls-webpki                  0.101.7  8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765 \
     rustybuzz                        0.7.0  162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a \
     ryu                             1.0.17  e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1 \
-    safemem                          0.3.3  ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.23  fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
@@ -418,6 +422,7 @@ cargo.crates \
     tap                              1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
     target-lexicon                 0.12.14  e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f \
     task-local-extensions            0.1.4  ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8 \
+    temp-dir                        0.1.12  dd16aa9ffe15fe021c6ee3766772132c6e98dfa395a167e16864f61a9cfb71d6 \
     tempfile                        3.10.1  85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1 \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
     termtree                         0.4.1  3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76 \
@@ -431,9 +436,6 @@ cargo.crates \
     thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
     tikv-jemalloc-sys  0.5.4+5.3.0-patched  9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1 \
     tikv-jemallocator                0.5.4  965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca \
-    time                            0.3.34  c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749 \
-    time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
-    time-macros                     0.2.17  7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774 \
     tiny-skia                        0.8.4  df8493a203431061e901613751931f047d1971337153f96d0e5e363d6dbf6a67 \
     tiny-skia-path                   0.8.4  adbfb5d3f3dd57a0e11d12f4f13d4ebbbc1b5c15b7ab0a156d030b21da5f677c \
     tinytemplate                     1.2.1  be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc \
@@ -446,9 +448,9 @@ cargo.crates \
     tokio-stream                    0.1.14  397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842 \
     tokio-tar                        0.3.1  9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75 \
     tokio-util                      0.7.10  5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15 \
-    toml                            0.8.11  af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e \
+    toml                            0.8.12  e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3 \
     toml_datetime                    0.6.5  3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1 \
-    toml_edit                       0.22.7  18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992 \
+    toml_edit                       0.22.8  c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd \
     tower-service                    0.3.2  b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52 \
     tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
     tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
@@ -505,13 +507,17 @@ cargo.crates \
     webpki-roots                    0.25.4  5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1 \
     weezl                            0.1.8  53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082 \
     which                            6.0.0  7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c \
+    widestring                       1.0.2  653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-util                      0.1.6  f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
+    windows                         0.52.0  e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be \
     windows                         0.54.0  9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49 \
     windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
     windows-core                    0.54.0  12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65 \
+    windows-implement               0.52.0  12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946 \
+    windows-interface               0.52.0  9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1 \
     windows-result                   0.1.0  cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
     windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
@@ -534,6 +540,7 @@ cargo.crates \
     winnow                           0.6.5  dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8 \
     winreg                          0.50.0  524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1 \
     wiremock                         0.6.0  ec874e1eef0df2dcac546057fe5e29186f09c378181cd7b635b4b7bcc98e9d81 \
+    wmi                             0.13.3  fc2f0a4062ca522aad4705a2948fd4061b3857537990202a8ddd5af21607f79a \
     wyz                              0.5.1  05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed \
     xattr                            1.3.1  8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f \
     xmlparser                       0.13.6  66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4 \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.1.23. [Changelog](https://github.com/astral-sh/uv/releases/tag/0.1.23).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
