### PR TITLE
micronaut: update to 4.4.2

### DIFF
--- a/java/micronaut/Portfile
+++ b/java/micronaut/Portfile
@@ -3,14 +3,14 @@
 PortSystem      1.0
 PortGroup       github 1.0
 
-github.setup    micronaut-projects micronaut-starter 4.4.1 v
+github.setup    micronaut-projects micronaut-starter 4.4.2 v
 revision        0
 name            micronaut
 categories      java
 platforms       {darwin any}
 maintainers     {breun.nl:nils @breun} openmaintainer
 license         Apache-2
-supported_archs x86_64
+supported_archs x86_64 arm64
 universal_variant no
 
 description     Micronaut is a modern, JVM-based, full-stack framework \
@@ -54,11 +54,18 @@ long_description Micronaut is a modern, JVM-based, full stack Java framework \
 
 homepage        https://micronaut.io
 github.tarball_from releases
-distname        mn-darwin-amd64-v${version}
 
-checksums       rmd160  01293f2785cc2b3f9643b59feab3cf664961b91d \
-                sha256  a5b38ac0b63847331462dca9d5821d607ab56f28ad163e20c3237b22d49ee950 \
-                size    23656783
+if {${configure.build_arch} eq "x86_64"} {
+    distname     mn-darwin-amd64-v${version}
+    checksums    rmd160  177ea7358399bc0874d2dbae5020df6fc7d09e43 \
+                 sha256  f59212f402f22d86f3be018c075f0280fed44ca6c435be575d21fdbc8b867eed \
+                 size    25649226
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     mn-darwin-aarch64-v${version}
+    checksums    rmd160  90f0c1cc5ec2da8ef4b335e0a4c736ef51d107d9 \
+                 sha256  c5f3bcbb62e62ba9b529a7a6ad1bd37b637f72dffa7e7fe906fffbe92128d2ed \
+                 size    25371473
+}
 
 use_zip         yes
 use_configure   no


### PR DESCRIPTION
#### Description

Update to Micronaut Starter 4.4.2.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?