### PR TITLE
antic: retire the port (it got merged into flint)

### DIFF
--- a/math/antic/Portfile
+++ b/math/antic/Portfile
@@ -1,34 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           obsolete 1.0
 
-github.setup        flintlib antic ba3b457281f492c7f9680247fb2c98208ecfa69c
+name                antic
 version             2022.11.30
-revision            0
+revision            1
 categories          math
 license             LGPL-2.1
-maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
-description         Algebraic Number Theory In C
-long_description    {*}${description}
-checksums           rmd160  2c2b8923b9a9826ba4864f09837a3696cf1cdcdc \
-                    sha256  e1b91e97823cca4fdb1a8932614a2a1f60780a562370d1c06710666e56de0aae \
-                    size    80398
-
-depends_lib-append  port:flint \
-                    port:gmp \
-                    port:mpfr
-
-post-patch {
-    reinplace "s|/usr/local|${prefix}|g" ${worksrcpath}/configure
-}
-
-compiler.thread_local_storage yes
-
-platform darwin 10 powerpc {
-    configure.args-append \
-                    --build=ppc-Darwin
-}
-
-test.run            yes
-test.target         check
+# https://github.com/flintlib/antic/issues/83
+# To-be-removed date: 2025-04-01
+replaced_by         flint


### PR DESCRIPTION
See: https://github.com/flintlib/antic/issues/83

#### Description

Retire the port

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
