### PR TITLE
ipatool: new port (2.1.4)

### DIFF
--- a/sysutils/ipatool/Portfile
+++ b/sysutils/ipatool/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               golang 1.0
+
+go.setup                github.com/majd/ipatool 2.1.4 v
+github.tarball_from     archive
+revision                0
+categories              sysutils
+license                 MIT
+platforms               {darwin >= 19}
+installs_libs           no
+maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
+
+description             CLI for searching and downloading iOS app packages from the App Store
+long_description        {*}${description}.
+
+checksums               rmd160  b450ad8cfd4fc4e22bafa6a98ed33f29b505cf95 \
+                        sha256  e0e01c88efb94f35a71f664267c6c9ab0e22932804e0af864a0a5cd8d348dbca \
+                        size    133997
+
+# Vendored libraries cause failure, fetch them at build time
+go.offline_build        no
+
+build.args-append       -ldflags \"-X ${go.package}/v2/cmd.version=${version}\"
+
+post-build {
+    # Generate shell completions for supported shells
+    foreach shell {zsh bash fish} {
+        system -W ${worksrcpath} "./${name} completion ${shell} > ${name}.${shell}"
+    }
+}
+
+destroot {
+    xinstall -m 0755 -W ${worksrcpath} ${name} ${destroot}${prefix}/bin/${name}
+
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_comp_path}
+    xinstall -m 0644 ${worksrcpath}/${name}.zsh ${zsh_comp_path}/_${name}
+
+    set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${bash_comp_path}
+    xinstall -m 0644 ${worksrcpath}/${name}.bash ${bash_comp_path}/${name}
+
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completion.d
+    xinstall -d ${fish_comp_path}
+    xinstall -m 0644 ${worksrcpath}/${name}.fish ${fish_comp_path}
+}


### PR DESCRIPTION
#### Description

Add `ipsw`, [a CLI that allows searching and downloading app packages from the iOS App Store](https://github.com/majd/ipatool)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
