### PR TITLE
auto-multiple-choice-devel : update to version 1.6.0-git20240317102301

### DIFF
--- a/x11/auto-multiple-choice/Portfile
+++ b/x11/auto-multiple-choice/Portfile
@@ -41,12 +41,12 @@ if {${subport} eq ${name}} {
 } else {
     # devel
     set amc.version.main        1.6.0
-    set amc.version.secondary   20231107111512
+    set amc.version.secondary   20240317102301
     set amc.version         ${amc.version.main}+git${amc.version.secondary}
     version                 ${amc.version.main}-git${amc.version.secondary}
-    checksums               rmd160  a0d5c18e30307321261bb63b9da97f104cd999d0 \
-                            sha256  ef3e7101457bbd4e0b600fd72c839be65ac80bc1e75b921fb16dc48d642dcf3f \
-                            size    14660991
+    checksums               rmd160  718b9e95615a49b07aa42a3d7ba5af387ead1b7c \
+                            sha256  143a05d354d5c7a68ae9dc78e7d3344336e48d524251c5130e96bf69cc9314e2 \
+                            size    15155724
 
     conflicts               auto-multiple-choice
 }


### PR DESCRIPTION
auto-multiple-choice-devel : update to version 1.6.0-git20240317102301

Multiple improvements.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4 23E214 arm64
Xcode 15.3 15E204a
MacPorts 2.9.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
