### PR TITLE
GPXSee: update to 13.18

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.17
+github.setup        tumic0 GPXSee 13.18
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  00bde6cf4feddf5c7c3d89a2de810c03aaaba6ba \
-                    sha256  047e2d7a22b383b8dc95211ab613e1f5bfae15c6ab915ab9ad3690ab0b924d59 \
-                    size    5570886
+checksums           rmd160  30fe9d1829db1e51acbd8741220fe49032e8a3ba \
+                    sha256  d80d77a271c5ac1857f87c7f5be2c7c1264b7c35a8f4e8f21e225c2b14e3b7da \
+                    size    5577442
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
