### PR TITLE
i2pchat: new port in net

### DIFF
--- a/net/i2pchat/Portfile
+++ b/net/i2pchat/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           qmake5 1.0
+
+qt5.depends_component qtmultimedia qtsvg
+
+# TODO: find a version working with Qt4.
+# https://github.com/vituperative/i2pchat/issues/31
+github.setup        vituperative i2pchat 0.2.37
+revision            0
+categories          net security aqua
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+
+description         Anonymous private secure open-source chat
+long_description    {*}${description} using end-to-end encrypted transport.
+license             GPL-2
+
+checksums           rmd160  aed05ec0b191872404ff7dd1da770a411c3e34b1 \
+                    sha256  7cab4d689fefbf60fd8ff13853126c76f7b70e5a90d38430ffb0b1c1ab88877e \
+                    size    1679202
+github.tarball_from archive
+
+compiler.cxx_standard   2011
+
+# Avoid a silly error:
+# https://github.com/vituperative/i2pchat/issues/32
+patchfiles-append   0001-Patch-gitversion.pri.patch
+
+destroot {
+    copy ${worksrcpath}/I2PChat.app ${destroot}${applications_dir}
+}

--- a/net/i2pchat/files/0001-Patch-gitversion.pri.patch
+++ b/net/i2pchat/files/0001-Patch-gitversion.pri.patch
@@ -1,0 +1,20 @@
+From 07370e2c987f02853e367614de6beec285f814f2 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Thu, 4 Apr 2024 03:31:56 +0800
+Subject: [PATCH] Patch gitversion.pri
+
+---
+ gitversion.pri | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git gitversion.pri gitversion.pri
+index 7202f57..33f7c3b 100644
+--- gitversion.pri
++++ gitversion.pri
+@@ -53,5 +53,5 @@ DEFINES += GIT_COMMIT_COUNT=\\\"$$GIT_COMMIT_COUNT\\\"
+ # This will rewrite Info.plist with full version
+ macx {
+     INFO_PLIST_PATH = $$shell_quote($${OUT_PWD}/$${TARGET}.app/Contents/Info.plist)
+-    QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString $${VERSION}\" $${INFO_PLIST_PATH}
++    # QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString $${VERSION}\" $${INFO_PLIST_PATH}
+ }


### PR DESCRIPTION
#### Description

New port, messenger over i2p.

At the moment, only Qt5 version, but Qt4 support is considered.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1
Xcode 15.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
