### PR TITLE
pavucontrol: set the correct cxx_standard, fix the port

### DIFF
--- a/audio/pavucontrol/Portfile
+++ b/audio/pavucontrol/Portfile
@@ -1,6 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.1
+
+# LegacySupport only used for providing wrappers here.
+# Neither headers nor the lib are used.
+legacysupport.newest_darwin_requires_legacy 0
 
 name                pavucontrol
 version             5.0
@@ -34,6 +39,9 @@ depends_lib-append  port:gettext-runtime \
                     port:libcanberra \
                     port:libsigcxx2 \
                     port:portaudio
+
+# pavucontrol(96824) malloc: *** error for object 0x2f80034: Non-aligned pointer being freed
+legacysupport.redirect_bins pavucontrol
 
 # configure: error: *** A compiler with support for C++11 language features is required
 compiler.cxx_standard   2011

--- a/audio/pavucontrol/Portfile
+++ b/audio/pavucontrol/Portfile
@@ -35,6 +35,9 @@ depends_lib-append  port:gettext-runtime \
                     port:libsigcxx2 \
                     port:portaudio
 
+# configure: error: *** A compiler with support for C++11 language features is required
+compiler.cxx_standard   2011
+
 test.run            no
 test.target         check
 


### PR DESCRIPTION
#### Description

C++11 is required.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
