### PR TITLE
ipsw: Update to 3.1.462

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -3,12 +3,12 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/blacktop/ipsw 3.1.461 v
+go.setup                github.com/blacktop/ipsw 3.1.462 v
 github.tarball_from     archive
 revision                0
 categories              security devel
 license                 MIT
-platforms               {darwin >= 17}
+platforms               {darwin >= 19}
 installs_libs           no
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
@@ -16,17 +16,23 @@ description             iOS/macOS Research Swiss Army Knife
 long_description        {*}${description}. Everything you need to start \
                         researching Apple security and internals.
 
-checksums               rmd160  147979bad0e97e464cf7c3b4ffaea9210cd51b6c \
-                        sha256  07046f136abc08c7e10c9645f78bc0e1895ede941660fa6b04c258972a5c9530 \
-                        size    4048865
+checksums               rmd160  c76625b209f70f05876664d5153de3727c93168b \
+                        sha256  b73c9e029e1e25e9a7c5cff018271b9e693e27e5beab29c290c7ad5aaae4f00e \
+                        size    4051704
 
 patch.pre_args          -p1
 patchfiles              reproducible-build.diff
 
+depends_build-append    path:bin/pkg-config:pkgconfig
+
+depends_lib-append      path:lib/pkgconfig/libusb-1.0.pc:libusb \
+                        port:unicorn
+
 # Vendored libraries cause failure, fetch them at build time
 go.offline_build        no
 
-build.args-append       -ldflags \"-s -w\" \
+build.args-append       -tags libusb,unicorn \
+                        -ldflags \"-s -w\" \
                         -ldflags \"-X ${go.package}/cmd/ipsw/cmd.AppVersion=${version}\"
 
 build.post_args-append  ./cmd/${name}


### PR DESCRIPTION
#### Description

Update `ipsw` to its latest released version, 3.1.462. Newly specified dependencies enable extra features that should be enabled by default (such as the [`pongo`](https://blacktop.github.io/ipsw/docs/guides/pongo) command).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
