### PR TITLE
Update ImageMagick to 6.9.13-7

### DIFF
--- a/R/R-magick/Portfile
+++ b/R/R-magick/Portfile
@@ -5,7 +5,7 @@ PortGroup           R 1.0
 
 # GitHub version lags behind.
 R.setup             cran ropensci magick 2.8.3
-revision            0
+revision            1
 categories-append   graphics
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT

--- a/databases/psiconv/Portfile
+++ b/databases/psiconv/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 
 name                psiconv
 version             0.9.9
-revision            4
+revision            5
 categories          databases
-platforms           darwin
 license             GPL-2
 maintainers         nomaintainer
 

--- a/devel/libtuxcap/Portfile
+++ b/devel/libtuxcap/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.0
 
 name                libtuxcap
 version             1.4.0
-revision            7
+revision            8
 checksums           rmd160  43d236b65fd6bb28b3ceaa6ba3193ecbcc5e6675 \
                     sha256  dae27bad276bffce6eba8114cd0e3edc0db710306f627b984464c4f0ec1fab2f \
                     size    4622159

--- a/devel/virtuoso-5/Portfile
+++ b/devel/virtuoso-5/Portfile
@@ -9,7 +9,7 @@ openssl.branch      1.0
 name                virtuoso-5
 set myname          virtuoso
 version             5.0.15
-revision            0
+revision            1
 categories          devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL

--- a/devel/virtuoso-6/Portfile
+++ b/devel/virtuoso-6/Portfile
@@ -9,14 +9,13 @@ openssl.branch      1.0
 name                virtuoso-6
 set myname          virtuoso
 version             6.1.8
-revision            8
+revision            9
 categories          devel
 maintainers         {snc @nerdling} openmaintainer
 license             GPL
 description         a high-performance object-relational SQL database
 long_description    Virtuoso is an enterprise-grade server that delivers a platform \
                     for Data Access, Integration and Management.
-platforms           darwin
 homepage            http://${myname}.openlinksw.com/dataspace/dav/wiki/Main/
 master_sites        sourceforge:project/${myname}/${myname}/${version}
 distname            ${myname}-opensource-${version}

--- a/devel/virtuoso-7/Portfile
+++ b/devel/virtuoso-7/Portfile
@@ -7,14 +7,13 @@ PortGroup           openssl 1.0
 name                virtuoso-7
 set myname          virtuoso
 version             7.2.10
-revision            0
+revision            1
 categories          devel
 maintainers         {snc @nerdling} openmaintainer
 license             GPL
 description         a high-performance object-relational SQL database
 long_description    Virtuoso is an enterprise-grade server that delivers a platform \
                     for Data Access, Integration and Management.
-platforms           darwin
 homepage            http://${myname}.openlinksw.com/dataspace/dav/wiki/Main/
 master_sites        sourceforge:project/${myname}/${myname}/${version}
 distname            ${myname}-opensource-${version}

--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -9,20 +9,16 @@ PortGroup                   conflicts_build 1.0
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-# 6.9.11-61 changes the major version of libMagickCore which will
-# require increasing the revision of all ports that link with it.
-version                     6.9.11-60
-revision                    13
-checksums                   rmd160  1c293ba06fd43833be35efb4476e559bf137ccef \
-                            sha256  ba0fa683b0721d1f22b0ccb364e4092e9a7a34ffd3bd6348c82b50fd93b1d7ba \
-                            size    9167220
+version                     6.9.13-7
+revision                    0
+checksums                   rmd160  9025e38a212d8cfe5706f07c4f900a96b708c016 \
+                            sha256  2a521f7992b3dd32469b7b7254a81df8a0045cb0b963372e3ba6404b0a4efeae \
+                            size    9604796
 
 categories                  graphics devel
 maintainers                 {ryandesign @ryandesign}
 license                     Apache-2
 use_xz                      yes
-platforms                   darwin
-use_parallel_build          yes
 
 description                 Tools and libraries to manipulate images in many formats
 

--- a/graphics/ale/Portfile
+++ b/graphics/ale/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 
 name                ale
 version             0.8.7
-revision            5
+revision            6
 categories          graphics
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-2+
 

--- a/graphics/autotrace/Portfile
+++ b/graphics/autotrace/Portfile
@@ -5,13 +5,12 @@ PortGroup               github 1.0
 
 github.setup            autotrace autotrace 20200219.65 travis-
 version                 0.40.0-${github.version}
