### PR TITLE
execline: update to 2.9.5.1

### DIFF
--- a/devel/skalibs/Portfile
+++ b/devel/skalibs/Portfile
@@ -7,7 +7,7 @@ legacysupport.newest_darwin_requires_legacy     13
 
 name                skalibs
 version             2.14.1.1
-revision            0
+revision            1
 categories          devel
 license             ISC
 maintainers         nomaintainer

--- a/lang/execline/Portfile
+++ b/lang/execline/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                execline
-version             2.9.5.0
+version             2.9.5.1
 revision            0
 categories          lang
 license             ISC
@@ -25,9 +25,9 @@ master_sites        ${homepage}
 
 depends_build       port:skalibs
 
-checksums           rmd160  1d20e9ec581e364229a5f49ccfaed1642e603cbe \
-                    sha256  c1eb0d3a2f4e9f5751452631617a147f532ac2dd4a07c564e33f1612d2de837e \
-                    size    110827
+checksums           rmd160  4d2be17efff8b4efd4040d1723d64cce6716b3f2 \
+                    sha256  df750035d0fb21c7265bffb7ed7e1b661de1e842944a2252bdcddc32d0d97217 \
+                    size    110874
 
 configure.args      --disable-shared \
                     --with-lib=${prefix}/lib/skalibs

--- a/sysutils/s6/Portfile
+++ b/sysutils/s6/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 
 name                s6
 version             2.12.0.4
-revision            0
+revision            1
 categories          sysutils
 license             ISC
 maintainers         nomaintainer


### PR DESCRIPTION
#### Description

There was a small [bug](https://skarnet.org/lists/skaware/2003.html) in execline 2.9.5.0.  Laurent [released a fix](https://skarnet.org/lists/skaware/2008.html) in .1.

Thank you, @herbygillot, for keeping this port up to date.

This works on my machine™, though GitHub Actions is complaining about some inscrutable failure on macOS 14.  I am unable to test on macOS 14.  Let me know if this is a true positive failure, and I will rework somehow.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.7.4 21H1123 x86_64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
