### PR TITLE
R: update Bioconductor packages to 3.19 release

### DIFF
--- a/R/R-ALL/Portfile
+++ b/R/R-ALL/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             bioconductor Bioconductor ALL 1.46.0
+revision            0
+categories-append   bioconductor
+maintainers         nomaintainer
+license             Artistic-2
+description         A data package
+long_description    {*}${description}
+master_sites        https://bioconductor.org/packages/release/data/experiment/src/contrib/
+checksums           rmd160  4bc9e3055403e27028aca18a7c23eedade95d3df \
+                    sha256  0a660bf324dadfe32e3b75cbe76857a425db13f6d0461e37e9338588305a88fa \
+                    size    11382429
+supported_archs     noarch
+
+depends_lib-append  port:R-Biobase
+
+test.run            yes

--- a/R/R-AnnotationDbi/Portfile
+++ b/R/R-AnnotationDbi/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor AnnotationDbi 7daf9f47046e11f412e04195a7743a3840541b79
-version             1.65.2
-revision            1
+R.setup             bioconductor Bioconductor AnnotationDbi 1.66.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Manipulation of SQLite-based annotations in Bioconductor
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  14e6cd65be419054465ca9b889ed1d8e78cc6a68 \
-                    sha256  9950ea4c323f4746cb677eb81ef2f718d8b27c9eca03bf6fcdc81ebdf5cdd4ad \
-                    size    3932444
+checksums           rmd160  081469e0c6d4d202377e279fa0a6f30508d8d4c9 \
+                    sha256  3aa793c6888ad50a63d88e2a2df59655c6384ada9db2c5d84473ca76fafa5ebc \
+                    size    4359386
 supported_archs     noarch
 platforms           {darwin any}
 

--- a/R/R-AnnotationForge/Portfile
+++ b/R/R-AnnotationForge/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor AnnotationForge 2bba05a2305c3c803b8d9747a5c44c0d22fe2631
-version             1.45.0
-revision            1
+R.setup             bioconductor Bioconductor AnnotationForge 1.46.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Tools for building SQLite-based annotation data packages
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  4eb9edad24f2fe2ad6d283a916cfed9f23b472a8 \
-                    sha256  ba6f56a58d2ce9f791bdf89b60f92ab92d6a6bc128b3f0cb1297e3253c0653c0 \
-                    size    3366069
+checksums           rmd160  c647fd409394fc43cd34ee47d273624f049a85d7 \
+                    sha256  c1b234391b582f5d10b87a80a3bbe00d3d2800d5fc3acf03ff12e8b0608a79c6 \
+                    size    3989356
 supported_archs     noarch
 platforms           {darwin any}
 

--- a/R/R-AnnotationHub/Portfile
+++ b/R/R-AnnotationHub/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor AnnotationHub 3.10.1
-revision            1
-categories-append   www
+R.setup             bioconductor Bioconductor AnnotationHub 3.12.0
+revision            0
+categories-append   bioconductor www
 maintainers         nomaintainer
 license             Artistic-2
 description         Client to access AnnotationHub resources
 long_description    {*}${description}
-checksums           rmd160  522499d73cb02a2303588cb78a383d9738d5ba91 \
-                    sha256  dd974316cea658f5ad099d92fe2cdcb19e77edc11e19a11ce30bbdfac6296c8b \
-                    size    994797
+checksums           rmd160  1571886c70a3738d15fe1fafc7f48e8a724e9094 \
+                    sha256  a138dc289305b598fa7c7ea732c1b5947a54bfd127fe7242b3da772147b042b5 \
+                    size    992371
 supported_archs     noarch
 platforms           {darwin any}
 

--- a/R/R-BSgenome/Portfile
+++ b/R/R-BSgenome/Portfile
@@ -3,15 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor BSgenome 1.70.2
-revision            1
+R.setup             bioconductor Bioconductor BSgenome 1.72.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
-description         Software infrastructure for efficient representation of full genomes and their SNPs
+description         Software infrastructure for efficient representation \
+                    of full genomes and their SNPs
 long_description    {*}${description}
-checksums           rmd160  2ca505383589549ece1b22cfaa57ba617ea1e592 \
-                    sha256  2d1879cc4aaab1ebdeeb36228143800dcbdee17cc13aba1f21524747cfc3190b \
-                    size    5909171
+checksums           rmd160  1526c109a69a66c046695640b3e2b51673cce55b \
+                    sha256  98541684ea234a3c102338b4a4d055817d92a088b9e67ea88b6a339fa79a4bde \
+                    size    5718748
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocGenerics \

--- a/R/R-BayesKnockdown/Portfile
+++ b/R/R-BayesKnockdown/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor BayesKnockdown 1.28.0
-revision            1
+R.setup             bioconductor Bioconductor BayesKnockdown 1.30.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-3
 description         Posterior probabilities for edges from knockdown data
 long_description    {*}${description}
-checksums           rmd160  a8d33e78796ffaf4214308899281148691c8d731 \
-                    sha256  88869bc99b67d947642bcf38110e2ab13e65ea9965bdbb37585e34ea1e692fab \
-                    size    116534
+checksums           rmd160  4790eac1899f84f11ee90e15be4c3148d6820b29 \
+                    sha256  0aefd1850059bbf595f6bf0ee135ed15a9eb9316713f36198112006d06acf416 \
+                    size    117801
 supported_archs     noarch
 
 depends_lib-append  port:R-Biobase

--- a/R/R-BioNet/Portfile
+++ b/R/R-BioNet/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor BioNet 1.62.0
-revision            1
+R.setup             bioconductor Bioconductor BioNet 1.64.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2+
 description         Routines for the functional analysis of biological networks
 long_description    {*}${description}
-checksums           rmd160  fc20c5cf00d92fba4fc7d0db41d192502592eccd \
-                    sha256  78012ebdb0dc4acfbb179a1030b76a835617129b2bfb0ef34a3849f2b2915988 \
-                    size    1687581
+checksums           rmd160  bd34049a504ac6d8657c82f2bb38a0455283c7e8 \
+                    sha256  06828daef6fdd94068b29dc7e63b015b70107a22ca1e28535af69ece40ddf852 \
+                    size    1680069
 supported_archs     noarch
 
 depends_lib-append  port:R-AnnotationDbi \

--- a/R/R-Biobase/Portfile
+++ b/R/R-Biobase/Portfile
@@ -3,15 +3,28 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor Biobase 4cf5590294d698b89f77ba639853ebd57a704d53
-version             2.63.0
-revision            1
+R.setup             bioconductor Bioconductor Biobase 2.64.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Base functions for Bioconductor
 long_description    {*}${description}
-checksums           rmd160  7daa612d833d4b86f6bcb8079949b8295c7fac3a \
-                    sha256  96491344516448fde15ccfb9560b370134795c12a79ee385d654b05d68fde5ca \
-                    size    1182396
+checksums           rmd160  821f629260b6c9acc2cdc79941fa65e4ac936f4c \
+                    sha256  a21e35cdf4eeb71fc144712bb619d4ea5124c4013ceb14034a4d638231a0b627 \
+                    size    1792985
 
 depends_lib-append  port:R-BiocGenerics
+
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-ALL \
+                    port:R-BiocStyle \
+                    port:R-golubEsets \
+                    port:R-knitr \
+                    port:R-limma \
+                    port:R-RUnit \
+                    port:R-tkWidgets
+
+    test.run        yes
+}

--- a/R/R-BiocBaseUtils/Portfile
+++ b/R/R-BiocBaseUtils/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor BiocBaseUtils 5bfff695290ae6db7ccbc5ceafdbbc9e5ddb32a7
-version             1.5.0
-revision            1
+R.setup             bioconductor Bioconductor BiocBaseUtils 1.6.0
+revision            0
+categories-append   bioconductor devel
 maintainers         nomaintainer
 license             Artistic-2
 description         General utility functions for developing Bioconductor packages
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  19b1135bcdad562ae3539f83fd6df7783cf7ea72 \
-                    sha256  aeddaed86f897f20f14d5d4ae1b5e3458775c20952f0894a13e7974ed6c78b92 \
-                    size    8212
+checksums           rmd160  b965c45d366bb2911345adc085ea613aa988c2a3 \
+                    sha256  a4d8aa652a1ab929cd66172b315d2fb79e489f06a2ddbdb4288a76132ffc0b39 \
+                    size    228328
 supported_archs     noarch
 
 depends_test-append port:R-BiocStyle \

--- a/R/R-BiocCheck/Portfile
+++ b/R/R-BiocCheck/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor BiocCheck 7e7e07e1dfd8ddae8bf14d35e9df0add09aad61a
-version             1.39.0
-revision            1
+R.setup             bioconductor Bioconductor BiocCheck 1.40.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Bioconductor-specific package checks
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  6ebe2e08e7a3005db3dba016da76f1fe7a453522 \
-                    sha256  9284956381683f6fd7db8d3baa9a2e828d3afb69569b76e1dcc54361c1202e76 \
-                    size    4136699
+checksums           rmd160  f193aae4052999471553abd374b583c3e3f12e8a \
+                    sha256  e885ee791975e4b69a94dbb1a6761370c4231de7dd8e90e43a395a551a327967 \
+                    size    4378887
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocBaseUtils \
@@ -22,11 +21,14 @@ depends_lib-append  port:R-BiocBaseUtils \
                     port:R-biocViews \
                     port:R-callr \
                     port:R-graph \
-                    port:R-httr \
+                    port:R-httr2 \
                     port:R-knitr \
+                    port:R-rvest \
                     port:R-stringdist
 
-depends_test-append port:R-Biobase \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-Biobase \
                     port:R-BiocGenerics \
                     port:R-BiocStyle \
                     port:R-callr \
@@ -37,5 +39,7 @@ depends_test-append port:R-Biobase \
                     port:R-RUnit \
                     port:R-usethis
 
-# One test fails on ppc: https://github.com/Bioconductor/BiocCheck/issues/188
-test.run            yes
+    # One test fails, at least on ppc:
+    # https://github.com/Bioconductor/BiocCheck/issues/188
+    test.run        yes
+}

--- a/R/R-BiocFileCache/Portfile
+++ b/R/R-BiocFileCache/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor BiocFileCache 19e9ee5be7bc44f7a187d12b4eb31a64f6a56b3f
-version             2.11.2
-revision            1
+R.setup             bioconductor Bioconductor BiocFileCache 2.12.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Manage files across sessions
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  e6cf87e3e167b7ce2f6eb0ce0883a1e062f5b70f \
-                    sha256  e0aa9ef23a9e9c802d075fabbf46336381f74f2cb37156408e3735f025df91d4 \
-                    size    52473
+checksums           rmd160  7537ab402764ab6bb14222a4fb3caec7e6455973 \
+                    sha256  2e716d10a27ecb677095144dd707273c534f8d1f11d248fed63aa45ea285664b \
+                    size    297080
 supported_archs     noarch
 
 depends_lib-append  port:R-curl \

--- a/R/R-BiocGenerics/Portfile
+++ b/R/R-BiocGenerics/Portfile
@@ -3,15 +3,14 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor BiocGenerics 2e1a2a6152989cb21ff44eb98906edd486d0eb23
-version             0.49.1
-revision            1
+R.setup             bioconductor Bioconductor BiocGenerics 0.50.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
-description         The package defines many S4 generic functions used in Bioconductor
-long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  32218f0af24f2562f9e266b410cdff84fac9e2ce \
-                    sha256  8ca9335a97878a84942da0749f505d32d6ed83c9ddb1aabff3312c8363dca08e \
-                    size    50319
+description         The package defines many S4 generic functions
+long_description    {*}${description} used in Bioconductor.
+checksums           rmd160  03d7d483fdf4d8d4502b150ddbc185cafdffe374 \
+                    sha256  11d72e20c087911a58d08db7898d47424930e00265d6e65ae87d14d786f20014 \
+                    size    49747
 supported_archs     noarch

--- a/R/R-BiocIO/Portfile
+++ b/R/R-BiocIO/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor BiocIO 96ba3c5d94859e51f551e7278c7b5f7f5fae2421
-version             1.13.0
-revision            1
+R.setup             bioconductor Bioconductor BiocIO 1.14.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Standard Input and Output for Bioconductor packages
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  aec6fd40c8045983b9100c0e31e9b401ac92ee7a \
-                    sha256  6f0806895f5ff31b815ac4e081f9340374edc8290178292918d1abe1b45cd999 \
-                    size    10336
+checksums           rmd160  80bef328f46c70e544afb3e2ffc12619dc05f406 \
+                    sha256  9010bd8bdf810f571825bc055464219365168c6daadb2d6b8c74ed616fa3fa5e \
+                    size    230564
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocGenerics \

--- a/R/R-BiocManager/Portfile
+++ b/R/R-BiocManager/Portfile
@@ -3,20 +3,21 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-# Revert to GitHub once updated there.
-R.setup             cran Bioconductor BiocManager 1.30.22
-revision            1
+R.setup             cran Bioconductor BiocManager 1.30.23
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Access the Bioconductor project package repository
 long_description    {*}${description}
 homepage            https://bioconductor.github.io/BiocManager
-checksums           rmd160  fc6ee5dee3741e34baa9852edc5d16ac3f070bf9 \
-                    sha256  5389c9c0d6562b0757659fb8262ab51b48225c4ba7e9acd4f5e7c0049735e835 \
-                    size    582690
+checksums           rmd160  8109de0d60d29f84302c111c9ec0af8f3730f169 \
+                    sha256  f7b45dbc49c97b2e6ec4b96ec1d472c6f1a5ad9bc0f933eea4c3ebc90dd8f34c \
+                    size    589753
 supported_archs     noarch
 
 depends_test-append port:R-BiocVersion \
+                    port:R-BiocStyle \
                     port:R-curl \
                     port:R-knitr \
                     port:R-remotes \

--- a/R/R-BiocNeighbors/Portfile
+++ b/R/R-BiocNeighbors/Portfile
@@ -3,27 +3,31 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor BiocNeighbors 1.20.2
-revision            1
+R.setup             bioconductor Bioconductor BiocNeighbors 1.22.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-3
 description         Nearest neighbor detection for Bioconductor packages
 long_description    {*}${description}
-checksums           rmd160  29602eaac6b0dc04eda53a9057e91769ffb67982 \
-                    sha256  04123fe8ceb2cc9a17af7d187460e601dcce389adb1fcc6f89ad9c0844e27a53 \
-                    size    1039738
+checksums           rmd160  16c2700bbd282314974b3c4003268f68dfc5c9d3 \
+                    sha256  2d727fa9e983afd7ff268eef5f6692846e44b50c7248868f98d51b4034232fcf \
+                    size    1042130
 
 depends_lib-append  port:R-BiocParallel \
                     port:R-Rcpp \
                     port:R-RcppHNSW \
                     port:R-S4Vectors
 
-depends_test-append port:R-BiocStyle \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-FNN \
                     port:R-knitr \
                     port:R-RcppAnnoy \
                     port:R-rmarkdown \
                     port:R-testthat
 
-# Tests freeze due to: https://trac.macports.org/ticket/67059
-test.run            yes
+    # Tests freeze due to: https://trac.macports.org/ticket/67059
+    test.run        yes
+}

--- a/R/R-BiocParallel/Portfile
+++ b/R/R-BiocParallel/Portfile
@@ -3,27 +3,28 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor BiocParallel 47856deee43f03646f070b2c079a6f1271a0d0e8
-version             1.37.1
-revision            1
-categories-append   parallel
+R.setup             bioconductor Bioconductor BiocParallel 1.38.0
+revision            0
+categories-append   bioconductor parallel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             {GPL-2 GPL-3}
 description         Bioconductor facilities for parallel evaluation
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  5ec70fde922c340ba46593093d124015ac837f44 \
-                    sha256  245623b3837b86a75a465166f93bdd4ac662cc67ca3fbf4c7af9d2afe2a5135e \
-                    size    147091
+checksums           rmd160  2e14674a9189d3db1f723ddf88a4f8510e3e61cb \
+                    sha256  7e96e07beb4e59ab08d8064aaf6b4e414c9ccd7657e9949d7d9b2325b2113cd6 \
+                    size    995485
 
 depends_lib-append  port:R-BH \
                     port:R-cpp11 \
                     port:R-futile.logger \
                     port:R-snow
 
-patchfiles          patch-remove-unavailable-suggests.diff
+variant tests description "Enable testing" {
+    patchfiles-append \
+                    patch-remove-unavailable-suggests.diff
 
-depends_test-append port:R-batchtools \
+    depends_test-append \
+                    port:R-batchtools \
                     port:R-BBmisc \
                     port:R-BiocGenerics \
                     port:R-BiocStyle \
@@ -39,9 +40,10 @@ depends_test-append port:R-batchtools \
                     port:R-ShortRead \
                     port:R-VariantAnnotation
 
-# FIXME: there are MPI-related failures in tests, at least on PowerPC:
-# Error in DEACTIVATED("MPI tests not run") : MPI tests not run
-# *** caught segfault ***
-# address 0x11e81414, cause 'memory not mapped'
-# Code from vignettes runs fine, however.
-test.run            yes
+    # FIXME: there are MPI-related failures in tests, at least on PowerPC:
+    # Error in DEACTIVATED("MPI tests not run") : MPI tests not run
+    # *** caught segfault ***
+    # address 0x11e81414, cause 'memory not mapped'
+    # Code from vignettes runs fine, however.
+    test.run        yes
+}

--- a/R/R-BiocParallel/files/patch-remove-unavailable-suggests.diff
+++ b/R/R-BiocParallel/files/patch-remove-unavailable-suggests.diff
@@ -1,15 +1,12 @@
---- DESCRIPTION	2023-10-24 21:51:58.000000000 +0800
-+++ DESCRIPTION	2023-10-26 19:42:16.000000000 +0800
-@@ -37,10 +37,8 @@
+--- DESCRIPTION	2024-05-01 10:47:25.000000000 +0800
++++ DESCRIPTION	2024-05-04 14:20:45.000000000 +0800
+@@ -37,8 +37,7 @@
  Depends: methods, R (>= 3.5.0)
  Imports: stats, utils, futile.logger, parallel, snow, codetools
  Suggests: BiocGenerics, tools, foreach, BBmisc, doParallel,
