### PR TITLE
reuse: update to 3.0.2

### DIFF
--- a/devel/reuse/Portfile
+++ b/devel/reuse/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                reuse
-version             2.1.0
+version             3.0.2
 revision            0
 
-checksums           rmd160  ce57648f4cffbc97158388a1e80cf146535d89d4 \
-                    sha256  4211e91caa4c9e433802618a89a2d49a67e2bf76a8029d6708090892f0cdebec \
-                    size    224518
+checksums           rmd160  d5ac122df1b887b57f3fbef885931cc169766733 \
+                    sha256  73eb8262b84527a90822404e7504f69081854759806830d402ea1e92176f32a6 \
+                    size    269385
 
 categories          devel
 supported_archs     noarch
@@ -23,7 +23,8 @@ long_description    {*}${description}
 
 homepage            https://reuse.software/
 
-python.versions     311
+python.default_version \
+                    312
 python.pep517       yes
 python.pep517_backend \
                     poetry
@@ -32,5 +33,6 @@ depends_lib-append  port:py${python.version}-binaryornot \
                     port:py${python.version}-boolean.py \
                     port:py${python.version}-jinja2 \
                     port:py${python.version}-license-expression \
-                    port:py${python.version}-python-debian \
-                    port:py${python.version}-requests
+                    port:py${python.version}-python-debian
+
+depends_run-append  path:share/curl/curl-ca-bundle.crt:curl-ca-bundle


### PR DESCRIPTION
* Using Python is updated to 3.12.
* Dependency on requests is removed on 1.1.0.
* urllib.request is used and CA certs are required.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 13.6.6 22G630 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
