### PR TITLE
micronaut: update to 4.3.8

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.3.7 v
+github.setup    micronaut-projects micronaut-starter 4.3.8 v
 revision        0
 name            micronaut
 categories      java
@@ -56,9 +56,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  a84bd1459958c83d3e34a78cf71035df0c683f7c \
-                sha256  a8cc49e09cb665f911efbf337d2cab3d876d1ba81a9a55de70d2410d9165f3e7 \
-                size    22918804
+checksums       rmd160  80fd26b379bbc640c031bb6bc38d96db4ebbed48 \
+                sha256  e10255711bedb6160a81e7490de36f1a8990ebac720482f1a98a1cd08a649efa \
+                size    22915259
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.3.8.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?