### PR TITLE
retroshare-qt4: new port

### DIFF
--- a/www/retroshare-qt4/Portfile
+++ b/www/retroshare-qt4/Portfile
@@ -1,0 +1,81 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           conflicts_build 1.0
+PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+PortGroup           openssl 1.0
+PortGroup           qmake 1.0
+
+openssl.branch      1.1
+
+name                retroshare-qt4
+github.setup        RetroShare RetroShare 0.6.4 v
+revision            0
+# This is a legacy version aimed at systems which lack support for Qt5–Qt6.
+platforms           {darwin < 17}
+categories          www security p2p
+# See: https://github.com/RetroShare/RetroShare/blob/master/.reuse/dep5
+license             {AGPL-3 LGPL-3 GPL-3}
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+
+description         RetroShare is a Free and Open Source cross-platform, Friend-2-Friend and secure decentralised communication platform
+long_description    {*}${description}
+homepage            https://retroshare.cc
+checksums           rmd160  4025206f4b940b5a81e120ef526509778cfca350 \
+                    sha256  84355c0f3be5ec1dfa7253e327ea1254f76f47739c233cfb8d0983ebd1a61f4a \
+                    size    20018361
+github.tarball_from archive
+
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  path:lib/pkgconfig/gnutls.pc:gnutls \
+                    port:bzip2 \
+                    port:gpgme \
+                    port:libassuan \
+                    port:libgpg-error \
+                    port:libmicrohttpd \
+                    port:miniupnpc \
+                    port:sqlcipher \
+                    port:zlib
+
+patchfiles-append   0001-Fix-broken-linking-and-settings.patch \
+                    0002-bdthreads.cc-fix-pointer-comparison.patch \
+                    0003-Add-missing-headers.patch
+
+post-patch {
+    reinplace "s|@PREFIX@|${prefix}|g" \
+                    ${worksrcpath}/libresapi/src/libresapi.pro \
+                    ${worksrcpath}/libretroshare/src/libretroshare.pro \
+                    ${worksrcpath}/retroshare.pri \
+                    ${worksrcpath}/retroshare-gui/src/retroshare-gui.pro \
+                    ${worksrcpath}/retroshare-nogui/src/retroshare-nogui.pro
+    reinplace "s|@TARGET@|${macosx_deployment_target}|g" \
+                    ${worksrcpath}/retroshare.pri
+}
+
+compiler.cxx_standard 2011
+
+# RetroShare can be configured to use either miniupnpc or libupnp. Having both active breaks linking. To be on a safe side, also deactivate gupnp.
+# Our libretroshare port tracks the upstream. It may not be compatible with a legacy or even current release of RetroShare.
+conflicts_build     gupnp libupnp libretroshare
+
+configure.pre_args-append \
+                    "CONFIG+=rs_v07_changes" \
+                    "CONFIG+=no_sqlcipher"
+
+# api/ApiServerMHD.cpp: error: invalid conversion from 'int (*)(void*, MHD_ValueKind, const char*, const char*)' to 'MHD_KeyValueIterator' {aka 'MHD_Result (*)(void*, MHD_ValueKind, const char*, const char*)'} [-fpermissive]
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.cxxflags-append \
+                    -fpermissive
+}
+
+destroot {
+    set docdir ${prefix}/share/doc/retroshare/${name}
+    xinstall -d ${destroot}${docdir}
+    xinstall -m 0644 -W ${worksrcpath} LICENSE.txt README.md TODO.txt ${destroot}${docdir}
+    move ${worksrcpath}/retroshare-gui/src/retroshare.app ${destroot}${applications_dir}/retroshare.app
+}
+
+# FIXME: on PowerPC the app builds and starts, however upon initial set-up it freezes on 0x0178bea8 in bn_mul4x_mont_int
+# See: https://github.com/RetroShare/RetroShare/issues/2762

