### PR TITLE
hdf5: Disable new float16 support for now.

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -9,7 +9,7 @@ PortGroup           github 1.0
 
 github.setup        HDFGroup hdf5 1.14.4.2 hdf5_
 set distversion     1.14.4-2
-revision            0
+revision            1
 #set mainversion     [lrange [split ${version} -] 0 0]
 #set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
 
@@ -70,6 +70,8 @@ compiler.c_standard 1999
 # Avoid duplicate LC_RPATH's in dylibs, satisfy Xcode 15 linker.
 compilers.add_gcc_rpath_support no
 
+# Disabling float16 for now: https://github.com/HDFGroup/hdf5/issues/4310,
+# MacPorts #69861
 # Use lib/hdf5 rather than hdf5/lib plugin directory
 configure.args \
                     --disable-cxx \
@@ -83,7 +85,8 @@ configure.args \
                     --enable-static \
                     --with-default-plugindir=${prefix}/lib/hdf5 \
                     --with-szlib=${prefix}/lib/libaec \
-                    --with-zlib=yes
+                    --with-zlib=yes \
+                    --disable-nonstandard-feature-float16
 
 # Actively checks how to get clang to warn on implicit functions with this.
 configure.checks.implicit_function_declaration.whitelist-append strchr


### PR DESCRIPTION
[User report](https://trac.macports.org/ticket/69861) of fortran tools failing with errors matching [upstream report](https://github.com/HDFGroup/hdf5/issues/4310).

Disabling new float16 support for now.