### PR TITLE
SuiteSparse: update to 7.7.0

### DIFF
--- a/math/SuiteSparse/Portfile
+++ b/math/SuiteSparse/Portfile
@@ -3,7 +3,7 @@
 PortSystem                  1.0
 PortGroup                   github 1.0
 
-github.setup                DrTimothyAldenDavis SuiteSparse 7.6.1 v
+github.setup                DrTimothyAldenDavis SuiteSparse 7.7.0 v
 # subports have independent revisions
 revision                    0
 epoch                       20200517
@@ -17,9 +17,9 @@ long_description            SuiteSparse is a single archive that contains all pa
 
 homepage                    https://people.engr.tamu.edu/davis/suitesparse.html
 
-checksums                   rmd160  467704e4663293361b6f5314662b73f6c57ded98 \
-                            sha256  69d5f4b5729d36532349f88e17550f72d2d1814c524385dafbecb6fcdb00cb33 \
-                            size    85515484
+checksums                   rmd160  7ec634d96c345144ec05069e74191ca22bc6552e \
+                            sha256  dc4ed0774b22b807252564922962ac8796a4abbcf7a5a407e1bf7f668ff74241 \
+                            size    85881814
 
 configure.optflags          -O3
 
@@ -43,7 +43,7 @@ compiler.log_verbose_output no
 subport SuiteSparse_config {
     PortGroup               linear_algebra 1.0
 
-    version                 7.6.1
+    version                 7.7.0
     revision                0
     # from the README.txt:
     #    "[n]o licensing restrictions apply"
@@ -56,8 +56,72 @@ subport SuiteSparse_config {
     configure.args-append   -DSUITESPARSE_CONFIG_USE_OPENMP=OFF
 }
 
+subport SuiteSparse_AMD {
+    version                 3.3.2
+    revision                0
+    depends_lib-append      port:SuiteSparse_config
+    license                 BSD
+    long_description-append ${subport}: approximate minimum degree ordering.
+}
+
+subport SuiteSparse_BTF {
+    version                 2.3.2
+    revision                0
+    depends_lib-append      port:SuiteSparse_config
+    license                 LGPL-2.1+
+    long_description-append ${subport}: permutation to block triangular form.
+}
+
+subport SuiteSparse_CAMD {
+    version                 3.3.2
+    revision                0
+    depends_lib-append      port:SuiteSparse_config
+    license                 BSD
+    long_description-append ${subport}: constrained approximate minimum degree ordering.
+}
+
+subport SuiteSparse_CCOLAMD {
+    version                 3.3.3
+    revision                0
+    depends_lib-append      port:SuiteSparse_config
+    license                 BSD
+    long_description-append ${subport}: constrained column approximate minimum degree ordering.
+}
+
+subport SuiteSparse_CHOLMOD {
+    PortGroup               linear_algebra 1.0
+
+    version                 5.2.1
+    revision                0
+    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CAMD port:SuiteSparse_COLAMD port:SuiteSparse_CCOLAMD
+    license                 LGPL-2.1+
+    long_description-append ${subport}: sparse Cholesky factorization.
+    linalg.setup            noveclibfort
+    pre-configure {
+        configure.args-append   ${cmake_linalglib}
+    }
+    # OpenMP is not essential for CHOLMOD, we turn it off
+    configure.args-append   -DCHOLMOD_USE_OPENMP=OFF
+}
+
+subport SuiteSparse_COLAMD {
+    version                 3.3.3
+    revision                0
+    depends_lib-append      port:SuiteSparse_config
+    license                 BSD
+    long_description-append ${subport}: column approximate minimum degree ordering.
+}
+
+subport SuiteSparse_CXSparse {
+    version                 4.4.0
+    revision                0
+    depends_lib-append      port:SuiteSparse_config
+    license                 LGPL-2.1+
+    long_description-append ${subport}: a concise extended sparse matrix package.
+}
+
 subport SuiteSparse_GraphBLAS {
-    version                 9.0.3
+    version                 9.1.0
     revision                0
     license                 Apache-2
     long_description-append ${subport}: graph algorithms in the language of linear algebra.
@@ -72,8 +136,24 @@ subport SuiteSparse_GraphBLAS {
     }
 }
 
+subport SuiteSparse_KLU {
+    version                 2.3.3
+    revision                0
+    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_BTF port:SuiteSparse_COLAMD port:SuiteSparse_CHOLMOD
+    license                 LGPL-2.1+
+    long_description-append ${subport}: sparse LU factorization, primarily for circuit simulation.
+}
+
+subport SuiteSparse_LDL {
+    version                 3.3.2
+    revision                0
+    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD
+    license                 LGPL-2.1+
+    long_description-append ${subport}: a very concise LDL' factorization package.
+}
+
 subport SuiteSparse_LAGraph {
-    version                 1.1.2
+    version                 1.1.3
     revision                0
     depends_lib-append      port:SuiteSparse_GraphBLAS
     license                 BSD
@@ -84,7 +164,7 @@ subport SuiteSparse_LAGraph {
 }
 
 subport SuiteSparse_Mongoose {
-    version                 3.3.2
+    version                 3.3.3
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 GPL-3
@@ -92,112 +172,28 @@ subport SuiteSparse_Mongoose {
     compiler.cxx_standard   2011
 }
 
-subport SuiteSparse_AMD {
-    version                 3.3.1
-    revision                0
-    depends_lib-append      port:SuiteSparse_config
-    license                 BSD
-    long_description-append ${subport}: approximate minimum degree ordering.
-}
-
-subport SuiteSparse_BTF {
-    version                 2.3.1
-    revision                0
-    depends_lib-append      port:SuiteSparse_config
-    license                 LGPL-2.1+
-    long_description-append ${subport}: permutation to block triangular form.
-}
-
-subport SuiteSparse_CAMD {
-    version                 3.3.1
-    revision                0
-    depends_lib-append      port:SuiteSparse_config
-    license                 BSD
-    long_description-append ${subport}: constrained approximate minimum degree ordering.
-}
-
-subport SuiteSparse_CCOLAMD {
-    version                 3.3.2
-    revision                0
-    depends_lib-append      port:SuiteSparse_config
-    license                 BSD
-    long_description-append ${subport}: constrained column approximate minimum degree ordering.
-}
-
-subport SuiteSparse_COLAMD {
-    version                 3.3.2
-    revision                0
-    depends_lib-append      port:SuiteSparse_config
-    license                 BSD
-    long_description-append ${subport}: column approximate minimum degree ordering.
-}
-
-subport SuiteSparse_CHOLMOD {
-    PortGroup               linear_algebra 1.0
-
-    version                 5.2.0
-    revision                0
-    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CAMD port:SuiteSparse_COLAMD port:SuiteSparse_CCOLAMD
-    license                 LGPL-2.1+
-    long_description-append ${subport}: sparse Cholesky factorization.
-    linalg.setup            noveclibfort
-    pre-configure {
-        configure.args-append   ${cmake_linalglib}
-    }
-    # OpenMP is not essential for CHOLMOD, we turn it off
-    configure.args-append   -DCHOLMOD_USE_OPENMP=OFF
-}
-
-subport SuiteSparse_CXSparse {
-    version                 4.3.1
-    revision                0
-    depends_lib-append      port:SuiteSparse_config
-    license                 LGPL-2.1+
-    long_description-append ${subport}: a concise extended sparse matrix package.
-}
-
-subport SuiteSparse_LDL {
-    version                 3.3.1
-    revision                0
-    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD
-    license                 LGPL-2.1+
-    long_description-append ${subport}: a very concise LDL' factorization package.
-}
-
-subport SuiteSparse_KLU {
-    version                 2.3.2
-    revision                0
-    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_BTF port:SuiteSparse_COLAMD port:SuiteSparse_CHOLMOD
-    license                 LGPL-2.1+
-    long_description-append ${subport}: sparse LU factorization, primarily for circuit simulation.
-}
-
-subport SuiteSparse_UMFPACK {
-    PortGroup               linear_algebra 1.0
-
-    version                 6.3.2
-    revision                0
-    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CHOLMOD
-    license                 GPL-2+
-    long_description-append ${subport}: sparse LU factorization.
-    linalg.setup            noveclibfort
-    pre-configure {
-        configure.args-append   ${cmake_linalglib}
-    }
-}
-
 subport SuiteSparse_RBio {
-    version                 4.3.1
+    version                 4.3.2
     revision                0
     depends_lib-append      port:SuiteSparse_config
     license                 GPL-2+
     long_description-append ${subport}: read/write sparse matrices in Rutherford/Boeing format.
 }
 
+subport SuiteSparse_SPEX {
+    version                 3.1.0
+    revision                0
+    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_COLAMD \
+                            port:gmp \
+                            port:mpfr
+    license                 GPL-3+
+    long_description-append ${subport}: a software package for SParse EXact algebra.
+}
+
 subport SuiteSparse_SPQR {
     PortGroup               linear_algebra 1.0
 
-    version                 4.3.2
+    version                 4.3.3
     revision                0
     depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_COLAMD port:SuiteSparse_CHOLMOD
     license                 GPL-2+
@@ -209,15 +205,20 @@ subport SuiteSparse_SPQR {
     compiler.cxx_standard   2011
 }
 
-subport SuiteSparse_SPEX {
-    version                 2.3.2
+subport SuiteSparse_UMFPACK {
+    PortGroup               linear_algebra 1.0
+
+    version                 6.3.3
     revision                0
-    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_COLAMD \
-                            port:gmp \
-                            port:mpfr
-    license                 GPL-3+
-    long_description-append ${subport}: a software package for SParse EXact algebra.
+    depends_lib-append      port:SuiteSparse_config port:SuiteSparse_AMD port:SuiteSparse_CHOLMOD
+    license                 GPL-2+
+    long_description-append ${subport}: sparse LU factorization.
+    linalg.setup            noveclibfort
+    pre-configure {
+        configure.args-append   ${cmake_linalglib}
+    }
 }
+
 
 if {${subport} eq ${name}} {
     depends_lib-append      port:SuiteSparse_config \


### PR DESCRIPTION
#### Description

- Update to 7.7.0
- Reorder subports alphabetically so that it's easier to check versions during update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
