### PR TITLE
libdispatch-legacy: minor fix-ups

### DIFF
--- a/devel/libdispatch-legacy/Portfile
+++ b/devel/libdispatch-legacy/Portfile
@@ -5,9 +5,11 @@ PortGroup           xcode 1.0
 
 name                libdispatch-legacy
 version             84.5.5
-revision            1
+revision            2
 categories          devel
 platforms           {darwin < 11}
+# TODO: ppc64 is not yet supported in 10.6 SDK.
+supported_archs     i386 ppc x86_64
 license             Apache-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Grand Central Dispatch for PowerPC systems and pre-Snow Leopard x86
@@ -63,6 +65,21 @@ post-extract {
 patch.dir           ${workpath}
 patchfiles-append   patch-project.pbxproj.diff
 patchfiles-append   pthread_threadid_np-expose-on-PowerPC.diff
+
+# This is not clear why __crashreporter_info__ does not work, it allegedly exists in 10.5+,
+# but other libs may fail to link with libdispatch if this symbol is used:
+# Undefined symbols: "___crashreporter_info__", referenced from:
+# ___crashreporter_info__$non_lazy_ptr in libdispatch.a(semaphore.o)
+# However, it is only used in a single instance for debugging info.
+# We can verily live without that.
+patchfiles-append   patch-no-crashreporter_info.diff
+# The following symbol is not supported in libpthreads for powerpc.
+# So we may get something like this:
+# Undefined symbols: "_pthread_workqueue_attr_setovercommit_np", referenced from:
+# __dispatch_root_queues_init in libdispatch.a(queue.o)
+# FIXME: perhaps it can be borrowed or reimplemented.
+# See: https://people.freebsd.org/~sson/thrworkq/pthread_workqueue_2009_12_14.diff
+patchfiles-append   patch-pthread-overcommit.diff
 
 worksrcdir          ${workpath}/${LIBDISPATCH}
 

--- a/devel/libdispatch-legacy/files/patch-no-crashreporter_info.diff
+++ b/devel/libdispatch-legacy/files/patch-no-crashreporter_info.diff
@@ -1,0 +1,47 @@
+--- libdispatch-84.5.5/src/internal.h	2021-10-06 13:21:40.000000000 +0800
++++ libdispatch-84.5.5/src/internal.h	2024-04-13 21:38:05.000000000 +0800
+@@ -264,7 +264,6 @@
+ // 2) A hand crafted call to mach_msg*() screwed up. Use MIG.
+ #define DISPATCH_VERIFY_MIG(x) do {	\
+ 		if ((x) == MIG_REPLY_MISMATCH) {	\
+-			__crashreporter_info__ = "MIG_REPLY_MISMATCH";	\
+ 			_dispatch_hardware_crash();	\
+ 		}	\
+ 	} while (0)
+@@ -272,24 +271,20 @@
+ #if defined(__x86_64__) || defined(__i386__)
+ // total hack to ensure that return register of a function is not trashed
+ #define DISPATCH_CRASH(x)	do {	\
+-		asm("mov	%1, %0" : "=m" (__crashreporter_info__) : "c" ("BUG IN LIBDISPATCH: " x));	\
+ 		_dispatch_hardware_crash();	\
+ 	} while (0)
+ 
+ #define DISPATCH_CLIENT_CRASH(x)	do {	\
+-		asm("mov	%1, %0" : "=m" (__crashreporter_info__) : "c" ("BUG IN CLIENT OF LIBDISPATCH: " x));	\
+ 		_dispatch_hardware_crash();	\
+ 	} while (0)
+ 
+ #else
+ 
+ #define DISPATCH_CRASH(x)	do {	\
+-		__crashreporter_info__ = "BUG IN LIBDISPATCH: " x;	\
+ 		_dispatch_hardware_crash();	\
+ 	} while (0)
+ 
+ #define DISPATCH_CLIENT_CRASH(x)	do {	\
+-		__crashreporter_info__ = "BUG IN CLIENT OF LIBDISPATCH: " x;	\
+ 		_dispatch_hardware_crash();	\
+ 	} while (0)
+ 
+
+--- libdispatch-84.5.5/src/os_shims.h	2021-10-06 13:21:40.000000000 +0800
++++ libdispatch-84.5.5/src/os_shims.h	2024-04-13 21:36:45.000000000 +0800
+@@ -31,7 +31,7 @@
+ #include <pthread_machdep.h>
+ #include <pthread_workqueue.h>
+ 
+-__private_extern__ const char *__crashreporter_info__;
++// extern const char *__crashreporter_info__;
+ 
+ static const unsigned long dispatch_queue_key = __PTK_LIBDISPATCH_KEY0;
+ static const unsigned long dispatch_sema4_key = __PTK_LIBDISPATCH_KEY1;

--- a/devel/libdispatch-legacy/files/patch-pthread-overcommit.diff
+++ b/devel/libdispatch-legacy/files/patch-pthread-overcommit.diff
@@ -1,0 +1,13 @@
+--- libdispatch-84.5.5/src/queue.c	2021-10-06 13:21:40.000000000 +0800
++++ libdispatch-84.5.5/src/queue.c	2024-04-13 20:44:43.000000000 +0800
+@@ -1160,8 +1160,10 @@
+ 	for (i = 0; i < DISPATCH_ROOT_QUEUE_COUNT; i++) {
+ 		r = pthread_workqueue_attr_setqueuepriority_np(&pwq_attr, _dispatch_rootq2wq_pri(i));
+ 		dispatch_assume_zero(r);
++#ifndef __POWERPC__
+ 		r = pthread_workqueue_attr_setovercommit_np(&pwq_attr, i & 1);
+ 		dispatch_assume_zero(r);
++#endif
+ // some software hangs if the non-overcommitting queues do not overcommit when threads block
+ #if 0
+ 		if (!(i & 1)) {


### PR DESCRIPTION
#### Description

Minor fixes allowing other ports to use `libdispatch`.

This port is only relevant for archaic macOS versions, primarily powerpc. It is restricted to old systems.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
