### PR TITLE
openjdk17-corretto: update to 17.0.11.9.1

### DIFF
--- a/java/openjdk17-corretto/Portfile
+++ b/java/openjdk17-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 # https://github.com/corretto/corretto-17/releases
 supported_archs  x86_64 arm64
 
-version      17.0.10.7.1
+version      17.0.11.9.1
 revision     0
 
 description  Amazon Corretto OpenJDK 17 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  77a3b7b6e190dd80ed3f2214852f1fc10eef2413 \
-                 sha256  03b56d0cc1d0d62f4cf6f1eb365380cad19fc35bc7a42051c6735183b78e3323 \
-                 size    188439197
+    checksums    rmd160  c7333a969cea060988c3e79902d00ebdf90b69b8 \
+                 sha256  b447e0c5e121c3f912c72bc8cdc86569a5d198d86a979b87948ac908fe1c7520 \
+                 size    188644158
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  d34a7592e9db95d28ff39e5ecc2dc78f1ef81e5e \
-                 sha256  8bea3c09966e0d44c56f61d31d28c12a8df8d8ec0ef18ed2f6146c303abae754 \
-                 size    186538073
+    checksums    rmd160  f6a83a7b555664d0392898a756102d318782dea1 \
+                 sha256  e2d4b5e34f4903278c8a8ba0582072a862fc6d6923ec6ce9f90130cf3cf787f8 \
+                 size    186719854
 }
 
 worksrcdir   amazon-corretto-17.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 17.0.11.9.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?