### PR TITLE
libimobiledevice-glue-devel: Update to latest commit

### DIFF
--- a/devel/libimobiledevice-glue/Portfile
+++ b/devel/libimobiledevice-glue/Portfile
@@ -34,15 +34,15 @@ depends_lib-append  port:libplist
 configure.args      --disable-silent-rules
 
 subport libimobiledevice-glue-devel {
-    github.setup    libimobiledevice libimobiledevice-glue 214bafdde6a1434ead87357afe6cb41b32318495
-    version         20230512
+    github.setup    libimobiledevice libimobiledevice-glue fde8946a3988790fd5d3f01fc0a1fd43609ab1d1
+    version         20240322
     revision        0
 
-    checksums       rmd160  ec1dc6bbed16a63917a4053ecaae4d2ecb98d932 \
-                    sha256  6be77b9b51a07fc89d41b29e2e65ada1bab72a7c9a0bebeb279030167decef4e \
-                    size    43281
+    checksums       rmd160  0ac2dffb1ace947a4fe832e011588e72d41064e9 \
+                    sha256  a0b78f08937b3a70b96975cd43de11be1e69895f7c8b2cd9bc4de89872547673 \
+                    size    52948
 
-    conflicts       libimobiledeviceglue
+    conflicts       libimobiledevice-glue
 
     depends_build-append \
                     port:autoconf \


### PR DESCRIPTION
#### Description

Update the devel subport of `libimobiledevice-glue` to its latest pushed commit. The devel subport correctly conflicts with the normal port.

Sidenote: MacPorts might want to reconsider re-caching the release tarball for `libimobiledevice-glue`, as there was [a bug that made the port fail to build on OS X 10.8 and below to 10.6](https://github.com/libimobiledevice/libimobiledevice-glue/issues/42). This can also be done if rightful to update the `revision` field.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