-revision                0
+revision                1
 checksums               rmd160  cbb9bb78ac51ab24835043cac02d4aef99db3d95 \
                         sha256  74ca2555aff1a968290f13602a90f836872e08d37ecaf80c5296ad223f6cd69a \
                         size    7880004
 
 categories              graphics
-platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
 license                 GPL-2+
 

--- a/graphics/converseen/Portfile
+++ b/graphics/converseen/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 PortGroup           qt5 1.0
 
 github.setup        Faster3ck converseen 0.12.2.1 v
-revision            0
+revision            1
 categories          graphics
 license             GPL-3
 maintainers         {mps @Schamschula} openmaintainer

--- a/graphics/dmtx-utils/Portfile
+++ b/graphics/dmtx-utils/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        dmtx dmtx-utils 0.7.6 v
-revision            1
+revision            2
 categories          graphics
-platforms           darwin
 maintainers         nomaintainer
 license             LGPL-2.1
 

--- a/graphics/inkscape-devel/Portfile
+++ b/graphics/inkscape-devel/Portfile
@@ -14,7 +14,7 @@ set ver_date        2023-07-21
 set ver_hash        0e150ed6c4
 set ver_gal_item    42328
 version             ${ver_num}
-revision            3
+revision            4
 epoch               2
 
 categories          graphics gnome
@@ -24,7 +24,7 @@ maintainers         {mascguy @mascguy} openmaintainer
 description         This is the current development pre-release version of Inkscape.
 long_description    Inkscape is an multi-platform, Open-Source Vector Graphics Editor \
                     that uses SVG as its native file format. \
-                    ${description}
+                    {*}${description}
 homepage            https://inkscape.org/
 
 master_sites        https://inkscape.org/gallery/item/${ver_gal_item}

--- a/graphics/inkscape/Portfile
+++ b/graphics/inkscape/Portfile
@@ -14,7 +14,7 @@ set ver_date        2023-07-21
 set ver_hash        0e150ed6c4
 set ver_gal_item    42328
 version             ${ver_num}
-revision            6
+revision            7
 epoch               0
 
 categories          graphics gnome
@@ -24,7 +24,7 @@ maintainers         {mascguy @mascguy} openmaintainer
 description         This is the current stable release version of Inkscape.
 long_description    Inkscape is an multi-platform, Open-Source Vector Graphics Editor \
                     that uses SVG as its native file format. \
-                    ${description}
+                    {*}${description}
 homepage            https://inkscape.org/
 
 master_sites        https://inkscape.org/gallery/item/${ver_gal_item}

--- a/graphics/oofcanvas/Portfile
+++ b/graphics/oofcanvas/Portfile
@@ -6,7 +6,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                oofcanvas
 version             1.1.1
-revision            1
+revision            2
 
 license             public-domain
 categories          graphics

--- a/graphics/photoqt/Portfile
+++ b/graphics/photoqt/Portfile
@@ -9,7 +9,7 @@ name                photoqt
 # https://trac.macports.org/ticket/69366
 # https://github.com/luspi/photoqt/issues/22
 github.setup        luspi photoqt 3.4 v
-revision            2
+revision            3
 categories          graphics
 license             GPL-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer

--- a/graphics/pstoedit/Portfile
+++ b/graphics/pstoedit/Portfile
@@ -8,9 +8,8 @@ legacysupport.redirect_bins pstoedit
 
 name                pstoedit
 version             4.00
-revision            1
+revision            2
 categories          graphics
-platforms           darwin
 maintainers         nomaintainer
 license             GPL-2+
 

