### PR TITLE
tcp_wrappers: Fix -Wimplicit-int errors

### DIFF
--- a/net/tcp_wrappers/Portfile
+++ b/net/tcp_wrappers/Portfile
@@ -6,7 +6,7 @@ name                    tcp_wrappers
 version                 20
 revision                5
 
-categories              devel net
+categories              net devel
 license                 Permissive
 maintainers             {mascguy @mascguy} {jeremyhu @jeremyhu} openmaintainer
 
@@ -33,7 +33,8 @@ checksums               rmd160  c98c1ad9cff26b10f5c5c80f38d41178f28a8a4d \
 
 patchfiles-append       patch-clang.diff \
                         patch-fix-prototypes.diff \
-                        patch-header-guard.diff
+                        patch-header-guard.diff \
+                        patch-no-return-type.diff
 
 post-patch {
     reinplace "s:/usr/lib/:${prefix}/lib/:g" ${worksrcpath}/Makefile

--- a/net/tcp_wrappers/files/patch-no-return-type.diff
+++ b/net/tcp_wrappers/files/patch-no-return-type.diff
@@ -1,0 +1,79 @@
+Fix -Wimplicit-int errors
+
+The build fails on modern macOS with:
+
+| error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
+
+This is likely because the default compiler now makes -Wimplicit-int an error
+by default. Fix this by adding the return type specifier.
+--- tcpd.c.orig	2024-03-25 23:39:11
++++ tcpd.c	2024-03-25 23:39:36
+@@ -42,7 +42,7 @@
+ int     allow_severity = SEVERITY;	/* run-time adjustable */
+ int     deny_severity = LOG_WARNING;	/* ditto */
+ 
+-main(argc, argv)
++int main(argc, argv)
+ int     argc;
+ char  **argv;
+ {
+--- fakelog.c	2003-06-18 21:29:18
++++ fakelog.c	2024-03-25 23:46:48
+@@ -17,7 +17,7 @@
+ 
+ /* ARGSUSED */
+ 
+-openlog(name, logopt, facility)
++void openlog(name, logopt, facility)
+ char   *name;
+ int     logopt;
+ int     facility;
+@@ -27,7 +27,7 @@
+ 
+ /* vsyslog - format one record */
+ 
+-vsyslog(severity, fmt, ap)
++void vsyslog(severity, fmt, ap)
+ int     severity;
+ char   *fmt;
+ va_list ap;
+@@ -43,7 +43,7 @@
+ 
+ /* VARARGS */
+ 
+-VARARGS(syslog, int, severity)
++void VARARGS(syslog, int, severity)
+ {
+     va_list ap;
+     char   *fmt;
+@@ -56,7 +56,7 @@
+ 
+ /* closelog - dummy */
+ 
+-closelog()
++void closelog()
+ {
+     /* void */
+ }
+--- try-from.c	2003-06-18 21:29:19
++++ try-from.c	2024-03-25 23:47:13
+@@ -37,7 +37,7 @@
+ int     allow_severity = SEVERITY;	/* run-time adjustable */
+ int     deny_severity = LOG_WARNING;	/* ditto */
+ 
+-main(argc, argv)
++int main(argc, argv)
+ int     argc;
+ char  **argv;
+ {
+--- safe_finger.c	2009-10-05 23:17:07
++++ safe_finger.c	2024-03-25 23:47:34
+@@ -54,7 +54,7 @@
+     exit(0);
+ }
+ 
+-main(argc, argv)
++int main(argc, argv)
+ int     argc;
+ char  **argv;
+ {


### PR DESCRIPTION
No revbump because it either builds correctly, or not at all.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.3.1 23D60 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
