### PR TITLE
qgis3, qgis-ltr: update to 3.36.2 and 3.34.6

### DIFF
--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -221,7 +221,7 @@ variant grass conflicts grass7 description "Build GRASS (latest) plugin" {
 }
 
 # PostgreSQL variants
-set pg_suffixes {15 14 13 12}
+set pg_suffixes {16 15 14 13 12}
 set pg_variants {}
 foreach suffix ${pg_suffixes} {
     lappend pg_variants postgresql${suffix}
@@ -235,7 +235,7 @@ foreach suffix ${pg_suffixes} {
         depends_lib-append      port:${vrt}
         configure.args-append   -DPostgreSQL_ROOT=${prefix}/lib/${vrt} \
                                 -DPostgreSQL_INCLUDE_DIR=${prefix}/include/${vrt}
-        configure.env-append    PostgreSQL_ADDITIONAL_VERSIONS=15
+        configure.env-append    PostgreSQL_ADDITIONAL_VERSIONS=15,16
     "
 }
 set pgdefault "if {"
@@ -243,7 +243,7 @@ foreach suffix ${pg_suffixes} {
     set pgdefault "${pgdefault}!\[variant_isset postgresql${suffix}\] && "
 }
 set pgdefault [string range ${pgdefault} 0 end-4]
-set pgdefault "${pgdefault}} { default_variants +postgresql15 }"
+set pgdefault "${pgdefault}} { default_variants +postgresql16 }"
 eval ${pgdefault}
 
 # PROJ variants

--- a/gis/qgis3/Portfile
+++ b/gis/qgis3/Portfile
@@ -25,25 +25,25 @@ subport ${name-ltr} {}
 
 if {${subport} eq ${name}} {
     # Latest version
-    github.setup    qgis QGIS 3_36_1 final-
-    revision        1
+    github.setup    qgis QGIS 3_36_2 final-
+    revision        0
     set app_name    QGIS3
 
-    checksums       rmd160  778513d1f9257e13328091b4a9f6dd1bf353727d \
-                    sha256  d69a199e524473b50343151ef53eb8c8ae525e765c96be61cb58a2b0840bc441 \
-                    size    199220288
+    checksums       rmd160  ad6cb1f69c37b9e3a73b1dad783a48007c26c1fd \
+                    sha256  d635322dbb84863b3aef781131cdbe5c68a83d604d63945f4133a1b8a81f0df9 \
+                    size    199334453
 
     set grass_utils_file grass_utils.py
 } else {
     # LTR version
-    github.setup    qgis QGIS 3_34_5 final-
-    revision        1
+    github.setup    qgis QGIS 3_34_6 final-
+    revision        0
     set app_name    QGIS3-LTR
     description     {*}${description} (LTR)
 
-    checksums       rmd160  161961469e10f3aaf55fceaf2aec82e8874d4fdc \
-                    sha256  563cf17fdd8db1995f0bba4750668bf8ac9104819651152febe7a9f28ab3a4e5 \
-                    size    196445110
+    checksums       rmd160  9d0148299a49a7cebec344761e1b4ba2c63f4ac2 \
+                    sha256  37c40bf35cd629cc5e3f8d4b38801bf7955d132b97e279044c5e227409f731d4 \
+                    size    196547397
 
     set grass_utils_file Grass7Utils.py
 }


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- Update `qgis3` to 3.36.2 and  `qgis-ltr` to 3.34.6.
- Add `postgresql16` variant.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