--    GenomicRanges, RNAseqData.HNRNPC.bam.chr14,
--    TxDb.Hsapiens.UCSC.hg19.knownGene, VariantAnnotation, Rsamtools,
--    GenomicAlignments, ShortRead, RUnit, BiocStyle, knitr, batchtools,
--    data.table
-+    GenomicRanges, VariantAnnotation, Rsamtools, data.table,
-+    GenomicAlignments, ShortRead, RUnit, BiocStyle, knitr, batchtools
+-        GenomicRanges, RNAseqData.HNRNPC.bam.chr14,
+-        TxDb.Hsapiens.UCSC.hg19.knownGene, VariantAnnotation,
++        GenomicRanges, VariantAnnotation,
+         Rsamtools, GenomicAlignments, ShortRead, RUnit, BiocStyle,
+         knitr, batchtools, data.table
  Enhances: Rmpi
- Collate: AllGenerics.R DeveloperInterface.R prototype.R
-     bploop.R ErrorHandling.R log.R

--- a/R/R-BiocPkgTools/Portfile
+++ b/R/R-BiocPkgTools/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor seandavi BiocPkgTools 1.20.0
-revision            1
+R.setup             bioconductor seandavi BiocPkgTools 1.22.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             MIT
 description         Collection of simple tools for learning about Bioconductor packages
 long_description    {*}${description}
 homepage            https://github.com/seandavi/BiocPkgTools
-checksums           rmd160  e063a61fc5c8c05ddac3e835de8324d4e0082396 \
-                    sha256  24acf9eacba1c0fec20d7a208d10e380b61d01fc8e09d62ceb61e8a66237916b \
-                    size    1478773
+checksums           rmd160  28f1aeaeb7754c2e4ef6156158a230b431014831 \
+                    sha256  dd782d47fa834ebaefeada6ca2da6b3730fbd4b65084c19007b9982f7dc87fd9 \
+                    size    1508067
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocFileCache \

--- a/R/R-BiocSingular/Portfile
+++ b/R/R-BiocSingular/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor LTLA BiocSingular 1.18.0
-revision            1
+R.setup             bioconductor LTLA BiocSingular 1.20.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3
 description         Singular value decomposition for Bioconductor packages
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  8a65fa8b21f7878637be75d7575c219d0f5f6606 \
-                    sha256  634824a2e15c13c9fefbb17605a3861bdced6fc182c8880ae862f2248600377c \
-                    size    616448
+checksums           rmd160  cff7bb33d58e6f6aad3a548bd381aa4ff462d622 \
+                    sha256  5ef96e2b745641e3a87429558d57e79d7417c115f8a3459fe47e48aa87e589f6 \
+                    size    614069
 
 depends_lib-append  port:R-beachmat \
                     port:R-BiocGenerics \

--- a/R/R-BiocStyle/Portfile
+++ b/R/R-BiocStyle/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor BiocStyle 18ce82ef90b5ab7cbdfa45dc0ab16dac0997111e
-version             2.31.0
-revision            1
+R.setup             bioconductor Bioconductor BiocStyle 2.32.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
-description         Provides standard formatting styles for Bioconductor PDF and HTML documents
+description         Provides standard formatting styles for Bioconductor \
+                    PDF and HTML documents
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  6d74f557ec271815e11bfa5a5c9434c8f38548e2 \
-                    sha256  9c82a19782a2c8d5fad47d6285bd4eab16bd697ea90900bccd5bd04601926079 \
-                    size    67411
+checksums           rmd160  b3744574c053f70e863f6cb113bd72568eddeb70 \
+                    sha256  1d8ca2b6c5a3e4014fc03ff142585dbb318d7987bedb6c62db51fe0f89e4a9ee \
+                    size    787833
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocManager \

--- a/R/R-BiocVersion/Portfile
+++ b/R/R-BiocVersion/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor BiocVersion 1b820443eeff6d0796f2e04ebaba215aa95918f1
-version             3.18.0
-revision            1
+R.setup             bioconductor Bioconductor BiocVersion 3.19.1
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Set the appropriate version of Bioconductor packages
 long_description    {*}${description}
-checksums           rmd160  e08f94b041e92ac49bae1adcf41c449258290964 \
-                    sha256  5d508bbc2f05d870864663f465be5b34684aacb01641e8dc41e887b0f06dc60f \
-                    size    826
+checksums           rmd160  979b54de95618a6c8337a74da08787ed2dd88884 \
+                    sha256  b096e4e98c2000dcc3aaf2aa0628b1c7ecb2f68f7835071dd34bbf11061215fe \
+                    size    987
 supported_archs     noarch
 
 test.run            yes

--- a/R/R-Biostrings/Portfile
+++ b/R/R-Biostrings/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor Biostrings 8324ca476b7d28e98b03e73c5fe3bba62727b44c
-version             2.71.5
-revision            1
+R.setup             bioconductor Bioconductor Biostrings 2.72.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Efficient manipulation of biological strings
 long_description    {*}${description}
-checksums           rmd160  3f78f6a9f3a968d805b10cf2d188ae86acba8287 \
-                    sha256  be3565c9a04a3a681c295dd68c7e7f69ec0443fd7d828ac8513057fbb8a90fe7 \
-                    size    11734457
+checksums           rmd160  cf718a5490b8342887bbedd550d13b6e65e44ea0 \
+                    sha256  b09a56c7d38cb7122044868ea849a66a01a08d1145a73fd6f0876b6a543f701b \
+                    size    12407742
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-crayon \

--- a/R/R-ChemmineDrugs/Portfile
+++ b/R/R-ChemmineDrugs/Portfile
@@ -5,6 +5,7 @@ PortGroup           R 1.0
 
 R.setup             bioconductor Bioconductor ChemmineDrugs 1.0.2
 revision            1
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         DrugBank data set

--- a/R/R-ChemmineOB/Portfile
+++ b/R/R-ChemmineOB/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor girke-lab ChemmineOB 1.40.0
-revision            1
+R.setup             bioconductor girke-lab ChemmineOB 1.42.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         R interface to a subset of OpenBabel functionalities
 long_description    {*}${description}
 homepage            https://github.com/girke-lab/ChemmineOB
-checksums           rmd160  30ebf8641edc7eb8e1e81c03c38a4f8375a24bb5 \
-                    sha256  b147d9e00df464d13b1c6d876b0a49e158510ff725da599e51b936faf997ca55 \
-                    size    1366043
+checksums           rmd160  1ef2d715160868a57c4fc443b7cf615c2c08a24c \
+                    sha256  7c914fec647ab0e8db8edf230788f341e9c11fdbc602137a6d615d135eabdb9f \
+                    size    1367470
 
 depends_build-append \
                     port:pkgconfig
@@ -26,7 +27,16 @@ depends_lib-append  path:share/pkgconfig/eigen3.pc:eigen3 \
 patchfiles          patch-fix-flags.diff
 
 post-patch {
-    reinplace "s,@PREFIX@,${prefix},g" ${worksrcpath}/src/Makevars.in
+    # https://github.com/girke-lab/ChemmineOB/issues/35
+    # https://github.com/girke-lab/ChemmineOB/issues/40
+    if {${configure.cxx_stdlib} ne "libc++"} {
+        reinplace "s|@PKG_CPPFLAGS@|-D_GLIBCXX_USE_CXX11_ABI=0 -DUSE_BOOST -DHAVE_EIGEN -I${prefix}/include/openbabel3 -I${prefix}/include/eigen3|" \
+                    ${worksrcpath}/src/Makevars.in
+    } else {
+        reinplace "s|@PKG_CPPFLAGS@|-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION -DUSE_BOOST -DHAVE_EIGEN -I${prefix}/include/openbabel3 -I${prefix}/include/eigen3|" \
+                    ${worksrcpath}/src/Makevars.in
+    }
+    reinplace "s|@PKG_LIBS@|-L${prefix}/lib -lopenbabel|" ${worksrcpath}/src/Makevars.in
 }
 
 depends_test-append port:R-BiocManager \
@@ -34,6 +44,7 @@ depends_test-append port:R-BiocManager \
                     port:R-ChemmineR \
                     port:R-knitr \
                     port:R-knitrBootstrap \
+                    port:R-rmarkdown \
                     port:R-RUnit
 
 test.run            yes

--- a/R/R-ChemmineOB/files/patch-fix-flags.diff
+++ b/R/R-ChemmineOB/files/patch-fix-flags.diff
@@ -1,12 +1,10 @@
 --- src/Makevars.in	2023-10-25 02:13:48.000000000 +0800
 +++ src/Makevars.in	2023-10-27 04:21:49.000000000 +0800
-@@ -6,5 +6,7 @@
+@@ -6,5 +6,5 @@
  #      endif
  #endif 
  
 -PKG_CPPFLAGS = -I/usr/include/openbabel3  -I/usr/include/eigen3  -DUSE_BOOST -DHAVE_EIGEN  -I/usr/local/include/eigen3 -I/usr/local/include/openbabel3  @OPENBABEL_CFLAGS@ 
 -PKG_LIBS =  -L/usr/local/lib/openbabel3  @OPENBABEL_LIBS@
-+PKG_CPPFLAGS = -DUSE_BOOST -DHAVE_EIGEN -I@PREFIX@/include/openbabel3 -I@PREFIX@/include/eigen3
-+PKG_LIBS = -L@PREFIX@/lib -lopenbabel
-+
-+PKG_CXXFLAGS = -D_GLIBCXX_USE_CXX11_ABI=0
++PKG_CPPFLAGS = @PKG_CPPFLAGS@
++PKG_LIBS = @PKG_LIBS@

--- a/R/R-ChemmineR/Portfile
+++ b/R/R-ChemmineR/Portfile
@@ -3,20 +3,21 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor girke-lab ChemmineR 3.54.0
-revision            1
+R.setup             bioconductor girke-lab ChemmineR 3.56.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Cheminformatics toolkit for R
 long_description    {*}${description}
 homepage            https://github.com/girke-lab/ChemmineR
-checksums           rmd160  c9ea71d72f93cc4bca758fbdf55d764cc39550f5 \
-                    sha256  01297549b77098b794d22158253a30989b8111a6998d1872dc993af82aaf488c \
-                    size    2062632
+checksums           rmd160  49c555dd3bd671d8bb085b8adcfe9058891f8e79 \
+                    sha256  ac6550157293f9a2b2ec7feb631c153ef747e77f196a021f6959be3586efa288 \
+                    size    2062989
 
 depends_lib-append  port:R-base64enc \
-                    port:R-BiocGenerics \
                     port:R-BH \
+                    port:R-BiocGenerics \
                     port:R-DBI \
                     port:R-digest \
                     port:R-DT \
@@ -30,7 +31,9 @@ depends_lib-append  port:R-base64enc \
                     port:R-rsvg \
                     port:R-stringi
 
-depends_test-append port:R-bibtex \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-bibtex \
                     port:R-BiocManager \
                     port:R-BiocStyle \
                     port:R-ChemmineDrugs \
@@ -46,5 +49,6 @@ depends_test-append port:R-bibtex \
                     port:R-scatterplot3d \
                     port:R-snow
 
-# Tests fail presently: https://github.com/girke-lab/ChemmineR/issues/19
-test.run            yes
+    # Tests fail presently: https://github.com/girke-lab/ChemmineR/issues/19
+    test.run        yes
+}

--- a/R/R-ComplexHeatmap/Portfile
+++ b/R/R-ComplexHeatmap/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor ComplexHeatmap 2.18.0
-revision            1
+R.setup             bioconductor Bioconductor ComplexHeatmap 2.20.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             MIT
 description         Complex heatmaps
 long_description    {*}${description}
-checksums           rmd160  fcc131c93dcb8fc3ee91e59d0762a9536185cd0b \
-                    sha256  8eb9912d9897c3914fadeb002bab1dff16a059db4d99b2fd754eb512d904f77f \
-                    size    1455170
+checksums           rmd160  c8edf67e4b214221d157ebc9f51e6e702cc862d8 \
+                    sha256  1bed53e570d491a6d5d7b6565d37c816f074d820f9bdd8c5876d6f0b0aeaffde \
+                    size    1455466
 supported_archs     noarch
 
 depends_lib-append  port:R-circlize \

--- a/R/R-DECIPHER/Portfile
+++ b/R/R-DECIPHER/Portfile
@@ -3,21 +3,24 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor DECIPHER 2.30.0
-revision            1
+R.setup             bioconductor Bioconductor DECIPHER 3.0.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-3
-description         Tools for curating, analyzing and manipulating biological sequences
+description         Tools for curating, analyzing and manipulating \
+                    biological sequences
 long_description    {*}${description}
-checksums           rmd160  e1c33b3719a71e2f2f72f5279562d16d3e110be7 \
-                    sha256  e9d06fe494792d31c2c547c04a409c26fe739c1000fc3aec7697e1367aa328e6 \
-                    size    18930005
+checksums           rmd160  ee810d351b0f09dec22892e5ae7809a50c5bfce5 \
+                    sha256  95da04138348bf370254893a41d96bc2cee7770b1ff199fb73bd50e2f5a0ffad \
+                    size    19822454
 
 depends_lib-append  port:R-Biostrings \
                     port:R-DBI \
                     port:R-IRanges \
-                    port:R-RSQLite \
                     port:R-S4Vectors \
                     port:R-XVector
+
+depends_test-append port:R-RSQLite
 
 test.run            yes

--- a/R/R-DESeq2/Portfile
+++ b/R/R-DESeq2/Portfile
@@ -3,15 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor mikelove DESeq2 1.42.1
-revision            1
+R.setup             bioconductor mikelove DESeq2 1.44.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             LGPL-3+
-description         Differential gene expression analysis based on the negative binomial distribution
+description         Differential gene expression analysis \
+                    based on the negative binomial distribution
 long_description    {*}${description}
-checksums           rmd160  fe91dcc24ad81544c7a5c2ee8c75f123c30e9637 \
-                    sha256  f79b5a96ee27f0243791f85acea635e1c447a217dc9b32b39c671532d32220e8 \
-                    size    2098789
+checksums           rmd160  ba8a7384cf1c6da393b42b8fa20ad5db543efef6 \
+                    sha256  b6b1f0e1d1c626196220e8d8238a71bde6aa36e227b54461ffb01cb6fadcf1c8 \
+                    size    2101810
 
 depends_lib-append  port:R-Biobase \
                     port:R-BiocGenerics \

--- a/R/R-DNAcopy/Portfile
+++ b/R/R-DNAcopy/Portfile
@@ -3,14 +3,15 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor DNAcopy 1.76.0
-revision            1
+R.setup             bioconductor Bioconductor DNAcopy 1.78.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2+
 description         DNA copy number data analysis
 long_description    {*}${description}
-checksums           rmd160  e82b27d63eda2d3cb596a2bebec7214773e4f7fe \
-                    sha256  dff9a0244fe0294c690bdfe803b0d85b9f8a96cca6e9ea315282a25d8e8dd243 \
-                    size    296724
+checksums           rmd160  078793cdb5f9999d5bb1603d829c952ffa24dd4d \
+                    sha256  b45f09b751ffff9f65737b89f6ff041dfc01c9f2ed552fa7ab2ced6856369ae0 \
+                    size    293675
 
 compilers.setup     require_fortran

--- a/R/R-DelayedArray/Portfile
+++ b/R/R-DelayedArray/Portfile
@@ -3,18 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor DelayedArray 700cfdc38e0f97a67942963c1555d0fd83a7bc41
-version             0.29.9
-revision            1
-categories-append   devel
+R.setup             bioconductor Bioconductor DelayedArray 0.30.0
+revision            0
+categories-append   bioconductor devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
 description         Unified framework for working transparently with on-disk and in-memory array-like datasets
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  7c35ad190cc9487018c21657cb2b659e70bd1823 \
-                    sha256  ba1a1113ce329a1afff6e8d45765ae0fa1f190a9e677cc7a2639742448305bd8 \
-                    size    159445
+checksums           rmd160  1a13be2e630140cc2bf3379ae92f04bec12ddc2b \
+                    sha256  a71e16b3eb5310847ae0fa25a98ed9f4a26263ead7eaa13b87dc51ac3b8253c2 \
+                    size    624793
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-IRanges \

--- a/R/R-DelayedMatrixStats/Portfile
+++ b/R/R-DelayedMatrixStats/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github PeteHaitch DelayedMatrixStats ef5c2cb5517b9705b1a50a241b57cdb822447253
-version             1.25.3
-revision            1
+R.setup             bioconductor PeteHaitch DelayedMatrixStats 1.26.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
 description         Functions that apply to rows and columns of DelayedMatrix objects
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  45fbf29a1815ea982e9f2355629dd712664c6509 \
-                    sha256  714b03530ee8768be3eb7df6c6641d3c4d0d8b923d224e52fa86b92f49b620d8 \
-                    size    43602
+homepage            https://github.com/PeteHaitch/DelayedMatrixStats
+checksums           rmd160  02deb994c8aef719b354fb818fec2c5fc71617dd \
+                    sha256  da8c23a5ab6328ce70ef2a9de7f48809b139b5956dbb27c34e86a0e080370eb3 \
+                    size    269061
 supported_archs     noarch
 
 depends_lib-append  port:R-DelayedArray \
@@ -22,7 +22,9 @@ depends_lib-append  port:R-DelayedArray \
                     port:R-S4Vectors \
                     port:R-sparseMatrixStats
 
-depends_test-append port:R-BiocStyle \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-HDF5Array \
                     port:R-knitr \
                     port:R-matrixStats \
@@ -31,5 +33,6 @@ depends_test-append port:R-BiocStyle \
                     port:R-rmarkdown \
                     port:R-testthat
 
-# One test fails on ppc: https://github.com/PeteHaitch/DelayedMatrixStats/issues/90
-test.run            yes
+    # One test fails on ppc: https://github.com/PeteHaitch/DelayedMatrixStats/issues/90
+    test.run        yes
+}

--- a/R/R-DelayedRandomArray/Portfile
+++ b/R/R-DelayedRandomArray/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor LTLA DelayedRandomArray 1.10.0
-revision            1
+R.setup             bioconductor LTLA DelayedRandomArray 1.12.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3
 description         Delayed arrays of random values
 long_description    {*}${description}
 homepage            https://github.com/LTLA/DelayedRandomArray
