### PR TITLE
openjdk21-corretto: update to 21.0.3.9.1

### DIFF
--- a/java/openjdk21-corretto/Portfile
+++ b/java/openjdk21-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-21/releases
-version      21.0.2.13.1
+version      21.0.3.9.1
 revision     0
 
 description  Amazon Corretto OpenJDK 21 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  c95951b3d03d6b750beb8bac79993672305735b4 \
-                 sha256  c8629aaabb7641220f61797ea08d9b8c50f15a989c67363f5075fb20ff2c7679 \
-                 size    203261361
+    checksums    rmd160  1860b8b8a6a9f7dd4a24378a8e6428b73635e880 \
+                 sha256  2c6497ced7b926d584243d512b3732a345eb1b5afefd416e6588c33a43c0fa70 \
+                 size    203301232
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  f5337b9494c8d88fe36337cfd9d7d64d031c9b12 \
-                 sha256  14bb4b9146a15daad93b273a952f88f4e0e6256b2cdd9f45c1447555000a27ac \
-                 size    201066708
+    checksums    rmd160  f027aa44a007636b82502abc8fd94aebf96e626f \
+                 sha256  db1df7a3fe5d481a2ec52ea3c12b51ba7e9121cdb3dd39e0cf7bc77fba88cd98 \
+                 size    201107917
 }
 
 worksrcdir   amazon-corretto-21.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 21.0.3.9.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?