### PR TITLE
imapsync: update to 2.264

### DIFF
--- a/mail/imapsync/Portfile
+++ b/mail/imapsync/Portfile
@@ -2,23 +2,24 @@
 
 PortSystem          1.0
 PortGroup           perl5 1.0
-PortGroup           github 1.0
 
-github.setup        imapsync imapsync 2.229 imapsync-
+name                imapsync
+version             2.264
 categories          mail perl
 platforms           any
 maintainers         nomaintainer
 license             Permissive
 description         imapsync is an IMAP synchronization, copy or migration tool.
 long_description    imapsync is an IMAP synchronization, copy or migration \
-                    tool. Synchronize mailboxes between two imap servers. It is \
-                    especially good at IMAP migration.
+                    tool. Synchronize mailboxes between two IMAP servers. It \
+                    is especially good at IMAP migration.
 
 homepage            https://imapsync.lamiral.info/
+master_sites        ${homepage}/dist/
 
-checksums           rmd160  29e4891c34858c58568a4bb315f96bca00a93ed4 \
-                    sha256  6c86254a780651be594b313fbecf22c322ad689835d85648497f72eeedac70ef \
-                    size    1923705
+checksums           rmd160  612bbbe7fabdf338d96565dfb924b71a509c1086 \
+                    sha256  14469e2de0d8deba6195a63e388bc38a6b7000ff12220912bf8f01a5673d6c7d \
+                    size    18343997
 
 perl5.require_variant   yes
 perl5.conflict_variants yes
@@ -44,6 +45,7 @@ depends_run         port:p${perl5.major}-crypt-openssl-rsa \
                     port:p${perl5.major}-json-xs \
                     port:p${perl5.major}-libwww-perl \
                     port:p${perl5.major}-mail-imapclient \
+                    port:p${perl5.major}-net-server \
                     port:p${perl5.major}-net-ssleay \
                     port:p${perl5.major}-pod-escapes \
                     port:p${perl5.major}-pod-simple \
@@ -60,17 +62,34 @@ depends_run         port:p${perl5.major}-crypt-openssl-rsa \
 supported_archs     noarch
 
 post-patch {
-    reinplace -locale C "s|^#!.*|#!${perl5.bin}|g" ${worksrcpath}/imapsync
+    reinplace -locale C "s|^#!.*|#!${perl5.bin}|g" \
+        ${worksrcpath}/imapsync \
+        ${worksrcpath}/webserver
 }
 
 use_configure       no
 
+extract.suffix      .tgz
+
 build               {}
 
+test.run            yes
+test.cmd            imapsync
+test.target         --version
+
 destroot {
-    xinstall -m 755 ${worksrcpath}/imapsync ${destroot}${prefix}/bin/imapsync.pl
-    ln -sf imapsync.pl ${destroot}${prefix}/bin/imapsync
-    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
-    xinstall -m 644 -W ${worksrcpath} CREDITS ChangeLog FAQ LICENSE INSTALL README \
-        TODO VERSION ${destroot}${prefix}/share/doc/${name}
+    set share_root ${prefix}/share/${name}
+    xinstall -d ${destroot}${share_root}
+    foreach f { ChangeLog CREDITS doc examples FAQ.d imapsync LICENSE oauth2 \
+        README S TODO VERSION webserver X } {
+        copy ${worksrcpath}/${f} ${destroot}${share_root}
+    }
+
+    ln -sf ${share_root}/imapsync ${destroot}${prefix}/bin/imapsync
+
+    # Create webserver launch script
+    set webserver_script [open ${destroot}${prefix}/bin/imapsync-webserver w 0755]
+    puts $webserver_script "#!/bin/sh"
+    puts $webserver_script "(cd ${share_root} && exec ${share_root}/webserver $@)"
+    close $webserver_script
 }


### PR DESCRIPTION
#### Description

Update imapsync to 2.264.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?