### PR TITLE
gitui: update to 0.26.1

### DIFF
--- a/devel/gitui/Portfile
+++ b/devel/gitui/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        extrawurst gitui 0.24.3 v
+github.setup        extrawurst gitui 0.26.1 v
 github.tarball_from archive
 revision            0
 
@@ -19,9 +19,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  66bb2a3c9b4239db74144b73b0d07be5404f8e91 \
-                    sha256  a5fc6b52a4db0037c3351b9743af49c8bb9ccff4dda5bdb064bab9e59f68fde2 \
-                    size    32830812 \
+                    rmd160  e37c1eb3411ab390da4a9d7a65ac98415139d947 \
+                    sha256  b1b0a6c692771a4e37f7ff33490365f8f330660a4110adf650b2483d99379c1d \
+                    size    34965412
 
 build.args-append   {--features "vendor-openssl"}
 
@@ -35,221 +35,295 @@ destroot {
 }
 
 cargo.crates \
-    addr2line                       0.19.0  a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97 \
+    addr2line                       0.21.0  8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb \
     adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
-    aho-corasick                     1.0.2  43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41 \
+    aead                             0.5.2  d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0 \
+    aes                              0.8.4  b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0 \
+    aes-gcm                         0.10.3  831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1 \
+    ahash                           0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
+    aho-corasick                     1.1.3  8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916 \
+    allocator-api2                  0.2.16  0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5 \
     android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anstream                         0.5.0  b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c \
-    anstyle                          1.0.2  15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea \
-    anstyle-parse                    0.2.1  938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333 \
-    anstyle-query                    1.0.0  5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b \
-    anstyle-wincon                   2.1.0  58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd \
-    anyhow                          1.0.75  a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6 \
+    anstream                        0.6.13  d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb \
+    anstyle                          1.0.6  8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc \
+    anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
+    anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
+    anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
+    anyhow                          1.0.82  f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519 \
     autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
-    backtrace                       0.3.67  233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca \
-    base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
+    backtrace                       0.3.71  26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d \
+    base16ct                         0.2.0  4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf \
+    base64                          0.21.7  9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567 \
+    base64ct                         1.6.0  8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b \
+    bcrypt-pbkdf                    0.10.0  6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2 \
     bincode                          1.3.3  b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad \
     bit-set                          0.5.3  0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1 \
     bit-vec                          0.6.3  349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
+    bitflags                         2.5.0  cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1 \
+    block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
+    block-padding                    0.3.3  a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93 \
+    blowfish                         0.9.1  e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7 \
     bugreport                        0.5.0  535120b8182547808081a66f1f77a64533c780b23da26763e0ee34dfb94f98c9 \
-    bumpalo                         3.12.0  0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535 \
+    bumpalo                         3.15.4  7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa \
     bwrap                            1.3.0  d13da3319ae5c5771712fba7b79b028793149bc462a08990bc8fd7c7554dbb95 \
+    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
     bytesize                         1.3.0  a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
-    cc                              1.0.79  50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f \
+    cbc                              0.1.2  26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6 \
+    cc                              1.0.90  8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    chrono                          0.4.30  defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877 \
-    clap                             4.4.2  6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6 \
-    clap_builder                     4.4.2  2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08 \
-    clap_lex                         0.5.1  cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961 \
-    codespan-reporting              0.11.1  3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e \
+    chacha20                         0.9.1  c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818 \
+    chrono                          0.4.37  8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e \
+    cipher                           0.4.4  773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad \
+    clap                             4.5.4  90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0 \
+    clap_builder                     4.5.2  ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4 \
+    clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
     colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
