### PR TITLE
gjs-devel: Update to 1.80.2

### DIFF
--- a/gnome/gjs-devel/Portfile
+++ b/gnome/gjs-devel/Portfile
@@ -6,12 +6,12 @@ PortGroup           gobject_introspection 1.0
 PortGroup           gitlab 1.0
 
 gitlab.instance     https://gitlab.gnome.org
-gitlab.setup        GNOME gjs 1.80.1
+gitlab.setup        GNOME gjs 1.80.2
 revision            0
 
-checksums           rmd160  151d8cba3eb10450c1871f4a6caa6efb007c2f65 \
-                    sha256  c14f0ac52a29686dc2b5bcece91124c0df0198098d72e200cb39be36ebe8e678 \
-                    size    703487
+checksums           rmd160  165a2ef5521c979b74087467df906c9961e7762b \
+                    sha256  6685b68b131acc8b2ad44a75e118bdecde169e68d6c5096db8ae146cfe6c080a \
+                    size    704030
 
 name                gjs-devel
 conflicts           gjs


### PR DESCRIPTION
#### Description

* Update 1.80.1 --> 1.80.2
* Also test very recent dependency fixes, in particular rust and libdeflate.

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

CI only.  macOS 11, 12, 13, 14 only.
Waiting to test earlier OS on builders.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?