### PR TITLE
R: fix a bug breaking installation of some packages on 32-bit platforms

### DIFF
--- a/math/R/Portfile
+++ b/math/R/Portfile
@@ -9,7 +9,7 @@ name                        R
 # Remember to set revision to 0 when bumping version
 # And also to update Rversion in R PortGroup
 version                     4.4.0
-revision                    0
+revision                    1
 
 set branch                  [join [lrange [split ${version} .] 0 1] .]
 categories                  math science
@@ -59,6 +59,12 @@ if {${os.platform} eq "darwin" && ${os.major} < 10} {
 
 compilers.choose            fc f77
 compilers.setup             require_fortran
+
+# https://trac.macports.org/ticket/69849
+# https://bugs.r-project.org/show_bug.cgi?id=18713
+if {${configure.build_arch} in [list i386 ppc]} {
+    patchfiles-append       patch-fix-memsize.diff
+}
 
 # https://trac.macports.org/ticket/67298
 # https://bugs.r-project.org/show_bug.cgi?id=18520

--- a/math/R/files/patch-fix-memsize.diff
+++ b/math/R/files/patch-fix-memsize.diff
@@ -1,0 +1,17 @@
+--- src/main/startup.c	2024-03-27 07:02:08.000000000 +0800
++++ src/main/startup.c	2024-04-30 01:36:27.000000000 +0800
+@@ -244,10 +244,10 @@
+        Setting the limit at the maximum of 16Gb and available physical
+        memory seems reasonable, but there may be better options. LT */
+     else {
+-	R_size_t pages = sysconf(_SC_PHYS_PAGES);
+-	R_size_t page_size = sysconf(_SC_PAGE_SIZE);
+-	R_size_t sysmem = pages * page_size;
+-	R_size_t MinMaxVSize = 17179869184; /* 16 Gb */
++	double pages = sysconf(_SC_PHYS_PAGES);
++	double page_size = sysconf(_SC_PAGE_SIZE);
++	double sysmem = pages * page_size;
++	double MinMaxVSize = 17179869184; /* 16 Gb */
+ 	Rp->max_vsize = sysmem > MinMaxVSize ? sysmem : MinMaxVSize;
+     }
+ #endif


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/69849

#### Description

@ryandesign This should fix the problem. We will not need to patch every affected package then.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
