### PR TITLE
valkey: fix on 10.6, remove brewism

### DIFF
--- a/databases/valkey/Portfile
+++ b/databases/valkey/Portfile
@@ -12,7 +12,7 @@ legacysupport.newest_darwin_requires_legacy 15
 
 github.setup        valkey-io valkey 7.2.5
 github.tarball_from archive
-revision            1
+revision            2
 categories          databases
 license             BSD
 
@@ -32,7 +32,9 @@ checksums           rmd160  877e2388d520f6fb3a1e4e6dd9effeb80b072fb7 \
 patchfiles          patch-valkey.conf.diff \
                     patch-hiredis.diff \
                     patch-gh-12585.diff \
-                    patch-fix-install.diff
+                    patch-fix-install.diff \
+                    patch-remove-brewism.diff \
+                    patch-fix-older-macOS.diff
 
 post-patch {
     reinplace "s|@PREFIX@|${prefix}|g" \
@@ -54,6 +56,13 @@ configure.optflags
 configure.cppflags-replace \
                     -I${prefix}/include \
                     -isystem${prefix}/include
+
+if {[string match *gcc* ${configure.compiler}] \
+    && ${configure.build_arch} in [list i386 ppc]} {
+    # https://github.com/valkey-io/valkey/issues/434
+    configure.ldflags-append \
+                    -latomic
+}
 
 # valkey doesn't know about CPPFLAGS so pass it this way
 build.args-append   SERVER_CFLAGS="${configure.cppflags}"

--- a/databases/valkey/files/patch-fix-older-macOS.diff
+++ b/databases/valkey/files/patch-fix-older-macOS.diff
@@ -1,0 +1,81 @@
+https://github.com/valkey-io/valkey/pull/436
+
+diff --git src/config.h src/config.h
+index 2468110f8..4646f653e 100644
+--- src/config.h
++++ src/config.h
+@@ -42,7 +42,7 @@
+ #include <fcntl.h>
+ #endif
+ 
+-#if defined(__APPLE__) && defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
++#if defined(__APPLE__) && defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+ #define MAC_OS_10_6_DETECTED
+ #endif
+ 
+@@ -217,12 +217,13 @@ void setproctitle(const char *fmt, ...);
+ 
+ #if defined(sel) || defined(pyr) || defined(mc68000) || defined(sparc) || \
+     defined(is68k) || defined(tahoe) || defined(ibm032) || defined(ibm370) || \
+-    defined(MIPSEB) || defined(_MIPSEB) || defined(_IBMR2) || defined(DGUX) ||\
++    defined(MIPSEB) || defined(_MIPSEB) || defined(_IBMR2) || defined(DGUX) || \
+     defined(apollo) || defined(__convex__) || defined(_CRAY) || \
+     defined(__hppa) || defined(__hp9000) || \
+     defined(__hp9000s300) || defined(__hp9000s700) || \
+-    defined (BIT_ZERO_ON_LEFT) || defined(m68k) || defined(__sparc)
+-#define BYTE_ORDER	BIG_ENDIAN
++    defined (BIT_ZERO_ON_LEFT) || defined(m68k) || defined(__sparc) || \
++    (defined(__APPLE__) && defined(__POWERPC__))
++#define BYTE_ORDER    BIG_ENDIAN
+ #endif
+ #endif /* linux */
+ #endif /* BSD */
+@@ -304,7 +305,7 @@ void setproctitle(const char *fmt, ...);
+ #include <kernel/OS.h>
+ #define valkey_set_thread_title(name) rename_thread(find_thread(0), name)
+ #else
+-#if (defined __APPLE__ && defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)
++#if (defined __APPLE__ && defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)
+ int pthread_setname_np(const char *name);
+ #include <pthread.h>
+ #define valkey_set_thread_title(name) pthread_setname_np(name)
+diff --git src/debug.c src/debug.c
+index 33d145b28..5fa9a70d5 100644
+--- src/debug.c
++++ src/debug.c
+@@ -1192,6 +1192,7 @@ static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
+     #elif defined(__i386__)
+     GET_SET_RETURN(uc->uc_mcontext->__ss.__eip, eip);
+     #else
++    /* OSX PowerPC */
+     GET_SET_RETURN(uc->uc_mcontext->__ss.__srr0, eip);
+     #endif
+ #elif defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)
+@@ -1200,6 +1201,8 @@ static void* getAndSetMcontextEip(ucontext_t *uc, void *eip) {
+     GET_SET_RETURN(uc->uc_mcontext->__ss.__rip, eip);
+     #elif defined(__i386__)
+     GET_SET_RETURN(uc->uc_mcontext->__ss.__eip, eip);
++    #elif defined(__ppc__)
++    GET_SET_RETURN(uc->uc_mcontext->__ss.__srr0, eip);
+     #else
+     /* OSX ARM64 */
+     void *old_val = (void*)arm_thread_state64_get_pc(uc->uc_mcontext->__ss);
+@@ -1344,7 +1347,7 @@ void logRegisters(ucontext_t *uc) {
+         (unsigned long) uc->uc_mcontext->__ss.__gs
+     );
+     logStackContent((void**)uc->uc_mcontext->__ss.__esp);
+-    #else
++    #elif defined(__arm64__)
+     /* OSX ARM64 */
+     serverLog(LL_WARNING,
+     "\n"
+@@ -1393,6 +1396,9 @@ void logRegisters(ucontext_t *uc) {
+         (unsigned long) uc->uc_mcontext->__ss.__cpsr
+     );
+     logStackContent((void**) arm_thread_state64_get_sp(uc->uc_mcontext->__ss));
++    #else
++    /* At the moment we do not implement this for PowerPC */
++    NOT_SUPPORTED();
+     #endif
+ /* Linux */
+ #elif defined(__linux__)

--- a/databases/valkey/files/patch-remove-brewism.diff
+++ b/databases/valkey/files/patch-remove-brewism.diff
@@ -1,0 +1,18 @@
+ld: warning: directory '/usr/local/opt/openssl/lib' following -L not found
+
+--- src/Makefile	2024-04-16 12:18:47.000000000 +0800
++++ src/Makefile	2024-05-04 12:03:20.000000000 +0800
+@@ -158,13 +158,6 @@
+ 	# Homebrew's OpenSSL is not linked to /usr/local to avoid
+ 	# conflicts with the system's LibreSSL installation so it
+ 	# must be referenced explicitly during build.
+-ifeq ($(uname_M),arm64)
+-	# Homebrew arm64 uses /opt/homebrew as HOMEBREW_PREFIX
+-	OPENSSL_PREFIX?=/opt/homebrew/opt/openssl
+-else
+-	# Homebrew x86/ppc uses /usr/local as HOMEBREW_PREFIX
+-	OPENSSL_PREFIX?=/usr/local/opt/openssl
+-endif
+ else
+ ifeq ($(uname_S),AIX)
+         # AIX


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69887

#### Description

Fix build on 10.6, drop unneeded brewism

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
