### PR TITLE
cdo: update to 2.4.0

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,19 +5,21 @@ PortGroup                   mpi 1.0
 PortGroup                   legacysupport 1.0
 
 name                        cdo
-version                     2.3.0
+version                     2.4.0
 revision                    0
 platforms                   darwin
-maintainers                 {takeshi @tenomoto} openmaintainer
+maintainers                 {takeshi @tenomoto} \
+                            {me.com:remko.scharroo @remkos} \
+                            openmaintainer
 license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/29019
+master_sites                https://code.mpimet.mpg.de/attachments/download/29313
 
-checksums           rmd160  a41fe5acd854a94f9d3915806b4f67cf2cc2f534 \
-                    sha256  10c878227baf718a6917837527d4426c2d0022cfac4457c65155b9c57f091f6b \
-                    size    13588973
+checksums           rmd160  b70d79025fd141b93bfb733467dc36fb74b51914 \
+                    sha256  a4790fb8cc07f353b11f9bbe49218b8e4be8e5ae56aade8420bad390510b4d2c \
+                    size    13497565
 
 long_description \
     CDO is a collection of command line Operators               \
@@ -27,7 +29,7 @@ long_description \
 
 fetch.ignore_sslcert        yes
 
-compiler.cxx_standard       2017
+compiler.cxx_standard       2020
 compiler.thread_local_storage yes
 compilers.choose            cc cxx
 mpi.setup
@@ -58,8 +60,8 @@ configure.ldflags-append    -lhdf5
 # for a recent Python and does not distinguish whether test is requested, it is added here as a build dependency.
 # To make sure that it works prior to Catalina, it is best to simply require the latest python3 package.
 
-depends_build-append        port:python311
-configure.env-append        PYTHON=${prefix}/bin/python3.11
+depends_build-append        port:python312
+configure.env-append        PYTHON=${prefix}/bin/python3.12
 
 test.run                    yes
 test.args                   -j1


### PR DESCRIPTION
#### Description

This is an update to upstream version 2.4.0 of cdo.

The new version of cdo switched to C++20 standards, which are supposedly supported by MacOS12 but fails to compile when including make_heap.h. Therefore I introduced a `compiler.blacklist` to allow only C++20 compatible compilers.

En passant, I changed the build dependency from Python 3.11 to 3.12 (used for test only, but checked at build stage irrespectively). In addition, after sending in so many PRs for this package, I finally added myself as maintainer. 

This makes PR #22907 obsolete.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.4.1 23E224 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
