### PR TITLE
cmake-1.1 PG: append link path to install rpath

### DIFF
--- a/_resources/port1.0/group/cmake-1.1.tcl
+++ b/_resources/port1.0/group/cmake-1.1.tcl
@@ -247,6 +247,7 @@ default configure.pre_args {[list \
                     -DCMAKE_FIND_FRAMEWORK=LAST \
                     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                     -DCMAKE_MAKE_PROGRAM=${build.cmd} \
+                    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
                     {*}[cmake::module_path] \
                     {*}[cmake::rpath_flags] \
                     -Wno-dev


### PR DESCRIPTION
#### Description

The [`CMAKE_INSTALL_RPATH_USE_LINK_PATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_RPATH_USE_LINK_PATH.html) flag tells CMake to append the link path to the install rpath to avoid having to specify it manually. This prevents the issue of potential runtime errors despite a successful build.

This is particularly an issue for any port that uses a library outside of the default `cmake.install_rpath` of `${prefix}/lib` (eg. LLVM or Clang libraries), such as the [include-what-you-use](https://github.com/macports/macports-ports/blob/5c6790d7ec5a0c0dfd27a831fc1374a581640d0a/devel/include-what-you-use/Portfile#L30) port. In that case the build might complete successfully but running the binary would result in a "Library not loaded" error.

###### Type(s)

- [x] enhancement