### PR TITLE
libnatpmp: new port in net

### DIFF
--- a/net/libnatpmp/Portfile
+++ b/net/libnatpmp/Portfile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libnatpmp
+version             20230423
+revision            0
+categories          net
+platforms           darwin freebsd
+license             BSD
+maintainers         {@edilmedeiros gmail.com:jose.edil+miniupnp} \
+                    openmaintainer
+description         Portable and fully compliant implementation of the NAT-PMP protocol for the client side
+long_description    ${description}
+
+homepage            http://miniupnp.free.fr/
+master_sites        http://miniupnp.free.fr/files/
+
+checksums           rmd160  01078bccd060e2d4601cfa941e5f352e34a64c55 \
+                    sha256  0684ed2c8406437e7519a1bd20ea83780db871b3a3a5d752311ba3e889dbfc70 \
+                    size    26506
+
+variant universal   {}
+
+patchfiles          makefile.diff
+use_configure       no
+build.env           PREFIX=${prefix} \
+                    CC=${configure.cc} \
+                    "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
+                    "LDFLAGS=${configure.cflags} [get_canonical_archflags ld]"
+destroot.env        PREFIX=${prefix}
+
+livecheck.type      regex
+livecheck.url       http://miniupnp.free.fr/files/
+livecheck.regex     ${name}-${version}

--- a/net/libnatpmp/files/makefile.diff
+++ b/net/libnatpmp/files/makefile.diff
@@ -1,0 +1,90 @@
+--- Makefile.orig	2024-03-29 17:21:55.000000000 -0300
++++ Makefile	2024-03-29 21:47:14.000000000 -0300
+@@ -6,7 +6,7 @@
+ 
+ OS = $(shell uname -s)
+ CC = gcc
+-INSTALL = install -p
++INSTALL = install
+ ARCH = $(shell uname -m | sed -e s/i.86/i686/)
+ VERSION = $(shell cat VERSION)
+ 
+@@ -56,11 +56,18 @@
+ endif
+ endif
+ 
+-HEADERS = natpmp.h
++HEADERS = natpmp.h natpmp_declspec.h
+ 
+ EXECUTABLES = testgetgateway natpmpc-shared natpmpc-static
+ 
+-INSTALLPREFIX ?= $(PREFIX)/usr
++#INSTALLPREFIX ?= $(PREFIX)
++#INSTALLPREFIX = $(DESTDIR)
++# install directories
++ifeq ($(strip $(PREFIX)),)
++INSTALLPREFIX ?= /usr
++else
++INSTALLPREFIX ?= $(PREFIX)
++endif
+ INSTALLDIRINC = $(INSTALLPREFIX)/include
+ INSTALLDIRLIB = $(INSTALLPREFIX)/lib
+ INSTALLDIRBIN = $(INSTALLPREFIX)/bin
+@@ -92,14 +99,14 @@
+ 	makedepend -f$(MAKEFILE_LIST) -Y $(OBJS:.o=.c) 2>/dev/null
+ 
+ install:	$(HEADERS) $(STATICLIB) $(SHAREDLIB) natpmpc-shared
+-	$(INSTALL) -d $(INSTALLDIRINC)
+-	$(INSTALL) -m 644 $(HEADERS) $(INSTALLDIRINC)
+-	$(INSTALL) -d $(INSTALLDIRLIB)
+-	$(INSTALL) -m 644 $(STATICLIB) $(INSTALLDIRLIB)
+-	$(INSTALL) -m 644 $(SHAREDLIB) $(INSTALLDIRLIB)/$(SONAME)
+-	$(INSTALL) -d $(INSTALLDIRBIN)
+-	$(INSTALL) -m 755 natpmpc-shared $(INSTALLDIRBIN)/natpmpc
+-	ln -s -f $(SONAME) $(INSTALLDIRLIB)/$(SHAREDLIB)
++	$(INSTALL) -d $(DESTDIR)$(INSTALLDIRINC)
++	$(INSTALL) -m 644 $(HEADERS) $(DESTDIR)$(INSTALLDIRINC)
++	$(INSTALL) -d $(DESTDIR)$(INSTALLDIRLIB)
++	$(INSTALL) -m 644 $(STATICLIB) $(DESTDIR)$(INSTALLDIRLIB)
++	$(INSTALL) -m 644 $(SHAREDLIB) $(DESTDIR)$(INSTALLDIRLIB)/$(SONAME)
++	$(INSTALL) -d $(DESTDIR)$(INSTALLDIRBIN)
++	$(INSTALL) -m 755 natpmpc-shared $(DESTDIR)$(INSTALLDIRBIN)/natpmpc
++	ln -s -f $(SONAME) $(DESTDIR)$(INSTALLDIRLIB)/$(SHAREDLIB)
+ 
+ $(JNIHEADERS): fr/free/miniupnp/libnatpmp/NatPmp.class
+ 	$(JAVAH) -jni fr.free.miniupnp.libnatpmp.NatPmp
+@@ -144,10 +151,10 @@
+ 	 -DcreateChecksum=true
+ 
+ cleaninstall:
+-	$(RM) $(addprefix $(INSTALLDIRINC), $(HEADERS))
+-	$(RM) $(INSTALLDIRLIB)/$(SONAME)
+-	$(RM) $(INSTALLDIRLIB)/$(SHAREDLIB)
+-	$(RM) $(INSTALLDIRLIB)/$(STATICLIB)
++	$(RM) $(addprefix $(DESTDIR)$(INSTALLDIRINC), $(HEADERS))
++	$(RM) $(DESTDIR)$(INSTALLDIRLIB)/$(SONAME)
++	$(RM) $(DESTDIR)$(INSTALLDIRLIB)/$(SHAREDLIB)
++	$(RM) $(DESTDIR)$(INSTALLDIRLIB)/$(STATICLIB)
+ 
+ testgetgateway:	testgetgateway.o getgateway.o
+ 	$(CC) $(LDFLAGS) -o $@ $^ $(EXTRA_LD)
+@@ -163,7 +170,7 @@
+ 
+ $(SHAREDLIB):	$(LIBOBJS)
+ ifeq ($(OS), Darwin)
+-	$(CC) -dynamiclib -Wl,-install_name,$(SONAME) -o $@ $^
++	$(CC) -dynamiclib -Wl,-install_name,$(INSTALLDIRLIB)/$(SONAME) -o $@ $^
+ else
+ 	$(CC) -shared -Wl,-soname,$(SONAME) -o $@ $^ $(EXTRA_LD)
+ endif
+@@ -171,7 +178,7 @@
+ 
+ # DO NOT DELETE
+ 
+-natpmp.o: natpmp.h getgateway.h declspec.h
+-getgateway.o: getgateway.h declspec.h
+-testgetgateway.o: getgateway.h declspec.h
++natpmp.o: natpmp.h getgateway.h natpmp_declspec.h
++getgateway.o: getgateway.h natpmp_declspec.h
++testgetgateway.o: getgateway.h natpmp_declspec.h
+ natpmpc.o: natpmp.h


### PR DESCRIPTION
#### Description

libnatpmp is a dependency for bitcoin core for folks that are building from source. The current bitcoin port does not support libnatpmp. This port opens the possibility of adding a new feature to the bitcoin port.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 12.7.1 21G920 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

#### Additional info

Bitcoin Core v26 was successfully compiled from source and tested with the library provided by this port.
