### PR TITLE
pulseaudio: fix segfault on powerpc

### DIFF
--- a/audio/pulseaudio/Portfile
+++ b/audio/pulseaudio/Portfile
@@ -11,7 +11,7 @@ PortGroup           perl5 1.0
 
 name                pulseaudio
 version             17.0
-revision            2
+revision            3
 license             {BSD LGPL-2.1+ MIT}
 categories          audio
 maintainers         {ionic @Ionic} openmaintainer
@@ -81,6 +81,12 @@ patchfiles-append   patch-src_modules_macosx_module_coreaudio_device.c-respect-P
 
 platform darwin 8 {
     patchfiles-append   patch-src_modules_macosx_module_coreaudio_device.c-tiger-compat.diff
+}
+
+platform darwin powerpc {
+    # This fixes a segfault on launch of pulseaudio on ppc.
+    patchfiles-append \
+                    patch-avoid-segfault-on-powerpc.diff
 }
 
 meson.native.binaries-append \

--- a/audio/pulseaudio/files/patch-avoid-segfault-on-powerpc.diff
+++ b/audio/pulseaudio/files/patch-avoid-segfault-on-powerpc.diff
@@ -1,0 +1,26 @@
+While this compiles fine, resulting binary fails to run.
+Program received signal EXC_BAD_ACCESS, Could not access memory.
+Reason: KERN_PROTECTION_FAILURE at address: 0x00000010
+0x003c4130 in pthread_getname_np ()
+So just avoid using it on powerpc.
+
+--- src/pulsecore/thread-posix.c	2024-01-13 01:22:09.000000000 +0800
++++ src/pulsecore/thread-posix.c	2024-04-17 17:13:57.000000000 +0800
+@@ -182,7 +182,7 @@
+ 
+ #ifdef __linux__
+     prctl(PR_SET_NAME, name);
+-#elif defined(HAVE_PTHREAD_SETNAME_NP) && defined(OS_IS_DARWIN)
++#elif defined(HAVE_PTHREAD_SETNAME_NP) && defined(OS_IS_DARWIN) && !defined(__POWERPC__)
+     pthread_setname_np(name);
+ #endif
+ }
+@@ -201,7 +201,7 @@
+             t->name = NULL;
+         }
+     }
+-#elif defined(HAVE_PTHREAD_GETNAME_NP) && defined(OS_IS_DARWIN)
++#elif defined(HAVE_PTHREAD_GETNAME_NP) && defined(OS_IS_DARWIN) && !defined(__POWERPC__)
+     if (!t->name) {
+         t->name = pa_xmalloc0(17);
+         pthread_getname_np(t->id, t->name, 16);


### PR DESCRIPTION
#### Description

Other stuff fixed in https://github.com/macports/macports-ports/commit/baa9797fc30ad642bec24014769c0d7c8da49f68 so I rebased to that, and just one patch needed.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

macOS 14.4.1
Xcode 15.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
