### PR TITLE
ruby32: update to v3.2.4; fix build on 10.4, 10.5

### DIFF
--- a/lang/ruby32/Portfile
+++ b/lang/ruby32/Portfile
@@ -10,14 +10,16 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 14
 
 set ruby_ver        3.2
-set ruby_patch      3
+set ruby_patch      4
 set ruby_ver_nodot  [string map {. {}} ${ruby_ver}]
 name                ruby${ruby_ver_nodot}
 version             ${ruby_ver}.${ruby_patch}
 revision            0
 
 categories          lang ruby
-maintainers         {kimuraw @kimuraw} openmaintainer
+maintainers         {kimuraw @kimuraw} \
+                    {fwright.net:fw @fhgwright} \
+                    openmaintainer
 platforms           darwin
 
 description         Powerful and clean object-oriented scripting language
@@ -25,22 +27,21 @@ long_description    Ruby is the interpreted scripting language for quick \
                     and easy object-oriented programming. It has many \
                     features to process text files and to do system \
                     management tasks (as in Perl). It is simple, \
-                    straight-forward, extensible, and portable.
+                    straightforward, extensible, and portable.
 
 homepage            https://www.ruby-lang.org/
 license             {Ruby BSD}
-
-# delete this when ruby-devel becomes ruby 3.3
-# conflicts           ruby-devel
 
 master_sites        ruby:${ruby_ver}
 distname            ruby-${version}
 dist_subdir         ruby${ruby_ver_nodot}
 
-checksums           rmd160 05d7fb2342e2d3161f469ccf313438676ee1a153 \
-                    sha256 af7f1757d9ddb630345988139211f1fd570ff5ba830def1cc7c468ae9b65c9ba \
-                    size 20577155
+checksums           rmd160  d7e5420af382751846b8a0c3013a913042372dad \
+                    sha256  c72b3c5c30482dca18b0f868c9075f3f47d8168eaf626d4e682ce5b59c858692 \
+                    size    20581711
 
+# Universal builds don't currently work, including via the approach used
+# in ruby30.
 universal_variant   no
 
 # ruby/openssl since ruby-3.2 supports openssl-3
@@ -58,12 +59,25 @@ depends_skip_archcheck pkgconfig
 select.group        ruby
 select.file         ${filespath}/ruby${ruby_ver_nodot}
 
-#----------------------------------------------------------------------------------------
+# Patches derived from MacPorts-enhanced GitHub fork at
+# github.com/fhgwright/ruby
+
+# patch-sources.diff: fixes for various issues.
+# This includes the 'gem' versioning fix formerly handled via reinplace.
+#
+# This diff is from v3_2_4 vs. macports-3_2_4.
+#
+patchfiles-append   patch-sources.diff
+
+#-------------------------------------------------------------------------------
 # Fix compilation on buildbots for 10.12 and earlier.
 # Issue: 62183: error: use of undeclared identifier 'fmt'; did you mean 'fma'?
-#----------------------------------------------------------------------------------------
+#
+# This issue only appears in Xcode clang 9 (clang 900), not MacPorts clang 9
+# (clang 901), so the blacklisting can be narrow.
+#-------------------------------------------------------------------------------
 compiler.blacklist-append \
