### PR TITLE
openjdk11-sap: update to 11.0.23

### DIFF
--- a/java/openjdk11-sap/Portfile
+++ b/java/openjdk11-sap/Portfile
@@ -14,7 +14,7 @@ universal_variant no
 # https://sap.github.io/SapMachine/latest/11
 supported_archs  x86_64 arm64
 
-version      11.0.22
+version      11.0.23
 revision     0
 
 description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
@@ -24,14 +24,14 @@ master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${ve
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     sapmachine-jdk-${version}_macos-x64_bin
-    checksums    rmd160  973cc8d65024408ff3a4a432e014a11e57ecb88f \
-                 sha256  b2908cd13e39e13aadbf15b8bcbec0710158b3a6ab43a1fcbece03a8c991de59 \
-                 size    187600512
+    checksums    rmd160  860c422a4e92858b96f809390536d8ade62d8ba0 \
+                 sha256  9492403416e4cd47c2428744fec680f4f0ad08316a01ceb7828a2f6a0cf129f3 \
+                 size    187762401
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     sapmachine-jdk-${version}_macos-aarch64_bin
-    checksums    rmd160  fc803208f350ed476227f6e4338fb0268d2103f6 \
-                 sha256  682c9ef9597e4ee9fef49b24d6b4f44316052553008c23efca6a89eb0344507d \
-                 size    185714756
+    checksums    rmd160  dd29dc1d8b1cc719456b62e3ffc978d74bd871bc \
+                 sha256  0d9ec8a90dcc711e793a695574e1a271765b727262d715985994324f3b5ff755 \
+                 size    185872728
 }
 
 worksrcdir   sapmachine-jdk-${version}.jdk


### PR DESCRIPTION
#### Description

Update to SAP Machine 11.0.23.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?