### PR TITLE
lang/sbcl: update to sbcl-2.4.3

### DIFF
--- a/lang/sbcl-bootstrap/Portfile
+++ b/lang/sbcl-bootstrap/Portfile
@@ -51,13 +51,13 @@ if {${build_arch} eq "ppc"} {
                     size    10038928
 
 } elseif {${build_arch} eq "arm64"} {
-    version         2.1.2
+    version         2.4.0
     revision        0
 
     distfiles       sbcl-${version}-arm64-darwin-binary${extract.suffix}
-    checksums       rmd160  ce5856a0e1f0040e95c9d79ef0a6199a0f932ab3 \
-                    sha256  1f400b8a05dc588ca9740f9f4dfee3111b1cc1b6fb40801f728c42b460e1d115 \
-                    size    9204605
+    checksums       rmd160  73e33754afb6e8fad340902a5abd2f5f74b0f361 \
+                    sha256  1d01fac2d9748f769c9246a0a11a2c011d7843337f8f06ca144f5a500e10c117 \
+                    size    9803838
 
 } elseif {${build_arch} eq "x86_64"} {
     version         2.2.9

--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -9,9 +9,9 @@ name            sbcl
 
 # Note to maintainers:
 #
-# Please bump the revision of math/maxima (and when it exists
-# math/maxima-devel) and fricas when this port changes.
-version         2.4.0
+# Please bump the revisions of math/maxima, math/fricas and possibly
+# math/maxima-devel when this port changes.
+version         2.4.3
 revision        0
 epoch           1
 
@@ -36,9 +36,9 @@ homepage        http://www.sbcl.org
 patchfiles      0001-fix-building-when-root-directory-contain-non-ASCII-c.patch \
                 0002-add-MacPorts-XDG_DATA_DIRS.patch
 
-checksums       rmd160  6dc78af458b04a70a992dce6ee26327c56fea1bb \
-                sha256  83d8b74f08d2254c59b9790bc1f669e09099457b884720ececbf45f4b46d1776 \
-                size    7695124
+checksums           rmd160  6fcdb0d7324e426fdc08b9bd768e753defcff4bf \
+                    sha256  89c9aadf92b82ad3c74a3d4f158a038893dea0e4f394dcafc963583c30b7c3f2 \
+                    size    8126417
 
 if {${name} eq ${subport}} {
     master_sites \
@@ -132,23 +132,17 @@ build.target    make.sh
 build.args-append \
                 --prefix=${prefix}
 
-# unfortunately sbcl-bootstrap doesn't support macOS Sonoma yet, use ECL instead
-# See: https://trac.macports.org/ticket/68271
-if {${os.major} >= 23} {
-    depends_build-append \
-                path:bin/ecl:ecl
+variant bootstrap_ecl description { Use ECL to bootstrap compilation instead of SBCL binary. } {}
 
-    build.args-append \
-                --xc-host=${prefix}/bin/ecl
+if { ![variant_isset bootstrap_ecl]  } {
+    depends_build-append           port:sbcl-bootstrap
+    depends_skip_archcheck-append  sbcl-bootstrap
+    build.args-append              --xc-host=${prefix}/libexec/sbcl-bootstrap/bin/sbcl
 } else {
-    depends_build-append \
-                port:sbcl-bootstrap
-    depends_skip_archcheck-append \
-                sbcl-bootstrap
-
-    build.args-append \
-                --xc-host=${prefix}/libexec/sbcl-bootstrap/bin/sbcl
+    depends_build-append           path:bin/ecl:ecl
+    build.args-append              --xc-host=${prefix}/bin/ecl
 }
+
 
 if {${configure.build_arch} eq "i386"} {
     build.args-append \
@@ -205,6 +199,8 @@ variant fancy conflicts threads description {Configure SBCL compilation with all
     # As of version 2.2.6, zstd is used for core compression.
     depends_lib-append  port:zstd
 }
+
+
 
 test.run        yes
 test.dir        ${worksrcpath}/tests

--- a/lang/sbcl/Portfile
+++ b/lang/sbcl/Portfile
@@ -143,7 +143,6 @@ if { ![variant_isset bootstrap_ecl]  } {
     build.args-append              --xc-host=${prefix}/bin/ecl
 }
 
-
 if {${configure.build_arch} eq "i386"} {
     build.args-append \
                 --arch=x86
@@ -199,8 +198,6 @@ variant fancy conflicts threads description {Configure SBCL compilation with all
     # As of version 2.2.6, zstd is used for core compression.
     depends_lib-append  port:zstd
 }
-
-
 
 test.run        yes
 test.dir        ${worksrcpath}/tests

--- a/math/fricas/Portfile
+++ b/math/fricas/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                fricas
 version             1.3.10
-revision            0
+revision            1
 categories          math
 maintainers         {@pietvo vanoostrum.org:pieter} openmaintainer
 platforms           darwin

--- a/math/maxima/Portfile
+++ b/math/maxima/Portfile
@@ -38,7 +38,7 @@ subport maxima-devel {
     # Date:  Sun Jul 30 06:55:16 2023 -0700
     # commit 65e393d796fedd34162d2a510af37c2448f07d74
     version     5.47-dev-20230730
-    revision    5
+    revision    6
     fetch.type  git
     git.url     https://git.code.sf.net/p/maxima/code
     git.branch  65e393d796fedd34162d2a510af37c2448f07d74
@@ -58,7 +58,7 @@ if {${subport} eq ${name}} {
     conflicts   maxima-devel
 
     version     5.47.0
-    revision    5
+    revision    6
     # get the source tarball from sourceforge.
     master_sites    sourceforge:project/maxima/Maxima-source/${version}-source
 


### PR DESCRIPTION
Add newly available sbcl-2.4.0 arm64 binary to sbcl-bootstrap. Use this binary to build SBCL on arm64.

Add 'boostrap_ecl' variant to use ECL to bootstrap SBCL compilation.

Update math/{maxima,fricas} revision as per maintainer request.
