### PR TITLE
lighttpd: Update to 1.4.76

### DIFF
--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -5,11 +5,11 @@ PortGroup                   legacysupport 1.0
 PortGroup                   lua 1.0
 
 name                        lighttpd
-version                     1.4.75
+version                     1.4.76
 revision                    0
-checksums                   rmd160  49eb179dcde249abcce5a9c3102de8d17587c3ec \
-                            sha256  8b721ca939d312afaa6ef31dcbd6afb5161ed385ac828e6fccd4c5b76be189d6 \
-                            size    1102080
+checksums                   rmd160  6f119159a4552b24d3c98fc486ed89144299d6b9 \
+                            sha256  8cbf4296e373cfd0cedfe9d978760b5b05c58fdc4048b4e2bcaf0a61ac8f5011 \
+                            size    847132
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  www
@@ -47,6 +47,8 @@ post-patch {
         ${worksrcpath}/doc/config/lighttpd.conf
 }
 
+use_autoreconf             yes
+autoreconf.args            --install --force
 configure.args-append       CC_FOR_BUILD="${configure.cc}" \
                             CFLAGS_FOR_BUILD="${configure.cflags}" \
                             --with-brotli \

--- a/www/lighttpd/Portfile
+++ b/www/lighttpd/Portfile
@@ -28,7 +28,15 @@ homepage                    https://www.lighttpd.net/
 master_sites                https://download.lighttpd.net/lighttpd/releases-${branch}.x/
 use_xz                      yes
 
-depends_build-append        port:pkgconfig
+# Upstream no longer provides a configure script in the tarball.
+use_autoreconf              yes
+autoreconf.cmd              ./autogen.sh
+autoreconf.args
+
+depends_build-append        port:autoconf \
+                            port:automake \
+                            port:libtool \
+                            path:bin/pkg-config:pkgconfig
 
 depends_lib                 port:brotli \
                             port:pcre2 \
@@ -47,8 +55,6 @@ post-patch {
         ${worksrcpath}/doc/config/lighttpd.conf
 }
 
-use_autoreconf             yes
-autoreconf.args            --install --force
 configure.args-append       CC_FOR_BUILD="${configure.cc}" \
                             CFLAGS_FOR_BUILD="${configure.cflags}" \
                             --with-brotli \


### PR DESCRIPTION
#### Description

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [x] security fix

###### Tested on

macOS 11.7

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?