### PR TITLE
miniupnpc: Update to 2.2.7

### DIFF
--- a/net/miniupnpc/Portfile
+++ b/net/miniupnpc/Portfile
@@ -4,21 +4,22 @@ PortSystem          1.0
 
 name                miniupnpc
 epoch               2
-version             2.2.6
+version             2.2.7
 revision            0
 categories          net
 platforms           darwin freebsd
 license             BSD
-maintainers         nomaintainer
+maintainers         {@edilmedeiros gmail.com:jose.edil+miniupnp} \
+                    openmaintainer
 description         Lightweight client for UPnP protocol
 long_description    ${description}
 
 homepage            http://miniupnp.free.fr/
 master_sites        http://miniupnp.free.fr/files/
 
-checksums           rmd160  0dcf4a305addea4a480132643d2d1345aab9edf5 \
-                    sha256  37fcd91953508c3e62d6964bb8ffbc5d47f3e13481fa54e6214fcc68704c66f1 \
-                    size    103949
+checksums           rmd160  77df65cf89aaabb44efb3ef754bbdf13788d9490 \
+                    sha256  b0c3a27056840fd0ec9328a5a9bac3dc5e0ec6d2e8733349cf577b0aa1e70ac1 \
+                    size    104258
 
 variant universal   {}
 use_configure       no


### PR DESCRIPTION
#### Description

This package is a dependency of bitcoin (both the port and for people compiling bitcoin core by themselves). This is not a critical update, but it's important to keep the ports up to date. In this regard, I added myself as a maintainer (together with the openmaintainer flag).

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
