### PR TITLE
libretroshare: update to 2024.04.01

### DIFF
--- a/net/libretroshare/Portfile
+++ b/net/libretroshare/Portfile
@@ -2,12 +2,13 @@
 
 PortSystem              1.0
 PortGroup               cmake 1.1
+PortGroup               compiler_blacklist_versions 1.0
 PortGroup               github 1.0
 PortGroup               legacysupport 1.1
 PortGroup               openssl 1.0
 
-github.setup            RetroShare libretroshare 526cdfb9c1e9f91fa7ef17dcaf447a353eb0caed
-version                 2024.03.05
+github.setup            RetroShare libretroshare 402f32eda026c3ec3e429b5fb842e87ebd985d73
+version                 2024.04.01
 revision                0
 categories              net devel security
 maintainers             {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -17,9 +18,9 @@ long_description        {*}${description} RetroShare functionalities (file shari
                         are implemented under the hood by libretroshare which offer a documented C++ and JSON API. \
                         While RetroShare is an application on its own, libretroshare is meant to be used as part of other programs.
 homepage                https://retroshare.cc
-checksums               rmd160  77315d9026ee46d351c5d59ea32fa11b072e3505 \
-                        sha256  16a0a97dd2fd3b540ba5f83be7403a41e3dc1474007bfeaa691b7722ddc24164 \
-                        size    1931496
+checksums               rmd160  634478d519e7c320b97b9776cc31b75dc7b95888 \
+                        sha256  feb01a58493a28e74443d23414fc93977a5f1b6c155a1b6b5aca230dadf47e53 \
+                        size    1932926
 github.tarball_from     archive
 
 # getline, strnlen
@@ -51,6 +52,8 @@ post-patch {
 }
 
 compiler.cxx_standard   2017
+compiler.blacklist-append \
+                        {clang < 1100}
 
 configure.args-append   -DPython_EXECUTABLE=${prefix}/bin/python${py_ver} \
                         -DRS_EXPORT_JNI_ONLOAD=OFF \


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
