### PR TITLE
symfony-cli: update to 5.8.14

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.12
+version             5.8.14
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  e6a363d2254bccd2175d342318912569aae6d377 \
-                        sha256  13a8b37bc48d49093f5b2e3658e168d0329797f93d63e3d0fab1693085d00b43 \
-                        size    265603
+    checksums           rmd160  4ad1642952701b622a717a84cacb74e1095f679a \
+                        sha256  63aa26a1cec91ca48d0039c1bd4ab02fcb97f68da9690eca831b91180d3cb407 \
+                        size    267354
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  66c30037f04b136957d5c356604b17c31e6d3f7a \
-                        sha256  eaf147e18e6f3b7ccede5c2397f2b6aba346f0e1eeca2489eef85ff3828f6b0e \
-                        size    11100371
+    checksums           rmd160  9143817f0c9e606b7e63b1edba5a928f1b670079 \
+                        sha256  334e74892cb0c995eb889c9c7901d316d30b5154f51931fe313cc50e5d1a9b19 \
+                        size    11382834
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.14

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
