### PR TITLE
openjdk17: switch from GitHub mirror to official source

### DIFF
--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 
 name                openjdk17
-# See https://github.com/openjdk/jdk17u/tags for the version and build number that matches the latest tag that ends with '-ga'
+# See https://openjdk-sources.osci.io/openjdk17/ for the version and build number that matches the latest '-ga' version
 version             17.0.11
 set build 9
-revision            0
+revision            1
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -15,13 +15,14 @@ description         OpenJDK 17
 long_description    JDK 17 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/17/
-master_sites        https://github.com/openjdk/jdk17u/archive/refs/tags
-distname            jdk-${version}-ga
-worksrcdir          jdk17u-${distname}
+master_sites        https://openjdk-sources.osci.io/openjdk17/
+distname            openjdk-${version}-ga
+extract.suffix      .tar.xz
+worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  b546b14fad77c73d685a5b51a6034eb9af2079ff \
-                    sha256  4aa214812f88b21c11ad91e111075f64d57e1b13096f98fc5d45f95f789d4642 \
-                    size    106574173
+checksums           rmd160  ddb86858821a2bd81ecf7067984dd6495337a093 \
+                    sha256  d16068baa8124125fb3dffd6a18fbea01df3f01658cfe4fbfcc85e4d48ab2bbb \
+                    size    65851368
 
 depends_lib         port:freetype \
                     port:libiconv
@@ -164,5 +165,5 @@ export JAVA_HOME=${jdk}/Contents/Home
 "
     
 livecheck.type      regex
-livecheck.url       https://github.com/openjdk/jdk17u/tags
-livecheck.regex     jdk-(17\.\[0-9.\]+)-ga
+livecheck.url       https://openjdk-sources.osci.io/openjdk17/
+livecheck.regex     openjdk-(17\.\[0-9.\]+)-ga


### PR DESCRIPTION
#### Description

Switch to source tarball from location in the [release announcement](https://mail.openjdk.org/pipermail/jdk-updates-dev/2024-April/032197.html) instead of the GitHub mirror.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?