-checksums           rmd160  83a31125ddd0c996ab3a89c5139f04f6fb1db24e \
-                    sha256  df2c9d8d3acec7813e052755104e1d6c7e38f27f3d0728737f1f224f28314453 \
-                    size    326005
+checksums           rmd160  265dd4453d6eaeb1f48e2cb3223c9aa9e2eba49e \
+                    sha256  16dfb2da60add29d920ea2e2fdfe0fdaed3c164a0dd39d03376d130cd305fd53 \
+                    size    325272
 
 depends_lib-append  port:R-BH \
                     port:R-DelayedArray \

--- a/R/R-DirichletMultinomial/Portfile
+++ b/R/R-DirichletMultinomial/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor DirichletMultinomial 1.44.0
-revision            1
+R.setup             bioconductor Bioconductor DirichletMultinomial 1.46.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             LGPL-3
 description         Dirichlet-multinomial mixture model machine learning for microbiome data
 long_description    {*}${description}
-checksums           rmd160  bf0a18dec8612bcc16e7a8925c49986d54a38c6f \
-                    sha256  9ea732aa74c1fd59d4a1641eb9c3c83863bb8ceac80d419e6a98b8ccd46071e7 \
-                    size    438123
+checksums           rmd160  87819b11c1eac7376d0859c9911f037a84dfbc53 \
+                    sha256  0b7f0d48ac584d1f50ab89ab928b7ef40cc577c6d317514d9653136737414d36 \
+                    size    437813
 
 depends_lib-append  port:gsl \
                     port:R-BiocGenerics \

--- a/R/R-DynDoc/Portfile
+++ b/R/R-DynDoc/Portfile
@@ -3,15 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor DynDoc 1.80.0
-revision            1
+R.setup             bioconductor Bioconductor DynDoc 1.82.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Dynamic document tools
-long_description    A set of functions to create and interact with dynamic documents and vignettes.
-checksums           rmd160  56c8802d3a557623fabcff3abae3ba4511315956 \
-                    sha256  c115174fcf50197ccb7b57d90f48b7a354707e687093e70f89371fffb5ea4a34 \
-                    size    11216
+long_description    A set of functions to create and interact \
+                    with dynamic documents and vignettes.
+checksums           rmd160  a15a5bcf83a1d367437c91c93b95e732eced1cc2 \
+                    sha256  5a9e0a67e0b628336d687ca5a7b14a265960cd70b3d5cd8fddf5bc837d73929c \
+                    size    11267
 supported_archs     noarch
 
 test.run            yes

--- a/R/R-EBImage/Portfile
+++ b/R/R-EBImage/Portfile
@@ -4,17 +4,17 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 # GitHub version lags behind.
-R.setup             bioconductor aoles EBImage 4.44.0
-revision            1
-categories-append   graphics
+R.setup             bioconductor aoles EBImage 4.46.0
+revision            0
+categories-append   bioconductor graphics
 maintainers         nomaintainer
 license             LGPL
 description         Image processing and analysis toolbox for R
 long_description    {*}${description}
 homepage            https://github.com/aoles/EBImage
-checksums           rmd160  f29e82832b39fd7c01ea7e72ec610337c9410f71 \
-                    sha256  1ebeda2a0a718a8655613e672b6cbaa5592d0cf0dad0b1fa2094964d2c2bb149 \
-                    size    5462541
+checksums           rmd160  de1e2b2134516e4c87b67ead5129a0ffbc54636a \
+                    sha256  5c343d8f0438bc9e1d317e9d8f1300ef4af86e1a8f1c783d9099d34493754a61 \
+                    size    5461615
 
 depends_lib-append  port:R-abind \
                     port:R-BiocGenerics \

--- a/R/R-EnrichedHeatmap/Portfile
+++ b/R/R-EnrichedHeatmap/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-# GitHub version lags behind.
-R.setup             bioconductor jokergoo EnrichedHeatmap 1.32.0
-revision            1
+R.setup             bioconductor jokergoo EnrichedHeatmap 1.34.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             MIT
 description         Making of enriched heatmaps
 long_description    {*}${description}
 homepage            https://github.com/jokergoo/EnrichedHeatmap
-checksums           rmd160  4b79d789ce9cbd581ce8d541382cfa9e607cb7c6 \
-                    sha256  f7a3bde456f4877491ebd4a9f1494e9837bad20b758530e2235dd7888de80749 \
-                    size    11862452
+checksums           rmd160  1af6ee1479e1ee6835997db1d3d682e1fc8cd23a \
+                    sha256  d875a11612be22730d99ed932cc88980317aef304cdfde8b4220048d7bfab83a \
+                    size    11869896
 
 depends_lib-append  port:R-circlize \
                     port:R-ComplexHeatmap \

--- a/R/R-ExperimentHub/Portfile
+++ b/R/R-ExperimentHub/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor ExperimentHub 2.10.0
-revision            1
-categories-append   www
+R.setup             bioconductor Bioconductor ExperimentHub 2.12.0
+revision            0
+categories-append   bioconductor www
 maintainers         nomaintainer
 license             Artistic-2
 description         Client to access ExperimentHub resources
 long_description    {*}${description}
-checksums           rmd160  97eb9778ccc135009c25aa1bc3fd406f47fb968b \
-                    sha256  dc8c442e81514a0986b40260a970179b8b1777ee2a8e5f4a1024d0f2341134df \
-                    size    497004
+checksums           rmd160  70745b6c1f8d3e8fbe5233be0a6136a87122a21f \
+                    sha256  1081ac5bc7bb90dd5a257b0ef52024a978ed65a46972076ab195a0eb3b564156 \
+                    size    499864
 supported_archs     noarch
 
 depends_lib-append  port:R-AnnotationHub \

--- a/R/R-GenomeInfoDb/Portfile
+++ b/R/R-GenomeInfoDb/Portfile
@@ -3,22 +3,21 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor GenomeInfoDb 58da6591fb92a8665a83b755bbab7cbc54c1b965
-version             1.39.5
-revision            1
+R.setup             bioconductor Bioconductor GenomeInfoDb 1.40.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Utilities for manipulating chromosome names, \
                     including modifying them to follow a particular naming style
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  87466df216e4f3d55b8ca66dfc4940dcccf55475 \
-                    sha256  1a0427348c54c1b8b465ae7329ee3cefb234800263dc36cea819240247bceda3 \
-                    size    3184532
+checksums           rmd160  36aed63a80304b91ab157dd8a320abdea93fe566 \
+                    sha256  9d351ff98199c50611fdb6ebf62bce4cdfa90e31f568de6f563467b1f3ab838b \
+                    size    3581539
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-GenomeInfoDbData \
                     port:R-IRanges \
-                    port:R-RCurl \
-                    port:R-S4Vectors
+                    port:R-S4Vectors \
+                    port:R-UCSC.utils

--- a/R/R-GenomeInfoDbData/Portfile
+++ b/R/R-GenomeInfoDbData/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor GenomeInfoDbData 1.2.11
-revision            1
+R.setup             bioconductor Bioconductor GenomeInfoDbData 1.2.12
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Species and taxonomy ID look-up tables used by R-GenomeInfoDb
 long_description    {*}${description}
 master_sites        https://bioconductor.org/packages/release/data/annotation/src/contrib/
-checksums           rmd160  6c473276a30a2a95f36eaab4c3231f3aaa6ac392 \
-                    sha256  311fe287842e6161f24fc1faaa824a6d5ce88afcbf4c0203f5e309456e667bc2 \
-                    size    12284235
+checksums           rmd160  3fc8b7ba0cc12c85302a4f1ed6f31654fa4edf86 \
+                    sha256  f7556dc1a0e7b8c33ae7b86519f3f4af15d77c3e2a7be2f6e4a291bf0a95a355 \
+                    size    12558310
 supported_archs     noarch
 
 test.run            yes

--- a/R/R-GenomicAlignments/Portfile
+++ b/R/R-GenomicAlignments/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor GenomicAlignments 1.38.2
-revision            1
+R.setup             bioconductor Bioconductor GenomicAlignments 1.40.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Representation and manipulation of short genomic alignments
 long_description    {*}${description}
-checksums           rmd160  2154880b9ce53676e713d69f729a69bfcb25a9d1 \
-                    sha256  816f078886e0b2054392f1432702372be9621e0da379c1cfa3b02dd5cb389644 \
-                    size    2265818
+checksums           rmd160  9b736c187ce5d6474ef42f6306f3e72961a49ec5 \
+                    sha256  fa68d1745004157501460f38d79b6ebb00975ad8a270bf97373665a0ac6c5f96 \
+                    size    2266620
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-BiocParallel \

--- a/R/R-GenomicFeatures/Portfile
+++ b/R/R-GenomicFeatures/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor GenomicFeatures 723829e39f9790ad50bc4b5f3081a6d6866449fe
-version             1.55.1
-revision            1
+R.setup             bioconductor Bioconductor GenomicFeatures 1.56.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Conveniently import and query gene models
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  8fcd5395372ad439cb070c9c57a7f5e44c6407e4 \
-                    sha256  f7a914d95975955bd3ea1969bc71425ce57261d19dcff3da721658a3cb8c56b5 \
-                    size    1164367
+checksums           rmd160  a497830c8225d87e946b18d8ab985d55b3617ddc \
+                    sha256  854d651450c227e9ba791e4424ad3905cc3096abaf8b2fb621c917bccb4b2de4 \
+                    size    567951
 supported_archs     noarch
 
 depends_lib-append  port:R-AnnotationDbi \

--- a/R/R-GenomicRanges/Portfile
+++ b/R/R-GenomicRanges/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor GenomicRanges 910b78473ca2d8c961732549565696616774c3fd
-version             1.55.1
-revision            1
+R.setup             bioconductor Bioconductor GenomicRanges 1.56.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Representation and manipulation of genomic intervals
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  16fe0c3c0551fdda516a042ac5298d6b064502db \
-                    sha256  df2b3f7516e267429b522c30c490f0fbddf37674f7a761860866497799eea9b1 \
-                    size    163626
+checksums           rmd160  1c27f3b5b372b8cea24f566f79d8b668f72d2104 \
+                    sha256  9d8398425923f54133896631c692117bd707daa30f827f31fff1f14a2048e8a3 \
+                    size    1140266
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-GenomeInfoDb \

--- a/R/R-HDF5Array/Portfile
+++ b/R/R-HDF5Array/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor HDF5Array 01340131dd044f92e0597a32b4e066a2454d62de
-version             1.31.0
-revision            2
+R.setup             bioconductor Bioconductor HDF5Array 1.32.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
 description         HDF5 backend for DelayedArray objects
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  4618924dcfce2b4ac2a0f178b744032ec4436156 \
-                    sha256  ade53025753e20377d30ef9d58feb9fe86b0c2c36c7efcd55d7ac81a4afe92d0 \
-                    size    8098851
+checksums           rmd160  ef4a9afd5619a308a47dd60fdcd283897fe3aa50 \
+                    sha256  e11ad98c43a280d9a14efaf09921b35546c6f4cc67b3e246d531078e53fa1949 \
+                    size    8102013
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-DelayedArray \

--- a/R/R-HilbertCurve/Portfile
+++ b/R/R-HilbertCurve/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor jokergoo HilbertCurve 1.32.0
-revision            1
-categories-append   graphics
+R.setup             bioconductor jokergoo HilbertCurve 1.34.0
+revision            0
+categories-append   bioconductor graphics
 maintainers         nomaintainer
 license             MIT
 description         Make a 2D Hilbert curve
 long_description    {*}${description}
 homepage            http://jokergoo.github.io/HilbertCurve
-checksums           rmd160  5ea84f27426a9bf7b33bd7f314cc7edeef9e10a6 \
-                    sha256  c8a23721389fc2d1bd308316740aba1ae546733a3a47c3ecb9f61305c92ea710 \
-                    size    10294739
+checksums           rmd160  33d958fd71cb9b51f4cfceec2426220a8c83037c \
+                    sha256  4b4103c3c45fe345c194f387bd096cf201ec2a8811788b79177b12a414146a4e \
+                    size    10300711
 supported_archs     noarch
 
 depends_lib-append  port:R-circlize \

--- a/R/R-HilbertVis/Portfile
+++ b/R/R-HilbertVis/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor HilbertVis 1.60.0
-revision            1
-categories-append   graphics
+R.setup             bioconductor Bioconductor HilbertVis 1.62.0
+revision            0
+categories-append   bioconductor graphics
 maintainers         nomaintainer
 license             GPL-3+
 description         Hilbert curve visualization
 long_description    {*}${description}
-checksums           rmd160  d8efa74a84db77af54d2d46a7ed32ee3e69b7d12 \
-                    sha256  96c7a4dfe42158e45bfb7a1e1a33e2577b23409249402cfa5ae742f2420060d5 \
-                    size    1038614
+checksums           rmd160  2e2dc78e4f40edbae30787941b4bacd3bf933d4d \
+                    sha256  edb6d8a360da96db159e64693d797836a475e5f189dab5d21c99ce2bf1b7cd1e \
+                    size    1037414
 
 depends_test-append port:R-EBImage \
                     port:R-IRanges

--- a/R/R-IRanges/Portfile
+++ b/R/R-IRanges/Portfile
@@ -3,25 +3,26 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor IRanges 60cf5502ce421eee47dfc14841cc8ccbc57381df
-version             2.37.1
-revision            1
-categories-append   math
+R.setup             bioconductor Bioconductor IRanges 2.38.0
+revision            0
+categories-append   bioconductor math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
 description         Foundation of integer range manipulation
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  d3f74494f76a33f2f354c721446066ef688d5a0b \
-                    sha256  6b9c236be75f341fd7cbd90335d3d57cb55c1ad1196da6c3b5197fda047c043a \
-                    size    261816
+checksums           rmd160  3fb9c6e4f9d4dcdb23313e0e00f48fd2c18e529e \
+                    sha256  62e646697a1dc2f292b2ea374abb1026ccbe2deedc2f1e5a87e2f99e2142e610 \
+                    size    482585
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-S4Vectors
 
-patchfiles          patch-remove-unavailable-suggests.diff
+variant tests description "Enable testing" {
+    patchfiles-append \
+                    patch-remove-unavailable-suggests.diff
 
-depends_test-append port:R-BiocStyle \
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-GenomicAlignments \
                     port:R-GenomicFeatures \
                     port:R-GenomicRanges \
@@ -29,4 +30,5 @@ depends_test-append port:R-BiocStyle \
                     port:R-RUnit \
                     port:R-XVector
 
-test.run            yes
+    test.run        yes
+}

--- a/R/R-IRanges/files/patch-remove-unavailable-suggests.diff
+++ b/R/R-IRanges/files/patch-remove-unavailable-suggests.diff
@@ -1,11 +1,12 @@
---- DESCRIPTION	2023-10-24 21:32:51.000000000 +0800
-+++ DESCRIPTION	2023-10-26 18:40:26.000000000 +0800
-@@ -23,7 +23,7 @@
+--- DESCRIPTION	2024-05-01 12:19:26.000000000 +0800
++++ DESCRIPTION	2024-05-04 14:13:59.000000000 +0800
+@@ -23,8 +23,7 @@
  Imports: stats4
  LinkingTo: S4Vectors
- Suggests: XVector, GenomicRanges, Rsamtools, GenomicAlignments, GenomicFeatures,
--	BSgenome.Celegans.UCSC.ce2, pasillaBamSubset, RUnit, BiocStyle
-+	RUnit, BiocStyle
- Collate: range-squeezers.R
- 	Vector-class-leftovers.R
- 	DataFrameList-class.R
+ Suggests: XVector, GenomicRanges, Rsamtools, GenomicAlignments,
+-        GenomicFeatures, BSgenome.Celegans.UCSC.ce2, pasillaBamSubset,
+-        RUnit, BiocStyle
++        GenomicFeatures, RUnit, BiocStyle
+ Collate: range-squeezers.R Vector-class-leftovers.R
+         DataFrameList-class.R DataFrameList-utils.R AtomicList-class.R
+         AtomicList-utils.R Ranges-and-RangesList-classes.R

--- a/R/R-Icens/Portfile
+++ b/R/R-Icens/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor Icens 233ce54178261214adc78a05e4badcc0896cf778
-version             1.75.0
-revision            1
+R.setup             bioconductor Bioconductor Icens 1.76.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         NPMLE for censored and truncated data
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  6c4da5a74662302cad53ac1aafc2d35b2f891772 \
-                    sha256  d02cff849ae3e42e314ed1fbebba73dba8d6b81b28b697ef6e9e7815c3d03eb8 \
-                    size    21516
+checksums           rmd160  5f03fca5787379076c478eda80d99c0463e5b2a4 \
+                    sha256  7f8ddee8ca6452401ef0c53184471bc16f241d05e3d6efbac2475e74fba46b99 \
+                    size    21053
 supported_archs     noarch
 
 # https://github.com/Bioconductor/Icens/issues/2

--- a/R/R-InteractionSet/Portfile
+++ b/R/R-InteractionSet/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor InteractionSet 1.30.0
-revision            1
+R.setup             bioconductor Bioconductor InteractionSet 1.32.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-3
 description         Base classes for storing genomic interaction data
 long_description    {*}${description}
-checksums           rmd160  fea87cd65bff77933912112081e4855cf1b0b16c \
-                    sha256  1a372f3d5e9908caf13ceaf67ca7cc9e80b3ecec23c965acbf649c0539ebef56 \
-                    size    400475
+checksums           rmd160  f229c7ce5f7097678da8d111a4687c67772f801c \
+                    sha256  1a06acb7baab7846de9fa437c0f9634453ba2a86495eefab9eb0e6673eac7346 \
+                    size    401992
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-GenomeInfoDb \

--- a/R/R-KEGGREST/Portfile
+++ b/R/R-KEGGREST/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor KEGGREST 192ddeea5f674dd66c18bf56c1cbe1e16dbba549
-version             1.43.0
-revision            1
+R.setup             bioconductor Bioconductor KEGGREST 1.44.0
+revision            0
+categories-append   bioconductor www
 maintainers         nomaintainer
 license             Artistic-2
