### PR TITLE
py-mac-alias: new submission

### DIFF
--- a/python/py-mac-alias/Portfile
+++ b/python/py-mac-alias/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-mac-alias
+version             2.2.2
+revision            0
+
+supported_archs     noarch
+platforms           {darwin any}
+license             MIT
+
+maintainers         nomaintainer
+
+description         mac_alias lets you generate or read binary Alias and \
+                    Bookmark records from Python code.
+long_description    {*}${description}
+
+homepage            https://pypi.org/project/mac-alias/
+
+distname            mac_alias-${version}
+
+checksums           rmd160  8d46ee63eb8cd89e6ac896a988f62f4d1ed70b03 \
+                    sha256  c99c728eb512e955c11f1a6203a0ffa8883b26549e8afe68804031aa5da856b7 \
+                    size    34073
+
+python.versions     312


### PR DESCRIPTION
#### Description

New port required as a dependency to update `osxphotos` to the latest version. I'll create a follow-up PR for that.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?