### PR TITLE
py-pyobjc6: fix the build of core library

### DIFF
--- a/python/py-pyobjc6/Portfile
+++ b/python/py-pyobjc6/Portfile
@@ -6,6 +6,7 @@ PortGroup           python 1.0
 
 # Pegged version for old systems.
 # https://github.com/ronaldoussoren/pyobjc/issues/587
+# The port is not going to be updated beyond maintenance and fix-ups.
 github.setup        ronaldoussoren pyobjc 6.2.2 v
 revision            1
 
@@ -17,7 +18,7 @@ github.tarball_from archive
 name                py-pyobjc6
 categories-append   devel
 license             MIT
-maintainers         nomaintainer
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 platforms           {darwin < 11}
 description         Bidirectional bridge between Python and Objective C
 long_description    The PyObjC project aims to provide a bridge between \
@@ -34,6 +35,7 @@ homepage            https://pyobjc.readthedocs.io
 # for event 'builder-inited' threw an exception (exception: invalid mode: 'rU')
 # hello <sphinx.application.Sphinx object at 0x4420870>
 python.versions     38 39 310
+# Please refrain from dropping Python versions support here.
 
 # https://trac.macports.org/ticket/69728
 python.pep517       no
@@ -53,7 +55,9 @@ if {${name} ne ${subport}} {
                     patch-docs-conf.py.diff \
                     patch-install.py.diff
 
-    # Backport newer code from upstream:
+    # Backport newer code from upstream.
+    # Based on https://github.com/ronaldoussoren/pyobjc/commit/db2cdc8b2df25c1ef871534edd1ed97b1c89aa6e
+    # and https://github.com/ronaldoussoren/pyobjc/commit/2ae69be6c9b185417fa472f7a961771ae2600405
     patchfiles-append \
                     0001-Fix-obsolete-Python-API.patch
 

--- a/python/py-pyobjc6/Portfile
+++ b/python/py-pyobjc6/Portfile
@@ -7,7 +7,7 @@ PortGroup           python 1.0
 # Pegged version for old systems.
 # https://github.com/ronaldoussoren/pyobjc/issues/587
 github.setup        ronaldoussoren pyobjc 6.2.2 v
-revision            0
+revision            1
 
 checksums           rmd160  7387bc8c6ec744ca2cf6328036dde9826bcb2763 \
                     sha256  0730edcdc5ca0bbc1e10983d3a7ef143ea80dfec9db8b02eb81d64e4fc18635f \
@@ -30,7 +30,15 @@ long_description    The PyObjC project aims to provide a bridge between \
 homepage            https://pyobjc.readthedocs.io
 
 # It fails to build with Python 3.11+
+# Extension error (examples): Handler <function build_examples at 0x4e29168>
+# for event 'builder-inited' threw an exception (exception: invalid mode: 'rU')
+# hello <sphinx.application.Sphinx object at 0x4420870>
 python.versions     38 39 310
+
+# https://trac.macports.org/ticket/69728
+python.pep517       no
+
+# FIXME: optional modules do not build at the moment.
 
 if {${name} ne ${subport}} {
     depends_lib-append \
@@ -44,6 +52,26 @@ if {${name} ne ${subport}} {
     patchfiles-append \
                     patch-docs-conf.py.diff \
                     patch-install.py.diff
+
+    # Backport newer code from upstream:
+    patchfiles-append \
+                    0001-Fix-obsolete-Python-API.patch
+
+    platform darwin powerpc {
+        # Exclude this for ppc:
+        patchfiles-append \
+                    0002-module.m-no-AssociatedObject-on-ppc.patch
+    }
+
+    if {[string match *gcc* ${configure.compiler}]} {
+        patchfiles-append \
+                    0003-properties.m-disable-test-that-fails-to-compile-with.patch
+    }
+
+    if {${python.version} > 39} {
+        patchfiles-append \
+                    0004-struct-wrapper-fix-for-python-3.10.patch
+    }
 
     post-patch {
         reinplace "s|use-system-libffi = 0|\\
@@ -76,6 +104,8 @@ deployment-target = ${macosx_deployment_target}\\
     # in fact, doing so breaks the build...
     destroot.cmd "${python.bin} install.py"
 
+    destroot.destdir    --prefix=${prefix}/lib/${subport} --root=${destroot}
+
     post-destroot {
         xinstall -m 644 -W ${worksrcpath}/pyobjc-core HISTORIC.txt Install.txt \
             License.txt README.txt \
@@ -83,5 +113,6 @@ deployment-target = ${macosx_deployment_target}\\
         copy ${worksrcpath}/docs/_build/html ${destroot}${prefix}/share/doc/${subport}/html
     }
 
-    livecheck.type  none
 }
+
+livecheck.type      none

--- a/python/py-pyobjc6/files/0001-Fix-obsolete-Python-API.patch
+++ b/python/py-pyobjc6/files/0001-Fix-obsolete-Python-API.patch
@@ -1,0 +1,3884 @@
+From a0ac312f52d9af26214c5d9c712bdbc07b15deaf Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 15:06:27 +0800
+Subject: [PATCH] Fix obsolete Python API
+
+---
+ pyobjc-core/Lib/PyObjCTools/TestSupport.py    | 12 ++++-----
+ pyobjc-core/Tools/pyobjc_setup.py             | 12 ++++++---
+ pyobjc-core/setup.py                          | 25 ++++++++++++++-----
+ pyobjc-framework-AVFoundation/pyobjc_setup.py | 12 ++++++---
+ pyobjc-framework-AVKit/pyobjc_setup.py        | 12 ++++++---
+ pyobjc-framework-Accounts/pyobjc_setup.py     | 12 ++++++---
+ pyobjc-framework-AdSupport/pyobjc_setup.py    | 12 ++++++---
+ pyobjc-framework-AddressBook/pyobjc_setup.py  | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-Automator/pyobjc_setup.py    | 12 ++++++---
+ pyobjc-framework-BusinessChat/pyobjc_setup.py | 12 ++++++---
+ pyobjc-framework-CFNetwork/pyobjc_setup.py    | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-CloudKit/pyobjc_setup.py     | 12 ++++++---
+ pyobjc-framework-Cocoa/pyobjc_setup.py        | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-ColorSync/pyobjc_setup.py    | 12 ++++++---
+ pyobjc-framework-Contacts/pyobjc_setup.py     | 12 ++++++---
+ pyobjc-framework-ContactsUI/pyobjc_setup.py   | 12 ++++++---
+ pyobjc-framework-CoreAudio/pyobjc_setup.py    | 12 ++++++---
+ pyobjc-framework-CoreAudioKit/pyobjc_setup.py | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-CoreData/pyobjc_setup.py     | 12 ++++++---
+ pyobjc-framework-CoreHaptics/pyobjc_setup.py  | 12 ++++++---
+ pyobjc-framework-CoreLocation/pyobjc_setup.py | 12 ++++++---
+ pyobjc-framework-CoreML/pyobjc_setup.py       | 12 ++++++---
+ pyobjc-framework-CoreMedia/pyobjc_setup.py    | 12 ++++++---
+ pyobjc-framework-CoreMediaIO/pyobjc_setup.py  | 12 ++++++---
+ pyobjc-framework-CoreMotion/pyobjc_setup.py   | 12 ++++++---
+ pyobjc-framework-CoreServices/pyobjc_setup.py | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-CoreText/pyobjc_setup.py     | 12 ++++++---
+ pyobjc-framework-CoreWLAN/pyobjc_setup.py     | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-DVDPlayback/pyobjc_setup.py  | 12 ++++++---
+ pyobjc-framework-DeviceCheck/pyobjc_setup.py  | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-EventKit/pyobjc_setup.py     | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-FSEvents/pyobjc_setup.py     | 12 ++++++---
+ pyobjc-framework-FileProvider/pyobjc_setup.py | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-FinderSync/pyobjc_setup.py   | 12 ++++++---
+ pyobjc-framework-GameCenter/pyobjc_setup.py   | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-GameKit/pyobjc_setup.py      | 12 ++++++---
+ pyobjc-framework-GameplayKit/pyobjc_setup.py  | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-IOSurface/pyobjc_setup.py    | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-Intents/pyobjc_setup.py      | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-MapKit/pyobjc_setup.py       | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-MediaLibrary/pyobjc_setup.py | 12 ++++++---
+ pyobjc-framework-MediaPlayer/pyobjc_setup.py  | 12 ++++++---
+ pyobjc-framework-MediaToolbox/pyobjc_setup.py | 12 ++++++---
+ pyobjc-framework-Message/pyobjc_setup.py      | 12 ++++++---
+ pyobjc-framework-Metal/pyobjc_setup.py        | 12 ++++++---
+ pyobjc-framework-MetalKit/pyobjc_setup.py     | 12 ++++++---
+ pyobjc-framework-ModelIO/pyobjc_setup.py      | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-NetFS/pyobjc_setup.py        | 12 ++++++---
+ pyobjc-framework-Network/pyobjc_setup.py      | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-OSAKit/pyobjc_setup.py       | 12 ++++++---
+ pyobjc-framework-OSLog/pyobjc_setup.py        | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-PencilKit/pyobjc_setup.py    | 12 ++++++---
+ pyobjc-framework-Photos/pyobjc_setup.py       | 12 ++++++---
+ pyobjc-framework-PhotosUI/pyobjc_setup.py     | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-PubSub/pyobjc_setup.py       | 12 ++++++---
+ pyobjc-framework-PushKit/pyobjc_setup.py      | 12 ++++++---
+ pyobjc-framework-QTKit/pyobjc_setup.py        | 12 ++++++---
+ pyobjc-framework-Quartz/pyobjc_setup.py       | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-SceneKit/pyobjc_setup.py     | 12 ++++++---
+ pyobjc-framework-ScreenSaver/pyobjc_setup.py  | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-SearchKit/pyobjc_setup.py    | 12 ++++++---
+ pyobjc-framework-Security/pyobjc_setup.py     | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-Social/pyobjc_setup.py       | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-Speech/pyobjc_setup.py       | 12 ++++++---
+ pyobjc-framework-SpriteKit/pyobjc_setup.py    | 12 ++++++---
+ pyobjc-framework-StoreKit/pyobjc_setup.py     | 12 ++++++---
+ pyobjc-framework-SyncServices/pyobjc_setup.py | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-VideoToolbox/pyobjc_setup.py | 12 ++++++---
+ pyobjc-framework-Vision/pyobjc_setup.py       | 12 ++++++---
+ pyobjc-framework-WebKit/pyobjc_setup.py       | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ .../pyobjc_setup.py                           | 12 ++++++---
+ pyobjc-framework-libdispatch/pyobjc_setup.py  | 12 ++++++---
+ 121 files changed, 1095 insertions(+), 370 deletions(-)
+
+diff --git pyobjc-core/Lib/PyObjCTools/TestSupport.py pyobjc-core/Lib/PyObjCTools/TestSupport.py
+index 5699e3576..5a946861e 100644
+--- pyobjc-core/Lib/PyObjCTools/TestSupport.py
++++ pyobjc-core/Lib/PyObjCTools/TestSupport.py
+@@ -175,13 +175,11 @@ def os_release():
+     if _os_release is not None:
+         return _os_release
+ 
+-    if hasattr(_pl, "load"):
+-        with open("/System/Library/CoreServices/SystemVersion.plist", "rb") as fp:
+-            pl = _pl.load(fp)
+-    else:
+-        pl = _pl.readPlist("/System/Library/CoreServices/SystemVersion.plist")
+-    v = pl["ProductVersion"]
+-    return ".".join(v.split("."))
++    _os_release = (
++        _subprocess.check_output(["sw_vers", "-productVersion"]).decode().strip()
++    )
++
++    return _os_release
+ 
+ 
+ def is32Bit():
+diff --git pyobjc-core/Tools/pyobjc_setup.py pyobjc-core/Tools/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-core/Tools/pyobjc_setup.py
++++ pyobjc-core/Tools/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-core/setup.py pyobjc-core/setup.py
+index 95730a2b8..e0e50e1ed 100644
+--- pyobjc-core/setup.py
++++ pyobjc-core/setup.py
+@@ -38,7 +38,8 @@ if sys.version_info < MIN_PYTHON:
+ 
+ 
+ def get_os_level():
+-    pl = plistlib.readPlist("/System/Library/CoreServices/SystemVersion.plist")
++    with open("/System/Library/CoreServices/SystemVersion.plist", "rb") as fp:
++        pl = plistlib.load(fp)
+     v = pl["ProductVersion"]
+     return ".".join(v.split(".")[:2])
+ 
+@@ -47,11 +48,23 @@ def get_sdk_level(sdk):
+     if sdk == "/":
+         return get_os_level()
+ 
+-    sdk = os.path.basename(sdk)
+-    assert sdk.startswith("MacOSX")
+-    assert sdk.endswith(".sdk")
+-    sdk = sdk[6:-4]
+-    return sdk
++    sdk = sdk.rstrip("/")
++    sdkname = os.path.basename(sdk)
++    assert sdkname.startswith("MacOSX")
++    assert sdkname.endswith(".sdk")
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
++        try:
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
++            return pl["Version"]
++        except Exception:
++            raise SystemExit("Cannot determine SDK version")
++    else:
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ # CFLAGS for the objc._objc extension:
+diff --git pyobjc-framework-AVFoundation/pyobjc_setup.py pyobjc-framework-AVFoundation/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-AVFoundation/pyobjc_setup.py
++++ pyobjc-framework-AVFoundation/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-AVKit/pyobjc_setup.py pyobjc-framework-AVKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-AVKit/pyobjc_setup.py
++++ pyobjc-framework-AVKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Accounts/pyobjc_setup.py pyobjc-framework-Accounts/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Accounts/pyobjc_setup.py
++++ pyobjc-framework-Accounts/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-AdSupport/pyobjc_setup.py pyobjc-framework-AdSupport/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-AdSupport/pyobjc_setup.py
++++ pyobjc-framework-AdSupport/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-AddressBook/pyobjc_setup.py pyobjc-framework-AddressBook/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-AddressBook/pyobjc_setup.py
++++ pyobjc-framework-AddressBook/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-AppleScriptKit/pyobjc_setup.py pyobjc-framework-AppleScriptKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-AppleScriptKit/pyobjc_setup.py
++++ pyobjc-framework-AppleScriptKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-AppleScriptObjC/pyobjc_setup.py pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
++++ pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ApplicationServices/pyobjc_setup.py pyobjc-framework-ApplicationServices/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ApplicationServices/pyobjc_setup.py
++++ pyobjc-framework-ApplicationServices/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-AuthenticationServices/pyobjc_setup.py pyobjc-framework-AuthenticationServices/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-AuthenticationServices/pyobjc_setup.py
++++ pyobjc-framework-AuthenticationServices/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
++++ pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Automator/pyobjc_setup.py pyobjc-framework-Automator/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Automator/pyobjc_setup.py
++++ pyobjc-framework-Automator/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-BusinessChat/pyobjc_setup.py pyobjc-framework-BusinessChat/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-BusinessChat/pyobjc_setup.py
++++ pyobjc-framework-BusinessChat/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CFNetwork/pyobjc_setup.py pyobjc-framework-CFNetwork/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CFNetwork/pyobjc_setup.py
++++ pyobjc-framework-CFNetwork/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CalendarStore/pyobjc_setup.py pyobjc-framework-CalendarStore/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CalendarStore/pyobjc_setup.py
++++ pyobjc-framework-CalendarStore/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CloudKit/pyobjc_setup.py pyobjc-framework-CloudKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CloudKit/pyobjc_setup.py
++++ pyobjc-framework-CloudKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Cocoa/pyobjc_setup.py pyobjc-framework-Cocoa/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Cocoa/pyobjc_setup.py
++++ pyobjc-framework-Cocoa/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Collaboration/pyobjc_setup.py pyobjc-framework-Collaboration/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Collaboration/pyobjc_setup.py
++++ pyobjc-framework-Collaboration/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ColorSync/pyobjc_setup.py pyobjc-framework-ColorSync/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ColorSync/pyobjc_setup.py
++++ pyobjc-framework-ColorSync/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Contacts/pyobjc_setup.py pyobjc-framework-Contacts/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Contacts/pyobjc_setup.py
++++ pyobjc-framework-Contacts/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ContactsUI/pyobjc_setup.py pyobjc-framework-ContactsUI/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ContactsUI/pyobjc_setup.py
++++ pyobjc-framework-ContactsUI/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreAudio/pyobjc_setup.py pyobjc-framework-CoreAudio/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreAudio/pyobjc_setup.py
++++ pyobjc-framework-CoreAudio/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreAudioKit/pyobjc_setup.py pyobjc-framework-CoreAudioKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreAudioKit/pyobjc_setup.py
++++ pyobjc-framework-CoreAudioKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreBluetooth/pyobjc_setup.py pyobjc-framework-CoreBluetooth/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreBluetooth/pyobjc_setup.py
++++ pyobjc-framework-CoreBluetooth/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreData/pyobjc_setup.py pyobjc-framework-CoreData/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreData/pyobjc_setup.py
++++ pyobjc-framework-CoreData/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreHaptics/pyobjc_setup.py pyobjc-framework-CoreHaptics/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreHaptics/pyobjc_setup.py
++++ pyobjc-framework-CoreHaptics/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreLocation/pyobjc_setup.py pyobjc-framework-CoreLocation/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreLocation/pyobjc_setup.py
++++ pyobjc-framework-CoreLocation/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreML/pyobjc_setup.py pyobjc-framework-CoreML/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreML/pyobjc_setup.py
++++ pyobjc-framework-CoreML/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreMedia/pyobjc_setup.py pyobjc-framework-CoreMedia/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreMedia/pyobjc_setup.py
++++ pyobjc-framework-CoreMedia/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreMediaIO/pyobjc_setup.py pyobjc-framework-CoreMediaIO/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreMediaIO/pyobjc_setup.py
++++ pyobjc-framework-CoreMediaIO/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreMotion/pyobjc_setup.py pyobjc-framework-CoreMotion/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreMotion/pyobjc_setup.py
++++ pyobjc-framework-CoreMotion/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreServices/pyobjc_setup.py pyobjc-framework-CoreServices/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreServices/pyobjc_setup.py
++++ pyobjc-framework-CoreServices/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreSpotlight/pyobjc_setup.py pyobjc-framework-CoreSpotlight/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreSpotlight/pyobjc_setup.py
++++ pyobjc-framework-CoreSpotlight/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreText/pyobjc_setup.py pyobjc-framework-CoreText/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreText/pyobjc_setup.py
++++ pyobjc-framework-CoreText/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CoreWLAN/pyobjc_setup.py pyobjc-framework-CoreWLAN/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CoreWLAN/pyobjc_setup.py
++++ pyobjc-framework-CoreWLAN/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-CryptoTokenKit/pyobjc_setup.py pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
++++ pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-DVDPlayback/pyobjc_setup.py pyobjc-framework-DVDPlayback/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-DVDPlayback/pyobjc_setup.py
++++ pyobjc-framework-DVDPlayback/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-DeviceCheck/pyobjc_setup.py pyobjc-framework-DeviceCheck/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-DeviceCheck/pyobjc_setup.py
++++ pyobjc-framework-DeviceCheck/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-DictionaryServices/pyobjc_setup.py pyobjc-framework-DictionaryServices/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-DictionaryServices/pyobjc_setup.py
++++ pyobjc-framework-DictionaryServices/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-DiscRecording/pyobjc_setup.py pyobjc-framework-DiscRecording/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-DiscRecording/pyobjc_setup.py
++++ pyobjc-framework-DiscRecording/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-DiscRecordingUI/pyobjc_setup.py pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
++++ pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-DiskArbitration/pyobjc_setup.py pyobjc-framework-DiskArbitration/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-DiskArbitration/pyobjc_setup.py
++++ pyobjc-framework-DiskArbitration/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-EventKit/pyobjc_setup.py pyobjc-framework-EventKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-EventKit/pyobjc_setup.py
++++ pyobjc-framework-EventKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ExceptionHandling/pyobjc_setup.py pyobjc-framework-ExceptionHandling/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ExceptionHandling/pyobjc_setup.py
++++ pyobjc-framework-ExceptionHandling/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ExecutionPolicy/pyobjc_setup.py pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
++++ pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ExternalAccessory/pyobjc_setup.py pyobjc-framework-ExternalAccessory/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ExternalAccessory/pyobjc_setup.py
++++ pyobjc-framework-ExternalAccessory/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-FSEvents/pyobjc_setup.py pyobjc-framework-FSEvents/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-FSEvents/pyobjc_setup.py
++++ pyobjc-framework-FSEvents/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-FileProvider/pyobjc_setup.py pyobjc-framework-FileProvider/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-FileProvider/pyobjc_setup.py
++++ pyobjc-framework-FileProvider/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-FileProviderUI/pyobjc_setup.py pyobjc-framework-FileProviderUI/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-FileProviderUI/pyobjc_setup.py
++++ pyobjc-framework-FileProviderUI/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-FinderSync/pyobjc_setup.py pyobjc-framework-FinderSync/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-FinderSync/pyobjc_setup.py
++++ pyobjc-framework-FinderSync/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-GameCenter/pyobjc_setup.py pyobjc-framework-GameCenter/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-GameCenter/pyobjc_setup.py
++++ pyobjc-framework-GameCenter/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-GameController/pyobjc_setup.py pyobjc-framework-GameController/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-GameController/pyobjc_setup.py
++++ pyobjc-framework-GameController/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-GameKit/pyobjc_setup.py pyobjc-framework-GameKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-GameKit/pyobjc_setup.py
++++ pyobjc-framework-GameKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-GameplayKit/pyobjc_setup.py pyobjc-framework-GameplayKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-GameplayKit/pyobjc_setup.py
++++ pyobjc-framework-GameplayKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-IMServicePlugIn/pyobjc_setup.py pyobjc-framework-IMServicePlugIn/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-IMServicePlugIn/pyobjc_setup.py
++++ pyobjc-framework-IMServicePlugIn/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-IOSurface/pyobjc_setup.py pyobjc-framework-IOSurface/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-IOSurface/pyobjc_setup.py
++++ pyobjc-framework-IOSurface/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ImageCaptureCore/pyobjc_setup.py pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
++++ pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-InputMethodKit/pyobjc_setup.py pyobjc-framework-InputMethodKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-InputMethodKit/pyobjc_setup.py
++++ pyobjc-framework-InputMethodKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-InstallerPlugins/pyobjc_setup.py pyobjc-framework-InstallerPlugins/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-InstallerPlugins/pyobjc_setup.py
++++ pyobjc-framework-InstallerPlugins/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-InstantMessage/pyobjc_setup.py pyobjc-framework-InstantMessage/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-InstantMessage/pyobjc_setup.py
++++ pyobjc-framework-InstantMessage/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Intents/pyobjc_setup.py pyobjc-framework-Intents/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Intents/pyobjc_setup.py
++++ pyobjc-framework-Intents/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-InterfaceBuilderKit/pyobjc_setup.py pyobjc-framework-InterfaceBuilderKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-InterfaceBuilderKit/pyobjc_setup.py
++++ pyobjc-framework-InterfaceBuilderKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
++++ pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-LaunchServices/pyobjc_setup.py pyobjc-framework-LaunchServices/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-LaunchServices/pyobjc_setup.py
++++ pyobjc-framework-LaunchServices/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-LinkPresentation/pyobjc_setup.py pyobjc-framework-LinkPresentation/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-LinkPresentation/pyobjc_setup.py
++++ pyobjc-framework-LinkPresentation/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-LocalAuthentication/pyobjc_setup.py pyobjc-framework-LocalAuthentication/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-LocalAuthentication/pyobjc_setup.py
++++ pyobjc-framework-LocalAuthentication/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-MapKit/pyobjc_setup.py pyobjc-framework-MapKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-MapKit/pyobjc_setup.py
++++ pyobjc-framework-MapKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-MediaAccessibility/pyobjc_setup.py pyobjc-framework-MediaAccessibility/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-MediaAccessibility/pyobjc_setup.py
++++ pyobjc-framework-MediaAccessibility/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-MediaLibrary/pyobjc_setup.py pyobjc-framework-MediaLibrary/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-MediaLibrary/pyobjc_setup.py
++++ pyobjc-framework-MediaLibrary/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-MediaPlayer/pyobjc_setup.py pyobjc-framework-MediaPlayer/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-MediaPlayer/pyobjc_setup.py
++++ pyobjc-framework-MediaPlayer/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-MediaToolbox/pyobjc_setup.py pyobjc-framework-MediaToolbox/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-MediaToolbox/pyobjc_setup.py
++++ pyobjc-framework-MediaToolbox/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Message/pyobjc_setup.py pyobjc-framework-Message/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Message/pyobjc_setup.py
++++ pyobjc-framework-Message/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Metal/pyobjc_setup.py pyobjc-framework-Metal/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Metal/pyobjc_setup.py
++++ pyobjc-framework-Metal/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-MetalKit/pyobjc_setup.py pyobjc-framework-MetalKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-MetalKit/pyobjc_setup.py
++++ pyobjc-framework-MetalKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ModelIO/pyobjc_setup.py pyobjc-framework-ModelIO/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ModelIO/pyobjc_setup.py
++++ pyobjc-framework-ModelIO/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
++++ pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-NaturalLanguage/pyobjc_setup.py pyobjc-framework-NaturalLanguage/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-NaturalLanguage/pyobjc_setup.py
++++ pyobjc-framework-NaturalLanguage/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-NetFS/pyobjc_setup.py pyobjc-framework-NetFS/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-NetFS/pyobjc_setup.py
++++ pyobjc-framework-NetFS/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Network/pyobjc_setup.py pyobjc-framework-Network/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Network/pyobjc_setup.py
++++ pyobjc-framework-Network/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-NetworkExtension/pyobjc_setup.py pyobjc-framework-NetworkExtension/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-NetworkExtension/pyobjc_setup.py
++++ pyobjc-framework-NetworkExtension/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-NotificationCenter/pyobjc_setup.py pyobjc-framework-NotificationCenter/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-NotificationCenter/pyobjc_setup.py
++++ pyobjc-framework-NotificationCenter/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-OSAKit/pyobjc_setup.py pyobjc-framework-OSAKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-OSAKit/pyobjc_setup.py
++++ pyobjc-framework-OSAKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-OSLog/pyobjc_setup.py pyobjc-framework-OSLog/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-OSLog/pyobjc_setup.py
++++ pyobjc-framework-OSLog/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-OpenDirectory/pyobjc_setup.py pyobjc-framework-OpenDirectory/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-OpenDirectory/pyobjc_setup.py
++++ pyobjc-framework-OpenDirectory/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-PencilKit/pyobjc_setup.py pyobjc-framework-PencilKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-PencilKit/pyobjc_setup.py
++++ pyobjc-framework-PencilKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Photos/pyobjc_setup.py pyobjc-framework-Photos/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Photos/pyobjc_setup.py
++++ pyobjc-framework-Photos/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-PhotosUI/pyobjc_setup.py pyobjc-framework-PhotosUI/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-PhotosUI/pyobjc_setup.py
++++ pyobjc-framework-PhotosUI/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-PreferencePanes/pyobjc_setup.py pyobjc-framework-PreferencePanes/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-PreferencePanes/pyobjc_setup.py
++++ pyobjc-framework-PreferencePanes/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-PubSub/pyobjc_setup.py pyobjc-framework-PubSub/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-PubSub/pyobjc_setup.py
++++ pyobjc-framework-PubSub/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-PushKit/pyobjc_setup.py pyobjc-framework-PushKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-PushKit/pyobjc_setup.py
++++ pyobjc-framework-PushKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-QTKit/pyobjc_setup.py pyobjc-framework-QTKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-QTKit/pyobjc_setup.py
++++ pyobjc-framework-QTKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Quartz/pyobjc_setup.py pyobjc-framework-Quartz/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Quartz/pyobjc_setup.py
++++ pyobjc-framework-Quartz/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
++++ pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-SafariServices/pyobjc_setup.py pyobjc-framework-SafariServices/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-SafariServices/pyobjc_setup.py
++++ pyobjc-framework-SafariServices/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-SceneKit/pyobjc_setup.py pyobjc-framework-SceneKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-SceneKit/pyobjc_setup.py
++++ pyobjc-framework-SceneKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ScreenSaver/pyobjc_setup.py pyobjc-framework-ScreenSaver/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ScreenSaver/pyobjc_setup.py
++++ pyobjc-framework-ScreenSaver/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ScriptingBridge/pyobjc_setup.py pyobjc-framework-ScriptingBridge/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ScriptingBridge/pyobjc_setup.py
++++ pyobjc-framework-ScriptingBridge/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-SearchKit/pyobjc_setup.py pyobjc-framework-SearchKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-SearchKit/pyobjc_setup.py
++++ pyobjc-framework-SearchKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Security/pyobjc_setup.py pyobjc-framework-Security/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Security/pyobjc_setup.py
++++ pyobjc-framework-Security/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-SecurityFoundation/pyobjc_setup.py pyobjc-framework-SecurityFoundation/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-SecurityFoundation/pyobjc_setup.py
++++ pyobjc-framework-SecurityFoundation/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-SecurityInterface/pyobjc_setup.py pyobjc-framework-SecurityInterface/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-SecurityInterface/pyobjc_setup.py
++++ pyobjc-framework-SecurityInterface/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ServerNotification/pyobjc_setup.py pyobjc-framework-ServerNotification/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ServerNotification/pyobjc_setup.py
++++ pyobjc-framework-ServerNotification/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-ServiceManagement/pyobjc_setup.py pyobjc-framework-ServiceManagement/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-ServiceManagement/pyobjc_setup.py
++++ pyobjc-framework-ServiceManagement/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Social/pyobjc_setup.py pyobjc-framework-Social/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Social/pyobjc_setup.py
++++ pyobjc-framework-Social/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-SoundAnalysis/pyobjc_setup.py pyobjc-framework-SoundAnalysis/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-SoundAnalysis/pyobjc_setup.py
++++ pyobjc-framework-SoundAnalysis/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Speech/pyobjc_setup.py pyobjc-framework-Speech/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Speech/pyobjc_setup.py
++++ pyobjc-framework-Speech/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-SpriteKit/pyobjc_setup.py pyobjc-framework-SpriteKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-SpriteKit/pyobjc_setup.py
++++ pyobjc-framework-SpriteKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-StoreKit/pyobjc_setup.py pyobjc-framework-StoreKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-StoreKit/pyobjc_setup.py
++++ pyobjc-framework-StoreKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-SyncServices/pyobjc_setup.py pyobjc-framework-SyncServices/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-SyncServices/pyobjc_setup.py
++++ pyobjc-framework-SyncServices/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-SystemConfiguration/pyobjc_setup.py pyobjc-framework-SystemConfiguration/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-SystemConfiguration/pyobjc_setup.py
++++ pyobjc-framework-SystemConfiguration/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-SystemExtensions/pyobjc_setup.py pyobjc-framework-SystemExtensions/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-SystemExtensions/pyobjc_setup.py
++++ pyobjc-framework-SystemExtensions/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-UserNotifications/pyobjc_setup.py pyobjc-framework-UserNotifications/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-UserNotifications/pyobjc_setup.py
++++ pyobjc-framework-UserNotifications/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
++++ pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-VideoToolbox/pyobjc_setup.py pyobjc-framework-VideoToolbox/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-VideoToolbox/pyobjc_setup.py
++++ pyobjc-framework-VideoToolbox/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-Vision/pyobjc_setup.py pyobjc-framework-Vision/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-Vision/pyobjc_setup.py
++++ pyobjc-framework-Vision/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-WebKit/pyobjc_setup.py pyobjc-framework-WebKit/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-WebKit/pyobjc_setup.py
++++ pyobjc-framework-WebKit/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-XgridFoundation/pyobjc_setup.py pyobjc-framework-XgridFoundation/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-XgridFoundation/pyobjc_setup.py
++++ pyobjc-framework-XgridFoundation/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-iTunesLibrary/pyobjc_setup.py pyobjc-framework-iTunesLibrary/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-iTunesLibrary/pyobjc_setup.py
++++ pyobjc-framework-iTunesLibrary/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):
+diff --git pyobjc-framework-libdispatch/pyobjc_setup.py pyobjc-framework-libdispatch/pyobjc_setup.py
+index ddc8c2c48..9e019cd14 100644
+--- pyobjc-framework-libdispatch/pyobjc_setup.py
++++ pyobjc-framework-libdispatch/pyobjc_setup.py
+@@ -229,17 +229,23 @@ def get_sdk_level():
+     if sdk == "/":
+         return get_os_level()
+ 
++    sdk = sdk.rstrip("/")
+     sdkname = os.path.basename(sdk)
+     assert sdkname.startswith("MacOSX")
+     assert sdkname.endswith(".sdk")
+-    if sdkname == "MacOSX.sdk":
++
++    settings_path = os.path.join(sdk, "SDKSettings.plist")
++    if os.path.exists(settings_path):
+         try:
+-            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
++            with open(os.path.join(sdk, "SDKSettings.plist"), "rb") as fp:
++                pl = plistlib.load(fp)
+             return pl["Version"]
+         except Exception:
+             raise SystemExit("Cannot determine SDK version")
+     else:
+-        return sdkname[6:-4]
++        version_part = sdkname[6:-4]
++        assert version_part
++        return version_part
+ 
+ 
+ class pyobjc_install_lib(install_lib.install_lib):

--- a/python/py-pyobjc6/files/0002-module.m-no-AssociatedObject-on-ppc.patch
+++ b/python/py-pyobjc6/files/0002-module.m-no-AssociatedObject-on-ppc.patch
@@ -1,0 +1,40 @@
+From 34c7bf187f8a33ce3d240cc9da79d91fb51cc1a7 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Sun, 14 Apr 2024 06:37:53 +0800
+Subject: [PATCH] module.m: no AssociatedObject on ppc
+
+---
+ pyobjc-core/Modules/objc/module.m | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git pyobjc-core/Modules/objc/module.m pyobjc-core/Modules/objc/module.m
+index ba50e4b46..b1f0e96fc 100644
+--- pyobjc-core/Modules/objc/module.m
++++ pyobjc-core/Modules/objc/module.m
+@@ -1499,7 +1499,7 @@ typestr2typestr(PyObject* args)
+     return result;
+ }
+ 
+-#if PyObjC_BUILD_RELEASE >= 1006
++#if PyObjC_BUILD_RELEASE >= 1006 && !defined(__ppc__)
+ /* Associated Object support. Functionality is available on OSX 10.6 or later.
+  */
+ 
+@@ -1943,7 +1943,7 @@ static PyMethodDef mod_methods[] = {
+      .ml_doc   = "_typestr2typestr(value)\n" CLINIC_SEP
+                "\nReturns the standard Objective-C version for a PyObjC typestr"},
+ 
+-#if PyObjC_BUILD_RELEASE >= 1006
++#if PyObjC_BUILD_RELEASE >= 1006 && !defined(__ppc__)
+ 
+     {.ml_name  = "setAssociatedObject",
+      .ml_meth  = (PyCFunction)PyObjC_setAssociatedObject,
+@@ -2345,7 +2345,7 @@ PyObject* __attribute__((__visibility__("default"))) PyInit__objc(void)
+ 
+     PyObjCPointerWrapper_Init();
+ 
+-#if PyObjC_BUILD_RELEASE >= 1006
++#if PyObjC_BUILD_RELEASE >= 1006 && !defined(__ppc__)
+ #if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
+     if (objc_setAssociatedObject != NULL) {
+ #endif /* MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6 */

--- a/python/py-pyobjc6/files/0003-properties.m-disable-test-that-fails-to-compile-with.patch
+++ b/python/py-pyobjc6/files/0003-properties.m-disable-test-that-fails-to-compile-with.patch
@@ -1,0 +1,31 @@
+From 4fa8f8d3de77e56dc7aa00b30717725ed4f3695c Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 17:37:13 +0800
+Subject: [PATCH] properties.m: disable test that fails to compile with gcc
+
+---
+ pyobjc-core/Modules/objc/test/properties.m | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git pyobjc-core/Modules/objc/test/properties.m pyobjc-core/Modules/objc/test/properties.m
+index b585db986..f05a46597 100644
+--- pyobjc-core/Modules/objc/test/properties.m
++++ pyobjc-core/Modules/objc/test/properties.m
+@@ -25,7 +25,7 @@ typedef NSObject<NSObject> ObjectClass;
+     id       _prop12;
+ }
+ 
+-#if (PyObjC_BUILD_RELEASE >= 1005)
++#if (PyObjC_BUILD_RELEASE >= 1007)
+ 
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Wobjc-property-no-attribute"
+@@ -51,7 +51,7 @@ typedef NSObject<NSObject> ObjectClass;
+ 
+ @implementation OCPropertyDefinitions
+ 
+-#if (PyObjC_BUILD_RELEASE >= 1005)
++#if (PyObjC_BUILD_RELEASE >= 1007)
+ 
+ @synthesize prop1  = _prop1;
+ @synthesize prop2  = _prop2;

--- a/python/py-pyobjc6/files/0004-struct-wrapper-fix-for-python-3.10.patch
+++ b/python/py-pyobjc6/files/0004-struct-wrapper-fix-for-python-3.10.patch
@@ -1,0 +1,22 @@
+From ee4df05e90d1fb374dcfebbb6887480f41cc073e Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 18:06:48 +0800
+Subject: [PATCH] struct-wrapper: fix for python 3.10
+
+---
+ pyobjc-core/Modules/objc/struct-wrapper.m | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git pyobjc-core/Modules/objc/struct-wrapper.m pyobjc-core/Modules/objc/struct-wrapper.m
+index dd753e43a..d601cf266 100644
+--- pyobjc-core/Modules/objc/struct-wrapper.m
++++ pyobjc-core/Modules/objc/struct-wrapper.m
+@@ -1289,7 +1289,7 @@ PyObjC_MakeStructType(const char* name, const char* doc, initproc tpinit,
+         return NULL;
+     }
+ 
+-    Py_REFCNT(result)         = 1;
++    Py_REFCNT(result) == 1;
+     result->base.tp_members   = members;
+     result->base.tp_basicsize = sizeof(PyObject) + (numFields * sizeof(PyObject*));
+     if (PyDict_SetItemString(result->base.tp_dict, "_fields", fields) == -1) {


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69728

#### Description

This fixes the build of core library. (Currently the port is totally broken and installs only docs.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
