### PR TITLE
vorbisgain: fix build failure by undeclared function

### DIFF
--- a/audio/vorbisgain/Portfile
+++ b/audio/vorbisgain/Portfile
@@ -23,7 +23,8 @@ long_description            VorbisGain ${description} by calculating the file's 
                             that knows about and acts on that suggestion.
 
 checksums                   rmd160  01de9516a7571c2ecdb3e4645c6c8e7ba8ce80cc \
-                            sha256  dd6db051cad972bcac25d47b4a9e40e217bb548a1f16328eddbb4e66613530ec
+                            sha256  dd6db051cad972bcac25d47b4a9e40e217bb548a1f16328eddbb4e66613530ec \
+                            size 208977
 
 depends_lib                 port:libogg \
                             port:libvorbis
@@ -31,6 +32,12 @@ depends_lib                 port:libogg \
 post-extract {
     file attributes ${worksrcpath}/configure -permissions a+x
 }
+
+pre-patch {
+    reinplace -W ${worksrcpath} "s|\r||g" misc.c
+}
+
+patchfiles                  undeclared-function-fix.diff
 
 configure.args-append       --mandir=${prefix}/share/man \
                             --enable-recursive

--- a/audio/vorbisgain/files/undeclared-function-fix.diff
+++ b/audio/vorbisgain/files/undeclared-function-fix.diff
@@ -1,0 +1,14 @@
+--- misc.c.orig	2024-02-18 17:49:37
++++ misc.c	2024-02-18 18:10:26
+@@ -24,6 +24,11 @@
+ #include <errno.h>
+ #include <ctype.h>
+
++#ifdef __APPLE__
++#include <unistd.h>
++#include <sys/ioctl.h>
++#endif /* __APPLE__ */
++
+ #ifndef DISABLE_WINSIZE
+
+ #if HAVE_TERMIOS_H


### PR DESCRIPTION
#### Description

* A patch to fix build failure is added.
* Line break of the patched file is converted.
* The size of the archive file is added.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.6 22G630 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
