### PR TITLE
ddrescue: update to 1.28

### DIFF
--- a/sysutils/ddrescue/Portfile
+++ b/sysutils/ddrescue/Portfile
@@ -4,7 +4,7 @@ PortSystem      1.0
 PortGroup       gnu_info 1.0
 
 name            ddrescue
-version         1.27
+version         1.28
 revision        0
 categories      sysutils
 platforms       darwin
@@ -22,9 +22,9 @@ master_sites    gnu:ddrescue
 
 use_lzip        yes
 
-checksums       rmd160  c9634f6bb2203f73d399d02780575ea84cb57f57 \
-                sha256  38c80c98c5a44f15e53663e4510097fd68d6ec20758efdf3a925037c183232eb \
-                size    93496
+checksums       rmd160  42c35f228eff7d5aef855103718c9f023fba9a22 \
+                sha256  6626c07a7ca1cc1d03cad0958522c5279b156222d32c342e81117cfefaeb10c1 \
+                size    93823
 
 variant universal {}
 configure.args  CXX="${configure.cxx}" \


### PR DESCRIPTION
Can ddrescue be made openmaintainer for minor version updates?

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
