### PR TITLE
openjdk21-zulu: update to 21.34.19

### DIFF
--- a/java/openjdk21-zulu/Portfile
+++ b/java/openjdk21-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-21-lts&os=macos&package=jdk#zulu
-version      21.32.17
+version      21.34.19
 revision     0
 
-set openjdk_version 21.0.2
+set openjdk_version 21.0.3
 
 description  Azul Zulu Community OpenJDK 21 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  f3a95a66787d31045faf06a2276dc6a2a7967aad \
-                 sha256  3ad8fe288eb57d975c2786ae453a036aa46e47ab2ac3d81538ebae2a54d3c025 \
-                 size    209221589
+    checksums    rmd160  2795a2025c810358ca124f7067eb146e1da50391 \
+                 sha256  148006a220a18922d7a9c52ac0bad099c5b4e60334a8d02b11f8c945e9ec9a34 \
+                 size    209294105
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  e0df6664de8ee2936750aed07bb2c37273e684cd \
-                 sha256  e8260516de8b60661422a725f1df2c36ef888f6fb35393566b00e7325db3d04e \
-                 size    206949495
+    checksums    rmd160  0ba5c957dc9ce6019d80877cf258d27dcd4ac70f \
+                 sha256  4f42a561909d71868a700cf2efa1390e1b9e04863f3fa75ea30c4965e5a702f0 \
+                 size    206998775
 }
 
 worksrcdir   ${distname}/zulu-21.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 21.34.19.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?