--- a/graphics/synfig/Portfile
+++ b/graphics/synfig/Portfile
@@ -28,14 +28,14 @@ if {${subport} in [list ${name} ${name}studio]} {
 }
 
 if {${subport} eq ${name}} {
-    revision            3
+    revision            4
     checksums           rmd160  35f55a26bdc7bce9a4675ed5ac259edb52d254ab \
                         sha256  cd9882a091433e22e484e47d7bfe542aaefd3f62bfd746d306be4ce964756f06 \
                         size    5177728
 
     description         vector-based 2-D animation package
 
-    long_description    Synfig is a ${description}. It is designed to be \
+    long_description    Synfig is a {*}${description}. It is designed to be \
                         capable of producing feature-film-quality animation. \
                         It eliminates the need for tweening, preventing the \
                         need to hand-draw each frame. Synfig features spatial \

--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -6,7 +6,7 @@ PortGroup           gobject_introspection 1.0
 PortGroup           meson 1.0
 
 github.setup        libvips libvips 8.15.1 v
-revision            2
+revision            3
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.

--- a/graphics/zbar/Portfile
+++ b/graphics/zbar/Portfile
@@ -6,7 +6,7 @@ PortGroup               active_variants 1.1
 
 github.setup            mchehab zbar 0.23.92
 github.tarball_from     archive
-revision                0
+revision                1
 
 checksums               rmd160  043e4904f567261148aa2223502c0ba2fc740ef1 \
                         sha256  dffc16695cb6e42fa318a4946fd42866c0f5ab735f7eaf450b108d1c3a19b4ba \
@@ -17,11 +17,10 @@ maintainers             {chello.at:knapoc @Knapoc} openmaintainer
 
 description             ZBar is an open source software suite for reading bar codes from \
                         various sources
-long_description        ${description}, such as video streams, image files \
+long_description        {*}${description}, such as video streams, image files \
                         and raw intensity sensors. It supports EAN-13/UPC-A, UPC-E, EAN-8, \
                         Code 128, Code 93, Code 39, Codabar, Interleaved 2 of 5, QR Code and SQ Code.
 
-platforms               darwin
 license                 LGPL-2.1+
 
 depends_build-append    port:libtool \

--- a/multimedia/dvdauthor/Portfile
+++ b/multimedia/dvdauthor/Portfile
@@ -4,9 +4,8 @@ PortSystem          1.0
 
 name                dvdauthor
 version             0.7.2
-revision            3
+revision            4
 categories          multimedia
-platforms           darwin
 maintainers         {perry.ch:maurice @robbyn}
 license             GPL-2+
 

--- a/multimedia/dvdrip/Portfile
+++ b/multimedia/dvdrip/Portfile
@@ -6,7 +6,7 @@ PortGroup           perl5 1.0
 name                dvdrip
 perl5.branches      5.34
 perl5.setup         ${name} 0.98.11
-revision            7
+revision            8
 categories          multimedia
 maintainers         nomaintainer
 license             {Artistic-1 GPL}

--- a/multimedia/libopenshot/Portfile
+++ b/multimedia/libopenshot/Portfile
@@ -6,6 +6,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        OpenShot libopenshot 0.3.2 v
+revision            1
 github.tarball_from archive
 checksums           rmd160  56febba77be0cc7f837ac26f211c9a6808d3f499 \
                     sha256  58765cfc8aec199814346e97ce31a5618a261260b380670a6fb2bf6f68733638 \
@@ -16,11 +17,10 @@ license             GPL-3+
 # qt-qtmultimedia, qt-svg, qt-qtwebkit all have OpenSSLException
 # does not link with or use anything else that depends on openssl
 license_noconflict  openssl openssl10 libpaper
-platforms           darwin
 maintainers         {ctreleaven @ctreleaven} openmaintainer
 
 description         Library for creating and editing videos
-long_description    ${description}. Includes python bindings but not ruby.
+long_description    {*}${description}. Includes python bindings but not ruby.
 
 # qt5.min_version     ??  # Project does not indicate
 qt5.depends_component \

--- a/multimedia/transcode/Portfile
+++ b/multimedia/transcode/Portfile
@@ -5,7 +5,7 @@ PortGroup       muniversal 1.0
 
 name        transcode
 version     1.1.7
-revision    28
+revision    29
 epoch       1
 license     GPL-2+
 categories  multimedia
@@ -57,8 +57,6 @@ depends_lib     path:lib/libavcodec.dylib:ffmpeg \
                 port:libdvdread \
                 path:include/turbojpeg.h:libjpeg-turbo \
                 port:lame
-
-platforms       darwin
 
 patch.pre_args  -p1
 patch.args      -b -V numbered

--- a/multimedia/xine-lib/Portfile
+++ b/multimedia/xine-lib/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                xine-lib
 version             1.2.13
-revision            2
+revision            3
 checksums           rmd160  2b1045e3dfe475c92a442f3506ee8b570b73da32 \
                     sha256  5f10d6d718a4a51c17ed1b32b031d4f9b80b061e8276535b2be31e5ac4b75e6f \
                     size    5004196

--- a/perl/p5-perlmagick/Portfile
+++ b/perl/p5-perlmagick/Portfile
@@ -7,18 +7,17 @@ PortGroup           perl5 1.0
 
 epoch               1
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         PerlMagick 6.9.11-60
+perl5.setup         PerlMagick 6.9.13-7
 revision            0
-checksums           rmd160  1c293ba06fd43833be35efb4476e559bf137ccef \
-                    sha256  ba0fa683b0721d1f22b0ccb364e4092e9a7a34ffd3bd6348c82b50fd93b1d7ba \
-                    size    9167220
+checksums           rmd160  9025e38a212d8cfe5706f07c4f900a96b708c016 \
+                    sha256  2a521f7992b3dd32469b7b7254a81df8a0045cb0b963372e3ba6404b0a4efeae \
+                    size    9604796
 
 set my_name         ImageMagick
 maintainers         {ryandesign @ryandesign}
 description         Perl extension for calling ImageMagick's libMagick methods
-long_description    ${description}
+long_description    {*}${description}
 license             Apache-2
-platforms           darwin
 use_xz              yes
 
 # We use the ImageMagick distribution version of PerlMagick to

--- a/perl/p5-perlmagick/files/no-usr-include-ImageMagick.patch
+++ b/perl/p5-perlmagick/files/no-usr-include-ImageMagick.patch
@@ -1,34 +1,34 @@
 Don't look in /usr/include/ImageMagick.
---- PerlMagick/Makefile.PL.in.orig	2019-11-29 12:39:22.000000000 -0600
-+++ PerlMagick/Makefile.PL.in	2019-12-01 05:51:53.000000000 -0600
+--- PerlMagick/Makefile.PL.in.orig	2024-02-26 01:29:03
++++ PerlMagick/Makefile.PL.in	2024-04-01 12:43:17
 @@ -161,7 +161,7 @@
  }
  
  # defaults for LIBS & INC & CCFLAGS params that we later pass to Writemakefile
 -my $INC_magick = '-I../ -I@top_srcdir@ @CPPFLAGS@ -I"' . $Config{'usrinc'} . '/ImageMagick"';
 +my $INC_magick = '-I../ -I@top_srcdir@ @CPPFLAGS@';
