### PR TITLE
gtk-vnc: patch for python3; explicitly disable sasl2; add missing deps

### DIFF
--- a/gnome/gtk-vnc/Portfile
+++ b/gnome/gtk-vnc/Portfile
@@ -6,7 +6,7 @@ PortGroup           meson 1.0
 
 name                gtk-vnc
 version             1.3.1
-revision            2
+revision            3
 maintainers         {danchr @danchr} openmaintainer
 categories          gnome devel
 license             {LGPL GPL-3}
@@ -33,38 +33,55 @@ checksums           rmd160  ea70671da05ef0024e93858c1ee41387470a4243 \
                     sha256  512763ac4e0559d0158b6682ca5dd1a3bd633f082f5e4349d7158e6b5f80f1ce \
                     size    222204
 
+# Disable unexpected download of subprojects
+meson.wrap_mode     nodownload
+
+set py_ver          3.12
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+
 depends_build-append \
-                    port:pkgconfig \
+                    port:gettext \
+                    path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     port:intltool \
+                    path:bin/pkg-config:pkgconfig \
+                    port:python${py_ver_nodot} \
                     path:bin/vala:vala
 
-depends_lib-append  path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+depends_lib-append  path:lib/pkgconfig/cairo.pc:cairo \
+                    path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
+                    port:gettext-runtime \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     path:lib/pkgconfig/gnutls.pc:gnutls \
                     port:libgcrypt \
                     port:pulseaudio
 
-patchfiles          MAP_ANONYMOUS.patch
+configure.python    ${prefix}/bin/python${py_ver}
 
-if {${os.platform} eq "darwin" && ${os.major} <= 13} {
-    # Mavericks comes with Python 2.7.5 which is too old to run keymap-gen properly
-    # See https://bugzilla.gnome.org/show_bug.cgi?id=792075
-    depends_build-append port:python27
-    configure.python    ${prefix}/bin/python2.7
+patchfiles-append   MAP_ANONYMOUS.patch
+
+patchfiles-append   patch-meson-python3.diff
+post-patch {
+   reinplace "s|@@PYTHON3_BIN@@|${configure.python}|" \
+                    src/meson.build
 }
 
 # for ucontext
 configure.cppflags-append \
-                -D_XOPEN_SOURCE
+                    -D_XOPEN_SOURCE
 
-livecheck.type      gnome
-livecheck.regex     LATEST-IS-(\\d+\\.\\d*\\d(?:\\.\\d+)*)
+configure.args-append \
+                    -Dintrospection=enabled \
+                    -Dpulseaudio=enabled \
+                    -Dsasl=disabled \
+                    -Dwith-vala=enabled
 
 variant quartz conflicts x11 {
     require_active_variants gtk3 quartz
     # src/vncdisplaykeymap.c includes <gdk/gdkquartz.h>, which in turn
     # includes AppKit -- and that one fails hard in a regular C compiler...
     configure.cflags-append \
-        -ObjC
+                    -ObjC
 }
 
 variant x11 conflicts quartz {
@@ -82,3 +99,7 @@ if {![variant_isset quartz] && ![variant_isset x11]} {
         return -code error "Either +x11 or +quartz is required"
     }
 }
+
+# Note: Unlike many other GNOME projects, stable releases for 'gtk-vnc' can be odd in number.
+# So we must use gnome-with-unstable, to avoid filtering those out.
+livecheck.type      gnome-with-unstable

--- a/gnome/gtk-vnc/files/patch-meson-python3.diff
+++ b/gnome/gtk-vnc/files/patch-meson-python3.diff
@@ -1,0 +1,11 @@
+--- src/meson.build.orig	2024-04-17 16:56:05.000000000 -0400
++++ src/meson.build	2024-04-17 16:59:36.000000000 -0400
+@@ -319,7 +319,7 @@
+   'vncdisplaykeymap.c',
+ ]
+ 
+-python = import('python').find_installation('python3')
++python = import('python').find_installation('@@PYTHON3_BIN@@')
+ keymaps = [
+   'xorgevdev',
+   'xorgkbd',


### PR DESCRIPTION
### Description

- Add patch to ensure python3 is found.
- Explicitly disable `sasl2`, otherwise it will be opportunistically used when installed. (Unless the desire is to have this enabled. In which case, we'll need to add a formal lib dep.)
- Add missing build and lib deps.

Fixes: https://trac.macports.org/ticket/69757