### PR TITLE
htop: Do not opportunistically link libunwind

### DIFF
--- a/sysutils/htop/Portfile
+++ b/sysutils/htop/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           legacysupport 1.1
 
 github.setup        htop-dev htop 3.3.0
-revision            1
+revision            2
 epoch               1
 
 checksums           rmd160  32f836bc4016f2ebf6b2332396993baad5c69ee6 \
@@ -37,6 +37,8 @@ patchfiles-append   0002-darwin-PlatformHelpers-fix-CPU-detection-for-PowerPC.pa
 pre-configure {
     system -W ${worksrcpath} "sh autogen.sh"
 }
+
+configure.args      --disable-unwind
 
 post-destroot {
     # Delete the .png and .desktop files


### PR DESCRIPTION
#### Description

When libunwind is installed, htop automatically detects and links against it, without declaring a dependency. Avoid this by explicitly disabling unwind support.

Closes: #23292

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a
with libunwind installed

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vs install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
