### PR TITLE
unpaper: update to 7.0, change build system, adopt

### DIFF
--- a/graphics/unpaper/Portfile
+++ b/graphics/unpaper/Portfile
@@ -2,43 +2,42 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           meson 1.0
 
-# When updating to the next version, please switch to xz tarball
-# and no longer autoreconf.
-github.setup        Flameeyes unpaper 6.1 unpaper-
-revision            2
+github.setup        unpaper unpaper 7.0.0 unpaper-
+github.tarball_from releases
+use_xz              yes
+
+revision            0
 categories          graphics
-maintainers         nomaintainer
-license             GPL-2+
+maintainers         {@akierig fastmail.de:akierig} openmaintainer
+license             GPL-2
 
 description         Post-processing scanned and photocopied book pages
 long_description    unpaper is a post-processing tool for scanned sheets of paper, especially for book pages that have been scanned from previously created photocopies. \
                     The main purpose is to make scanned book pages better readable on screen after conversion to PDF. \
                     Additionally, unpaper might be useful to enhance the quality of scanned pages before performing optical character recognition (OCR).
-platforms           darwin
 
 homepage            https://www.flameeyes.eu/projects/unpaper
 
-checksums           rmd160  29bfd4b927ecd5e56d49b0f8f540d5138544a8a4 \
-                    sha256  9421fa66c8506f12dc0cc4c3814f1b41903420f6afeecd0db50fae49fcdb5740 \
-                    size    2704127
+checksums           rmd160  704cbff899afa1a21268351afbcb76556422844d \
+                    sha256  2575fbbf26c22719d1cb882b59602c9900c7f747118ac130883f63419be46a80 \
+                    size    4430572
 
-depends_build       port:docbook-xsl-ns \
+set py_ver          3.12
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+set ffmpeg_ver      6
+
+depends_build-append \
                     port:libxslt \
                     port:netpbm \
-                    port:pkgconfig
-
-depends_lib-append  path:lib/libavcodec.dylib:ffmpeg
-
+                    port:pkgconfig \
+                    port:py${py_ver_nodot}-sphinx
+depends_lib         port:ffmpeg${ffmpeg_ver}
 depends_run         port:netpbm
 
-# tarball does not include configure script
-# https://github.com/Flameeyes/unpaper/issues/17
-use_autoreconf      yes
+configure.pkg_config_path   ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
 
-configure.args      --disable-silent-rules
-
-if {[string match *clang* ${configure.compiler}]} {
-    configure.cflags-append \
-                    -flto
+pre-configure {
+    reinplace "s|sphinx-build|sphinx-build-${py_ver}|" ${worksrcpath}/meson.build
 }


### PR DESCRIPTION
#### Description

This updates unpaper to 7.0.0 which involves changing the build system to meson. I have also adopted the port since it was unmaintained.

###### Type(s)

- [x] bugfix
- [x] enhancement

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
