### PR TITLE
openjdk22-temurin: update to 22.0.1

### DIFF
--- a/java/openjdk22-temurin/Portfile
+++ b/java/openjdk22-temurin/Portfile
@@ -15,8 +15,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}
-set build    36
+version      ${feature}.0.1
+set build    8
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature}
@@ -27,14 +27,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  b9b563b6e3696fb688e1669f4a984f842f858009 \
-                 sha256  f67a17def29c19fb5a1be33dc5a25aeaa80dd92999c8bfdd0e9458058b585f90 \
-                 size    192678886
+    checksums    rmd160  64a21ef7bf13e885923492fc54387c53ee8d0ea7 \
+                 sha256  9445952d4487451af024a9a3f56373df76fbd928d9ff9186988aa27be2e4f10c \
+                 size    192732365
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  e18e69a6a8171c5bab7d8a7ba1f432ad8a2623ce \
-                 sha256  40662ca5c0626c1fed23c2f1c658c9ceaf5b644e365f7df5c572b7e72421a4a4 \
-                 size    190161232
+    checksums    rmd160  d9180cd45f1f7b9f07f6d603ea05c8c86c4a63e3 \
+                 sha256  80d6fa75e87280202ae7660139870fe50f07fca9dc6c4fbd3f2837cbd70ec902 \
+                 size    190213165
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to Eclipse Temurin 22.0.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?