### PR TITLE
py-pypng: Update to 0.20220715.0

### DIFF
--- a/python/py-pypng/Portfile
+++ b/python/py-pypng/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pypng
-version             0.0.20
+version             0.20220715.0
 platforms           {darwin any}
 supported_archs     noarch
 license             MIT
@@ -14,13 +14,13 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 description         Pure Python PNG image encoder/decoder
 long_description    {*}${description}
 
-homepage            https://github.com/drj11/pypng
+homepage            https://gitlab.com/drj11/pypng
 
-checksums           rmd160  cbc12a8c877ad7161ba3cf541dfe967bd73c2995 \
-                    sha256  1032833440c91bafee38a42c38c02d00431b24c42927feb3e63b104d8550170b \
-                    size    649538
+checksums           rmd160  015598175d3ea4000e9c8a43a2ca3ced270d8685 \
+                    sha256  739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1 \
+                    size    128992
 
-python.versions     38 39 310 311
+python.versions     38 39 310 311 312
 
 if {${name} ne ${subport}} {
     post-destroot {


### PR DESCRIPTION
#### Description

Update `pypng` to version 0.20220715.0, while adding the Python 3.12 subport

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
