### PR TITLE
typescript-language-server: update to 4.3.3

### DIFF
--- a/devel/typescript-language-server/Portfile
+++ b/devel/typescript-language-server/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           npm 1.0
 
 name                typescript-language-server
-version             1.0.0
+version             4.3.3
 revision            0
 
 categories          devel
@@ -18,6 +18,6 @@ long_description    Language Server Protocol implementation for TypeScript wrapp
 
 homepage            https://github.com/typescript-language-server/typescript-language-server
 
-checksums           rmd160  72ee7f53c692b69f652eec5ec9e2db21b5d735bb \
-                    sha256  07056f4c8600fa7e3d3fb55938b6f96cf2c5af69539b9d28f5626c04348a33e0 \
-                    size    115256
+checksums           rmd160  4c85d003d183dbdeb7aff267e379af7023890dae \
+                    sha256  4a0e1c596fe598ff07db9221bf851a96a691718d99a12a9d4637dc64604914d0 \
+                    size    488222


### PR DESCRIPTION
This should allow upgrading the npm portgroup to use nodejs20

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files? `typescript-language-server --version`

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
