### PR TITLE
macports-libcxx: ensure correct installation

### DIFF
--- a/lang/macports-libcxx/Portfile
+++ b/lang/macports-libcxx/Portfile
@@ -1,10 +1,10 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           active_variants 1.1
 
 name                macports-libcxx
 categories          lang
-platforms           darwin
 maintainers         nomaintainer
 license             NCSA
 homepage            https://libcxx.llvm.org
@@ -19,7 +19,7 @@ long_description    This port installs a recent libc++ from llvm \
 # the clang-11 version in use when this port is updated will be used
 version             11.1.0
 set clangversion    11
-revision            0
+revision            1
 
 depends_build       port:clang-${clangversion}
 
@@ -30,6 +30,25 @@ checksum {}
 use_configure no
 build {}
 variant universal {}
+
+post-extract {
+    if {![catch {set result [active_variants clang-$clangversion libstdcxx]}]} {
+        if {$result} {
+            ui_msg "Error: clang-$clangversion should be installed without +libstdcxx!"
+            return -code error "Variant mismatch."
+        }
+    }
+
+    # https://trac.macports.org/ticket/69189
+    if {[variant_isset universal]} {
+        if {![catch {set result [active_variants clang-$clangversion universal]}]} {
+            if {!$result} {
+                ui_msg "Error: clang-$clangversion should be installed with +universal!"
+                return -code error "Variant mismatch."
+            }
+        }
+    }
+}
 
 destroot {
 

--- a/lang/macports-libcxx/Portfile
+++ b/lang/macports-libcxx/Portfile
@@ -5,6 +5,8 @@ PortGroup           active_variants 1.1
 
 name                macports-libcxx
 categories          lang
+# Match platforms for clang version used to provide libcxx.
+platforms           {darwin < 23}
 maintainers         nomaintainer
 license             NCSA
 homepage            https://libcxx.llvm.org


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69189

#### Description

Fix this annoying bug finally.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5
Xcode 5.1.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
