### PR TITLE
libxmlb: update to 0.3.19

### DIFF
--- a/devel/libxmlb/Portfile
+++ b/devel/libxmlb/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 PortGroup           meson 1.0
 
@@ -29,7 +30,7 @@ depends_lib-append  path:lib/pkgconfig/glib-2.0.pc:glib2 \
 
 # cc1: error: unrecognized command line option "-fstack-protector-strong"
 compiler.blacklist-append \
-                    *gcc-4.0 *gcc-4.2
+                    *gcc-4.0 *gcc-4.2 {clang < 700}
 
 configure.args-append \
                     -Dcli=true \

--- a/devel/libxmlb/Portfile
+++ b/devel/libxmlb/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           meson 1.0
 
-github.setup        hughsie libxmlb 0.3.18
+github.setup        hughsie libxmlb 0.3.19
 revision            0
 
 categories          devel
@@ -14,9 +14,9 @@ maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 description         Library to help create and query binary XML blobs
 long_description    {*}${description}
 
-checksums           rmd160  466fd37764ea6ad076fae7cbfd2cf24b5283921e \
-                    sha256  3798be088653a939b8516900eb5bd9491eda8975c5b9886434c670fa79cc56aa \
-                    size    131331
+checksums           rmd160  5fb2b3c051516a8011f9515cd9ecb802050db443 \
+                    sha256  7050a3e43c4e1f53020cfbdfcb6fd5dc664c6c240faceb5ae3c8830423918262 \
+                    size    131490
 github.tarball_from archive
 
 depends_build-append \


### PR DESCRIPTION
#### Description

Update, fix for older systems using clangs.
They also cannot take a problematic flag: https://build.macports.org/builders/ports-10.9_x86_64-builder/builds/271597/steps/install-port/logs/stdio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
