### PR TITLE
macfuse: update to 4.6.2

### DIFF
--- a/fuse/macfuse/Portfile
+++ b/fuse/macfuse/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        osxfuse osxfuse 4.5.0 macfuse-
+github.setup        osxfuse osxfuse 4.6.2 macfuse-
 revision            0
 name                macfuse
 conflicts           osxfuse
@@ -24,9 +24,9 @@ github.tarball_from releases
 distname            ${name}-${version}
 use_dmg             yes
 
-checksums           rmd160  ff3fbf4c08e6cbadfc25304e481daa0c90d62ebb \
-                    sha256  9df7257315a9b9a97a9ba3a76011cabed7bc3784515b69fa098f8d81efec726d \
-                    size    5974209
+checksums           rmd160  0a08e4e45db644d3ae7acc71474b1c505a18f72c \
+                    sha256  ee64053075ee4d7a1026505ebb22a58dd3638a8f7e74d186adaec265cf058c1f \
+                    size    6202160
 
 if {${os.platform} eq "darwin" && ${os.major} < 16} {
     known_fail yes


### PR DESCRIPTION
###### Tested on
macOS 14.4 23E214 x86_64
Xcode 15.3 15E204a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?