### PR TITLE
ntpsec: Fix livecheck

### DIFF
--- a/sysutils/ntpsec/Portfile
+++ b/sysutils/ntpsec/Portfile
@@ -171,5 +171,6 @@ startupitem.create      yes
 startupitem.netchange   yes
 startupitem.executable  ${prefix}/sbin/ntpd -n -g -p ${prefix}/var/run/ntpd.pid -f ${prefix}/var/db/ntp.drift -c ${prefix}/etc/ntp.conf
 
-# Allow an optional letter after the version for patch releases
-livecheck.regex ${name}-(\\d+(?:\\.\\d+)*\\w+)
+# Match most tarball patterns, but disallow versions with dashes to filter out
+# X.Y.Z-rcN, etc.
+livecheck.regex ${name}-(\[^-]+)\\.tar\\.gz


### PR DESCRIPTION
The previous regex change to allow the patch letter broke the case where the letter is absent.  The regex is now derived from the GitHub default regex, but adjusted to exclude patterns with dashes to avoid versions such as X.Y.Z-rcN.  The unnecessary quote exclusion is dropped.

TESTED:
Tested with current and older port versions, including with modified regex to make 1.2.2a the apparent latest.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [NO] tried existing tests with `sudo port test`?
- [NO] tried a full install with `sudo port -vst install`?
- [NO] tested basic functionality of all binary files?
- [NO] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

Abbreviated testing since the only change is the livecheck regex (and comment).

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
