### PR TITLE
kitty: Fix build error with Clang 15

### DIFF
--- a/aqua/kitty/Portfile
+++ b/aqua/kitty/Portfile
@@ -9,7 +9,7 @@ PortGroup           python 1.0
 # correctly again.
 github.setup        kovidgoyal kitty 0.33.0 v
 github.tarball_from releases
-revision            0
+revision            1
 
 categories          aqua
 platforms           macosx
@@ -45,6 +45,7 @@ if {${os.major} <= 15} {
 }
 
 patchfiles-append   patch-kitty-no-deprecated-declarations.diff
+patchfiles-append   patch-kitty-incorrect-prefix-in-arm-neon-vshrn-intrinsic.diff
 
 python.default_version \
                     311

--- a/aqua/kitty/files/patch-kitty-incorrect-prefix-in-arm-neon-vshrn-intrinsic.diff
+++ b/aqua/kitty/files/patch-kitty-incorrect-prefix-in-arm-neon-vshrn-intrinsic.diff
@@ -1,0 +1,25 @@
+Fix incorrect prefix in Arm NEON shift right narrow intrinsic
+
+Fixes build error caused by 'simde_vshrn_n_u16()' being seen as
+undeclared in Clang 15, where the -Wimplicit-function-declaration
+warning diagnostic defaults to an error in C99 and later.
+---
+ kitty/simd-string-impl.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kitty/simd-string-impl.h b/kitty/simd-string-impl.h
+index 3bbf95a15..6f9473a38 100644
+--- kitty/simd-string-impl.h
++++ kitty/simd-string-impl.h
+@@ -241,7 +241,7 @@ static inline integer_t shuffle_impl256(const integer_t value, const integer_t s
+ 
+ static inline uint64_t
+ movemask_arm128(const simde__m128i vec) {
+-    simde_uint8x8_t res = simde_vshrn_n_u16(simde_vreinterpretq_u16_u8((simde_uint8x16_t)vec), 4);
++    simde_uint8x8_t res = vshrn_n_u16(simde_vreinterpretq_u16_u8((simde_uint8x16_t)vec), 4);
+     return simde_vget_lane_u64(simde_vreinterpret_u64_u8(res), 0);
+ }
+ 
+-- 
+2.44.0
+


### PR DESCRIPTION
#### Description

Building Kitty on MacOS 14.4 with Xcode 15 fails in error due to implicit function declaration. The error caused by the [vshrn_n_u16](https://developer.arm.com/architectures/instruction-sets/intrinsics/vshrn_n_u16) ARM NEON intrinsic having an incorrect `simde_ `prefix in [kitty/simd-string-impl.h](https://github.com/kovidgoyal/kitty/blob/a0aba4da4a338585c4e6f3d1abba9d53a1efafd4/kitty/simd-string-impl.h#L244) causing simde_vshrn_n_u16() to be seen as an undeclared function in Clang 15, where the `-Wimplicit-function-declaration` warning diagnostic defaults to an error in C99 and later:

```
In file included from kitty/simd-string-128.c:9:
kitty/simd-string-impl.h:244:27: error: call to undeclared function 'simde_vshrn_n_u16'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    simde_uint8x8_t res = simde_vshrn_n_u16(simde_vreinterpretq_u16_u8((simde_uint8x16_t)vec), 4);
                           ^
kitty/simd-string-impl.h:244:21: error: initializing 'simde_uint8x8_t' (aka 'uint8x8_t') with an expression of incompatible type 'int'
     simde_uint8x8_t res = simde_vshrn_n_u16(simde_vreinterpretq_u16_u8((simde_uint8x16_t)vec), 4);
                     ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2 errors generated.
```
This change patches the port with the correct intrinsic name to allow it to build with Xcode 15.

Fixes [#69513](https://trac.macports.org/ticket/69513)
Upstream issue: kovidgoyal/kitty#7252 

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
   - Unable to run with trace-mode due to [#66356](https://trac.macports.org/ticket/66358)
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
