### PR TITLE
micronaut: update to 4.4.1

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,7 +3,7 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.4.0 v
+github.setup    micronaut-projects micronaut-starter 4.4.1 v
 revision        0
 name            micronaut
 categories      java
@@ -56,9 +56,9 @@ homepage        https://micronaut.io
 github.tarball_from releases
 distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  7d5ca979c4807cfe6db3291b963dc734e6873c8a \
-                sha256  a1b6c5cddce79632deeb6b1e40b8e1ad266914842f371c84c3d2c1762b5fab65 \
-                size    23656837
+checksums       rmd160  01293f2785cc2b3f9643b59feab3cf664961b91d \
+                sha256  a5b38ac0b63847331462dca9d5821d607ab56f28ad163e20c3237b22d49ee950 \
+                size    23656783
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.4.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?