-description         Client-side REST access to the Kyoto Encyclopedia of Genes and Genomes (KEGG)
+description         Client-side REST access to the Kyoto Encyclopedia \
+                    of Genes and Genomes (KEGG)
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  d670cc94279b3f6170b92cade3665947959e7171 \
-                    sha256  da2d0f6d86608fc9e69d9a6ccc149a182c273a558e262f7d5773c6f64b13bbf7 \
-                    size    15677
+checksums           rmd160  22c12d375b8204536df1fe86687c35ae90ece6c2 \
+                    sha256  c079a74d37d4246ef67bcfa1da00d33bc87ac5fb74e1eb5015728fcc7d0871f7 \
+                    size    23171
 supported_archs     noarch
 
 depends_lib-append  port:R-Biostrings \

--- a/R/R-KEGGgraph/Portfile
+++ b/R/R-KEGGgraph/Portfile
@@ -3,15 +3,15 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor KEGGgraph 1.62.0
-revision            1
+R.setup             bioconductor Bioconductor KEGGgraph 1.64.0
+revision            0
 maintainers         nomaintainer
 license             GPL-2+
 description         A graph approach to KEGG pathway in R and Bioconductor
 long_description    {*}${description}
-checksums           rmd160  5e8717906e65e508de0189f3223082359a019de1 \
-                    sha256  7412ccf6f30faf1cd5ef6081c5eef7ce933ed0507c74b9660630e27a50c63145 \
-                    size    1364014
+checksums           rmd160  108f5eba850d6b270280bfe7e3419b0438e67c61 \
+                    sha256  e71a46e0d81999c3b473fc07fc1c5e7094b5ed4f26e55e7de14bbacaf7c2ce51 \
+                    size    1363503
 supported_archs     noarch
 
 depends_lib-append  port:R-graph \
@@ -19,12 +19,16 @@ depends_lib-append  port:R-graph \
                     port:R-Rgraphviz \
                     port:R-XML
 
-patchfiles          patch-missing-test-deps.diff
+variant tests description "Enable testing" {
+    patchfiles-append \
+                    patch-missing-test-deps.diff
 
-depends_test-append port:R-RBGL \
+    depends_test-append \
+                    port:R-RBGL \
                     port:R-RColorBrewer \
                     port:R-SPIA \
                     port:R-testthat
 
-# There are no specific tests though.
-test.run            yes
+    # There are no specific tests though.
+    test.run        yes
+}

--- a/R/R-MassSpecWavelet/Portfile
+++ b/R/R-MassSpecWavelet/Portfile
@@ -3,16 +3,18 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor zeehio MassSpecWavelet 1.68.0
-revision            1
+R.setup             bioconductor zeehio MassSpecWavelet 1.70.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             LGPL-2+
-description         Peak detection for mass spectrometry data using wavelet-based algorithms
+description         Peak detection for mass spectrometry data \
+                    using wavelet-based algorithms
 long_description    {*}${description}
 homepage            https://github.com/zeehio/MassSpecWavelet
-checksums           rmd160  ef55b2d26d120d35976eb4ed34e8e1d5403138fc \
-                    sha256  5ea71adfc8e632ab10c5b208572e398a1fc799b01d02a1608a688bafbbf89910 \
-                    size    1967774
+checksums           rmd160  0ed56568634fa76e138ef64c5efc210202dc410e \
+                    sha256  426a6dfa39f95fbfca9f04f940ac67b7dbe0c70493e7471533bf4c06a0b27b32 \
+                    size    1962420
 
 depends_test-append port:R-bench \
                     port:R-BiocStyle \

--- a/R/R-MatrixGenerics/Portfile
+++ b/R/R-MatrixGenerics/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor MatrixGenerics 7287502c7b94f9572c8b1fbd385e0e88a04c1fcb
-version             1.15.1
-revision            1
+R.setup             bioconductor Bioconductor MatrixGenerics 1.16.0
+revision            0
+categories-append   bioconductor math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
 description         S4 generic summary statistic functions that operate on matrix-like objects
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  2636ef0c66a81002c1a08bff52b5f9d42669e22c \
-                    sha256  3019158fa394ed20793d2fc3189d172a7a3f7e3fd43d0271183307a0eb6e8592 \
-                    size    34958
+checksums           rmd160  c544dc675721de53aa97076c8d4a249195de8758 \
+                    sha256  ccff61558f067237b96ea71509e4ca95ad465000294067eb21101892d02df6e4 \
+                    size    31669
 supported_archs     noarch
 
 depends_lib-append  port:R-matrixStats

--- a/R/R-MeSHDbi/Portfile
+++ b/R/R-MeSHDbi/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor MeSHDbi 1.38.0
-revision            1
+R.setup             bioconductor Bioconductor MeSHDbi 1.40.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         DBI to construct MeSH-related package from sqlite file
 long_description    {*}${description}
-checksums           rmd160  05cc5b6bae40982c36119c079c291396c62365e9 \
-                    sha256  284be71bb511be9796a85e54f6f2f2bbaea91d8f6bebf9b7dab169395dae548c \
-                    size    52359
+checksums           rmd160  adaeb97e7a112ad76b0acc9a73ed5c733bc4da57 \
+                    sha256  bc4e5d4abea6b8a0bdcb0b28d63ab9e3cfab733495b658c219a250f68689a634 \
+                    size    50417
 supported_archs     noarch
 
 depends_lib-append  port:R-AnnotationDbi \

--- a/R/R-MsCoreUtils/Portfile
+++ b/R/R-MsCoreUtils/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor RforMassSpectrometry MsCoreUtils 1.14.1
-revision            1
+R.setup             bioconductor RforMassSpectrometry MsCoreUtils 1.16.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Core utils for mass spectrometry data
 long_description    {*}${description}
 homepage            https://github.com/RforMassSpectrometry/MsCoreUtils
-checksums           rmd160  ca233a06deda6f16a7aee0aed5f4d8523178a421 \
-                    sha256  5fe7604847d3e6936009f1d20d2c1a75afe7a2da70125fecd0ed26f4ee6cd950 \
-                    size    408688
+checksums           rmd160  e5d13dc288275d6732959e5edca963cb72356205 \
+                    sha256  8aa0d960ce488c83d7c644ccd519fed832387e09369edb74d6dfdc41e4c2a6a2 \
+                    size    420437
 
 depends_lib-append  port:R-clue \
                     port:R-Rcpp \

--- a/R/R-MultiAssayExperiment/Portfile
+++ b/R/R-MultiAssayExperiment/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github waldronlab MultiAssayExperiment a04fa9191a6939f5a77f1cccc66ae89242a431af
-version             1.29.0
-revision            1
+R.setup             bioconductor waldronlab MultiAssayExperiment 1.30.1
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
-description         Software for the integration of multi-omics experiments in Bioconductor
-long_description    {*}${description}
+description         Software for the integration of multi-omics experiments
+long_description    {*}${description} in Bioconductor.
 homepage            https://waldronlab.io/MultiAssayExperiment
-checksums           rmd160  a7027d102fad926bb74c16c7a33adf035f43d138 \
-                    sha256  4cb01076ed5fcfb243132d20195dd8394cd485deb3f81c7bd5d61720da27e83d \
-                    size    373682
+checksums           rmd160  06c509bfc517dc52f606053b447768501ae244e0 \
+                    sha256  1c3621018740694cc98ce5477e9703a215f0d8b8d793caaeae1899c604634e1f \
+                    size    1181656
 supported_archs     noarch
 
 depends_lib-append  port:R-Biobase \

--- a/R/R-MultiAssayExperiment/files/patch-no-maftools.diff
+++ b/R/R-MultiAssayExperiment/files/patch-no-maftools.diff
@@ -1,10 +1,13 @@
---- DESCRIPTION	2023-10-24 22:49:00.000000000 +0800
-+++ DESCRIPTION	2023-10-27 01:32:33.000000000 +0800
-@@ -33,7 +33,6 @@
-     BiocStyle,
-     HDF5Array (>= 1.19.17),
-     knitr,
--    maftools (>= 2.7.10),
-     rmarkdown,
-     R.rsp,
-     RaggedExperiment,
+--- DESCRIPTION	2024-05-03 06:49:42.000000000 +0800
++++ DESCRIPTION	2024-05-04 21:03:38.000000000 +0800
+@@ -26,8 +26,8 @@
+ Imports: Biobase, BiocBaseUtils, BiocGenerics, DelayedArray,
+         GenomicRanges (>= 1.25.93), IRanges, methods, S4Vectors (>=
+         0.23.19), tidyr, utils
+-Suggests: BiocStyle, HDF5Array (>= 1.19.17), knitr, maftools (>=
+-        2.7.10), R.rsp, RaggedExperiment, reshape2, rmarkdown,
++Suggests: BiocStyle, HDF5Array (>= 1.19.17), knitr, R.rsp,
++        RaggedExperiment, reshape2, rmarkdown,
+         survival, survminer, testthat, UpSetR
+ VignetteBuilder: knitr, R.rsp
+ biocViews: Infrastructure, DataRepresentation

--- a/R/R-RBGL/Portfile
+++ b/R/R-RBGL/Portfile
@@ -3,27 +3,28 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor RBGL ebeedfab659b89f99ad5fe216f4d28c71299b588
-version             1.79.0
-revision            1
-categories-append   devel
+R.setup             bioconductor Bioconductor RBGL 1.80.0
+revision            0
+categories-append   bioconductor devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
 description         Interface to the graph algorithms contained in the Boost library
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  e706f032b675798c2eadbd39263b5e8a6fb97b58 \
-                    sha256  265672cc35e0f7af3ef5230859bad692fab37591c3136f7acd18081878d16d83 \
-                    size    2009647
+checksums           rmd160  be0bb5cde0442e4de44d20ce0b49543e88ac8da2 \
+                    sha256  63376ec40804f76035ef64dfe6f697ae179071b43a6d33feaf263eba5976d9d8 \
+                    size    3075056
 
 depends_lib-append  port:R-BH \
                     port:R-graph
 
-depends_test-append port:R-BiocGenerics \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocGenerics \
                     port:R-BiocStyle \
                     port:R-knitr \
                     port:R-Rgraphviz \
                     port:R-RUnit \
                     port:R-XML
 
-test.run            yes
+    test.run        yes
+}

--- a/R/R-RaggedExperiment/Portfile
+++ b/R/R-RaggedExperiment/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor RaggedExperiment 1fbbbdc0f3ebc9af41ae5a13045830a08367f001
-version             1.27.0
-revision            1
+R.setup             bioconductor Bioconductor RaggedExperiment 1.28.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Representation of sparse experiments and assays across samples
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  bf51c90d5f3493cd8eb07ed059771d419d60e9c2 \
-                    sha256  a64d9bf9189afdcf5de8cdc3339f198279e932e099971d88be74ff1a3ef9d404 \
-                    size    53157
+checksums           rmd160  5ef2aaee9ef4aa80ee53d6ec44478bc52c2e55e7 \
+                    sha256  bd8f4ff5022810a21c7bd8a3a969facf0f6fc2544b34b39dcbcb38654561f2d7 \
+                    size    701031
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocBaseUtils \

--- a/R/R-ResidualMatrix/Portfile
+++ b/R/R-ResidualMatrix/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor LTLA ResidualMatrix 1.12.0
-revision            1
+R.setup             bioconductor LTLA ResidualMatrix 1.14.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3
 description         Creating a DelayedMatrix of regression residuals
 long_description    {*}${description}
 homepage            https://github.com/LTLA/ResidualMatrix
-checksums           rmd160  1a7bba283e2e2357013ca86cce5c34147edf48c8 \
-                    sha256  bbb066105053c04b4d2d5fdbda6b2d2eb708c8e80272354bc1dc3dbf7a38fe1a \
-                    size    340952
+checksums           rmd160  9414b56447b3e656806190038a1891aa4ef45a4a \
+                    sha256  f63df941d0df726562ead6d3b8ff87e65c728cbaf6ca4ea615028353e8ff47e0 \
+                    size    340089
 supported_archs     noarch
 
 depends_lib-append  port:R-DelayedArray \

--- a/R/R-Rgraphviz/Portfile
+++ b/R/R-Rgraphviz/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor kasperdanielhansen Rgraphviz 2.46.0
-revision            1
-categories-append   graphics
+R.setup             bioconductor kasperdanielhansen Rgraphviz 2.48.0
+revision            0
+categories-append   bioconductor graphics
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             EPL
 description         Interfaces R with graphviz library for plotting R graph objects
 long_description    {*}${description}
-checksums           rmd160  2b925f656aa9e5d47c1bb50e24fced4a3940eb91 \
-                    sha256  5e87fa40363e7ccc294946436b25cbdc3fa7b080e081e0777464db684ef6860e \
-                    size    7395971
+homepage            https://github.com/kasperdanielhansen/Rgraphviz
+checksums           rmd160  ff1498f6630e5b35aab0ec99d3204e8cde3b4a1c \
+                    sha256  a5186c8834061f77da944f562d1561ee2e332942529f63ccf2781f8314392126 \
+                    size    7400723
 
 # Not using MacPorts Graphviz due to: https://github.com/kasperdanielhansen/Rgraphviz/issues/19
 depends_lib-append  port:R-graph

--- a/R/R-Rhdf5lib/Portfile
+++ b/R/R-Rhdf5lib/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor grimbough Rhdf5lib 1.24.2
-revision            1
+R.setup             bioconductor grimbough Rhdf5lib 1.26.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
 description         HDF5 library as an R package
 long_description    {*}${description}
 homepage            https://github.com/grimbough/Rhdf5lib
-checksums           rmd160  4e1547cab98e14831d1992a13871ecf488f2f222 \
-                    sha256  65522399d08dc95ee220061718ddc1c35f8a3c3bbf91179bc1b6fedddb294f2c \
-                    size    12062265
+checksums           rmd160  d89ddf214378ff453480271086096c95a2fcb128 \
+                    sha256  4b3147da31b60c1f2b37db770059762862da7d28cab66d2aaf3799fcede89160 \
+                    size    12061633
 
 # FIXME: reason is unknown at the moment, but recent versions may fail to build on Rosetta:
 # See: https://github.com/grimbough/Rhdf5lib/issues/53

--- a/R/R-Rhtslib/Portfile
+++ b/R/R-Rhtslib/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor Rhtslib 4e1c963a6ef8f73163ebbd3793fa97b69f22dbb5
-version             2.5.0
-revision            1
+R.setup             bioconductor Bioconductor Rhtslib 3.0.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             LGPL
 description         HTSlib high-throughput sequencing library as an R package
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  2fa7ce6f0753915d993fed24ee88393f79fcf04b \
-                    sha256  b6bad5c3560738847c0c414888b66e616e7cd681d0713b0178925f267438afb9 \
-                    size    4391035
+checksums           rmd160  891808dd62c33d8385a96cd6d289c9ae973b3c17 \
+                    sha256  dbecc8c9c6763f636eef38e207be238bd2e80feec0813149f6d8b1ce07592711 \
+                    size    5148302
 
 depends_lib-append  port:bzip2 \
                     port:curl \

--- a/R/R-Rsamtools/Portfile
+++ b/R/R-Rsamtools/Portfile
@@ -3,17 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor Rsamtools cb532a85d712c82431ed72e874f97e71e08d588a
-version             2.19.0
-revision            1
+R.setup             bioconductor Bioconductor Rsamtools 2.20.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
-description         Binary alignment (BAM), FASTA, variant call (BCF) and tabix file import
+description         Binary alignment (BAM), FASTA, variant call (BCF) \
+                    and tabix file import
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  59a349af41459807672ba699670cdbc718c2f1b0 \
-                    sha256  bc6eab191fb59e7335ff9b6ba461d7521218535b29cc87d0c43edc8bdaa75f2f \
-                    size    2682456
+checksums           rmd160  7a5d6a2e2d3a1bc414c9de750aa853a9596b80b2 \
+                    sha256  689d914c78a085d15cf6d8a2511cd9ae2c6f2c95755ded799228beca7f039f12 \
+                    size    2920003
 
 depends_lib-append  port:curl \
                     port:R-BiocGenerics \

--- a/R/R-S4Arrays/Portfile
+++ b/R/R-S4Arrays/Portfile
@@ -3,18 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor S4Arrays c1f8e6f1f5008a04d336454254302b040229d6db
-version             1.3.7
-revision            1
-categories-append   devel
+R.setup             bioconductor Bioconductor S4Arrays 1.4.0
+revision            0
+categories-append   bioconductor devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
 description         Foundation of array-like containers in Bioconductor
 long_description    {*}${description}
 homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  fcb8e6aec7b0306593b422d375613c6d931aac4c \
-                    sha256  787df9f2f3026f829f2816a39d15232b3d45b9c9782ef331a7be945604dc4876 \
-                    size    61407
+checksums           rmd160  63e5e1830f4a2b5b7e43a4743a3b50f67e574995 \
+                    sha256  de209beeda0e9022b4c423d11422bbd5184a531f498111418553b223e9eef6cc \
+                    size    280654
 
 depends_lib-append  port:R-abind \
                     port:R-BiocGenerics \

--- a/R/R-S4Vectors/Portfile
+++ b/R/R-S4Vectors/Portfile
@@ -3,21 +3,22 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor S4Vectors c54a595b76e7d2ae52ef4906ef4b1389b47df9e4
-version             0.41.6
-revision            1
+R.setup             bioconductor Bioconductor S4Vectors 0.42.0
+revision            0
+categories-append   bioconductor devel
 maintainers         nomaintainer
 license             Artistic-2
 description         Foundation of vector-like and list-like containers
 long_description    {*}${description}
-homepage-append     https://bioconductor.org/packages/${R.package}
-checksums           rmd160  ece9ce258423a56dbac7112784e1945e7276a055 \
-                    sha256  4e24452cd6e25cd62454a36cd72f790a74745ded0d3dfbcb9c69ebaf94a6a48f \
-                    size    276895
+checksums           rmd160  06202088e78e522165a74a58041f3eb767efd9b5 \
+                    sha256  a94ac904e9e86cccefcade949f27992956727ce3ad2f15d8134421aac191002b \
+                    size    880659
 
 depends_lib-append  port:R-BiocGenerics
 
-depends_test-append port:R-BiocStyle \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-data.table \
                     port:R-DelayedArray \
                     port:R-GenomicRanges \
@@ -28,4 +29,5 @@ depends_test-append port:R-BiocStyle \
                     port:R-ShortRead \
                     port:R-SummarizedExperiment
 
-test.run            yes
+    test.run        yes
+}

