### PR TITLE
zstd: update to 1.5.6

### DIFF
--- a/archivers/zstd/Portfile
+++ b/archivers/zstd/Portfile
@@ -17,12 +17,13 @@ subport zstdConfig.cmake {
 
 }
 
-github.setup                facebook zstd 1.5.5 v
+github.setup                facebook zstd 1.5.6 v
+github.tarball_from         archive
 revision                    0
 
-checksums                   rmd160  afab9fe65b1c72babfc7b12ba31f2b49de14d32e \
-                            sha256  9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4 \
-                            size    2368543
+checksums                   rmd160  abd88b93773b57b18e4ac57661131d6c79152404 \
+                            sha256  30f35f71c1203369dc979ecde0400ffea93c27391bfd2ac5a9715d2173d92ff7 \
+                            size    2425452
 
 categories                  archivers devel
 license                     {BSD GPL-2}
@@ -40,8 +41,6 @@ subport zstdConfig.cmake {
     description             CMake files for zstd
     long_description        Installs {*}${description}.
 }
-
-github.tarball_from         releases
 
 patchfiles                  patch-zstd-tiger-no-backtrace.diff \
                             flags.patch

--- a/python/py-zstd/Portfile
+++ b/python/py-zstd/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        indygreg python-zstandard 0.20.0
+github.setup        indygreg python-zstandard 0.22.0
 github.tarball_from archive
 name                py-zstd
 
@@ -16,15 +16,21 @@ long_description    This extension allows Zstandard compression from Python
 
 homepage            https://github.com/indygreg/python-zstandard
 
-checksums           rmd160  6b54c29daadff331d3bc2d7eeb5337be38d76f5d \
-                    sha256  4f44f00c8abb5faf051c900576816bec6612bb975fcbccf383b72087e78f30d0 \
-                    size    712241
+checksums           rmd160  3e089548b0d937e998e03b3d4bce537613ed278e \
+                    sha256  34ce7ef020afca1344c538a778e2a2e30dc43b11509aa4cb5cf076228d959ca7 \
+                    size    707644
 
 python.versions     38 39 310 311 312
+python.pep517_backend \
+                    poetry
+
+patchfiles-append   patch-pyproject.toml.diff
 
 if {${name} ne ${subport}} {
     depends_build-append \
-                    port:py${python.version}-cffi
+                    port:py${python.version}-cffi \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-wheel
 
     depends_lib-append \
                     port:zstd

--- a/python/py-zstd/files/patch-pyproject.toml.diff
+++ b/python/py-zstd/files/patch-pyproject.toml.diff
@@ -1,0 +1,14 @@
+--- ./pyproject.toml	2024-03-30 00:51:04
++++ ./pyproject.toml	2024-03-30 00:52:01
+@@ -1,8 +1,8 @@
+ [build-system]
+ requires = [
+-    "cffi==1.16.0",
+-    "setuptools==68.2.2",
+-    "wheel==0.41.2",
++    "cffi>=1.16.0",
++    "setuptools>=68.2.2",
++    "wheel>=0.41.2",
+ ]
+ # Need to use legacy backend because setup_zstd.py breaks build isolation.
+ build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
Update `zstd` and `py-zstd`

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
