### PR TITLE
rnnoise: Use release tarball

### DIFF
--- a/audio/rnnoise/Portfile
+++ b/audio/rnnoise/Portfile
@@ -4,34 +4,27 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        xiph rnnoise 0.2 v
-revision            0
+revision            1
+checksums           rmd160  247533f4803d58e064037d852c1feb27bede927c \
+                    sha256  90fce4b00b9ff24c08dbfe31b82ffd43bae383d85c5535676d28b0a2b11c0d37 \
+                    size    2294308
+# Remove with next version update.
+dist_subdir         ${name}/${version}_1
+
 categories          audio
 license             BSD
 maintainers         @jasonliu-- openmaintainer
 
 homepage            https://jmvalin.ca/demo/rnnoise
+github.tarball_from releases
+
 description         Recurrent neural network for audio noise reduction
 long_description    RNNoise is a noise suppression library based \
                     on a recurrent neural network.
 
-checksums           rmd160  a3460eb584cab6dad4607ca2f12fec0964407581 \
-                    sha256  e4a17eb1493b7551f9f7781d2acc67b8847d6ed7c4b64db0fd62c017021ae1ec \
-                    size    91363
-github.tarball_from archive
-
 # https://github.com/xiph/rnnoise/issues/222
 patch.pre_args      -p1
 patchfiles          patch-372f7b4b76cde4ca1ec4605353dd17898a99de38.diff
-
-use_autoreconf      yes
-autoreconf.cmd      ./autogen.sh
-
-# Used by download_model.sh
-depends_build-append \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool \
-                    port:wget
 
 # FIXME: no Altivec support at the moment:
 # https://github.com/xiph/rnnoise/issues/223


### PR DESCRIPTION
#### Description

Removes the need to autoreconf. Removes need for autoconf, automake, libtool, wget dependencies. No longer downloads a file at build time. The version number is now correct in rnnoise.pc.

Closes: https://trac.macports.org/ticket/69882

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 21H1123 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
