### PR TITLE
mpdecimal: Use absolute path in install names

### DIFF
--- a/math/mpdecimal/Portfile
+++ b/math/mpdecimal/Portfile
@@ -4,14 +4,14 @@ PortSystem          1.0
 
 name                mpdecimal
 version             4.0.0
-revision            0
+revision            1
 categories          math
 license             BSD
 maintainers         {mps @Schamschula} openmaintainer
 description         mpdecimal is a package for correctly-rounded arbitrary precision \
                     decimal floating point arithmetic.
 long_description    {*}${description}
-platforms           darwin
+
 homepage            https://www.bytereef.org/mpdecimal/
 master_sites        https://www.bytereef.org/software/mpdecimal/releases/
 
@@ -20,6 +20,8 @@ checksums           rmd160  e0d465bb433d4f53db9192175fdedb9388e7aed1 \
                     size    315325
 
 depends_build       port:gmake
+
+patchfiles          no-rpath.patch
 
 build.target        default
 

--- a/math/mpdecimal/files/no-rpath.patch
+++ b/math/mpdecimal/files/no-rpath.patch
@@ -1,0 +1,47 @@
+Use absolute paths in install names, not @rpath-based ones.
+--- configure.orig	2024-01-09 18:25:00.000000000 -0600
++++ configure	2024-04-30 01:41:34.000000000 -0500
+@@ -2843,7 +2843,7 @@
+     LIBNAME="libmpdec.dylib"
+     LIBSONAME="libmpdec.4.dylib"
+     LIBSHARED="libmpdec.4.0.0.dylib"
+-    CONFIGURE_LDFLAGS="-dynamiclib $FPIC -install_name @rpath/$LIBSONAME -compatibility_version 4.0 -current_version 4.0.0"
++    CONFIGURE_LDFLAGS="-dynamiclib $FPIC -install_name \$(libdir)/$LIBSONAME -compatibility_version 4.0 -current_version 4.0.0"
+     ;;
+   *-*-aix*)
+     LIBNAME=
+@@ -2887,7 +2887,7 @@
+     LIBNAME_CXX="libmpdec++.dylib"
+     LIBSONAME_CXX="libmpdec++.4.dylib"
+     LIBSHARED_CXX="libmpdec++.4.0.0.dylib"
+-    CONFIGURE_LDXXFLAGS="-dynamiclib $FPIC -install_name @rpath/$LIBSONAME_CXX -compatibility_version 4.0 -current_version 4.0.0"
++    CONFIGURE_LDXXFLAGS="-dynamiclib $FPIC -install_name \$(libdir)/$LIBSONAME_CXX -compatibility_version 4.0 -current_version 4.0.0"
+     ;;
+   *-*-aix*)
+     LIBNAME_CXX=
+--- libmpdec/Makefile.in.orig	2024-01-09 18:25:00.000000000 -0600
++++ libmpdec/Makefile.in	2024-04-30 01:46:37.000000000 -0500
+@@ -3,6 +3,10 @@
+ #                          Unix Makefile for libmpdec
+ # ==============================================================================
+ 
++prefix = @prefix@
++exec_prefix = @exec_prefix@
++libdir = @libdir@
++
+ ENABLE_STATIC = @ENABLE_STATIC@
+ ENABLE_SHARED = @ENABLE_SHARED@
+ ENABLE_MINGW = @ENABLE_MINGW@
+--- libmpdec++/Makefile.in.orig	2024-01-09 18:25:00.000000000 -0600
++++ libmpdec++/Makefile.in	2024-04-30 01:46:24.000000000 -0500
+@@ -3,6 +3,10 @@
+ #                          Unix Makefile for libmpdec++
+ # ==============================================================================
+ 
++prefix = @prefix@
++exec_prefix = @exec_prefix@
++libdir = @libdir@
++
+ ENABLE_STATIC = @ENABLE_STATIC@
+ ENABLE_SHARED = @ENABLE_SHARED@
+ ENABLE_MINGW = @ENABLE_MINGW@


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/69870

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 21H1123 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
