### PR TITLE
libarchive: backport upstream fix

### DIFF
--- a/archivers/libarchive/Portfile
+++ b/archivers/libarchive/Portfile
@@ -7,6 +7,7 @@ PortGroup muniversal 1.0
 
 github.setup    libarchive libarchive 3.7.2 v
 github.tarball_from releases
+revision        1
 
 categories      archivers
 license         BSD
@@ -30,7 +31,8 @@ depends_lib     port:bzip2 port:zlib port:libxml2 port:xz \
                 port:lz4 port:zstd \
                 port:libb2
 
-patchfiles      fix_pc_file.patch
+patchfiles      fix_pc_file.patch \
+                patch-use-correct-errno.patch
 
 platform darwin 8 {
     patchfiles-append   patch-libarchive-3.5-fix-tests-tiger.diff \

--- a/archivers/libarchive/files/patch-use-correct-errno.patch
+++ b/archivers/libarchive/files/patch-use-correct-errno.patch
@@ -1,0 +1,21 @@
+From 6110e9c82d8ba830c3440f36b990483ceaaea52c Mon Sep 17 00:00:00 2001
+From: Ed Maste <emaste@freebsd.org>
+Date: Fri, 29 Mar 2024 18:02:06 -0400
+Subject: [PATCH] tar: make error reporting more robust and use correct errno
+ (#2101)
+
+As discussed in #1609.
+--- tar/read.c
++++ tar/read.c
+@@ -371,8 +371,9 @@ read_archive(struct bsdtar *bsdtar, char mode, struct archive *writer)
+ 			if (r != ARCHIVE_OK) {
+ 				if (!bsdtar->verbose)
+ 					safe_fprintf(stderr, "%s", archive_entry_pathname(entry));
+-				fprintf(stderr, ": %s: ", archive_error_string(a));
+-				fprintf(stderr, "%s", strerror(errno));
++				safe_fprintf(stderr, ": %s: %s",
++				    archive_error_string(a),
++				    strerror(archive_errno(a)));
+ 				if (!bsdtar->verbose)
+ 					fprintf(stderr, "\n");
+ 				bsdtar->return_value = 1;


### PR DESCRIPTION
An echo of the xz backdoor drama: https://github.com/libarchive/libarchive/pull/1609

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
