### PR TITLE
py-svgpath: new port

### DIFF
--- a/python/py-svgpath/Portfile
+++ b/python/py-svgpath/Portfile
@@ -1,0 +1,25 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-svgpath
+python.rootname     svg.path
+version             6.3
+revision            0
+
+checksums           rmd160  bb83fad1fc8bd5132bf3fbf352cea2666c63d686 \
+                    sha256  e937740a316a7fec86acd217ab6226e112f51328078524126bb7ea9dbe7b1ade \
+                    size    20920
+
+maintainers         {@flyingsamson tuxcad.de:flyingsamson} openmaintainer
+description         SVG path objects and parser
+long_description    svg.path is a collection of objects that implement the different path \
+                    commands in SVG, and a parser for SVG path definitions.
+license             MIT
+supported_archs     noarch
+platforms           {darwin any}
+
+homepage            https://github.com/regebro/svg.path
+
+python.versions     38 39 310 311 312


### PR DESCRIPTION
#### Description

This adds the python package `svg.path` which offers functionality to parse, manipulate, and work with SVG path objects.

###### Tested on
macOS 13.6.4 22G513 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
