### PR TITLE
castxml: add missing deps

### DIFF
--- a/lang/castxml/Portfile
+++ b/lang/castxml/Portfile
@@ -9,7 +9,7 @@ github.setup        CastXML CastXML 0.6.5 v
 
 name                castxml
 epoch               20190718
-revision            0
+revision            1
 categories          lang
 platforms           darwin
 license             Apache-2
@@ -30,10 +30,13 @@ compiler.blacklist-append \
 compiler.cxx_standard \
                     2017
 
-depends_lib-append  port:zlib \
-                    port:libffi \
+depends_lib-append \
                     port:libedit \
-                    port:ncurses
+                    port:libffi \
+                    port:libxml2 \
+                    port:ncurses \
+                    port:zlib \
+                    port:zstd
 
 configure.args-append \
                     -DCastXML_INSTALL_DOC_DIR=share/doc/castxml


### PR DESCRIPTION
### Description

- Add missing deps, per the configure output

Fixes: https://trac.macports.org/ticket/69802