### PR TITLE
wget2: add deps gettext, gettext-runtime

### DIFF
--- a/net/wget2/Portfile
+++ b/net/wget2/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                wget2
 version             2.1.0
-revision            0
+revision            1
 
 homepage            https://gitlab.com/gnuwget/wget2
 
@@ -27,11 +27,13 @@ checksums           rmd160  c078e8d02bd9b0d741f53f23cb01d3bd9c687df6 \
                     size    2122122
 
 depends_build-append \
+                    port:gettext \
                     path:bin/pkg-config:pkgconfig
 
 depends_lib-append  path:lib/pkgconfig/gnutls.pc:gnutls \
                     port:brotli \
                     port:bzip2 \
+                    port:gettext-runtime \
                     port:gpgme \
                     port:libhsts \
                     port:libidn2 \


### PR DESCRIPTION
### Description

Port 'gettext' will be used opportunistically, if installed. But even if it isn't installed/available - such as when `wget2` is built via trace mode - `gettext-runtime` will still be linked to. (Albeit without an explicit dependency on it.)

Add formal deps for both, to ensure all is well.