### PR TITLE
dagger: update to 0.11.2

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.11.0 v
+github.setup        dagger dagger 0.11.2 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  15722e656e5fe571c2cd27e81d2de447794c7158 \
-                            sha256  87a0ddc7da20f42e6edff8e3e542c24524f4aa6886c9520499ba1a8654b69cb1 \
-                            size    10093211
+        checksums           rmd160  a72546535b5be79b93a4ff5cef5eacdb1a72019c \
+                            sha256  7d21142b79fc2827099f1b4023c31215fd6aa817a7e4df803840b973766356e3 \
+                            size    10148037
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  f06faffc12d75d9f4caf6a32bad3f99524eda332 \
-                            sha256  902f51639879b54caccda77d00ff5b24de79a44431e2b4195cdd30b654da691d \
-                            size    9745388
+        checksums           rmd160  b16fda5e664b1e152466cfeafa1c010ca1cbe674 \
+                            sha256  a38748f17850d7167006347ea060c72f6dd540ae1235063074796e8a257bed38 \
+                            size    9806862
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

upgrade to latest version from https://github.com/dagger/dagger/releases

###### Tested on
macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

I updated the x64_64 variant's checksum's and file size but did not test its binary.
