### PR TITLE
Maintainer fixed https://trac.macports.org/ticket/67860

### DIFF
--- a/audio/nrsc5/Portfile
+++ b/audio/nrsc5/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cmake 1.1
 
-github.setup        theori-io nrsc5 eb76474193f228fd8fa697fc267b123c6c845a22
+github.setup        theori-io nrsc5 073726340ede83c596187f89d4442ab8d5180b77
 
 revision            0
-version             1.0-20230418
+version             1.0-20240327
 categories          audio
 maintainers         {netjibbing.com:blake @trodemaster} \
                     openmaintainer
@@ -17,9 +17,9 @@ description         This program receives NRSC-5 digital radio stations using an
 long_description    \
 This program receives NRSC-5 digital radio stations using an RTL-SDR dongle. It offers a command-line interface as well as an API upon which other applications can be built.
 
-checksums           rmd160  c0bade3db2333ebe2a8bc7a2ce27b88b1f229a59 \
-                    sha256  793a70b25c585babe5041267ab7bccf7d8f549bebe53d9228c4bf1e00c20ab41 \
-                    size    23168318
+checksums           rmd160  75f0e0458de45d23ab8e010505ae967c3c0f455d \
+                    sha256  a325d36638aed27e211235d98bf7675bb3d63c6df67ce14cab524bb86fe947fa \
+                    size    23170595
 
 patchfiles         CMakeLists.txt.diff
 
@@ -29,14 +29,11 @@ configure.args-append \
     -DUSE_FAAD2=ON
 
 depends_build-append \
-                    path:bin/cmake:cmake \
                     port:libtool \
                     port:autoconf \
                     port:automake
 
-depends_run         port:fftw \
-                    port:faad2
-
 depends_lib-append  port:rtl-sdr \
-                    port:libao
-
+                    port:libao \
+                    port:fftw-3-single \
+                    port:faad2


### PR DESCRIPTION
#### Description

Fixes https://trac.macports.org/ticket/67860 by adding missing port dependencies. This also stops the build from downloading and building additional libraries.
###### Type(s)

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.4.1 23E224 arm64
Command Line Tools 15.3.0.0.1.1708646388
###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
