### PR TITLE
openjdk17-temurin: update to 17.0.11

### DIFF
--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      17.0.10
-set build    7
+version      17.0.11
+set build    9
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 17
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin17-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK17U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  c16604dd53999a642dfdfe17015fe554c1b37658 \
-                 sha256  e16ee89d3304bb2ba706f9a7b0ba279725c2aea55d5468336f8de4bb859f300d \
-                 size    180364858
+    checksums    rmd160  c1f53690c250c5012029dec1af629c791ead4f6f \
+                 sha256  f8b96724618f4df557c47f11048d1084e98ed3eb87f0dbd5b84f768a80c3348e \
+                 size    180563846
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK17U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  697605647c7c812823e6958ad2779d6dff30332b \
-                 sha256  a6ec3b94f61695e8f445ee508411c56a2ce0cabc16ea4c4296ff062d13559d92 \
-                 size    178168341
+    checksums    rmd160  2c391fdfcb64a1ec0ac7b58479d772819aa52ba9 \
+                 sha256  09a162c58dd801f7cfacd87e99703ed11fb439adc71cfa14ceb2d3194eaca01c \
+                 size    178367345
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 17.0.11.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?