-    core-foundation-sys              0.8.3  5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc \
-    crc32fast                        1.3.2  b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d \
-    crossbeam-channel                0.5.8  a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200 \
-    crossbeam-deque                  0.8.2  715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc \
-    crossbeam-epoch                 0.9.13  01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a \
-    crossbeam-utils                 0.8.14  4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f \
-    crossterm                       0.26.1  a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13 \
-    crossterm_winapi                 0.9.0  2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c \
-    cxx                             1.0.90  90d59d9acd2a682b4e40605a242f6670eaa58c5957471cbf85e8aa6a0b97a5e8 \
-    cxx-build                       1.0.90  ebfa40bda659dd5c864e65f4c9a2b0aff19bea56b017b9b77c73d3766a453a38 \
-    cxxbridge-flags                 1.0.90  457ce6757c5c70dc6ecdbda6925b958aae7f959bda7d8fb9bde889e34a09dc03 \
-    cxxbridge-macro                 1.0.90  ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263 \
-    dashmap                          5.4.0  907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc \
+    const-oid                        0.9.6  c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8 \
+    core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
+    cpufeatures                     0.2.12  53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504 \
+    crc32fast                        1.4.0  b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa \
+    crossbeam-channel               0.5.12  ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95 \
+    crossbeam-deque                  0.8.5  613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d \
+    crossbeam-epoch                 0.9.18  5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e \
+    crossbeam-utils                 0.8.19  248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345 \
+    crossterm                       0.27.0  f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df \
+    crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
+    crypto-bigint                    0.5.5  0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76 \
+    crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
+    ctr                              0.9.2  0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835 \
+    curve25519-dalek                 4.1.2  0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348 \
+    curve25519-dalek-derive          0.1.1  f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3 \
+    dashmap                          5.5.3  978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856 \
+    der                              0.7.9  f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0 \
+    deranged                        0.3.11  b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4 \
     diff                            0.1.13  56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8 \
+    digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     dirs                             5.0.1  44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225 \
     dirs-sys                         0.4.1  520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c \
     easy-cast                        0.5.2  10936778145f3bea71fd9bf61332cce28c28e96a380714f7ab34838b80733fd6 \
-    either                           1.8.1  7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91 \
-    env_logger                      0.10.0  85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0 \
-    errno                            0.2.8  f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1 \
-    errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
+    ecdsa                           0.16.9  ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca \
+    ed25519                          2.2.3  115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53 \
+    ed25519-dalek                    2.1.1  4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871 \
+    either                          1.10.0  11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a \
+    elliptic-curve                  0.13.8  b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47 \
+    env_filter                       0.1.0  a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea \
+    env_logger                      0.11.3  38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9 \
+    equivalent                       1.0.1  5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5 \
+    errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
     fancy-regex                     0.11.0  b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2 \
-    fastrand                         1.9.0  e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be \
-    filetime                        0.2.20  8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412 \
-    flate2                          1.0.25  a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841 \
+    fastrand                         2.0.1  25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5 \
+    ff                              0.13.0  ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449 \
+    fiat-crypto                      0.2.7  c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f \
+    filetime                        0.2.23  1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd \
+    flate2                          1.0.28  46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    form_urlencoded                  1.2.0  a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652 \
+    form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     fsevent-sys                      4.1.0  76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2 \
-    futures                         0.3.26  13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84 \
-    futures-channel                 0.3.26  2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5 \
-    futures-core                    0.3.26  ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608 \
-    futures-executor                0.3.26  e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e \
-    futures-io                      0.3.26  bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531 \
-    futures-sink                    0.3.26  f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364 \
-    futures-task                    0.3.26  dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366 \
-    futures-util                    0.3.26  9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1 \
+    futures                         0.3.30  645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0 \
+    futures-channel                 0.3.30  eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78 \
+    futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
+    futures-executor                0.3.30  a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d \
+    futures-io                      0.3.30  a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1 \
+    futures-sink                    0.3.30  9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5 \
+    futures-task                    0.3.30  38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004 \
+    futures-util                    0.3.30  3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48 \
     fuzzy-matcher                    0.3.7  54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94 \
-    getrandom                        0.2.8  c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31 \
-    gh-emoji                         1.0.7  30ad64b43d48c1745c0059e5ba223816eb599eec8956c668fc0a31f6b9cd799e \
-    gimli                           0.27.3  b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e \
-    git-version                      0.3.5  f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899 \
-    git-version-macro                0.3.5  fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f \
-    git2                            0.17.2  7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044 \
-    hashbrown                       0.12.3  8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888 \
-    hermit-abi                       0.3.2  443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b \
+    generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
+    getrandom                       0.2.12  190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5 \
+    gh-emoji                         1.0.8  eb8adf61df288369c9d1c6bb142f61db30c18619a71f64915d64e916f23c8c37 \
+    ghash                            0.5.1  f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1 \
+    gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
+    git-version                      0.3.9  1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19 \
+    git-version-macro                0.3.9  53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0 \
+    git2                            0.18.3  232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70 \
+    group                           0.13.0  f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63 \
+    hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
+    heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
+    hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
+    home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
     humantime                        2.1.0  9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4 \
