### PR TITLE
VLC2: fix build on 10.10

### DIFF
--- a/multimedia/VLC2/Portfile
+++ b/multimedia/VLC2/Portfile
@@ -153,7 +153,9 @@ if {(${subport} eq ${name}) || (${subport} eq "lib${name}")} {
     # Some plugins require C++11
     compiler.cxx_standard       2011
     # fatal error: 'stdatomic.h' file not found
-    compiler.blacklist-append   {clang < 601}
+    # ld: Assertion failed: (name != NULL), function Fixup,
+    # file /Library/Caches/com.apple.xbs/Sources/ld64/ld64-253.9/src/ld/ld.hpp
+    compiler.blacklist-append   {clang < 800}
 
     patchfiles          patch-buildsystem.diff \
                         PR-34741-no__clang_version__.patch \


### PR DESCRIPTION
#### Description

A quick fix for 10.10, where Xcode clang fails.
10.9 is okay since uses Clang-16.
https://ports.macports.org/port/VLC2/details

Cannot test it, but presumably it should work.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
