### PR TITLE
mkvtoolnix-legacy: use Boost 1.81

### DIFF
--- a/multimedia/mkvtoolnix-legacy/Portfile
+++ b/multimedia/mkvtoolnix-legacy/Portfile
@@ -6,6 +6,8 @@ PortGroup           muniversal 1.0
 PortGroup           boost 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
+boost.version       1.81
+
 # The developer does not accept macOS-specific bug reports, but does
 # accept pull requests.
 
@@ -28,14 +30,14 @@ use_xz              yes
 
 if {${os.platform} ne "darwin" || ${os.major} >= 14} {
     version         81.0
-    revision        0
+    revision        1
     # Versions newer than this requires Qt 6 - do not update
     checksums       rmd160  03c1ad905f5313303fc104b4e19f54353775d564 \
                     sha256  422f2bec88d5d93547df0c3e1399272a6dc4c23050b45d34343bbdd6d55e5ad6 \
                     size    11067288
 } else {
     version         58.0.0
-    revision        0
+    revision        1
     # This is the latest version that does not require Qt with GUI disabled
     checksums       rmd160  3c513bf1851cfa9f439e2739a8027692ad2de6ea \
                     sha256  1af727fa203e2bd8c54a005f28b635c96a4b80aa4ee8d23b4def0b6800ca6e38 \


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/69735

#### Description

Switch to Boost version which works for all systems (1.76 has a bug in multiprecision library which breaks build on powerpc).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
