### PR TITLE
symfony-cli: update to 5.8.16

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.15
+version             5.8.16
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  e6677310ed8d9e9a4c516534a646ff5e7f478719 \
-                        sha256  4eb374cbcbf7bf6a2fe291d59e4d36004d28f7c44c6a1d9167fc6a848c69eb98 \
-                        size    267355
+    checksums           rmd160  a7e54702a0dc6c98ebe0d6e795bdba3f1f3b81f6 \
+                        sha256  2bce16ac11f72bc916a6fe7bb1e2f4e6c10f44e7c29ec6a4705ee8d671e78cf0 \
+                        size    267104
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  3f4d1cd7e8323f8e83a5890d2802fea43370ffa3 \
-                        sha256  a01587120eec150c48315f9019bf529d48c889da53200deaac4ef800f4da2077 \
-                        size    11393110
+    checksums           rmd160  3bd0958e4a64419b7cda0fdf10b7436208e27a33 \
+                        sha256  b4c2c245d130be48bc885de6734dd06858245e03891f35c77241d4ac9b918559 \
+                        size    11397435
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.16

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
