### PR TITLE
OCRmyPDF: add in variants for python 3.10 and 3.11 per request.

### DIFF
--- a/textproc/ocrmypdf/Portfile
+++ b/textproc/ocrmypdf/Portfile
@@ -26,7 +26,19 @@ long_description    {*}${description}. ${name} also supports plugins \
 supported_archs     noarch
 platforms           {darwin any}
 license             MPL-2
-python.default_version 312
+
+variant python310 conflicts python311 python312 description "Use Python 3.10" {}
+variant python311 conflicts python310 python312 description "Use Python 3.11" {}
+variant python312 conflicts python310 python311 description "Use Python 3.12" {}
+
+if {[variant_isset python310]} {
+    python.default_version 310
+} elseif {[variant_isset python311]} {
+    python.default_version 311
+} else {
+    default_variants +python312
+    python.default_version 312
+}
 
 depends_build-append \
                     port:py${python.version}-setuptools_scm


### PR DESCRIPTION
#### Description

per an email i received on 2024-04-07, adding in variants for python 3.10 and 3.11. 3.12 remains the default.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
