### PR TITLE
ImageMagick: Update description only

### DIFF
--- a/graphics/ImageMagick/Portfile
+++ b/graphics/ImageMagick/Portfile
@@ -26,7 +26,11 @@ use_xz                      yes
 
 description                 Tools and libraries to manipulate images in many formats
 
-long_description            ImageMagick is a robust collection of tools and \
+long_description            This is the legacy ImageMagick version 6.  For the \
+                            modern ImageMagick version 7, please go to port \
+                            ImageMagick7. \
+                            \
+                            ImageMagick is a robust collection of tools and \
                             libraries to create, edit and compose bitmap images \
                             in a wide variety of formats. You can crop, resize, \
                             rotate, sharpen, color reduce or add effects or text \


### PR DESCRIPTION
#### Description

* Update only long_description in Portfile.
* Add reference to new ImageMagick7 port.

###### Type(s)

- [x] enhancement

###### Tested on

CI only.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?