### PR TITLE
gnuastro: update to 0.22

### DIFF
--- a/science/gnuastro/Portfile
+++ b/science/gnuastro/Portfile
@@ -4,8 +4,8 @@ PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
 
 name                    gnuastro
-version                 0.21
-revision                1
+version                 0.22
+revision                0
 categories              science
 license                 GPL-3+
 maintainers             {@sikmir disroot.org:sikmir} openmaintainer
@@ -16,9 +16,9 @@ long_description        The GNU Astronomy Utilities (Gnuastro) is an official GN
 homepage                https://www.gnu.org/software/gnuastro/
 master_sites            gnu
 
-checksums               rmd160  bb31d76785a71ba58c88f6903c6b04cd274b6ff4 \
-                        sha256  2fba993d8422391517b55f7eb511788946d7a886aa1584984fd4678bdd27537f \
-                        size    7601435
+checksums               rmd160  4a2cbf8c98dea640cf482c0676450af09748f56d \
+                        sha256  7fd7f16a06bde55aed96282090cd922135beea902369e5af814389eab9cc7308 \
+                        size    7722836
 
 depends_build-append    port:libtool
 

--- a/science/gnuastro/files/patch-buildjobs.diff
+++ b/science/gnuastro/files/patch-buildjobs.diff
@@ -1,13 +1,13 @@
 # https://trac.macports.org/ticket/66254
 
---- configure.orig	2022-07-22 01:21:10.000000000 +0800
-+++ configure	2022-11-14 15:15:22.000000000 +0800
-@@ -21228,7 +21228,7 @@
+--- configure.orig	2024-03-29 13:43:02.000000000 +0400
++++ configure	2024-03-29 13:43:37.000000000 +0400
+@@ -21930,7 +21930,7 @@
  
          if test $has_sysctl = yes
  then :
 -  jobs=$(sysctl -a | awk '/^hw\.ncpu/{print $2}')
 +  jobs=@MP_BUILDJOBS@
- else $as_nop
-   jobs=8
- fi
+ else case e in #(
+   e) jobs=8 ;;
+ esac


### PR DESCRIPTION
#### Description
[Changelog](https://git.savannah.gnu.org/cgit/gnuastro.git/plain/NEWS?id=gnuastro_v0.22)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
