### PR TITLE
eiffelstudio: Add another maintainer

### DIFF
--- a/lang/eiffelstudio/Portfile
+++ b/lang/eiffelstudio/Portfile
@@ -7,7 +7,7 @@ version           ${major_version}.${minor_version}
 categories        lang
 license           GPL-2
 platforms         darwin
-maintainers       {jann @roederja} openmaintainer
+maintainers       {jann @roederja} {javierv @jvelilla} openmaintainer
 description       The ISE Eiffel Compiler and IDE
 long_description  EiffelStudio is a development environment for the \
                   Eiffel programming language developed by Eiffel Software. \


### PR DESCRIPTION

#### Description

* updated maintainer's list

###### Type(s)

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 14.4.1 23E224 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? 
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
