### PR TITLE
openjdk21-microsoft: update to 21.0.3

### DIFF
--- a/java/openjdk21-microsoft/Portfile
+++ b/java/openjdk21-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-21
 supported_archs  x86_64 arm64
 
-version      21.0.2
-set build    13
+version      21.0.3
+set build    9
 revision     0
 
 description  Microsoft Build of OpenJDK 21 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  eacba13da46ff6680683c08899da0d2bcf924f21 \
-                 sha256  33c92626121e81e13796b974192d821b11f628b3133bbc9957c043e931a28667 \
-                 size    202912867
+    checksums    rmd160  dd2ced70234146bd64b39ee8da5a1e5ae3a92b3c \
+                 sha256  cf7d2c967088ac71b29cf28ad791a071bbf2c1dab333dd73dc0e791cb974c1f6 \
+                 size    202947464
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  bf792c77e27d801ff37bbc8438edc27ff102526b \
-                 sha256  efaab69d58d6515438aa6344c1ef019a3b211ab5bd13338f1fd2343be16f4ff2 \
-                 size    200420322
+    checksums    rmd160  eb3e320efb4635dbe4c89fee5c0d3ea5ca035e82 \
+                 sha256  489c96c8a4d3592811d1907346c05b75c12642729f83576982b9f62d0aafc672 \
+                 size    200438427
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 21.0.3.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?