### PR TITLE
pkgconf: Update to 2.2.0

### DIFF
--- a/devel/pkgconf/Portfile
+++ b/devel/pkgconf/Portfile
@@ -1,10 +1,9 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                  1.0
-PortGroup                   github 1.0
 
-github.setup                pkgconf pkgconf 2.1.1 pkgconf-
-github.tarball_from         archive
+name                        pkgconf
+version                     2.2.0
 revision                    0
 categories                  devel
 license                     ISC
@@ -13,14 +12,19 @@ description                 a program which helps to configure compiler and link
 long_description            pkgconf is ${description}. \
                             It is similar to pkg-config from freedesktop.org.
 
+homepage                    https://github.com/pkgconf/pkgconf
 master_sites                https://distfiles.ariadne.space/pkgconf/
 
-checksums                   rmd160  00496d3d13a0cdeda579c6942a36b063b69d2240 \
-                            sha256  1a00b7fa08c7b506a24c40f7cc8d9e0e59be748d731af8f7aa0b4d722bd8ccbe \
-                            size    451327
+checksums                   rmd160  3bad459c012b072b43bf92f6007e821c0d8df41f \
+                            sha256  28f8dfc279a10ef66148befa3f6eb266e5f3570316600208ed50e9781c7269d8 \
+                            size    451551
 
 # both ports install ${prefix}/share/aclocal/pkg.m4
 conflicts                   pkgconfig
+
+# See: https://trac.macports.org/wiki/WimplicitFunctionDeclaration#AddnamestowhitelistviaPortfile
+configure.checks.implicit_function_declaration.whitelist-append strchr
+
 post-destroot {
     # since ports already conflict, follow https://github.com/pkgconf/pkgconf/#pkg-config-symlink
     ln -s pkgconf ${destroot}${prefix}/bin/pkg-config


### PR DESCRIPTION
#### Description

Update `pkgconf` to its latest released version, 2.2.0.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
