### PR TITLE
google-cloud-sdk: update to 470.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             469.0.0
+version             470.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  020c51234240613befa16472c63ba0f439934530 \
-                    sha256  0bbd953a0822299ce465306c4170841b2495a7d187a8d21d8007746271864600 \
-                    size    128538664
+    checksums       rmd160  288e3ce7b96f553a7b89db93ee7a02ec30bb41e0 \
+                    sha256  396648bb05af0151a9c47ee377f5ca2d1cbe36982cb62a6dd6ce00af549420b5 \
+                    size    128518450
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  ad5bc84c226a001e7ba90660a7ecee519b4e60bf \
-                    sha256  90a20a2faaa1d069c99d3fa52f7d4d2f52235299784ccd0f1a1c63ecc0d0a37d \
-                    size    129822186
+    checksums       rmd160  1d0ed6a6ba7d5e9936594a3fb1e09fe9790e99e6 \
+                    sha256  d8cba679b0116460dace415a2fab3ee06c74f5f5cce7813f02e70ec2df124d9c \
+                    size    129802911
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  a37def9a190bb71549bad31bb27792d50a2ee35e \
-                    sha256  ee2f100d75ec4f9ec85f1244db302115de937d71f65155cb247a8c33e0492a05 \
-                    size    126894412
+    checksums       rmd160  dbf2b0b4a23cec1332ace1492eab9ebdc42ae471 \
+                    sha256  5ca02eaf4413553faa395487c9442a8ae2d2994247372db6ef16a8696036b671 \
+                    size    126874125
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 470.0.0.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?