### PR TITLE
libpixman/libpixman-devel: fix ppc build failure

### DIFF
--- a/graphics/libpixman-devel/Portfile
+++ b/graphics/libpixman-devel/Portfile
@@ -2,10 +2,14 @@
 
 PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
+PortGroup               legacysupport 1.1
 PortGroup               meson 1.0
 PortGroup               muniversal 1.0
 
 # Please keep the libpixman and libpixman-devel ports as similar as possible.
+
+# posix_memalign
+legacysupport.newest_darwin_requires_legacy 9
 
 name                    libpixman-devel
 conflicts               libpixman
@@ -36,7 +40,7 @@ long_description        libpixman is a generic library for manipulating pixel \
 # Disable unexpected download of subprojects
 meson.wrap_mode         nodownload
 
-# Upstream patch for dylib versioning. Expected to be included in future release.
+# Upstream patch for dylib versioning. Expected to be included in next release.
 # See: https://gitlab.freedesktop.org/pixman/pixman/-/issues/81
 patchfiles-append       patch-meson-dylib-versions.diff
 
@@ -45,7 +49,7 @@ depends_build-append \
 
 # llvm-gcc-4.2 makes cairo fail to generate PDFs properly
 # clang on Xcode 4.1 cannot build libpixman
-compiler.blacklist      llvm-gcc-4.2 {clang < 211.10.1}
+compiler.blacklist-append      {clang < 211.10.1} {*gcc-4.[0-2]}
 
 configure.checks.implicit_function_declaration.whitelist-append \
                         strchr
@@ -65,11 +69,6 @@ post-destroot {
         COPYING \
         README \
         ${docdir}
-}
-
-platform darwin 8 powerpc {
-    # apple-gcc-4.2 makes Tiger ppc fail to detect pthread support and then fail to build
-    compiler.blacklist-append apple-gcc-4.2
 }
 
 livecheck.type          regex

--- a/graphics/libpixman/Portfile
+++ b/graphics/libpixman/Portfile
@@ -2,10 +2,14 @@
 
 PortSystem              1.0
 PortGroup               compiler_blacklist_versions 1.0
+PortGroup               legacysupport 1.1
 PortGroup               meson 1.0
 PortGroup               muniversal 1.0
 
 # Please keep the libpixman and libpixman-devel ports as similar as possible.
+
+# posix_memalign
+legacysupport.newest_darwin_requires_legacy 9
 
 name                    libpixman
 conflicts               libpixman-devel
@@ -51,7 +55,7 @@ depends_build-append \
 
 # llvm-gcc-4.2 makes cairo fail to generate PDFs properly
 # clang on Xcode 4.1 cannot build libpixman
-compiler.blacklist      llvm-gcc-4.2 {clang < 211.10.1}
+compiler.blacklist-append      {clang < 211.10.1} {*gcc-4.[0-2]}
 
 configure.checks.implicit_function_declaration.whitelist-append \
                         strchr
@@ -71,11 +75,6 @@ post-destroot {
         COPYING \
         README \
         ${docdir}
-}
-
-platform darwin 8 powerpc {
-    # apple-gcc-4.2 makes Tiger ppc fail to detect pthread support and then fail to build
-    compiler.blacklist-append apple-gcc-4.2
 }
 
 livecheck.type          regex


### PR DESCRIPTION
#### Description

I've applied @kencu's patch for https://trac.macports.org/ticket/68473 found at https://trac.macports.org/ticket/69385 such that libpixman can build and be used by other ports on Leopard PPC.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.5 9A581 Power Macintosh
Xcode 3.1.4 9M2809

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
