### PR TITLE
new port: pkcs11-provider, an OpenSSL 3 PKCS#11 provider

### DIFF
--- a/security/pkcs11-provider/Portfile
+++ b/security/pkcs11-provider/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+PortGroup           github 1.0
+PortGroup           meson 1.0
+
+github.setup        latchset pkcs11-provider c822c110760b53d701558a347eae2803891a1c7b
+version             0.3-54-gc822c11
+checksums           rmd160  6b750f4dc60305f2b37908d684c47106196d5e55 \
+                    sha256  454cccbbb6ee6fc0e220662c6241b8e2a2965b417b6bbde7fbbda61414b7562d \
+                    size    179352
+
+maintainers         {cal @neverpanic} openmaintainer
+
+categories          security crypto
+license             Apache-2.0
+description         A pkcs#11 provider for OpenSSL 3.0+
+long_description    \
+    An OpenSSL 3 provider to access Hardware or Software Tokens using the \
+    PKCS#11 Cryptographic Token Interface
+
+platforms           darwin
+
+patchfiles          0001-build-Install-provider-in-correct-path.patch
+
+# NSS, softhsm, p11-kit, gnutls, and opensc are used for testing, but detection happens at build time
+depends_build       port:gnutls \
+                    port:nss \
+                    port:opensc \
+                    port:p11-kit \
+                    port:pkgconfig \
+                    port:softhsm
+
+depends_lib         port:openssl3
+
+test.run            yes

--- a/security/pkcs11-provider/files/0001-build-Install-provider-in-correct-path.patch
+++ b/security/pkcs11-provider/files/0001-build-Install-provider-in-correct-path.patch
@@ -1,0 +1,34 @@
+From bf797c5ea8f4deff0bf067fba2c7dd2e6481aee9 Mon Sep 17 00:00:00 2001
+From: Clemens Lang <cllang@redhat.com>
+Date: Tue, 23 Apr 2024 10:36:33 +0200
+Subject: [PATCH] build: Install provider in correct path
+
+OpenSSL's libcrypto.pc file does expose the correct path for providers
+in the modulesdir pkg-config variable (queryable using pkg-config
+--variable=modulesdir libcrypto), and we do obtain that path in
+./meson.build.
+
+However, that variable is unused at the moment, and instead
+src/meson.build "guesses" that path as $libdir/ossl-modules, which may
+not actually be correct.
+
+Signed-off-by: Clemens Lang <cllang@redhat.com>
+Upstream-Status: Submitted [https://github.com/latchset/pkcs11-provider/pull/380]
+---
+ src/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/meson.build b/src/meson.build
+index 631d474..11aacc8 100644
+--- ./src/meson.build
++++ ./src/meson.build
+@@ -34,5 +34,5 @@ pkcs11_provider = shared_module(
+   link_depends: [pkcs11_provider_map],
+   link_args: pkcs11_provider_ldflags,
+   install: true,
+-  install_dir: get_option('libdir') / 'ossl-modules',
++  install_dir: provider_path,
+ )
+-- 
+2.44.0
+


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.6 22G630 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
