### PR TITLE
CI: disable fail-fast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
       group: ${{ github.ref }}/${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-11, macos-12, macos-13, macos-14]
 


### PR DESCRIPTION
While this will use more resources for changes with build problems, it is often useful to be able to see if something is only failing on a subset of platforms.
