### PR TITLE
py-virtualenvwrapper: Update to 6.0.0

### DIFF
--- a/python/py-virtualenv-clone/Portfile
+++ b/python/py-virtualenv-clone/Portfile
@@ -23,9 +23,12 @@ checksums           rmd160  885b90024880e4cd45410caeab0014d5a160d14a \
                     sha256  418ee935c36152f8f153c79824bb93eaf6f0f7984bae31d3f48f350b9183501a \
                     size    6454
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
+    depends_lib-append \
+                    port:py${python.version}-setuptools
+
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}

--- a/python/py-virtualenv-clone/files/virtualenv-clone312
+++ b/python/py-virtualenv-clone/files/virtualenv-clone312
@@ -1,0 +1,1 @@
+bin/virtualenv-clone-3.12

--- a/python/py-virtualenv-clone/virtualenv-clone312
+++ b/python/py-virtualenv-clone/virtualenv-clone312
@@ -1,0 +1,1 @@
+bin/virtualenv-clone-3.12

--- a/python/py-virtualenvwrapper/Portfile
+++ b/python/py-virtualenvwrapper/Portfile
@@ -5,8 +5,8 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-virtualenvwrapper
-version             4.8.4
-revision            1
+version             6.0.0
+revision            0
 
 supported_archs     noarch
 platforms           {darwin any}
@@ -24,15 +24,16 @@ long_description    virtualenvwrapper is a set of extensions to Ian \
 
 homepage            https://virtualenvwrapper.readthedocs.io/
 
-checksums           rmd160  1d7791e2df3689b44e3293757825bd89405c2af1 \
-                    sha256  51a1a934e7ed0ff221bdd91bf9d3b604d875afbb3aa2367133503fee168f5bfa \
-                    size    334920
+checksums           rmd160  d0354163a6dbbd67641e1eef4d991717f57377fd \
+                    sha256  4cdaca4a01bb11c3343b01439cf2d76ebe97bb28c4b9a653a9b1f1f7585cd097 \
+                    size    95407
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     depends_lib-append  port:py${python.version}-pbr \
                         port:py${python.version}-setuptools \
+                        port:py${python.version}-setuptools_scm \
                         port:py${python.version}-stevedore \
                         port:py${python.version}-virtualenv \
                         port:py${python.version}-virtualenv-clone
@@ -41,7 +42,7 @@ if {${name} ne ${subport}} {
         set docdir ${prefix}/share/doc/${subport}
         xinstall -d ${destroot}${docdir}
         xinstall -m 0644 -W ${worksrcpath} README.txt LICENSE \
-            ChangeLog AUTHORS ${destroot}${docdir}
+            ${destroot}${docdir}
     }
 
     depends_run-append  port:virtualenvwrapper_select

--- a/python/py-virtualenvwrapper/files/virtualenvwrapper312
+++ b/python/py-virtualenvwrapper/files/virtualenvwrapper312
@@ -1,0 +1,2 @@
+bin/virtualenvwrapper.sh-3.12
+bin/virtualenvwrapper_lazy.sh-3.12


### PR DESCRIPTION
Notable improvements: compatibility with python 3.12, and thus it is now possible to have py312-virtualenvwrapper.

Reference: [​https://github.com/python-virtualenvwrapper/virtualenvwrapper/releases/tag/6.0.0](https://github.com/python-virtualenvwrapper/virtualenvwrapper/releases/tag/6.0.0)

See here for more details: https://trac.macports.org/ticket/69090