### PR TITLE
rb-fsevent-legacy: fix build with clang

### DIFF
--- a/ruby/rb-fsevent-legacy/Portfile
+++ b/ruby/rb-fsevent-legacy/Portfile
@@ -16,3 +16,11 @@ homepage            https://rubygems.org/gems/rb-fsevent-legacy
 checksums           rmd160  bf8a908eb97ef7ee7ceb2d83fce1f5ff741e9bda \
                     sha256  41c6c423124ee99886a6c6fc0564a4106e0f1da765eff754ddbfbd5569591c4a \
                     size    11776
+
+# Clang gets unhappy: error: '__declspec' attributes are not enabled;
+# use '-fdeclspec' or '-fms-extensions' to enable support for __declspec attributes
+# We can use -fms-extensions unconditionally, it works with GCC too.
+if {${name} ne ${subport}} {
+    destroot.post_args-append \
+                    -- --with-cflags="-fms-extensions"
+}


### PR DESCRIPTION
#### Description

Fix a build failure with clang.
See: https://build.macports.org/builders/ports-10.6_x86_64-builder/builds/197130/steps/install-port/logs/stdio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
