### PR TITLE
gl-headers: New Portfile

### DIFF
--- a/devel/gl-headers/Portfile
+++ b/devel/gl-headers/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           gitlab 1.0
+PortGroup           meson 1.0
+
+gitlab.setup        meson-ports gl-headers 5c8c7c0d
+gitlab.instance     https://gitlab.freedesktop.org/gstreamer
+version             2019.1.0
+revision            0
+
+categories          devel
+maintainers         nomaintainer
+license             LGPL-2+
+platforms           any
+supported_archs     noarch
+
+description         OpenGL headers for building GStreamer's OpenGL support
+long_description    {*}${description}
+
+checksums  \
+    rmd160  63be03f0bceab33498938835065961358906ce96 \
+    sha256  b9669d7fa9e3ab21b42f7277ca3d49ddfd2226ae72a3af85131da8f37b843d4c \
+    size    83645
+
+configure.args \
+    -Dglext=enabled \
+    -Dwglext=enabled


### PR DESCRIPTION
#### Description

A GStreamer dependency as of 
[1.19.3](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/13ff7f43ec18128ec1dc8abeeae57d236e70a3a0), without this the meson will use the included wrap. Falling back to the wrap could cause issues for older systems.

Version taken from [gl-headers/meson.build](https://gitlab.freedesktop.org/gstreamer/meson-ports/gl-headers/-/blob/master/meson.build?ref_type=heads), commit used was taken from [gl-headers.wrap](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/subprojects/gl-headers.wrap?ref_type=heads)

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4 23E214 x86_64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->