### PR TITLE
legacy-support: update to v1.2.3

### DIFF
--- a/devel/legacy-support/Portfile
+++ b/devel/legacy-support/Portfile
@@ -22,7 +22,7 @@ long_description    {*}${description}
 epoch               1
 
 # Primary release version
-set release_ver     1.2.2
+set release_ver     1.2.3
 
 # Binary compatibility version
 set compat_ver      1.0.0
@@ -31,9 +31,9 @@ subport ${name} {
     conflicts           ${name}-devel
     github.setup        macports macports-legacy-support ${release_ver} v
     revision            0
-    checksums           rmd160  86aa4edf8de2fd011549fe4868a5d51bb6ce9d6d \
-                        sha256  3fd9e012755359db44f3173d2c3eddae0021a778993661e345596d56e2085bb7 \
-                        size    74875
+    checksums           rmd160  53baafdf912c86e756a94b5e6059690c2c84ff62 \
+                        sha256  e7fdcd48727eeb733527ff7e059406c3ea7f8abbcc5e754bf3fc344ede696c23 \
+                        size    75998
 }
 
 subport ${name}-devel {
@@ -67,13 +67,9 @@ post-extract {
     delete ${worksrcpath}/src/macports_legacy_atexit.c
 }
 
-set max_darwin_reexport 19
-set max_darwin_optool   20
-
 build.env-append    LD=ld \
                     "LIPO=/usr/bin/lipo" \
                     PLATFORM=${os.major} \
-                    MAX_DARWIN_REEXPORT=${max_darwin_reexport} \
                     SOCURVERSION=${release_ver} \
                     SOCOMPATVERSION=${compat_ver}
 
@@ -107,46 +103,6 @@ proc tiger_copy {from to} {
         } else {
             ui_debug "Copying ${f} to ${to}"
             copy ${f} ${to}
-        }
-    }
-}
-
-# The legacy-support build cannot create the LegacySupportSystem library
-# directly on newer systems as the reexport link option to
-# /usr/lib/libSystem.B.dylib does not work, due to the file system
-# library cache added in macOS11.
-#
-# Fall back to using optool here. Optool does not currently work on arm64.
-# This means that LegacySupportSystem will be missing on arm64, and that
-# universal builds of LegacySupportSystem will lack the arm64 slice
-# (which will produce a warning).
-
-if { ${os.major} > ${max_darwin_reexport}
-     && ${os.major} <= ${max_darwin_optool}
-     && ${subport} ne "${name}-devel" } {
-     # First determine whether any non-arm64 slice will be built
-    set optool_needed no
-    foreach arch ${muniversal.architectures} {
-        if { ${arch} ne "arm64"} {
-            set optool_needed yes
-        }
-    }
-    # If any non-arm64, add optool dependency
-    if { ${optool_needed} } {
-        depends_build-append port:optool
-        depends_skip_archcheck-append optool
-    }
-    # After destroot, apply optool to any non-arm64 slice
-    post-destroot {
-        if { ${muniversal.build_arch} ne "arm64" } {
-            set legSupp   ${prefix}/lib/libMacportsLegacySupport.dylib
-            set legSystem ${prefix}/lib/libMacportsLegacySystem.B.dylib
-            if {![file exists ${destroot}${legSystem}]} {
-                copy ${destroot}${legSupp} ${destroot}${legSystem}
-                system "${prefix}/bin/optool install -c reexport -p /usr/lib/libSystem.B.dylib -t ${destroot}${legSystem}"
-            } else {
-                ui_warn "${destroot}${legSystem} already exists."
-            }
         }
     }
 }


### PR DESCRIPTION
Adds support for stpncpy().

Fixes reexport issue building libMacportsLegacySystem.B.dylib on 11.x+, without relying on optool.

Fixes a warning building one of the tests.

TESTED:
Tested both normal and -devel versions (currently identical) on 10.4-10.5 ppc, 10.5-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-14.x arm64.
Builds on all tested platforms except 10.5 ppc +universal. Passes all tests in all buildable cases.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.4 21H1123, x86_64, Xcode 14.2 14C18
macOS 12.7.4 21H1123, arm64, Xcode 14.2 14C18
macOS 13.6.6 22G630, arm64, Xcode 15.2 15C500b
macOS 14.4.1 23E224, arm64, Xcode 15.3 15E204a
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
