### PR TITLE
ruby-build: Upgrade to 20240423

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20240416 v
+github.setup        rbenv ruby-build 20240423 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  a8c6e4f4ed55a36d7902b85d5d606eaa4f5e3fc0 \
-                    sha256  aace976e204b37c52d30c7896d3906318b32f4db795ea380bada668621b59abb \
-                    size    89325
+checksums           rmd160  d72aff0b93394b19de30d1b5f25aed17115a0fc8 \
+                    sha256  f482cf3f2dfcff5f12c14756cf8b09dc9467885e70a834d99c0ace7353617d36 \
+                    size    89592
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Upgrade to 20240423

##### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
