### PR TITLE
openjdk22: update to 22.0.1

### DIFF
--- a/java/openjdk22/Portfile
+++ b/java/openjdk22/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 
 name                openjdk22
 # See https://github.com/openjdk/jdk22u/tags for the version and build number that matches the latest tag that ends with '-ga'
-version             22
-set build 36
+version             22.0.1
+set build 8
 revision            0
 categories          java devel
 supported_archs     x86_64 arm64
@@ -19,9 +19,9 @@ master_sites        https://github.com/openjdk/jdk22u/archive/refs/tags
 distname            jdk-${version}-ga
 worksrcdir          jdk22u-${distname}
 
-checksums           rmd160  6e66e0d59d2198bdc84d4b8d96001e8821bc2c20 \
-                    sha256  684efabcd2ff8d58d3dc36c79e3bf9724a5a31121e17450dba45880ffa63f7bd \
-                    size    111982946
+checksums           rmd160  226bab2be0f7ad89322619194925c726b2096730 \
+                    sha256  dd2d8acd685c07e0ccf5f8b4ac562f50ff31421db90f121be36f06e54dfe41f1 \
+                    size    112021509
 
 set bootjdk_port    openjdk21-zulu
 


### PR DESCRIPTION
#### Description

Update to OpenJDK 22.0.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?