### PR TITLE
translate-toolkit: update to 3.12.2, use Python 3.12

### DIFF
--- a/python/py-vobject/Portfile
+++ b/python/py-vobject/Portfile
@@ -2,11 +2,10 @@
 
 PortSystem          1.0
 PortGroup           python 1.0
-PortGroup           github 1.0
 
-github.setup        eventable vobject 0.9.6.1
-revision            0
 name                py-vobject
+version             0.9.7
+revision            0
 
 license             Apache-2
 maintainers         nomaintainer
@@ -20,28 +19,21 @@ long_description    vObject is intended to be a full featured Python package \
                     is being developed in concert with the Open Source \
                     Application Foundation`s Chandler project.
 
-homepage            https://eventable.github.io/vobject/
+homepage            https://py-vobject.github.io/vobject/
 
-checksums           rmd160  3f07a57c17c8f0d4031082e267df186d65f1268a \
-                    sha256  6a88ae77ef4ea8b5fcb966032a8deb04c17ed7e4a8b3c236bc86a92442429bc1 \
-                    size    216594
+checksums           rmd160  4c9d9385c3ed376d2b262edbab0779669c40b4bc \
+                    sha256  ab727bf81de88984ada5c11f066f1e1649903d3e3d7ec91f1ce968172afd5256 \
+                    size    58657
 
-python.versions     37 38 39 310
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
-    depends_build-append \
-                    port:py${python.version}-setuptools
+    depends_lib-append \
+                    port:py${python.version}-dateutil \
+                    port:py${python.version}-six
 
-    depends_lib-append  port:py${python.version}-dateutil \
-                        port:py${python.version}-six
-
-    if {${python.version} < 38} {
-        depends_run-append \
-                    port:py${python.version}-importlib-metadata
-    }
-
-    test.run            yes
-    test.cmd            ${python.bin} tests.py
+    test.run        yes
+    test.cmd        ${python.bin} tests.py
     python.test_framework
 
     post-destroot   {
@@ -50,10 +42,7 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} \
             ACKNOWLEDGEMENTS.txt \
             LICENSE-2.0.txt \
-            MANIFEST.in \
             README.md \
             ${destroot}${docdir}
     }
-
-    livecheck.type      none
 }

--- a/textproc/translate-toolkit/Portfile
+++ b/textproc/translate-toolkit/Portfile
@@ -1,34 +1,32 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        translate translate 2.5.0
 name                translate-toolkit
+version             3.12.2
+revision            0
+
 categories          textproc
-platforms           darwin
+supported_archs     noarch
+platforms           {darwin any}
 license             GPL-2+
 maintainers         {l2dy @l2dy} openmaintainer
 
 description         Tools and API for translation and localization engineering.
-long_description    ${description}
+long_description    {*}${description}
 
 homepage            https://toolkit.translatehouse.org/
-github.tarball_from releases
-distname            translate-toolkit-${version}
 
-checksums           rmd160  258a0801d15813a2d79baa5c953e96acf32bafb0 \
-                    sha256  e9f19c5ebbef8d2c551319d9ff42f6799d65ed5a102e0a2cea77ee93dcfe7c5f \
-                    size    7679224
+checksums           rmd160  21a52e49b16dac58b42a431d65461185607c21fc \
+                    sha256  acee42b816f7796809b9b4768693664f6bd19fb96eae3d8dfec0932fa8761706 \
+                    size    1466431
 
-python.default_version \
-                    37
+python.default_version 312
 
 depends_build-append \
-                    port:py${python.version}-setuptools
-depends_lib-append  port:py${python.version}-diff-match-patch \
-                    port:py${python.version}-levenshtein \
+                    port:py${python.version}-setuptools_scm
+
+depends_lib-append  port:py${python.version}-levenshtein \
                     port:py${python.version}-lxml \
-                    port:py${python.version}-six \
                     port:py${python.version}-vobject


### PR DESCRIPTION
#### Description
- update translate-toolkit to its latest upstream version and use Python 3.12
Please note, there are many [optional dependencies](https://github.com/translate/translate/blob/master/requirements/optional.txt) that could be included but only the ones that were originally there are kept.
- also update `py-vobject` and its subports

###### Tested on
macOS 14.4 23E214 x86_64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
