### PR TITLE
libomp: grab ompx.h from temporary install loc.

### DIFF
--- a/lang/libomp/Portfile
+++ b/lang/libomp/Portfile
@@ -139,7 +139,7 @@ if {${os.major} <= 10} {
     set hnames              {omp.h}
     configure.args-append   -DLIBOMP_OMPT_SUPPORT=FALSE
 } else {
-    set hnames              {omp-tools.h omp.h ompt.h}
+    set hnames              {omp-tools.h omp.h ompt.h ompx.h}
 }
 
 variant top_level description \


### PR DESCRIPTION
Fixes https://trac.macports.org/ticket/69557