### PR TITLE
mbusd: update to 0.5.2

### DIFF
--- a/net/mbusd/Portfile
+++ b/net/mbusd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
 
-github.setup        3cky mbusd 0.5.1 v
+github.setup        3cky mbusd 0.5.2 v
 revision            0
 categories          net
 license             BSD
@@ -12,9 +12,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Modbus TCP to Modbus RTU (RS-232/485) gateway
 long_description    {*}${description}
 
-checksums           rmd160  4d72656f0c1cd41f0bcec407dafb55123544fae7 \
-                    sha256  c1e21b246e542df505f7a4f95d1921d11c4414aac6c60950739fd20558d5b134 \
-                    size    43630
+checksums           rmd160  5a26ff400c9e7ceac5510ef284192c887a5a2097 \
+                    sha256  885e8150de852a43990e7f76d1fffb291b047141f3b7d2bca4571c210b43ae8a \
+                    size    45752
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig


### PR DESCRIPTION
#### Description
https://github.com/3cky/mbusd/releases/tag/v0.5.2

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
