### PR TITLE
imposm: new port

### DIFF
--- a/gis/imposm/Portfile
+++ b/gis/imposm/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/omniscale/imposm3 0.12.0 v
+go.offline_build    no
+github.tarball_from archive
+name                imposm
+revision            0
+categories          gis
+maintainers         {@sikmir disroot.org:sikmir} openmaintainer
+license             Apache-2
+
+description         Imposm imports OpenStreetMap data into PostGIS
+long_description    {*}${description}
+homepage            https://imposm.org/
+
+checksums           rmd160  413a4278bff28af61b94d38d15ed93df5ef16a32 \
+                    sha256  ab9edc262bd79dd6ee0d5547021ecd14c9931b35abb76cdeeb7cc93433ff9e13 \
+                    size    2283404
+
+depends_lib-append  port:geos \
+                    port:leveldb
+
+set go_ldflags      "-s -w -X ${go.package}.Version=${version}"
+build.args          -ldflags \"${go_ldflags}\" ./cmd/imposm
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
#### Description
[Imposm](https://github.com/omniscale/imposm3) imports OpenStreetMap data into PostGIS.

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
