### PR TITLE
ixwebsocket: fix for < 10.6

### DIFF
--- a/net/ixwebsocket/Portfile
+++ b/net/ixwebsocket/Portfile
@@ -20,6 +20,8 @@ github.tarball_from archive
 
 # https://github.com/machinezone/IXWebSocket/pull/512
 patchfiles-append   0001-IXSocket.h-add-missing-sys-types.h-for-macOS.patch
+# https://github.com/machinezone/IXWebSocket/pull/515
+patchfiles-append   0002-fix-older-systems.patch
 
 depends_build-append \
                     port:pkgconfig

--- a/net/ixwebsocket/files/0002-fix-older-systems.patch
+++ b/net/ixwebsocket/files/0002-fix-older-systems.patch
@@ -1,0 +1,60 @@
+From e9366b030c5a7151e5364463b212c7e41f0f666e Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 22 Apr 2024 16:48:50 +0800
+Subject: [PATCH] Fix for missing AI_NUMERICSERV on < 10.6
+
+---
+ ixwebsocket/IXDNSLookup.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git ixwebsocket/IXDNSLookup.cpp ixwebsocket/IXDNSLookup.cpp
+index 5966be23..cc39a383 100644
+--- ixwebsocket/IXDNSLookup.cpp
++++ ixwebsocket/IXDNSLookup.cpp
+@@ -35,6 +35,12 @@
+ #endif
+ #endif
+ 
++#ifdef __APPLE__
++#ifndef AI_NUMERICSERV
++#define AI_NUMERICSERV 0
++#endif
++#endif
++
+ namespace ix
+ {
+     const int64_t DNSLookup::kDefaultWait = 1; // ms
+
+From f315e1f91321cc436d48a0a86886d2b16403e77b Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Mon, 22 Apr 2024 16:52:09 +0800
+Subject: [PATCH] Do not use pthread_setname_np on < 10.6
+
+---
+ ixwebsocket/IXSetThreadName.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git ixwebsocket/IXSetThreadName.cpp ixwebsocket/IXSetThreadName.cpp
+index b1e77379..2f4ee75b 100644
+--- ixwebsocket/IXSetThreadName.cpp
++++ ixwebsocket/IXSetThreadName.cpp
+@@ -15,6 +15,10 @@
+ #include <pthread_np.h>
+ #endif
+ 
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++
+ // Windows
+ #ifdef _WIN32
+ #include <windows.h>
+@@ -58,7 +62,7 @@ namespace ix
+ 
+     void setThreadName(const std::string& name)
+     {
+-#if defined(__APPLE__)
++#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1060)
+         //
+         // Apple reserves 16 bytes for its thread names
+         // Notice that the Apple version of pthread_setname_np


### PR DESCRIPTION
#### Description

Fix for < 10.6

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
