### PR TITLE
py-pikepdf: added missing dependency

### DIFF
--- a/python/py-pikepdf/Portfile
+++ b/python/py-pikepdf/Portfile
@@ -7,7 +7,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                py-pikepdf
 github.setup        pikepdf pikepdf 8.14.0 v
-revision            0
+revision            1
 categories-append   graphics
 license             MPL-2
 maintainers         {mps @Schamschula} openmaintainer
@@ -29,7 +29,7 @@ if {${name} ne ${subport}} {
                     port:py${python.version}-wheel
 
     depends_lib-append  \
-                    port:py${python.version}-deprecation \
+                    port:py${python.version}-deprecated \
                     port:py${python.version}-lxml \
                     port:py${python.version}-packaging \
                     port:py${python.version}-Pillow \


### PR DESCRIPTION
- per the upstream pyproject.toml, py-deprecated is a required (and missing from the portfile) dependency. (cf. https://github.com/pikepdf/pikepdf/blob/7f3c540f4904a19cec4363bbd13e93085ee5b72d/pyproject.toml#L29)

- the missing py-deprecated module is causing errors when using OCRmyPDF (#23347)

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