-    iana-time-zone                  0.1.53  64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765 \
-    iana-time-zone-haiku             0.1.1  0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca \
-    idna                             0.4.0  7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c \
-    indexmap                         1.9.3  bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99 \
+    iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
+    iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
+    idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
+    indexmap                         2.2.6  168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26 \
+    indoc                            2.0.4  1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8 \
     inotify                          0.9.6  f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff \
     inotify-sys                      0.1.5  e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb \
-    instant                         0.1.12  7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c \
-    io-lifetimes                     1.0.5  1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3 \
-    is-terminal                      0.4.3  22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef \
+    inout                            0.1.3  a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5 \
     itertools                       0.11.0  b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57 \
-    itoa                             1.0.8  62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a \
-    jobserver                       0.1.25  068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b \
-    js-sys                          0.3.61  445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730 \
-    kqueue                           1.0.7  2c8fc60ba15bf51257aa9807a48a61013db043fcf3a78cb0d916e8e396dcad98 \
-    kqueue-sys                       1.0.3  8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587 \
+    itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
+    itoa                            1.0.10  b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c \
+    jobserver                       0.1.28  ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6 \
+    js-sys                          0.3.69  29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d \
+    kqueue                           1.0.8  7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c \
+    kqueue-sys                       1.0.4  ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
-    libc                           0.2.139  201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79 \
-    libgit2-sys               0.15.2+1.6.4  a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa \
+    libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
+    libgit2-sys                   0.16.2+1.7.2  ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8 \
+    libm                             0.2.8  4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058 \
+    libredox                         0.0.1  85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8 \
     libssh2-sys                      0.3.0  2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee \
-    libz-sys                         1.1.8  9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf \
-    link-cplusplus                   1.0.8  ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5 \
-    linux-raw-sys                    0.1.4  f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4 \
-    lock_api                        0.4.10  c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16 \
-    log                             0.4.20  b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f \
-    memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
-    memoffset                        0.7.1  5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4 \
-    miniz_oxide                      0.6.2  b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa \
-    mio                              0.8.5  e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de \
-    notify                           5.2.0  729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486 \
-    notify-debouncer-mini            0.2.1  e23e9fa24f094b143c1eb61f90ac6457de87be6987bc70746e0179f7dbc9007b \
-    num-traits                      0.2.15  578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd \
-    num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
-    object                          0.30.3  ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439 \
-    once_cell                       1.18.0  dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d \
+    libz-sys                        1.1.15  037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6 \
+    linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
+    lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
+    log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
+    lru                             0.12.3  d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc \
+    memchr                           2.7.1  523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149 \
+    miniz_oxide                      0.7.2  9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7 \
+    mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
+    notify                           6.1.1  6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d \
+    notify-debouncer-mini            0.4.1  5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43 \
+    num-bigint-dig                   0.8.4  dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151 \
+    num-conv                         0.1.0  51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9 \
+    num-integer                     0.1.46  7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f \
+    num-iter                        0.1.44  d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9 \
+    num-traits                      0.2.18  da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a \
+    object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
+    once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
     onig                             6.4.0  8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f \
     onig_sys                        69.8.1  7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7 \
+    opaque-debug                     0.3.1  c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381 \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
-    openssl-src              300.1.3+3.1.2  cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107 \
-    openssl-sys                     0.9.93  db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d \
+    openssl-src                   300.2.3+3.2.1  5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843 \
+    openssl-sys                    0.9.102  c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
+    p256                            0.13.2  c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b \
+    p384                            0.13.0  70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209 \
+    p521                            0.13.3  0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2 \
     parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
-    parking_lot_core                 0.9.7  9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521 \
-    percent-encoding                 2.3.0  9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94 \
-    phf                             0.11.1  928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c \
-    phf_shared                      0.11.1  e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676 \
-    pin-project-lite                 0.2.9  e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116 \
+    parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
+    paste                           1.0.14  de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c \
+    pbkdf2                          0.12.2  f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2 \
+    pem-rfc7468                      0.7.0  88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412 \
+    percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
+    phf                             0.11.2  ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc \
+    phf_shared                      0.11.2  90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b \
+    pin-project-lite                0.2.13  8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58 \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
-    pkg-config                      0.3.26  6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160 \
+    pkcs1                            0.7.5  c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f \
+    pkcs8                           0.10.2  f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7 \
+    pkg-config                      0.3.30  d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec \
+    platforms                        3.4.0  db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7 \
+    poly1305                         0.8.0  8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf \
+    polyval                          0.6.2  9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25 \
+    powerfmt                         0.2.0  439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391 \
+    ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
     pretty_assertions                1.4.0  af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66 \
