### PR TITLE
buku: set Python default version to 3.12

### DIFF
--- a/python/buku/Portfile
+++ b/python/buku/Portfile
@@ -33,7 +33,7 @@ supported_archs     noarch
 maintainers         {isi.edu:calvin @cardi} openmaintainer
 license             GPL-3
 
-python.versions     38 39 310 311 312
+python.default_version  312
 
 depends_build-append \
                     port:py${python.version}-setuptools


### PR DESCRIPTION
#### Description

buku: set Python default version to 3.12

###### Type(s)
- [x] bugfix

###### Tested on
macOS 12.7.4 21H1123 arm64
Xcode 13.1 13A1030d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?