### PR TITLE
cpp-peglib: update to 1.8.8

### DIFF
--- a/devel/cpp-peglib/Portfile
+++ b/devel/cpp-peglib/Portfile
@@ -4,8 +4,13 @@ PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 
-github.setup        yhirose cpp-peglib 1.8.6 v
+# https://trac.macports.org/ticket/67411
+legacysupport.newest_darwin_requires_legacy 16
+legacysupport.use_mp_libcxx yes
+
+github.setup        yhirose cpp-peglib 1.8.8 v
 revision            0
 categories          devel
 # Do not set is as noarch until this issue is fixed:
@@ -16,9 +21,9 @@ license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         A single file C++ header-only PEG (Parsing Expression Grammars) library
 long_description    {*}${description}
-checksums           rmd160  74da160bc9b10a849b8ec9a3dbd1fbeeb1d1d6e8 \
-                    sha256  b2ebdc135a66074a386d377b761b38e050088fba6482575ca3028d0e184ecd91 \
-                    size    226506
+checksums           rmd160  498939f9f017000a5b98ae9597d49527fdbb420a \
+                    sha256  3019d8084a146562fe2fd4c71e3226ac6e3994e8cee21cab27b3cd5a86bcef34 \
+                    size    228192
 github.tarball_from archive
 
 # The port needs Gtest for building tests, however linking to external Gtest fails.


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
