### PR TITLE
toxic: update to 0.15.1

### DIFF
--- a/net/toxic/Portfile
+++ b/net/toxic/Portfile
@@ -8,7 +8,7 @@ PortGroup               makefile 1.0
 # clock_gettime in game_base
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup            JFreegman toxic 0.15.0 v
+github.setup            JFreegman toxic 0.15.1 v
 revision                0
 categories              net security
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -16,9 +16,9 @@ license                 GPL-3
 description             An ncurses-based Tox client
 long_description        Toxic is a Tox-based instant messaging and video chat client.
 homepage                https://toktok.ltd
-checksums               rmd160  44dd5c68b22a832fca85d38216e7a27923200bcf \
-                        sha256  c62a7b11aa4213eff43f3da2c5650ca14846e4020d5ca059dc1fd944efd0b584 \
-                        size    1246181
+checksums               rmd160  86596cc3fd2d466abec2b570d53a924aad5f0465 \
+                        sha256  56cedc37b22a1411c68fd8b395f40f515d6a4779be02540c5cd495665caa127c \
+                        size    1246436
 github.tarball_from     archive
 
 depends_build-append    port:pkgconfig


### PR DESCRIPTION
#### Description

Simple update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
