### PR TITLE
Upgrade oof2 to 2.3.3 and oofcanvas to 1.1.2

### DIFF
--- a/graphics/oofcanvas/Portfile
+++ b/graphics/oofcanvas/Portfile
@@ -5,8 +5,8 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 name                oofcanvas
-version             1.1.1
-revision            2
+version             1.1.2
+revision            0
 
 license             public-domain
 categories          graphics
@@ -28,9 +28,9 @@ long_description    OOFCanvas is a replacement for libgnomecanvas, designed \
 homepage            https://www.ctcms.nist.gov/oof/oofcanvas
 master_sites        ${homepage}/source
 
-checksums           rmd160 6fc895f62482b8e616952555a8945c71b84c0762 \
-                    sha256 78e14ac9226bf5831ff0a90a39d31cd0fb80e055a0ce92ddbf3b834a46960bad \
-                    size 98484
+checksums           rmd160 cfaa3fa935ac55183ee02dd06dffe60e13c7bc36 \
+                    sha256 6d4faef05ab89f7644deecb7c7bef65d874852227b1c0818bbc0967bfe7f4ed5 \
+                    size 100083
 
 compiler.cxx_standard 2011
 cmake.build_type    Release
@@ -51,7 +51,7 @@ depends_lib-append  path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
 
 configure.args-append -DOOFCANVAS_SWIG_VERSION=4.1
 
-set python_versions {311 38 310 39}
+set python_versions {312 311 38 310 39}
 
 foreach v ${python_versions} {
     set minor [string range ${v} 1 end]

--- a/science/oof2/Portfile
+++ b/science/oof2/Portfile
@@ -6,7 +6,7 @@ PortGroup           active_variants 1.1
 PortGroup           compiler_blacklist_versions 1.0
 
 name                oof2
-version             2.3.2
+version             2.3.3
 revision            0
 
 license             public-domain
@@ -21,9 +21,9 @@ long_description    OOF2 computes properties of materials with complex \
 homepage            https://www.ctcms.nist.gov/oof/oof2
 master_sites        ${homepage}/source
 
-checksums           rmd160 eb4d015929e14d905d15bb300d5958dbc738bd29 \
-                    sha256 3b7c9bb58979b06cc029977574fb6a7b5a796d05cfb5e93e781500f508792179 \
-                    size 13836267
+checksums           rmd160 568cd6ba0de1ebc325bd56f31f07da4b76516c27 \
+                    sha256 5f996050ccec7173a86e1554831a94e360d4712349e71183aee4cdf24f2dcb71 \
+                    size 14958599
 
 compiler.cxx_standard 2011
 
@@ -40,7 +40,7 @@ depends_run         port:adwaita-icon-theme
 configure.args-append -DOOF2_SWIG_VERSION=4.1
 
 # Create a variant for each supported python version
-set python_versions {38 39 310 311}
+set python_versions {38 39 310 311 312}
 foreach v ${python_versions} {
     # Create a list of the other python versions, which this variant
     # is incompatible with.
@@ -73,3 +73,6 @@ if { !$vactive } {
     default_variants +python311
 }
 
+variant dev description "Install development files for building extensions" {
+    configure.args-append -DOOF2_DEV_INSTALL=ON
+}


### PR DESCRIPTION
#### Description

Upgrade oof2 to version 2.3.3 and oofcanvas to version 1.1.2.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1 23E224 x86_64
Xcode 15.3 15E204a


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
