### PR TITLE
editorconfig-core-c: Update to 0.12.7

### DIFF
--- a/devel/editorconfig-core-c/Portfile
+++ b/devel/editorconfig-core-c/Portfile
@@ -4,23 +4,21 @@ PortSystem              1.0
 PortGroup               cmake  1.1
 PortGroup               github 1.0
 
-github.setup            editorconfig editorconfig-core-c 0.12.6 v
+github.setup            editorconfig editorconfig-core-c 0.12.7 v
 github.tarball_from     archive
 revision                0
 categories              devel
 license                 BSD
-maintainers             {@therealketo gmail.com:therealketo} openmaintainer
+maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
 
 description             EditorConfig makes it easy to maintain the correct coding style
 long_description        This code produces a program that accepts a filename as input and will \
                         look for .editorconfig files with sections applicable to the given file, \
                         outputting any properties found.
 
-checksums               rmd160  c837d7f7f58fc3f7661f8e8ec99f86e71ce2de1f \
-                        sha256  36052a5371731d915b53d9c7a24a11c4032585ccacb392ec9d58656eef4c0edf \
-                        size    76525
+checksums               rmd160  6a089514e08e395033d5b152c73ef52216f617ac \
+                        sha256  f89d2e144fd67bdf0d7acfb2ac7618c6f087e1b3f2c3a707656b4180df422195 \
+                        size    77426
 
 depends_build-append    port:doxygen
 depends_lib-append      port:pcre2
-
-github.livecheck.regex  {([^"-]+)}


### PR DESCRIPTION
#### Description

Update `editorconfig-core-c` to its latest released version, 0.12.7. [Changelog](https://github.com/editorconfig/editorconfig-core-c/blob/v0.12.7/CHANGELOG).

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
