### PR TITLE
emacs, emacs-devel: allow build on powerpc

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -66,6 +66,8 @@ depends_lib-append     port:gmp \
                        port:sqlite3 \
                        port:webp
 
+compiler.blacklist-append  *gcc-4.0 *gcc-4.2
+
 post-destroot {
     xinstall -d ${destroot}${prefix}/share/emacs/${version}/leim
     delete ${destroot}${prefix}/bin/ctags
@@ -107,6 +109,9 @@ if {$subport eq $name || $subport eq "emacs-app"} {
     checksums       rmd160  74592d7dba2f02b2d827a74b5a5aa5e2077fc73f \
                     sha256  2de8df5cab8ac697c69a1c46690772b0cf58fe7529f1d1999582c67d927d22e4 \
                     size    78508272
+
+    patchfiles-append \
+                    patch-allow-powerpc.diff
 }
 
 if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
@@ -124,6 +129,9 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     checksums       rmd160  ff0c37c5f8df3e7e0c8c65fdeca086d64a455129 \
                     sha256  b8e0ae5ecca0d2f908759dacd00503f2d4e44562443ce2ac6c5f335dc8960f52 \
                     size    49660683
+
+    patchfiles-append \
+                    patch-allow-powerpc-devel.diff
 
     pre-configure {
         system -W ${worksrcpath} "sh ./autogen.sh"
@@ -317,4 +325,11 @@ variant treesitter description {Builds emacs with tree-sitter support} {
     }
 }
 
-default_variants-append +nativecomp +treesitter
+default_variants-append     +treesitter
+
+# JIT not supported in gcc for i386, so configure will fail.
+# On ppc it is supported, but the build with +nativecomp segfaults.
+# https://trac.macports.org/ticket/69677
+if {${configure.build_arch} ni [list i386 ppc]} {
+    default_variants-append +nativecomp
+}

--- a/editors/emacs/files/patch-allow-powerpc-devel.diff
+++ b/editors/emacs/files/patch-allow-powerpc-devel.diff
@@ -1,0 +1,14 @@
+--- configure.ac	2024-03-24 21:02:33.000000000 +0800
++++ configure.ac	2024-04-05 10:19:13.000000000 +0800
+@@ -738,11 +738,6 @@
+ 
+   ## Apple Darwin / macOS
+   *-apple-darwin* )
+-    case "${canonical}" in
+-      *-apple-darwin[0-9].*) unported=yes ;;
+-      i[3456]86-* | x86_64-* | arm-* | aarch64-* )  ;;
+-      * )            unported=yes ;;
+-    esac
+     opsys=darwin
+     ## FIXME: Find a way to use Fink if available (Bug#11507).
+   ;;

--- a/editors/emacs/files/patch-allow-powerpc.diff
+++ b/editors/emacs/files/patch-allow-powerpc.diff
@@ -1,0 +1,16 @@
+--- configure	2024-03-24 21:15:23.000000000 +0800
++++ configure	2024-04-05 10:22:30.000000000 +0800
+@@ -6108,13 +6108,7 @@
+ 
+   ## Apple Darwin / macOS
+   *-apple-darwin* )
+-    case "${canonical}" in
+-      *-apple-darwin[0-9].*) unported=yes ;;
+-      i[3456]86-* | x86_64-* | arm-* | aarch64-* )  ;;
+-      * )            unported=yes ;;
+-    esac
+     opsys=darwin
+-    ## FIXME: Find a way to use Fink if available (Bug#11507).
+   ;;
+ 
+   ## Chromium Native Client


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69677

#### Description

CI on macOS 14 will likely fail for non-devel version. But I hope, changes are easy to review.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

![emacs](https://github.com/macports/macports-ports/assets/92015510/e76d48c8-247a-4a39-bb0d-9eafc232f678)


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
