### PR TITLE
openjdk22-graalvm: update to 22.0.1

### DIFF
--- a/java/openjdk22-graalvm/Portfile
+++ b/java/openjdk22-graalvm/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://github.com/graalvm/graalvm-ce-builds/releases
 supported_archs  x86_64 arm64
 
-version     22.0.0
-set build 36
+version     22.0.1
+set build 8
 revision    0
 
 description  GraalVM Community Edition based on OpenJDK 22
@@ -26,17 +26,17 @@ master_sites https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-community-jdk-${version}_macos-x64_bin
-    checksums    rmd160  9eb6930b7da89ccfa311221774334653a5b1f9d2 \
-                 sha256  691b71450bcfea19eb5a3564f7a159072f9bd51a7a901e3a4775127da24a10d1 \
-                 size    290929149
+    checksums    rmd160  2e0d1339308e6f1b8a7c2ba44d486eabfb08fc4d \
+                 sha256  553c2dff3febd45f917e45f4dd620c194d8225bc28d13f5545ddffea9eeb30f8 \
+                 size    290983419
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-community-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  0cf220b7eaa625cf08892f074df1ade11a47f928 \
-                 sha256  87b111900c5f78f919bb55103978d3b9ff44789140bb20be1c59abd23871cc86 \
-                 size    303830402
+    checksums    rmd160  4a4f0072289b0035989a7ace7b84ff152f104c40 \
+                 sha256  b96a16359c800374af5fbd3cb685aaa91cfc590ea4be35538c24b37e12c769c0 \
+                 size    303929385
 }
 
-worksrcdir   graalvm-community-openjdk-22+${build}.1
+worksrcdir   graalvm-community-openjdk-${version}+${build}.1
 
 homepage     https://www.graalvm.org
 


### PR DESCRIPTION
#### Description

Update to GraalVM Community Edition 22.0.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?