### PR TITLE
most: update to 5.2.0

### DIFF
--- a/textproc/most/Portfile
+++ b/textproc/most/Portfile
@@ -1,7 +1,7 @@
 PortSystem      1.0
 
 name            most
-version         5.1.0
+version         5.2.0
 revision        0
 categories      textproc
 license         GPL-2+
@@ -15,12 +15,12 @@ long_description \
     most supports multiple windows and can scroll left and right. \
     Why settle for less?
 
-homepage        http://www.jedsoft.org/${name}/
+homepage        https://www.jedsoft.org/${name}/
 master_sites    https://www.jedsoft.org/releases/${name}/
 
-checksums       rmd160  46017a27d9104707c86c6c8b0e89c2f5cc30dfa8 \
-                sha256  db805d1ffad3e85890802061ac8c90e3c89e25afb184a794e03715a3ed190501 \
-                size    162172
+checksums       rmd160  2abd8b43c9e5f44f0f93d93b231b70f1a69238f2 \
+                sha256  9455aeb8f826fa8385c850dc22bf0f22cf9069b3c3423fba4bf2c6f6226d9903 \
+                size    256075
 
 depends_lib     port:slang2
 


### PR DESCRIPTION
#### Description

Upgrades `most` to the most recent version from https://www.jedsoft.org/releases/most/

###### Type(s)
update

###### Tested on
macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
