### PR TITLE
hdf5: Update to 1.14.4.2

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -5,12 +5,14 @@ PortGroup           muniversal 1.0
 PortGroup           mpi 1.0
 PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           github 1.0
 
-name                hdf5
-version             1.14.3
-set mainversion     [lrange [split ${version} -] 0 0]
-revision            4
-set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
+github.setup        HDFGroup hdf5 1.14.4.2 hdf5_
+set distversion     1.14.4-2
+revision            0
+#set mainversion     [lrange [split ${version} -] 0 0]
+#set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
+
 categories          science
 maintainers         {eborisch @eborisch} openmaintainer
 
@@ -27,16 +29,24 @@ long_description    HDF5 is a data model, library, and file format for storing\
 homepage            https://www.hdfgroup.org/solutions/hdf5/
 platforms           darwin
 
-distfiles           ${name}-${version}.tar.bz2
-master_sites \
-    https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${shortversion}/hdf5-${mainversion}/src
+# Looks like upstream gave up on BZ2.  Maybe they will restore it later.
+distfiles           ${name}-${distversion}.tar.gz
+#distfiles           ${name}-${version}.tar.bz2
+#use_bzip2           yes
+
+# Github download assets path is not quite right, for some unknown reason.
+master_sites        ${github.homepage}/releases/download/${git.branch}
+
+## Full target currently:
+## https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.4.2/hdf5-1.14.4-2.tar.gz
+
 checksums \
-    rmd160  4038e67868ffa4d5bde3ed02a5cd03f24056b072 \
-    sha256  9425f224ed75d1280bb46d6f26923dd938f9040e7eaebf57e66ec7357c08f917 \
-    size    16320137
+    rmd160  da80b0fcf47248e869da9112890edf79905bf95c \
+    sha256  618934b9d45e34f328393e1fde73a8a67e973f8e5a6bae8b609d098a84cb0efe \
+    size    37033062
+
 mpi.setup           -gcc44 -gcc45
 
-use_bzip2           yes
 depends_lib         port:zlib port:libaec
 use_parallel_build  yes
 
@@ -210,6 +220,7 @@ Otherwise errors such as "unable to open file" or "HDF5 error" may be\
 encountered.
 }
 
-livecheck.type      regex
-livecheck.url       https://www.hdfgroup.org/downloads/hdf5
-livecheck.regex     hdf5-(\[0-9.-\]+)-Std
+# Now attempting livecheck via github portgroup.
+#livecheck.type      regex
+#livecheck.url       https://www.hdfgroup.org/downloads/hdf5
+#livecheck.regex     hdf5-(\[0-9.-\]+)-Std

--- a/science/hdf5/files/patch-tools-src-misc-h5cc.in.diff
+++ b/science/hdf5/files/patch-tools-src-misc-h5cc.in.diff
@@ -1,6 +1,6 @@
---- bin/h5cc.in.orig	2017-04-26 06:45:02.000000000 +0900
-+++ bin/h5cc.in	2017-07-16 09:57:18.000000000 +0900
-@@ -95,9 +95,6 @@
+--- bin/h5cc.in.orig	2024-04-15 13:47:31.000000000 -0600
++++ bin/h5cc.in	2024-04-20 15:14:36.000000000 -0600
+@@ -94,9 +94,6 @@
  
  CC="${HDF5_CC:-$CCBASE}"
  CLINKER="${HDF5_CLINKER:-$CLINKERBASE}"
@@ -10,16 +10,3 @@
  LIBS="${HDF5_LIBS:-$LIBSBASE}"
  
  # If a static library is available, the default will be to use it.  If the only
-@@ -258,10 +255,12 @@
-       ;;
-     *\"*)
-       qarg="'"$arg"'"
-+      compile_args="$compile_args $qarg"
-       allargs="$allargs $qarg"
-       ;;
-     *\'*)
-       qarg='\"'"$arg"'\"'
-+      compile_args="$compile_args $qarg"
-       allargs="$allargs $qarg"
-       ;;
-     *)


### PR DESCRIPTION
#### Description

* Update hdf5 1.14.3 --> 1.14.4.2
* Use github portgroup.
* Switch distfile to one of the official GH release assets.
* Remove broken part of the `h5cc` wrapper script patch file.
* Looks like upstream worked on that wrapper script, maybe fixed something.

###### Type(s)

- [x] Update

###### Tested on

macOS 13.6.4 22G513 x86_64
Xcode 15.2 / Command Line Tools 15.1.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `port -vs install`?
- [ ] tested basic functionality of all binary files?
- [x] tested basic functionality of TWO binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?