### PR TITLE
openvdb: update to 11.0.0

### DIFF
--- a/graphics/openvdb/Portfile
+++ b/graphics/openvdb/Portfile
@@ -7,10 +7,10 @@ PortGroup               active_variants 1.1
 PortGroup               compiler_blacklist_versions 1.0
 PortGroup               boost 1.0
 
-github.setup            AcademySoftwareFoundation openvdb 10.0.1 v
-revision                6
+github.setup            AcademySoftwareFoundation openvdb 11.0.0 v
+github.tarball_from     archive
+revision                0
 categories              graphics
-platforms               darwin
 license                 {MPL-2 LGPL-2.1+}
 maintainers             {mcalhoun @MarcusCalhoun-Lopez} \
                         @jasonliu-- openmaintainer
@@ -27,9 +27,9 @@ long_description        OpenVDB is an open source C++ library \
                         encountered in computer-generated graphics and \
                         animation.
 
-checksums               rmd160  acf32c4e91b9ff05863ff3966f33de144fec05a2 \
-                        sha256  2b5dee3f2d5e1802c44d040856c6ddb440af4c959286799f8c8e3d0ee9842a7a \
-                        size    3464059
+checksums               rmd160  3e870caf094446807748dc77744cd1ffc0992f79 \
+                        sha256  6314ff1db057ea90050763e7b7d7ed86d8224fcd42a82cdbb9c515e001b96c74 \
+                        size    4620858
 
 # it uses constexpr if statement
 compiler.cxx_standard   2017
@@ -41,11 +41,11 @@ depends_build-append    port:pkgconfig
 
 depends_lib-append      port:zlib \
                         port:blosc \
-                        port:tbb \
+                        port:onetbb \
                         path:lib/pkgconfig/glfw3.pc:glfw
 
-configure.args-append   -DTBB_INCLUDEDIR=${prefix}/libexec/tbb/include \
-                        -DTBB_LIBRARYDIR=${prefix}/libexec/tbb/lib
+configure.args-append   -DTBB_INCLUDEDIR=${prefix}/libexec/onetbb/include \
+                        -DTBB_LIBRARYDIR=${prefix}/libexec/onetbb/lib
 
 # Disable building command-line tools.
 # We control whether to build them using the +utils variant below.
@@ -215,7 +215,7 @@ variant benchmark requires nanovdb examples \
 
 ############################# PyOpenVDB ##############################
 
-set python_suffixes     {27 38 39 310 311}
+set python_suffixes     {27 38 39 310 311 312}
 set python_ports        {}
 foreach s $python_suffixes {
     lappend python_ports python$s


### PR DESCRIPTION
#### Description

- use onetbb
- add python312

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.4 23E214 x86_64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?