### PR TITLE
R-clock: fix for < 10.13 with clang

### DIFF
--- a/R/R-clock/Portfile
+++ b/R/R-clock/Portfile
@@ -21,6 +21,15 @@ depends_lib-append  port:R-cli \
                     port:R-tzdb \
                     port:R-vctrs
 
+# https://trac.macports.org/ticket/68533
+platform darwin {
+    if {${os.major} < 16 && ${configure.cxx_stdlib} eq "libc++"} {
+        post-extract {
+            copy ${filespath}/Makevars ${worksrcpath}/src/
+        }
+    }
+}
+
 depends_test-append port:R-covr \
                     port:R-knitr \
                     port:R-magrittr \

--- a/R/R-clock/files/Makevars
+++ b/R/R-clock/files/Makevars
@@ -1,0 +1,1 @@
+CXX_STD = CXX11


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/68533

#### Description

Fix

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5
Xcode 5.1.1

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
