### PR TITLE
mod_tile: Update to proj7, variants to use Postgresql15-16

### DIFF
--- a/gis/mod_tile/Portfile
+++ b/gis/mod_tile/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 
 github.setup        openstreetmap mod_tile 0.5
 github.tarball_from archive
-revision            9
+revision            10
 
 categories-append   gis
 platforms           darwin
@@ -33,6 +33,7 @@ checksums           rmd160  e6c2224c6500f695e4a17addc7d05086ce5bebd5 \
 boost.version       1.76
 
 depends_build       port:apache2 \
+                    port:carto \
                     port:iniparser
 
 depends_lib         port:curl \
@@ -42,7 +43,7 @@ depends_lib         port:curl \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:libpng \
                     port:mapnik \
-                    port:proj4 \
+                    port:proj7 \
                     port:tiff \
                     port:webp \
                     port:zlib
@@ -59,6 +60,7 @@ set apxs            ${prefix}/bin/apxs
 set docdir          ${prefix}/share/doc/${name}
 set mdir            ${prefix}/lib/apache2/modules/
 set renderd_user    nobody
+set pgsqlbinpath    /bin
 
 startupitem.type    launchd
 startupitem.create  yes
@@ -88,14 +90,16 @@ test.run            yes
 
 require_active_variants mapnik postgis
 
