### PR TITLE
openjdk7-bootstrap: use Macports X11 by default to avoid a breakage

### DIFF
--- a/java/openjdk7-bootstrap/Portfile
+++ b/java/openjdk7-bootstrap/Portfile
@@ -14,7 +14,7 @@ maintainers         {outlook.com:usersword123 @usersxx} \
                     openmaintainer
 description         OpenJDK 7 Boot JDK
 long_description    OpenJDK 7 Boot JDK to bootstrap Openjdk8 port
-homepage            
+homepage            https://openjdk.org/projects/bsd-port
 master_sites        https://macintoshgarden.org/sites/macintoshgarden.org/files/apps \
                     http://mirror.macintosharchive.org/macintoshgarden.org/files/apps \
                     http://old.macintosh.garden/apps \
@@ -34,9 +34,10 @@ use_configure       no
 # Incompatible library version: /Library/Java/JavaVirtualMachines/openjdk7-bootstrap/jre/lib/ppc/libfontmanager.dylib requires version 13.0.0 or later
 depends_lib         port:freetype
 
-build {}
+build               {}
 
 set path /Library/Java/JavaVirtualMachines/${name}
+
 destroot {
     xinstall -m 755 -d ${destroot}${path}
     copy ${worksrcpath}/ASSEMBLY_EXCEPTION ${destroot}${path}
@@ -52,6 +53,7 @@ destroot {
     copy ${worksrcpath}/src.zip ${destroot}${path}
     copy ${worksrcpath}/THIRD_PARTY_README ${destroot}${path}
 }
+
 destroot.violate_mtree  yes
 
 post-destroot {

--- a/java/openjdk7-bootstrap/Portfile
+++ b/java/openjdk7-bootstrap/Portfile
@@ -6,7 +6,7 @@ name                openjdk7-bootstrap
 version             1.7.0_2
 set build           2012-03-14
 categories          java devel
-platforms           {darwin any}
+platforms           {darwin < 11}
 supported_archs     ppc
 license             GPL-2+
 maintainers         {outlook.com:usersword123 @usersxx} \

--- a/java/openjdk7-bootstrap/Portfile
+++ b/java/openjdk7-bootstrap/Portfile
@@ -4,6 +4,7 @@ PortSystem          1.0
 
 name                openjdk7-bootstrap
 version             1.7.0_2
+revision            1
 set build           2012-03-14
 categories          java devel
 platforms           {darwin < 11}
@@ -31,8 +32,12 @@ worksrcdir          ${distname}
 use_xcode           no
 use_configure       no
 
-# Incompatible library version: /Library/Java/JavaVirtualMachines/openjdk7-bootstrap/jre/lib/ppc/libfontmanager.dylib requires version 13.0.0 or later
-depends_lib         port:freetype
+depends_lib         port:freetype \
+                    port:xorg-libX11 \
+                    port:xorg-libXext \
+                    port:xorg-libXi \
+                    port:xorg-libXtst \
+                    port:xrender
 
 build               {}
 
@@ -56,6 +61,35 @@ destroot {
 
 destroot.violate_mtree  yes
 
+variant apple_x11 description "Use Apple version of X11" {
+    depends_lib-delete \
+                    port:xorg-libX11 port:xorg-libXext \
+                    port:xorg-libXi port:xorg-libXtst \
+                    port:xrender
+}
+
 post-destroot {
-    system "install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${prefix}/lib/libfreetype.6.dylib ${destroot}${path}/jre/lib/ppc/libfontmanager.dylib"
+    # This is a required change, since the Apple one is too old:
+    # Incompatible library version: /Library/Java/JavaVirtualMachines/openjdk7-bootstrap/jre/lib/ppc/libfontmanager.dylib
+    # requires version 13.0.0 or later
+    system "install_name_tool -change /usr/X11/lib/libfreetype.6.dylib \
+                    ${prefix}/lib/libfreetype.6.dylib ${destroot}${path}/jre/lib/ppc/libfontmanager.dylib"
+
+    # Remaining ones are optional, however we rather avoid depending on Apple X11, since it is not a part
+    # of macOS as such, and can be missing or uninstalled later. Also, having two X11 versions tends to create conflicts
+    # and lead to obscure bugs. It is safer to use only Macports X11.
+    if {![variant_isset apple_x11]} {
+        foreach x11lib [list libX11.6 libXext.6 libXi.6 libXrender.1 libXtst.6] {
+            system "install_name_tool -change /usr/X11/lib/${x11lib}.dylib \
+                    ${prefix}/lib/${x11lib}.dylib ${destroot}${path}/bin/appletviewer"
+            system "install_name_tool -change /usr/X11/lib/${x11lib}.dylib \
+                    ${prefix}/lib/${x11lib}.dylib ${destroot}${path}/bin/policytool"
+            system "install_name_tool -change /usr/X11/lib/${x11lib}.dylib \
+                    ${prefix}/lib/${x11lib}.dylib ${destroot}${path}/jre/bin/policytool"
+            system "install_name_tool -change /usr/X11/lib/${x11lib}.dylib \
+                    ${prefix}/lib/${x11lib}.dylib ${destroot}${path}/jre/lib/ppc/libsplashscreen.dylib"
+            system "install_name_tool -change /usr/X11/lib/${x11lib}.dylib \
+                    ${prefix}/lib/${x11lib}.dylib ${destroot}${path}/jre/lib/ppc/xawt/libmawt.dylib"
+        }
+    }
 }

--- a/java/openjdk7-bootstrap/Portfile
+++ b/java/openjdk7-bootstrap/Portfile
@@ -9,7 +9,9 @@ categories          java devel
 platforms           {darwin any}
 supported_archs     ppc
 license             GPL-2+
-maintainers         {outlook.com:usersword123 @usersxx} openmaintainer
+maintainers         {outlook.com:usersword123 @usersxx} \
+                    {@barracuda156 gmail.com:vital.had} \
+                    openmaintainer
 description         OpenJDK 7 Boot JDK
 long_description    OpenJDK 7 Boot JDK to bootstrap Openjdk8 port
 homepage            


### PR DESCRIPTION
#### Description

1. Existing version was linked to Apple X11, however there is no guarantee it is installed, and even if it is, uninstalling it will leave openjdk broken. (This is what I experienced myself.) Move usage of Apple X11 into a variant, relink to Macports X11 by default.
2. Add homepage to make lint happy.
3. Since this is a powerpc-only port, add myself as a co-maintainer.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
