### PR TITLE
gtk3, libepoxy: Remove dependency to mesa for +quartz

### DIFF
--- a/gnome/gtk3-devel/Portfile
+++ b/gnome/gtk3-devel/Portfile
@@ -13,7 +13,7 @@ name                gtk3-devel
 conflicts           gtk3
 set my_name         gtk3
 version             3.24.41
-revision            1
+revision            2
 epoch               0
 
 set proj_name       gtk+
@@ -60,9 +60,6 @@ depends_lib-append \
                     port:libepoxy \
                     path:lib/pkgconfig/pango.pc:pango
 
-# mesa required to configure both +x11, +quartz (not just +x11) due to their dependency on libepoxy
-depends_lib-append  port:mesa
-                    
 depends_run-append \
                     port:shared-mime-info \
                     port:hicolor-icon-theme
@@ -71,9 +68,6 @@ compiler.cxx_standard 2011
 
 # darwin 10 and earlier requires legacy support for O_CLOEXEC
 legacysupport.newest_darwin_requires_legacy 10
-
-# Upstream disables X11 for macOS; disable that behavior
-patchfiles-append   patch-meson.build-x11-enabled.diff
 
 # Quartz patch to fix QuartzCore linking and compiling with 10.11
 # Upstream merge request: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4298
@@ -143,7 +137,7 @@ post-destroot {
     # avoid conflict with the gtk-update-icon-cache installed by gtk2
     move ${destroot}${prefix}/bin/gtk-update-icon-cache \
          ${destroot}${prefix}/bin/gtk-update-icon-cache-3.0
-    
+
     ui_debug "Creating gtk.immodules..."
     system "DYLD_LIBRARY_PATH=${destroot}${prefix}/lib \
         ${destroot}${prefix}/bin/gtk-query-immodules-3.0 \
@@ -247,7 +241,7 @@ if {${universal_possible} && [variant_isset universal]} {
         reinplace s/@host@/${host}-apple-darwin${os.version}/ \
             {*}[glob -directory ${worksrcpath} *.pc.in]
     }
