### PR TITLE
audacious-plugins: enable more plugins

### DIFF
--- a/multimedia/audacious-plugins/Portfile
+++ b/multimedia/audacious-plugins/Portfile
@@ -2,12 +2,13 @@
 
 PortSystem          1.0
 PortGroup           meson 1.0
+PortGroup           active_variants 1.1
 
 name                audacious-plugins
 
 # Please keep audacious, audacious-core and audacious-plugins synchronized.
 version             4.3.1
-revision            0
+revision            1
 
 # FIXME: probably more licenses involved here...
 license             BSD GPL-2+
@@ -32,10 +33,10 @@ checksums           rmd160  d6b7be1e180665bcf8c039463c6e1f12c1fca178 \
 universal_variant   no
 
 depends_lib         port:audacious-core \
-                    port:gettext\
+                    port:gettext \
                     port:libxml2 \
-                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
-                    port:neon
+                    port:zlib \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2
 
 depends_run         port:unzip
 
@@ -54,7 +55,7 @@ configure.args-append \
 # transport
 configure.args-append \
                     -Dmms=false \
-                    -Dneon=true
+                    -Dneon=false
 
 # input
 configure.args-append \
@@ -62,7 +63,7 @@ configure.args-append \
                     -Dadplug=false \
                     -Damidiplug=false \
                     -Dcdaudio=false \
-                    -Dconsole=false \
+                    -Dconsole=true \
                     -Dffaudio=false \
                     -Dflac=false \
                     -Dmodplug=false \
@@ -82,7 +83,7 @@ configure.args-append \
 configure.args-append \
                     -Dalsa=false \
                     -Dcoreaudio=true \
-                    -Dfilewriter=false \
+                    -Dfilewriter=true \
                     -Dfilewriter-flac=false \
                     -Dfilewriter-mp3=false \
                     -Dfilewriter-ogg=false \
@@ -132,22 +133,19 @@ post-destroot {
     xinstall -m 0644 ${worksrcpath}/COPYING ${destroot}${prefix}/share/doc/${name}
 }
 
-variant console description {Add console game music decoder} {
-    depends_lib-append      port:zlib
-    configure.args-replace  -Dconsole=false \
-                            -Dconsole=true
-}
-
 variant pulseaudio description {Add support for PulseAudio} {
     depends_lib-append      port:pulseaudio
     configure.args-replace  -Dpulse=false \
                             -Dpulse=true
 }
 
