### PR TITLE
nvi: blacklist old Xcode gcc, which does not build this

### DIFF
--- a/editors/nvi/Portfile
+++ b/editors/nvi/Portfile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
 PortSystem      1.0
 
 name            nvi
@@ -14,7 +16,6 @@ long_description \
     (4BSD), by the University of California, Berkeley.
 
 homepage        http://www.bostic.com/vi/
-platforms       darwin
 master_sites    ftp://ftp.stack.nl/pub/users/johans/nvi/
 checksums       md5 88d1e23115ee9f2961186b62e55f5704 \
                 rmd160 0db8568bea96392d9a027044177c60317c8ade36 \
@@ -40,6 +41,10 @@ patchfiles \
     patch-includes.diff \
     patch-common_msg.c.diff \
     patch-powerof2.diff
+
+# https://trac.macports.org/ticket/69888
+compiler.blacklist-append \
+                {*gcc-[34].*}
 
 configure.args \
     --program-prefix=n \


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69888

#### Description

Fix this version too

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
