### PR TITLE
openjdk11: switch from GitHub mirror to official source

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -3,10 +3,10 @@
 PortSystem          1.0
 
 name                openjdk11
-# See https://github.com/openjdk/jdk11u/tags for the version and build number that matches the latest tag that ends with '-ga'
+# See https://openjdk-sources.osci.io/openjdk11/ for the version and build number that matches the latest '-ga' version
 version             11.0.23
 set build 9
-revision            0
+revision            1
 categories          java devel
 supported_archs     x86_64 arm64
 license             GPL-2+
@@ -15,13 +15,14 @@ description         OpenJDK 11
 long_description    JDK 11 builds of OpenJDK, the Open-Source implementation \
                     of the Java Platform, Standard Edition, and related projects.
 homepage            https://openjdk.org/projects/jdk/11/
-master_sites        https://github.com/openjdk/jdk11u/archive/refs/tags
-distname            jdk-${version}-ga
-worksrcdir          jdk11u-${distname}
+master_sites        https://openjdk-sources.osci.io/openjdk11/
+distname            openjdk-${version}-ga
+extract.suffix      .tar.xz
+worksrcdir          jdk-${version}+${build}
 
-checksums           rmd160  2858a610ba1c7e1f7f6d227addce449943183d11 \
-                    sha256  82bd91cc58909c6b08a8066e8ed8cf3ad09532b250126eb1159390b15db1f9fd \
-                    size    116316363
+checksums           rmd160  0b31aa900cefffb02d0fea57c81e49ed7e442484 \
+                    sha256  f51be67721f6cb8d14b0cd75cc9b53634e7d83e808148940d64e67c8b77accfc \
+                    size    71402820
 
 depends_lib         port:freetype \
                     port:libiconv
@@ -174,6 +175,6 @@ export JAVA_HOME=${jdk}/Contents/Home
 "
 
 livecheck.type      regex
-livecheck.url       https://github.com/openjdk/jdk11u/tags
-livecheck.regex     jdk-(\[0-9.\]+)-ga
+livecheck.url       https://openjdk-sources.osci.io/openjdk11/
+livecheck.regex     openjdk-(\[0-9.\]+)-ga
 


### PR DESCRIPTION
#### Description

Switch to source tarball from location in the [release announcement](https://mail.openjdk.org/pipermail/jdk-updates-dev/2024-April/032198.html) instead of the GitHub mirror.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?