--- a/R/R-SPIA/Portfile
+++ b/R/R-SPIA/Portfile
@@ -3,16 +3,19 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor SPIA 2.54.0
-revision            1
+R.setup             bioconductor Bioconductor SPIA 2.56.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Restrictive
-description         Signaling Pathway Impact Analysis (SPIA) using combined evidence \
-                    of pathway over-representation and unusual signaling perturbations
+# https://bioconductor.org/packages/release/bioc/licenses/SPIA/LICENSE
+description         Signaling Pathway Impact Analysis (SPIA) \
+                    using combined evidence of pathway over-representation \
+                    and unusual signalling perturbations
 long_description    {*}${description}
-checksums           rmd160  cb80ca34429f20e2ba069c288f9e2efc3fcbbe83 \
-                    sha256  a5ea2bedf20f9f538f1705d65265b24df6d9709c98ab14a0e964577df7a33724 \
-                    size    2566459
+checksums           rmd160  5a599f0f8054e0c009e0e81700381b1f4b0901fd \
+                    sha256  88683c83f5355a52d8402d216a34020545ca84317d9a12adc39007718b4fd32a \
+                    size    2566334
 supported_archs     noarch
 
 depends_lib-append  port:R-KEGGgraph

--- a/R/R-SQLDataFrame/Portfile
+++ b/R/R-SQLDataFrame/Portfile
@@ -3,38 +3,33 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor SQLDataFrame 6eced9bdf3a8ba4fc1fa3aecbf3203a1c4bcbd84
-version             1.17.0
-revision            1
-categories-append   databases
+R.setup             bioconductor Bioconductor SQLDataFrame 1.18.0
+revision            0
+categories-append   bioconductor databases
 maintainers         nomaintainer
-license             GPL-3
+license             LGPL-3
 description         Representation of SQL database in DataFrame metaphor
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  cfe98dee69b391c256c2c59bc40ca9e817e34769 \
-                    sha256  8ea59ec7a097cf223bac4bb0c603351db1c13874e4259844b7680d7fd600beb8 \
-                    size    55219
+checksums           rmd160  76290dc4eba0d8eb82073e3d1c27b6d00ee91261 \
+                    sha256  90d34ef5a650fb1f0c93d800d90e6ee73989ab6dc69004a995acbc997733aeb9 \
+                    size    240583
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-DBI \
-                    port:R-dbplyr \
-                    port:R-dplyr \
-                    port:R-lazyeval \
-                    port:R-RSQLite \
-                    port:R-S4Vectors \
-                    port:R-tibble
-
-# There are some warnings during checks:
-# https://github.com/Bioconductor/SQLDataFrame/issues/7
-
-depends_test-append port:R-bigrquery \
                     port:R-DelayedArray \
-                    port:R-GenomicRanges \
+                    port:R-duckdb \
+                    port:R-RSQLite \
+                    port:R-S4Vectors
+
+# Some tests fail: https://github.com/Bioconductor/SQLDataFrame/issues/10
+# On PowerPC [ FAIL 11 | WARN 0 | SKIP 0 | PASS 96 ]
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-knitr \
                     port:R-rmarkdown \
-                    port:R-RMySQL \
                     port:R-testthat
 
-test.run            yes
+    test.run        yes
+}

--- a/R/R-ScaledMatrix/Portfile
+++ b/R/R-ScaledMatrix/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor LTLA ScaledMatrix 1.10.0
-revision            1
+R.setup             bioconductor LTLA ScaledMatrix 1.12.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3
 description         Creating a DelayedMatrix of scaled and centered values
 long_description    {*}${description}
 homepage            https://github.com/LTLA/ScaledMatrix
-checksums           rmd160  37ccfcec8d7cd0b93a2461248fd69d121e6cd192 \
-                    sha256  8a40a14537c47caaf9aa1dc4b7b8c2354fca77ba895e548821b132a481622faa \
-                    size    313034
+checksums           rmd160  4029c4afd6af6fa9b11483b39ccb5653c8ca60fa \
+                    sha256  f15ea729ef6162a68c437d887d40981aa7f0d613ac777a727e3e0c7d6db9da30 \
+                    size    311705
 supported_archs     noarch
 
 depends_lib-append  port:R-DelayedArray \

--- a/R/R-SeqArray/Portfile
+++ b/R/R-SeqArray/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor zhengxwen SeqArray 1.42.4
-revision            1
+R.setup             bioconductor zhengxwen SeqArray 1.44.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-3
 description         Data management of large-scale whole-genome sequence variant calls
 long_description    {*}${description}
 homepage            https://github.com/zhengxwen/SeqArray
-checksums           rmd160  8b8524693e0695593a4dd540e58afaf01ceea809 \
-                    sha256  2d55f287546a9cfa5e02923e934a1318bdf22b6d6bac67bcbc65d0202727ef4c \
-                    size    3594809
+checksums           rmd160  9fcaf5f207f8dda2d8745844157548935c95a2b6 \
+                    sha256  13a1b9b44dd66e6e4141ae089f2c9f762bdbf9090c6ac14186113963fc3108bd \
+                    size    3580975
 
 depends_lib-append  port:R-Biostrings \
                     port:R-gdsfmt \

--- a/R/R-ShortRead/Portfile
+++ b/R/R-ShortRead/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor ShortRead 6b48c2b6a26162a3ebd7eb610a88875b1e899d3d
-version             1.61.0
-revision            1
+R.setup             bioconductor Bioconductor ShortRead 1.62.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         FASTQ input and manipulation
 long_description    {*}${description}
-checksums           rmd160  e1afa20e00c55d33739bc1a590497fbc87f7995f \
-                    sha256  d13774360749fc42412828943aaecd3374da6dc35a8bc460feee0ecfc1ce0438 \
-                    size    5009082
+checksums           rmd160  da8875044bccc06edae361e1845e5c96373aeac4 \
+                    sha256  550ead16ef1aa2dca0f221a570ca8216b077d1627701c824cf45773145c7b174 \
+                    size    5313872
 
 depends_lib-append  port:R-Biobase \
                     port:R-BiocGenerics \
@@ -24,17 +24,21 @@ depends_lib-append  port:R-Biobase \
                     port:R-hwriter \
                     port:R-IRanges \
                     port:R-latticeExtra \
+                    port:R-pwalign \
                     port:R-Rhtslib \
                     port:R-Rsamtools \
                     port:R-S4Vectors \
                     port:R-XVector \
                     port:R-zlibbioc
 
-depends_test-append port:R-BiocStyle \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-biomaRt \
                     port:R-RUnit \
                     port:R-GenomicFeatures \
                     port:R-yeastNagalakshmi
 
-# One example fails: https://github.com/Bioconductor/ShortRead/issues/13
-test.run            yes
+    # One example fails: https://github.com/Bioconductor/ShortRead/issues/13
+    test.run        yes
+}

--- a/R/R-SingleCellExperiment/Portfile
+++ b/R/R-SingleCellExperiment/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor SingleCellExperiment 1.24.0
-revision            1
+R.setup             bioconductor Bioconductor SingleCellExperiment 1.26.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-3
 description         S4 classes for single-cell data
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  c21b6f47471ede03cd2d5ee8065361c4a740df3a \
-                    sha256  c4670774e28468028bc62971a78f2576a10fb90c4b832c0a6c34785a4fb28460 \
-                    size    985002
+checksums           rmd160  7a39ab4cb45fa4004a11b7450ac465ce5d36ea18 \
+                    sha256  76e080bbed5634caf152a02799d722750ede9ecf2b97bd9743bd949732984b27 \
+                    size    979460
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocGenerics \

--- a/R/R-SparseArray/Portfile
+++ b/R/R-SparseArray/Portfile
@@ -3,18 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor SparseArray 25665f0500c9b59b8ba7d97a5b136708697a3255
-version             1.3.5
-revision            1
-categories-append   devel
+R.setup             bioconductor Bioconductor SparseArray 1.4.0
+revision            0
+categories-append   bioconductor devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
 description         Efficient in-memory representation of multi-dimensional sparse arrays
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  820c678c2e5f0c595a1d648d098d2ac5d6394af3 \
-                    sha256  9778f025dcbca98e3ccccd5c4e195659f1be07fa555b7c927024c991b3a003d7 \
-                    size    142659
+checksums           rmd160  6bfa03fb02a070445feaca70edcda09073ef9498 \
+                    sha256  0d2cfd75da16c471713b0d9e0c9b83ae21c6467779231ec6ddd1de151668617f \
+                    size    374420
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-IRanges \
@@ -24,10 +22,20 @@ depends_lib-append  port:R-BiocGenerics \
                     port:R-S4Vectors \
                     port:R-XVector
 
-depends_test-append port:R-BiocStyle \
+# Temporarily disable OpenMP with Clang due to:
+# https://github.com/Bioconductor/SparseArray/issues/9
+if {[string match *clang* ${configure.compiler}]} {
+    patchfiles-append \
+                    patch-disable-openmp.diff
+}
+
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-DelayedArray \
                     port:R-knitr \
                     port:R-rmarkdown \
                     port:R-testthat
 
-test.run            yes
+    test.run        yes
+}

