### PR TITLE
openjdk21-temurin: update to 21.0.3

### DIFF
--- a/java/openjdk21-temurin/Portfile
+++ b/java/openjdk21-temurin/Portfile
@@ -14,8 +14,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      21.0.2
-set build    13
+version      21.0.3
+set build    9
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK 21
@@ -25,14 +25,14 @@ master_sites https://github.com/adoptium/temurin21-binaries/releases/download/jd
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK21U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  8c130d84b0942c0e7a44942fb1ff067b8ce4d2df \
-                 sha256  ba696ec46c1ca2b1b64c4e9838e21a2d62a1a4b6857a0770adc64451510065db \
-                 size    194433403
+    checksums    rmd160  b463ba38acf005041f1f0db0212725f657b2580c \
+                 sha256  f777103aab94330d14a29bd99f3a26d60abbab8e2c375cec9602746096721a7c \
+                 size    194512621
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK21U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  17ea1f40c30d0d3e30d2696bcf5fb42e34118552 \
-                 sha256  57d9e0f0e8639f9f2fb1837518fd83043f23953ff69a677f885aa060994d0c19 \
-                 size    191948584
+    checksums    rmd160  e1f623f8b1345a8e5a4c6147a2fed3d3e955b88d \
+                 sha256  b6be6a9568be83695ec6b7cb977f4902f7be47d74494c290bc2a5c3c951e254f \
+                 size    192027805
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 21.0.3.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?