### PR TITLE
gjs-devel: Update to 1.80.1

### DIFF
--- a/gnome/gjs-devel/Portfile
+++ b/gnome/gjs-devel/Portfile
@@ -6,12 +6,12 @@ PortGroup           gobject_introspection 1.0
 PortGroup           gitlab 1.0
 
 gitlab.instance     https://gitlab.gnome.org
-gitlab.setup        GNOME gjs 1.78.4
+gitlab.setup        GNOME gjs 1.80.1
 revision            0
 
-checksums           rmd160  dad53f8fad8ea45ec1077f31c1d4449bbbae68fe \
-                    sha256  dc635cb481047dbdee3395f3ff3ac121e8449d5fce71682ad0a21df503237a3b \
-                    size    691601
+checksums           rmd160  151d8cba3eb10450c1871f4a6caa6efb007c2f65 \
+                    sha256  c14f0ac52a29686dc2b5bcece91124c0df0198098d72e200cb39be36ebe8e678 \
+                    size    703487
 
 name                gjs-devel
 conflicts           gjs


### PR DESCRIPTION
#### Description

* Update to 1.80.1.
* Avoids typedef problem in 1.79.3 through 1.80.0, was fixed upstream.

Closes https://trac.macports.org/ticket/69549

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  Mac OS 11, 12, 13, 14.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?