### PR TITLE
opencolorio, openimageio, osl: Fix version pinning

### DIFF
--- a/graphics/opencolorio/Portfile
+++ b/graphics/opencolorio/Portfile
@@ -30,13 +30,8 @@ github.livecheck.regex  {([0-9.]+)}
 configure.args-append \
     -DCMAKE_CONFIGURATION_TYPES=MacPorts
 
-# pin the used version before macOS 11
-# keep in mind that openimageio had the same pin
-if {${os.platform} eq "darwin" && ${os.major} >= 20} {
-    set port_latest     yes
-} else {
-    set port_latest     no
-}
+# Keep this condition the same in the opencolorio, openimageio, and osl ports.
+set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
 
 if {!${port_latest}} {
     github.setup        AcademySoftwareFoundation OpenColorIO 1.1.1 v
@@ -111,7 +106,7 @@ if {${configure.build_arch} in [list ppc ppc64]} {
         -DOCIO_USE_SSE=OFF
 }
 
-# OpenColorIO intentially installs Python module in lib
+# OpenColorIO intentionally installs Python module in lib
 # see https://github.com/imageworks/OpenColorIO/blob/15e96c1f579d3640947a5fcb5ec831383cc3956e/src/pyglue/CMakeLists.txt#L85
 
 variant python38 description {Build the Python 3.8 bindings} conflicts python39 python310 python311 python312 {

--- a/graphics/openimageio/Portfile
+++ b/graphics/openimageio/Portfile
@@ -16,13 +16,8 @@ description             a library for reading and writing images
 long_description        OpenImageIO is a library for reading and writing images, and a bunch of \
                         related classes, utilities, and applications.
 
-# Pin the used version before macOS 11, which is required by pinned versions
-# of opencolorio and osl.
-if {${os.platform} eq "darwin" && ${os.major} >= 20} {
-    set port_latest     yes
-} else {
-    set port_latest     no
-}
+# Keep this condition the same in the opencolorio, openimageio, and osl ports.
+set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
 
 if {${port_latest}} {
     github.setup        OpenImageIO oiio 2.4.5.0 v

--- a/graphics/osl/Portfile
+++ b/graphics/osl/Portfile
@@ -36,12 +36,13 @@ compiler.cxx_standard   2014
 
 # Keep this value synchronized with the
 # newest LLVM that is compatible with OSL
-# and be sure that parito is build by the same compiler
+# and be sure that partio is built by the same compiler
 set llvm_version        14
 
-# pin the used version before macOS 11
-# which is forced by used version of openimageio
-if {${os.platform} eq "darwin" && ${os.major} < 20} {
+# Keep this condition the same in the opencolorio, openimageio, and osl ports.
+set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
+
+if {!${port_latest}} {
     github.setup        AcademySoftwareFoundation OpenShadingLanguage 1.11.13.0 Release-
     name                osl
     revision            3
@@ -70,7 +71,7 @@ depends_lib-append      port:llvm-$llvm_version \
                         port:openimageio
 
 # As MP clang is available at build time, use for consistency and
-# to avoid potentially a second MP clang being installed unneccessarily.
+# to avoid potentially a second MP clang being installed unnecessarily.
 compiler.blacklist-append clang
 compiler.fallback macports-clang-${llvm_version}
 


### PR DESCRIPTION
#### Description

I don't know why the versions of opencolorio, openimageio, and osl are pinned ([this comment](https://trac.macports.org/ticket/67005#comment:2) suggests there is no reason), but if there is a reason, then this unifies all three ports to use the same condition, and in particular it fixes opencolorio and openimageio to allow non-macOS operating systems to see the latest version. I hope this will allow the ports.macports.org web site to see the current versions of these ports.

Also fix some typos in comments.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix
