### PR TITLE
ruby-build: Upgrade to 20240501

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20240423 v
+github.setup        rbenv ruby-build 20240501 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  d72aff0b93394b19de30d1b5f25aed17115a0fc8 \
-                    sha256  f482cf3f2dfcff5f12c14756cf8b09dc9467885e70a834d99c0ace7353617d36 \
-                    size    89592
+checksums           rmd160  5c308b5da93dd043f2c6df346bd6d697360eb6ce \
+                    sha256  03601991e0e99ae5e75b1047e77498e329c3f8253cd3de5adabab56c05886079 \
+                    size    89667
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Upgrade to 20240501

##### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](htps://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
