### PR TITLE
checkssl: update to 0.5.1

### DIFF
--- a/sysutils/checkssl/Portfile
+++ b/sysutils/checkssl/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/szazeski/checkssl 0.5.0 v
+go.setup            github.com/szazeski/checkssl 0.5.1 v
 revision            0
 
 homepage            https://www.checkssl.org
@@ -19,9 +19,9 @@ installs_libs       no
 maintainers         {breun.nl:nils @breun} \
                     openmaintainer
 
-checksums           rmd160  1dd2cbecb36c1960536c37d76df42bef92cf6248 \
-                    sha256  91b0fe338f0d6fcc6ce7f6f4f16f2ccf2673a1a4b6496c9540ba3c7ea5100ac5 \
-                    size    12271
+checksums           rmd160  bec45146c382baafeb41426c6c95e39c1f92fe2a \
+                    sha256  9dc89404b70cb9dd26702daafee0f8214ab036f595fde794db41f767d8ee0237 \
+                    size    13049
 
 destroot {
     set doc_dir ${destroot}${prefix}/share/doc/${name}


### PR DESCRIPTION
#### Description

Update to checkssl 0.5.1.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?