### PR TITLE
symfony-cli: update to 5.8.17

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.16
+version             5.8.17
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  a7e54702a0dc6c98ebe0d6e795bdba3f1f3b81f6 \
-                        sha256  2bce16ac11f72bc916a6fe7bb1e2f4e6c10f44e7c29ec6a4705ee8d671e78cf0 \
-                        size    267104
+    checksums           rmd160  1b073ce95a80e0db82351bfea004e33904ffcf54 \
+                        sha256  4825aa3e825c4584cfa2979fc4c8b01c90886e00b91743ff60ffada2c924c9a8 \
+                        size    267082
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  3bd0958e4a64419b7cda0fdf10b7436208e27a33 \
-                        sha256  b4c2c245d130be48bc885de6734dd06858245e03891f35c77241d4ac9b918559 \
-                        size    11397435
+    checksums           rmd160  edc27cb259dc1cca12a063edbfb62d3e397b4df8 \
+                        sha256  230e348564e62780eb941933c1b4d2ba079f2f8a5e274d53988d4f41ae8c7ba9 \
+                        size    11397787
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.17

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
