### PR TITLE
ffmpeg6: remove prog suffix, new symlink variant

### DIFF
--- a/multimedia/ffmpeg6/Portfile
+++ b/multimedia/ffmpeg6/Portfile
@@ -17,7 +17,7 @@ name                ffmpeg6
 set my_name         ffmpeg
 
 version             6.1.1
-revision            2
+revision            3
 epoch               0
 
 license             LGPL-2.1+
@@ -158,7 +158,6 @@ configure.pre_args-append \
                     --cc="${configure.cc}" \
                     --datadir=${port_datadir} \
                     --docdir=${port_docdir} \
-                    --progs-suffix=${port_ver_major} \
                     --prefix=${port_prefix}
 
 configure.args-append \
@@ -384,16 +383,24 @@ post-destroot {
     foreach f [glob ${worksrcpath}/doc/*.txt] {
         file copy $f ${destroot}${port_docdir}
     }
+}
 
-    # Create bin symlinks
-    set port_bin_list \
-        [glob -type f -directory ${destroot}${port_bindir} *]
-    foreach f ${port_bin_list} {
-        set fname [file tail ${f}]
-        ui_info "Symlinking bin: ${prefix}/bin/${fname} -> ${port_bindir}/${fname}"
-        ln -s ${port_bindir}/${fname} ${destroot}${prefix}/bin/${fname}
+variant symlink description {Create binary symlinks for easier access} {
+    configure.pre_args-append \
+        --progs-suffix=${port_ver_major}
+    post-destroot {
+        # Create bin symlinks
+        set port_bin_list \
+            [glob -type f -directory ${destroot}${port_bindir} *]
+        foreach f ${port_bin_list} {
+            set fname [file tail ${f}]
+            ui_info "Symlinking bin: ${prefix}/bin/${fname} -> ${port_bindir}/${fname}"
+            ln -s ${port_bindir}/${fname} ${destroot}${prefix}/bin/${fname}
+        }
     }
 }
+
+default_variants-append +symlink
 
 variant x11 {
     # enable x11grab_xcb input device
@@ -542,6 +549,18 @@ notes-append "
 This build of ${name} includes no GPLed or nonfree code and is therefore licensed under LGPL v2.1 or later.
 "
 }
+
+notes-append ""
+notes-append "
+To use the ${name} command-line programs without suffix, add\
+${prefix}/libexec/ffmpeg6/bin to your \$PATH,\
+in front of the normal ${prefix}/bin; or else use full paths.
+To compile and link with ${name}, add\
+-I${prefix}/libexec/ffmpeg6/include and\
+-L${prefix}/libexec/ffmpeg6/lib to your compile command.
+For builds using pkg-config, add\
+${prefix}/libexec/ffmpeg6/lib/pkgconfig to \$PKG_CONFIG_PATH.
+"
 
 livecheck.type      regex
 livecheck.url       ${master_sites}


### PR DESCRIPTION
Add notes on how to use command line progs and how to use ffmpeg libraries

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
