### PR TITLE
openjdk11-zulu: update to 11.72.19

### DIFF
--- a/java/openjdk11-zulu/Portfile
+++ b/java/openjdk11-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 # https://www.azul.com/downloads/?version=java-11-lts&os=macos&package=jdk
 supported_archs  x86_64 arm64
 
-version      11.70.15
+version      11.72.19
 revision     0
 
-set openjdk_version 11.0.22
+set openjdk_version 11.0.23
 
 description  Azul Zulu Community OpenJDK 11 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  7dba06a920d4bd2fed5a5f2cfc3f3cd2097584dc \
-                 sha256  71afedb643dedad6dc9b5aee82e0e03ecc4a59b11d29c202b0a0835daba9f4de \
-                 size    194428089
+    checksums    rmd160  03a61d920ecf64515329ff9bd347c7d41865aa84 \
+                 sha256  e5b19b82045826ae09c9d17742691bc9e40312c44be7bd7598ae418a3d4edb1c \
+                 size    194631852
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  fac4293b2c4f885aa54220118a8169d0de39ddc8 \
-                 sha256  3d640e17e3fd76365aae3009684dc8d2db88d44e07ffde7ce15374e013339af3 \
-                 size    192540120
+    checksums    rmd160  11d3f6e570bda3d34d08b496a699de87ea449b90 \
+                 sha256  40fb1918385e03814b67b7608c908c7f945ccbeddbbf5ed062cdfb2602e21c83 \
+                 size    192715919
 }
 
 worksrcdir   ${distname}/zulu-11.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 11.72.19.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?