### PR TITLE
xmp: allow universal

### DIFF
--- a/audio/xmp/Portfile
+++ b/audio/xmp/Portfile
@@ -14,9 +14,6 @@ build.type          gnu
 # Disable silent rules.
 build.args-append   V=1
 
-# Cannot turn off dependency tracking for libxmp.
-universal_variant   no
-
 if {${subport} eq ${name}} {
     version             4.2.0
     revision            0


### PR DESCRIPTION
#### Description

```
10:~ svacchanda$ file /opt/local/lib/libxmp.4.dylib
/opt/local/lib/libxmp.4.dylib: Mach-O universal binary with 2 architectures
/opt/local/lib/libxmp.4.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
/opt/local/lib/libxmp.4.dylib (for architecture i386):	Mach-O dynamically linked shared library i386
10:~ svacchanda$ port -v installed libxmp 
The following ports are currently installed:
  libxmp @4.6.0_0+universal (active) requested_variants='+universal' platform='darwin 12' archs='i386 x86_64' date='2024-04-05T04:41:31+0800'
```

```
10:~ svacchanda$ file /opt/local/bin/xmp
/opt/local/bin/xmp: Mach-O universal binary with 2 architectures
/opt/local/bin/xmp (for architecture x86_64):	Mach-O 64-bit executable x86_64
/opt/local/bin/xmp (for architecture i386):	Mach-O executable i386
10:~ svacchanda$ port -v installed xmp
The following ports are currently installed:
  xmp @4.2.0_0+universal (active) requested_variants='+universal' platform='darwin 12' archs='i386 x86_64' date='2024-04-05T04:46:22+0800'
```

Why is it prohibited? Everything works fine. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5
Xcode 5.1.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
