### PR TITLE
Octave: fix build on PowerPC systems

### DIFF
--- a/_resources/port1.0/group/octave-1.0.tcl
+++ b/_resources/port1.0/group/octave-1.0.tcl
@@ -226,17 +226,20 @@ pre-destroot {
 
     destroot.pre_args -q -f -H --eval
 
-    if { ${os.arch} eq "i386" } {
-        if { ${os.major} >= 9 && ![catch {sysctl hw.cpu64bit_capable} result] && $result == 1 } {
-            set short_host_name x86_64-apple-${os.platform}${os.major}.x.x
-        } else {
-            set short_host_name i686-apple-${os.platform}${os.major}.x.x
-        }
-    } else {
-        if { ${os.major} >= 9 && ![catch {sysctl hw.cpu64bit_capable} result] && $result == 1 } {
-            set short_host_name powerpc64-apple-${os.platform}${os.major}.x.x
-        } else {
+    platform darwin {
+        # Keep ppc before i386, so that Rosetta builds for ppc.
+        # Also, use build_arch and not sysctl:
+        # https://trac.macports.org/ticket/69573
+        if { ${configure.build_arch} eq "ppc" } {
             set short_host_name powerpc-apple-${os.platform}${os.major}.x.x
+        } elseif { ${configure.build_arch} eq "ppc64" } {
+            set short_host_name powerpc64-apple-${os.platform}${os.major}.x.x
+        } elseif { ${os.arch} eq "i386" } {
+            if { ${os.major} >= 9 && [sysctl hw.cpu64bit_capable] == 1 } {
+                set short_host_name x86_64-apple-${os.platform}${os.major}.x.x
+            } else {
+                set short_host_name i686-apple-${os.platform}${os.major}.x.x
+            }
         }
     }
 

--- a/_resources/port1.0/group/octave-1.0.tcl
+++ b/_resources/port1.0/group/octave-1.0.tcl
@@ -230,7 +230,9 @@ pre-destroot {
         # Keep ppc before i386, so that Rosetta builds for ppc.
         # Also, use build_arch and not sysctl:
         # https://trac.macports.org/ticket/69573
-        if { ${configure.build_arch} eq "ppc" } {
+        if { ${configure.build_arch} eq "arm64" } {
+            set short_host_name aarch64-apple-${os.platform}${os.major}.x.x
+        } elseif { ${configure.build_arch} eq "ppc" } {
             set short_host_name powerpc-apple-${os.platform}${os.major}.x.x
         } elseif { ${configure.build_arch} eq "ppc64" } {
             set short_host_name powerpc64-apple-${os.platform}${os.major}.x.x

--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -337,9 +337,11 @@ depends_lib-append  port:hdf5
 #    fatal error: 'mpi.h' file not found
 # see https://github.com/macports/macports-ports/pull/1865
 #    for a discussion
-foreach mpi {mpich mpich_devel openmpi openmpi_devel} {
-    require_active_variants hdf5 "" ${mpi}
-}
+# UPD. 2024.03. No longer an issue, apparently:
+# https://trac.macports.org/ticket/69574
+# foreach mpi {mpich mpich_devel openmpi openmpi_devel} {
+#     require_active_variants hdf5 "" ${mpi}
+# }
 
 #--disable-fftw-threads
 #--without-fftw3

--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 PortGroup           compilers  1.0
 PortGroup           muniversal 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           legacysupport 1.1
 PortGroup           linear_algebra 1.0
 
 name                octave
@@ -72,6 +73,22 @@ post-patch {
     reinplace \
         "s|__MACPORTS_JAVA_VERSION__|${java_version}|g" \
         ${worksrcpath}/Makefile.in
+}
+
+# https://trac.macports.org/ticket/69575
+legacysupport.redirect_bins mkoctfile-${version} octave-${version} octave-cli-${version} octave-config-${version}
+
+if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libc++"} {
+    # Patch the script which runs at destroot:
+    patchfiles-append patch-run-octave-libstdcpp.diff
+
+    # Patch scripts installed by LegacySupport so that they call correct binaries.
+    post-activate {
+        foreach obin {mkoctfile octave octave-cli octave-config} {
+            reinplace "s|\"\${0}-orig\"|$obin-${version}-orig|" \
+                ${prefix}/bin/${obin}-${version}
+        }
+    }
 }
 
 post-patch {

--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -79,7 +79,9 @@ post-patch {
         # Keep ppc before i386, so that Rosetta builds for ppc.
         # Also, use build_arch and not sysctl:
         # https://trac.macports.org/ticket/69573
-        if { ${configure.build_arch} eq "ppc" } {
+        if { ${configure.build_arch} eq "arm64" } {
+            set short_host_name aarch64-apple-${os.platform}${os.major}.x.x
+        } elseif { ${configure.build_arch} eq "ppc" } {
             set short_host_name powerpc-apple-${os.platform}${os.major}.x.x
         } elseif { ${configure.build_arch} eq "ppc64" } {
             set short_host_name powerpc64-apple-${os.platform}${os.major}.x.x

--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -38,7 +38,8 @@ patchfiles-append patch-better_error.diff
 
 # bsdtar and tar have different outputs
 # starting in Mac OS X Snow Leopard (10.6), tar is an alias of bsdtar
-if { ${os.platform} eq "darwin" && ${os.major} >= 10 } {
+# this patch breaks packages builds on 10.6 ppc, so exclude it there
+if { ${os.platform} eq "darwin" && ${os.major} >= 10 && ${os.arch} ne "powerpc" } {
     patchfiles-append patch-bsdtar.diff
 }
 

--- a/math/octave/Portfile
+++ b/math/octave/Portfile
@@ -74,17 +74,20 @@ post-patch {
 }
 
 post-patch {
-    if { ${os.arch} eq "i386" } {
-        if { ${os.platform} eq "darwin" && ${os.major} >= 9 && [sysctl hw.cpu64bit_capable] == 1 } {
-            set short_host_name x86_64-apple-${os.platform}${os.major}.x.x
-        } else {
-            set short_host_name i686-apple-${os.platform}${os.major}.x.x
-        }
-    } else {
-        if { ${os.platform} eq "darwin" && ${os.major} >= 9 && [sysctl hw.cpu64bit_capable] == 1 } {
-            set short_host_name powerpc64-apple-${os.platform}${os.major}.x.x
-        } else {
+    platform darwin {
+        # Keep ppc before i386, so that Rosetta builds for ppc.
+        # Also, use build_arch and not sysctl:
+        # https://trac.macports.org/ticket/69573
+        if { ${configure.build_arch} eq "ppc" } {
             set short_host_name powerpc-apple-${os.platform}${os.major}.x.x
+        } elseif { ${configure.build_arch} eq "ppc64" } {
+            set short_host_name powerpc64-apple-${os.platform}${os.major}.x.x
+        } elseif { ${os.arch} eq "i386" } {
+            if { ${os.major} >= 9 && [sysctl hw.cpu64bit_capable] == 1 } {
+                set short_host_name x86_64-apple-${os.platform}${os.major}.x.x
+            } else {
+                set short_host_name i686-apple-${os.platform}${os.major}.x.x
+            }
         }
     }
     reinplace \

--- a/math/octave/files/patch-run-octave-libstdcpp.diff
+++ b/math/octave/files/patch-run-octave-libstdcpp.diff
@@ -1,0 +1,16 @@
+--- run-octave.in	2024-03-13 02:00:23.000000000 +0800
++++ run-octave.in	2024-03-23 11:58:26.000000000 +0800
+@@ -134,6 +134,13 @@
+   export ASAN_OPTIONS
+ fi
+ 
++if [ -n "$DYLD_LIBRARY_PATH" ]; then
++   DYLD_LIBRARY_PATH=/opt/local/lib/libgcc:${DYLD_LIBRARY_PATH}
++else
++   DYLD_LIBRARY_PATH=/opt/local/lib/libgcc
++fi
++export DYLD_LIBRARY_PATH
++
+ exec $builddir/libtool --mode=execute $driver \
+   "$octave_executable" --no-init-path --path="$LOADPATH" \
+   --image-path="$IMAGEPATH" --doc-cache-file="$DOCFILE" \


### PR DESCRIPTION
#### Description

This PR fixes Octave 9.1.0 for PowerPC.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
