### PR TITLE
asciidoctor: update to v2.0.22

### DIFF
--- a/textproc/asciidoctor/Portfile
+++ b/textproc/asciidoctor/Portfile
@@ -7,7 +7,7 @@ PortGroup           ruby 1.0
 # architectures.  Don't change it without preserving this property.
 # The choice of Ruby versions doesn't affect clients.
 #
-ruby.setup          asciidoctor 2.0.21 gem {} rubygems ruby30
+ruby.setup          asciidoctor 2.0.22 gem {} rubygems ruby33
 name                asciidoctor
 revision            0
 
@@ -32,8 +32,8 @@ long_description    Asciidoctor is a fast, open source, Ruby-based \
                     content written in AsciiDoc.
 homepage            https://asciidoctor.org/
 
-checksums           rmd160  9e45eab40c558c947a55697c8362ea4414f04bac \
-                    sha256  07138c69d2aa320932d38beb17fedb09090cdb38e64d14c1f6926b620715c100 \
+checksums           rmd160  f4214ef8f132ec9d2b57ee822876b66a53e16352 \
+                    sha256  a6d8f1bb593a3617c0334fdf36b1e25186c4f4d0e15636538c5811de9bb1cad6 \
                     size    282624
 
 # Use normal distfile location, instead of 'ruby'.


### PR DESCRIPTION
Also updates the underlying ruby version to 3.3, just to avoid EOL concerns (since it doesn't affect the behavior of asciidoctor itself). 3.3 is outside the compatible version range stated on the asciidoctor homepage, but that appears to be outdated.

TESTED:
Tested on 10.4-10.5 ppc, 10.4-10.6 i386, 10.5-12.x x86_64, and 11.x-14.x arm64.
Builds and passes tests on all versions.
Functionally tested with gpsd and ntpsec on 10.9.  Generated docs match except for expected metadata differences specifically related to asciidoctor version.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.4 21H1123, x86_64, Xcode 14.2 14C18
macOS 12.7.4 21H1123, arm64, Xcode 14.2 14C18
macOS 13.6.6 22G630, arm64, Xcode 15.2 15C500b
macOS 14.4.1 23E224, arm64, Xcode 15.3 15E204a
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [N/A] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
