### PR TITLE
openjdk22-corretto: update to 22.0.1.8.1

### DIFF
--- a/java/openjdk22-corretto/Portfile
+++ b/java/openjdk22-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-22/releases
-version      22.0.0.36.2
+version      22.0.1.8.1
 revision     0
 
 description  Amazon Corretto OpenJDK 22 (Short Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  ff7bc1438055d45748547adec741a543d259254a \
-                 sha256  01ab8522d542b2338ac8055ba19d226286dc3710a0daa48a7569e5b98c0464d3 \
-                 size    201528918
+    checksums    rmd160  c344c69938bcb6f6d4e066fcea2baae5b1baf553 \
+                 sha256  19ebd361cd244bbe63a40b3014f28a163ced98a4f4f995a28f6126ae5ce7ea25 \
+                 size    201547240
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  fb1f40ab3e7a78025a358b015f145cd2c70cc7a6 \
-                 sha256  914b5747eac275b811830ed687605b8921729b82ff3a1e1c77834a97798c85c7 \
-                 size    199304730
+    checksums    rmd160  e7c2e87bc1ab3ffe79107d735e83dbaa52bd0e94 \
+                 sha256  8749511feb553bcb1fed3f3e17c5d9e3cbe7b52c51ce591f9e76f00f66d7423d \
+                 size    199318825
 }
 
 worksrcdir   amazon-corretto-22.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 22.0.1.8.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?