### PR TITLE
jdk17: update to 17.0.11

### DIFF
--- a/java/jdk17/Portfile
+++ b/java/jdk17/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 supported_archs  x86_64 arm64
 
 # https://www.oracle.com/java/technologies/downloads/#jdk17-mac
-version      17.0.10
+version      17.0.11
 revision     0
 
 description  Oracle Java SE Development Kit 17
@@ -26,14 +26,14 @@ master_sites https://download.oracle.com/java/17/archive/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     jdk-${version}_macos-x64_bin
-    checksums    rmd160  2272fd55801daf37148ac21f7ed060f1674cf2da \
-                 sha256  7b68b833f392aa543ba538f94c60fd477581fef96a9c1ae059fa4158e9ce75ff \
-                 size    178930871
+    checksums    rmd160  1adbe617cc03a46d834930bfd2ea345cf862ffb2 \
+                 sha256  e0d18b22ba40529ff1131e2683abf370ddb0a718c8209436bc33590ce3bc2ee5 \
+                 size    179146853
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  bfe8ef24aae795bc177732962688d244739ebdc4 \
-                 sha256  d5bec93922815e9337040678ddf3f40e50b63c2b588cf63574fa1f2010206042 \
-                 size    176369331
+    checksums    rmd160  fad56653962aa7f702e21e6f4d5b2242d3f3b578 \
+                 sha256  ac3ff5a57b9d00606e9b319bde7309a4ecb9f2c4ddc0f48d001f234e93b9da86 \
+                 size    176604808
 }
 
 worksrcdir   jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to Oracle JDK 17.0.11.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?