### PR TITLE
xorg-xcb-util-cursor: update to 0.1.4

### DIFF
--- a/x11/xorg-xcb-util-cursor/Portfile
+++ b/x11/xorg-xcb-util-cursor/Portfile
@@ -1,26 +1,29 @@
-PortSystem 1.0
-PortGroup   compiler_blacklist_versions 1.0
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-name		xorg-xcb-util-cursor
-version		0.1.4
+PortSystem      1.0
+PortGroup       compiler_blacklist_versions 1.0
+
+name            xorg-xcb-util-cursor
+version         0.1.4
 revision        0
-categories	x11 devel
-license		X11
-maintainers	{jeremyhu @jeremyhu} openmaintainer
-description	X.org xcb-util-cursor
-homepage	https://xcb.freedesktop.org/
-platforms	darwin macosx
-long_description Utility libraries for XCB
-master_sites	 ${homepage}/dist/
+categories      x11 devel
+license         X11
+maintainers     {jeremyhu @jeremyhu} openmaintainer
+description     X.org xcb-util-cursor
+long_description \
+                Utility libraries for XCB
+homepage        https://xcb.freedesktop.org
+platforms       darwin macosx
+master_sites    ${homepage}/dist/
 
-distname	xcb-util-cursor-${version}
-checksums           rmd160  a5bb983f4eb8deacfb61aaa48c1e57595a7ce05c \
-                    sha256  cc8608ebb695742b6cf84712be29b2b66aa5f6768039528794fca0fa283022bf \
-                    size    394342
+distname        xcb-util-cursor-${version}
+checksums       rmd160  a5bb983f4eb8deacfb61aaa48c1e57595a7ce05c \
+                sha256  cc8608ebb695742b6cf84712be29b2b66aa5f6768039528794fca0fa283022bf \
+                size    394342
 
 depends_build   port:pkgconfig \
                 port:xorg-util-macros
-depends_lib	port:xorg-xcb-util \
+depends_lib     port:xorg-xcb-util \
                 port:xorg-xcb-util-image \
                 port:xorg-xcb-util-renderutil \
                 port:xorg-xorgproto

--- a/x11/xorg-xcb-util-cursor/Portfile
+++ b/x11/xorg-xcb-util-cursor/Portfile
@@ -1,8 +1,9 @@
 PortSystem 1.0
+PortGroup   compiler_blacklist_versions 1.0
 
 name		xorg-xcb-util-cursor
-version		0.1.3
-revision        1
+version		0.1.4
+revision        0
 categories	x11 devel
 license		X11
 maintainers	{jeremyhu @jeremyhu} openmaintainer
@@ -13,10 +14,9 @@ long_description Utility libraries for XCB
 master_sites	 ${homepage}/dist/
 
 distname	xcb-util-cursor-${version}
-checksums           rmd160  29ad840667af37c00b06fbf4ccea215dbe8df2d8 \
-                    sha256  05a10a0706a1a789a078be297b5fb663f66a71fb7f7f1b99658264c35926394f
-use_bzip2	yes
-use_parallel_build yes
+checksums           rmd160  a5bb983f4eb8deacfb61aaa48c1e57595a7ce05c \
+                    sha256  cc8608ebb695742b6cf84712be29b2b66aa5f6768039528794fca0fa283022bf \
+                    size    394342
 
 depends_build   port:pkgconfig \
                 port:xorg-util-macros
@@ -29,7 +29,7 @@ depends_lib	port:xorg-xcb-util \
 # shape_to_id.gperf:82: error: type qualifiers ignored on function return type
 # cursor.h:164: error: type qualifiers ignored on function return type
 # cursor.h:164: error: type qualifiers ignored on function return type
-compiler.blacklist *gcc-4.2
+compiler.blacklist *gcc-4.0 *gcc-4.2 {clang < 421}
 
 livecheck.type  regex
 livecheck.url   ${master_sites}?C=M&O=D


### PR DESCRIPTION
#### Description

Update.
Make lint happy.
Also fix build on 10.6, where old Xcode clang cannot build this just like gcc-4.2 (same error).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
