### PR TITLE
xmake: new port

### DIFF
--- a/devel/xmake/Portfile
+++ b/devel/xmake/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        xmake-io xmake 2.9.1 v
+github.tarball_from archive
+revision            0
+
+homepage            https://xmake.io/
+
+description         A cross-platform build utility based on Lua
+
+long_description    \
+    Xmake is a cross-platform build utility based on the Lua scripting \
+    language. Xmake is very lightweight and has no dependencies outside of \
+    the standard library. Uses the xmake.lua file to maintain project builds \
+    with a simple and readable syntax.
+
+categories          devel
+installs_libs       no
+license             Apache-2
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+fetch.type          git
+
+depends_build-append \
+                    port:pkgconfig
+depends_lib-append  port:ncurses
+
+post-fetch {
+    system -W ${worksrcpath} "git submodule update --init --recursive"
+}


### PR DESCRIPTION
https://xmake.io/

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
