### PR TITLE
httpie-go: new port (version 0.7.0)

### DIFF
--- a/net/httpie-go/Portfile
+++ b/net/httpie-go/Portfile
@@ -1,0 +1,149 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/nojima/httpie-go 0.7.0 v
+categories          net
+revision            0
+
+maintainers         {sub-pop.net:link @subpop} openmaintainer
+license             MIT
+
+description         httpie-like HTTP client written in Go
+
+long_description    ${description}
+
+checksums           ${distname}${extract.suffix} \
+                        rmd160  4de3c1dadec0005655223d007f7dabc8920e0027 \
+                        sha256  375a6a96d31ee33da9c205763bae1690b7a2c9b15f5347ae8064ebbb9f21f0e9 \
+                        size    138377
+
+build.target        ./cmd/ht
+
+go.vendors          gopkg.in/yaml.v2 \
+                        lock    v2.2.4 \
+                        rmd160  e7d6084770eadd1aea75e3e6ad70962436c22989 \
+                        sha256  14dda753969aacb4366477ac95e2b371e1ee940e7e76bfffdec737a55dbd27e0 \
+                        size    72218 \
+                    gopkg.in/tomb.v1 \
+                        lock    dd632973f1e7 \
+                        rmd160  ae07f5ddbbc6afc772d6dc5273bb72eaba50529a \
+                        sha256  91c562a4e31c89d13e5391143ff653231fc2d80562743db89ce2172ad8f81008 \
+                        size    3636 \
+                    gopkg.in/fsnotify.v1 \
+                        repo    github.com/fsnotify/fsnotify \
+                        lock    v1.4.7 \
+                        rmd160  24712e412814020224e2779186e634610e2f6926 \
+                        sha256  bc839ee158ad34b81c1f11c3b9e3bcbabfba3297f61d165599880c400b8171dc \
+                        size    31147 \
+                    gopkg.in/check.v1 \
+                        lock    20d25e280405 \
+                        rmd160  412aa0d109919182ff84259e9b5bbc9f24d78117 \
+                        sha256  233f8faf427ce6701ac3427f85c28bc6b6ae7cdc97a303a52873c69999223325 \
+                        size    30360 \
+                    golang.org/x/xerrors \
+                        lock    a985d3407aa7 \
+                        rmd160  b6292b8b271245f925086a11c023a1eb2da9bca7 \
+                        sha256  1bda326d6ff46923acf39d3c399420d00547da618fb197b3281168af7c800e86 \
+                        size    12271 \
+                    golang.org/x/text \
+                        lock    v0.3.0 \
+                        rmd160  81061ce2006da3d6f7a8ef8dae237d65305513d3 \
+                        sha256  6243d5bbd9d8550bc44cb58a0d70180f7a3f6767299b490015107b4d27c604ae \
+                        size    6102563 \
+                    golang.org/x/sys \
+                        lock    v0.8.0 \
+                        rmd160  e678fbf405f6f2de2dd29b0a8b71baec9f1f1321 \
+                        sha256  8c0922a390cb8c22c340d69aa24ecf3cd923b30ca28dc96965d32d4b3a4e917d \
+                        size    1436856 \
+                    golang.org/x/sync \
+                        lock    1d60e4601c6f \
+                        rmd160  963f53b16a0fa1fa30f5dc26126ef361d92e5b54 \
+                        sha256  f8ec0b925881b4d055830db12febd93b9771836488a5fb1e2b8881d357176ec0 \
+                        size    16330 \
+                    golang.org/x/net \
+                        lock    eb5bcb51f2a3 \
+                        rmd160  cb943e35e512e30b1a1ee9a9af23e200de7fc2fd \
+                        sha256  50ba342bcc50da4b4590ee91a6586f9d0aab43907596c2a0995e6f0868353e7a \
+                        size    976956 \
+                    golang.org/x/crypto \
+                        lock    78000ba7a073 \
+                        rmd160  9a12d00c20ae0a4dba65e412ecf221bb30753394 \
+                        sha256  057fd9d742d083c627242afe24658be0475262dee7aff210ee36fd66b9a2b856 \
+                        size    1727061 \
+                    github.com/vbauerster/mpb \
+                        lock    v5.0.2 \
+                        rmd160  2084118aff80243567e7247dc847ccfa6296c468 \
+                        sha256  8ddee8ef65f70ca99ba9dd633048d920d168b58e26782af75ea380d20f43762e \
+                        size    56676 \
+                    github.com/pkg/errors \
+                        lock    v0.9.1 \
+                        rmd160  dc065c655f8a24c6519b58f9d1202eb266ecda40 \
+                        sha256  208d21a7da574026f68a8c9818fa7c6ede1b514ef9e72dc733b496ddcb7792a6 \
+                        size    13422 \
+                    github.com/pborman/getopt \
+                        lock    ee0cd42419d3 \
+                        rmd160  a8e973b4ad177bf0b96f7025741068cda381ae82 \
+                        sha256  ad0b33b6de45c9c305dd9d9f90ee092deccb0b35161fc30fdc384b189362c6db \
+                        size    39712 \
+                    github.com/onsi/gomega \
+                        lock    v1.9.0 \
+                        rmd160  82bcf5f0bb56669bc69b395acc205bac6a2e88ea \
+                        sha256  50573d2ae4c54dd98ef4dc88d776897cdf62d44f9679dd0878081b499bfb6b96 \
+                        size    93615 \
+                    github.com/onsi/ginkgo \
+                        lock    v1.12.0 \
+                        rmd160  9b958135a345cbf58867dbaa4e520483bfade214 \
+                        sha256  49da9c5b71b76320d2b5640b3fe29fd72fa97e994e5c7a5f06e5c25bce7334c2 \
+                        size    138578 \
+                    github.com/mtibben/androiddnsfix \
+                        lock    ff0280446354 \
+                        rmd160  870e87bc60bdfb168081a021f955d1d0832859f8 \
+                        sha256  fb26f3be15f162080134a9fcf667c3faadaba4d00fc401fc69b9152bf61b941b \
+                        size    2272 \
+                    github.com/mattn/go-isatty \
+                        lock    v0.0.12 \
+                        rmd160  4f55aecbddbee6089cbac8456d2932bce2cb57e7 \
+                        sha256  d4d1912998d401389e06ee1dbed06e32a8db95350416f227fbe6a59ac84f0651 \
+                        size    4549 \
+                    github.com/logrusorgru/aurora \
+                        lock    e9ef32dff381 \
+                        rmd160  27e9a9bf2789acb5da740ed564043f65101db1e2 \
+                        sha256  b430980e939900f71c8bf977b3abb9c57a6a1c62e40a4f5480cc9c236762bbcc \
+                        size    133632 \
+                    github.com/hpcloud/tail \
+                        lock    v1.0.0 \
+                        rmd160  2c6daf876a9a3ff47d239f3485810799ae9ced66 \
+                        sha256  aa9d7b729c8ee8b00c1a755ade77024e6b3ec4ac88585a39e31882260249f86b \
+                        size    37817 \
+                    github.com/golang/protobuf \
+                        lock    v1.2.0 \
+                        rmd160  501a9bf9f60a18e27d18218ebc07dede37919caa \
+                        sha256  f2969cdcd53da3798ace0c4e3c612c9228ee39086bf45249c213db188bc32c4e \
+                        size    332622 \
+                    github.com/fsnotify/fsnotify \
+                        lock    v1.6.0 \
+                        rmd160  2d5150222f41b06715da40ebdceafb183979bd07 \
+                        sha256  af0e2b174dd969ee214e5899eb499fec5a75f5319ab4c810256f6018649b2a2c \
+                        size    46049 \
+                    github.com/acarl005/stripansi \
+                        lock    5a71ef0e047d \
+                        rmd160  fd222fb597292536232f066479c48f1e7769373f \
+                        sha256  7c4d6ffa5a4401bffde46366e0c4976893ee8d6210543bc70cc1c514c22e29ae \
+                        size    1479 \
+                    github.com/VividCortex/ewma \
+                        lock    v1.1.1 \
+                        rmd160  6b8bf4660d058b82578645c8ad7ab1613efbf07e \
+                        sha256  6a4094d5d00f3db00f44400796e8e13dba57419d350d88cf3f0a5a8e463a073a \
+                        size    6049 \
+                    code.cloudfoundry.org/bytefmt \
+                        repo    github.com/cloudfoundry/bytefmt \
+                        lock    cf55d5288a48 \
+                        rmd160  057871e4b5bedb4ea10321f6215637f00371d291 \
+                        sha256  fb70486fe5e181ad76dae73b0c95b56111d7dfc58e940e75d3c90440c449cca8 \
+                        size    7823
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/ht ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description

Add `httpie-go`, an httpie-like client written in Go.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix
- [x] new port

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
