### PR TITLE
libdeflate: fix build on older systems

### DIFF
--- a/archivers/libdeflate/Portfile
+++ b/archivers/libdeflate/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           cmake           1.1
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github          1.0
 PortGroup           legacysupport   1.1
 
@@ -23,11 +24,17 @@ long_description    libdeflate is a library for fast, whole-buffer \
                     It is heavily optimized, and significantly faster than \
                     the zlib library, both for compression and decompression, \
                     and especially on x86 processors. In addition, libdeflate \
-                    provides optional high compression modes that provide a \
-                    better compression ratio than the zlib's \"level 9\".
+                    provides optional high compression modes that provide \
+                    a better compression ratio than the zlib's \"level 9\".
 
 categories          archivers devel
 license             MIT
 maintainers         {linux.com:nickblack @dankamongmen} \
                     {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
+
+# https://github.com/ebiggers/libdeflate/commit/a83fb24e1cb0ec6b6fd53446c941013edf055192
+compiler.blacklist-append   *gcc-4.* {clang < 400} {macports-clang-3.[0-8]}
+
+# TODO: verify powerpc defs in common_defs.h
+# https://github.com/ebiggers/libdeflate/issues/362


### PR DESCRIPTION
#### Description

Archaic compilers are not supported anymore, see: https://github.com/ebiggers/libdeflate/commit/a83fb24e1cb0ec6b6fd53446c941013edf055192

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
