### PR TITLE
libdeflate: Fix builds for 10.7-10.10

### DIFF
--- a/archivers/libdeflate/Portfile
+++ b/archivers/libdeflate/Portfile
@@ -34,7 +34,7 @@ maintainers         {linux.com:nickblack @dankamongmen} \
                     openmaintainer
 
 # https://github.com/ebiggers/libdeflate/commit/a83fb24e1cb0ec6b6fd53446c941013edf055192
-compiler.blacklist-append   *gcc-4.* {clang < 400} {macports-clang-3.[0-8]}
+compiler.blacklist-append   *gcc-4.* {clang < 800} {macports-clang-3.[0-8]}
 
 # TODO: verify powerpc defs in common_defs.h
 # https://github.com/ebiggers/libdeflate/issues/362


### PR DESCRIPTION
#### Description

* Fix Apple clang version numbering in blacklisting.
* Applies for recent update to libdeflate 1.20.
* Per suggestion in the following ticket, comment no. 1.
* Closes https://trac.macports.org/ticket/69600

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  OS 11, 12, 13, 14 only.
Testing for the targets OS 10.7 through 10.10 is deferred to builders.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
