### PR TITLE
openjdk11-microsoft: update to 11.0.23

### DIFF
--- a/java/openjdk11-microsoft/Portfile
+++ b/java/openjdk11-microsoft/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11
 supported_archs  x86_64 arm64
 
-version      11.0.22
-set build    7
+version      11.0.23
+set build    9
 revision     0
 
 description  Microsoft Build of OpenJDK 11 (Long Term Support)
@@ -26,14 +26,14 @@ master_sites https://aka.ms/download-jdk/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     microsoft-jdk-${version}-macOS-x64
-    checksums    rmd160  c070bb556c29ba3c8bc07b8c6d071076ec3a5752 \
-                 sha256  eabc1804f379b055e39e01de3753304f0820d774b14766204f25af0d197bfcb5 \
-                 size    191303341
+    checksums    rmd160  1bf7bfa7bc550ec3b6c93725ec14c33e00b0176b \
+                 sha256  2234a37249f4235c9096a9c18b85d5bb80a052295e9b4f068f866692dc8249eb \
+                 size    191462906
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     microsoft-jdk-${version}-macOS-aarch64
-    checksums    rmd160  e66839eca648a4f1191124ea3e8adee9e4d5af68 \
-                 sha256  790cf8a740b06b34b7b6cba1d4d324ea4ca91f2694261354284b2b9d480d59da \
-                 size    185392579
+    checksums    rmd160  e934be126cd8d58cfb567c0f13b46507339f4ca4 \
+                 sha256  a0d6bceeee9f99eba1756c34da321769ea05df54db101178986bfb2ab452bf34 \
+                 size    185546235
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Microsoft OpenJDK 11.0.23.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?