### PR TITLE
R: do not use versioned path in R framework

### DIFF
--- a/_resources/port1.0/group/R-1.0.tcl
+++ b/_resources/port1.0/group/R-1.0.tcl
@@ -170,8 +170,7 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libc++"} {
 global prefix frameworks_dir
 # Please update R version here:
 set Rversion        4.4.0
-set branch          [join [lrange [split ${Rversion} .] 0 1] .]
-set packages        ${frameworks_dir}/R.framework/Versions/${branch}/Resources/library
+set packages        ${frameworks_dir}/R.framework/Versions/MacPorts/Resources/library
 set suffix          .tar.gz
 set r.cmd           ${prefix}/bin/R
 set builddir        ${workpath}/build

--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -9,9 +9,8 @@ name                        R
 # Remember to set revision to 0 when bumping version
 # And also to update Rversion in R PortGroup
 version                     4.4.0
-revision                    0
+revision                    1
 
-set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  math science
 maintainers                 {me.com:kjell.konis @kjellpk} \
                             {i0ntempest @i0ntempest} \
@@ -66,6 +65,9 @@ compilers.setup             require_fortran
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     patchfiles-append       patch-fix-10.6.diff
 }
+
+# https://trac.macports.org/ticket/69837
+patchfiles-append           patch-FW_VERSION.diff
 
 # We wanna ensure the same compiler is used for R itself and R packages.
 # See R PortGroup.
@@ -122,7 +124,7 @@ platform darwin 22 {
 
 universal_variant           no
 
-set resources               ${frameworks_dir}/R.framework/Versions/${branch}/Resources
+set resources               ${frameworks_dir}/R.framework/Versions/MacPorts/Resources
 
 post-patch {
     reinplace "s|R_HOME|\"${resources}\"|" "${worksrcpath}/src/unix/Rscript.c"

--- a/math/R/files/patch-FW_VERSION.diff
+++ b/math/R/files/patch-FW_VERSION.diff
@@ -1,0 +1,11 @@
+--- configure	2024-04-24 12:01:15
++++ configure	2024-04-27 16:30:07
+@@ -4531,7 +4531,7 @@
+       ## FW_VERSION is the sub-directory name used in R.framework/Version
+       ## By default it's the a.b form of the full a.b.c version to simplify
+       ## binary updates.
+-      : ${FW_VERSION=`echo "${PACKAGE_VERSION}" | sed -e "s/[\.][0-9]$//"`}
++      : ${FW_VERSION=`echo "MacPorts"`}
+       ;;
+     *)
+       want_R_framework=no


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69837

#### Description

@ryandesign This should solve the problem once and for all. No more mass revbumps.
(Then, if some individual packages ever happen to get broken and need to be rebuilt with a newer `R`, that can be done case-by-case.)

Does this fix the issue you raised?

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1
Xcode 15.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
