### PR TITLE
openjdk17: update to 17.0.11

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk17
 # See https://github.com/openjdk/jdk17u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             17.0.10
-set build 11
+version             17.0.11
+set build 9
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,9 +19,9 @@ master_sites        https://github.com/openjdk/jdk17u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk17u-${distname}
 
-checksums           rmd160  dab270e839d8b9d06e4f9675920a323a4a320dc3 \
-                    sha256  fac2539384ba8d86cdcf3553e69aaf4001a3cec1134bbf6f5f04f64f0acbc055 \
-                    size    106398664
+checksums           rmd160  b546b14fad77c73d685a5b51a6034eb9af2079ff \
+                    sha256  4aa214812f88b21c11ad91e111075f64d57e1b13096f98fc5d45f95f789d4642 \
+                    size    106574173
 
 depends_lib         port:freetype \
                     port:libiconv


### PR DESCRIPTION
#### Description

Update to OpenJDK 17.0.11.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?