### PR TITLE
kdepim4: Remove link-grammar dependency

### DIFF
--- a/kde/kdepim4-runtime/Portfile
+++ b/kde/kdepim4-runtime/Portfile
@@ -9,12 +9,11 @@ name                kdepim4-runtime
 version             4.14.3
 revision            6
 categories          kde kde4
-maintainers         intevation.de:bjoern.ricks
+maintainers         nomaintainer
 license             GPL-2+ LGPL-2+
 description         KDE4 groupware suite runtime libraries
 long_description    KDE4 groupware suite including a Mail client, \
                     addressbook, organizer and groupware integration.
-platforms           darwin
 homepage            https://www.kde.org
 master_sites        kde:stable/${version}/src/
 use_xz              yes

--- a/kde/kdepim4/Portfile
+++ b/kde/kdepim4/Portfile
@@ -9,7 +9,7 @@ name                kdepim4
 version             4.14.3
 revision            6
 categories          kde kde4
-maintainers         intevation.de:bjoern.ricks
+maintainers         nomaintainer
 license             GPL-2+ LGPL-2+
 description         KDE4 groupware suite
 long_description    KDE4 groupware suite including a Mail client, \

--- a/kde/kdepim4/Portfile
+++ b/kde/kdepim4/Portfile
@@ -7,14 +7,13 @@ PortGroup           boost 1.0
 
 name                kdepim4
 version             4.14.3
-revision            5
+revision            6
 categories          kde kde4
 maintainers         intevation.de:bjoern.ricks
 license             GPL-2+ LGPL-2+
 description         KDE4 groupware suite
 long_description    KDE4 groupware suite including a Mail client, \
                     addressbook, organizer and groupware integration.
-platforms           darwin
 homepage            https://www.kde.org
 master_sites        kde:stable/${version}/src/
 use_xz              yes
@@ -30,7 +29,6 @@ depends_lib-append  port:kde4-runtime \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:shared-desktop-ontologies port:libassuan \
                     port:kdepim4-runtime \
-                    port:link-grammar \
                     port:baloo
 
 configure.args-append   ../${distname} \


### PR DESCRIPTION
#### Description

Remove link-grammar dependency

Support for link-grammar was removed in kdepim4 4.13.1.

See KDE/kdepim@9fed451

@bjoernricks Are you the Björn Ricks listed as the maintainer of this port? If so we would like to add your GitHub handle to this port and the others you maintain, unless you no longer wish to maintain them, in which case we can remove your email address from them.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
