### PR TITLE
jdk22: update to 22.0.1

### DIFF
--- a/java/jdk22/Portfile
+++ b/java/jdk22/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk22-mac
-version      22
+version      22.0.1
 revision     0
 
 description  Oracle Java SE Development Kit 22
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/22/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  070e8b3fab4ca25c50df5e1490355a33feb8a699 \
-                 sha256  75d53f907aaa4614e10088feee1727d42a854ebe56dc34f09065286eb33e951a \
-                 size    191047193
+    checksums    rmd160  c0517acc27c4041e642652e398c445b52dd75bae \
+                 sha256  77fe51266240dbae4d12cf8116894132b22fb65b5d28190da179cf20e21560ad \
+                 size    191062144
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  01bbb8e44eaef1bb993b73e05c2b787e7c7bde61 \
-                 sha256  cc788fffa8c89e52b78f7dc581a09cfec336d4e34c0713f2c0d532793d1bc8bd \
-                 size    188762676
+    checksums    rmd160  e8166b6e0858ef5a2240e15d4a17a4323256a60f \
+                 sha256  48a6ed00e051cdb87f36ad861ee30e9ba11c9101ef14619d603985bfded8d796 \
+                 size    188772318
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 22.0.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?