- my $LIBS_magick = '-L../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ -lperl @MATH_LIBS@';
+ my $LIBS_magick = '-L../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ @MATH_LIBS@ -L' . $Config{'archlib'} . '/CORE';
  my $CCFLAGS_magick = "$Config{'ccflags'} @CFLAGS@";
  my $LDFLAGS_magick   = "-L../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ $Config{'ldflags'} @LDFLAGS@";
---- PerlMagick/default/Makefile.PL.in.orig	2019-11-29 12:39:22.000000000 -0600
-+++ PerlMagick/default/Makefile.PL.in	2019-12-01 05:52:00.000000000 -0600
+--- PerlMagick/default/Makefile.PL.in.orig	2024-02-26 01:29:03
++++ PerlMagick/default/Makefile.PL.in	2024-04-01 12:43:54
 @@ -161,7 +161,7 @@
  }
  
  # defaults for LIBS & INC & CCFLAGS params that we later pass to Writemakefile
 -my $INC_magick = '-I../.. -I@top_srcdir@ @CPPFLAGS@ -I"' . $Config{'usrinc'} . '/ImageMagick"';
 +my $INC_magick = '-I../.. -I@top_srcdir@ @CPPFLAGS@';
- my $LIBS_magick = '-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ -lperl @MATH_LIBS@';
+ my $LIBS_magick = '-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ @MATH_LIBS@ -L' . $Config{'archlib'} . '/CORE';
  my $CCFLAGS_magick = "$Config{'ccflags'} @CFLAGS@";
  my $LDFLAGS_magick   = "-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ $Config{'ldflags'} @LDFLAGS@";
---- PerlMagick/quantum/Makefile.PL.in.orig	2019-11-29 12:39:22.000000000 -0600
-+++ PerlMagick/quantum/Makefile.PL.in	2019-12-01 05:51:42.000000000 -0600
+--- PerlMagick/quantum/Makefile.PL.in.orig	2024-02-26 01:29:03
++++ PerlMagick/quantum/Makefile.PL.in	2024-04-01 12:44:09
 @@ -161,7 +161,7 @@
  }
  
  # defaults for LIBS & INC & CCFLAGS params that we later pass to Writemakefile
 -my $INC_magick = '-I../../ -I@top_srcdir@ @CPPFLAGS@ -I"' . $Config{'usrinc'} . '/ImageMagick"';
 +my $INC_magick = '-I../../ -I@top_srcdir@ @CPPFLAGS@';