-    
+
     merger_arch_compiler yes
 } else {
     configure.cc "${configure.cc} ${configure.cc_archflags}"
@@ -290,10 +284,12 @@ variant x11 conflicts quartz {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo x11
     require_active_variants path:lib/pkgconfig/pango.pc:pango x11
 
+    # mesa is required to configure with +x11 due to the dependency on libepoxy
     depends_lib-append \
                             port:at-spi2-atk \
                             port:fontconfig \
                             port:libxkbcommon-x11 \
+                            port:mesa \
                             port:xorg-libXi \
                             port:xorg-libXrandr \
                             port:xorg-libXcursor \
@@ -301,6 +297,9 @@ variant x11 conflicts quartz {
                             port:xorg-libXdamage \
                             port:xorg-libXcomposite \
                             port:xorg-libXfixes
+
+    # Upstream disables X11 for macOS; disable that behavior
+    patchfiles-append       patch-meson.build-x11-enabled.diff
 
     configure.args-append \
                             -Dx11_backend=true \

--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -13,7 +13,7 @@ name                gtk3
 conflicts           gtk3-devel
 set my_name         gtk3
 version             3.24.41
-revision            1
+revision            2
 epoch               1
 
 set proj_name       gtk+
@@ -60,9 +60,6 @@ depends_lib-append \
                     port:libepoxy \
                     path:lib/pkgconfig/pango.pc:pango
 
-# mesa required to configure both +x11, +quartz (not just +x11) due to their dependency on libepoxy
-depends_lib-append  port:mesa
-                    
 depends_run-append \
                     port:shared-mime-info \
                     port:hicolor-icon-theme
@@ -71,9 +68,6 @@ compiler.cxx_standard 2011
 
 # darwin 10 and earlier requires legacy support for O_CLOEXEC
 legacysupport.newest_darwin_requires_legacy 10
-
-# Upstream disables X11 for macOS; disable that behavior
-patchfiles-append   patch-meson.build-x11-enabled.diff
 
 # Quartz patch to fix QuartzCore linking and compiling with 10.11
 # Upstream merge request: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4298
@@ -143,7 +137,7 @@ post-destroot {
     # avoid conflict with the gtk-update-icon-cache installed by gtk2
     move ${destroot}${prefix}/bin/gtk-update-icon-cache \
          ${destroot}${prefix}/bin/gtk-update-icon-cache-3.0
-    
+
     ui_debug "Creating gtk.immodules..."
     system "DYLD_LIBRARY_PATH=${destroot}${prefix}/lib \
         ${destroot}${prefix}/bin/gtk-query-immodules-3.0 \
@@ -247,7 +241,7 @@ if {${universal_possible} && [variant_isset universal]} {
         reinplace s/@host@/${host}-apple-darwin${os.version}/ \
             {*}[glob -directory ${worksrcpath} *.pc.in]
     }
-    
+
     merger_arch_compiler yes
 } else {
     configure.cc "${configure.cc} ${configure.cc_archflags}"
@@ -290,10 +284,12 @@ variant x11 conflicts quartz {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo x11
     require_active_variants path:lib/pkgconfig/pango.pc:pango x11
 
+    # mesa is required to configure with +x11 due to the dependency on libepoxy
     depends_lib-append \
                             port:at-spi2-atk \
                             port:fontconfig \
                             port:libxkbcommon-x11 \
+                            port:mesa \
                             port:xorg-libXi \
                             port:xorg-libXrandr \
                             port:xorg-libXcursor \
@@ -301,6 +297,9 @@ variant x11 conflicts quartz {
                             port:xorg-libXdamage \
                             port:xorg-libXcomposite \
                             port:xorg-libXfixes
+
+    # Upstream disables X11 for macOS; disable that behavior
+    patchfiles-append       patch-meson.build-x11-enabled.diff
 
     configure.args-append \
                             -Dx11_backend=true \

--- a/graphics/libepoxy/Portfile
+++ b/graphics/libepoxy/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           meson 1.0
 
 github.setup        anholt libepoxy 1.5.10
-revision            0
+revision            1
 license             MIT permissive
 categories          graphics
 maintainers         nomaintainer
@@ -20,29 +20,10 @@ checksums           rmd160  0c12937f3ab3645d4b1b96f29ffd2fb5ffc92712 \
                     sha256  b3e076c5bea209ffa7789cb460d76718be206ccad65a8c915757957c76318376 \
                     size    332119
 
-# Yes, mesa and xorg-libX11 are *build* dependencies.  The library will function correctly
-# if they are not present because it loads mesa dynamically only when GLX is used.  When
-# OpenGL.framework is used, there is no need to have mesa at runtime.
-#
-# Clients of this library must link mesa directly and have it listed as their dependency
-# in order to use mesa with libepoxy.
-
-depends_build       port:pkgconfig \
-                    port:xorg-util-macros \
-                    port:mesa \
-                    port:xorg-libX11
+depends_build       port:pkgconfig
 
 patchfiles          prefix.patch \
                     patch-src-gen_dispatch.py.diff
-
-# enable GLX support
-# without this any gtk3 +x11 app will fail on load as follows
-# dyld: Symbol not found: _epoxy_glXBindTexImageEXT
-#   Referenced from: /opt/local/lib/libgdk-3.0.dylib
-#   Expected in: /opt/local/lib/libepoxy.0.dylib
-#   in /opt/local/lib/libgdk-3.0.dylib
-configure.args-append \
-                    -Dglx=yes
 
 # https://trac.macports.org/ticket/64468
 platform darwin 8 {
@@ -56,4 +37,40 @@ depends_build-append    port:python310
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" ${worksrcpath}/src/dispatch_common.c
     reinplace "s|@PYTHON3@|${prefix}/bin/python${python_vers}|g" ${worksrcpath}/src/gen_dispatch.py
+}
+
+variant quartz conflicts x11 {
+    configure.args-append -Dx11=false
+}
+
+variant x11 conflicts quartz {
+    # Yes, mesa and xorg-libX11 are *build* dependencies. The library will function correctly
+    # if they are not present because it loads mesa dynamically only when GLX is used. When
+    # OpenGL.framework is used, there is no need to have mesa at runtime.
+    #
+    # Clients of this library must link mesa directly and have it listed as their dependency
+    # in order to use mesa with libepoxy.
+    depends_build-append port:xorg-util-macros \
+                         port:mesa \
+                         port:xorg-libX11
+
+    # enable GLX support
+    # without this any gtk3 +x11 app will fail on load as follows
+    # dyld: Symbol not found: _epoxy_glXBindTexImageEXT
+    #   Referenced from: /opt/local/lib/libgdk-3.0.dylib
+    #   Expected in: /opt/local/lib/libepoxy.0.dylib
+    #   in /opt/local/lib/libgdk-3.0.dylib
+    configure.args-append -Dglx=yes
+}
+
+if {![variant_isset quartz]} {
+    default_variants +x11
+}
+if {![variant_isset x11]} {
+    default_variants +quartz
+}
+if {![variant_isset quartz] && ![variant_isset x11]} {
+    pre-configure {
+        return -code error "Either +x11 or +quartz is required"
+    }
 }


### PR DESCRIPTION
#### Description

Currently `gtk3` depends on `mesa` and other `x11` related packages even when building with `+quartz -x11`. This dependency was required through `gtk3`'s dependency on `libepoxy`, which pulls those build-dependencies in to support GLX and proposes to make them required by dependees at link time.

From what I could find out, GLX is also specific to X11 and thus not required when building with `+quartz -x11`.

This PR removes the build dependency on `mesa` and cohorts from `libepoxy` and the lib-dependency from `gtk3`, if variant is `+quartz`.

This was sufficient to make `gstreamer1-gst-plugins-good +quartz -x11` installable again (related track ticket: [https://trac.macports.org/ticket/69787](https://trac.macports.org/ticket/69787). I therefor did not check further dependees of `libepoxy` if, we can/should remove the lib-dependency to `mesa` there, too. If you feel that this should be part of this PR, just say a word and I will have a closer look at those, too, and update the branch behind this PR.

I build both variants (i.e., `+quartz -x11` and `-quartz +x11`) in a clean macports instance and tested them by running a `gstreamer` example.

I hope my using the
```
if {![variant_isset quartz]} {
  ...
}
```
is the appropriate way to handle this, otherwise I will gladly change it whatever you deem correct.

For reference: The track ticket that, I believe, ultimately resulted in these X11 dependencies being included in `gtk3`:
[https://trac.macports.org/ticket/55967](https://trac.macports.org/ticket/55967)

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.6 22G630 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