--- a/R/R-SparseArray/files/patch-disable-openmp.diff
+++ b/R/R-SparseArray/files/patch-disable-openmp.diff
@@ -1,0 +1,45 @@
+--- src/Makevars	2024-05-01 08:54:02.000000000 +0800
++++ src/Makevars	2024-05-05 04:55:32.000000000 +0800
+@@ -1,2 +1,2 @@
+-PKG_CFLAGS = $(SHLIB_OPENMP_CFLAGS)
+-PKG_LIBS = $(SHLIB_OPENMP_CFLAGS)
++PKG_CFLAGS =
++PKG_LIBS =
+
+--- src/thread_control.c	2024-05-01 08:54:02.000000000 +0800
++++ src/thread_control.c	2024-05-05 04:57:12.000000000 +0800
+@@ -3,14 +3,14 @@
+  ****************************************************************************/
+ #include "thread_control.h"
+ 
+-#ifdef _OPENMP
++#if defined(_OPENMP) && !defined(__clang__)
+ #include <omp.h>
+ #endif
+ 
+ 
+ static int get_num_procs(void)
+ {
+-#ifdef _OPENMP
++#if defined(_OPENMP) && !defined(__clang__)
+ 	return omp_get_num_procs();
+ #else
+ 	return 0;
+@@ -19,7 +19,7 @@
+ 
+ static int get_max_threads(void)
+ {
+-#ifdef _OPENMP
++#if defined(_OPENMP) && !defined(__clang__)
+ 	return omp_get_max_threads();
+ #else
+ 	return 0;
+@@ -28,7 +28,7 @@
+ 
+ static void set_max_threads(int nthread)
+ {
+-#ifdef _OPENMP
++#if defined(_OPENMP) && !defined(__clang__)
+ 	omp_set_num_threads(nthread);
+ #endif
+ 	return;

--- a/R/R-Structstrings/Portfile
+++ b/R/R-Structstrings/Portfile
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             bioconductor FelixErnst Structstrings 1.20.0
+revision            0
+categories-append   bioconductor
+maintainers         nomaintainer
+license             Artistic-2
+description         Implementation of the dot bracket annotations with Biostrings
+long_description    ${name} implements the widely used dot bracket annotation \
+                    for storing base pairing information in structured RNA.
+homepage            https://github.com/FelixErnst/Structstrings
+checksums           rmd160  4034158efe7a6042dd258d96959a43d2c84d2e37 \
+                    sha256  e9efa165ccff880429acba1b2d149ead365fda46ed3b14b2723bb1077b9c49cd \
+                    size    375653
+
+depends_lib-append  port:R-BiocGenerics \
+                    port:R-Biostrings \
+                    port:R-crayon \
+                    port:R-IRanges \
+                    port:R-S4Vectors \
+                    port:R-stringi \
+                    port:R-stringr \
+                    port:R-XVector
+
+variant tests description "Enable testing" {
+    patchfiles-append \
+                    patch-no-tRNAscanImport.diff
+
+    depends_test-append \
+                    port:R-BiocStyle \
+                    port:R-knitr \
+                    port:R-rmarkdown \
+                    port:R-testthat
+
+    # Tests pass, one example from vignettes fails.
+    test.run        yes
+}

--- a/R/R-Structstrings/files/patch-no-tRNAscanImport.diff
+++ b/R/R-Structstrings/files/patch-no-tRNAscanImport.diff
@@ -1,0 +1,11 @@
+--- DESCRIPTION	2024-05-02 07:40:27.000000000 +0800
++++ DESCRIPTION	2024-05-05 05:08:04.000000000 +0800
+@@ -24,7 +24,7 @@
+ LinkingTo: IRanges, S4Vectors
+ Imports: methods, BiocGenerics, XVector, stringr, stringi, crayon,
+         grDevices
+-Suggests: testthat, knitr, rmarkdown, tRNAscanImport, BiocStyle
++Suggests: testthat, knitr, rmarkdown, BiocStyle
+ VignetteBuilder: knitr
+ RoxygenNote: 7.3.1
+ Collate: 'Structstrings.R' 'AllGenerics.R'

--- a/R/R-SummarizedExperiment/Portfile
+++ b/R/R-SummarizedExperiment/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor SummarizedExperiment 6393bb8e050f3a02d4aaad4b82582353a76b8efb
-version             1.33.0
-revision            1
+R.setup             bioconductor Bioconductor SummarizedExperiment 1.34.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         SummarizedExperiment container
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  c364962f883df538d6e0bf16e908bdeb797bda56 \
-                    sha256  eae7af1c67c5772025e6f3b598ddc9a5c323a06e7b8b0430b2592459c3fc6f74 \
-                    size    93765
+checksums           rmd160  a6a120b3351243d5cf7a655f792a8bc640765779 \
+                    sha256  e0c2b2c512dcf273b6c74115bac49093932753b69bb0d95ff80fbcb7057e9b09 \
+                    size    688177
 supported_archs     noarch
 
 depends_lib-append  port:R-Biobase \

--- a/R/R-TileDBArray/Portfile
+++ b/R/R-TileDBArray/Portfile
@@ -3,17 +3,18 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor LTLA TileDBArray 1.12.0
-revision            1
+R.setup             bioconductor LTLA TileDBArray 1.14.0
+revision            0
+categories-append   bioconductor
 categories-append   databases
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
 description         Use TileDB as a DelayedArray backend
 long_description    {*}${description}
 homepage            https://github.com/LTLA/TileDBArray
-checksums           rmd160  994f49297750004ecba3e17a2c6b276f831a877a \
-                    sha256  920703cc68b3dbad43aaac626efb3d8a1e5c7f18fbdf95f9ade80ef878ada1d7 \
-                    size    313671
+checksums           rmd160  c768ef48ad6e5025856ad5fef33288923b467ec5 \
+                    sha256  030096dc995559762968fa785a420fda55b80f0480de3596741694e75c67fcc1 \
+                    size    312953
 
 depends_lib-append  port:R-DelayedArray \
                     port:R-Rcpp \
@@ -22,13 +23,16 @@ depends_lib-append  port:R-DelayedArray \
 
 compiler.cxx_standard 2017
 
-depends_test-append port:R-BiocParallel \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocParallel \
                     port:R-BiocStyle \
                     port:R-knitr \
                     port:R-rmarkdown \
                     port:R-testthat
 
-# Status of tests on ppc: [ FAIL 5 | WARN 0 | SKIP 0 | PASS 28 ]
-# Those failing spit out the same message: [TileDB::ArrayDirectory] Error: FilterCreate: Deserialization error; not enough data in buffer for metadata
-# See notes in TileDB and R-tiledb ports; also: https://github.com/TileDB-Inc/TileDB/issues/4096
-test.run            yes
+    # Status of tests on ppc: [ FAIL 5 | WARN 0 | SKIP 0 | PASS 28 ]
+    # Those failing spit out the same message: [TileDB::ArrayDirectory] Error: FilterCreate: Deserialization error; not enough data in buffer for metadata
+    # See notes in TileDB and R-tiledb ports; also: https://github.com/TileDB-Inc/TileDB/issues/4096
+    test.run        yes
+}

--- a/R/R-UCSC.utils/Portfile
+++ b/R/R-UCSC.utils/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             bioconductor Bioconductor UCSC.utils 1.0.0
+revision            0
+categories-append   bioconductor
+maintainers         nomaintainer
+license             Artistic-2
+description         Low-level utilities to retrieve data \
+                    from the UCSC Genome Browser
+long_description    {*}${description}
+checksums           rmd160  d313396ce690328a86d8712b1b8f6d9e041e82ad \
+                    sha256  349de171d96d28875fdbac104e4a10f0d6c891fdec6676d755d1fa6c5a2f2e71 \
+                    size    236116
+supported_archs     noarch
+
+depends_lib-append  port:R-httr \
+                    port:R-jsonlite \
+                    port:R-S4Vectors
+
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
+                    port:R-DBI \
+                    port:R-GenomeInfoDb \
+                    port:R-knitr \
+                    port:R-RMariaDB \
+                    port:R-rmarkdown \
+                    port:R-testthat
+
+    test.run        yes
+}

--- a/R/R-VariantAnnotation/Portfile
+++ b/R/R-VariantAnnotation/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor VariantAnnotation 1.48.1
-revision            1
+R.setup             bioconductor Bioconductor VariantAnnotation 1.50.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Annotation of genetic variants
 long_description    {*}${description}
-checksums           rmd160  c18dfae72b50c99b350caf19211988c5feaeb875 \
-                    sha256  2af6d1164152f9722fc83cfe16cf43e1a83ba5c9d133d9663175b0ac779e3d51 \
-                    size    1886512
+checksums           rmd160  c794a4e477d9fcabbfe945956baeb1fe9d16016f \
+                    sha256  e7b91042f123b6fbab0d9f84a1dae68e56a308886fe84fffd572c2622aa49b6a \
+                    size    2109705
 
 depends_lib-append  port:curl \
                     port:R-AnnotationDbi \

--- a/R/R-XVector/Portfile
+++ b/R/R-XVector/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor XVector 26ce2819a1b46b16e4023c50e1d987707ee491ba
-version             0.43.1
-revision            1
-categories-append   devel
+R.setup             bioconductor Bioconductor XVector 0.44.0
+revision            0
+categories-append   bioconductor devel
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
-description         Foundation of external vector representation and manipulation in Bioconductor
-long_description    {*}${description}
-checksums           rmd160  583272b79ae2e28ea031cda0d5108073a148b749 \
-                    sha256  8c03732b63014b8f1ff717e1c5eba88d3b03c74651b99173d05766313ca39d41 \
-                    size    68422
+description         Foundation of external vector representation and manipulation
+long_description    {*}${description} in Bioconductor.
+checksums           rmd160  25b07a5078bd5a6e68471b58a28a6aa6fab09605 \
+                    sha256  42a35e3056f4289369082b3f04f6fdd66ea8cccf2dddb7388117f074ea49bb3b \
+                    size    67826
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-IRanges \

--- a/R/R-XVector/files/patch-no-drosophila2probe.diff
+++ b/R/R-XVector/files/patch-no-drosophila2probe.diff
@@ -1,11 +1,11 @@
---- DESCRIPTION	2023-10-24 21:54:02.000000000 +0800
-+++ DESCRIPTION	2023-10-26 20:18:39.000000000 +0800
-@@ -14,7 +14,7 @@
- 	S4Vectors (>= 0.27.12), IRanges (>= 2.23.9)
- Imports: methods, utils, tools, zlibbioc, BiocGenerics, S4Vectors, IRanges
+--- DESCRIPTION	2024-05-01 14:35:47.000000000 +0800
++++ DESCRIPTION	2024-05-04 15:57:40.000000000 +0800
+@@ -16,7 +16,7 @@
+ Imports: methods, utils, tools, zlibbioc, BiocGenerics, S4Vectors,
+         IRanges
  LinkingTo: S4Vectors, IRanges
 -Suggests: Biostrings, drosophila2probe, RUnit
 +Suggests: Biostrings, RUnit
- Collate: io-utils.R
- 	RDS-random-access.R
- 	SharedVector-class.R
+ Collate: io-utils.R RDS-random-access.R SharedVector-class.R
+         SharedRaw-class.R SharedInteger-class.R SharedDouble-class.R
+         XVector-class.R XRaw-class.R XInteger-class.R XDouble-class.R

--- a/R/R-annotate/Portfile
+++ b/R/R-annotate/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor annotate 1.80.0
-revision            1
+R.setup             bioconductor Bioconductor annotate 1.82.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Annotation for microarrays
 long_description    {*}${description}
-checksums           rmd160  1da1eeccf17f0ec8e608c11a356b717438f6fb2a \
-                    sha256  4dab9615498f6c58d1e6ecc1ecd0052187e46bdf971b18d73149b6bddea2ad82 \
-                    size    1497628
+checksums           rmd160  c88730085b3224390f37021ba07585e088cc88f9 \
+                    sha256  0e688a52c2234dc5e30032aa7633899b73840e8d123c05392814664e85c09aec \
+                    size    1768157
 supported_archs     noarch
 
 depends_lib-append  port:R-AnnotationDbi \

--- a/R/R-apeglm/Portfile
+++ b/R/R-apeglm/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor apeglm 1.24.0
-revision            1
+R.setup             bioconductor Bioconductor apeglm 1.26.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2+
 description         Approximate posterior estimation for GLM coefficients
 long_description    {*}${description}
-checksums           rmd160  e5625333e1d6cc8c2d16775ae771379b7864d685 \
-                    sha256  a4ff49d510b9021328c9f56bfbd3af55905c8a2c53ccdaf3986ef004ebf74932 \
-                    size    1111327
+checksums           rmd160  c443079a07b684a2009266955d8421f0e6651ae7 \
+                    sha256  faf1036b12330e7c889febec532dd1aff21993356202c7c30018f41989d30451 \
+                    size    1110415
 
 depends_lib-append  port:R-emdbook \
                     port:R-GenomicRanges \

--- a/R/R-aroma.light/Portfile
+++ b/R/R-aroma.light/Portfile
@@ -3,18 +3,18 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-# GitHub version lags behind.
-R.setup             bioconductor Bioconductor aroma.light 3.32.0
-revision            1
+R.setup             bioconductor HenrikBengtsson aroma.light 3.34.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2+
 description         Light-weight methods for normalization and visualization \
                     of microarray data
 long_description    {*}${description} using only basic R data types.
 homepage            https://github.com/HenrikBengtsson/aroma.light
-checksums           rmd160  fffcd7ccb54ba82482aa3dd1c8a33139e1f8f1fa \
-                    sha256  68a1adac23a4f756bc6369af82f54de57c717bfe1e5e3d54004e3baa01add9c4 \
-                    size    388364
+checksums           rmd160  a7b9c355247ebfde1cf590dd760fa5fb1d616ee5 \
+                    sha256  9fef7be410af21d4a02217f3f459168147d9f745fbe7f909e1576a3b075944ec \
+                    size    386690
 supported_archs     noarch
 
 depends_lib-append  port:R-matrixStats \

--- a/R/R-beachmat/Portfile
+++ b/R/R-beachmat/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor tatami-inc beachmat 2.18.1
-revision            1
+R.setup             bioconductor tatami-inc beachmat 2.20.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3
 description         Compiling Bioconductor to handle each matrix type
 long_description    {*}${description}
 homepage            https://github.com/tatami-inc/beachmat
-checksums           rmd160  ffa4d619516b656f2ce5d615b309a004988c523a \
-                    sha256  54cc8e943c607012c9760814b0305b8ad75a083f54a4d6c2dc3063358795e8cf \
-                    size    512143
+checksums           rmd160  35fb758dfd8e67399dfc08698faa305693374b62 \
+                    sha256  deec903046f14e656a92076e4c7bdf1c1ecdb456d942e83d661ac52a78fa7d3f \
+                    size    515309
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-DelayedArray \

--- a/R/R-bioDist/Portfile
+++ b/R/R-bioDist/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor bioDist c8c15c5aad46d3a63131f9b4b1f7b0a024f3504f
-version             1.75.0
-revision            1
+R.setup             bioconductor Bioconductor bioDist 1.76.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Different distance measures
 long_description    {*}${description}
-checksums           rmd160  5a6119a29c92b52723378e703b20088283809415 \
-                    sha256  e1fdd33c73abc28f74458dec1b6a276f9cee810995640205f8d8c5aa49130d4e \
-                    size    9737
+checksums           rmd160  f65e58f9ade0508980f7669fc9ce5a3d8a53edc8 \
+                    sha256  1806d2542d07a9fa24b29e0b194adc92a777b441f20858636265231f5c2bb9fb \
+                    size    113606
 supported_archs     noarch
 
 depends_lib-append  port:R-Biobase

--- a/R/R-biobroom/Portfile
+++ b/R/R-biobroom/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor StoreyLab biobroom 1.34.0
-revision            1
+R.setup             bioconductor StoreyLab biobroom 1.36.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             LGPL
 description         Turn Bioconductor objects into tidy data frames
 long_description    {*}${description}
-checksums           rmd160  88a18d33ad8bc8694440b0d4798ed8632584340c \
-                    sha256  ae7a64554a7703208072d6788b1480a732ea30cbf80277ba42ee45e16fa46cc7 \
-                    size    509027
+checksums           rmd160  66c9b3595cce973149d5c92a756a613914b7bc9e \
+                    sha256  a081948abdca666c0c78505d19752b12e85cb03c13b4cbbe0bb92a851a09923a \
+                    size    492184
 supported_archs     noarch
 
 depends_lib-append  port:R-Biobase \

--- a/R/R-biocViews/Portfile
+++ b/R/R-biocViews/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor biocViews e4a1a5ac568fb07e03f7b700c2fcda049f367a37
-version             1.71.1
-revision            1
+R.setup             bioconductor Bioconductor biocViews 1.72.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Categorized views of R package repositories
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  2fbc2a87b5c9378944d745f5dda69e19b06e71d8 \
-                    sha256  d2d75813d6f9c69cc0de822c7ea7636f47afb1ddb69fd90583a2f6d26462cc81 \
-                    size    75090
+checksums           rmd160  20c16d45d56192dab4e5d959abf8e7f1427b18ba \
+                    sha256  05ca88945b8db5e144194ed976fe09b73f6281a64b4d2ecac9a8bb7b41d14982 \
+                    size    513326
 supported_archs     noarch
 
 depends_lib-append  port:R-Biobase \

--- a/R/R-biocthis/Portfile
+++ b/R/R-biocthis/Portfile
@@ -3,18 +3,19 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor lcolladotor biocthis 1.12.0
-revision            1
-categories-append   devel
+R.setup             bioconductor lcolladotor biocthis 1.14.0
+revision            0
+categories-append   bioconductor devel
 maintainers         nomaintainer
 license             Artistic-2
 description         Automate package and project setup for Bioconductor packages
-long_description    This package expands the usethis package with the goal of helping automate \
-                    the process of creating R packages for Bioconductor or making them Bioconductor-friendly.
+long_description    This package expands the usethis package with the goal \
+                    of helping automate the process of creating R packages \
+                    for Bioconductor or making them Bioconductor-friendly.
 homepage            https://github.com/lcolladotor/biocthis
-checksums           rmd160  74919928cf49077cb66ee3fe20397d03c5ef07ef \
-                    sha256  e8ad317d1599295e196f4274f08c84ad8947da4634c438eedc1cad080ed7ac53 \
-                    size    673525
+checksums           rmd160  d2f95c98616930c265e47d07db31c429c094cfb1 \
+                    sha256  571ffaa1bf1a74ff424bc4678f3c88e09fd73995d6eed5cbcfd177890bdf09b8 \
+                    size    675200
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocManager \

--- a/R/R-biomaRt/Portfile
+++ b/R/R-biomaRt/Portfile
@@ -3,32 +3,34 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor grimbough biomaRt 2.58.2
-revision            1
+R.setup             bioconductor grimbough biomaRt 2.60.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Interface to BioMart databases
 long_description    {*}${description}
-checksums           rmd160  acf879168daae28143cbad0b91d3515c0e0c9c77 \
-                    sha256  4484dd7ab2a382af67c97d97944ff4bdbdc2ff1fc5f0c4ff23dc4e772431140e \
-                    size    670061
+checksums           rmd160  1bf5d1ea2d94d1997265bb950ee066dbb26ff474 \
+                    sha256  78e2ad6c877e2b38f12c07fffcf7ce3121423f5e1359a7ce37fa4daf67a3526f \
+                    size    859866
 supported_archs     noarch
 
 depends_lib-append  port:R-AnnotationDbi \
                     port:R-BiocFileCache \
                     port:R-digest \
-                    port:R-httr \
+                    port:R-httr2 \
                     port:R-progress \
                     port:R-rappdirs \
                     port:R-stringr \
                     port:R-XML \
                     port:R-xml2
 
+patchfiles          patch-no-httptest2.diff
+
 depends_test-append port:R-BiocStyle \
                     port:R-knitr \
                     port:R-mockery \
                     port:R-rmarkdown \
-                    port:R-testthat \
-                    port:R-webmockr
+                    port:R-testthat
 
 test.run            yes

--- a/R/R-biomaRt/files/patch-no-httptest2.diff
+++ b/R/R-biomaRt/files/patch-no-httptest2.diff
@@ -1,0 +1,11 @@
+--- DESCRIPTION	2024-05-01 10:48:24.000000000 +0800
++++ DESCRIPTION	2024-05-05 04:16:41.000000000 +0800
+@@ -26,7 +26,7 @@
+ Depends: methods
+ Imports: utils, AnnotationDbi, progress, stringr, httr2, digest,
+         BiocFileCache, rappdirs, xml2
+-Suggests: BiocStyle, knitr, mockery, rmarkdown, testthat, httptest2
++Suggests: BiocStyle, knitr, mockery, rmarkdown, testthat
+ URL: https://github.com/grimbough/biomaRt
+ BugReports: https://github.com/grimbough/biomaRt/issues
+ VignetteBuilder: knitr

--- a/R/R-bluster/Portfile
+++ b/R/R-bluster/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor LTLA bluster 1.12.0
-revision            1
+R.setup             bioconductor LTLA bluster 1.14.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-3
 description         Clustering algorithms for Bioconductor
 long_description    {*}${description}
 homepage            https://github.com/LTLA/bluster
-checksums           rmd160  0ef37d1881722193ba9316720bf91bc892437893 \
-                    sha256  0c564cfe750c16f4cb5def26289dbd036b027c096239e8352a228d764cd9f39b \
-                    size    2995786
+checksums           rmd160  1f28583a0aeb4e697e742a1cbb88444346f0fa8a \
+                    sha256  8a7b1818ca21442a1d1166f82e248e8eab5d02c21557d69fd87971db44e747ae \
+                    size    2953678
 
 depends_lib-append  port:R-BiocNeighbors \
                     port:R-BiocParallel \

--- a/R/R-clustComp/Portfile
+++ b/R/R-clustComp/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor clustComp 1.30.0
-revision            1
+R.setup             bioconductor Bioconductor clustComp 1.32.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2+
 description         Clustering Comparison
 long_description    {*}${description}
-checksums           rmd160  2b1e0dc5b685d192b6ad8c3327432745c841eff6 \
-                    sha256  a53c4f1b22ecb2a2cb4dd50327b23f58eab48c619925a45a53de3f8cc2449dcb \
-                    size    811128
+checksums           rmd160  2b20eb125b0f2e0cfa3a8eedb4959d37947e73c1 \
+                    sha256  782612f54ceb2516b377ddd1c88971b4fe091970e230bcc094052c49612b6537 \
+                    size    808189
 supported_archs     noarch
 
 depends_lib-append  port:R-sm

--- a/R/R-csaw/Portfile
+++ b/R/R-csaw/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor csaw 1.36.1
-revision            1
+R.setup             bioconductor Bioconductor csaw 1.38.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-3
 description         ChIP-Seq Analysis with Windows
 long_description    {*}${description}
-checksums           rmd160  8dca70fe4fb759d873cd3afc19d2bd1f8bf36733 \
-                    sha256  ff64fb074c81f05bb105d9d3bdb95e6f8963e881ba129ae99f074da3ea5d4a0b \
-                    size    398432
+checksums           rmd160  d1272ccc31390b84d6fc8f9a5e9bb252c612f37c \
+                    sha256  e06b3b371e3361d28f8b62bee6f35e66ee4906f0987c7317e7c32a80c8070729 \
+                    size    397784
 
 depends_lib-append  port:curl \
                     port:R-BiocGenerics \

--- a/R/R-dcanr/Portfile
+++ b/R/R-dcanr/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor dcanr 1.18.0
-revision            1
-categories-append   math
+R.setup             bioconductor Bioconductor dcanr 1.20.0
+revision            0
+categories-append   bioconductor math
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3
 description         Differential co-expression/association network analysis
 long_description    {*}${description}
-checksums           rmd160  3c3b6969da003c8432989320217a356c317755d1 \
-                    sha256  dc738f961797895c18d996a5e1e6471b829d8c94906f2014faf9ff8dc95d5a0b \
-                    size    1751233
+checksums           rmd160  5339166ebf4e8069ae4efb14acc4ec863c450b5b \
+                    sha256  2b0a3ceb13ec37d1f0ee7c49902182e2f4adf15ed16da7f05890da1e02f28a97 \
+                    size    1745910
 supported_archs     noarch
 
 depends_lib-append  port:R-circlize \

--- a/R/R-dir.expiry/Portfile
+++ b/R/R-dir.expiry/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor dir.expiry 1.10.0
-revision            1
+R.setup             bioconductor Bioconductor dir.expiry 1.12.0
+revision            0
+categories-append   bioconductor devel
 maintainers         nomaintainer
 license             GPL-3
 description         Managing expiration for cache directories
 long_description    {*}${description}
-checksums           rmd160  5d21ff857362560a68b25e254ccbb5fbe5cce3d8 \
-                    sha256  38b5c0460b8022e1c801d574fd3aaea0d74603730e304113e07af74621462ba4 \
-                    size    307918
+checksums           rmd160  fdb186a8fb6eb9ead2a8841082c844254943b212 \
+                    sha256  716764398f3058886b65d892bbf6d3339149e75c39686d282e5473cf7947250d \
+                    size    305225
 supported_archs     noarch
 
 depends_lib-append  port:R-filelock

--- a/R/R-edgeR/Portfile
+++ b/R/R-edgeR/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor edgeR 4.0.16
-revision            2
+R.setup             bioconductor Bioconductor edgeR 4.2.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2+
 description         Empirical analysis of digital gene expression data in R
 long_description    {*}${description}
-checksums           rmd160  dc2a6e2268377311e79665adcfe0dcfba7d7e98c \
-                    sha256  d145e4f8423632dbea1cf1c2e53ae72ea05a937924090f3c4aff6bcd035cd449 \
-                    size    3571783
+checksums           rmd160  428b5356d754d6b2091e0ab409b6e0378e087947 \
+                    sha256  0f4343a340dbb609b6688d9b1eecb99bc474572c720c8ae7a21e4b30e0b86df0 \
+                    size    3430399
 
 depends_lib-append  port:R-limma \
                     port:R-locfit \

--- a/R/R-fmcsR/Portfile
+++ b/R/R-fmcsR/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor girke-lab fmcsR 1.44.0
-revision            1
+R.setup             bioconductor girke-lab fmcsR 1.46.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Mismatch-tolerant maximum common substructure searching
 long_description    {*}${description}
 homepage            https://github.com/girke-lab/fmcsR
-checksums           rmd160  6f3f2d7e0971d28aeab1d053233ad27f81ac6d1d \
-                    sha256  cd42c4ab473a52595dc8b32a57b83c06f3d0a5029f0615c921f4a918624d349e \
-                    size    780213
+checksums           rmd160  5381a7a4d5045c177ee4bbfdf21cdf372949a258 \
+                    sha256  8f14aa1c03d70664c28a9dd7925724f1250a468999a88bd25c7b724906cb1a20 \
+                    size    779434
 
 depends_build-append \
                     port:grep

--- a/R/R-gdsfmt/Portfile
+++ b/R/R-gdsfmt/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor zhengxwen gdsfmt 1.38.0
-revision            1
+R.setup             bioconductor zhengxwen gdsfmt 1.40.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             LGPL-3
 description         R interface to CoreArray Genomic Data Structure (GDS) files
 long_description    {*}${description}
 homepage            https://github.com/zhengxwen/gdsfmt
-checksums           rmd160  0071c43fa4dba0a57d00fdfdd5f9f83e119e8b73 \
-                    sha256  f5d27de87206a250ee88408acfb7cd4058d90677c3d2c86696710e51388f0f0f \
-                    size    2931483
+checksums           rmd160  19ac669906cee802b6d4e85fca5a3c962d34a9ab \
+                    sha256  275595c55e959234e3f80fa565c1dcc333e308b697466962d7b5028002366aea \
+                    size    2927535
 
 # TODO: consider switching to external libs: https://github.com/zhengxwen/gdsfmt/issues/35
 

--- a/R/R-genefilter/Portfile
+++ b/R/R-genefilter/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor genefilter 1.84.0
-revision            1
+R.setup             bioconductor Bioconductor genefilter 1.86.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Methods for filtering genes from high-throughput experiments
 long_description    {*}${description}
-checksums           rmd160  448566d0e1bebc1b37240a4f70496dadb19b177e \
-                    sha256  5c629c6477b77177e423b76a8d49ffc5415df7ef7894958c97e18f260efa0061 \
-                    size    993568
+checksums           rmd160  3c0e2c2620ef89605d1d0bf77b0214e1d99083af \
+                    sha256  f956579624e4445e6c83e7d9655cb4f2c6481fa4682669ce057a85f5df96e74a \
+                    size    986403
 
 depends_lib-append  port:R-annotate \
                     port:R-AnnotationDbi \
@@ -19,3 +20,17 @@ depends_lib-append  port:R-annotate \
                     port:R-MatrixGenerics
 
 compilers.setup     require_fortran
+
+variant tests description "Enable testing" {
+    # Some optional deps are omitted.
+    depends_test-append \
+                    port:R-ALL \
+                    port:R-BiocStyle \
+                    port:R-knitr \
+                    port:R-RColorBrewer \
+                    port:R-tkWidgets
+
+    # Some examples gonna fail since they rely
+    # on a missing package.
+    test.run        yes
+}

--- a/R/R-ggtree/Portfile
+++ b/R/R-ggtree/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github YuLab-SMU ggtree 33a07af48961d893c2a5dcbdc221881899d0456f
-version             3.11.0
-revision            1
+R.setup             bioconductor YuLab-SMU ggtree 3.12.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         R package for visualization of tree and annotation data
 long_description    {*}${description}
-checksums           rmd160  787ced0a85881637cc08aa3230bbef941e3ff031 \
-                    sha256  405036de1e95b3f219894bdca0449a7ff736170aa8ec6a1832577ef2b8f539aa \
-                    size    330025
+homepage            https://github.com/YuLab-SMU/ggtree
+checksums           rmd160  21abb3cbbc4c1c400ba8921e2e8fffb16b15f471 \
+                    sha256  b0d6682a3686d487471828c715747abb81c6dc59e51044b7946a61340d61a7ae \
+                    size    359019
 supported_archs     noarch
 
 depends_lib-append  port:R-ape \

--- a/R/R-ggtreeExtra/Portfile
+++ b/R/R-ggtreeExtra/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor YuLab-SMU ggtreeExtra 1.12.0
-revision            1
-categories-append   graphics
+R.setup             bioconductor YuLab-SMU ggtreeExtra 1.14.0
+revision            0
+categories-append   bioconductor graphics
 maintainers         nomaintainer
 license             GPL-3+
 description         Add geometric layers on circular or other layout tree of ggtree
 long_description    {*}${description}
-checksums           rmd160  d33c65d3ab9fc8596dbcba0bdd046169fb4afc56 \
-                    sha256  ac7d90266591011f72d242fa79fba44370eedf557f66ff49f52ee1826b401361 \
-                    size    527917
+checksums           rmd160  805c812fdf7a09247df8eec8873730a725de5cd0 \
+                    sha256  f557cae3528472ecef71c724d66b9724900db74b953a424284a68c6b7312c2f3 \
+                    size    526655
 supported_archs     noarch
 
 depends_lib-append  port:R-cli \

--- a/R/R-golubEsets/Portfile
+++ b/R/R-golubEsets/Portfile
@@ -1,0 +1,21 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             bioconductor Bioconductor golubEsets 1.46.0
+revision            0
+categories-append   bioconductor
+maintainers         nomaintainer
+license             LGPL
+description         exprSets for golub leukemia data
+long_description    {*}${description}
+master_sites        https://bioconductor.org/packages/release/data/experiment/src/contrib/
+checksums           rmd160  1022f39ece05f919ba720ab92de88b178456b44c \
+                    sha256  f4910847f8afd589fa0b4e63e7187e3b8bd0c201a36140377aed6622d9f165e7 \
+                    size    4511112
+supported_archs     noarch
+
+depends_lib-append  port:R-Biobase
+
+test.run            yes

--- a/R/R-graph/Portfile
+++ b/R/R-graph/Portfile
@@ -3,21 +3,22 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor graph 40a730b85c43bbb092329570f4f82624965e93b5
-version             1.81.0
-revision            1
-categories-append   graphics
+R.setup             bioconductor Bioconductor graph 1.82.0
+revision            0
+categories-append   bioconductor graphics math
 maintainers         nomaintainer
 license             Artistic-2
 description         Package that implements some simple graph-handling capabilities
 long_description    {*}${description}
-checksums           rmd160  dbf11361e5a28b64b781092f793ce34a4b2d6dc0 \
-                    sha256  17ff3a7a46e48609bfb4e60dd62c28e1fa751bf917ff606bad777811f614c3a8 \
-                    size    334080
+checksums           rmd160  5eabc7926ae7bafba5eb48c528981e0355b51d06 \
+                    sha256  1ba6c6c24905dd081880b9faeb8c3fdf11e67b267cd150a354d45ca4920641f1 \
+                    size    1487244
 
 depends_lib-append  port:R-BiocGenerics
 
-depends_test-append port:R-BiocStyle \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-knitr \
                     port:R-RBGL \
                     port:R-Rgraphviz \
@@ -25,4 +26,5 @@ depends_test-append port:R-BiocStyle \
                     port:R-SparseM \
                     port:R-XML
 
-test.run            yes
+    test.run        yes
+}

