### PR TITLE
gpgme: temporarily disable c++ part on Tiger to unbreak the port

### DIFF
--- a/devel/gpgme/Portfile
+++ b/devel/gpgme/Portfile
@@ -65,7 +65,8 @@ lappend languages cl
 # This has to be enabled, otherwise CMake config files are not installed,
 # which breaks some dependents, like Poppler.
 # Contrary to the earlier situation, it does build now against libstdc++.
-platform darwin {
+# FIXME: on 10.4 it does not build: https://trac.macports.org/ticket/69279
+if {${os.platform} eq "darwin" && ${os.major} > 8} {
     lappend languages cpp
 }
 


### PR DESCRIPTION
See: https://trac.macports.org/ticket/69279

#### Description

This is not a proper fix, so the ticket should not be closed.
This merely reverts enabling of C++ part for Tiger, since otherwise `gpgme` is just broken there.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.4.11
Xcode 2.5

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