-                    { clang < 901 }
+                    { clang >= 900 < 901 }
 
 if { [string match macports-clang-* ${configure.compiler}] } {
     # clang-mp-14 => dsymutil-mp-14; fix POSTLINK
@@ -71,6 +85,20 @@ if { [string match macports-clang-* ${configure.compiler}] } {
 }
 
 compiler.thread_local_storage yes
+
+# At least one version of clang doesn't offer cstdbool (introduced in C++11)
+# with -stdlib=libstc++ but still reports as C++14.  This causes an include
+# failure in include/ruby/internal/stdbool.h when built as C++.  Setting the
+# standard to C++03 removes the expectation that cstdbool is available.
+#
+# This has only been observed when building for 10.5, and in fact, ruby
+# makes very little use of C++, and would probably be fine if this were
+# unconditional.  Nevertheless, we limit it to the failing case.
+#
+if {[string match *clang* ${configure.compiler}] \
+    && ${configure.cxx_stdlib} eq "libstdc++"} {
+                    configure.cxxflags-append -std=c++03
+}
 
 configure.args      --enable-shared \
                     --enable-install-static-library \
@@ -91,15 +119,6 @@ configure.args-append   AR=${prefix}/bin/ar RANLIB=${prefix}/bin/ranlib
 # Add the architecture flag as required
 if {[info exists build_arch] && ${build_arch} != ""} {
     configure.args-append "--with-arch=${build_arch}"
-}
-
-post-patch {
-    # rewrite "gem" to "gem${ruby_ver}"
-    # def gem_command
-    #   ENV["GEM_COMMAND"]&.shellsplit || ["gem"]
-    # end
-    reinplace -E "s/(shellsplit .. .)(\"gem\")/\\1\"gem${ruby_ver}\"/g" \
-        ${worksrcpath}/lib/bundler/gem_helper.rb
 }
 
 post-destroot {
@@ -148,7 +167,6 @@ if {${os.major} >= 19 && [info exists build_arch]} {
         default_variants-append +yjit
     }
 }
-
 
 variant relative description "Enable relative loading of libraries to allow for relocation of binaries." {
         #enable relative loading

--- a/lang/ruby32/files/patch-sources.diff
+++ b/lang/ruby32/files/patch-sources.diff
@@ -1,0 +1,154 @@
+--- .gdbinit.orig	2024-04-23 03:20:09.000000000 -0700
++++ .gdbinit	2024-04-27 17:32:33.000000000 -0700
+@@ -1,4 +1,5 @@
+-set startup-with-shell off
++# Move this to end, so failure on older gdbs doesn't blow the rest
++# set startup-with-shell off
+ 
+ define hook-run
+   set $color_type = 0
+@@ -1348,3 +1349,6 @@ define print_flags
+   printf "RUBY_FL_USER17      : %s\n", ((struct RBasic*)($arg0))->flags & RUBY_FL_USER17 ? "1" : "0"
+   printf "RUBY_FL_USER18      : %s\n", ((struct RBasic*)($arg0))->flags & RUBY_FL_USER18 ? "1" : "0"
+ end
++
++# Moved from beginning, since it fails on older gdbs
++set startup-with-shell off
+--- ext/digest/md5/md5cc.h.orig	2024-04-23 03:20:09.000000000 -0700
++++ ext/digest/md5/md5cc.h	2024-04-27 17:32:33.000000000 -0700
+@@ -17,3 +17,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(MD5
+ #undef MD5_Finish
+ #define MD5_Update rb_digest_MD5_update
+ #define MD5_Finish rb_digest_MD5_finish
++
++/*
++ * Pre-10.6 defines are with args, which don't match the argless use in
++ * the function pointer inits.  Thus, we redefine MD5_Init as well.
++ * This is a NOP on 10.6+.
++ */
++#undef MD5_Init
++#define MD5_Init CC_MD5_Init
+--- ext/digest/sha1/sha1cc.h.orig	2024-04-23 03:20:09.000000000 -0700
++++ ext/digest/sha1/sha1cc.h	2024-04-27 17:32:33.000000000 -0700
+@@ -12,3 +12,11 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(SHA
+ #undef SHA1_Finish
+ #define SHA1_Update rb_digest_SHA1_update
+ #define SHA1_Finish rb_digest_SHA1_finish
++
++/*
++ * Pre-10.6 defines are with args, which don't match the argless use in
++ * the function pointer inits.  Thus, we redefine SHA1_Init as well.
++ * This is a NOP on 10.6+.
++ */
++#undef SHA1_Init
++#define SHA1_Init CC_SHA1_Init
+--- ext/digest/sha2/sha2cc.h.orig	2024-04-23 03:20:09.000000000 -0700
++++ ext/digest/sha2/sha2cc.h	2024-04-27 17:32:33.000000000 -0700
+@@ -1,6 +1,33 @@
+ #define COMMON_DIGEST_FOR_OPENSSL 1
+ #include <CommonCrypto/CommonDigest.h>
+ 
++/*
++ * Prior to 10.5, OpenSSL-compatible definitions are missing for
++ * SHA2 macros, though the CC_ versions are present.
++ * Add the missing definitions we actually use here if needed.
++ * Note that the definitions are the argless 10.6+-style.
++ * The weird CTX mismatch is copied from the 10.6 header.
++ */
++#ifndef SHA256_DIGEST_LENGTH
++#define SHA256_DIGEST_LENGTH		CC_SHA256_DIGEST_LENGTH
++#define SHA256_CTX					CC_SHA256_CTX
++#define SHA256_Update				CC_SHA256_Update
++#define SHA256_Final				CC_SHA256_Final
++#endif /* !defined SHA256_DIGEST_LENGTH */
++
++#ifndef SHA384_DIGEST_LENGTH
++#define SHA384_DIGEST_LENGTH		CC_SHA384_DIGEST_LENGTH
++#define SHA512_CTX					CC_SHA512_CTX
++#define SHA384_Update				CC_SHA384_Update
++#define SHA384_Final				CC_SHA384_Final
++#endif /* !defined SHA384_DIGEST_LENGTH */
++
++#ifndef SHA512_DIGEST_LENGTH
++#define SHA512_DIGEST_LENGTH		CC_SHA512_DIGEST_LENGTH
++#define SHA512_Update				CC_SHA512_Update
++#define SHA512_Final				CC_SHA512_Final
++#endif /* !defined SHA512_DIGEST_LENGTH */
++
+ #define SHA256_BLOCK_LENGTH	CC_SHA256_BLOCK_BYTES
+ #define SHA384_BLOCK_LENGTH	CC_SHA384_BLOCK_BYTES
+ #define SHA512_BLOCK_LENGTH	CC_SHA512_BLOCK_BYTES
+@@ -29,3 +56,15 @@ static DEFINE_FINISH_FUNC_FROM_FINAL(SHA
+ #undef SHA512_Finish
+ #define SHA512_Update rb_digest_SHA512_update
+ #define SHA512_Finish rb_digest_SHA512_finish
++
++/*
++ * Pre-10.6 defines are with args, which don't match the argless use in
++ * the function pointer inits.  Thus, we redefine SHA*_Init as well.
++ * This is a NOP on 10.6+.
++ */
++#undef SHA256_Init
++#define SHA256_Init CC_SHA256_Init
++#undef SHA384_Init
++#define SHA384_Init CC_SHA384_Init
++#undef SHA512_Init
++#define SHA512_Init CC_SHA512_Init
+--- lib/bundler/gem_helper.rb.orig	2024-04-23 03:20:09.000000000 -0700
++++ lib/bundler/gem_helper.rb	2024-04-27 17:32:33.000000000 -0700
+@@ -231,7 +231,7 @@ module Bundler
+     end
+ 
+     def gem_command
+-      ENV["GEM_COMMAND"]&.shellsplit || ["gem"]
++      ENV["GEM_COMMAND"]&.shellsplit || ["gem3.2"]
+     end
+   end
+ end
+--- signal.c.orig	2024-04-23 03:20:09.000000000 -0700
++++ signal.c	2024-04-27 17:32:33.000000000 -0700
+@@ -841,7 +841,8 @@ check_stack_overflow(int sig, const uint
+     const greg_t bp = mctx->gregs[REG_EBP];
+ #   endif
+ # elif defined __APPLE__
+-#   if __DARWIN_UNIX03
++#   include <AvailabilityMacros.h>
++#   if MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+ #     define MCTX_SS_REG(reg) __ss.__##reg
+ #   else
+ #     define MCTX_SS_REG(reg) ss.reg
+--- tool/transform_mjit_header.rb.orig	2024-04-23 03:20:09.000000000 -0700
++++ tool/transform_mjit_header.rb	2024-04-27 17:32:33.000000000 -0700
+@@ -181,7 +181,9 @@ module MJITHeader
+   def self.conflicting_types?(code, cc, cflags)
+     with_code(code) do |path|
+       cmd = "#{cc} #{cflags} #{path}"
+-      out = IO.popen(cmd, err: [:child, :out], &:read)
++      # As per gcc docs, set LC_ALL=C to avoid curly quotes in messages
++      cmd_env = {"LC_ALL" => "C"}
++      out = IO.popen(cmd_env, cmd, err: [:child, :out], &:read)
+       !$?.success? &&
+         (out.match?(/error: conflicting types for '[^']+'/) ||
+          out.match?(/error: redefinition of parameter '[^']+'/))
+--- vm_dump.c.orig	2024-04-23 03:20:09.000000000 -0700
++++ vm_dump.c	2024-04-27 17:32:33.000000000 -0700
+@@ -470,7 +470,8 @@ rb_vmdebug_thread_dump_state(VALUE self)
+ }
+ 
+ #if defined __APPLE__
+-# if __DARWIN_UNIX03
++# include <AvailabilityMacros.h>
++# if MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+ #   define MCTX_SS_REG(reg) __ss.__##reg
+ # else
+ #   define MCTX_SS_REG(reg) ss.reg
+@@ -482,7 +483,8 @@ rb_vmdebug_thread_dump_state(VALUE self)
+ # ifdef HAVE_LIBUNWIND
+ #  undef backtrace
+ #  define backtrace unw_backtrace
+-# elif defined(__APPLE__) && defined(HAVE_LIBUNWIND_H)
++# elif defined(__APPLE__) && defined(HAVE_LIBUNWIND_H) \
++       && MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+ #  define UNW_LOCAL_ONLY
+ #  include <libunwind.h>
+ #  include <sys/mman.h>


### PR DESCRIPTION
See:
https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/

This incorporates the applicable patches from ruby30, including converting the reinplace patch for the gem program name to a normal source patch.

It adds two new patches related to the CommonCrypto headers on 10.4 and 10.5.

All source patches are in a single patchfile derived from the ruby fork at github.com/fhgwright/ruby.  The changes are much more readable in the git repo.

It also narrows the compiler blacklisting, corresponding to what was done in ruby30.

It also incorporates the cstdbool fix for 10.5, from ruby30.

Also adds self as co-maintainer.

TESTED:
Built successfully with no variants on 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-14.x arm64.
Built with all variants except jemalloc and yjit on 10.4-10.5, all variants except yjit on 10.6-10.13, and all variants on 10.14+. Tests not run due to test framework issues.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.4 21H1123, x86_64, Xcode 14.2 14C18
macOS 12.7.4 21H1123, arm64, Xcode 14.2 14C18
macOS 13.6.6 22G630, arm64, Xcode 15.2 15C500b
macOS 14.4.1 23E224, arm64, Xcode 15.3 15E204a
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [NO] tried existing tests with `sudo port test`? *
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

`*` - The test framework has issues.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
