### PR TITLE
google-cloud-sdk: update to 474.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             473.0.0
+version             474.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  824613b423673030a5a78f62d7f50741e48c3fa8 \
-                    sha256  328cd238e62bcf326247bf67b6915c3bd4faf8801489cb42fbbd1385297f36a2 \
-                    size    123609947
+    checksums       rmd160  3435cc0770d15e7a3f1d0aa8c8cf68b35d05fb70 \
+                    sha256  774fc19c0819dd7cd822e142f9f226cb00f0efab2571eec2c53c0f801014f954 \
+                    size    123628553
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  65d16b15ed5f237b990eb3df70d8f346ccda4a02 \
-                    sha256  ac5e3d16f53a03cf1aba6587d65f77a4565c044ab18c7783ad42cc7da1949b3d \
-                    size    124894569
+    checksums       rmd160  1ad9df06529fb8107e77a76a8379a05b5f3c47d5 \
+                    sha256  de13df2e137cbf1f8917229a198ada67f5ce8a970c40d4e2175db5e6e3175ce5 \
+                    size    124915031
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  614478c24477daf8b35c942fd9ff3b4574020e99 \
-                    sha256  3b26e9682379f8b5e875f5982411fb7f4f635f5155a9fe6284f62dedffd5840b \
-                    size    121956770
+    checksums       rmd160  dc22a3cb1edf55b3c7fc6f293e342f9703625fe4 \
+                    sha256  937908fd50f6aab87c08c72a70fa96abef10786fc664363ee6a92a4f2a7d1c8b \
+                    size    121975066
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 474.0.0.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?