### PR TITLE
ipsw: Update to 3.1.469

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/blacktop/ipsw 3.1.468 v
+go.setup                github.com/blacktop/ipsw 3.1.469 v
 github.tarball_from     archive
 revision                0
 categories              security devel
@@ -16,9 +16,9 @@ description             iOS/macOS Research Swiss Army Knife
 long_description        {*}${description}. Everything you need to start \
                         researching Apple security and internals.
 
-checksums               rmd160  1d5892e16ad482c3b4de8e9a89ce276d453cef06 \
-                        sha256  172fda85b48a601057c90085ec45e8d432942bdce8c1d5f0e1100c1d484e4db2 \
-                        size    4050699
+checksums               rmd160  a8e229a9bef1166033470b3642d5789370abea23 \
+                        sha256  d2c81b04efa04684a1c3f8388667aeafceda6c9cab6ba80596a2a42c02f06da7 \
+                        size    4053740
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `ipsw` to its latest released version, 3.1.469. [Changelog](https://github.com/blacktop/ipsw/releases/tag/v3.1.469)

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
