### PR TITLE
micronaut: update to 4.3.7

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.3.6 v
+github.setup    micronaut-projects micronaut-starter 4.3.7 v
 revision        0
 name            micronaut
 categories      java
@@ -14,18 +14,21 @@ supported_archs x86_64
 universal_variant no
 
 description     Micronaut is a modern, JVM-based, full-stack framework \
-                for building modular, easily testable microservice and serverless applications.
+                for building modular, easily testable microservice and \
+                serverless applications.
 
-long_description Micronaut is a modern, JVM-based, full stack Java framework designed for \
-                building modular, easily testable JVM applications with support for Java, \
-                Kotlin and the Groovy language. \
+long_description Micronaut is a modern, JVM-based, full stack Java framework \
+                designed for building modular, easily testable JVM \
+                applications with support for Java, Kotlin and the Groovy \
+                language. \
                 \n\
-                \nMicronaut is developed by the creators of the Grails framework and takes \
-                inspiration from lessons learnt over the years building real-world applications \
-                from monoliths to microservices using Spring, Spring Boot and Grails. \
+                \nMicronaut is developed by the creators of the Grails \
+                framework and takes inspiration from lessons learnt over the \
+                years building real-world applications from monoliths to \
+                microservices using Spring, Spring Boot and Grails. \
                 \n\
-                \nMicronaut aims to provide all the tools necessary to build microservice \
-                applications including: \
+                \nMicronaut aims to provide all the tools necessary to build \
+                microservice applications including: \
                 \n\
                 \n* Dependency Injection and Inversion of Control (IoC) \
                 \n* Aspect Oriented Programming (AOP) \
@@ -39,8 +42,8 @@ long_description Micronaut is a modern, JVM-based, full stack Java framework des
                 \n* HTTP Routing \
                 \n* Client-Side Load Balancing \
                 \n\
-                \nAt the same time Micronaut aims to avoid the downsides of frameworks like Spring, \
-                Spring Boot and Grails by providing: \
+                \nAt the same time Micronaut aims to avoid the downsides of \
+                frameworks like Spring, Spring Boot and Grails by providing: \
                 \n\
                 \n* Fast startup time \
                 \n* Reduced memory footprint \
@@ -53,9 +56,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  2daf682cb13514ae9e4d0a1b78a1328a58278cf8 \
-                sha256  817cc0fd024b420898646bde59e05e35651e966c8d3ddb26f3a05c5ae57de7e4 \
-                size    22294722
+checksums       rmd160  a84bd1459958c83d3e34a78cf71035df0c683f7c \
+                sha256  a8cc49e09cb665f911efbf337d2cab3d876d1ba81a9a55de70d2410d9165f3e7 \
+                size    22918804
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.3.7, and limit lines in Portfile to 80 columns where possible.

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?