### PR TITLE
symfony-cli: update to 5.8.15

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.14
+version             5.8.15
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  4ad1642952701b622a717a84cacb74e1095f679a \
-                        sha256  63aa26a1cec91ca48d0039c1bd4ab02fcb97f68da9690eca831b91180d3cb407 \
-                        size    267354
+    checksums           rmd160  e6677310ed8d9e9a4c516534a646ff5e7f478719 \
+                        sha256  4eb374cbcbf7bf6a2fe291d59e4d36004d28f7c44c6a1d9167fc6a848c69eb98 \
+                        size    267355
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  9143817f0c9e606b7e63b1edba5a928f1b670079 \
-                        sha256  334e74892cb0c995eb889c9c7901d316d30b5154f51931fe313cc50e5d1a9b19 \
-                        size    11382834
+    checksums           rmd160  3f4d1cd7e8323f8e83a5890d2802fea43370ffa3 \
+                        sha256  a01587120eec150c48315f9019bf529d48c889da53200deaac4ef800f4da2077 \
+                        size    11393110
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.15

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
