### PR TITLE
openjdk22-sap: update to 22.0.1

### DIFF
--- a/java/openjdk22-sap/Portfile
+++ b/java/openjdk22-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://sap.github.io/SapMachine/latest/22
-version      22
+version      22.0.1
 revision     0
 
 description  SAP Machine 22
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  5075e4ad49154c2c6b6c5db1b51f4da9d41bff40 \
-                 sha256  63f5c6ecb1aebea19892c740e0bed610a85376b0115566b83d34ded642d19d8a \
-                 size    201319016
+    checksums    rmd160  8cb43d58796a4e9b5b12f3bb69fcdf7f208e24fb \
+                 sha256  99d49029c3fd6afaf8630ddb6444e879b203fe50c868b2e24c6b738330ed9876 \
+                 size    201398827
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  c60817e3ac80f3c7c5bca223cc765dd64d5e49e3 \
-                 sha256  ee55231c8d2da95c1be4f85361b4cca2d0f3d5b25e63c4b649b6c4b1c7a5d866 \
-                 size    198961874
+    checksums    rmd160  20e216cc4681d1afdf9f4b0e6e62456924d18132 \
+                 sha256  cce91a02f4a2c6cc7f6be169794df9b18d462f1daaa200b3475df7936929562c \
+                 size    199028008
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SAP Machine 22.0.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?