### PR TITLE
osxphotos: update to 0.67.9

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.67.7
+version                 0.67.9
 revision                0
 
 categories              graphics python
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  d01c78f22be6e972580ae96c011f7ad9f3303eca \
-                        sha256  cb4ca009f62b355c661104508a653c6bc3cb6237b4415c06ced4cc0dcfbff782 \
-                        size    2098823
+checksums               rmd160  cb24ac2d2eb504bc8c2c881103c1f2c4fd98d9ce \
+                        sha256  5c209324959059faec22a4482cb85ca1be337d45fa08bdb1b4502ed6f2d24f79 \
+                        size    2104218
 
 python.default_version  312
 
@@ -37,6 +37,7 @@ depends_build-append    port:py${python.version}-setuptools
 depends_lib-append      port:py${python.version}-bitmath \
                         port:py${python.version}-bpylist2 \
                         port:py${python.version}-click \
+                        port:py${python.version}-mac-alias \
                         port:py${python.version}-mako \
                         port:py${python.version}-more-itertools \
                         port:py${python.version}-objexplore \


### PR DESCRIPTION
#### Description

Update to osxphotos 0.67.9.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?