### PR TITLE
rb-fsevent-legacy: new port

### DIFF
--- a/ruby/rb-fsevent-legacy/Portfile
+++ b/ruby/rb-fsevent-legacy/Portfile
@@ -1,0 +1,18 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           ruby 1.0
+
+name                rb-fsevent-legacy
+ruby.branches       3.3 3.2 3.1 3.0 2.7
+ruby.setup          rb-fsevent-legacy 0.2.0 gem {} rubygems
+categories-append   devel
+license             MIT
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+platforms           {darwin < 11}
+description         Legacy version of an FSEvents API for Darwin
+long_description    {*}${description} - it works on PowerPCs and 10.5.8.
+homepage            https://rubygems.org/gems/rb-fsevent-legacy
+checksums           rmd160  bf8a908eb97ef7ee7ceb2d83fce1f5ff741e9bda \
+                    sha256  41c6c423124ee99886a6c6fc0564a4106e0f1da765eff754ddbfbd5569591c4a \
+                    size    11776


### PR DESCRIPTION
#### Description

A version for old systems.
(In this case -legacy is a part of the original gem name.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
