### PR TITLE
openjdk22-zulu: update to 22.30.13

### DIFF
--- a/java/openjdk22-zulu/Portfile
+++ b/java/openjdk22-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-22-lts&os=macos&package=jdk#zulu
-version      22.28.91
+version      22.30.13
 revision     0
 
-set openjdk_version 22.0.0
+set openjdk_version 22.0.1
 
 description  Azul Zulu Community OpenJDK 22 (Short Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  659663dc7a92cca52eccec0363342823515dc05e \
-                 sha256  63a3d23508c7457ba4c2ec76b156efa5322a4fe0a0f8a786d42d22484c32299c \
-                 size    206853748
+    checksums    rmd160  e426c12470d470a3fef20db0605265f14a387c76 \
+                 sha256  a5af3434d9b283b55b41548f6de9d5d3dcb20c300254402cf8b02bbeecf3c37d \
+                 size    206862940
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  da4291685143f750f181cddc95ce25f13b4ad869 \
-                 sha256  a34564581e3e3f306634d5b2f85665ca34e0ba40537baa307f275bdd835f104d \
-                 size    204558045
+    checksums    rmd160  32cb735987216d21ed4145b7f47454262ff382cb \
+                 sha256  d1b8282c032b55384dfda337dd97d424f69cc0dd0dbb196d870e7029acdad133 \
+                 size    204575444
 }
 
 worksrcdir   ${distname}/zulu-22.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 22.30.13.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?