### PR TITLE
podman: workaround for macOS 11 and below

### DIFF
--- a/sysutils/podman/Portfile
+++ b/sysutils/podman/Portfile
@@ -9,6 +9,7 @@ PortGroup           golang 1.0
 go.setup            github.com/containers/podman 5.0.1 v
 github.tarball_from archive
 revision            0
+epoch               0
 
 categories          sysutils
 license             Apache-2
@@ -47,6 +48,26 @@ build.args          PYTHON=${prefix}/bin/python${py_ver} \
                     PRE_COMMIT=${prefix}/bin/pre-commit
 build.target        ${name}-remote ${name}-mac-helper docs
 
+if {${os.platform} eq "darwin" && ${os.major} <= 20} {
+    # See https://trac.macports.org/ticket/69578
+    go.setup            github.com/containers/podman 4.9.3 v
+    epoch               1
+
+    checksums           ${distname}${extract.suffix} \
+                         rmd160  dd87729822e5486c174815445e814546b3a7e98b \
+                         sha256  37afc5bba2738c68dc24400893b99226c658cc9a2b22309f4d7abe7225d8c437 \
+                         size    21727849
+
+    depends_run-delete   port:vfkit
+
+    notes-append "
+    WARN: Currently using podman 4.9.3 instead of 5.0.0+. See the reasons:
+    https://trac.macports.org/ticket/69683
+
+    ***
+    "
+}
+
 destroot {
     xinstall -m 0755 ${worksrcpath}/bin/darwin/${name} \
         ${destroot}${prefix}/bin/
@@ -71,7 +92,7 @@ destroot {
         ${destroot}${prefix}/share/fish/vendor_completions.d/
 }
 
-notes "
+notes-append "
 If you have an issue where podman won't run on ARM then try the following:
 
 https://trac.macports.org/ticket/67731#comment:14


### PR DESCRIPTION
#### Description

See
- https://trac.macports.org/ticket/69683
- https://github.com/crc-org/vfkit/issues/125

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
