### PR TITLE
pv: Fix support for OSX < 10.12

### DIFF
--- a/sysutils/pv/Portfile
+++ b/sysutils/pv/Portfile
@@ -2,7 +2,11 @@
 
 PortSystem          1.0
 PortGroup           muniversal 1.0
+PortGroup           legacysupport 1.1
 PortGroup           codeberg 1.0
+
+# clock_gettime
+legacysupport.newest_darwin_requires_legacy 15
 
 codeberg.setup      a-j-wood pv 1.8.5 v
 
@@ -34,10 +38,5 @@ patchfiles          fix-modifiers-direct-io-test.diff
 depends_build-append \
                     port:gettext
 depends_lib-append  port:gettext-runtime
-
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
-    # Attempt to still work on *old* systems by redefining *stat to *stat64
-    configure.cppflags-append -Dfstat=fstat64 -Dlstat=lstat64 -Dstat=stat64
-}
 
 test.run            yes


### PR DESCRIPTION
#### Description

Fix `pv` on OSX < 10.12 with `legacysupport`, since it requires `clock_gettime`, which isn't available on OSX < 10.12

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
