### PR TITLE
meson portgroup improvements

### DIFF
--- a/_resources/port1.0/group/meson-1.0.tcl
+++ b/_resources/port1.0/group/meson-1.0.tcl
@@ -41,19 +41,21 @@ namespace eval meson { }
 
 proc meson::get_post_args {} {
     global configure.dir build_dir build.dir muniversal.current_arch muniversal.build_arch
+    set args [list ${configure.dir}]
     if {[info exists muniversal.build_arch]} {
         # muniversal 1.1 PG is being used
+        lappend args ${build.dir}
         if {[option muniversal.is_cross.[option muniversal.build_arch]]} {
-            return "${configure.dir} ${build.dir} --cross-file=[option muniversal.build_arch]-darwin --wrap-mode=[option meson.wrap_mode]"
-        } else {
-            return "${configure.dir} ${build.dir} --wrap-mode=[option meson.wrap_mode]"
+            lappend args --cross-file=[option muniversal.build_arch]-darwin
         }
     } elseif {[info exists muniversal.current_arch]} {
         # muniversal 1.0 PG is being used
-        return "${configure.dir} ${build_dir}-${muniversal.current_arch} --cross-file=${muniversal.current_arch}-darwin --wrap-mode=[option meson.wrap_mode]"
+        lappend args ${build_dir}-${muniversal.current_arch} --cross-file=${muniversal.current_arch}-darwin
     } else {
-        return "${configure.dir} ${build_dir} --wrap-mode=[option meson.wrap_mode]"
+        lappend args ${build_dir}
     }
+    lappend args --wrap-mode=[option meson.wrap_mode]
+    return ${args}
 }
 
 proc meson::add_depends {} {

--- a/_resources/port1.0/group/meson-1.0.tcl
+++ b/_resources/port1.0/group/meson-1.0.tcl
@@ -59,6 +59,8 @@ proc meson::get_post_args {} {
 }
 
 proc meson::add_depends {} {
+    depends_build-delete    port:meson \
+                            port:ninja
     depends_build-append    port:meson \
                             port:ninja
 }

--- a/audio/pulseaudio/Portfile
+++ b/audio/pulseaudio/Portfile
@@ -81,19 +81,9 @@ platform darwin 8 {
     patchfiles-append   patch-src_modules_macosx_module_coreaudio_device.c-tiger-compat.diff
 }
 
-set meson_config    ${workpath}/meson_config.ini
-
-configure.args-append \
-                    --native-file ${meson_config}
-
-post-patch {
-    # TODO: Generalize this in the meson portgroup.
-    set fp [open ${meson_config} w]
-    puts ${fp} {[binaries]}
-    puts ${fp} "m4='${prefix}/bin/gm4'"
-    puts ${fp} "perl='${perl5.bin}'"
-    close ${fp}
-}
+meson.native.binaries-append \
+                    m4=${prefix}/bin/gm4 \
+                    perl=${perl5.bin}
 
 compiler.c_standard 2011
 # orc uses stdatomic.h


### PR DESCRIPTION
#### Description

This tries to improve the meson portgroup in a couple ways:

* `meson::add_depends` added meson and ninja dependencies which could have resulted in duplicate dependencies if the port or another portgroup it included already added them. Fixed this by deleting the dependencies first. It is not an error to delete nonexistent items from a list so this should not be a problem.
* `meson::get_post_args` added the same arguments in different conditions. Streamlined the code by adding each argument only once, or at least fewer times than before. The procedure now returns a list instead of a string which also better matches its destination (`configure.post_args`).
* meson.build files use `find_program` to locate programs but MacPorts might install them by a different name or with a version suffix. There is no way to override `find_program`'s results on the command line directly. The [suggested workaround](https://github.com/mesonbuild/meson/issues/13096) is to use a "[machine file](https://mesonbuild.com/Machine-files.html)" to define a "[native environment](https://mesonbuild.com/Native-environments.html)". Introduced `meson.native.binaries` option Portfiles can append to which will be written to the `[binaries]` section of a native file and causes `--native-file` argument to be appended to `configure.post_args`. Other sections of the native file could easily be supported as well if there's a need for that.
* Introduced `meson.native_file` option for the name of the native file. Probably no need for a Portfile ever to override this but I needed a variable for it anyway so I made it an option just in case.
* Modified the pulseaudio port as a demonstration of how `meson.native.binaries` would be used.

Does this seem like a reasonable way to handle this?

Does it seem like this will help with https://trac.macports.org/ticket/63356?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 21H1123 x86_64
Xcode 14.2 14C18