### PR TITLE
OCRmyPDF: new port

### DIFF
--- a/textproc/ocrmypdf/Portfile
+++ b/textproc/ocrmypdf/Portfile
@@ -1,0 +1,56 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                ocrmypdf
+version             16.1.2
+revision            0
+categories          textproc
+
+homepage            https://github.com/ocrmypdf/OCRmyPDF
+
+maintainers         {@akierig fastmail.de:akierig} openmaintainer
+
+checksums           rmd160  25b94fbd304d1fb8235cbd12c1b8fb2af0cf868a \
+                    sha256  d1f9c62b3a0cb090218e8f719d85d110bad95cb73e83dec05842652d173b0c29 \
+                    size    6720680
+
+description         ${name} adds an OCR text layer to scanned PDF files, \
+                    allowing them to be searched
+long_description    {*}${description}. ${name} also supports plugins \
+                    that enable customization of its processing steps, \
+                    and it is highly tolerant of PDFs containing scanned \
+                    images and “born digital” content that doesn’t require text recognition.
+
+supported_archs     noarch
+platforms           {darwin any}
+license             MPL-2
+python.default_version 312
+
+depends_build-append \
+                    port:py${python.version}-setuptools_scm
+
+depends_lib-append  port:ghostscript \
+                    port:img2pdf \
+                    port:jbig2enc \
+                    port:libpng \
+                    port:pngquant \
+                    port:qpdf \
+                    port:tesseract \
+                    port:unpaper \
+                    port:py${python.version}-deprecation \
+                    port:py${python.version}-freetype \
+                    port:py${python.version}-packaging \
+                    port:py${python.version}-pdfminer \
+                    port:py${python.version}-Pillow \
+                    port:py${python.version}-pikepdf \
+                    port:py${python.version}-pluggy \
+                    port:py${python.version}-pybind11 \
+                    port:py${python.version}-rich
+
+notes "
+You will need to install the tesseract language ports of your choice.
+e.g., to add English and German support:
+
+    port install tesseract-eng tesseract-deu"


### PR DESCRIPTION
#### Description

Adding OCRmyPDF, a tool that extends tesseract to create PDFs with searchable text.

depends on py-deprecated getting python 3.12 support as in #23346  

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
