### PR TITLE
libimobiledevice: Revision bump (libusbmuxd 2.1.0)

### DIFF
--- a/devel/libimobiledevice/Portfile
+++ b/devel/libimobiledevice/Portfile
@@ -2,9 +2,10 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           openssl 1.0
 
 github.setup        libimobiledevice libimobiledevice 1.3.0
-revision            2
+revision            3
 
 categories          devel
 
@@ -37,8 +38,7 @@ depends_build-append \
                     port:libtool \
                     port:pkgconfig
 
-depends_lib         port:libplist \
-                    path:lib/libssl.dylib:openssl \
+depends_lib-append  port:libplist \
                     port:libusbmuxd
 
 # Avoid redefinition errors with libplist v2.3
@@ -55,7 +55,7 @@ configure.args      --disable-silent-rules \
 subport libimobiledevice-devel {
     github.setup    libimobiledevice libimobiledevice 333eb1aec92f02b0b61f9ec23880861b93d42c60
     version         20200618
-    revision        2
+    revision        3
 
     checksums       rmd160  27591925392cbc0ee4076ab02491b1d8e832f7bc \
                     sha256  127cb57199e4538eee7e8e01f711cb1cb53d73b70181b0ba6c37c8371ab4faca \


### PR DESCRIPTION
#### Description

A new update to `libusbmuxd` was introduced in #23285. Without this revision bump, this port remains broken with `libusbmuxd` [due to a new soversion](https://github.com/libimobiledevice/libusbmuxd/commit/499fb0c4e25ba1eb82607ca3f6c6f5a2510b9b53); the port correctly uses the `openssl` PortGroup to link with said library.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
