### PR TITLE
osxphotos: update to 0.67.10

### DIFF
--- a/graphics/osxphotos/Portfile
+++ b/graphics/osxphotos/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               python 1.0
 
 name                    osxphotos
-version                 0.67.9
+version                 0.67.10
 revision                0
 
 categories              graphics python
@@ -26,9 +26,9 @@ long_description        {*}${description}
 
 homepage                https://github.com/RhetTbull/osxphotos
 
-checksums               rmd160  cb24ac2d2eb504bc8c2c881103c1f2c4fd98d9ce \
-                        sha256  5c209324959059faec22a4482cb85ca1be337d45fa08bdb1b4502ed6f2d24f79 \
-                        size    2104218
+checksums               rmd160  9cdf7c9c75053e4ae46252d89670c2b7badf8ebc \
+                        sha256  96ae4830cd09b1cc40491c06269ddf8c7d96cf492cd4468cd0c88bdad91601bb \
+                        size    2104706
 
 python.default_version  312
 


### PR DESCRIPTION
#### Description

Update to osxphotos 0.67.10.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?