### PR TITLE
samba4: fix build on macOS <10.13

### DIFF
--- a/net/samba4/Portfile
+++ b/net/samba4/Portfile
@@ -4,10 +4,10 @@ PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           perl5 1.0
 
-# O_CLOEXEC, AT_FDCWD
+# O_CLOEXEC, AT_FDCWD, utimensat
 PortGroup           legacysupport 1.1
 
-legacysupport.newest_darwin_requires_legacy 13
+legacysupport.newest_darwin_requires_legacy 16
 
 name                samba4
 conflicts           samba3


### PR DESCRIPTION
#### Description

https://build.macports.org/builders/ports-10.12_x86_64-builder/builds/272986/steps/install-port/logs/stdio
This does not happen where legacysupport is enabled (Mavericks and older).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
