### PR TITLE
luajit: needs thread-local storage and TARGET_OS_IPHONE macro fix

### DIFF
--- a/lang/luajit/Portfile
+++ b/lang/luajit/Portfile
@@ -32,6 +32,7 @@ github.tarball_from archive
 conflicts           luajit-openresty
 
 patchfiles          powerpc.patch
+patchfiles-append   TARGET_OS.patch
 
 post-patch {
     reinplace "s|/usr/local|${prefix}|" ${worksrcpath}/etc/luajit.pc \

--- a/lang/luajit/Portfile
+++ b/lang/luajit/Portfile
@@ -48,7 +48,11 @@ post-patch {
     close ${relver}
 }
 
-compiler.blacklist  {clang < 700} *gcc-4.2 macports-clang-3.3 macports-clang-3.4
+compiler.thread_local_storage yes
+
+# crashes at runtime with these compilers
+# https://trac.macports.org/ticket/45343
+compiler.blacklist  {clang < 700} macports-clang-3.3 macports-clang-3.4
 
 ## Fix universal builds, see:
 # - https://www.freelists.org/post/luajit/Building-universal-libraries-x86-64-and-arm64-for-osx,4

--- a/lang/luajit/files/TARGET_OS.patch
+++ b/lang/luajit/files/TARGET_OS.patch
@@ -1,0 +1,16 @@
+Fix:
+
+./lj_arch.h:127:5: error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
+
+https://github.com/LuaJIT/LuaJIT/pull/1189
+--- src/lj_arch.h.orig	2024-03-10 11:29:48.000000000 -0500
++++ src/lj_arch.h	2024-04-21 16:44:53.000000000 -0500
+@@ -124,7 +124,7 @@
+ #define LJ_TARGET_POSIX		(LUAJIT_OS > LUAJIT_OS_WINDOWS)
+ #define LJ_TARGET_DLOPEN	LJ_TARGET_POSIX
+ 
+-#if TARGET_OS_IPHONE
++#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+ #define LJ_TARGET_IOS		1
+ #else
+ #define LJ_TARGET_IOS		0


### PR DESCRIPTION
#### Description

Fix two build issues observed by @rmottola on Mac OS X 10.5:

* Indicate that thread-local storage is required so that old compilers are not used. Manual blacklisting for gcc-4.2 removed since MacPorts knows it doesn't support thread-local storage. Leave the other blacklisting explicit since there was a runtime crash associated with building with those compilers.
* Check if `TARGET_OS_IPHONE` is defined before checking its value, since old SDKs don't define it and new clangs consider it an error to check an undefined `TARGET_OS_` macro.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 21H1123 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
