### PR TITLE
medainfo,mediainfolib: update to version 24.04

### DIFF
--- a/devel/mediainfolib/Portfile
+++ b/devel/mediainfolib/Portfile
@@ -5,10 +5,11 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 # normally update mediainfo port at the same time
-github.setup        MediaArea MediaInfoLib 23.11 v
-checksums           rmd160  1f4927c9c682b8240fe56c53e79da2907ad6b570 \
-                    sha256  48c47c09481bd29299e1bac42ad8148aa2222db170cac23ee46a44e25ea3e837 \
-                    size    2876528
+github.setup        MediaArea MediaInfoLib 24.04 v
+github.tarball_from archive
+checksums           rmd160  23826e847a6e22d733e50635978a3e76db9beca6 \
+                    sha256  ab81016e2e0f8c385d440487f2f202df407ef00b5f0bc26f06da4523d712f788 \
+                    size    2929636
 
 name                mediainfolib
 description         Supplies technical and tag information about a video or audio file

--- a/multimedia/mediainfo/Portfile
+++ b/multimedia/mediainfo/Portfile
@@ -4,10 +4,11 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 # normally update mediainfolib port at the same time
-github.setup        MediaArea MediaInfo 23.11 v
-checksums           rmd160  7ec5e4e4dcadba9ac7158540b74cf9a43b0a81ac \
-                    sha256  43415765a19f0c380478ae4c62598eb264865dccac19fa8facc76ffcd7f40cd7 \
-                    size    3309288
+github.setup        MediaArea MediaInfo 24.04 v
+github.tarball_from archive
+checksums           rmd160  80acd7a4c1f84e0705f72fbd31632adccd157522 \
+                    sha256  9d2538c766b01ce61544472fa926b6ad750d22cc5bccfbc87f4494cd7fe83af2 \
+                    size    3334485
 
 name                mediainfo
 categories          multimedia


### PR DESCRIPTION
#### Description

Update to version 24.04

###### Tested on

macOS 13.6.3 22G436 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
