### PR TITLE
stern: update to 1.29.0

### DIFF
--- a/sysutils/stern/Portfile
+++ b/sysutils/stern/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/stern/stern 1.28.0 v
+go.setup            github.com/stern/stern 1.29.0 v
 maintainers         {breun.nl:nils @breun} openmaintainer
 platforms           darwin
 categories          sysutils
@@ -15,9 +15,9 @@ long_description    Stern allows you to tail multiple pods on Kubernetes and \
                     multiple containers within the pod. Each result is color \
                     coded for quicker debugging.
 
-checksums           rmd160  ee38124a99f6f26fe091b96243403c056b25459c \
-                    sha256  a329f48d0e9708ac10b60f942ba6bfdbf4b8a6c5a04b00bc16beb97579d4cad0 \
-                    size    57321
+checksums           rmd160  fa445b19a930bc26942599ee2a94e075bae816bf \
+                    sha256  506bb1f32eeeda7ab7db394b732d4a6f62d14ec63d1577a36b2aeffef215011e \
+                    size    59095
 
 set go_ldflags      "-s -w -X ${go.package}/cmd.version=${version}"
 build.args          -ldflags \"${go_ldflags}\" -o bin/${name}
@@ -26,6 +26,11 @@ build.args          -ldflags \"${go_ldflags}\" -o bin/${name}
 # dependencies during the build phase. See
 # https://trac.macports.org/ticket/61192
 go.offline_build no
+
+test.run    yes
+test.cmd    bin/stern
+test.target
+test.args   --version
 
 destroot {
     xinstall -m 755 ${worksrcpath}/bin/${name} ${destroot}${prefix}/bin/${name}


### PR DESCRIPTION
#### Description

Update to Stern 1.29.0.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?