### PR TITLE
ImageMagick7: fix port installation&build

### DIFF
--- a/graphics/ImageMagick7/files/Color.cpp.patch
+++ b/graphics/ImageMagick7/files/Color.cpp.patch
@@ -8,7 +8,7 @@ https://github.com/ImageMagick/ImageMagick/commit/9cf419c6eb5e64b3571d98938a4a66
        _pixelOwn = false;
        delete _pixel;
 -      _pixel = nullptr;
-+      _pixel = (PixelPacket *)NULL;
++      _pixel = (PixelInfo *)NULL;
      }
    ThrowPPException(false);
  


### PR DESCRIPTION
#### Description

Fixes the installation of the port by aligning a type in the port's patch with the upstream.

fixes: https://trac.macports.org/ticket/69692

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

Not tested, just copied the line with a proper type from the upstream to the patch.

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