-variant mp3 description {Add support for reading MP3 files} {
-    depends_lib-append      port:mpg123
+variant mp3 description {Add support for MP3 files} {
+    depends_lib-append      port:mpg123 \
+                            port:lame
     configure.args-replace  -Dmpg123=false \
-                            -Dmpg123=true
+                            -Dmpg123=true \
+                            -Dfilewriter-mp3=false \
+                            -Dfilewriter-mp3=true
 }
 
 variant dbus description {Adds support for GNOME shortcuts and remote control via DBUS} {
@@ -177,21 +175,21 @@ variant notifications description {Adds support for notifications via libnotify}
                             -Dnotify=true
 }
 
-variant filewriter description {Add support for the filewriter output plugin} {
-    configure.args-replace  -Dfilewriter=false \
-                            -Dfilewriter=true
-}
-
-variant vorbis requires filewriter description {Add support for the OggVorbis audio codec} {
+variant vorbis description {Add support for the OggVorbis audio codec} {
     depends_lib-append      port:libvorbis
-    depends_lib-append      port:libogg
     configure.args-replace  -Dvorbis=false \
                             -Dvorbis=true \
                             -Dfilewriter-ogg=false \
                             -Dfilewriter-ogg=true
 }
 
-variant flac requires filewriter description {Add support for FLAC: Free Lossless Audio Codec} {
+variant opus description {Add support for the Opus codec} {
+    depends_lib-append      port:opusfile
+    configure.args-replace  -Dopus=false \
+                            -Dopus=true
+}
+
+variant flac description {Add support for FLAC: Free Lossless Audio Codec} {
     depends_lib-append      port:flac
     configure.args-replace  -Dflac=false \
                             -Dflac=true \
@@ -223,6 +221,24 @@ variant modplug description {Add support for MOD audio codec} {
                             -Dmodplug=true
 }
 
+variant openmpt description {Add support for MOD, XM, S3M,IT, MPTM and others} {
+    depends_lib-append      port:libopenmpt
+    configure.args-replace  -Dopenmpt=false \
+                            -Dopenmpt=true
+}
+
+variant adplug description {Add support for the AdLib synthesizer} {
+    depends_lib-append      port:adplug
+    configure.args-replace  -Dadplug=false \
+                            -Dadplug=true
+}
+
+variant bs2b description {Add support for Bauer stereophonic-to-binaural} {
+    depends_lib-append      port:libbs2b
+    configure.args-replace  -Dbs2b=false \
+                            -Dbs2b=true
+}
+
 variant ffmpeg conflicts sdl1 description {Add support for decoding audio streams via ffmpeg} {
     set ffmpeg_ver          6
     depends_lib-append      port:ffmpeg${ffmpeg_ver}
@@ -238,12 +254,11 @@ variant jack description {Add support for the JACK Audio Connection Kit} {
                             -Djack=true
 }
 
-# libsidplayfp not ported yet.
-#variant sid description {Build with SID (Commodore 64 Audio) support} {
-#    depends_lib-append      port:libsidplayfp
-#    configure.args-replace  -Dsid=false \
-#                            -Dsid=true
-#}
+variant sid description {Build with SID (Commodore 64 Audio) support} {
+    depends_lib-append      port:libsidplayfp
+    configure.args-replace  -Dsid=false \
+                            -Dsid=true
+}
 
 variant midi description {Add MIDI playback support via fluidsynth} {
     depends_lib-append      port:fluidsynth
@@ -252,8 +267,7 @@ variant midi description {Add MIDI playback support via fluidsynth} {
 }
 
 variant cdaudio description {Add support for CDAudio} {
-    depends_lib-append      port:libcdio \
-                            port:libcdio-paranoia \
+    depends_lib-append      port:libcdio-paranoia \
                             port:libcddb
     configure.args-replace  -Dcdaudio=false \
                             -Dcdaudio=true
@@ -265,17 +279,24 @@ variant lastfm description {Add support for last.fm} {
                             -Dscrobbler2=true
 }
 
-# ampache_browser not ported yet.
-#variant ampache requires qt5 description {Add support for browsing music on an Ampache server} {
-#   depends_lib-append      port:ampache_browser
-#   configure.args-replace  -Dampache=false \
-#                           -Dampache=true
-#}
+variant ampache requires qt5 description {Add support for browsing music on an Ampache server} {
+    depends_lib-append      port:ampache_browser
+    configure.args-replace  -Dampache=false \
+                            -Dampache=true
+
+    require_active_variants ampache_browser qt5
+}
 
 variant mms description {Add support for Microsoft Media Server (MMS) streams} {
     depends_lib-append      port:libmms
     configure.args-replace  -Dmms=false \
                             -Dmms=true
+}
+
+variant neon description {Add support for neon HTTP client} {
+    depends_lib-append      port:neon
+    configure.args-replace  -Dneon=false \
+                            -Dneon=true
 }
 
 variant cue description {Add support for CUE sheets} {
@@ -284,29 +305,21 @@ variant cue description {Add support for CUE sheets} {
                             -Dcue=true
 }
 
-variant lame requires filewriter description {Add support for writing MP3 files} {
-    depends_lib-append      port:lame
-    configure.args-replace  -Dfilewriter-mp3=false \
-                            -Dfilewriter-mp3=true
-}
-
 variant transform description {Add support for audio transformation, most notably resampling, pitching and speed control} {
     depends_lib-append      port:libsamplerate \
                             port:soxr
     configure.args-replace  -Dresample=false \
-                            -Dresample=true
-    configure.args-replace  -Dspeedpitch=false \
-                            -Dspeedpitch=true
-    configure.args-replace  -Dsoxr=false \
+                            -Dresample=true \
+                            -Dspeedpitch=false \
+                            -Dspeedpitch=true \
+                            -Dsoxr=false \
                             -Dsoxr=true
 }
 
 variant opengl description {Add support for spectrum visualization via OpenGL} {
-    if {[variant_isset gtk2] || [variant_isset gtk3]} {
-        depends_lib-append      path:lib/libGL.dylib:mesa
-        configure.args-replace  -Dgl-spectrum=false \
-                                -Dgl-spectrum=true
-    }
+    depends_lib-append      path:lib/libGL.dylib:mesa
+    configure.args-replace  -Dgl-spectrum=false \
+                            -Dgl-spectrum=true
 }
 
 variant sdl1 conflicts sdl2 ffmpeg description {Add SDL audio output via libsdl1} {
@@ -327,10 +340,13 @@ variant qt5 description {Add Qt5 support} {
     qt5.depends_component   qtmultimedia
 
     configure.args-replace  -Dqt=false \
-                            -Dqt=true
+                            -Dqt=true \
+                            -Dqtaudio=false \
+                            -Dqtaudio=true \
+                            -Dvumeter=false \
+                            -Dvumeter=true
 
-    configure.args-replace  -Dqtaudio=false \
-                            -Dqtaudio=true
+    require_active_variants audacious-core qt5
 }
 
 variant gtk2 conflicts gtk3 description {Add GTK2 support} {
@@ -338,9 +354,11 @@ variant gtk2 conflicts gtk3 description {Add GTK2 support} {
                             path:lib/pkgconfig/gdk-x11-2.0.pc:gtk2
 
     configure.args-replace  -Dgtk=false \
-                            -Dgtk=true
-    configure.args-replace  -Dhotkey=false \
+                            -Dgtk=true \
+                            -Dhotkey=false \
                             -Dhotkey=true
+
+    require_active_variants audacious-core gtk2
 }
 
 variant gtk3 conflicts gtk2 description {Add GTK3 support} {
@@ -348,16 +366,18 @@ variant gtk3 conflicts gtk2 description {Add GTK3 support} {
                             path:lib/pkgconfig/gdk-x11-3.0.pc:gtk3
 
     configure.args-replace  -Dgtk=false \
-                            -Dgtk=true
-    configure.args-replace  -Dhotkey=false \
+                            -Dgtk=true \
+                            -Dhotkey=false \
                             -Dhotkey=true
 
     configure.args-append   -Dgtk3=true
+
+    require_active_variants audacious-core gtk3
 }
 
-variant full requires console mp3 dbus wavpack aac sndfile modplug \
-                      midi cdaudio mms cue lame flac transform opengl \
-                      filewriter notifications \
+variant full requires mp3 dbus wavpack aac sndfile modplug openmpt sid \
+                      midi cdaudio lastfm mms neon cue flac transform \
+                      vorbis opus adplug bs2b notifications \
              description {Build all plugins, except additional sound output plugins and potentially conflicting variants} {}
 
 if {[variant_isset jack]} {
@@ -373,32 +393,36 @@ if {![variant_isset sdl1]} {
     default_variants-append +sdl2 +ffmpeg
 }
 
-# Need either one of gtk2, gtk3 or Qt5 to have a GUI. Default to qt5, which is preferred by upstream.
-if {![variant_isset gtk2] && ![variant_isset gtk3] && ![variant_isset qt5]} {
+# Need either one of gtk2, gtk3 or Qt5 to have a GUI.
+# Default to qt5, which is preferred by upstream.
+if {![variant_isset gtk2] && ![variant_isset gtk3]} {
     default_variants-append +qt5
 }
 
-# Add other variants to the "full" set if gtk2 or gtk3 have been enabled.
-if {[variant_isset full] && ([variant_isset gtk2] || [variant_isset gtk3])} {
-    default_variants-append +osd +osd_composite +lastfm
-}
+# UI required variants
 
-# OSD only supported with gtk2 or gtk3.
-if {![variant_isset gtk2] && ![variant_isset gtk3] && ([variant_isset osd] || [variant_isset osd_composite])} {
-    ui_debug "The osd or osd_composite variants require either the gtk2 or gtk3 variants to be enabled."
-    error "+osd or +osd_composite require +gtk2 or +gtk3."
-}
-
-# LastFM/scrobbler2 only supported with gtk2 or gtk3.
-if {![variant_isset gtk2] && ![variant_isset gtk3] && [variant_isset lastfm]} {
-    ui_debug "The lastfm variant requires either the gtk2 or gtk3 variants to be enabled."
-    error "+lastfm requires +gtk2 or +gtk3."
+# Add other variants to the "full" set if gtk2, gtk3 or qt5 have been enabled.
+if {[variant_isset full] && ([variant_isset gtk2] || [variant_isset gtk3] || [variant_isset qt5])} {
+    default_variants-append +opengl
 }
 
 # OpenGL only supported with gtk2, gtk3 or Qt5.
 if {![variant_isset gtk2] && ![variant_isset gtk3] && ![variant_isset qt5] && [variant_isset opengl]} {
-    ui_debug "The opengl variant requires either the gtk2, gtk3 or qt5 variants to be enabled."
+    ui_debug "The opengl variant requires either the gtk2, gtk3 or qt5 variant to be enabled."
     error "+opengl requires +gtk2, +gtk3 or +qt5."
+}
+
+# GTK only
+
+# Add other variants to the "full" set if gtk2 or gtk3 have been enabled.
+if {[variant_isset full] && ([variant_isset gtk2] || [variant_isset gtk3])} {
+    default_variants-append +osd
+}
+
+# OSD only supported with gtk2 or gtk3.
+if {![variant_isset gtk2] && ![variant_isset gtk3] && [variant_isset osd]} {
+    ui_debug "The osd variant requires either the gtk2 or gtk3 variant to be enabled."
+    error "+osd require +gtk2 or +gtk3."
 }
 
 livecheck.type      regex


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/60227

###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.4.1 23E224 x86_64
Xcode 15.3 15E204a

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?