### PR TITLE
skopeo: update to 1.15

### DIFF
--- a/sysutils/skopeo/Portfile
+++ b/sysutils/skopeo/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/containers/skopeo 1.12.0 v
+go.setup            github.com/containers/skopeo 1.15.0 v
 github.tarball_from archive
 revision            1
 
@@ -20,9 +20,9 @@ license             Apache-2
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
-checksums           rmd160  dc1c05e5f1e18f3f05e71b56db831ac3589d031e \
-                    sha256  f7bbb3748eeb0c29abf5bfe9b1c1a149464c4ea65705e25686df3b9bcbd7bb89 \
-                    size    8216468
+checksums           rmd160  8a80ae68a23c545ecefd58785dba606cda1c1e92 \
+                    sha256  f219d31e5f3742b08a6e7327d84fd84cdcf8e5a297914bb6e19a96fef1b19b76 \
+                    size    10710505
 
 depends_build-append \
                     port:go-md2man


### PR DESCRIPTION
#### Description

Updated to the latest version: https://github.com/containers/skopeo/releases

###### Tested on
macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?