--- a/www/retroshare-qt4/files/0001-Fix-broken-linking-and-settings.patch
+++ b/www/retroshare-qt4/files/0001-Fix-broken-linking-and-settings.patch
@@ -1,0 +1,240 @@
+From 6d53fbdf4f2c381500fa4e1dc04aa3a166b1988b Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Thu, 10 Aug 2023 04:45:28 +0800
+Subject: [PATCH 1/3] Fix broken linking and settings
+
+---
+ libresapi/src/libresapi.pro               |  4 +-
+ libretroshare/src/libretroshare.pro       | 19 +++-----
+ retroshare-gui/src/retroshare-gui.pro     | 14 +++---
+ retroshare-nogui/src/retroshare-nogui.pro | 16 +++++--
+ retroshare.pri                            | 57 +++++++----------------
+ 5 files changed, 47 insertions(+), 63 deletions(-)
+
+diff --git libresapi/src/libresapi.pro libresapi/src/libresapi.pro
+index ea2daa082..06ac04930 100644
+--- libresapi/src/libresapi.pro
++++ libresapi/src/libresapi.pro
+@@ -146,8 +146,8 @@ libresapihttpserver {
+ 	} else {
+ 		mac {
+ 			INCLUDEPATH += . $$INC_DIR
+-			#for(lib, LIB_DIR):exists($$lib/libmicrohttpd.a){ LIBS *= $$lib/libmicrohttpd.a}
+-			LIBS *= -lmicrohttpd
++			# for(lib, LIB_DIR):exists($$lib/libmicrohttpd.a){ LIBS *= $$lib/libmicrohttpd.a}
++			LIBS *= @PREFIX@/lib/libmicrohttpd.a
+ 		} else {
+ 			LIBS *= -lmicrohttpd
+ 		}
+diff --git libretroshare/src/libretroshare.pro libretroshare/src/libretroshare.pro
+index c2604fa4a..3c1872dcd 100644
+--- libretroshare/src/libretroshare.pro
++++ libretroshare/src/libretroshare.pro
+@@ -306,32 +306,27 @@ mac {
+ 		QMAKE_CC = $${QMAKE_CXX}
+ 		OBJECTS_DIR = temp/obj
+ 		MOC_DIR = temp/moc
+-		#DEFINES = WINDOWS_SYS WIN32 STATICLIB MINGW
+-		#DEFINES *= MINIUPNPC_VERSION=13
++		# DEFINES *= MINIUPNPC_VERSION=25
+ 
+ 		CONFIG += upnp_miniupnpc
+-                CONFIG += c++11
++		CONFIG += c++11
+ 
+ 		# zeroconf disabled at the end of libretroshare.pro (but need the code)
+-		#CONFIG += zeroconf
+-		#CONFIG += zcnatassist
++		# CONFIG += zeroconf
++		# CONFIG += zcnatassist
+ 
+-		# Beautiful Hack to fix 64bit file access.
++		# Beautiful Hack to fix 64-bit file access.
+ 		QMAKE_CXXFLAGS *= -Dfseeko64=fseeko -Dftello64=ftello -Dfopen64=fopen -Dvstatfs64=vstatfs
+ 
+-		#GPG_ERROR_DIR = ../../../../libgpg-error-1.7
+-		#GPGME_DIR  = ../../../../gpgme-1.1.8
+-
+ 		for(lib, LIB_DIR):LIBS += -L"$$lib"
+-		for(bin, BIN_DIR):LIBS += -L"$$bin"
+ 
+ 		DEPENDPATH += . $$INC_DIR
+ 		INCLUDEPATH += . $$INC_DIR
+ 		INCLUDEPATH += ../../../.
++		INCLUDEPATH += @PREFIX@/include
+ 
+ 		# We need a explicit path here, to force using the home version of sqlite3 that really encrypts the database.
+-		LIBS += /usr/local/lib/libsqlcipher.a
+-		#LIBS += -lsqlite3
++		LIBS += -lsqlite3
+ 
+ 		DEFINES *= PLUGIN_DIR=\"\\\"$${PLUGIN_DIR}\\\"\"
+ 		DEFINES *= DATA_DIR=\"\\\"$${DATA_DIR}\\\"\"
+diff --git retroshare-gui/src/retroshare-gui.pro retroshare-gui/src/retroshare-gui.pro
+index 7a6d8d2a9..8f25e2891 100644
+--- retroshare-gui/src/retroshare-gui.pro
++++ retroshare-gui/src/retroshare-gui.pro
+@@ -238,8 +238,8 @@ win32 {
+ 
+ macx {
+ 	# ENABLE THIS OPTION FOR Univeral Binary BUILD.
+-	#CONFIG += ppc x86
+-	#QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.4
++	# CONFIG += ppc x86
++	# QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.4
+ 	QMAKE_INFO_PLIST = Info.plist
+ 	mac_icon.files = $$files($$PWD/rsMacIcon.icns)
+ 	mac_icon.path = Contents/Resources
+@@ -249,18 +249,20 @@ macx {
+ 	QMAKE_BUNDLE_DATA += mac_webui
+ 
+ 	CONFIG += version_detail_bash_script
+-        LIBS += -lssl -lcrypto -lz 
+-        #LIBS += -lssl -lcrypto -lz -lgpgme -lgpg-error -lassuan
+-	for(lib, LIB_DIR):exists($$lib/libminiupnpc.a){ LIBS += $$lib/libminiupnpc.a}
++	LIBS += -lssl -lcrypto -lgnutls -lz -lgpg-error -lassuan
++	LIBS += -lsqlite3
++	LIBS += @PREFIX@/lib/libgpgme.a
++	# LIBS += @PREFIX@/lib/libgpg-error.a
++	LIBS += @PREFIX@/lib/libminiupnpc.a
+ 	LIBS += -framework CoreFoundation
+ 	LIBS += -framework Security
+ 	LIBS += -framework Carbon
+ 
+ 	for(lib, LIB_DIR):LIBS += -L"$$lib"
+-	for(bin, BIN_DIR):LIBS += -L"$$bin"
+ 
+ 	DEPENDPATH += . $$INC_DIR
+ 	INCLUDEPATH += . $$INC_DIR
++	INCLUDEPATH += @PREFIX@/include
+ 
+ 	#DEFINES *= MAC_IDLE # for idle feature
+ 	CONFIG -= uitools
+diff --git retroshare-nogui/src/retroshare-nogui.pro retroshare-nogui/src/retroshare-nogui.pro
+index 1fdb27b71..e825982f6 100644
+--- retroshare-nogui/src/retroshare-nogui.pro
++++ retroshare-nogui/src/retroshare-nogui.pro
+@@ -98,15 +98,19 @@ macx {
+ 	# CONFIG += ppc x86
+ 
+ 	LIBS += -Wl,-search_paths_first
+-	LIBS += -lssl -lcrypto -lz
+-	for(lib, LIB_DIR):exists($$lib/libminiupnpc.a){ LIBS += $$lib/libminiupnpc.a}
++	LIBS += -lssl -lcrypto -lgnutls -lz -lbz2 -lgpg-error
++	LIBS += -lsqlite3
++	LIBS += @PREFIX@/lib/libgpgme.a
++	# LIBS += @PREFIX@/lib/libgpg-error.a
++	LIBS += @PREFIX@/lib/libminiupnpc.a
++	LIBS += @PREFIX@/lib/libmicrohttpd.a
+ 	LIBS += -framework CoreFoundation
+ 	LIBS += -framework Security
+ 	for(lib, LIB_DIR):LIBS += -L"$$lib"
+-	for(bin, BIN_DIR):LIBS += -L"$$bin"
+ 
+ 	DEPENDPATH += . $$INC_DIR
+ 	INCLUDEPATH += . $$INC_DIR
++	INCLUDEPATH += @PREFIX@/include
+ 
+ 	QMAKE_CXXFLAGS *= -Dfseeko64=fseeko -Dftello64=ftello -Dstat64=stat -Dstatvfs64=statvfs -Dfopen64=fopen
+ }
+@@ -162,6 +166,12 @@ INCLUDEPATH += . $$PWD/../../libretroshare/src
+ PRE_TARGETDEPS *= $$OUT_PWD/../../libretroshare/src/lib/libretroshare.a
+ LIBS *= $$OUT_PWD/../../libretroshare/src/lib/libretroshare.a
+ 
++PRE_TARGETDEPS *= $$OUT_PWD/../../openpgpsdk/src/lib/libops.a
++LIBS *= $$OUT_PWD/../../openpgpsdk/src/lib/libops.a
++
++PRE_TARGETDEPS *= $$OUT_PWD/../../libbitdht/src/lib/libbitdht.a
++LIBS *= $$OUT_PWD/../../libbitdht/src/lib/libbitdht.a
++
+ # Input
+ HEADERS +=  notifytxt.h
+ SOURCES +=  notifytxt.cc \
+diff --git retroshare.pri retroshare.pri
+index 446c1bd61..dae663386 100644
+--- retroshare.pri
++++ retroshare.pri
+@@ -85,7 +85,7 @@ rs_cppwarning:CONFIG -= no_rs_cppwarning
+ # To disable GXS mail append the following assignation to qmake command line
+ # "CONFIG+=no_rs_gxs_trans"
+ CONFIG *= rs_gxs_trans
+-#no_rs_gxs_trans:CONFIG -= rs_gxs_trans ## Disabing not supported ATM
++# no_rs_gxs_trans:CONFIG -= rs_gxs_trans ## Disabing not supported ATM
+ 
+ # To enable GXS based async chat append the following assignation to qmake
+ # command line "CONFIG+=rs_async_chat"
+@@ -93,12 +93,8 @@ CONFIG *= no_rs_async_chat
+ rs_async_chat:CONFIG -= no_rs_async_chat
+ 
+ # To select your MacOsX version append the following assignation to qmake
+-# command line "CONFIG+=rs_macos10.11" where 10.11 depends your version
+-macx:CONFIG *= rs_macos10.11
+-rs_macos10.8:CONFIG -= rs_macos10.11
+-rs_macos10.9:CONFIG -= rs_macos10.11
+-rs_macos10.10:CONFIG -= rs_macos10.11
+-rs_macos10.12:CONFIG -= rs_macos10.11
++# command line "CONFIG+=rs_macos@TARGET@" where @TARGET@ depends your version
++# macx:CONFIG *= rs_macos@TARGET@
+ 
+ 
+ linux-* {
+@@ -165,45 +161,26 @@ win32 {
+ }
+ 
+ macx {
+-	rs_macos10.8 {
+-		message(***retroshare.pri: Set Target and SDK to MacOS 10.8 )
+-		QMAKE_MACOSX_DEPLOYMENT_TARGET=10.8
+-		QMAKE_MAC_SDK = macosx10.8
++	rs_macos@TARGET@ {
++		message(***retroshare.pri: Set Target and SDK to MacOS @TARGET@ )
++		QMAKE_MACOSX_DEPLOYMENT_TARGET=@TARGET@
++		QMAKE_MAC_SDK = macosx@TARGET@
+ 	}
+ 
+-	rs_macos10.9 {
+-		message(***retroshare.pri: Set Target and SDK to MacOS 10.9 )
+-		QMAKE_MACOSX_DEPLOYMENT_TARGET=10.9
+-		QMAKE_MAC_SDK = macosx10.9
+-	}
+-
+-	rs_macos10.10 {
+-		message(***retroshare.pri: Set Target and SDK to MacOS 10.10 )
+-		QMAKE_MACOSX_DEPLOYMENT_TARGET=10.10
+-		QMAKE_MAC_SDK = macosx10.10
+-	}
+-
+-	rs_macos10.11 {
+-		message(***retroshare.pri: Set Target and SDK to MacOS 10.11 )
+-		QMAKE_MACOSX_DEPLOYMENT_TARGET=10.11
+-		QMAKE_MAC_SDK = macosx10.11
+-	}
+-
+-	rs_macos10.12 {
+-		message(***retroshare.pri: Set Target and SDK to MacOS 10.12 )
+-		QMAKE_MACOSX_DEPLOYMENT_TARGET=10.12
+-		QMAKE_MAC_SDK = macosx10.12
+-		QMAKE_CXXFLAGS += -Wno-nullability-completeness
+-		QMAKE_CFLAGS += -Wno-nullability-completeness
+-	}
++#	rs_macos10.12 {
++#		message(***retroshare.pri: Set Target and SDK to MacOS 10.12 )
++#		QMAKE_MACOSX_DEPLOYMENT_TARGET=10.12
++#		QMAKE_MAC_SDK = macosx10.12
++#		QMAKE_CXXFLAGS += -Wno-nullability-completeness
++#		QMAKE_CFLAGS += -Wno-nullability-completeness
++#	}
+ 
+ 	message(***retroshare.pri:MacOSX)
+ 	BIN_DIR += "/usr/bin"
+ 	INC_DIR += "/usr/include"
+-	INC_DIR += "/usr/local/include"
+-	INC_DIR += "/opt/local/include"
+-	LIB_DIR += "/usr/local/lib"
+-	LIB_DIR += "/opt/local/lib"
++	BIN_DIR += "@PREFIX@/bin"
++	INC_DIR += "@PREFIX@/include"
++	LIB_DIR += "@PREFIX@/lib"
+ 	CONFIG += c++11
+ }
+ 

--- a/www/retroshare-qt4/files/0002-bdthreads.cc-fix-pointer-comparison.patch
+++ b/www/retroshare-qt4/files/0002-bdthreads.cc-fix-pointer-comparison.patch
@@ -1,0 +1,24 @@
+# This is just borrowed from a later upstream version.
+
+From 9c5ae1c29b0646b501f9704ce335f835ce33c1c0 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Thu, 10 Aug 2023 04:51:25 +0800
+Subject: [PATCH 2/3] bdthreads.cc: fix pointer comparison
+
+---
+ libbitdht/src/util/bdthreads.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git libbitdht/src/util/bdthreads.cc libbitdht/src/util/bdthreads.cc
+index b52d152da..6a944d6b2 100644
+--- libbitdht/src/util/bdthreads.cc
++++ libbitdht/src/util/bdthreads.cc
+@@ -126,7 +126,7 @@ void bdThread::join() /* waits for the the mTid thread to stop */
+ 
+     mMutex.lock();
+     {
+-#if defined(_WIN32) || defined(__MINGW32__)
++#if defined(_WIN32) || defined(__MINGW32__) || defined(__APPLE__)
+ 	/* Its a struct in Windows compile and the member .p ist checked in the pthreads library */
+ #else
+ 	if(mTid > 0)

--- a/www/retroshare-qt4/files/0003-Add-missing-headers.patch
+++ b/www/retroshare-qt4/files/0003-Add-missing-headers.patch
@@ -1,0 +1,21 @@
+From 9f950e44a2fc7222a051f0d466b524339bfa8662 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Fri, 20 Oct 2023 05:51:44 +0800
+Subject: [PATCH 3/3] Add missing headers
+
+---
+ libretroshare/src/util/rstime.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git libretroshare/src/util/rstime.h libretroshare/src/util/rstime.h
+index 4359a28ff..9b9540379 100644
+--- libretroshare/src/util/rstime.h
++++ libretroshare/src/util/rstime.h
+@@ -24,6 +24,7 @@
+  */
+ 
+ #include <string>
++#include <cstdint>
+ 
+ namespace rstime {
+ 


### PR DESCRIPTION
#### Description

UPD. There is really no need to torture the code to build for the latest OS, where instead Qt5-based version should be used.
I will restrict this to older OS.

retroshare-qt5 upcoming, but I need time to sort out the build. There is one module broken in the master, I need to find a neat way to fix it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
