### PR TITLE
smake: update to 1.7-2024-03-21

### DIFF
--- a/devel/smake/Portfile
+++ b/devel/smake/Portfile
@@ -7,7 +7,7 @@ PortGroup               conflicts_build 1.0
 PortGroup               codeberg 1.0
 
 name                    smake
-codeberg.setup          schilytools schilytools 2023-09-28
+codeberg.setup          schilytools schilytools 2024-03-21
 version                 1.7-${codeberg.version}
 revision                0
 categories              devel
@@ -21,9 +21,9 @@ long_description        Smake is a highly portable make program with automake \
 
 homepage                https://codeberg.org/schilytools/schilytools
 master_sites            ${homepage}/archive/
-checksums               rmd160  c9d662b84c1a013cd68d38050020e112a9a0b2a7 \
-                        sha256  c813cc19a320f8d3b5d82f5b1ca6a93ab1bb5f4c50f86fdac58101fe472d2143 \
-                        size    5891733
+checksums               rmd160  e937719c3a68efac9f6aacfaaaed4cb1775805e5 \
+                        sha256  4d66bf35a5bc2927248fac82266b56514fde07c1acda66f25b9c42ccff560a02 \
+                        size    5892015
 
 post-extract {
     copy ${filespath}/Gmake.smake ${worksrcpath}


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
smake: update to 1.7-2024-03-21

* Update codeberg.setup to version 2024-03-21
* Update checksums

See:  https://trac.macports.org/ticket/69395

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
