### PR TITLE
libgit2-devel: fix environ, unbreak the build on < 10.8

### DIFF
--- a/devel/libgit2-devel/Portfile
+++ b/devel/libgit2-devel/Portfile
@@ -49,6 +49,9 @@ depends_lib-append \
 # See: https://trac.macports.org/ticket/65585
 patchfiles-append   patch-tests-no-error.diff
 
+# https://github.com/libgit2/libgit2/pull/6792
+patchfiles-append   0001-process.c-fix-environ-for-macOS.patch
+
 post-patch {
     # Upstream compiles with C standard set to 90, which isn't sufficient for
     # legacy-support. So patch all CMake files, and raise that to C 99.

--- a/devel/libgit2-devel/files/0001-process.c-fix-environ-for-macOS.patch
+++ b/devel/libgit2-devel/files/0001-process.c-fix-environ-for-macOS.patch
@@ -1,0 +1,27 @@
+From 4b043541ab480aaa083707c134c23d17be5baafc Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 8 Apr 2024 03:46:17 +0800
+Subject: [PATCH] process.c: fix environ for macOS
+
+---
+ src/util/unix/process.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git src/util/unix/process.c src/util/unix/process.c
+index 15092cb21..68c0384a4 100644
+--- src/util/unix/process.c
++++ src/util/unix/process.c
+@@ -15,7 +15,12 @@
+ #include "process.h"
+ #include "strlist.h"
+ 
+-extern char **environ;
++#ifdef __APPLE__
++	#include <crt_externs.h>
++	#define environ (*_NSGetEnviron())
++#else
++	extern char **environ;
++#endif
+ 
+ struct git_process {
+ 	char **args;


### PR DESCRIPTION
#### Description

Fix environ for macOS

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
