### PR TITLE
openjdk8-zulu: update to 8.78.0.19

### DIFF
--- a/java/openjdk8-zulu/Portfile
+++ b/java/openjdk8-zulu/Portfile
@@ -14,10 +14,10 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu
-version      8.76.0.17
+version      8.78.0.19
 revision     0
 
-set openjdk_version 8.0.402
+set openjdk_version 8.0.412
 
 description  Azul Zulu Community OpenJDK 8 (Long Term Support)
 long_description Azul® Zulu® is a Java Development Kit (JDK), and a compliant implementation of the Java Standard Edition (SE)\
@@ -29,14 +29,14 @@ master_sites https://cdn.azul.com/zulu/bin/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_x64
-    checksums    rmd160  8947d7c00cc6a001a201ed76ed986940da1a6686 \
-                 sha256  79d66a0c4b327500831300b56420c5fcc8d65539ee40d59c291da4fd18da2042 \
-                 size    106619658
+    checksums    rmd160  c395ef28a9cef9236d9adac2b6bd9d96f7707011 \
+                 sha256  2bfa0506196962bddb21a604eaa2b0b39eaf3383d0bdad08bdbe7f42f25d8928 \
+                 size    106646303
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     zulu${version}-ca-jdk${openjdk_version}-macosx_aarch64
-    checksums    rmd160  347c1e9fa66bf8e5f99ba56dd75cafdc10f0fdab \
-                 sha256  d153e53ae341dfd8039d4fa92b40c64d25234c74ed628c5a460dd80f62f22d78 \
-                 size    104513477
+    checksums    rmd160  da308c2de7d9e9b85b1b4be5ea46114b1633ad93 \
+                 sha256  35bc35808379400e4a70e1f7ee379778881799b93c2cc9fe1ae515c03c2fb057 \
+                 size    104517359
 }
 
 worksrcdir   ${distname}/zulu-8.jdk


### PR DESCRIPTION
#### Description

Update to Azul Zulu 8.78.0.19.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?