### PR TITLE
google-cloud-sdk: update to 473.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             472.0.0
+version             473.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  d028a9ed5a5585c069c24c7b17cc06cef3a339a9 \
-                    sha256  528f89827c883415ef56dbe8b7e2fd3358870c9d1ad7c6f6501ba49abef60df7 \
-                    size    123519701
+    checksums       rmd160  824613b423673030a5a78f62d7f50741e48c3fa8 \
+                    sha256  328cd238e62bcf326247bf67b6915c3bd4faf8801489cb42fbbd1385297f36a2 \
+                    size    123609947
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  c349cce8266d82d3c2aa2e1f0f3bc5fe6018e996 \
-                    sha256  fbd1fa576a950d99fe79feced0d0f34812e573ca20e74f7bd97b7043a79d2127 \
-                    size    124803753
+    checksums       rmd160  65d16b15ed5f237b990eb3df70d8f346ccda4a02 \
+                    sha256  ac5e3d16f53a03cf1aba6587d65f77a4565c044ab18c7783ad42cc7da1949b3d \
+                    size    124894569
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  97e9052a80ba5010c7622c0b7b66ea6618ea0cb2 \
-                    sha256  6b0b04ebcf66a77c9db933eb5abe679b42cdb81447b103e7c21572153bb8b0f7 \
-                    size    121869208
+    checksums       rmd160  614478c24477daf8b35c942fd9ff3b4574020e99 \
+                    sha256  3b26e9682379f8b5e875f5982411fb7f4f635f5155a9fe6284f62dedffd5840b \
+                    size    121956770
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 473.0.0.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?