--- a/R/R-graphite/Portfile
+++ b/R/R-graphite/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor sales-lab graphite 1.48.0
-revision            1
+R.setup             bioconductor sales-lab graphite 1.50.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             AGPL-3
 description         GRAPH interaction from pathway topological environment
 long_description    {*}${description}
 homepage            https://github.com/sales-lab/graphite
-checksums           rmd160  0e43018daecdc063fdafc91e3fbbd50464ccb9ec \
-                    sha256  5678e693530ed9e5727e45b938ff830db24efc1bbac59f8deefa0bd0250812c1 \
-                    size    782528
+checksums           rmd160  8208bb36a1568b487ed4415be8e707f80a0a6dc7 \
+                    sha256  fab5eb46d8d48d149a2ad4ca42d2970dd074d4560fff71629a2113f9e07bd5f7 \
+                    size    782063
 supported_archs     noarch
 
 depends_lib-append  port:R-AnnotationDbi \

--- a/R/R-groHMM/Portfile
+++ b/R/R-groHMM/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Kraus-Lab groHMM 1.36.0
-revision            1
+R.setup             bioconductor Kraus-Lab groHMM 1.38.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-3
 description         GRO-seq analysis pipeline
 long_description    {*}${description}
 homepage            https://github.com/Kraus-Lab/groHMM
-checksums           rmd160  25887e7af432b3fc4b4f0bbb469456ecbca0d730 \
-                    sha256  7813bef49b4dc17e92365affafc60f81594f1337808b6b5dbf1eef23ef6a2b96 \
-                    size    4360078
+checksums           rmd160  00d1f0fb56521ab8c4ec8cc8d44953e9fea6e543 \
+                    sha256  259c1d472433cf516982da1aa774ceb1d8d341e768eb73881053ca16739aacee \
+                    size    4358351
 
 depends_lib-append  port:R-GenomeInfoDb \
                     port:R-GenomicAlignments \

--- a/R/R-impute/Portfile
+++ b/R/R-impute/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor impute 1.76.0
-revision            1
+R.setup             bioconductor Bioconductor impute 1.78.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2
 description         Imputation for microarray data
 long_description    {*}${description}
-checksums           rmd160  07acd7d8b967a2adfd652594bc0baddbc91e8938 \
-                    sha256  f412bbf66f664297379b6f71eac6e018798af860f26c90450eca369b52b7f560 \
-                    size    641568
+checksums           rmd160  c6849fde61017c9f51b7dd2126b8eb64a4c18cdb \
+                    sha256  7929cc5eb5895d7f2498e96d4f8e67c3a79ce769b9b03ab09570668d924815bc \
+                    size    640993
 
 compilers.setup     require_fortran
 

--- a/R/R-interactiveDisplayBase/Portfile
+++ b/R/R-interactiveDisplayBase/Portfile
@@ -3,15 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor interactiveDisplayBase 1.40.0
-revision            1
+R.setup             bioconductor Bioconductor interactiveDisplayBase 1.42.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
-description         Base package for enabling powerful Shiny web displays of Bioconductor objects
+description         Base package for enabling powerful Shiny web displays \
+                    of Bioconductor objects
 long_description    {*}${description}
-checksums           rmd160  a26a0b2cf5a172cc182daa92dadac90b77dc89df \
-                    sha256  5cf685f42230bc3e9d38ac9231ac466bf10f374635f6a31d98c4a34b31489c91 \
-                    size    7758
+checksums           rmd160  3019ca5c7de34865662bbcc1517edf47d21fc736 \
+                    sha256  ebcb21c762d19262aecab0f8070a5c7cd695ed4c04335ee12628bf80ac590946 \
+                    size    7719
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocGenerics \

--- a/R/R-kebabs/Portfile
+++ b/R/R-kebabs/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor UBod kebabs 1.36.0
-revision            1
+R.setup             bioconductor UBod kebabs 1.38.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2.1+
 description         Kernel-Based Analysis of Biological Sequences
 long_description    {*}${description}
 homepage            https://github.com/UBod/kebabs
-checksums           rmd160  a1cc143a231e0f6b9af49383a5292bc43019426e \
-                    sha256  a39c12d8400d668497ef1f2ec4a7bea66542b0a091d4b3b4dce8370c48a6919e \
-                    size    2409074
+checksums           rmd160  50f251dea322a014512f38196869877c436797aa \
+                    sha256  e71880f5391ecf02504c2aa21377291cbce61c005c202e47fe7444e8777f9a6c \
+                    size    2284516
 
 depends_lib-append  port:R-apcluster \
                     port:R-Biostrings \

--- a/R/R-limma/Portfile
+++ b/R/R-limma/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor limma 3.58.1
-revision            1
+R.setup             bioconductor Bioconductor limma 3.60.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2+
 description         Linear models for microarray data
 long_description    {*}${description}
 homepage            https://bioinf.wehi.edu.au/limma
-checksums           rmd160  a56879909b38b6a67c28f24e889297793ae303fb \
-                    sha256  3539e1645808dd7fe16d0b53df8c0a775283f15b68e670504fb37b09a1957e05 \
-                    size    2804950
+checksums           rmd160  b684b1ac02659f659e228aa51a2f78bf982c4123 \
+                    sha256  6faa93597ba5b020ab82f4f54c35ef9e0050a46757a677e6d27294e92dc73faa \
+                    size    2805873
 
 depends_lib-append  port:R-statmod

--- a/R/R-marray/Portfile
+++ b/R/R-marray/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor marray 1.80.0
-revision            1
+R.setup             bioconductor Bioconductor marray 1.82.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             LGPL
 description         Exploratory analysis for two-color spotted microarray data
 long_description    {*}${description}
-checksums           rmd160  2ff52cf1ea69ebb6dea54c9b706665c6e31ac8db \
-                    sha256  6d4f8a27ec9cce495f6681a62539843082603cb44cccfcc717d3956857ab44be \
-                    size    5056102
+checksums           rmd160  40b51b778c16dbcd8b8d004f39b893e69aadb7b4 \
+                    sha256  1e742111e2d7e3dfdf40f21591089939bd867ee37de79a994fa6a925125626c1 \
+                    size    5054750
 supported_archs     noarch
 
 depends_lib-append  port:R-limma

--- a/R/R-metapod/Portfile
+++ b/R/R-metapod/Portfile
@@ -3,23 +3,27 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor metapod 1.10.1
-revision            1
+R.setup             bioconductor Bioconductor metapod 1.12.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-3
 description         Meta-analyses on p-values of differential analyses
 long_description    {*}${description}
-checksums           rmd160  2155316098c3057d60d7402df090001c4832ba16 \
-                    sha256  c6b882b359f79efc2b26365fee457da1e4cfd4d1def52b68bac2a223771f9e15 \
-                    size    331432
+checksums           rmd160  99bb627067aaa158e1e9ca4a8de8772c02b3e2ef \
+                    sha256  16b9a417ec3bcb68a18e859f24e6ba1b3764892d53af32fbc9c980e3c5d31c80 \
+                    size    330991
 
 depends_lib-append  port:R-Rcpp
 
-depends_test-append port:R-BiocStyle \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-knitr \
                     port:R-rmarkdown \
                     port:R-testthat
 
-# Tests err out due to a broken R-BATCH.
-# See: https://trac.macports.org/ticket/67059
-test.run            yes
+    # Tests err out due to a broken R-BATCH.
+    # See: https://trac.macports.org/ticket/67059
+    test.run        yes
+}

--- a/R/R-mixOmics/Portfile
+++ b/R/R-mixOmics/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor mixOmics 6.26.0
-revision            1
+R.setup             bioconductor Bioconductor mixOmics 6.28.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2+
 description         Omics Data Integration Project
 long_description    {*}${description}
 homepage            http://www.mixOmics.org
-checksums           rmd160  de5ae86af75f571942d2a93533035a2e1782863f \
-                    sha256  ec1ad9959f3c290fb3b4c37c1b9719f10bac0d5d59ef6b99a56b86607442d145 \
-                    size    18901703
+checksums           rmd160  21881654effbd763cd7d0453331eeae54aa6e2ab \
+                    sha256  72f37405011a34e5a001c0feeb397488f334154a20ada9f08bde72f2a178ed0e \
+                    size    18848374
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocParallel \

--- a/R/R-multtest/Portfile
+++ b/R/R-multtest/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor multtest 2.58.0
-revision            1
+R.setup             bioconductor Bioconductor multtest 2.60.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             LGPL
 description         Resampling-based multiple hypothesis testing
 long_description    {*}${description}
-checksums           rmd160  669c10a566181c3913de85d402889a578a9613ba \
-                    sha256  92c40644fb6a3adbca9cba1da864482ec5db737fcbcfc8c4e3cadc2e5e161d69 \
-                    size    1294473
+checksums           rmd160  34d2164530dcc916918fb06219775c0f2b3ef108 \
+                    sha256  e4cb2c1a8bec46b6b097f67d828622fa2d2f21926cc3214f8d605f8e592ebb11 \
+                    size    1295259
 
 depends_lib-append  port:R-Biobase \
                     port:R-BiocGenerics

--- a/R/R-pcaMethods/Portfile
+++ b/R/R-pcaMethods/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor hredestig pcaMethods 1.94.0
-revision            1
+R.setup             bioconductor hredestig pcaMethods 1.96.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             GPL-3+
 description         Collection of PCA methods
 long_description    {*}${description}
 homepage            https://github.com/hredestig/pcamethods
-checksums           rmd160  b26b9cdef7f482e4d0d80fb5ef763cf1acfaf2f4 \
-                    sha256  e0babf4e0bae227ca3e4ef74968eb942ebe48bdd5d27297644a9fee6542455ab \
-                    size    612404
+checksums           rmd160  54a78e03edb36daade8ca1ac67d353b83e358afe \
+                    sha256  f15662bdd30fa86cde65a7a2bc17cbc271a80cca4953133d2c89867c6b0738c3 \
+                    size    608928
 
 depends_lib-append  port:R-Biobase \
                     port:R-BiocGenerics \

--- a/R/R-preprocessCore/Portfile
+++ b/R/R-preprocessCore/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor bmbolstad preprocessCore 1.64.0
-revision            1
+R.setup             bioconductor bmbolstad preprocessCore 1.66.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             LGPL-2+
 description         Collection of pre-processing functions
 long_description    {*}${description}
 homepage            https://github.com/bmbolstad/preprocessCore
-checksums           rmd160  b4c0c3801e88ac042258cd2ee4b0fc763ba768a3 \
-                    sha256  3e74536992d1ef1c8f371d850a18d2b1b9397ddbbef30567e6d97469f91ede95 \
-                    size    123999
+checksums           rmd160  27739a0424459123d2f616f2325e1ab10696c557 \
+                    sha256  b59794e3a0dce5b80392c88eef087e6c18a832c69a10a6bd84c2dd35550ca9b1 \
+                    size    123414
 
 compilers.setup     require_fortran
 

--- a/R/R-pwalign/Portfile
+++ b/R/R-pwalign/Portfile
@@ -1,0 +1,28 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           R 1.0
+
+R.setup             bioconductor Bioconductor pwalign 1.0.0
+revision            0
+categories-append   bioconductor
+maintainers         nomaintainer
+license             Artistic-2
+description         Perform pairwise sequence alignments
+long_description    {*}${description}
+checksums           rmd160  6b17459360d7ec92a1f0fbd45f3040fc20515f62 \
+                    sha256  67f1cc7342b2bf887e46fdee8e7ce41be9c4c61fffdfe952bbbab8284b0d12d4 \
+                    size    351779
+
+depends_lib-append  port:R-BiocGenerics \
+                    port:R-Biostrings \
+                    port:R-IRanges \
+                    port:R-S4Vectors \
+                    port:R-XVector
+
+depends_test-append port:R-RUnit
+
+# Optional, avoid for now:
+# depends_test-append port:R-Rmpi
+
+test.run            yes

--- a/R/R-qvalue/Portfile
+++ b/R/R-qvalue/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor StoreyLab qvalue 2.34.0
-revision            1
+R.setup             bioconductor StoreyLab qvalue 2.36.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             LGPL
 description         Q-value estimation for false discovery rate control
 long_description    {*}${description}
 homepage            https://github.com/StoreyLab/qvalue
-checksums           rmd160  1a09573322afc59dfab507e54a560c075449d8b6 \
-                    sha256  d16fd855856b479bd8a0812bbfc2e2d918929c28fe83411a41ca059d2d9c6583 \
-                    size    2767953
+checksums           rmd160  15fe5b6ae7b461a5fa7af2aa2cb4f6b5b3fc6873 \
+                    sha256  4a3cf7ec1f241779f893e15858c44ea4b74f4a5669c602c26ac8e5a0d7cef3c1 \
+                    size    2760802
 supported_archs     noarch
 
 depends_lib-append  port:R-ggplot2 \

