### PR TITLE
openjdk21: update to 21.0.3

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 
 name                openjdk21
 # See https://github.com/openjdk/jdk21u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             21.0.2
-set build 13
-revision            2
+version             21.0.3
+set build 9
+revision            0
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -19,9 +19,9 @@ master_sites        https://github.com/openjdk/jdk21u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk21u-${distname}
 
-checksums           rmd160  840b44086b26c773b28e9a6f3333c6769e5bc41f \
-                    sha256  17eda717843ffbbacc7de4bdcd934f404a23a57ebb3cda3cec630a668651531f \
-                    size    112252812
+checksums           rmd160  9c475209878d5ce8e8fe30cc2d8c685105930d2f \
+                    sha256  818e9dee28ae390f2781406d594690fc42bd994d078ad9f8360a4fbca6a3df1f \
+                    size    112404688
 
 set bootjdk_port    openjdk21-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 21.0.3.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?