### PR TITLE
jdk17-graalvm: update to 17.0.11

### DIFF
--- a/java/jdk17-graalvm/Portfile
+++ b/java/jdk17-graalvm/Portfile
@@ -15,7 +15,7 @@ universal_variant no
 # https://www.oracle.com/java/technologies/downloads/#graalvmjava17-mac
 supported_archs  x86_64 arm64
 
-version     17.0.10
+version     17.0.11
 revision    0
 
 master_sites https://download.oracle.com/graalvm/17/archive/
@@ -33,17 +33,17 @@ long_description Oracle GraalVM for JDK 17 compiles your Java applications ahead
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     graalvm-jdk-${version}_macos-x64_bin
-    checksums    rmd160  500f10cf0aaf60703151eb2538acd11bff137306 \
-                 sha256  14f4bd6417809905f86e786c779d0fc2feb840d7dac35ae3503eb25af0530da0 \
-                 size    313651594
+    checksums    rmd160  45f92e1b1f21880f4a9f3fc69e87f19ef51aa9f7 \
+                 sha256  abd6fa23985256debb82463352db090d28b86cf124ce9928782e59cb17ea2517 \
+                 size    314075766
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     graalvm-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  1fcf801b00f2df5b7227ac8300440b6ff299117c \
-                 sha256  e944c5ce5da56e683fc8f1a57191b46d9cb702930b1688bda064fcf467d876b8 \
-                 size    367385416
+    checksums    rmd160  4b5d70d731d3ab26c2be480c4e0cb675a2e0d168 \
+                 sha256  a3804609f9c3db90156301b53a5fb678354282207e9a4e08d490488f21132bab \
+                 size    367727166
 }
 
-worksrcdir   graalvm-jdk-${version}+11.1
+worksrcdir   graalvm-jdk-${version}+7.1
 
 variant Applets \
     description { Advertise the JVM capability "Applets".} {}


### PR DESCRIPTION
#### Description

Update to GraalVM for JDK 17.0.11.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?