### PR TITLE
google-cloud-sdk: update to 471.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             470.0.0
+version             471.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  288e3ce7b96f553a7b89db93ee7a02ec30bb41e0 \
-                    sha256  396648bb05af0151a9c47ee377f5ca2d1cbe36982cb62a6dd6ce00af549420b5 \
-                    size    128518450
+    checksums       rmd160  a5ec90ca01ea890ddb2d3dccf3df35c41aecf9ae \
+                    sha256  158f1651f458a98f44ca8f61106621eab8e333f9a9ed1bd3b77013685c2e35ad \
+                    size    123408791
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  1d0ed6a6ba7d5e9936594a3fb1e09fe9790e99e6 \
-                    sha256  d8cba679b0116460dace415a2fab3ee06c74f5f5cce7813f02e70ec2df124d9c \
-                    size    129802911
+    checksums       rmd160  d5cde031adadc63a23ea0bcd955ac12a7be042ad \
+                    sha256  5f49aad1487334efc1c0a7b89d99ad334417cdff1d85d49dda896de61861cffa \
+                    size    124694562
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  dbf2b0b4a23cec1332ace1492eab9ebdc42ae471 \
-                    sha256  5ca02eaf4413553faa395487c9442a8ae2d2994247372db6ef16a8696036b671 \
-                    size    126874125
+    checksums       rmd160  ef87974ed75a4bd52c1d119875e5d2995858525c \
+                    sha256  9e2bd6acbc258c301fbad5f0ad0d73dc33e283f127a17ba83c6e498c68920164 \
+                    size    121762731
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 471.0.0.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?