-    proc-macro-error                 1.0.4  da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c \
-    proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
-    proc-macro-hack      0.5.20+deprecated  dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068 \
-    proc-macro2                     1.0.63  7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb \
-    quote                           1.0.29  573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105 \
-    ratatui                         0.21.0  ce841e0486e7c2412c3740168ede33adeba8e154a15107b879d8162d77c7174e \
-    rayon                            1.7.0  1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b \
-    rayon-core                      1.11.0  4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d \
-    redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
-    redox_users                      0.4.3  b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b \
-    regex                            1.9.1  b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575 \
-    regex-automata                   0.3.4  b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294 \
-    regex-syntax                     0.7.4  e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2 \
-    ron                              0.8.0  300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff \
-    rustc-demangle                  0.1.21  7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342 \
-    rustix                          0.36.8  f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644 \
-    ryu                             1.0.14  fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9 \
+    primeorder                      0.13.6  353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6 \
+    proc-macro2                     1.0.79  e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e \
+    quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
+    rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
+    rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
+    rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
+    ratatui                         0.24.0  0ebc917cfb527a566c37ecb94c7e3fd098353516fb4eb6bea17015ade0182425 \
+    rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
+    rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
+    redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
+    redox_users                      0.4.4  a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4 \
+    regex                           1.10.3  b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15 \
+    regex-automata                   0.4.6  86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea \
+    regex-syntax                     0.8.2  c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f \
+    rfc6979                          0.4.0  f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2 \
+    ron                              0.8.1  b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94 \
+    rsa                              0.9.6  5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc \
+    rustc-demangle                  0.1.23  d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76 \
+    rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
+    rustix                         0.38.32  65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89 \
+    rustversion                     1.0.14  7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4 \
+    ryu                             1.0.17  e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1 \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
-    scratch                          1.0.3  ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2 \
-    serde                          1.0.156  314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4 \
-    serde_derive                   1.0.156  d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d \
-    serde_json                      1.0.93  cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76 \
-    serial_test                      1.0.0  538c30747ae860d6fb88330addbbd3e0ddbe46d662d032855596d8a8ca260611 \
-    serial_test_derive               1.0.0  079a83df15f85d89a68d64ae1238f142f172b1fa915d0d76b26a7cba1b659a69 \
+    sec1                             0.7.3  d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc \
+    semver                          1.0.22  92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca \
+    serde                          1.0.197  3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2 \
+    serde_derive                   1.0.197  7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b \
+    serde_json                     1.0.114  c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0 \
+    serial_test                      3.0.0  953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d \
+    serial_test_derive               3.0.0  b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212 \
+    sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
     shell-escape                     0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
     shellexpand                      3.1.0  da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b \
-    signal-hook                     0.3.15  732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9 \
+    signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
     signal-hook-mio                  0.2.3  29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af \
     signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
-    simplelog                       0.12.1  acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369 \
-    siphasher                       0.3.10  7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de \
-    slab                             0.4.8  6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d \
-    smallvec                        1.11.0  62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9 \
-    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
-    struct-patch                     0.2.3  e0c25d7271340ea5e82f6d598a02ad5fc155c11b703c808b120a8873279027b4 \
-    struct-patch-derive              0.2.3  dead485b43c32fccb5a6ac1e94a938adcd616d80903d92fb1b1d9d633ea0d29f \
-    syn                            1.0.107  1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5 \
-    syntect                          5.1.0  e02b4b303bf8d08bfeb0445cba5068a3d306b6baece1d5582171a9bf49188f91 \
+    signature                        2.2.0  77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de \
+    simplelog                       0.12.2  16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0 \
+    siphasher                       0.3.11  38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d \
+    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
+    smallvec                        1.13.1  e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7 \
+    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    spki                             0.7.3  d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d \
+    ssh-cipher                       0.2.0  caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f \
+    ssh-encoding                     0.2.0  eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15 \
+    ssh-key                          0.6.5  3b71299a724c8d84956caaf8fc3b3ea57c3587fe2d0b800cd0dc1f3599905d7e \
+    strsim                          0.11.0  5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01 \
+    struct-patch                     0.4.1  7c52ef523e89b3172242bbabefd8a92493ae5571224c29ed2f00185c39b395c2 \
+    struct-patch-derive              0.4.1  f14a349c27ebe59faba22f933c9c734d428da7231e88a247e9d8c61eea964ddb \
+    strum                           0.25.0  290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125 \
+    strum_macros                    0.25.3  23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0 \
+    subtle                           2.5.0  81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc \
+    syn                             2.0.49  915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496 \
+    syntect                          5.2.0  874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1 \
     sys-info                         0.9.1  0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c \
