### PR TITLE
ruby-build: Update to 20240416

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20240318 v
+github.setup        rbenv ruby-build 20240416 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  fe3b638aeef767ac723fd3c1a3fa8b801c3a5e72 \
-                    sha256  3edc96e725afc6f6dcd06c74b0438058c4878434e67ab0fa7d82aeb486df07d5 \
-                    size    88256
+checksums           rmd160  a8c6e4f4ed55a36d7902b85d5d606eaa4f5e3fc0 \
+                    sha256  aace976e204b37c52d30c7896d3906318b32f4db795ea380bada668621b59abb \
+                    size    89325
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

Upgrade ruby-build to 20240416

##### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
