### PR TITLE
pan2: update to 0.157

### DIFF
--- a/news/pan2/Portfile
+++ b/news/pan2/Portfile
@@ -3,10 +3,11 @@
 PortSystem          1.0
 PortGroup           app 1.0
 PortGroup           active_variants 1.1
+PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 name                pan2
-version             0.155
+version             0.157
 revision            0
 categories          news
 license             GPL-2
@@ -20,40 +21,29 @@ long_description    Pan2 is a newsreader for GTK+ that is based on \
 
 homepage            https://gitlab.gnome.org/GNOME/pan
 master_sites        https://gitlab.gnome.org/GNOME/pan/-/archive/v${version}
-
 distname            pan-v${version}
 use_bzip2           yes
 
-checksums           rmd160  3e450a66c574dbcb06ea37674fd00015f24fcf7b \
-                    sha256  3624ac3171fa8089825ce55b62b053db4f86d592f717c4d874c48ce0e885dff2 \
-                    size    1797355
+checksums           rmd160  8902a51c43d825805cc09a9dd5b297115ded1272 \
+                    sha256  1ab5f59a9e1e9cb9bfe978be55fda812d5b46936c1c14d9dae30a555c665eb51 \
+                    size    1819034
 
 depends_build-append \
-                    port:autoconf-archive \
                     port:pkgconfig \
-                    port:itstool \
-                    port:yelp-tools
+                    port:gettext
 
 depends_lib-append  port:desktop-file-utils \
-                    port:pcre \
                     port:gmime3 \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:gtkspell3 \
-                    port:libiconv
+                    port:libiconv \
+                    port:zlib
 
 depends_run-append  port:adwaita-icon-theme
 
-use_autoreconf      yes
-
 compiler.cxx_standard       2011
 compiler.blacklist-append   {clang < 900}
-
-configure.cxxflags-append   -std=c++11
-
-configure.args      --with-gnutls \
-                    --disable-gkr  \
-                    --disable-silent-rules
 
 app.icon                pan/icons/icon_pan_about_logo.png
 app.name                Pan
@@ -63,7 +53,7 @@ app.use_launch_script   yes
 variant x11 conflicts quartz {
    require_active_variants gtk3 x11 quartz
    depends_lib-append      port:gcr port:libsecret
-   configure.args-replace  --disable-gkr --enable-gkr
+   configure.args-append   -DWANT_GKR=ON
 }
 
 variant quartz conflicts x11 {


### PR DESCRIPTION
build now uses cmake
autotools is deprecated

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7 21G816 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

both quartz and x11 work OK.

Run this past CI for assessment.