- my $LIBS_magick = '-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ -lperl @MATH_LIBS@';
+ my $LIBS_magick = '-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ @MATH_LIBS@ -L' . $Config{'archlib'} . '/CORE';
  my $CCFLAGS_magick = "$Config{'ccflags'} @CFLAGS@";
  my $LDFLAGS_magick   = "-L../../magick/.libs -lMagickCore-@MAGICK_MAJOR_VERSION@.@MAGICK_ABI_SUFFIX@ $Config{'ldflags'} @LDFLAGS@";

--- a/php/php-imagick/Portfile
+++ b/php/php-imagick/Portfile
@@ -20,7 +20,7 @@ long_description        Imagick is a native PHP extension for creating and \
 if {[vercmp ${php.branch} >= 5.4]} {
     epoch               1
     version             3.7.0
-    revision            0
+    revision            1
     checksums           rmd160  60d5c6cc154b65bdfd31be6980633ff1e659bc73 \
                         sha256  5a364354109029d224bcbb2e82e15b248be9b641227f45e63425c06531792d3e \
                         size    360138
@@ -29,7 +29,7 @@ if {[vercmp ${php.branch} >= 5.4]} {
     # https://pecl.php.net/package-info.php?package=imagick&version=3.4.0RC1
     epoch               2
     version             3.3.0
-    revision            0
+    revision            1
     checksums           rmd160  5746dc20ed455049a6eb5cea8dfe2b6c702c8f7c \
                         sha256  bd69ebadcedda1d87592325b893fa78a5710a0ca7307f8e18c5e593949b1db2d \
                         size    179978
@@ -42,8 +42,6 @@ if {${name} ne ${subport}} {
     depends_lib-append  port:ImageMagick
 
     configure.args      --with-imagick=${prefix}
-
-    use_parallel_build  yes
 
     post-destroot {
         set docdir ${prefix}/share/doc/${subport}

--- a/php/php-magickwand/Portfile
+++ b/php/php-magickwand/Portfile
@@ -5,9 +5,8 @@ PortGroup           php 1.1
 
 name                php-magickwand
 version             1.0.9-2
-revision            5
+revision            6
 categories-append   graphics
-platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             ImageMagick
 

--- a/ruby/rb-rmagick/Portfile
+++ b/ruby/rb-rmagick/Portfile
@@ -5,7 +5,7 @@ PortGroup               ruby 1.0
 
 ruby.branches           3.2 3.1 3.0 2.7 2.6 2.5 2.4 2.3
 ruby.setup              rmagick 5.0.0 gem
-revision                0
+revision                1
 categories-append       graphics
 maintainers             nomaintainer
 license                 MIT

--- a/science/opendx/Portfile
+++ b/science/opendx/Portfile
@@ -5,12 +5,11 @@ PortGroup               deprecated 1.0
 
 name                    opendx
 version                 4.4.4
-revision                11
+revision                12
 categories              science
 license                 Permissive
 # "IBM PUBLIC LICENSE", http://opendx.org/dlSource.html
 maintainers             nomaintainer
-platforms               darwin
 
 description             IBM's Open Visualization Data Explorer
 long_description        OpenDX is a uniquely powerful, full-featured software   \

--- a/science/xastir/Portfile
+++ b/science/xastir/Portfile
@@ -7,17 +7,16 @@ PortGroup           app 1.0
 name                xastir
 categories          science
 license             GPL-2+
-platforms           darwin
 maintainers         {ra1nb0w @ra1nb0w} openmaintainer
 description         Amateur Radio APRS tracking software
-long_description    ${description}
+long_description    {*}${description}
 homepage            http://www.xastir.org/
 
 github.setup        Xastir Xastir 2.1.8 Release-
 checksums           rmd160  8e32480f5bd43d262d3ca2153fb69c492273ad25 \
                     sha256  8b010e0ae665c1dd5f83c609940b6b8b56ad0f777bac0f637f599311111bf973 \
                     size    2222069
-revision            9
+revision            10
 
 use_autoconf        yes
 autoconf.cmd        ./bootstrap.sh

--- a/textproc/cuneiform/Portfile
+++ b/textproc/cuneiform/Portfile
@@ -5,9 +5,8 @@ PortGroup               cmake 1.1
 
 name                    cuneiform
 version                 1.1.0
-revision                7
+revision                8
 set branch              [join [lrange [split ${version} .] 0 1] .]
-platforms               darwin
 maintainers             nomaintainer
 categories              textproc graphics
 


### PR DESCRIPTION
#### Description

Also rev bump dependents that link with the libs.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
