### PR TITLE
ipsw: Update to 3.1.461

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -3,12 +3,12 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/blacktop/ipsw 3.1.456 v
+go.setup                github.com/blacktop/ipsw 3.1.461 v
 github.tarball_from     archive
 revision                0
 categories              security devel
 license                 MIT
-platforms               {darwin >= 11}
+platforms               {darwin >= 17}
 installs_libs           no
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
@@ -16,9 +16,9 @@ description             iOS/macOS Research Swiss Army Knife
 long_description        {*}${description}. Everything you need to start \
                         researching Apple security and internals.
 
-checksums               rmd160  4080714c4c112f4a959f0bd470e230eae8cf0fda \
-                        sha256  0e5a54d8e526186d8b904d1cdaec5930c6f92d89497754bb1aaefac43014bc58 \
-                        size    4028544
+checksums               rmd160  147979bad0e97e464cf7c3b4ffaea9210cd51b6c \
+                        sha256  07046f136abc08c7e10c9645f78bc0e1895ede941660fa6b04c258972a5c9530 \
+                        size    4048865
 
 patch.pre_args          -p1
 patchfiles              reproducible-build.diff


### PR DESCRIPTION
#### Description

Update `ipsw` to its latest released version, 3.1.461.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
