### PR TITLE
fpc: fix for 10.8 and enable i386 (https://trac.macports.org/ticket/69315)

### DIFF
--- a/lang/fpc/Portfile
+++ b/lang/fpc/Portfile
@@ -21,25 +21,22 @@ long_description    Free Pascal is a 32, 64 and 16 bit professional Pascal \
                     and Android.
 homepage            https://www.freepascal.org
 
-# TODO: add support for i386
-supported_archs     x86_64 arm64 ppc ppc64
-
 # Bootstrap compiler version
 set boot_v          3.0.4
 
 master_sites        sourceforge:freepascal:main \
                     https://downloads.freepascal.org/fpc/dist/${boot_v}/bootstrap/:bootstrap \
                     https://downloads.freepascal.org/fpc/dist/${boot_v}/powerpc-macosx/:bootstrap \
-                    https://downloads.freepascal.org/fpc/dist/${version}/i386-macosx/:bootstrap
+                    https://downloads.freepascal.org/fpc/dist/${boot_v}/i386-macosx/:bootstrap
 
 set src             ${name}build-${version}.tar.gz
 checksums           ${src} \
                     rmd160  3106b4aff1adc4cd08dfdd39cc3ef4e800888255 \
                     sha256  85ef993043bb83f999e2212f1bca766eb71f6f973d362e2290475dbaaf50161f \
                     size    84195619
-# PowerPC compiler is only available as a dmg
+# PowerPC bootstrap compiler is only available as a dmg
 if {${configure.build_arch} in [list ppc ppc64]} {
-    set pp          fpc-${boot_v}.powerpc-macosx.dmg
+    set pp          ${name}-${boot_v}.powerpc-macosx.dmg
     checksums-append \
                     ${pp} \
                     rmd160  c1dbe7fb71382a69146023b2cdac768e05fea8e3 \
@@ -47,12 +44,12 @@ if {${configure.build_arch} in [list ppc ppc64]} {
                     size    98748823
 # MacOSX < 10.8 requires bootstrap compiler from dmg
 } elseif {${os.platform} eq "darwin" && ${os.major} <= 12} { # 10.8, Mountain Lion
-    set pp          fpc-${version}.intelarm64-macosx.dmg
+    set pp          ${name}-${boot_v}a.intel-macosx.dmg
     checksums-append \
                     ${pp} \
-                    rmd160  600bc2e86e450bba748f3fa54939fb96db0eee41 \
-                    sha256  05d4510c8c887e3c68de20272abf62171aa5b2ef1eba6bce25e4c0bc41ba8b7d \
-                    size    274206896
+                    rmd160  1b838335467c0ab31f856031139e25954602b1ad \
+                    sha256  56b870fbce8dc9b098ecff3c585f366ad3e156ca32a6bf3b20091accfb252616 \
+                    size    108371671
 
 } else {
     set pp          x86_64-macosx-10.9-ppcx64.tar.bz2
@@ -145,6 +142,15 @@ subport "${name}-cross" {
         }
         arm64 {
             build.target-delete aarch64 i386 i8086
+        }
+        i386 {
+            build.target-delete i386
+        }
+        ppc {
+            build.target-delete powerpc i386 i8086
+        }
+        ppc64 {
+            build.target-delete powerpc64 i386 i8086
         }
     }
     destroot {
@@ -292,18 +298,19 @@ if {${subport} eq "${name}"} {
     } elseif {${os.platform} eq "darwin" \
               && ${os.major} <= 12} { # 10.8, Mountain Lion
         post-extract {
+            depends_extract port:xar
+            set packagename ${name}-${boot_v}a.intel-macosx.pkg
             xinstall -d ${workpath}/tmp/boot
             system "hdiutil attach ${distpath}/${pp} -private -nobrowse \
                     -mountpoint ${workpath}/tmp/boot"
-            copy ${workpath}/tmp/boot/${name}-${version}-intelarm64-macosx.mpkg \
-                    ${workpath}/pkg
+            xinstall -d ${workpath}/pkg
+            system -W ${workpath} "${prefix}/bin/xar -xf \
+                    ${workpath}/tmp/boot/${packagename} -C ${workpath}/pkg"
             system "hdiutil detach ${workpath}/tmp/boot -force"
             delete -force ${workpath}/tmp
-            system -W ${workpath} "pkgutil --expand \
-                    pkg/Contents/Packages/${name}-${version}-intelarm64-macosx.pkg \
-                    content"
-            system -W ${workpath}/content "gzip -dc Payload | cpio -id"
-            copy ${workpath}/content/usr/local/lib/${name}/${version}/${bootstrapCompiler} \
+            set packagepath ${workpath}/pkg/${packagename}
+            system -W ${packagepath} "gzip -dc Payload | cpio -id"
+            copy ${packagepath}/usr/local/lib/${name}/${boot_v}/${bootstrapCompiler} \
                     ${workpath}
         }
     } else {
@@ -329,6 +336,11 @@ if {${subport} eq "${name}"} {
             set bootstrapCompiler ppcx64
             set cpuTarget aarch64
             set compiler ppca64
+        }
+        i386 {
+            set bootstrapCompiler ppc386
+            set cpuTarget i386
+            set compiler ppc386
         }
         ppc {
             set bootstrapCompiler ppcppc


### PR DESCRIPTION
#### Description

fpc: fix for 10.8 and enable i386

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -→
  However, not sure, whether this ticket is fixed. Waiting for comments/checks from barracuda156
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
