### PR TITLE
ImageMagick, ImageMagick7: prevent opportunistic use of libraqm

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -14,7 +14,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                        ImageMagick
 version                     6.9.13-7
-revision                    0
+revision                    1
 checksums                   rmd160  9025e38a212d8cfe5706f07c4f900a96b708c016 \
                             sha256  2a521f7992b3dd32469b7b7254a81df8a0045cb0b963372e3ba6404b0a4efeae \
                             size    9604796
@@ -108,6 +108,7 @@ configure.args              --enable-shared \
                             --without-rsvg \
                             --without-lqr \
                             --without-pango \
+                            --without-raqm \
                             --without-x \
                             --without-zstd \
                             --with-gs-font-dir=${prefix}/share/fonts/urw-fonts \

--- a/graphics/ImageMagick7/Portfile
+++ b/graphics/ImageMagick7/Portfile
@@ -22,7 +22,7 @@ legacysupport.newest_darwin_requires_legacy 10
 
 name                ImageMagick7
 github.setup        ImageMagick ImageMagick 7.1.1-29
-revision            1
+revision            2
 
 checksums           rmd160  00103408a31dfde61cca6800dd626ab0ab3f0915 \
                     sha256  6069d80a6db7ef895ef0cdc482505323d843db2b9da4564b7c51bf4fbebea791 \
@@ -126,6 +126,7 @@ configure.args-append \
                     --without-rsvg \
                     --without-lqr \
                     --without-pango \
+                    --without-raqm \
                     --without-x \
                     --without-zstd \
                     --with-gs-font-dir=${prefix}/share/fonts/urw-fonts \


### PR DESCRIPTION
### Description

By default, `ImageMagick` will opportunistically use `libraqm` if it's installed. Explicitly disable that behavior.