### PR TITLE
virtuoso-7: Fix compilation problems on macOS 14.4

### DIFF
--- a/devel/virtuoso-7/Portfile
+++ b/devel/virtuoso-7/Portfile
@@ -7,7 +7,7 @@ PortGroup           openssl 1.0
 name                virtuoso-7
 set myname          virtuoso
 version             7.2.10
-revision            0
+revision            1
 categories          devel
 maintainers         {snc @nerdling} openmaintainer
 license             GPL
@@ -26,7 +26,10 @@ checksums           rmd160  a7d1d7c7333b3e125543a70c4644b36de8f7da45 \
 # https://trac.macports.org/ticket/61216
 patchfiles-append   patch-libsrc-Wi-numeric.c.diff
 configure.cflags-append \
-                    -Wno-error=implicit-function-declaration
+                    -Wno-error=implicit-function-declaration \
+                    -Wno-error=incompatible-pointer-types \
+                    -Wno-error=implicit-int \
+                    -Wno-error=int-conversion
 
 supported_archs     x86_64 arm64
 conflicts           virtuoso-6 virtuoso-5


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1
Xcode 15.3 / Command Line Tools 15.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
