### PR TITLE
wxHexEditor: new port in sysutils; wxgtk-3.0-cxx11: new subport of wxWidgets

### DIFF
--- a/_resources/port1.0/group/wxWidgets-1.0.tcl
+++ b/_resources/port1.0/group/wxWidgets-1.0.tcl
@@ -170,6 +170,7 @@ PortGroup   compiler_blacklist_versions 1.0
 ## - wxGTK-2.8
 ## - wxWidgets-3.0
 ## - wxGTK-3.0
+## - wxGTK-3.0-cxx11
 ## - wxPython-3.0
 ## - wxWidgets-3.0-cxx11
 ## - wxWidgets-3.2
@@ -257,6 +258,16 @@ proc wxWidgets._set {option action args} {
         }
         # this doesn't work
         # PortGroup cxx11 1.1
+    } elseif {${args} eq "wxGTK-3.0-cxx11"} {
+        global cxx_stdlib
+        wxWidgets.name          "wxGTK"
+        if {${cxx_stdlib} eq "libstdc++"} {
+            wxWidgets.version   "3.0-cxx11"
+            wxWidgets.port      "wxgtk-3.0-cxx11"
+        } else {
+            wxWidgets.version   "3.0"
+            wxWidgets.port      "wxgtk-3.0"
+        }
     # preliminary support for wxWidgets 3.1/3.2
     } elseif {${args} eq "wxWidgets-3.2"} {
         wxWidgets.name      "wxWidgets"

--- a/graphics/wxWidgets-3.0/Portfile
+++ b/graphics/wxWidgets-3.0/Portfile
@@ -17,6 +17,8 @@ subport             wxWidgets-3.0-cxx11 {}
 subport             wxPython-3.0 {}
 # build against GTK 3
 subport             wxgtk-3.0 {}
+# build against GTK 3 with C++11
+subport             wxgtk-3.0-cxx11 {}
 # TODO: fix dist_subdir and subset name at next release
 set wxpython_ver    3.0.2.0
 # when revbumping remember to change the revision also for wxPython-3.0
@@ -35,12 +37,18 @@ if {${subport} eq ${name}} {
     version         3.0.2
     revision        8
 } elseif {${subport} eq "wxgtk-3.0"} {
-    # with satisfactory Cocoa support there is no real need for GTK-based wxWidgets any more
-    # wxgtk-3.0 is here mainly for testing purposes
-    # it might be useful to report GTK-related bugs upstream
-    # and play with quartz-based GTK
+    # wxgtk-3.0 is need to support older systems where wxWidgets-3.0
+    # do not work correctly (they do build, but are unusable).
+    # It might also be useful for testing purposes, to report GTK-related bugs
+    # to upstream and play with quartz-based GTK
     # (and maybe backport changes to 2.8)
     wxWidgets.use   wxGTK-3.0
+    set installname wxGTK
+    set wxtype      gtk3
+} elseif {${subport} eq "wxgtk-3.0-cxx11"} {
+    # Subport to allow C++11-using apps to build correctly.
+    wxWidgets.use   wxGTK-3.0-cxx11
+    compiler.cxx_standard   2011
     set installname wxGTK
     set wxtype      gtk3
 }
@@ -243,6 +251,22 @@ if {${subport} eq "wxPython-3.0"} {
     #        require_active_variants gtk3 x11
     #    }
     #}
+} elseif {${subport} eq "wxgtk-3.0-cxx11"} {
+    patchfiles-append       patch-sdl.diff
+
+    depends_build-append    port:pkgconfig
+    depends_lib-append      path:lib/pkgconfig/cairo.pc:cairo \
+                            path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                            port:libGLU \
+                            port:libsdl2 \
+                            port:libsdl2_mixer \
+                            port:mesa
+
+    require_active_variants path:lib/pkgconfig/cairo.pc:cairo x11
+    require_active_variants gtk3 x11
+
+    configure.args-replace  --with-cocoa --with-gtk=3 \
+                            --without-sdl --with-sdl
 }
 
 post-destroot {

--- a/sysutils/wxHexEditor/Portfile
+++ b/sysutils/wxHexEditor/Portfile
@@ -1,0 +1,75 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
+PortGroup           wxWidgets 1.0
+
+github.setup        EUA wxHexEditor 0.24 v
+revision            0
+categories          sysutils devel
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+
+description         Free hex editor / disk editor
+long_description    {*}${description}
+license             GPL-2
+homepage            https://www.wxhexeditor.org
+
+checksums           rmd160  dfb5fd7030291b9cbebd8625408e6c57304c11aa \
+                    sha256  6ad993ba13a0076b31fb95daa7a812eae3b613d86f5e6709021e4d3398afcf00 \
+                    size    1699052
+github.tarball_from archive
+
+if {${os.platform} eq "darwin" && ${os.major} > 20} {
+    wxWidgets.use   wxWidgets-3.2
+
+    # https://github.com/EUA/wxHexEditor/commit/ebe2449fac22089825d124935a215fd1c0739403
+    patchfiles-append \
+                    0001-Fix-build-for-wxWidgets-v3.1.2.patch
+} elseif {${os.platform} eq "darwin" && ${os.major} > 12} {
+    wxWidgets.use   wxWidgets-3.0-cxx11
+} else {
+    # While it builds on older systems with wxWidgets-3.0-cxx11,
+    # it does not work due to a bug in wxWidgets-3.0.
+    wxWidgets.use   wxGTK-3.0-cxx11
+}
+
+post-patch {
+    reinplace "s|= /usr|= ${prefix}|" ${worksrcpath}/Makefile
+}
+
+set py_ver          3.12
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:gettext \
+                    port:libtool \
+                    port:pkgconfig \
+                    port:python${py_ver_nodot}
+
+depends_lib-append  port:gettext-runtime \
+                    port:${wxWidgets.port}
+
+configure.python        ${prefix}/bin/python${py_ver}
+
+compiler.cxx_standard   2011
+compiler.openmp_version 2.5
+
+if {[string match macports-clang* ${configure.compiler}]} {
+    configure.ldflags-append \
+                    -L${prefix}/lib/libomp \
+                    -lomp
+}
+
+# See: https://github.com/EUA/wxHexEditor/issues/211
+platform macosx {
+    build.target    mac
+}
+
+build.args-append   WXCONFIG=${wxWidgets.wxconfig}
+
+destroot {
+    move ${worksrcpath}/${name}.app ${destroot}${applications_dir}/${name}.app
+}

--- a/sysutils/wxHexEditor/files/0001-Fix-build-for-wxWidgets-v3.1.2.patch
+++ b/sysutils/wxHexEditor/files/0001-Fix-build-for-wxWidgets-v3.1.2.patch
@@ -1,0 +1,40 @@
+From ebe2449fac22089825d124935a215fd1c0739403 Mon Sep 17 00:00:00 2001
+From: GT <george@tsimperopoulos.com>
+Date: Tue, 10 Sep 2019 23:52:19 +0100
+Subject: [PATCH] Fix build for wxWidgets v3.1.2
+
+---
+ src/HexDialogs.cpp                  | 2 +-
+ src/HexEditorCtrl/HexEditorCtrl.cpp | 6 +++---
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git src/HexDialogs.cpp src/HexDialogs.cpp
+index 260571b..9c312ba 100644
+--- src/HexDialogs.cpp
++++ src/HexDialogs.cpp
+@@ -420,7 +420,7 @@ void FindDialog::OnChar( wxKeyEvent& event ){
+ 	}
+ 
+ void FindDialog::EventHandler( wxCommandEvent& event ){
+-	WX_CLEAR_ARRAY(parent->HighlightArray )
++	WX_CLEAR_ARRAY(parent->HighlightArray);
+ 	parent->HighlightArray.Shrink();
+ 
+ 	if( event.GetId() == btnFind->GetId())
+diff --git src/HexEditorCtrl/HexEditorCtrl.cpp src/HexEditorCtrl/HexEditorCtrl.cpp
+index 37a6e4b..6f3a4a0 100644
+--- src/HexEditorCtrl/HexEditorCtrl.cpp
++++ src/HexEditorCtrl/HexEditorCtrl.cpp
+@@ -64,9 +64,9 @@ HexEditorCtrl::~HexEditorCtrl( void ){
+ 	Dynamic_Disconnector();
+ 	Clear();
+ 
+-	WX_CLEAR_ARRAY(MainTagArray)
+-	WX_CLEAR_ARRAY(HighlightArray)
+-   WX_CLEAR_ARRAY(CompareArray)
++	WX_CLEAR_ARRAY(MainTagArray);
++	WX_CLEAR_ARRAY(HighlightArray);
++	WX_CLEAR_ARRAY(CompareArray);
+ 
+    MainTagArray.Shrink();
+    HighlightArray.Shrink();


### PR DESCRIPTION
#### Description

New port

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1 arm64
Xcode 15.3

macOS 10.6.8 x86_64
Xcode 3.2.6

macOS 10a190 ppc
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

![wxHexEditor](https://github.com/macports/macports-ports/assets/92015510/1750dce5-a581-4a01-a248-5a7c59385bea)

