### PR TITLE
jdk22-graalvm: update to 22.0.1

### DIFF
--- a/java/jdk22-graalvm/Portfile
+++ b/java/jdk22-graalvm/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava22-mac
 supported_archs  x86_64 arm64
 
-version     22
+version     22.0.1
 revision    0
 
 master_sites https://download.oracle.com/graalvm/22/archive/
@@ -33,17 +33,17 @@ long_description Oracle GraalVM for JDK 22 compiles your Java applications ahead
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  dfb3f3a561f67169b29231f82429e0b4654dbea1 \
-                 sha256  5b83f20dbc4c636ed41f19c3309f09839d4f5c6442dba986f460589c494a476c \
-                 size    324973526
+    checksums    rmd160  d0545dc7b2ce5a5478ba5d6055a0c6beab3ab766 \
+                 sha256  c1a477f4be38130f30ce745cebbb580f71c6159d94503e3e10b7ab5a7c4da66b \
+                 size    324653544
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  ceaf240f6e9afd7384dffaffc3f6bb4ee6a2942a \
-                 sha256  61632065cfcdc4e121362f1fd25a543955836bbacd6c1aadbcbe0d469d5ab8a3 \
-                 size    337590077
+    checksums    rmd160  cb0d8fa067ce137bb28abe33bd34cdf92c5a31c8 \
+                 sha256  7735153e287cd63a29bb1031f2c018770a2734e5c7cb28ab5143a1bd2b4ad45f \
+                 size    337075904
 }
 
-worksrcdir   graalvm-jdk-${version}+36.1
+worksrcdir   graalvm-jdk-${version}+8.1
 
 variant Applets \
     description { Advertise the JVM capability "Applets".} {}


### PR DESCRIPTION
#### Description

Update to Oracle GraalVM for JDK 22.0.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?