### PR TITLE
coeurl: fix build on old systems

### DIFF
--- a/net/coeurl/Portfile
+++ b/net/coeurl/Portfile
@@ -24,6 +24,13 @@ meson.wrap_mode     default
 # Fix subproject wrap file for curl: [provides] should be [provide]
 patchfiles-append   patch-subproj-curl.diff
 
+# Backport of:
+# https://github.com/gabime/spdlog/commit/c65aa4e4889939c1afa82001db349cac237a13f8
+pre-build {
+    system -W {*}[glob ${worksrcpath}/subprojects/spdlog-*] \
+        "/usr/bin/patch -p0 < [shellescape ${filespath}]/patch-pthread.diff"
+}
+
 depends_build-append \
                     port:pkgconfig
 

--- a/net/coeurl/files/patch-pthread.diff
+++ b/net/coeurl/files/patch-pthread.diff
@@ -1,0 +1,31 @@
+--- include/spdlog/details/os-inl.h	2021-03-26 03:00:48.000000000 +0800
++++ include/spdlog/details/os-inl.h	2024-04-22 00:29:01.000000000 +0800
+@@ -42,6 +42,10 @@
+ #include <fcntl.h>
+ #include <unistd.h>
+ 
++#if defined __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ #ifdef __linux__
+ #include <sys/syscall.h> //Use gettid() syscall under linux to get thread id
+ 
+@@ -336,7 +340,17 @@
+     return static_cast<size_t>(::thr_self());
+ #elif __APPLE__
+     uint64_t tid;
++#if (MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || defined(__POWERPC__)
++        tid = pthread_mach_thread_np(pthread_self());
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++    if (&pthread_threadid_np) {
++        pthread_threadid_np(nullptr, &tid);
++    } else {
++        tid = pthread_mach_thread_np(pthread_self());
++    }
++#else
+     pthread_threadid_np(nullptr, &tid);
++#endif
+     return static_cast<size_t>(tid);
+ #else // Default to standard C++11 (other Unix)
+     return static_cast<size_t>(std::hash<std::thread::id>()(std::this_thread::get_id()));


### PR DESCRIPTION
#### Description

Backport a fix for spdlog (port uses an older bundled version, not our spdlog).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
