### PR TITLE
nco: update to 5.2.2

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           github 1.0
 
-github.setup        nco nco 5.2.1
+github.setup        nco nco 5.2.2
 revision            0
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
@@ -21,9 +21,9 @@ if {${os.major} > 12} {
     compilers.setup -clang33 -clang34
 }
 
-checksums           rmd160  025285981b204f1be7a130289853d8d826903ee7 \
-                    sha256  d05ff044080326b2634f996c1ba84e460ed328fbbcc94a1b73c748799eddfe50 \
-                    size    6507681
+checksums           rmd160  2e916cd3db97b287e26b9301010f7207bce2abdc \
+                    sha256  687570f8d0af2d00b5cda916b06e3d3112007a52480ba0a0a9e98b897c80a2bf \
+                    size    6515852
 
 homepage            http://nco.sourceforge.net/
 long_description \


### PR DESCRIPTION
#### Description
Simple update to upstream version 5.2.2
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.4 23E214 x86_64
Command Line Tools 15.3.0.0.1.1708646388
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
