### PR TITLE
jdk21: update to 21.0.3

### DIFF
--- a/java/jdk21/Portfile
+++ b/java/jdk21/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk21-mac
-version      21.0.2
+version      21.0.3
 revision     0
 
 description  Oracle Java SE Development Kit 21
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/21/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  c3011bf9e5682f8f12048730b535e881e233f0ac \
-                 sha256  197a923b1f7ea2b224fafdfb9c3ef5fc8eb197d9817d7631d96da02b619f5975 \
-                 size    193307033
+    checksums    rmd160  da48a77db7daa2a1773ff9784a73b1e43ef4a0f0 \
+                 sha256  f51a83c6328d1327aac38eb7345e0846fea8e859ef5bcf65f98a5793aa027253 \
+                 size    193323870
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  52ea466df3eb3f27b67d11868b9d68ddbd054530 \
-                 sha256  4b94951f03efe44cb6656e43f1098db3ce254a00412f9d22dff18a8328a7efdd \
-                 size    190953252
+    checksums    rmd160  0f39082d6c4b242512001cbe0ea0814a5011f7de \
+                 sha256  ca48fd25426061754f4c54eef98edd0e1ac4fe57ef17358afdb935ef6e6f6c46 \
+                 size    190976481
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle Java SE Development Kit 21.0.3. 

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?