### PR TITLE
abaddon: new port, GTK-based Discord client

### DIFF
--- a/net/abaddon/Portfile
+++ b/net/abaddon/Portfile
@@ -1,0 +1,147 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           conflicts_build 1.0
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+github.setup        uowuo abaddon 0.2.1 v
+revision            0
+categories          net www
+license             GPL-3
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+description         Alternative Discord client with voice support
+long_description    {*}${description} made with C++ and GTK3. \
+                    The app runs on all systems from PowerPC to aarch64.
+
+github.tarball_from archive
+
+set miniaudio_hash  3ba0595c6afffa37f9715c2db50efcb516febf4b
+
+master_sites-append https://github.com/mackron/miniaudio/archive/${miniaudio_hash}/:miniaudio
+distfiles-append    miniaudio-${miniaudio_hash}.tar.gz:miniaudio
+
+checksums           ${distname}${extract.suffix} \
+                    rmd160  ee93f18a4dabc0bd29ecd577238bf9a871e694a3 \
+                    sha256  407d14bc7659c65eca1c5266fb96a60b1e169b31c122159ae7f54e69a86e0b45 \
+                    size    14187672 \
+                    miniaudio-${miniaudio_hash}.tar.gz \
+                    rmd160  d72f7cac3679df69bd0c9892a0eb2b734e53796b \
+                    sha256  e25ada69d716af44945077b92c3c7c52d512374abe9cefd7416d0b49337ca620 \
+                    size    1473742
+
+extract.only        ${distname}${extract.suffix}
+
+post-extract {
+    set tar [findBinary tar ${portutil::autoconf::tar_command}]
+    system -W ${workpath} "${tar} -zxf ${distpath}/miniaudio-${miniaudio_hash}.tar.gz"
+    delete ${worksrcpath}/subprojects/miniaudio
+    move ${workpath}/miniaudio-${miniaudio_hash} ${worksrcpath}/subprojects/miniaudio
+}
+
+# https://github.com/uowuo/abaddon/pull/291
+patchfiles-append   0001-Do-not-use-precomp-headers-target-with-GCC-on-Apple.patch
+patchfiles-append   0002-platform.cpp-add-missing-unistd.h.patch
+patchfiles-append   0003-CMakeLists-also-link-to-AudioUnit-on-Apple.patch
+# https://github.com/uowuo/abaddon/pull/292
+patchfiles-append   0004-platform.cpp-add-a-missing-spdlog-include.patch
+
+# https://github.com/mackron/miniaudio/pull/840
+patchfiles-append   0005-miniaudio.h-fix-for-macOS.patch
+
+post-patch {
+    reinplace "s|@PREFIX@|${prefix}|" \
+                    ${worksrcpath}/src/platform.cpp \
+                    ${worksrcpath}/CMakeLists.txt
+}
+
+# Linking to libunwind leads to random crashes,
+# at least on Sonoma. And older macOS do not need it anyway.
+conflicts_build     libunwind
+
+set abaddon_root    ${prefix}/share/${name}
+
+# Default libfmt version, customize when adding subports
+set libfmt_ver      10
+cmake.module_path-append \
+                    ${prefix}/lib/libfmt${libfmt_ver}/cmake
+
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:curl \
+                    port:libfmt${libfmt_ver} \
+                    port:fontconfig \
+                    path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                    port:gtkmm3 \
+                    port:ixwebsocket \
+                    port:libhandy \
+                    port:libopus \
+                    port:libsodium \
+                    port:nlohmann-json \
+                    port:rnnoise \
+                    port:spdlog \
+                    port:sqlite3 \
+                    port:zlib
+
+compiler.cxx_standard   2017
+
+configure.args-append \
+                    -DENABLE_NOTIFICATION_SOUNDS=ON \
+                    -DENABLE_QRCODE_LOGIN=OFF \
+                    -DENABLE_RNNOISE=ON \
+                    -DENABLE_VOICE=ON \
+                    -DUSE_KEYCHAIN=OFF \
+                    -DUSE_LIBHANDY=ON
+
+if {[string match *gcc* ${configure.compiler}]} {
+    # miniaudio.h: error: invalid conversion from 'UInt32*' {aka 'long unsigned int*'}
+    # to 'ma_uint32*' {aka 'unsigned int*'} [-fpermissive]
+    # https://github.com/mackron/miniaudio/issues/841
+    configure.cxxflags-append \
+                    -fpermissive
+}
+
+# Install target is broken: https://github.com/uowuo/abaddon/issues/290
+# We need to do it manually.
+destroot {
+    xinstall -d ${destroot}${abaddon_root}
+    copy ${cmake.build_dir}/${name} ${destroot}${abaddon_root}
+
+    foreach res {css res} {
+        copy ${worksrcpath}/res/${res} ${destroot}${abaddon_root}
+    }
+
+    # https://github.com/uowuo/abaddon/issues/293
+    set abexec      ${prefix}/bin/${name}
+
+    if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libc++"} {
+        set  wrapper    [open "${destroot}${abexec}" w 0755]
+        puts ${wrapper} "#!/bin/bash"
+        puts ${wrapper} ""
+        puts ${wrapper} {if [ -n "$DYLD_LIBRARY_PATH" ]; then}
+        puts ${wrapper} "   DYLD_LIBRARY_PATH=${prefix}/lib/libgcc:\${DYLD_LIBRARY_PATH}"
+        puts ${wrapper} {else}
+        puts ${wrapper} "   DYLD_LIBRARY_PATH=${prefix}/lib/libgcc"
+        puts ${wrapper} {fi}
+        puts ${wrapper} {export DYLD_LIBRARY_PATH}
+        puts ${wrapper} ""
+        puts ${wrapper} "cd $abaddon_root"
+        puts ${wrapper} "exec \./$name \"\$@\""
+        close $wrapper
+    } else {
+        set  wrapper    [open "${destroot}${abexec}" w 0755]
+        puts ${wrapper} "#!/bin/bash"
+        puts ${wrapper} ""
+        puts ${wrapper} "cd $abaddon_root"
+        puts ${wrapper} "exec \./$name \"\$@\""
+        close $wrapper
+    }
+}
+
+notes "
+You will need your Discord token in order to log in.
+Upstream refers to the following thread:
+https://github.com/Tyrrrz/DiscordChatExporter/issues/76
+Make sure to keep your token safe.
+"

