### PR TITLE
libtool: Remove stray $ after variable assignment

### DIFF
--- a/devel/libtool/Portfile
+++ b/devel/libtool/Portfile
@@ -5,7 +5,7 @@ PortGroup           clang_dependency 1.0
 
 name                libtool
 version             2.4.7
-revision            2
+revision            3
 categories          devel sysutils
 platforms           darwin freebsd
 # Scripts are GPL-2+, libltdl is LGPL-2+, but all parts that tend to be

--- a/devel/libtool/files/hardcode-m4.patch
+++ b/devel/libtool/files/hardcode-m4.patch
@@ -39,7 +39,7 @@ Index: configure
  LN_S=$lt_LN_S
  
 +# GNU M4.
-+M4=$lt_M4$
++M4=$lt_M4
 +
  # What is the maximum length of a command?
  max_cmd_len=$max_cmd_len


### PR DESCRIPTION
#### Description

libtool: Remove stray $ after variable assignment

Closes: https://trac.macports.org/ticket/69599

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 21H1123 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
