### PR TITLE
stow: Update to 2.4.0

### DIFF
--- a/sysutils/stow/Portfile
+++ b/sysutils/stow/Portfile
@@ -5,12 +5,12 @@ PortGroup           perl5 1.0
 
 name                stow
 
-perl5.setup         Stow v2.3.1 ../../authors/id/A/AS/ASPIERS
-revision            1
+perl5.setup         Stow v2.4.0 ../../authors/id/A/AS/ASPIERS
+revision            0
 
 categories          sysutils
 platforms           {darwin any}
-maintainers         nomaintainer
+maintainers         {@TheRealKeto gmail.com:therealketo} openmaintainer
 license             GPL-3+
 supported_archs     noarch
 
@@ -20,9 +20,9 @@ long_description    Stow is a symlink farm manager which takes distinct sets of 
                     and/or data located in separate directories on the filesystem, and makes \
                     them all appear to be installed in a single directory tree.
 
-checksums           rmd160  d65ffe0d4c9a6676c5e0ae63f751135a4c1f7dce \
-                    sha256  5062a1f8d0c03e38aca5cf46b72de0cba03f901279729338b7b2f93e518182d8 \
-                    size    704878
+checksums           rmd160  f8b6e973d77336e644f274c1a762dbe1a6efc2c5 \
+                    sha256  a777927b076b08ac96d8aa3e1b68573064b9a87eb4cdb7831e86915d4598af45 \
+                    size    782650
 
 post-patch {
     reinplace "s|^#!/usr/bin/perl|#!${perl5.bin}|" \


### PR DESCRIPTION
#### Description

Update `stow` to its latest released version, 2.4.0, while claiming maintainer role.

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
