### PR TITLE
openjdk21: switch from GitHub mirror to official source

### DIFF
--- a/java/openjdk21/Portfile
+++ b/java/openjdk21/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 
 name                openjdk21
-# See https://github.com/openjdk/jdk21u/tags for the version and build number that matches the latest tag that ends with '-ga'
+# See https://openjdk-sources.osci.io/openjdk21/ for the version and build number that matches the latest '-ga' version
 version             21.0.3
 set build 9
-revision            0
+revision            1
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -15,13 +15,14 @@ description         OpenJDK 21
 long_description    JDK 21 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/21/
-master_sites        https://github.com/openjdk/jdk21u/archive/refs/tags
-distname            jdk-${version}-ga
-worksrcdir          jdk21u-${distname}
+master_sites        https://openjdk-sources.osci.io/openjdk21/
+distname            openjdk-${version}-ga
+extract.suffix      .tar.xz
+worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  9c475209878d5ce8e8fe30cc2d8c685105930d2f \
-                    sha256  818e9dee28ae390f2781406d594690fc42bd994d078ad9f8360a4fbca6a3df1f \
-                    size    112404688
+checksums           rmd160  0c3c2fc6f9460460c6804c914b916f8d67fdc8e9 \
+                    sha256  1a73d369c125ca45240a02f8b5c4b01b113d5fa7041145bb6492807d123d4da7 \
+                    size    69593116
 
 set bootjdk_port    openjdk21-zulu
 
@@ -169,5 +170,5 @@ export JAVA_HOME=${jdk}/Contents/Home
 "
     
 livecheck.type      regex
-livecheck.url       https://github.com/openjdk/jdk21u/tags
-livecheck.regex     jdk-(21\.\[0-9.\]+)-ga
+livecheck.url       https://openjdk-sources.osci.io/openjdk21/
+livecheck.regex     openjdk-(21\.\[0-9.\]+)-ga


### PR DESCRIPTION
#### Description

Switch to source tarball from location in the [release announcement](https://mail.openjdk.org/pipermail/jdk-updates-dev/2024-April/032196.html) instead of the GitHub mirror.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?