### PR TITLE
star: update to 1.7.0-2024-03-21

### DIFF
--- a/archivers/star/Portfile
+++ b/archivers/star/Portfile
@@ -7,7 +7,7 @@ PortGroup               conflicts_build 1.0
 PortGroup               codeberg 1.0
 
 name                    star
-codeberg.setup          schilytools schilytools 2023-09-28
+codeberg.setup          schilytools schilytools 2024-03-21
 version                 1.7.0-${codeberg.version}
 revision                0
 categories              archivers
@@ -55,9 +55,9 @@ long_description        The ${name} port provides fully POSIX compliant implemen
                         \nOmitted from the port are the mt, smt and rmt binaries to control \
                         magnetic tape drives.
 
-checksums               rmd160  c9d662b84c1a013cd68d38050020e112a9a0b2a7 \
-                        sha256  c813cc19a320f8d3b5d82f5b1ca6a93ab1bb5f4c50f86fdac58101fe472d2143 \
-                        size    5891733
+checksums               rmd160  e937719c3a68efac9f6aacfaaaed4cb1775805e5 \
+                        sha256  4d66bf35a5bc2927248fac82266b56514fde07c1acda66f25b9c42ccff560a02 \
+                        size    5892015
 
 post-patch {
                         reinplace -locale C "s|gnutar|sgnutar|g" \
@@ -172,7 +172,8 @@ pre-build {
 }
 
 depends_build-append    port:smake \
-                        port:gettext
+                        port:gettext \
+                        port:bison
 
 depends_lib-append      port:gettext-runtime \
                         port:libiconv


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->
star: update to 1.7.0-2024-03-21

* Update codeberg.setup to version 2024-03-21
* Update checksums
* Add bison as a build dependency

See: https://trac.macports.org/ticket/69395

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [X] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
- [X] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
