### PR TITLE
luajit: Update to commit d06beb048 and support universal variant

### DIFF
--- a/lang/luajit/Portfile
+++ b/lang/luajit/Portfile
@@ -6,6 +6,7 @@ PortGroup           xcode_workaround 1.0
 PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
+PortGroup           muniversal 1.1
 
 set branch          2.1
 set version_date    2024-03-10T16:29:48Z
@@ -48,6 +49,18 @@ post-patch {
 }
 
 compiler.blacklist  {clang < 700} *gcc-4.2 macports-clang-3.3 macports-clang-3.4
+
+## Fix universal builds, see:
+# - https://www.freelists.org/post/luajit/Building-universal-libraries-x86-64-and-arm64-for-osx,4
+# - https://git.openembedded.org/meta-openembedded/plain/meta-oe/recipes-devtools/luajit/luajit_git.bb
+# Clean automatically set options that apply to both host and target architectures (which we do not want)
+build.post_args-append  CCOPT= CCOPT_x86= TARGET_STRIP='@:'
+foreach arch ${muniversal.architectures} {
+    build.args.${arch}-append  TARGET_FLAGS+="[muniversal::get_archflag cc ${arch}]"
+    build.post_args.${arch}-append \
+        CFLAGS="${configure.cflags} [configure.cflags.${arch}]" \
+        LDFLAGS="${configure.ldflags} [configure.ldflags.${arch}]"
+}
 
 # changes to compiler flags must be made before `CFLAGS=...`
 xcode_workaround.type append_to_compiler_flags

--- a/lang/luajit/Portfile
+++ b/lang/luajit/Portfile
@@ -8,12 +8,12 @@ PortGroup           legacysupport 1.1
 PortGroup           makefile 1.0
 
 set branch          2.1
-set version_date    2023-12-23T19:06:17Z
-github.setup        LuaJIT LuaJIT c525bcb9024510cad9e170e12b6209aedb330f83
+set version_date    2024-03-10T16:29:48Z
+github.setup        LuaJIT LuaJIT d06beb0480c5d1eb53b3343e78063950275aa281
 revision            0
-checksums           rmd160  db4a5de50bfef270d080ae8023b77f879997cbee \
-                    sha256  eb20affc70a9e97a8a0e1e0b10456f220fca7637a198e4a937b5fc827dd1ef95 \
-                    size    1079440
+checksums           rmd160  3214ac12acb255991c7f7532bbb913b838a1f439 \
+                    sha256  6abd146a1dfa240a965748f63221633446affa2a715e3eb03879136e3efb95f4 \
+                    size    1081883
 
 set version_date_s  [clock scan "${version_date}" -format {%Y-%m-%dT%H:%M:%SZ} -timezone :UTC]
 version             ${branch}.${version_date_s}


### PR DESCRIPTION
#### Description

- Update to commit [d06beb048](https://github.com/LuaJIT/LuaJIT/commit/d06beb0480c5d1eb53b3343e78063950275aa281) of 2024-03-10 (still branch 2.1)
- Add PortGroup muniversal to support variant `+universal`
  - Closes: https://trac.macports.org/ticket/41304

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
