### PR TITLE
SuiteSparse: update to 7.6.1

### DIFF
--- a/math/SuiteSparse/Portfile
+++ b/math/SuiteSparse/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                DrTimothyAldenDavis SuiteSparse 7.6.0 v
+github.setup                DrTimothyAldenDavis SuiteSparse 7.6.1 v
 # subports have independent revisions
 revision                    0
 epoch                       20200517
@@ -17,9 +17,9 @@ long_description            SuiteSparse is a single archive that contains all pa
 
 homepage                    https://people.engr.tamu.edu/davis/suitesparse.html
 
-checksums                   rmd160  76a21ff5cc4458b60c40c8a59c530f75c3c9aa57 \
-                            sha256  3178af2e5d2fa58fde129ab6fffccecdc380dee79cd7e8e3de05577cd5119cfd \
-                            size    85512801
+checksums                   rmd160  467704e4663293361b6f5314662b73f6c57ded98 \
+                            sha256  69d5f4b5729d36532349f88e17550f72d2d1814c524385dafbecb6fcdb00cb33 \
+                            size    85515484
 
 configure.optflags          -O3
 
@@ -43,7 +43,7 @@ compiler.log_verbose_output no
 subport SuiteSparse_config {
     PortGroup               linear_algebra 1.0
 
-    version                 7.6.0
+    version                 7.6.1
     revision                0
     # from the README.txt:
     #    "[n]o licensing restrictions apply"
@@ -57,7 +57,7 @@ subport SuiteSparse_config {
 }
 
 subport SuiteSparse_GraphBLAS {
-    version                 9.0.1
+    version                 9.0.3
     revision                0
     license                 Apache-2
     long_description-append ${subport}: graph algorithms in the language of linear algebra.


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
