### PR TITLE
draco: patch cmake to not use --start-group ,--end-group on mac

### DIFF
--- a/archivers/draco/Portfile
+++ b/archivers/draco/Portfile
@@ -22,7 +22,8 @@ checksums           rmd160  8570f7264777ac166dfec8db1d09c07cd997f4ee \
                     sha256  bf6b105b79223eab2b86795363dfe5e5356050006a96521477973aba8f036fe1 \
                     size    60465968
 
-patchfiles          patch-gltf-decoder-cc.diff
+patchfiles          patch-gltf-decoder-cc.diff \
+                    patch-draco-targets-cmake.diff
 
 compiler.cxx_standard   2017
 cmake.set_cxx_standard  yes

--- a/archivers/draco/files/patch-draco-targets-cmake.diff
+++ b/archivers/draco/files/patch-draco-targets-cmake.diff
@@ -1,0 +1,13 @@
+Issue reported with https://github.com/google/draco/issues/1058
+
+--- cmake/draco_targets.cmake.orig	2024-01-17 21:42:36
++++ cmake/draco_targets.cmake	2024-04-15 11:11:13
+@@ -162,7 +162,7 @@
+   endif()
+ 
+   if(exe_LIB_DEPS)
+-    if(CMAKE_CXX_COMPILER_ID MATCHES "^Clang|^GNU")
++    if(NOT APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "^Clang|^GNU")
+       # Third party dependencies can introduce dependencies on system and test
+       # libraries. Since the target created here is an executable, and CMake
+       # does not provide a method of controlling order of link dependencies,


### PR DESCRIPTION
#### Description

Apply patch to not use the linker flags -start-group and --end-group on macOS systems, as [noted by Ryan](https://trac.macports.org/ticket/69719#comment:8).

Hopefully this finally closes https://trac.macports.org/ticket/69719.



<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
