### PR TITLE
vorbis-tools: fix missing dependency to build ogg123

### DIFF
--- a/audio/vorbis-tools/Portfile
+++ b/audio/vorbis-tools/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                vorbis-tools
 version             1.4.2
-revision            1
+revision            2
 categories          audio
 maintainers         nomaintainer
 
@@ -28,7 +28,7 @@ checksums           rmd160  f0f4f859b3a280dfe7ea9a13dc4c39ed3ed37c80 \
                     sha256  db7774ec2bf2c939b139452183669be84fda5774d6400fc57fde37f77624f0b0 \
                     size    1389947
 
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig
 
 depends_lib-append \
                     port:libogg \

--- a/audio/vorbis-tools/Portfile
+++ b/audio/vorbis-tools/Portfile
@@ -28,6 +28,8 @@ checksums           rmd160  f0f4f859b3a280dfe7ea9a13dc4c39ed3ed37c80 \
                     sha256  db7774ec2bf2c939b139452183669be84fda5774d6400fc57fde37f77624f0b0 \
                     size    1389947
 
+depends_build       port:pkgconfig
+
 depends_lib-append \
                     port:libogg \
                     port:libvorbis \


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.6 22G630 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
