### PR TITLE
pv: Update to 1.8.9

### DIFF
--- a/sysutils/pv/Portfile
+++ b/sysutils/pv/Portfile
@@ -8,7 +8,7 @@ PortGroup           codeberg 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-codeberg.setup      a-j-wood pv 1.8.5 v
+codeberg.setup      a-j-wood pv 1.8.9 v
 
 revision            0
 categories          sysutils
@@ -28,9 +28,9 @@ homepage            https://www.ivarch.com/programs/pv.shtml
 master_sites        ${codeberg.homepage}/releases/download/v${version}
 
 distname            ${name}-${version}
-checksums           rmd160  8ff4da8318795e8fcfc9a474fb9c9c0d8988aef8 \
-                    sha256  d22948d06be06a5be37336318de540a2215be10ab0163f8cd23a20149647b780 \
-                    size    327072
+checksums           rmd160  036524f7edf64de10e85fd40f295fc905b827eb9 \
+                    sha256  a0789d8f8c5a08faf370b5a07d1d936aeff9504a4f49da76d4164797ac4606e6 \
+                    size    330129
 
 patch.pre_args      -p1
 patchfiles          fix-modifiers-direct-io-test.diff


### PR DESCRIPTION
#### Description

Update `pv` to its latest released version, 1.8.9

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.7.5 11G63 x86_64
Xcode 4.6.3 4H1503

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
