### PR TITLE
openjdk17-sap: update to 17.0.11

### DIFF
--- a/java/openjdk17-sap/Portfile
+++ b/java/openjdk17-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/17
 supported_archs  x86_64 arm64
 
-version      17.0.10
+version      17.0.11
 revision     0
 
 description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  458aa35e154fcf9aec0dbfd54e12fe681c299173 \
-                 sha256  e46767f542377315bd7986454cbc227711ae89c0e273ec51c6dd65177062a914 \
-                 size    188267984
+    checksums    rmd160  af080ec438a650040ce4cd97378dd5b13580e801 \
+                 sha256  c5ee60451b8781856417954c94c007e13df9b9af234b08a455514a4ecad5e8d5 \
+                 size    188478048
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  3c8bc616c2e0712c885631ad424a08b0633cbf1a \
-                 sha256  5f52866432a5b4df193b332cce51195e5f3b1bdd5507338c10c125d8a3e2bbdc \
-                 size    186151337
+    checksums    rmd160  457cc70c55d00ffe2d10b722ba7453fec3d7aaad \
+                 sha256  8e06ed19f293e6f545723e7744b80545ee9400ce8ce5b8c3dbdcf6f49f211ae0 \
+                 size    186367644
 }
 worksrcdir   sapmachine-jdk-${version}.jdk
 


### PR DESCRIPTION
#### Description

Update to SAP Machine 17.0.11.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?