### PR TITLE
gstreamer1-gst-libav: Remove unnecessary deps

### DIFF
--- a/gnome/gstreamer1-gst-libav/Portfile
+++ b/gnome/gstreamer1-gst-libav/Portfile
@@ -30,13 +30,11 @@ set py_ver_nodot    [string map {. {}} ${py_ver}]
 set python.bin      ${prefix}/bin/python${py_ver}
 
 depends_build-append \
-                    path:bin/cmake:cmake \
                     port:gtk-doc \
-                    port:nasm \
                     port:pkgconfig \
                     port:python${py_ver_nodot}
 
-depends_lib-append  path:lib/libavcodec.dylib:ffmpeg \
+depends_lib-append  path:lib/pkgconfig/libavcodec.pc:ffmpeg \
                     port:gstreamer1-gst-plugins-base
 
 post-patch {
@@ -44,9 +42,6 @@ post-patch {
         ${worksrcpath}/scripts/extract-release-date-from-doap-file.py \
         ${worksrcpath}/scripts/gen-changelog.py
 }
-
-# This will cause the installed ffmpeg headers to be used, remove it.
-configure.cppflags-delete -I${prefix}/include
 
 if {[lsearch [get_canonical_archs] i386] != -1} {
     # https://trac.macports.org/ticket/37802


### PR DESCRIPTION
Removed unnecessary dependencies.

Also fix build for other platforms.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1
Xcode 15.3

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
