### PR TITLE
libusbmuxd: Update to 2.1.0

### DIFF
--- a/devel/libusbmuxd/Portfile
+++ b/devel/libusbmuxd/Portfile
@@ -29,19 +29,34 @@ depends_lib-append  port:libimobiledevice-glue \
 configure.args      --disable-silent-rules
 
 subport libusbmuxd-devel {
-    github.setup    libimobiledevice libusbmuxd c7d7d1a03f65a27be2eddb13d1f2b0c0e7a60ec6
-    version         20200615
+    github.setup    libimobiledevice libusbmuxd 2387d8e5820ee4621494e20434c0017aba6bea71
+    version         20240327
     # Epoch 1: Downgrade due to https://github.com/libimobiledevice/libusbmuxd/issues/71
     epoch           1
-    revision        1
+    revision        0
 
-    checksums       rmd160  f16ea53953c3c14140eb5d3c978521ce28d8b83f \
-                    sha256  1bccb0e79a0f1bf455102e2c08298fe474252a4181479d5e64c0deba911ccaaf \
-                    size    48941
+    checksums       rmd160  cfb6ea05671686e8dd5e8785827242b2cb9ba62c \
+                    sha256  3377a23ce86fd59bb6b2313fff60ff9410ec9ac3eebb5963ef5c45583f4a6433 \
+                    size    46674
+
+    depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
+
+    depends_lib-replace \
+                    port:libimobiledevice-glue \
+                    port:libimobiledevice-glue-devel
 
     depends_lib-replace port:libplist port:libplist-devel
 
     conflicts       libusbmuxd
+
+    pre-configure {
+        system -W ${worksrcpath} "echo ${version} > .tarball-version"
+    }
+
+    configure.cmd   ./autogen.sh
 
     livecheck.url   ${github.homepage}/commits/${github.livecheck.branch}.atom
 }

--- a/devel/libusbmuxd/Portfile
+++ b/devel/libusbmuxd/Portfile
@@ -3,33 +3,28 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        libimobiledevice libusbmuxd 2.0.2
-revision            1
+github.setup        libimobiledevice libusbmuxd 2.1.0
+revision            0
 
 categories          devel
-platforms           darwin
 
 maintainers         {ijackson @JacksonIsaac} {i0ntempest @i0ntempest} openmaintainer
 
-description         A client library to multiplex connections from and to iOS devices.
-long_description    A client library to multiplex connections from and to iOS devices \
-    by connecting to a socket provided by a usbmuxd daemon.
+description         A client library to multiplex connections from and to iOS devices
+long_description    {*}${description} by connecting to a socket provided by a usbmuxd daemon.
 
 license             LGPL-2.1
+conflicts           libusbmuxd-devel
 
-checksums           rmd160  704c2d8918740afd81dcd79b6fab4d63dd488417 \
-                    sha256  61c75a0e271ef5c0a49f25f481ca51ae9a9c4d7b0f84735368f727702b78eea7 \
-                    size    48943
+checksums           rmd160  9ba9806615a6121a80927a4c133843cb1e80fa50 \
+                    sha256  c35bf68f8e248434957bd5b234c389b02206a06ecd9303a7fb931ed7a5636b16 \
+                    size    325055
 
 depends_build-append \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool \
                     port:pkgconfig
 
-depends_lib         port:libplist
-
-configure.cmd       ./autogen.sh
+depends_lib-append  port:libimobiledevice-glue \
+                    port:libplist
 
 configure.args      --disable-silent-rules
 
@@ -52,5 +47,8 @@ subport libusbmuxd-devel {
 }
 
 if {${subport} eq ${name}} {
-    conflicts       libusbmuxd-devel
+    github.tarball_from     releases
+    use_bzip2               yes
+} else {
+    github.tarball_from     archive
 }


### PR DESCRIPTION
#### Description

Update `libusbmuxd` to its latest released version, 2.1.0. [Changelog](https://github.com/libimobiledevice/libusbmuxd/releases/tag/2.1.0).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
