### PR TITLE
transcode: fix build on newer systems

### DIFF
--- a/multimedia/transcode/Portfile
+++ b/multimedia/transcode/Portfile
@@ -72,8 +72,15 @@ patchfiles-append \
                 transcode-ffmpeg3.patch:ffmpeg3 \
                 transcode-ffmpeg4.patch:ffmpeg4
 
+# add some missing function definitions from an older ffmpeg version
+patchfiles-append \
+                patch-transcode-filter-resample.diff
+
 use_autoreconf  yes
 autoreconf.args -fiv
+
+# allow deprecated function names in lame to be used
+configure.cppflags-append -DDEPRECATED_OR_OBSOLETE_CODE_REMOVED=0
 
 configure.args  --disable-mmx \
                 --enable-libmpeg2 \

--- a/multimedia/transcode/files/patch-transcode-filter-resample.diff
+++ b/multimedia/transcode/files/patch-transcode-filter-resample.diff
@@ -1,0 +1,100 @@
+--- a/filter/filter_resample.c.orig	2024-05-03 20:55:07.000000000 -0700
++++ b/filter/filter_resample.c	2024-05-03 20:55:38.000000000 -0700
+@@ -39,6 +39,97 @@
+ #include "libtc/tcmodule-plugin.h"
+ #include <libavresample/avresample.h>
+ 
++/**
++ * @defgroup lavc_resample Audio resampling
++ * @ingroup libavc
++ * @deprecated use libswresample instead
++ *
++ * @{
++ */
++struct ReSampleContext;
++struct AVResampleContext;
++
++typedef struct ReSampleContext ReSampleContext;
++
++/**
++ *  Initialize audio resampling context.
++ *
++ * @param output_channels  number of output channels
++ * @param input_channels   number of input channels
++ * @param output_rate      output sample rate
++ * @param input_rate       input sample rate
++ * @param sample_fmt_out   requested output sample format
++ * @param sample_fmt_in    input sample format
++ * @param filter_length    length of each FIR filter in the filterbank relative to the cutoff frequency
++ * @param log2_phase_count log2 of the number of entries in the polyphase filterbank
++ * @param linear           if 1 then the used FIR filter will be linearly interpolated
++                           between the 2 closest, if 0 the closest will be used
++ * @param cutoff           cutoff frequency, 1.0 corresponds to half the output sampling rate
++ * @return allocated ReSampleContext, NULL if error occurred
++ */
++attribute_deprecated
++ReSampleContext *av_audio_resample_init(int output_channels, int input_channels,
++                                        int output_rate, int input_rate,
++                                        enum AVSampleFormat sample_fmt_out,
++                                        enum AVSampleFormat sample_fmt_in,
++                                        int filter_length, int log2_phase_count,
++                                        int linear, double cutoff);
++
++attribute_deprecated
++int audio_resample(ReSampleContext *s, short *output, short *input, int nb_samples);
++
++/**
++ * Free resample context.
++ *
++ * @param s a non-NULL pointer to a resample context previously
++ *          created with av_audio_resample_init()
++ */
++attribute_deprecated
++void audio_resample_close(ReSampleContext *s);
++
++
++/**
++ * Initialize an audio resampler.
++ * Note, if either rate is not an integer then simply scale both rates up so they are.
++ * @param filter_length length of each FIR filter in the filterbank relative to the cutoff freq
++ * @param log2_phase_count log2 of the number of entries in the polyphase filterbank
++ * @param linear If 1 then the used FIR filter will be linearly interpolated
++                 between the 2 closest, if 0 the closest will be used
++ * @param cutoff cutoff frequency, 1.0 corresponds to half the output sampling rate
++ */
++attribute_deprecated
++struct AVResampleContext *av_resample_init(int out_rate, int in_rate, int filter_length, int log2_phase_count, int linear, double cutoff);
++
++/**
++ * Resample an array of samples using a previously configured context.
++ * @param src an array of unconsumed samples
++ * @param consumed the number of samples of src which have been consumed are returned here
++ * @param src_size the number of unconsumed samples available
++ * @param dst_size the amount of space in samples available in dst
++ * @param update_ctx If this is 0 then the context will not be modified, that way several channels can be resampled with the same context.
++ * @return the number of samples written in dst or -1 if an error occurred
++ */
++attribute_deprecated
++int av_resample(struct AVResampleContext *c, short *dst, short *src, int *consumed, int src_size, int dst_size, int update_ctx);
++
++
++/**
++ * Compensate samplerate/timestamp drift. The compensation is done by changing
++ * the resampler parameters, so no audible clicks or similar distortions occur
++ * @param compensation_distance distance in output samples over which the compensation should be performed
++ * @param sample_delta number of output samples which should be output less
++ *
++ * example: av_resample_compensate(c, 10, 500)
++ * here instead of 510 samples only 500 samples would be output
++ *
++ * note, due to rounding the actual compensation might be slightly different,
++ * especially if the compensation_distance is large and the in_rate used during init is small
++ */
++attribute_deprecated
++void av_resample_compensate(struct AVResampleContext *c, int sample_delta, int compensation_distance);
++attribute_deprecated
++void av_resample_close(struct AVResampleContext *c);
++
+ 
+ typedef struct {
+     uint8_t *resample_buf;


### PR DESCRIPTION
patch in missing function definitions, found in
an old version of ffmpeg

allow deprecated function names to be used with lame

closes: https://trac.macports.org/ticket/61696

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 12.7 21G816 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
