### PR TITLE
atomvm: bump epoch due to unrecognized update and mbedtls3 API change

### DIFF
--- a/erlang/atomvm/Portfile
+++ b/erlang/atomvm/Portfile
@@ -11,6 +11,7 @@ legacysupport.newest_darwin_requires_legacy 16
 
 github.setup            atomvm atomvm 0.6.0 v
 revision                0
+epoch                   1
 categories              erlang devel
 maintainers             {pguyot @pguyot} openmaintainer
 license                 Apache-2

--- a/erlang/atomvm/Portfile
+++ b/erlang/atomvm/Portfile
@@ -10,7 +10,7 @@ PortGroup               legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 16
 
 github.setup            atomvm atomvm 0.6.0 v
-revision                0
+revision                1
 epoch                   1
 categories              erlang devel
 maintainers             {pguyot @pguyot} openmaintainer


### PR DESCRIPTION
Due to a recent mbedtls3 update, revbump is required. However, going from 0.6.0-beta.1 to 0.6.0 is seen as a version downgrade by Macports, and revbumping does not solve that. Instead, bump epoch, solves both issues.

#### Description

Bump epoch.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
