### PR TITLE
gcc12, gcc13: fix build with recent libc++

### DIFF
--- a/lang/gcc12/Portfile
+++ b/lang/gcc12/Portfile
@@ -178,6 +178,9 @@ if { ${os.platform} eq "darwin" } {
 #  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
 patchfiles-append   patch-gcc10-disable-macports-cctools-as-changes.diff
 
+# see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111632
+patchfiles-append   patch-avoid-over-poisoning.diff
+
 configure.env-append \
                     DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
                     DISABLE_XCODE_AS_CLANG_SEARCH=1

--- a/lang/gcc12/files/patch-avoid-over-poisoning.diff
+++ b/lang/gcc12/files/patch-avoid-over-poisoning.diff
@@ -1,0 +1,136 @@
+From 9970b576b7e4ae337af1268395ff221348c4b34a Mon Sep 17 00:00:00 2001
+From: Francois-Xavier Coudert <fxcoudert@gcc.gnu.org>
+Date: Thu, 7 Mar 2024 14:36:03 +0100
+Subject: [PATCH] Include safe-ctype.h after C++ standard headers, to avoid
+ over-poisoning
+
+When building gcc's C++ sources against recent libc++, the poisoning of
+the ctype macros due to including safe-ctype.h before including C++
+standard headers such as <list>, <map>, etc, causes many compilation
+errors, similar to:
+
+  In file included from /home/dim/src/gcc/master/gcc/gensupport.cc:23:
+  In file included from /home/dim/src/gcc/master/gcc/system.h:233:
+  In file included from /usr/include/c++/v1/vector:321:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_bool.h:20:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_integral.h:32:
+  In file included from /usr/include/c++/v1/locale:202:
+  /usr/include/c++/v1/__locale:546:5: error: '__abi_tag__' attribute
+  only applies to structs, variables, functions, and namespaces
+    546 |     _LIBCPP_INLINE_VISIBILITY
+        |     ^
+  /usr/include/c++/v1/__config:813:37: note: expanded from macro
+  '_LIBCPP_INLINE_VISIBILITY'
+    813 | #  define _LIBCPP_INLINE_VISIBILITY _LIBCPP_HIDE_FROM_ABI
+        |                                     ^
+  /usr/include/c++/v1/__config:792:26: note: expanded from macro
+  '_LIBCPP_HIDE_FROM_ABI'
+    792 |
+    __attribute__((__abi_tag__(_LIBCPP_TOSTRING(
+  _LIBCPP_VERSIONED_IDENTIFIER))))
+        |                          ^
+  In file included from /home/dim/src/gcc/master/gcc/gensupport.cc:23:
+  In file included from /home/dim/src/gcc/master/gcc/system.h:233:
+  In file included from /usr/include/c++/v1/vector:321:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_bool.h:20:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_integral.h:32:
+  In file included from /usr/include/c++/v1/locale:202:
+  /usr/include/c++/v1/__locale:547:37: error: expected ';' at end of
+  declaration list
+    547 |     char_type toupper(char_type __c) const
+        |                                     ^
+  /usr/include/c++/v1/__locale:553:48: error: too many arguments
+  provided to function-like macro invocation
+    553 |     const char_type* toupper(char_type* __low, const
+    char_type* __high) const
+        |                                                ^
+  /home/dim/src/gcc/master/gcc/../include/safe-ctype.h:146:9: note:
+  macro 'toupper' defined here
+    146 | #define toupper(c) do_not_use_toupper_with_safe_ctype
+        |         ^
+
+This is because libc++ uses different transitive includes than
+libstdc++, and some of those transitive includes pull in various ctype
+declarations (typically via <locale>).
+
+There was already a special case for including <string> before
+safe-ctype.h, so move the rest of the C++ standard header includes to
+the same location, to fix the problem.
+
+gcc/ChangeLog:
+
+	* system.h: Include safe-ctype.h after C++ standard headers.
+
+Signed-off-by: Dimitry Andric <dimitry@andric.com>
+---
+ gcc/system.h | 39 ++++++++++++++++++---------------------
+ 1 file changed, 18 insertions(+), 21 deletions(-)
+
+diff --git a/gcc/system.h b/gcc/system.h
+index b0edab0288548..ab29fc1977644 100644
+--- gcc/system.h
++++ gcc/system.h
+@@ -194,27 +194,8 @@ extern int fprintf_unlocked (FILE *, const char *, ...);
+ #undef fread_unlocked
+ #undef fwrite_unlocked
+ 
+-/* Include <string> before "safe-ctype.h" to avoid GCC poisoning
+-   the ctype macros through safe-ctype.h */
+-
+-#ifdef __cplusplus
+-#ifdef INCLUDE_STRING
+-# include <string>
+-#endif
+-#endif
+-
+-/* There are an extraordinary number of issues with <ctype.h>.
+-   The last straw is that it varies with the locale.  Use libiberty's
+-   replacement instead.  */
+-#include "safe-ctype.h"
+-
+-#include <sys/types.h>
+-
+-#include <errno.h>
+-
+-#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
+-extern int errno;
+-#endif
++/* Include C++ standard headers before "safe-ctype.h" to avoid GCC
++   poisoning the ctype macros through safe-ctype.h */
+ 
+ #ifdef __cplusplus
+ #if defined (INCLUDE_ALGORITHM) || !defined (HAVE_SWAP_IN_UTILITY)
+@@ -229,6 +210,9 @@ extern int errno;
+ #ifdef INCLUDE_SET
+ # include <set>
+ #endif
++#ifdef INCLUDE_STRING
++# include <string>
++#endif
+ #ifdef INCLUDE_VECTOR
+ # include <vector>
+ #endif
+@@ -245,6 +229,19 @@ extern int errno;
+ # include <type_traits>
+ #endif
+ 
++/* There are an extraordinary number of issues with <ctype.h>.
++   The last straw is that it varies with the locale.  Use libiberty's
++   replacement instead.  */
++#include "safe-ctype.h"
++
++#include <sys/types.h>
++
++#include <errno.h>
++
++#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
++extern int errno;
++#endif
++
+ /* Some of glibc's string inlines cause warnings.  Plus we'd rather
+    rely on (and therefore test) GCC's string builtins.  */
+ #define __NO_STRING_INLINES

--- a/lang/gcc13/Portfile
+++ b/lang/gcc13/Portfile
@@ -173,6 +173,9 @@ if { ${os.platform} eq "darwin" } {
 #  - https://github.com/gcc-mirror/gcc/commit/b410cf1dc056aab195c5408871ffca932df8a78a
 patchfiles-append   patch-gcc10-disable-macports-cctools-as-changes.diff
 
+# see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111632
+patchfiles-append   patch-avoid-over-poisoning.diff
+
 configure.env-append \
                     DISABLE_MACPORTS_AS_CLANG_SEARCH=1 \
                     DISABLE_XCODE_AS_CLANG_SEARCH=1

--- a/lang/gcc13/files/patch-avoid-over-poisoning.diff
+++ b/lang/gcc13/files/patch-avoid-over-poisoning.diff
@@ -1,0 +1,136 @@
+From 9970b576b7e4ae337af1268395ff221348c4b34a Mon Sep 17 00:00:00 2001
+From: Francois-Xavier Coudert <fxcoudert@gcc.gnu.org>
+Date: Thu, 7 Mar 2024 14:36:03 +0100
+Subject: [PATCH] Include safe-ctype.h after C++ standard headers, to avoid
+ over-poisoning
+
+When building gcc's C++ sources against recent libc++, the poisoning of
+the ctype macros due to including safe-ctype.h before including C++
+standard headers such as <list>, <map>, etc, causes many compilation
+errors, similar to:
+
+  In file included from /home/dim/src/gcc/master/gcc/gensupport.cc:23:
+  In file included from /home/dim/src/gcc/master/gcc/system.h:233:
+  In file included from /usr/include/c++/v1/vector:321:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_bool.h:20:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_integral.h:32:
+  In file included from /usr/include/c++/v1/locale:202:
+  /usr/include/c++/v1/__locale:546:5: error: '__abi_tag__' attribute
+  only applies to structs, variables, functions, and namespaces
+    546 |     _LIBCPP_INLINE_VISIBILITY
+        |     ^
+  /usr/include/c++/v1/__config:813:37: note: expanded from macro
+  '_LIBCPP_INLINE_VISIBILITY'
+    813 | #  define _LIBCPP_INLINE_VISIBILITY _LIBCPP_HIDE_FROM_ABI
+        |                                     ^
+  /usr/include/c++/v1/__config:792:26: note: expanded from macro
+  '_LIBCPP_HIDE_FROM_ABI'
+    792 |
+    __attribute__((__abi_tag__(_LIBCPP_TOSTRING(
+  _LIBCPP_VERSIONED_IDENTIFIER))))
+        |                          ^
+  In file included from /home/dim/src/gcc/master/gcc/gensupport.cc:23:
+  In file included from /home/dim/src/gcc/master/gcc/system.h:233:
+  In file included from /usr/include/c++/v1/vector:321:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_bool.h:20:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_integral.h:32:
+  In file included from /usr/include/c++/v1/locale:202:
+  /usr/include/c++/v1/__locale:547:37: error: expected ';' at end of
+  declaration list
+    547 |     char_type toupper(char_type __c) const
+        |                                     ^
+  /usr/include/c++/v1/__locale:553:48: error: too many arguments
+  provided to function-like macro invocation
+    553 |     const char_type* toupper(char_type* __low, const
+    char_type* __high) const
+        |                                                ^
+  /home/dim/src/gcc/master/gcc/../include/safe-ctype.h:146:9: note:
+  macro 'toupper' defined here
+    146 | #define toupper(c) do_not_use_toupper_with_safe_ctype
+        |         ^
+
+This is because libc++ uses different transitive includes than
+libstdc++, and some of those transitive includes pull in various ctype
+declarations (typically via <locale>).
+
+There was already a special case for including <string> before
+safe-ctype.h, so move the rest of the C++ standard header includes to
+the same location, to fix the problem.
+
+gcc/ChangeLog:
+
+	* system.h: Include safe-ctype.h after C++ standard headers.
+
+Signed-off-by: Dimitry Andric <dimitry@andric.com>
+---
+ gcc/system.h | 39 ++++++++++++++++++---------------------
+ 1 file changed, 18 insertions(+), 21 deletions(-)
+
+diff --git a/gcc/system.h b/gcc/system.h
+index b0edab0288548..ab29fc1977644 100644
+--- gcc/system.h
++++ gcc/system.h
+@@ -194,27 +194,8 @@ extern int fprintf_unlocked (FILE *, const char *, ...);
+ #undef fread_unlocked
+ #undef fwrite_unlocked
+ 
+-/* Include <string> before "safe-ctype.h" to avoid GCC poisoning
+-   the ctype macros through safe-ctype.h */
+-
+-#ifdef __cplusplus
+-#ifdef INCLUDE_STRING
+-# include <string>
+-#endif
+-#endif
+-
+-/* There are an extraordinary number of issues with <ctype.h>.
+-   The last straw is that it varies with the locale.  Use libiberty's
+-   replacement instead.  */
+-#include "safe-ctype.h"
+-
+-#include <sys/types.h>
+-
+-#include <errno.h>
+-
+-#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
+-extern int errno;
+-#endif
++/* Include C++ standard headers before "safe-ctype.h" to avoid GCC
++   poisoning the ctype macros through safe-ctype.h */
+ 
+ #ifdef __cplusplus
+ #if defined (INCLUDE_ALGORITHM) || !defined (HAVE_SWAP_IN_UTILITY)
+@@ -229,6 +210,9 @@ extern int errno;
+ #ifdef INCLUDE_SET
+ # include <set>
+ #endif
++#ifdef INCLUDE_STRING
++# include <string>
++#endif
+ #ifdef INCLUDE_VECTOR
+ # include <vector>
+ #endif
+@@ -245,6 +229,19 @@ extern int errno;
+ # include <type_traits>
+ #endif
+ 
++/* There are an extraordinary number of issues with <ctype.h>.
++   The last straw is that it varies with the locale.  Use libiberty's
++   replacement instead.  */
++#include "safe-ctype.h"
++
++#include <sys/types.h>
++
++#include <errno.h>
++
++#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
++extern int errno;
++#endif
++
+ /* Some of glibc's string inlines cause warnings.  Plus we'd rather
+    rely on (and therefore test) GCC's string builtins.  */
+ #define __NO_STRING_INLINES


### PR DESCRIPTION
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111632

No revbump since ports build correctly or not at all.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
