### PR TITLE
openjdk8-corretto: update to 8.412.08.1

### DIFF
--- a/java/openjdk8-corretto/Portfile
+++ b/java/openjdk8-corretto/Portfile
@@ -19,7 +19,7 @@ universal_variant no
 # https://github.com/corretto/corretto-8/releases
 supported_archs  x86_64 arm64
 
-version      8.402.08.1
+version      8.412.08.1
 revision     0
 
 description  Amazon Corretto OpenJDK 8 (Long Term Support)
@@ -29,14 +29,14 @@ master_sites https://corretto.aws/downloads/resources/${version}/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     amazon-corretto-${version}-macosx-x64
-    checksums    rmd160  a512f691d8f738122961e63865d5d9e1af5763c5 \
-                 sha256  386b48d3c33de51882f8082c9aad0eea87b0e57e64f1f66b1db6fb17241570d9 \
-                 size    118464710
+    checksums    rmd160  acb7d98a14a9dbe17c2195bde4d7e9ad62e76cfa \
+                 sha256  edb4b85d5ad81a4d1cb29516e15ec99d065537a7b9fed6001d7653a6fcece7a3 \
+                 size    118465453
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     amazon-corretto-${version}-macosx-aarch64
-    checksums    rmd160  12b21da69bbd8ade37721550a14218a9b084808c \
-                 sha256  7eadf4efa3571f6726ebb8a498db9a2c257c4fc8db3ba00dd49edc4c1a4bd7cc \
-                 size    102879147
+    checksums    rmd160  87e67ff3a925d13a2b2b13c99b5680c8e4be9c3c \
+                 sha256  9d328d143afefb3bb0612297aa0b339fc1afe390d9f1fde0fe750dacdd56f51d \
+                 size    102889992
 }
 
 worksrcdir   amazon-corretto-8.jdk


### PR DESCRIPTION
#### Description

Update to Amazon Corretto 8.412.08.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?