-    tempfile                         3.4.0  af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95 \
-    termcolor                        1.2.0  be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6 \
-    thiserror                       1.0.39  a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c \
-    thiserror-impl                  1.0.39  5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e \
-    thread_local                     1.1.7  3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152 \
-    time                            0.3.22  ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd \
-    time-core                        0.1.1  7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb \
-    time-macros                      0.2.9  372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b \
+    tempfile                        3.10.1  85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1 \
+    thiserror                       1.0.58  03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297 \
+    thiserror-impl                  1.0.58  c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7 \
+    thread_local                     1.1.8  8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c \
+    time                            0.3.34  c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749 \
+    time-core                        0.1.2  ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3 \
+    time-macros                     0.2.17  7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774 \
     tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    unicode-bidi                    0.3.10  d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58 \
-    unicode-ident                    1.0.6  84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc \
-    unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
-    unicode-segmentation            1.10.1  1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36 \
+    tui-textarea                     0.4.0  a3e38ced1f941a9cfc923fbf2fe6858443c42cc5220bfd35bdd3648371e7bd8e \
+    two-face                         0.3.0  37bed2135b2459c7eefba72c906d374697eb15949c205f2f124e3636a46b5eeb \
+    typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
+    unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
+    unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
+    unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
+    unicode-segmentation            1.11.0  d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202 \
     unicode-truncate                 0.2.0  a04be5ca5f7a4a7270ffea82bc41c59b87c611ed04f20e77c338e8d3c2348e42 \
-    unicode-width                   0.1.10  c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b \
-    url                              2.4.1  143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5 \
+    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
+    universal-hash                   0.5.1  fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea \
+    url                              2.5.0  31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633 \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
-    walkdir                          2.3.3  36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698 \
-    wasi     0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.84  31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b \
-    wasm-bindgen-backend            0.2.84  95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9 \
-    wasm-bindgen-macro              0.2.84  4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5 \
-    wasm-bindgen-macro-support      0.2.84  2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6 \
-    wasm-bindgen-shared             0.2.84  0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d \
-    which                            4.4.0  2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269 \
+    walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \
+    wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
+    wasm-bindgen                    0.2.92  4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8 \
+    wasm-bindgen-backend            0.2.92  614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da \
+    wasm-bindgen-macro              0.2.92  a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726 \
+    wasm-bindgen-macro-support      0.2.92  e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7 \
+    wasm-bindgen-shared             0.2.92  af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96 \
+    which                            6.0.1  8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
-    winapi-util                      0.1.5  70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178 \
+    winapi-util                      0.1.6  f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows-sys                     0.42.0  5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7 \
-    windows-sys                     0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
-    windows-targets                 0.42.1  8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7 \
-    windows-targets                 0.48.1  05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f \
-    windows_aarch64_gnullvm         0.42.1  8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608 \
-    windows_aarch64_gnullvm         0.48.0  91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc \
-    windows_aarch64_msvc            0.42.1  4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7 \
-    windows_aarch64_msvc            0.48.0  b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3 \
-    windows_i686_gnu                0.42.1  de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640 \
-    windows_i686_gnu                0.48.0  622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241 \
-    windows_i686_msvc               0.42.1  bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605 \
-    windows_i686_msvc               0.48.0  4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00 \
-    windows_x86_64_gnu              0.42.1  c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45 \
-    windows_x86_64_gnu              0.48.0  ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1 \
-    windows_x86_64_gnullvm          0.42.1  628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463 \
-    windows_x86_64_gnullvm          0.48.0  7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953 \
-    windows_x86_64_msvc             0.42.1  447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd \
-    windows_x86_64_msvc             0.48.0  1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a \
-    yansi                            0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec
+    windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows-targets                 0.52.0  8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_gnullvm         0.52.0  cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_aarch64_msvc            0.52.0  bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_gnu                0.52.0  a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313 \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_i686_msvc               0.52.0  ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnu              0.52.0  3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_gnullvm          0.52.0  1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
+    windows_x86_64_msvc             0.52.0  dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04 \
+    winsafe                         0.0.19  d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904 \
+    yansi                            0.5.1  09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec \
+    zerocopy                        0.7.32  74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be \
+    zerocopy-derive                 0.7.32  9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6 \
+    zeroize                          1.7.0  525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d


### PR DESCRIPTION
#### Description
https://github.com/extrawurst/gitui/releases

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
