### PR TITLE
jdk21-graalvm: update to 21.0.3

### DIFF
--- a/java/jdk21-graalvm/Portfile
+++ b/java/jdk21-graalvm/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava21-mac
 supported_archs  x86_64 arm64
 
-version     21.0.2
+version     21.0.3
 revision    0
 
 master_sites https://download.oracle.com/graalvm/21/archive/
@@ -33,17 +33,17 @@ long_description Oracle GraalVM for JDK 21 compiles your Java applications ahead
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  0323837a61555d485fa14ca5f307073402ed63ce \
-                 sha256  3e24632f27be74d039508ea2b0b7862ef8c40784f55785cf6b6e40b4b28d9d53 \
-                 size    316581361
+    checksums    rmd160  3fc32a68c1aed57d2898f09b2df22dff3061f715 \
+                 sha256  6d29cacd2e3b46ee33d573757f1098fec5b487a89a98f68a5315d45a4f89a1bb \
+                 size    313490466
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  73e08ce8d9755306ec3575b03b4cae9cb0313a60 \
-                 sha256  b504f7c570836a9c6b1b92813c5123718636d0ff0f832321129a4fe3a7b9a0b3 \
-                 size    329328620
+    checksums    rmd160  11bae340ae9c1478561e200732edb18c8c1e6c63 \
+                 sha256  501b3163e663f154bd816fa889810f94004530e6fcef62e6e87554247d0952c0 \
+                 size    326113782
 }
 
-worksrcdir   graalvm-jdk-${version}+13.1
+worksrcdir   graalvm-jdk-${version}+7.1
 
 variant Applets \
     description { Advertise the JVM capability "Applets".} {}


### PR DESCRIPTION
#### Description

Update to Oracle GraalVM for JDK 21.0.3.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?