--- a/net/abaddon/files/0001-Do-not-use-precomp-headers-target-with-GCC-on-Apple.patch
+++ b/net/abaddon/files/0001-Do-not-use-precomp-headers-target-with-GCC-on-Apple.patch
@@ -1,0 +1,24 @@
+From 37341e9dbd382d51f00c1a3bdb3cd494cbdc04ce Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sat, 20 Apr 2024 02:15:10 +0800
+Subject: [PATCH] Do not use precomp headers target with GCC on Apple
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git CMakeLists.txt CMakeLists.txt
+index 236dbd2..a118b10 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -66,7 +66,9 @@ if (ENABLE_QRCODE_LOGIN)
+     target_compile_definitions(abaddon PRIVATE WITH_QRLOGIN)
+ endif ()
+ 
+-target_precompile_headers(abaddon PRIVATE <gtkmm.h> src/abaddon.hpp src/util.hpp)
++if (NOT (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
++    target_precompile_headers(abaddon PRIVATE <gtkmm.h> src/abaddon.hpp src/util.hpp)
++endif()
+ 
+ if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR
+ (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND

--- a/net/abaddon/files/0002-platform.cpp-add-missing-unistd.h.patch
+++ b/net/abaddon/files/0002-platform.cpp-add-missing-unistd.h.patch
@@ -1,0 +1,21 @@
+From 55bb31b12088acf947a9056eaf7713829100ec53 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sat, 20 Apr 2024 03:39:13 +0800
+Subject: [PATCH] platform.cpp: add missing <unistd.h>
+
+---
+ src/platform.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git src/platform.cpp src/platform.cpp
+index 0a69721..01dbab2 100644
+--- src/platform.cpp
++++ src/platform.cpp
+@@ -3,6 +3,7 @@
+ #include <filesystem>
+ #include <fstream>
+ #include <string>
++#include <unistd.h>
+ 
+ using namespace std::literals::string_literals;
+ 

--- a/net/abaddon/files/0003-CMakeLists-also-link-to-AudioUnit-on-Apple.patch
+++ b/net/abaddon/files/0003-CMakeLists-also-link-to-AudioUnit-on-Apple.patch
@@ -1,0 +1,21 @@
+From 08a50ea27c713fc96d5f6f7a91915f1a5ae9d88c Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sat, 20 Apr 2024 04:12:48 +0800
+Subject: [PATCH] CMakeLists: also link to AudioUnit on Apple
+
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git CMakeLists.txt CMakeLists.txt
+index a118b10..99cc9ef 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -148,6 +148,7 @@ if (APPLE)
+     target_link_libraries(abaddon "-framework CoreFoundation")
+     target_link_libraries(abaddon "-framework CoreAudio")
+     target_link_libraries(abaddon "-framework AudioToolbox")
++    target_link_libraries(abaddon "-framework AudioUnit")
+ endif ()
+ 
+ if (ENABLE_VOICE)

--- a/net/abaddon/files/0004-platform.cpp-add-a-missing-spdlog-include.patch
+++ b/net/abaddon/files/0004-platform.cpp-add-a-missing-spdlog-include.patch
@@ -1,0 +1,22 @@
+From 7ed65a89ae71c3c5d2ba99797bd2b1d93ce172ca Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sat, 20 Apr 2024 04:16:57 +0800
+Subject: [PATCH] platform.cpp: add a missing spdlog include
+
+---
+ src/platform.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git src/platform.cpp src/platform.cpp
+index 0a69721..a26822d 100644
+--- src/platform.cpp
++++ src/platform.cpp
+@@ -4,6 +4,8 @@
+ #include <fstream>
+ #include <string>
+ 
++#include <spdlog/spdlog.h>
++
+ using namespace std::literals::string_literals;
+ 
+ #if defined(_WIN32)

--- a/net/abaddon/files/0005-miniaudio.h-fix-for-macOS.patch
+++ b/net/abaddon/files/0005-miniaudio.h-fix-for-macOS.patch
@@ -1,0 +1,60 @@
+From f0914664a174ddf10fea909fc532c91f718fa594 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sat, 20 Apr 2024 02:55:56 +0800
+Subject: [PATCH] miniaudio.h: fix for macOS
+
+---
+ miniaudio.h | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git miniaudio.h miniaudio.h
+index 1be3ec8..2ab67ce 100644
+--- subprojects/miniaudio/miniaudio.h
++++ subprojects/miniaudio/miniaudio.h
+@@ -3749,8 +3749,7 @@ extern "C" {
+ #endif
+ 
+ 
+-
+-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(_M_ARM64) || defined(__powerpc64__)
++#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || defined(_M_IA64) || defined(__aarch64__) || defined(_M_ARM64) || defined(__powerpc64__) || defined(__ppc64__)
+     #define MA_SIZEOF_PTR   8
+ #else
+     #define MA_SIZEOF_PTR   4
+@@ -17977,9 +17976,13 @@ DEVICE I/O
+     #endif
+ #endif
+ 
++#ifdef MA_APPLE
++    #include <AvailabilityMacros.h>
++#endif
++
+ #ifndef MA_NO_DEVICE_IO
+ 
+-#if defined(MA_APPLE) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 101200)
++#if defined(MA_APPLE) && (MAC_OS_X_VERSION_MIN_REQUIRED < 101200)
+     #include <mach/mach_time.h> /* For mach_absolute_time() */
+ #endif
+ 
+@@ -18545,7 +18548,7 @@ Timing
+ 
+         return (double)(counter.QuadPart - pTimer->counter) / g_ma_TimerFrequency.QuadPart;
+     }
+-#elif defined(MA_APPLE) && (__MAC_OS_X_VERSION_MIN_REQUIRED < 101200)
++#elif defined(MA_APPLE) && (MAC_OS_X_VERSION_MIN_REQUIRED < 101200)
+     static ma_uint64 g_ma_TimerFrequency = 0;
+     static void ma_timer_init(ma_timer* pTimer)
+     {
+@@ -32308,6 +32311,12 @@ static ma_result ma_get_channel_map_from_AudioChannelLayout(AudioChannelLayout*
+ #define AUDIO_OBJECT_PROPERTY_ELEMENT kAudioObjectPropertyElementMaster
+ #endif
+ 
++/* kAudioDevicePropertyScope* were renamed to kAudioObjectPropertyScope* in 10.8. */
++#if !defined(MAC_OS_X_VERSION_10_8) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_8)
++#define kAudioObjectPropertyScopeInput kAudioDevicePropertyScopeInput
++#define kAudioObjectPropertyScopeOutput kAudioDevicePropertyScopeOutput
++#endif
++
+ static ma_result ma_get_device_object_ids__coreaudio(ma_context* pContext, UInt32* pDeviceCount, AudioObjectID** ppDeviceObjectIDs) /* NOTE: Free the returned buffer with ma_free(). */
+ {
+     AudioObjectPropertyAddress propAddressDevices;


### PR DESCRIPTION
#### Description

New port, a Discord client on GTK3.

Works on PowerPC :) 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

macOS 14.4.1
Xcode 15.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
