### PR TITLE
ipsw: Update to 3.1.475

### DIFF
--- a/security/ipsw/Portfile
+++ b/security/ipsw/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/blacktop/ipsw 3.1.472 v
+go.setup                github.com/blacktop/ipsw 3.1.475 v
 github.tarball_from     archive
 revision                0
 categories              security devel
@@ -16,9 +16,9 @@ description             iOS/macOS Research Swiss Army Knife
 long_description        {*}${description}. Everything you need to start \
                         researching Apple security and internals.
 
-checksums               rmd160  b18e1f75afda223ec7b4802252b1419a237da7f4 \
-                        sha256  3357d99cf13990dcfa9c60f9bb4a5e566ac104a02e8b735d46dd5e9b4d8e560d \
-                        size    4054067
+checksums               rmd160  cdd9ce2fd1ea36727c590c1190063864a7c85147 \
+                        sha256  7153c0de990c4b2f3cae5da87d55513ad424aee7ad504bca6736c554271a0a39 \
+                        size    4056719
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 


### PR DESCRIPTION
#### Description

Update `ipsw` to its latest released version, 3.1.475

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
