### PR TITLE
skaffold: update to 2.11.1

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.11.0 v
+github.setup        GoogleContainerTools skaffold 2.11.1 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  a427d8e6217b556377b0861a5c57d0750586ec31 \
-                    sha256  3c9b21cef0247edabed26b6e329476bae893b56756bf3eb483d09873ee45889a \
-                    size    61136293
+checksums           rmd160  7e07e42d9e88e819a80edfaa2ddf821d1a442227 \
+                    sha256  2b0d7e3bf6b0f744ba5214b8f8d8429a207a3bfb03bf3d975dda0039813e052c \
+                    size    61134098
 
 depends_build       port:go
 


### PR DESCRIPTION
#### Description

Update to Skaffold 2.11.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?