### PR TITLE
enigma4: new port in security/net

### DIFF
--- a/security/enigma4/Portfile
+++ b/security/enigma4/Portfile
@@ -1,0 +1,55 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+github.setup        m3sserschmitt enigma4 e53879f73b439d318f0171cffd4c63719aa270d5
+version             2022.07.02
+revision            0
+categories          security net
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             MIT
+description         Onion Routing App
+long_description    {*}${description}
+
+fetch.type          git
+
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init --recursive"
+}
+
+# Ensure correct path for dylibs:
+configure.args-append   -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
+
+# GCC can build this as-is, but Clang needs C++17 specified explicitly.
+# https://github.com/m3sserschmitt/enigma4/issues/6
+# Can be set for both though.
+compiler.cxx_standard   2017
+
+configure.cxxflags-append \
+                        -std=c++17
+
+notes "
+To test functionality please refer to the README:\
+https://github.com/m3sserschmitt/enigma4/blob/master/README.md
+"
+
+destroot {
+    foreach ebin {circuit_example eclient enigma4} {
+        copy ${cmake.build_dir}/${ebin} ${destroot}${prefix}/bin
+    }
+    set docdir ${prefix}/share/${name}/doc
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} LICENSE README.md ${destroot}${docdir}
+    foreach dir {example test_conf test_keys test_scripts} {
+        copy ${worksrcpath}/${dir} ${destroot}${prefix}/share/${name}
+    }
+    fs-traverse elib ${cmake.build_dir} {
+        if {[file isfile ${elib}] && ([file extension ${elib}] == ".dylib" \
+            || [file extension ${elib}] == ".a")} {
+                copy ${elib} ${destroot}${prefix}/lib
+        }
+    }
+}


### PR DESCRIPTION
#### Description

New port

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1
Xcode 15.3

macOS 10.6
Xcode 3.2

(I have ran test demo only on Sonoma, but binaries were functional on 10.6 too.)

![enigma4](https://github.com/macports/macports-ports/assets/92015510/2e82dc06-be3f-4c4c-a349-75204dce362a)


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
