### PR TITLE
lapack @3.12.0_1: tweak cmake config file directory

### DIFF
--- a/math/lapack/Portfile
+++ b/math/lapack/Portfile
@@ -72,10 +72,8 @@ if {${subport} eq ${name}} {
     }
     post-destroot {
         # move CMake scripts to the directory cmake expects to find them in
-        xinstall -m 755 -d ${destroot}${cmake_share_module_dir}
-        file delete -force ${destroot}${cmake_share_module_dir}
         move ${destroot}${prefix}/lib/${name}/cmake \
-            ${destroot}${cmake_share_module_dir}
+            ${destroot}/${prefix}/lib
     }
 }
 


### PR DESCRIPTION
cmake looks by default in
```
${prefix}/lib/cmake/${packagename}
```
for it's config files. This PR moves the
cmake config files for lapack to this location,
so they can be found by cmake without modifications to search paths.

closes: https://trac.macports.org/ticket/64379

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7 21G816 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->


The end result of this is that the cmake config files are installed here:

```
% port contents lapack | grep cmake
  /opt/local/lib/cmake/cblas-3.12.0/cblas-config-version.cmake
  /opt/local/lib/cmake/cblas-3.12.0/cblas-config.cmake
  /opt/local/lib/cmake/cblas-3.12.0/cblas-targets-macports.cmake
  /opt/local/lib/cmake/cblas-3.12.0/cblas-targets.cmake
  /opt/local/lib/cmake/lapack-3.12.0/lapack-config-version.cmake
  /opt/local/lib/cmake/lapack-3.12.0/lapack-config.cmake
  /opt/local/lib/cmake/lapack-3.12.0/lapack-targets-macports.cmake
  /opt/local/lib/cmake/lapack-3.12.0/lapack-targets.cmake
  /opt/local/lib/cmake/lapacke-3.12.0/lapacke-config-version.cmake
  /opt/local/lib/cmake/lapacke-3.12.0/lapacke-config.cmake
  /opt/local/lib/cmake/lapacke-3.12.0/lapacke-targets-macports.cmake
  /opt/local/lib/cmake/lapacke-3.12.0/lapacke-targets.cmake
```

and in that location, they can be found by cmake without any manual modification of paths. 

Test CMakeLists.txt here:
```
 % cat CMakeLists.txt
cmake_minimum_required(VERSION 3.20)

project(DiscoverLAPACKE VERSION 1.0.0 LANGUAGES C)

find_package(lapacke CONFIG REQUIRED)
```

I noticed the pkgconfig files are still installed in the old location. Maybe they should be moved too?
```
% port contents lapack | grep pkg  
  /opt/local/lib/lapack/pkgconfig/blas.pc
  /opt/local/lib/lapack/pkgconfig/cblas.pc
  /opt/local/lib/lapack/pkgconfig/lapack.pc
  /opt/local/lib/lapack/pkgconfig/lapacke.pc
```

or perhaps this PR is not doing things the way the various linear algebra ports need things to be. I defer here to the maintainers of said ports.


