### PR TITLE
ocaml-stringext: new port 1.6.0

### DIFF
--- a/ocaml/ocaml-stringext/Portfile
+++ b/ocaml/ocaml-stringext/Portfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           ocaml 1.1
+PortGroup           github 1.0
+
+name                ocaml-stringext
+version             1.6.0
+revision            0
+categories          ocaml devel
+maintainers         {pguyot @pguyot} openmaintainer
+license             MIT
+
+github.setup        rgrinberg stringext ${version}
+github.tarball_from releases
+use_bzip2           yes
+distname            stringext-${version}
+extract.suffix      .tbz
+
+description         Extra string functions for OCaml
+long_description    Extra string functions for OCaml. Mainly splitting. All \
+                    functions are in the Stringext module.
+
+homepage            https://github.com/rgrinberg/stringext
+
+checksums           rmd160  45794360c2ac26af1f1e31ef9907a896a75dd8df \
+                    sha256  db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea \
+                    size    7445
+
+ocaml.build_type    dune


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1 23E224 x86_64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
