### PR TITLE
netcdf-cxx4: Remove overlinking to HDF5

### DIFF
--- a/science/netcdf-cxx4/Portfile
+++ b/science/netcdf-cxx4/Portfile
@@ -7,7 +7,7 @@ PortGroup                   github 1.0
 PortGroup                   mpi 1.0
 
 github.setup                Unidata netcdf-cxx4 4.3.1 v
-revision                    0
+revision                    1
 distname                    ${name}-${version}
 maintainers                 {takeshi @tenomoto} openmaintainer
 platforms                   darwin

--- a/science/netcdf-cxx4/Portfile
+++ b/science/netcdf-cxx4/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem                  1.0
 PortGroup                   github 1.0
+
 #PortGroup                   cmake 1.0
 PortGroup                   mpi 1.0
 
@@ -30,14 +31,16 @@ mpi.setup
 
 #cmake.out_of_source         yes
 
-mpi.enforce_variant         hdf5
+#mpi.enforce_variant         hdf5
 
-depends_lib         port:netcdf
+depends_lib                 port:netcdf
+
+configure.args              --disable-filter-testing
 
 configure.cppflags-append   -DNDEBUG
 configure.cxxflags-append   -fno-common
 configure.cflags-append     -fno-common
-configure.ldflags-append    -lnetcdf -lhdf5
+configure.ldflags-append    -lnetcdf
 
 post-configure {
     file rename ${worksrcpath}/VERSION ${worksrcpath}/VERSION.txt


### PR DESCRIPTION
#### Description

* Remove accidental dependency on HDF5.
* Disable filter tests which caused accidental dependency.
* Fix whitespace nitpicks.

There was a choice to either formally add the `hdf5` dependency, or eliminate it.  The `hdf5` dependency was in some optional filter tests, not in the core library.  Disabling the optional tests seems to have no impact on the core library build.

Furthermore, enabling filter tests installed some extra bundled plugins, which may have conflicted with plugins installed by the main `hdf5` port.

I chose to eliminate the `hdf5` dependency as the safer strategy.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on

macOS 13.6.4
Xcode 15.2 / Command Line Tools 15.1.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `port -vs install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?