### PR TITLE
imagemagick7: bump the portfile revision following the merged fix

### DIFF
--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -22,7 +22,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                ImageMagick7
 github.setup        ImageMagick ImageMagick 7.1.1-29
-revision            1
+revision            2
 
 checksums           rmd160  00103408a31dfde61cca6800dd626ab0ab3f0915 \
                     sha256  6069d80a6db7ef895ef0cdc482505323d843db2b9da4564b7c51bf4fbebea791 \


### PR DESCRIPTION

#### Description

A pull request #23399 with a fix for IM7 was merged but the portfile's revision wasn't changed. This commit bumps the revision to reflect the change in the portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

No test is required as this only bumps a revision.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