-variant postgresql12 conflicts postgresql13 description {Use with PostgreSQL 12} {
-    depends_lib-append port:postgresql12 \
-                       port:pg12-postgis3    
+variant postgresql15 conflicts postgresql16 description {Use with PostgreSQL 15} {
+    set pgsqlbinpath "/lib/postgresql15/bin";
+    depends_lib-append port:postgresql15 \
+                       port:pg15-postgis3
 }
 
-variant postgresql13 conflicts postgresql12 description {Use with PostgreSQL 13} {
-    depends_lib-append port:postgresql13 \
-                       port:pg13-postgis3    
+variant postgresql16 conflicts postgresql15 description {Use with PostgreSQL 16} {
+    set pgsqlbinpath "/lib/postgresql16/bin";
+    depends_lib-append port:postgresql16 \
+                       port:pg16-postgis3
 }
 
 variant osmosis description {Perform incremental OSM updates} {
@@ -111,8 +115,9 @@ variant logrotate description {Logrotate configuration} {
 
 default_variants +osmosis +logrotate
 
-if {![variant_isset postgresql12] && ![variant_isset postgresql13]} {
-    default_variants-append +postgresql13
+if {![variant_isset postgresql15] && ![variant_isset postgresql16]} {
+    set pgsqlbinpath "/lib/postgresql16/bin";
+    default_variants-append +postgresql16
 }
 
 post-extract {
@@ -132,9 +137,9 @@ post-patch {
 post-destroot {
     system -W ${worksrcpath} "make install-mod_tile DESTDIR=${destroot} PREFIX=${prefix}"
     if {[variant_isset osmosis]} {
-        xinstall -m 0755 -d ${destroot}${prefix}/etc/LaunchAgents/${agent_uniquename}
+        xinstall -m 0755 -d ${destroot}${prefix}/etc/LaunchDaemons/${agent_uniquename}
         set minutes 20; # Run every ${minutes} minutes
-        set plist [open "${destroot}${prefix}/etc/LaunchAgents/${agent_uniquename}/${agent_uniquename}.plist" w 0644]
+        set plist [open "${destroot}${prefix}/etc/LaunchDaemons/${agent_uniquename}/${agent_uniquename}.plist" w 0644]
         puts ${plist} {<?xml version="1.0" encoding="UTF-8"?>}
         puts ${plist} {<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"}
         puts ${plist} {"http://www.apple.com/DTDs/PropertyList-1.0.dtd">}
@@ -166,10 +171,10 @@ post-destroot {
 
         # install the plist
         if {[getuid] == 0  && ${startupitem.install}} {
-            xinstall -m 0755 -d ${destroot}/Library/LaunchAgents
-            ln -sf ${prefix}/etc/LaunchAgents/${agent_uniquename}/${agent_uniquename}.plist ${destroot}/Library/LaunchAgents
+            xinstall -m 0755 -d ${destroot}/Library/LaunchDaemons
+            ln -sf ${prefix}/etc/LaunchDaemons/${agent_uniquename}/${agent_uniquename}.plist ${destroot}/Library/LaunchDaemons
         } else {
-            ln -sf ${prefix}/etc/LaunchAgents/${agent_uniquename}/${agent_uniquename}.plist ${destroot}${prefix}/etc/LaunchAgents
+            ln -sf ${prefix}/etc/LaunchDaemons/${agent_uniquename}/${agent_uniquename}.plist ${destroot}${prefix}/etc/LaunchDaemons
         }
     }
 
@@ -186,6 +191,15 @@ post-destroot {
     xinstall -o root -m 0644 ${worksrcpath}/renderd.conf.dist \
         ${destroot}${prefix}/etc/renderd/renderd.conf.dist
     xinstall -m 0755 -d ${destroot}${prefix}/etc/${name}
+    exec -ignorestderr sudo -u ${macportsuser} carto -qf ${workpath}/.tmp/mapnik.xml.dist ${prefix}/share/openstreetmap-carto/project.mml >& /dev/null
+    xinstall -o root -m 0644 ${workpath}/.tmp/mapnik.xml.dist \
+        ${destroot}${prefix}/etc/renderd/mapnik.xml.dist
+    if {[file exists ${prefix}/share/openstreetmap-carto/symbols]} {
+        ln -s ${prefix}/share/openstreetmap-carto/symbols ${destroot}${prefix}/etc/renderd/symbols
+    }
+    if {[file exists ${prefix}/share/openstreetmap-carto/patterns]} {
+        ln -s ${prefix}/share/openstreetmap-carto/patterns ${destroot}${prefix}/etc/renderd/patterns
+    }
     xinstall -o root -m 0644 ${worksrcpath}/osm-tiles-update.conf.dist \
         ${destroot}${prefix}/etc/${name}/osm-tiles-update.conf.dist
     xinstall -m 0755 -d \
@@ -197,6 +211,8 @@ post-destroot {
         ${destroot}${prefix}/share/${name}
     xinstall -o ${renderd_user} -m 0755 -d ${destroot}${prefix}/var/run/${name}
     xinstall -o ${renderd_user} -m 0755 -d ${destroot}${prefix}/var/lib/${name}
+    xinstall -o ${renderd_user} -m 0755 -d ${destroot}${prefix}/var/run/renderd
+    xinstall -o ${renderd_user} -m 0755 -d ${destroot}${prefix}/var/log/renderd
 
     if {[variant_isset logrotate]} {
         xinstall -m 0755 -d ${destroot}${prefix}/etc/logrotate.d
@@ -206,12 +222,20 @@ post-destroot {
         ${destroot}${prefix}/share/${name}/osm_setup_db.sh \
         ${destroot}${prefix}/share/${name}/openstreetmap-tiles-update-expire
 
+    reinplace "s|/lib/postgresql/bin|${pgsqlbinpath}|g" \
+        ${destroot}${prefix}/share/${name}/osm_setup_db.sh
+
     destroot.keepdirs \
         ${destroot}${prefix}/var/run/${name} \
-        ${destroot}${prefix}/var/lib/${name}
+        ${destroot}${prefix}/var/lib/${name} \
+        ${destroot}${prefix}/var/run/renderd \
+        ${destroot}${prefix}/var/log/renderd
 }
 
 post-activate {
+    if {![file exists ${prefix}/etc/renderd/mapnik.xml]} {
+        file copy ${prefix}/etc/renderd/mapnik.xml.dist ${prefix}/etc/renderd/mapnik.xml
+    }
     if {![file exists ${prefix}/etc/renderd/renderd.conf]} {
         file copy ${prefix}/etc/renderd/renderd.conf.dist ${prefix}/etc/renderd/renderd.conf
     }
@@ -229,7 +253,7 @@ post-activate {
 
 pre-deactivate {
     if {[variant_isset osmosis]} {
-        system "launchctl unload /Library/LaunchAgents/${agent_uniquename}.plist"
+        system "launchctl unload /Library/LaunchDaemons/${agent_uniquename}.plist"
     }
 }
 
@@ -248,6 +272,6 @@ And then relaunch Apache:
 if {[variant_isset osmosis]} {
     notes-append "To load ${agent_name}:
 
-    sudo launchctl load -w /Library/LaunchAgents/${agent_uniquename}.plist
+    sudo launchctl load -w /Library/LaunchDaemons/${agent_uniquename}.plist
 "
 }

--- a/gis/mod_tile/files/README_MacPorts.md
+++ b/gis/mod_tile/files/README_MacPorts.md
@@ -42,13 +42,18 @@ Optionally, you can download and apply incremental updates to the database by
 running an import script which can be scheduled with:
 
 	$ sudo launchctl load -w \
-	/Library/LaunchAgents/org.macports.fetch-osm-db-updates.plist
+	/Library/LaunchDaemons/org.macports.fetch-osm-db-updates.plist
 
 This script downloads an hourly snapshot, so it has to be run at least that
 frequently to keep up-to-date.  The default installation runs it more
 frequently to allow it to catch up, allowing for a little downtime.  Depending
 on your requirements, it may be better not to run this process at all and just
 refresh the entire region every few months or so.
+
+If the daemon is loaded you can use the following command to immediately
+initiate the process before the next scheduled session.
+
+	$ sudo launchctl kickstart -p system/org.macports.fetch-osm-db-updates
 
 The output of the various scripts and utilities are written to log files under
 `@PREFIX@/var/log/renderd`.  A configuration file for `logrotate` is
@@ -100,7 +105,7 @@ configuration files:
 
 - `@PREFIX@/etc/mod_tile/osm-tiles-update.conf`
 - `@PREFIX@/etc/openstreetmap-carto/external-data.yml`
-- `@PREFIX@/etc/openstreetmap-carto/mapnik.xml`
+- `@PREFIX@/etc/renderd/mapnik.xml`
 
 The `mapnik.xml` configuration file repeatedly defines the database name for
 every style.  It may be easier to re-create the entire configuration file from
@@ -113,7 +118,7 @@ its original source file as follows:
     source file:
 
 		$ sudo port install carto
-		$ carto project.mml | sudo tee @PREFIX@/etc/openstreetmap-carto/mapnik.xml
+		$ carto project.mml | sudo tee @PREFIX@/etc/renderd/mapnik.xml
 
 ## Useful Resources
 

--- a/gis/mod_tile/files/osm_setup_db.sh
+++ b/gis/mod_tile/files/osm_setup_db.sh
@@ -71,6 +71,7 @@ set +e
 #set -x
 
 PREFIX="${PREFIX:-/usr/local}"
+PGSQLBINPATH="${PREFIX}/lib/postgresql/bin"
 
 if [ -r $PREFIX/etc/mod_tile/osm-tiles-update.conf ]; then
     source $PREFIX/etc/mod_tile/osm-tiles-update.conf
@@ -101,9 +102,9 @@ fi
 
 initializeDatabase()
 {
-    sudo -u "$PG_SUPER_USER" "$PREFIX/bin/createuser" "$GIS_DB_USER" -DRS >/dev/null 2>&1
-    sudo -u "$PG_SUPER_USER" "$PREFIX/bin/createdb" "$GIS_DB" --owner="$GIS_DB_USER" --encoding=UTF8 >/dev/null 2>&1
-    cat <<EOF | sudo -u "$PG_SUPER_USER" psql "$GIS_DB" >/dev/null 2>&1
+    sudo -u "$PG_SUPER_USER" "$PGSQLBINPATH/createuser" "$GIS_DB_USER" -DRS >/dev/null 2>&1
+    sudo -u "$PG_SUPER_USER" "$PGSQLBINPATH/createdb" "$GIS_DB" --owner="$GIS_DB_USER" --encoding=UTF8 >/dev/null 2>&1
+    cat <<EOF | sudo -u "$PG_SUPER_USER" "$PGSQLBINPATH/psql" "$GIS_DB" >/dev/null 2>&1
 CREATE EXTENSION postgis;
 CREATE EXTENSION hstore;
 ALTER TABLE geometry_columns OWNER TO $GIS_DB_USER;
@@ -187,7 +188,7 @@ createDatabase()
 	    exit 1
 	fi
 	>&2 echo "Creating indexes... (This can also take a very long time)"
-	sudo -u "$GIS_USER" psql -d "$GIS_DB" -U "$GIS_DB_USER" \
+	sudo -u "$GIS_USER" "$PGSQLBINPATH/psql" -d "$GIS_DB" -U "$GIS_DB_USER" \
 	     -f "$PREFIX/share/openstreetmap-carto/indexes.sql" >/dev/null
 	if [ $? -ne 0 ]; then
 	    >&2 echo "Error creating indexes in PostgreSQL"
@@ -243,6 +244,7 @@ initializeIncrementalUpdates()
     fi
 }
 
+cd /tmp
 if [ -z "$SKIP_IMPORT" ]; then
     initializeDatabase
     readPbf

--- a/gis/mod_tile/files/renderd.conf.dist
+++ b/gis/mod_tile/files/renderd.conf.dist
@@ -12,7 +12,7 @@ font_dir_recurse=1
 [ajt]
 URI=/tile/
 TILEDIR=@PREFIX@/var/lib/mod_tile
-XML=@PREFIX@/etc/openstreetmap-carto/mapnik.xml
+XML=@PREFIX@/etc/renderd/mapnik.xml
 HOST=localhost
 TILESIZE=256
 MAXZOOM=20


### PR DESCRIPTION
Fixed launch daemon failing to start on macOS 14.4.1 (Sonoma)

Also now creates `mapnik.xml.dist` during the build/install so it longer needs to be distributed with the `openstreetmap-carto` port.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->

@nilason - available for your review and comments. 
