### PR TITLE
openjdk11-corretto: update to 11.0.23.9.1

### DIFF
--- a/java/openjdk11-corretto/Portfile
+++ b/java/openjdk11-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://github.com/corretto/corretto-11/releases
-version      11.0.22.7.1
+version      11.0.23.9.1
 revision     0
 
 description  Amazon Corretto OpenJDK 11 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  39fea7de5639fae58ab4869e4764188abdaafda1 \
-                 sha256  820ed56b43c1f61b329a6b1af0e2dea2af62b3ec0523b1d7bb6af08e4b893204 \
-                 size    187626669
+    checksums    rmd160  aa3a5de78de49e7c1664f13435eb614d888f8bed \
+                 sha256  da2bd4fd790efce6a75eb81180734806dc5dd6d050da02242d9f8017ccaafaa1 \
+                 size    187782886
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  cba79e0f01d5e0907d9e6b95bba1b4b0e9be2b28 \
-                 sha256  f0f2794187d6af76ce65d70a7f483ee61b991280f055af8ce0196c2f06f8b73e \
-                 size    185207203
+    checksums    rmd160  e0868906aa4cefe736d3fbb70733208508ea6141 \
+                 sha256  f4a33483955730105b3364ccd0a59b7e1047407895acf445625783794b7f7ecf \
+                 size    185369910
 }
 
 worksrcdir   amazon-corretto-11.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 11.0.23.9.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?