### PR TITLE
gitu: Update to 0.14.0

### DIFF
--- a/devel/gitu/Portfile
+++ b/devel/gitu/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            altsem gitu 0.13.1 v
+github.setup            altsem gitu 0.14.0 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -16,9 +16,9 @@ description             A TUI Git client inspired by Magit
 long_description        {*}${description}, launched straight from the terminal.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  02cb830f99a7b4784b01f014b110126ea33a241a \
-                        sha256  e4eb4fc8444996878f894f35494cf1a72a1a530b8a84094d535143729547f405 \
-                        size    3949379
+                        rmd160  a0afc5217408d77e1b3b4a515145a0a2f74e8fd9 \
+                        sha256  a6142c15904655768512df261be0673c89690af8e0b7e5e20ddfb356959957c4 \
+                        size    3949814
 
 destroot {
     set bindir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -171,7 +171,7 @@ cargo.crates \
     toml                            0.8.12  e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3 \
     toml_datetime                    0.6.5  3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1 \
     toml_edit                       0.22.9  8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4 \
-    tui-prompts                      0.3.8  24b83b48e255f374d99cf78dc97455db9454a39b5cca103e26e5f9c930210c06 \
+    tui-prompts                     0.3.10  5e500909aaebfb05b51371252c7c076d92d11717eeaa6aef575c9a5db3958370 \
     uncased                         0.9.10  e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697 \
     unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
     unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \


### PR DESCRIPTION
#### Description

Update `gitu` to its latest released version, 0.14.0

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