--- a/R/R-rhdf5/Portfile
+++ b/R/R-rhdf5/Portfile
@@ -3,22 +3,24 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor grimbough rhdf5 2.46.1
-revision            2
+R.setup             bioconductor grimbough rhdf5 2.48.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
 description         R Interface to HDF5
 long_description    {*}${description}
 homepage            https://github.com/grimbough/rhdf5
-checksums           rmd160  617ed55b8d9317431badba04292d131e57c672f5 \
-                    sha256  b68f4960bf8498e83984467b07ed8fa10b3ef68fb5abbc776d6b7dee9307de79 \
-                    size    1272215
+checksums           rmd160  09fee5f05ed08f1f221819809275e205280fef98 \
+                    sha256  9683e5b11da8bda62894f1fefd488490592ed6b739ac4954fa03735a3fb7cb20 \
+                    size    1269365
 
 depends_lib-append  port:R-rhdf5filters \
                     port:R-Rhdf5lib \
                     port:R-S4Vectors
 
-depends_test-append port:R-bench \
+variant tests description "Enable testing" {
+    depends_test-append port:R-bench \
                     port:R-BiocParallel \
                     port:R-BiocStyle \
                     port:R-bit64 \
@@ -29,5 +31,6 @@ depends_test-append port:R-bench \
                     port:R-rmarkdown \
                     port:R-testthat
 
-# Some tests fail on PPC: https://github.com/grimbough/rhdf5/issues/122
-test.run            yes
+    # Some tests fail on PPC: https://github.com/grimbough/rhdf5/issues/122
+    test.run        yes
+}

--- a/R/R-rhdf5filters/Portfile
+++ b/R/R-rhdf5filters/Portfile
@@ -3,8 +3,9 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor grimbough rhdf5filters 1.14.1
-revision            2
+R.setup             bioconductor grimbough rhdf5filters 1.16.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             BSD
 description         HDF5 compression filters
@@ -12,9 +13,9 @@ long_description    Provides a collection of additional compression filters for 
                     The package is intended to provide seemless integration with rhdf5, \
                     however the compiled filters can also be used with external applications.
 homepage            https://github.com/grimbough/rhdf5filters
-checksums           rmd160  92bc6ddd0ad716a43400dca7f00341e23ed343bd \
-                    sha256  6636612d28ea6f2e658400cbd186066926fe3d4b8d07261ad7a49299c23c0e33 \
-                    size    1179474
+checksums           rmd160  ff6c91e582b31dd887194bbd0e349990c60ffb7a \
+                    sha256  1df1452264bdb9057c682d6c5d90178046bdd34addd923c100b32c77c9b84e3b \
+                    size    1176741
 
 depends_lib-append  port:R-Rhdf5lib
 
@@ -28,11 +29,14 @@ platform darwin 10 {
     }
 }
 
-depends_test-append port:R-BiocStyle \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-knitr \
                     port:R-rhdf5 \
                     port:R-rmarkdown \
                     port:R-testthat
 
-# Tests may fail to run due to: https://trac.macports.org/ticket/67059
-test.run            yes
+    # Tests may fail to run due to: https://trac.macports.org/ticket/67059
+    test.run        yes
+}

--- a/R/R-rsbml/Portfile
+++ b/R/R-rsbml/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor rsbml 2.60.0
-revision            1
+R.setup             bioconductor Bioconductor rsbml 2.62.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         R support for SBML, using libsbml
 long_description    {*}${description}
-checksums           rmd160  8ff3ca4d6c2aea16e5d0724e8c64c81799095931 \
-                    sha256  51d436494276e446fc20b0e76478168158b71f0886b97bd313a041c31e06725f \
-                    size    566651
+checksums           rmd160  caddc5dd6bc4cf7471ff5160d55fbce694334494 \
+                    sha256  7a91f571e74fb1fafa58423a3402261c5e213dae7384cbb4d42af87bc1ebf50a \
+                    size    565386
 
 depends_build-append \
                     port:pkgconfig
@@ -19,4 +20,12 @@ depends_lib-append  port:libsbml \
                     port:R-BiocGenerics \
                     port:R-graph
 
-test.run            yes
+platform darwin {
+    if {${os.major} > 10 && ${configure.cxx_stdlib} eq "libc++"} {
+    build.args-append   --configure-vars=' \
+                        RSBML_CPPFLAGS="-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION" \
+                        '
+    }
+}
+
+test.run            no

--- a/R/R-rtracklayer/Portfile
+++ b/R/R-rtracklayer/Portfile
@@ -4,23 +4,27 @@ PortSystem          1.0
 PortGroup           openssl 1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor lawremi rtracklayer 1.62.0
-revision            1
+R.setup             bioconductor lawremi rtracklayer 1.64.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
-description         R interface to genome annotation files and the UCSC genome browser
+description         R interface to genome annotation files \
+                    and the UCSC genome browser
 long_description    {*}${description}
 homepage            https://github.com/lawremi/rtracklayer
-checksums           rmd160  b17725f5955503ba182d83c03f162fc0e8f18d1f \
-                    sha256  c28217936c81248f2576af8327356324ccf7101b04f3358d049f0a839dd8b0cb \
-                    size    4019225
+checksums           rmd160  a34c56bb184d94c61746eba1de7155bd31c25f79 \
+                    sha256  6f8cbfd14ac9919c28778f8745f72ee6867a2fa2eed98bebdc1d632c43c64c40 \
+                    size    3951281
 
 depends_lib-append  port:R-BiocGenerics \
                     port:R-BiocIO \
                     port:R-Biostrings \
+                    port:R-curl \
                     port:R-GenomeInfoDb \
                     port:R-GenomicAlignments \
                     port:R-GenomicRanges \
+                    port:R-httr \
                     port:R-IRanges \
                     port:R-RCurl \
                     port:R-restfulr \

--- a/R/R-sparseMatrixStats/Portfile
+++ b/R/R-sparseMatrixStats/Portfile
@@ -3,17 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github const-ae sparseMatrixStats 511322bbf36176b6150534c742ed3ab0caf08328
-version             1.15.1
-revision            1
+R.setup             bioconductor const-ae sparseMatrixStats 1.16.0
+revision            0
+categories-append   bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             MIT
 description         Summary statistics for rows and columns of sparse matrices
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  c9c7bd5e93ade8fc75078545f294fbfcd4e695e6 \
-                    sha256  a30bf05e38be3f66d1a9e72e893355102a558b7bd85114fe7d5c706f0f460bec \
-                    size    481817
+checksums           rmd160  9d0dabb36aac2a09fb5e32757feb5e86d6127de7 \
+                    sha256  eed13a7335ef09168ece41481484a5e43c5281644d1e296af76d20a84d4e1312 \
+                    size    703132
 
 depends_lib-append  port:R-MatrixGenerics \
                     port:R-matrixStats \

--- a/R/R-ssize/Portfile
+++ b/R/R-ssize/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor ssize 1.76.0
-revision            1
+R.setup             bioconductor Bioconductor ssize 1.78.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             LGPL
 description         Estimate microarray sample size
 long_description    {*}${description}
-checksums           rmd160  5f901947b9d3f77a5a18698af424acb92cf1093d \
-                    sha256  1cb6061432220cf41a857b05a8c0998ff4555c4fd862b8e0afbfb489250bc42e \
-                    size    374308
+checksums           rmd160  b326624303774a945e3d884ceb8399b0cda87302 \
+                    sha256  358da56f198b23fc1ff1f5fbfee38ff7ac185fa86f47aa24e191a6b16ae2151d \
+                    size    373307
 supported_archs     noarch
 
 depends_lib-append  port:R-gdata \

--- a/R/R-survcomp/Portfile
+++ b/R/R-survcomp/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor survcomp 1.52.0
-revision            1
+R.setup             bioconductor Bioconductor survcomp 1.54.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Performance assessment and comparison for survival analysis
 long_description    {*}${description}
-checksums           rmd160  b1f9761f03cbc337cb7bcb425ec5111b90ed564e \
-                    sha256  364e6d7e35b0d2ac2a91e4afb7cd0cf977c29ce08616df6676437684f60e48a1 \
-                    size    837759
+checksums           rmd160  b7e57775b7fcc6fa2eba5aef28dc210422e25e45 \
+                    sha256  ec79816eed2bd76fc73f0bde33c18b5617d1238313ced0efb02c720650a10d24 \
+                    size    604517
 
 depends_lib-append  port:R-bootstrap \
                     port:R-ipred \

--- a/R/R-systemPipeR/Portfile
+++ b/R/R-systemPipeR/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor tgirke systemPipeR 2.8.0
-revision            1
+R.setup             bioconductor tgirke systemPipeR 2.10.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         NGS workflow and report generation environment
 long_description    {*}${description}
 homepage            https://systempipe.org
-checksums           rmd160  c3ff8d80ab2b12ed586149da7ca4fe66dc6344f6 \
-                    sha256  ead9681978cbfd512ecffc2d77f8b8fe0ba4b5a63b127f7b0a2e439556c45505 \
-                    size    7417929
+checksums           rmd160  122d5be0dadad2c061b2d8479e2306de82076b6d \
+                    sha256  dde61514c472f019a4e8a5bc46b09c4ec7daac41ec994ddf2fc443583c66bd8f \
+                    size    7419683
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocGenerics \
@@ -29,9 +30,12 @@ depends_lib-append  port:R-BiocGenerics \
                     port:R-SummarizedExperiment \
                     port:R-yaml
 
-patchfiles          patch-no-GO.db.diff
+variant tests description "Enable testing" {
+    patchfiles-append \
+                    patch-no-GO.db.diff
 
-depends_test-append port:R-annotate \
+    depends_test-append \
+                    port:R-annotate \
                     port:R-AnnotationDbi \
                     port:R-batchtools \
                     port:R-BiocStyle \
@@ -53,4 +57,5 @@ depends_test-append port:R-annotate \
                     port:R-systemPipeRdata \
                     port:R-VariantAnnotation
 
-test.run            yes
+    test.run        yes
+}

--- a/R/R-systemPipeRdata/Portfile
+++ b/R/R-systemPipeRdata/Portfile
@@ -3,17 +3,18 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor tgirke systemPipeRdata 2.6.0
-revision            1
+R.setup             bioconductor tgirke systemPipeRdata 2.8.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Workflow templates and sample data
 long_description    {*}${description}
 homepage            https://github.com/tgirke/systemPipeRdata
 master_sites        https://bioconductor.org/packages/release/data/experiment/src/contrib/
-checksums           rmd160  76e810ec8ade0f4e0e0bc0fd46a0dfd5bcc0c459 \
-                    sha256  0ea66cc404368e3456118d2ed696c8bc8a3a679ecaf14a1c0918260bf7939a00 \
-                    size    283914326
+checksums           rmd160  99144b9a72132fb0c3a1852223495e74122024c8 \
+                    sha256  3d86fe3aa6982ec65643f040733c93dd7e950a90feb7a2c470e5d4c78a26378c \
+                    size    283914585
 supported_archs     noarch
 
 depends_lib-append  port:R-BiocGenerics \
@@ -21,7 +22,9 @@ depends_lib-append  port:R-BiocGenerics \
                     port:R-jsonlite \
                     port:R-remotes
 
-depends_test-append port:R-BiocStyle \
+variant tests description "Enable testing" {
+    depends_test-append \
+                    port:R-BiocStyle \
                     port:R-GenomicFeatures \
                     port:R-GenomicRanges \
                     port:R-IRanges \
@@ -33,4 +36,5 @@ depends_test-append port:R-BiocStyle \
                     port:R-ShortRead \
                     port:R-systemPipeR
 
-test.run            yes
+    test.run        yes
+}

--- a/R/R-tkWidgets/Portfile
+++ b/R/R-tkWidgets/Portfile
@@ -3,16 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor tkWidgets 1.80.0
-revision            1
-categories-append   graphics
+R.setup             bioconductor Bioconductor tkWidgets 1.82.0
+revision            0
+categories-append   bioconductor graphics
 maintainers         nomaintainer
 license             Artistic-2
 description         R-based tk widgets
 long_description    {*}${description}
-checksums           rmd160  509641ea265b8c1b188eb84a145108c3b609b425 \
-                    sha256  3267fca54e0f0e1232365e8bf71b104e7febfc5cb47d5be8304da857a9cb4885 \
-                    size    338585
+checksums           rmd160  0d3bff2d17441bbbe190417137c1befc01a93c63 \
+                    sha256  f4ebf026463b09f89c6e1c6e417ba5bda911a221e2627f20f0795503462e2d4c \
+                    size    337757
 supported_archs     noarch
 
 depends_lib-append  port:R-DynDoc \

--- a/R/R-treeio/Portfile
+++ b/R/R-treeio/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor YuLab-SMU treeio 1.26.0
-revision            1
+R.setup             bioconductor YuLab-SMU treeio 1.28.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Base classes and functions for phylogenetic tree input and output
 long_description    {*}${description}
 homepage            https://github.com/YuLab-SMU/treeio
-checksums           rmd160  36009941c2b50a77aa0f85cbe3bd86c34e998c8c \
-                    sha256  393ea7c7df0e5d40df43b63f78f4b889701ed0b359b7d6f9232793c37d6e7fcf \
-                    size    692839
+checksums           rmd160  f91daa662b0620078820b983c760869ac0c00d26 \
+                    sha256  01fa3dba09a75ab99f3726c3320dc463753429305538fa7f3bdfe5e847c0d275 \
+                    size    693419
 supported_archs     noarch
 
 depends_lib-append  port:R-ape \

--- a/R/R-vsclust/Portfile
+++ b/R/R-vsclust/Portfile
@@ -3,15 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor vsclust 1.4.0
-revision            1
+R.setup             bioconductor Bioconductor vsclust 1.6.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             GPL-2
 description         Feature-based variance-sensitive quantitative clustering
 long_description    {*}${description}
-checksums           rmd160  c61eb8917fc925455a84167fd41c997bf59b4ced \
-                    sha256  3438992407e27098a9304721bbb07d30fb85d3c238bdda0d96a5cca9d0e9748d \
-                    size    3452501
+checksums           rmd160  2f8504d6fb89f7c927fa86c9432c87f9dc128366 \
+                    sha256  a5e2585b8f4ea7f6a33514a3d3a6b5d5f27d58afab7db62eadcf2845aa1a664d \
+                    size    3453067
 
 depends_lib-append  port:R-limma \
                     port:R-matrixStats \

--- a/R/R-widgetTools/Portfile
+++ b/R/R-widgetTools/Portfile
@@ -3,15 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor widgetTools 1.80.0
-revision            1
+R.setup             bioconductor Bioconductor widgetTools 1.82.0
+revision            0
+categories-append   bioconductor devel
 maintainers         nomaintainer
 license             LGPL
 description         Create an interactive tcltk widget
-long_description    This packages contains tools to support the construction of tcltk widgets.
-checksums           rmd160  6e1e1d2109fa63af31268bb8e8e19e25157c3442 \
-                    sha256  819b299090c78642369dadc1779be4e7cd3e76fc183e7dac5a0b87a5cb116cfe \
-                    size    127837
+long_description    This packages contains tools to support \
+                    the construction of tcltk widgets.
+checksums           rmd160  761d5ad33e31ae5aa7f35dc4e7268a73720c2eb8 \
+                    sha256  1b9b1bf9e611519244f7c7674fc03b8e5625b55b189154f697b6d9ab5cfeda4e \
+                    size    124670
 supported_archs     noarch
 
 depends_test-append port:R-Biobase

--- a/R/R-yeastNagalakshmi/Portfile
+++ b/R/R-yeastNagalakshmi/Portfile
@@ -3,16 +3,17 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             bioconductor Bioconductor yeastNagalakshmi 1.38.0
-revision            1
+R.setup             bioconductor Bioconductor yeastNagalakshmi 1.40.0
+revision            0
+categories-append   bioconductor
 maintainers         nomaintainer
 license             Artistic-2
 description         Yeast genome RNA sequencing data based on Nagalakshmi et al.
 long_description    {*}${description}
 master_sites        https://bioconductor.org/packages/release/data/experiment/src/contrib/
-checksums           rmd160  d09a215c57427b4cb95a3e4cf7b627d73eef70b2 \
-                    sha256  e00fd43bab3e556b9b43001741726c518a983fad61a88ac58eefc7f76e3f3eb4 \
-                    size    15020997
+checksums           rmd160  d479236a119cd7f54bf100b4477556d26b77eff5 \
+                    sha256  6a40780739908bf09b52ba02165bc5a5d69c82fbb19b7418ad6c18ea1945c49a \
+                    size    15021003
 supported_archs     noarch
 
 test.run            yes

--- a/R/R-zlibbioc/Portfile
+++ b/R/R-zlibbioc/Portfile
@@ -3,18 +3,16 @@
 PortSystem          1.0
 PortGroup           R 1.0
 
-R.setup             github Bioconductor zlibbioc 77920bcab5ef50132fbcbf9e1e13ddb04692c2db
-version             1.49.0
-revision            1
-categories-append   archivers
+R.setup             bioconductor Bioconductor zlibbioc 1.50.0
+revision            0
+categories-append   archivers bioconductor
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             Artistic-2
 description         An R-packaged zlib-1.2.5
 long_description    {*}${description}
-homepage            https://bioconductor.org/packages/${R.package}
-checksums           rmd160  db8fc7f33a310aaffd9dc99a90cb6a649fe7774b \
-                    sha256  aee04ea8c78e4252c544a6558d09870c4e121ff9611095d67e72a0840d124c99 \
-                    size    164507
+checksums           rmd160  85ef79aa9f0c301d75e802ffd27b0caaac5c72d4 \
+                    sha256  0298d59b3bb87179a6accd506a51c80fb9ff922defd24208beb2c93e5032b894 \
+                    size    381734
 
 depends_test-append port:R-BiocStyle
 


### PR DESCRIPTION
#### Description

Since upstream holds that it is better to either use only release versions or only devel versions (and tracking devel for that many packages is unfeasible), I use this convenient moment to switch everything Bioconductor to its new v. 3.19 release.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
