### PR TITLE
the_Foundation: update to 1.8.1

### DIFF
--- a/devel/the_Foundation/Portfile
+++ b/devel/the_Foundation/Portfile
@@ -10,7 +10,7 @@ PortGroup           legacysupport 1.1
 legacysupport.newest_darwin_requires_legacy 15
 
 gitea.domain        git.skyjake.fi
-gitea.setup         skyjake the_Foundation 1.7.0 v
+gitea.setup         skyjake the_Foundation 1.8.1 v
 revision            0
 categories          devel
 license             BSD
@@ -19,9 +19,9 @@ maintainers         {@sikmir disroot.org:sikmir} openmaintainer
 description         Opinionated C11 library for low-level functionality
 long_description    {*}${description}
 
-checksums           rmd160  ef510b94deb04e1f06e4856579eab2ce1e9acc64 \
-                    sha256  c0b4b8b8ec583419d3fdec98a0850385deced9bfa3a7b39474ef06600bfb9dc8 \
-                    size    218322
+checksums           rmd160  7bd00d5e3af782fee8794d47aba3436de3644335 \
+                    sha256  d86ce34a864464b482ca3dcde93a77bf5f986bddb00c9b05380a8211741483e2 \
+                    size    219300
 
 depends_build-append \
                     port:pkgconfig


### PR DESCRIPTION
#### Description
https://git.skyjake.fi/skyjake/the_Foundation/releases/tag/v1.8.1

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
