### PR TITLE
gstreamer1-gst-plugins-base: Don't conflict with gl-headers & mesa

### DIFF
--- a/gnome/gstreamer1-gst-plugins-base/Portfile
+++ b/gnome/gstreamer1-gst-plugins-base/Portfile
@@ -133,6 +133,10 @@ platform macosx {
         if {(${universal_possible} && [variant_isset universal]) || ${build_arch} eq "i386"} {
             compiler.blacklist-append *gcc* {macports-clang-3.[0-8]} {clang < 703}
         }
+        # Use mesa headers if found else use gl-headers to ensure we don't conflict with gl-headers & mesa later
+        depends_build-append \
+                    path:include/GL/glext.h:gl-headers
+
         configure.args-replace \
                     -Dgl=disabled \
                     -Dgl=enabled


### PR DESCRIPTION
When the GL headers are not found meson will download them using  the gl-headers wrap, this causes gstreamer1-gst-plugins-base to conflict with gl-headers port & mesa.

Use the gl-headers Port to avoid embedding the headers, this also avoids the download from failing as it requires a modern version of git to download the subproject.

<br>

This is only seen when not using the default variants, trying to fixup the `gstreamer1` Portfiles to possibly remove the custom ones from my overlay.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
