### PR TITLE
gcli: new port, CLI utility to interact with various Git forges

### DIFF
--- a/devel/gcli/Portfile
+++ b/devel/gcli/Portfile
@@ -1,0 +1,36 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem            1.0
+
+PortGroup             github 1.0
+
+github.setup          herrhotzenplotz gcli 2.3.0 v
+github.tarball_from   archive
+
+revision              0
+
+categories            devel
+
+license               BSD
+
+maintainers           nomaintainer
+
+description           CLI utility to interact with various Git forges
+
+long_description      GCLI is a simple and portable CLI tool for interacting with GitHub, \
+                      GitLab, and Gitea from the command line.
+
+homepage              https://herrhotzenplotz.de/gcli/
+
+checksums             rmd160  e83b12f4f618f81ae79ea7e2a096b0227b64fedd \
+                      sha256  3e25d9667ed6317087f2425390f4f4f1890b21bbaa7652c1e03fe34038e24229 \
+                      size    391000
+
+depends_lib-append    port:curl
+
+depends_build-append  port:bison \
+                      port:flex \
+                      port:pkgconfig
+
+use_autoreconf        yes
+


### PR DESCRIPTION
###### Description

A new port submission.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
