### PR TITLE
buku: update to 4.9, clean up Portfile

### DIFF
--- a/python/buku/Portfile
+++ b/python/buku/Portfile
@@ -1,14 +1,14 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        jarun buku 4.8 v
-revision            1
-checksums           rmd160  ff1f9c8a01360e6f47e3e2c4d71bab7140ecec28 \
-                    sha256  6962f7c493abacc8cba063e62f7f7fff7093ffb1aca0ceb4d1c40ceafbb92504 \
-                    size    591956
+name                buku
+version             4.9
+revision            0
+checksums           rmd160  61dcd129406658f123b64b834ae9503546746301 \
+                    sha256  7b5371a0961c6e0d9d126a2874cb25af3394bfa8b7d441bc016c853320e3fa6c \
+                    size    249347
 
 description         A command-line bookmark manager
 long_description    buku is a powerful bookmark manager written in \
@@ -25,13 +25,15 @@ long_description    buku is a powerful bookmark manager written in \
                     buku is too busy to track you: no hidden history, \
                     obsolete records, usage analytics or homing.
 
-categories          www
+homepage            https://github.com/jarun/buku
+
+categories-append   www
 platforms           {darwin any}
 supported_archs     noarch
 maintainers         {isi.edu:calvin @cardi} openmaintainer
 license             GPL-3
 
-python.default_version  39
+python.versions     38 39 310 311 312
 
 depends_build-append \
                     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description
buku: update to 4.9, clean up Portfile
* Remove github PortGroup and fetch packages from PyPI instead
* Add supported Python versions (3.8 to 3.12)
* Remove explicitly set Python default version (was: 3.9) and use MacPorts's default instead (currently: 3.12)
* Move port from folder `www` to `python`, and append the `www` category

###### Tested on
macOS 12.7.4 21H1123 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
