### PR TITLE
mousepad: Update to 0.6.2

### DIFF
--- a/xfce/mousepad/Portfile
+++ b/xfce/mousepad/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                mousepad
-version             0.4.1
+version             0.6.2
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          xfce
 platforms           darwin
@@ -14,23 +14,23 @@ description         A text editor for Xfce based on Leafpad
 long_description    ${description}
 
 homepage            https://www.xfce.org
-master_sites        http://archive.xfce.org/src/apps/${name}/${branch}/
+master_sites        https://archive.xfce.org/src/apps/${name}/${branch}/
 use_bzip2           yes
 
-checksums           sha256  39a7379b929d964665299c385b2cf705e32e8760698ccc34f91c990bb733518b \
-                    rmd160  07b8d2295a23180d5c3ae8d3b1d8099ce7e36f34 \
-                    size    644161
+checksums           sha256  e7cacb3b8cb1cd689e6341484691069e73032810ca51fc747536fc36eb18d19d \
+                    rmd160  186289b9c197e25b812cea87f354f78dc3608ecb \
+                    size    1402314
 
 depends_build       port:desktop-file-utils \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:intltool \
                     port:pkgconfig
-depends_lib         path:lib/pkgconfig/gtk+-2.0.pc:gtk2 \
-                    port:gtksourceview2 \
+depends_lib         path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                    port:gtksourceview4 \
                     port:libxfce4ui \
                     port:libxfce4util
 
-configure.args      --enable-dbus --disable-gtk3
+configure.args      --enable-dbus
 
 post-activate {
     system "${prefix}/bin/update-desktop-database ${prefix}/share/applications"


### PR DESCRIPTION
#### Description

Updates Mousepad to 0.6.2, enabling GTK3 in the process.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
