### PR TITLE
R-QuickJSR: do not try libatomic linking with clang builds

### DIFF
--- a/R/R-QuickJSR/Portfile
+++ b/R/R-QuickJSR/Portfile
@@ -30,6 +30,10 @@ depends_lib-append  port:R-jsonlite \
 if {[string match macports-gcc* ${configure.compiler}] && (${configure.build_arch} in [list i386 ppc])} {
     patchfiles-append \
                     patch-libatomic.diff
+} elseif {[string match *clang* ${configure.compiler}]} {
+    # https://trac.macports.org/ticket/69872
+    patchfiles-append \
+                    patch-no-libatomic.diff
 }
 
 # https://trac.macports.org/ticket/68152

--- a/R/R-QuickJSR/files/patch-no-libatomic.diff
+++ b/R/R-QuickJSR/files/patch-no-libatomic.diff
@@ -1,0 +1,13 @@
+--- src/Makevars	2024-01-31 17:42:22.000000000 +0800
++++ src/Makevars	2024-05-05 05:32:22.000000000 +0800
+@@ -2,10 +2,6 @@
+ PKG_CPPFLAGS += -DCONFIG_VERSION=\"$(shell cat quickjs/VERSION)\"
+ PKG_LIBS = ../inst/lib/$(R_ARCH)/libquickjs.a
+ 
+-ifeq ($(shell getconf LONG_BIT), 32)
+-	PKG_LIBS += -latomic
+-endif
+-
+ # Older versions of gcc and clang don't provide the stdatomic.h header
+ CC_CHECK := $(shell $(CC) --version 2>&1)
+ CC_VERSION :=  $(shell $(CC) -dumpfullversion -dumpversion 2>&1)


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69872

#### Description

@ryandesign Cannot check, but I hope this solves the issue raised in the ticket.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
