### PR TITLE
py-lxml: avoid old Xcode gcc, which cannot build this anymore

### DIFF
--- a/python/py-lxml/Portfile
+++ b/python/py-lxml/Portfile
@@ -51,10 +51,11 @@ if {${name} ne ${subport}} {
     patchfiles-append   patch-setupinfo-remove-xcrun-call.diff
 
     # https://trac.macports.org/ticket/69386
-    if {[string match {*gcc-[34].*} ${configure.compiler}]} {
-        python.add_cflags   yes
-        configure.cflags    -std=gnu99
-    }
+    # As of 5.1.1, it does not build with gcc-4.2 anymore,
+    # even if pragmas are patched out:
+    # etree.h: error: wrong number of arguments specified for ‘__deprecated__’ attribute
+    compiler.blacklist-append \
+                    {*gcc-[34].*}
 
     test.run        yes
     python.test_framework


### PR DESCRIPTION
[skip ci]

#### Description

Skipping CI, the fix is inconsequential for systems using Clangs, since only old Xcode gccs are blacklisted.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
