### PR TITLE
openimageio: fix the build for Darwin < 20 and powerpc

### DIFF
--- a/graphics/openimageio/Portfile
+++ b/graphics/openimageio/Portfile
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
-PortGroup               qt5 1.0
 PortGroup               cmake 1.1
 PortGroup               active_variants 1.1
 PortGroup               compiler_blacklist_versions 1.0
@@ -27,7 +26,7 @@ if {${port_latest}} {
                         size    52061055
 } else {
     github.setup        AcademySoftwareFoundation OpenImageIO 2.1.20.0 v
-    revision            14
+    revision            15
     checksums           rmd160  7f241baddcc6e731a29fb37090e4582953560f38 \
                         sha256  0ad46bda55d6357a3c474b8c8ccbb41d9732313247cffaf4a65fc50e6aad9e78 \
                         size    29116032
@@ -40,6 +39,7 @@ github.tarball_from     archive
 if {${port_latest}} {
     depends_lib-append  port:imath \
                         port:openexr \
+                        port:openvdb \
                         port:onetbb
     #configure.args-append       -DUSE_TBB=OFF
     configure.args-append       -DTBB_ROOT=${prefix}/libexec/onetbb
@@ -62,6 +62,10 @@ if {${port_latest}} {
 
     configure.pkg_config_path-prepend \
                         ${prefix}/libexec/openexr2/lib/pkgconfig
+
+    # https://trac.macports.org/ticket/69842
+    configure.args-append       -DUSE_OPENVDB=OFF
+
     #configure.args-append       -DUSE_TBB=OFF
     configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
 
@@ -82,8 +86,13 @@ compiler.thread_local_storage yes
 
 configure.cxxflags-append \
                         -Wno-deprecated-declarations \
-                        -Wno-error=unknown-warning-option \
                         -Wno-unknown-warning-option
+
+if {[string match *clang* ${configure.compiler}]} {
+    # This is a clang-specific flag:
+    configure.cxxflags-append \
+                        -Wno-error=unknown-warning-option
+}
 
 # NOTE: Ensure we prepend 'libfmt9', to include it before 'openexr2'
 set port_libfmt         libfmt9
@@ -112,9 +121,21 @@ depends_lib-append      port:robin-map \
 
 # optional components
 
-#configure.args-append   -DUSE_OPENGL=OFF \
-#                        -DUSE_QT=OFF
-qt5.min_version         5.6
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    configure.args-append \
+                        -DUSE_QT=OFF
+    # configure.args-append -DUSE_OPENGL=OFF
+} else {
+    PortGroup           qt5 1.0
+
+    qt5.min_version     5.6
+}
+
+if {[string match *gcc* ${configure.compiler}] \
+    && ${configure.build_arch} in [list i386 ppc]} {
+    configure.ldflags-append \
+                        -latomic
+}
 
 configure.args-append   -DUSE_PYTHON=OFF
 
@@ -165,11 +186,15 @@ configure.args-append       -DOpenJpeg_ROOT=${prefix}
 #configure.args-append       -DUSE_OCIO=OFF
 depends_lib-append          port:opencolorio
 
-#configure.args-append       -DUSE_OPENCV=OFF
 set opencv_ver 4
-depends_lib-append          path:lib/opencv${opencv_ver}/libopencv_core.dylib:opencv${opencv_ver}
-configure.args-append       -DOpenCV_INCLUDE_DIR=${prefix}/include/opencv${opencv_ver} \
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # opencv4 does not build on 10.6 and earlier.
+    configure.args-append   -DUSE_OPENCV=OFF
+} else {
+    depends_lib-append      path:lib/opencv${opencv_ver}/libopencv_core.dylib:opencv${opencv_ver}
+    configure.args-append   -DOpenCV_INCLUDE_DIR=${prefix}/include/opencv${opencv_ver} \
                             -DOpenCV_ROOT=${prefix}/lib/opencv${opencv_ver}
+}
 
 #configure.args-append       -DUSE_FREETYPE=OFF
 depends_lib-append          port:freetype
@@ -185,9 +210,6 @@ depends_lib-append          port:ptex
 
 #configure.args-append       -DUSE_LIBRAW=OFF
 depends_lib-append          port:libraw
-
-#configure.args-append       -DUSE_OPENVDB=OFF
-depends_lib-append          port:openvdb
 
 # not in MacPorts
 configure.args-append       -DUSE_NUKE=OFF


### PR DESCRIPTION
#### Description

Fix the port:
1. Disable `openvdb` for Darwin < 20, due to https://trac.macports.org/ticket/69842
2. Since GUI requires Qt5 5.6+, build with GUI on 10.7+.
3. Unbreak build with GCC.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
