### PR TITLE
openjdk17-zulu: update to 17.50.19

### DIFF
--- a/java/openjdk17-zulu/Portfile
+++ b/java/openjdk17-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-17-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      17.48.15
+version      17.50.19
 revision     0
 
-set openjdk_version 17.0.10
+set openjdk_version 17.0.11
 
 description  Azul Zulu Community OpenJDK 17 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  74a23bb2e685acab7c3e3a523c43f50e967453dd \
-                 sha256  86e48a1af3a7ac4500884d8c25b7475ad176b1a78b19a424665957cc3a3ca3e8 \
-                 size    194280558
+    checksums    rmd160  21dab02b17acb3981665b0135817d7aace0b66b6 \
+                 sha256  b384991e93af39abe5229c7f5efbe912a7c5a6480674a6e773f3a9128f96a764 \
+                 size    194484713
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  d42f4f65e342f65cf3b0bae6a4e5c925b30a9f86 \
-                 sha256  92e1221d291be1616d3c1de6d00f7af0b3d9c3b5a5d2c2aaba16f30c5f2f412f \
-                 size    192149620
+    checksums    rmd160  3674f400958b0ec378a081f49261930c7922d890 \
+                 sha256  dd1a82d57e80cdefb045066e5c28b5bd41e57eea9c57303ec7e012b57230bb9c \
+                 size    192349922
 }
 
 worksrcdir   ${distname}/zulu-17.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 17.50.19.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?