### PR TITLE
openjdk8: fix initial build errors on powerpc

### DIFF
--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -7,10 +7,10 @@ name                openjdk8
 # https://guide.macports.org/chunked/reference.portgroup.html#reference.portgroup.java
 # https://github.com/openjdk/jdk8u/tags
 # Tags: https://github.com/openjdk/jdk8u/tags
-set major 8
-set update 372
+set major           8
+set update          372
 # Set to the build of the 'jdk8u${update}-b${build}' tag that corresponds to the latest tag with '-ga'
-set build 07
+set build           07
 version             ${major}u${update}
 revision            2
 categories          java devel
@@ -55,11 +55,11 @@ depends_build       port:autoconf \
 
 set tpath /Library/Java
 use_xcode           yes
-use_configure    yes
+use_configure       yes
 if {${configure.build_arch} in [list i386 ppc]} {
-    set datamodel 32
+    set datamodel   32
 } else {
-    set datamodel 64
+    set datamodel   64
 }
 
 # Update config.{guess,sub} to recognise arm64
@@ -123,9 +123,9 @@ post-patch {
 }
 
 if {${configure.build_arch} eq "ppc"} {
-    depends_build-append       port:openjdk7-bootstrap
-    configure.args-append      --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk7-bootstrap
-    configure.post_args --disable-headful
+    depends_build-append    port:openjdk7-bootstrap
+    configure.args-append   --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk7-bootstrap
+    configure.post_args     --disable-headful
     post-patch {
         reinplace "s|WARNINGS_ARE_ERRORS = -Werror|WARNING_FLAGS =|g" hotspot/make/bsd/makefiles/gcc.make
         reinplace "s|WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wformat=2|WARNING_FLAGS = |g" hotspot/make/bsd/makefiles/gcc.make
@@ -149,26 +149,26 @@ if {${configure.build_arch} eq "ppc"} {
         }
     }
 
-    depends_build-append       port:openjdk8-bootstrap
-    configure.args-append      --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk8-bootstrap/Contents/Home
+    depends_build-append    port:openjdk8-bootstrap
+    configure.args-append   --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk8-bootstrap/Contents/Home
 }
 
 variant server \
     conflicts core zero zeroshark \
     description {JVM with normal interpreter and a tiered C1/C2 compiler} {
-    configure.args-append  --with-jvm-variants=server
+    configure.args-append   --with-jvm-variants=server
 }
 
 variant release \
     conflicts debug \
     description {OpenJDK with no debug information, all optimizations and no asserts} {
-    configure.args-append  --with-debug-level=release 
+    configure.args-append   --with-debug-level=release 
 }
 
 variant debug \
     conflicts release \
     description {OpenJDK with debug information, all optimizations and all asserts} {
-    configure.args-append  --with-debug-level=fastdebug
+    configure.args-append   --with-debug-level=fastdebug
     configure.args-delete   --with-native-debug-symbols=none
 }
 
@@ -182,28 +182,28 @@ variant zero \
     conflicts core zeroshark server \
     description {JVM with no assembler, no machine code interpreter and no compiler} {
     set archuc [string toupper ${configure.build_arch}]
-    depends_lib-append         port:libffi
-    configure.args-append  --with-jvm-variants=zero \
-                           --with-extra-cflags="${configure.cflags} -I${prefix}/include -arch ${configure.build_arch}" \
-                           --with-extra-cxxflags="${configure.cxxflags} -arch ${configure.build_arch}" \
-                           --with-extra-ldflags="${configure.ldflags} -I${prefix}/lib -arch ${configure.build_arch}"
-    configure.args-delete  --with-extra-cflags="${configure.cflags}" \
-                           --with-extra-cxxflags="${configure.cxxflags}" \
-                           --with-extra-ldflags="${configure.ldflags}"
+    depends_lib-append      port:libffi
+    configure.args-append   --with-jvm-variants=zero \
+                            --with-extra-cflags="${configure.cflags} -I${prefix}/include -arch ${configure.build_arch}" \
+                            --with-extra-cxxflags="${configure.cxxflags} -arch ${configure.build_arch}" \
+                            --with-extra-ldflags="${configure.ldflags} -I${prefix}/lib -arch ${configure.build_arch}"
+    configure.args-delete   --with-extra-cflags="${configure.cflags}" \
+                            --with-extra-cxxflags="${configure.cxxflags}" \
+                            --with-extra-ldflags="${configure.ldflags}"
 }
 
 variant zeroshark \
     conflicts core zero server \
     description {JVM with no assembler, zero interpreter and shark/llvm compiler backend} {
     set archuc [string toupper ${configure.build_arch}]
-    depends_lib-append         port:libffi
-    configure.args-append  --with-jvm-variants=zeroshark \
-                           --with-extra-cflags="${configure.cflags} -I${prefix}/include -arch ${configure.build_arch}" \
-                           --with-extra-cxxflags="${configure.cxxflags} -arch ${configure.build_arch}" \
-                           --with-extra-ldflags="${configure.ldflags} -I${prefix}/lib -arch ${configure.build_arch}"
-    configure.args-delete  --with-extra-cflags="${configure.cflags}" \
-                           --with-extra-cxxflags="${configure.cxxflags}" \
-                           --with-extra-ldflags="${configure.ldflags}"
+    depends_lib-append      port:libffi
+    configure.args-append   --with-jvm-variants=zeroshark \
+                            --with-extra-cflags="${configure.cflags} -I${prefix}/include -arch ${configure.build_arch}" \
+                            --with-extra-cxxflags="${configure.cxxflags} -arch ${configure.build_arch}" \
+                            --with-extra-ldflags="${configure.ldflags} -I${prefix}/lib -arch ${configure.build_arch}"
+    configure.args-delete   --with-extra-cflags="${configure.cflags}" \
+                            --with-extra-cxxflags="${configure.cxxflags}" \
+                            --with-extra-ldflags="${configure.ldflags}"
 }
 
 if {![variant_isset debug] && ![variant_isset release]} {

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -135,7 +135,7 @@ if {${configure.build_arch} eq "ppc"} {
             ${worksrcpath}/common/autoconf/platform.m4
         reinplace "s|WARNINGS_ARE_ERRORS = -Werror|WARNING_FLAGS =|g" hotspot/make/bsd/makefiles/gcc.make
         reinplace "s|WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wformat=2|WARNING_FLAGS = |g" hotspot/make/bsd/makefiles/gcc.make
-        reinplace "s|@ZERO_ARCHDEF@|PPC|g" hotspot/make/bsd/platform_zero.in
+        reinplace "s|@ZERO_ARCHDEF@|PPC32|g" hotspot/make/bsd/platform_zero.in
         reinplace "s|@ZERO_LIBARCH@|ppc|g" hotspot/make/bsd/platform_zero.in
         reinplace "s|dtraceCheck| |g" hotspot/make/bsd/makefiles/vm.make
         reinplace "s|LP64=1|LP64=0|g" hotspot/make/bsd/Makefile

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -37,13 +37,19 @@ patchfiles          0001-8181503-Can-t-compile-hotspot-with-c-11.patch \
                     0006-Disable-C-11-warnings.patch \
                     0007-Added-macosx-bin-zero-jvm.cfg.patch \
                     0008-ExtendedOptionsImpl.c-define-TCP_KEEPINTVL-and-TCP_K.patch \
-                    Support-arm64-and-fix-zero-assembler.diff \
                     finite.patch
 
 # NSFullSizeContentViewWindowMask is available since 10.10
 if {${os.platform} eq "darwin" && ${os.major} < 14} {
     patchfiles-append \
                     0009-Revert-8211301-macos-support-full-window-content-opt.patch
+}
+
+# This patch creates a conflict in definitions and breaks ppc build:
+# https://trac.macports.org/ticket/69922
+if {${configure.build_arch} ni [list ppc ppc64]} {
+    patchfiles-append \
+                    Support-arm64-and-fix-zero-assembler.diff
 }
 
 depends_lib         port:freetype \

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -189,7 +189,7 @@ variant server \
 variant release \
     conflicts debug \
     description {OpenJDK with no debug information, all optimizations and no asserts} {
-    configure.args-append   --with-debug-level=release 
+    configure.args-append   --with-debug-level=release
 }
 
 variant debug \

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -131,6 +131,8 @@ if {${configure.build_arch} eq "ppc"} {
         reinplace "s|MACOSX_VERSION_MIN=10.7.0|MACOSX_VERSION_MIN=${macosx_deployment_target}.0|g" \
             ${worksrcpath}/common/autoconf/flags.m4 \
             ${worksrcpath}/common/autoconf/generated-configure.sh
+        reinplace "s|REQUIRED_OS_VERSION=11.2|REQUIRED_OS_VERSION=${macosx_deployment_target}|g" \
+            ${worksrcpath}/common/autoconf/platform.m4
         reinplace "s|WARNINGS_ARE_ERRORS = -Werror|WARNING_FLAGS =|g" hotspot/make/bsd/makefiles/gcc.make
         reinplace "s|WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wformat=2|WARNING_FLAGS = |g" hotspot/make/bsd/makefiles/gcc.make
         reinplace "s|@ZERO_ARCHDEF@|PPC|g" hotspot/make/bsd/platform_zero.in

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -52,6 +52,21 @@ if {${configure.build_arch} ni [list ppc ppc64]} {
                     Support-arm64-and-fix-zero-assembler.diff
 }
 
+platform powerpc {
+    # Patches here improve support for PowerPC, but may not be compatible
+    # with other platforms. Keep them isolated.
+    patchfiles-append \
+                    1001-os_bsd.cpp-fix-for-32-bit.patch \
+                    1002-os_bsd.cpp-fix-thread_id.patch \
+                    1003-CoreLibraries.gmk-do-not-hardcode-wrong-arch.patch \
+                    1004-java_md_macosx.c-fix-archs.patch \
+                    1005-BuildJaxws.gmk-mkdir-that-actually-works.patch \
+                    1006-jniTypes_ppc.hpp-allow-ppc32.patch \
+                    1007-Awt2dLibraries.gmk-fnested-functions-gcc-wants-it.patch \
+                    1008-toolchain.m4-hack-around-a-broken-Xcode-version-dete.patch \
+                    1009-os_bsd.cpp-remove-breaking-macro-for-Apple.patch
+}
+
 depends_lib         port:freetype \
                     port:libiconv
 depends_build       port:autoconf \

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -127,6 +127,10 @@ if {${configure.build_arch} eq "ppc"} {
     configure.args-append   --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk7-bootstrap
     configure.post_args     --disable-headful
     post-patch {
+        # Obviously, 10.7 cannot work for ppc. Fix the target:
+        reinplace "s|MACOSX_VERSION_MIN=10.7.0|MACOSX_VERSION_MIN=${macosx_deployment_target}.0|g" \
+            ${worksrcpath}/common/autoconf/flags.m4 \
+            ${worksrcpath}/common/autoconf/generated-configure.sh
         reinplace "s|WARNINGS_ARE_ERRORS = -Werror|WARNING_FLAGS =|g" hotspot/make/bsd/makefiles/gcc.make
         reinplace "s|WARNING_FLAGS = -Wpointer-arith -Wsign-compare -Wundef -Wunused-function -Wformat=2|WARNING_FLAGS = |g" hotspot/make/bsd/makefiles/gcc.make
         reinplace "s|@ZERO_ARCHDEF@|PPC|g" hotspot/make/bsd/platform_zero.in

--- a/java/openjdk8/files/1001-os_bsd.cpp-fix-for-32-bit.patch
+++ b/java/openjdk8/files/1001-os_bsd.cpp-fix-for-32-bit.patch
@@ -1,0 +1,35 @@
+From 5457a4998853b9c4efe1e098e80a94aaee7c55c0 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 11:09:49 +0800
+Subject: [PATCH] os_bsd.cpp: fix for 32-bit
+
+---
+ hotspot/src/os/bsd/vm/os_bsd.cpp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git hotspot/src/os/bsd/vm/os_bsd.cpp hotspot/src/os/bsd/vm/os_bsd.cpp
+index 6d1009b84c..f26229beef 100644
+--- hotspot/src/os/bsd/vm/os_bsd.cpp
++++ hotspot/src/os/bsd/vm/os_bsd.cpp
+@@ -171,12 +171,21 @@ julong os::available_memory() {
+ julong os::Bsd::available_memory() {
+   uint64_t available = physical_memory() >> 2;
+ #ifdef __APPLE__
++#if defined __ppc__ || defined __i386__
++  mach_msg_type_number_t count = HOST_VM_INFO_COUNT;
++  vm_statistics_data_t vmstat;
++  kern_return_t kerr = host_statistics(mach_host_self(), HOST_VM_INFO,
++                                         (host_info_t)&vmstat, &count);
++  assert(kerr == KERN_SUCCESS,
++         "host_statistics failed - check mach_host_self() and count");
++#else // 64-bit
+   mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+   vm_statistics64_data_t vmstat;
+   kern_return_t kerr = host_statistics64(mach_host_self(), HOST_VM_INFO64,
+                                          (host_info64_t)&vmstat, &count);
+   assert(kerr == KERN_SUCCESS,
+          "host_statistics64 failed - check mach_host_self() and count");
++#endif
+   if (kerr == KERN_SUCCESS) {
+     available = vmstat.free_count * os::vm_page_size();
+   }

--- a/java/openjdk8/files/1002-os_bsd.cpp-fix-thread_id.patch
+++ b/java/openjdk8/files/1002-os_bsd.cpp-fix-thread_id.patch
@@ -1,0 +1,41 @@
+From b55cf4107fd0231b33049023fa6e2e0908c0e113 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 11:27:24 +0800
+Subject: [PATCH] os_bsd.cpp: fix thread_id
+
+---
+ hotspot/src/os/bsd/vm/os_bsd.cpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git hotspot/src/os/bsd/vm/os_bsd.cpp hotspot/src/os/bsd/vm/os_bsd.cpp
+index f26229beef..7e5e4d6db6 100644
+--- hotspot/src/os/bsd/vm/os_bsd.cpp
++++ hotspot/src/os/bsd/vm/os_bsd.cpp
+@@ -112,6 +112,7 @@
+ # include <mach-o/dyld.h>
+ # include <sys/proc_info.h>
+ # include <objc/objc-auto.h>
++# include <AvailabilityMacros.h>
+ #endif
+ 
+ #ifndef MAP_ANONYMOUS
+@@ -685,6 +686,11 @@ objc_registerThreadWithCollector_t objc_registerThreadWithCollectorFunction = NU
+ 
+ #ifdef __APPLE__
+ static uint64_t locate_unique_thread_id(mach_port_t mach_thread_port) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060 || defined __ppc__
++  uint64_t thread_id;
++  thread_id = pthread_mach_thread_np(pthread_self());
++  return thread_id;
++#else
+   // Additional thread_id used to correlate threads in SA
+   thread_identifier_info_data_t     m_ident_info;
+   mach_msg_type_number_t            count = THREAD_IDENTIFIER_INFO_COUNT;
+@@ -693,6 +699,7 @@ static uint64_t locate_unique_thread_id(mach_port_t mach_thread_port) {
+               (thread_info_t) &m_ident_info, &count);
+ 
+   return m_ident_info.thread_id;
++#endif
+ }
+ #endif
+ 

--- a/java/openjdk8/files/1003-CoreLibraries.gmk-do-not-hardcode-wrong-arch.patch
+++ b/java/openjdk8/files/1003-CoreLibraries.gmk-do-not-hardcode-wrong-arch.patch
@@ -1,0 +1,22 @@
+From 1350fc749bec8c4c32249323746fca276f8424b6 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 11:28:41 +0800
+Subject: [PATCH] CoreLibraries.gmk: do not hardcode wrong arch
+
+---
+ jdk/make/lib/CoreLibraries.gmk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git jdk/make/lib/CoreLibraries.gmk jdk/make/lib/CoreLibraries.gmk
+index bb915869d6..34d61140b5 100644
+--- jdk/make/lib/CoreLibraries.gmk
++++ jdk/make/lib/CoreLibraries.gmk
+@@ -77,7 +77,7 @@ else
+       LANG := C, \
+       CFLAGS := $(CFLAGS_JDKLIB) \
+           -I$(JDK_TOPDIR)/src/share/native/java/lang/fdlibm/include, \
+-      LDFLAGS := -nostdlib -r -arch x86_64, \
++      LDFLAGS := -nostdlib -r, \
+       OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libfdlibm, \
+       DEBUG_SYMBOLS := $(DEBUG_ALL_BINARIES)))
+ 

--- a/java/openjdk8/files/1004-java_md_macosx.c-fix-archs.patch
+++ b/java/openjdk8/files/1004-java_md_macosx.c-fix-archs.patch
@@ -1,0 +1,22 @@
+From 1a31d607e76cf2c582105e5047463fe39e4ec44d Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 11:29:59 +0800
+Subject: [PATCH] java_md_macosx.c: fix archs
+
+---
+ jdk/src/macosx/bin/java_md_macosx.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git jdk/src/macosx/bin/java_md_macosx.c jdk/src/macosx/bin/java_md_macosx.c
+index 6aa0eb588a..5a21a8d3db 100644
+--- jdk/src/macosx/bin/java_md_macosx.c
++++ jdk/src/macosx/bin/java_md_macosx.c
+@@ -228,6 +228,8 @@ static InvocationFunctions *GetExportedJNIFunctions() {
+         preferredJVM = "client";
+ #elif defined(__x86_64__)
+         preferredJVM = "server";
++#elif defined(__POWERPC__)
++        preferredJVM = "zero";
+ #else
+ #error "Unknown architecture - needs definition"
+ #endif

--- a/java/openjdk8/files/1005-BuildJaxws.gmk-mkdir-that-actually-works.patch
+++ b/java/openjdk8/files/1005-BuildJaxws.gmk-mkdir-that-actually-works.patch
@@ -1,0 +1,31 @@
+From 344d0baed0f6c7e5833cad57f2019e3975c373f7 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 11:30:58 +0800
+Subject: [PATCH] BuildJaxws.gmk: mkdir that actually works
+
+---
+ jaxws/make/BuildJaxws.gmk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git jaxws/make/BuildJaxws.gmk jaxws/make/BuildJaxws.gmk
+index 204dd47fb5..ca0aac119a 100644
+--- jaxws/make/BuildJaxws.gmk
++++ jaxws/make/BuildJaxws.gmk
+@@ -78,7 +78,7 @@ BUILD_JAXWS += $(JAXWS_OUTPUTDIR)/jaxws_classes/META-INF/services/com.sun.tools.
+ # for now, even though it actually breaks properties containing # in the value.
+ # Using nawk to avoid solaris sed.
+ $(JAXWS_OUTPUTDIR)/jaxws_classes/%.properties: $(JAXWS_TOPDIR)/src/share/jaxws_classes/%.properties
+-	$(MKDIR) -p $(@D)
++	mkdir -p $(@D)
+ 	$(RM) $@ $@.tmp
+ 	$(CAT) $< | LANG=C $(NAWK) '{ sub(/#.*$$/,"#"); print }' > $@.tmp
+ 	$(MV) $@.tmp $@
+@@ -88,7 +88,7 @@ TARGET_PROP_FILES := $(patsubst $(JAXWS_TOPDIR)/src/share/jaxws_classes/%, \
+     $(JAXWS_OUTPUTDIR)/jaxws_classes/%, $(JAXWS_SRC_PROP_FILES))
+ 
+ $(JAXWS_OUTPUTDIR)/jaf_classes/%.properties: $(JAXWS_TOPDIR)/src/share/jaf_classes/%.properties
+-	$(MKDIR) -p $(@D)
++	mkdir -p $(@D)
+ 	$(RM) $@ $@.tmp
+ 	$(CAT) $< | LANG=C $(NAWK) '{ sub(/#.*$$/,"#"); print }' > $@.tmp
+ 	$(MV) $@.tmp $@

--- a/java/openjdk8/files/1006-jniTypes_ppc.hpp-allow-ppc32.patch
+++ b/java/openjdk8/files/1006-jniTypes_ppc.hpp-allow-ppc32.patch
@@ -1,0 +1,22 @@
+From eaaa4af169a8cdabf0e8b300eb6030653ced1c16 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 11:33:27 +0800
+Subject: [PATCH] jniTypes_ppc.hpp: allow ppc32
+
+---
+ hotspot/src/cpu/ppc/vm/jniTypes_ppc.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git hotspot/src/cpu/ppc/vm/jniTypes_ppc.hpp hotspot/src/cpu/ppc/vm/jniTypes_ppc.hpp
+index 9178bd442a..0440bdf9b2 100644
+--- hotspot/src/cpu/ppc/vm/jniTypes_ppc.hpp
++++ hotspot/src/cpu/ppc/vm/jniTypes_ppc.hpp
+@@ -46,7 +46,7 @@ class JNITypes : AllStatic {
+  private:
+ 
+ #ifndef PPC64
+-#error "ppc32 support currently not implemented!!!"
++#pragma GCC warning "ppc32 is untested!"
+ #endif // PPC64
+ 
+  public:

--- a/java/openjdk8/files/1007-Awt2dLibraries.gmk-fnested-functions-gcc-wants-it.patch
+++ b/java/openjdk8/files/1007-Awt2dLibraries.gmk-fnested-functions-gcc-wants-it.patch
@@ -1,0 +1,21 @@
+From b40673c5c3ade2a62eb6166f80641a9561ae056c Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 11:35:01 +0800
+Subject: [PATCH] Awt2dLibraries.gmk: -fnested-functions, gcc wants it
+
+---
+ jdk/make/lib/Awt2dLibraries.gmk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git jdk/make/lib/Awt2dLibraries.gmk jdk/make/lib/Awt2dLibraries.gmk
+index 01e0369017..cd579f7a9a 100644
+--- jdk/make/lib/Awt2dLibraries.gmk
++++ jdk/make/lib/Awt2dLibraries.gmk
+@@ -1370,6 +1370,7 @@ ifeq ($(OPENJDK_TARGET_OS), macosx)
+       OPTIMIZATION := LOW, \
+       CFLAGS := $(CFLAGS_JDKLIB) \
+           $(X_CFLAGS) \
++          -fnested-functions \
+           $(X_LIBS) \
+           $(foreach dir, $(LIBAWT_LWAWT_DIRS), -I$(dir)) \
+           -I$(JDK_TOPDIR)/src/macosx/native/sun/osxapp \

--- a/java/openjdk8/files/1008-toolchain.m4-hack-around-a-broken-Xcode-version-dete.patch
+++ b/java/openjdk8/files/1008-toolchain.m4-hack-around-a-broken-Xcode-version-dete.patch
@@ -1,0 +1,77 @@
+From 5e6c5c476700f9bd27b6a4fb217859edcb466a28 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Mon, 6 May 2024 21:18:03 +0800
+Subject: [PATCH] toolchain.m4: hack around a broken Xcode version detect
+
+Xcode version detection may or may not work. When it does not, it breaks configure.
+Thankfully, we do not need it at all on Darwin PowerPC.
+
+---
+ common/autoconf/generated-configure.sh | 19 ++-----------------
+ common/autoconf/toolchain.m4           | 16 +---------------
+ 2 files changed, 3 insertions(+), 32 deletions(-)
+
+diff --git common/autoconf/generated-configure.sh common/autoconf/generated-configure.sh
+index 6f17436eff..fcef8fb4e2 100644
+--- common/autoconf/generated-configure.sh
++++ common/autoconf/generated-configure.sh
+@@ -26102,22 +26102,7 @@ fi
+   VALID_TOOLCHAINS=${!toolchain_var_name}
+ 
+   if test "x$OPENJDK_TARGET_OS" = xmacosx; then
+-    # On Mac OS X, default toolchain to clang after Xcode 5
+-    XCODE_VERSION_OUTPUT=`xcodebuild -version 2>&1 | $HEAD -n 1`
+-    $ECHO "$XCODE_VERSION_OUTPUT" | $GREP "Xcode " > /dev/null
+-    if test $? -ne 0; then
+-      as_fn_error $? "Failed to determine Xcode version." "$LINENO" 5
+-    fi
+-    XCODE_MAJOR_VERSION=`$ECHO $XCODE_VERSION_OUTPUT | \
+-        $SED -e 's/^Xcode \([1-9][0-9.]*\)/\1/' | \
+-        $CUT -f 1 -d .`
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: Xcode major version: $XCODE_MAJOR_VERSION" >&5
+-$as_echo "$as_me: Xcode major version: $XCODE_MAJOR_VERSION" >&6;}
+-    if test $XCODE_MAJOR_VERSION -ge 5; then
+-        DEFAULT_TOOLCHAIN="clang"
+-    else
+-        DEFAULT_TOOLCHAIN="gcc"
+-    fi
++    DEFAULT_TOOLCHAIN="gcc"
+   else
+     # First toolchain type in the list is the default
+     DEFAULT_TOOLCHAIN=${VALID_TOOLCHAINS%% *}
+@@ -27518,7 +27503,7 @@ $as_echo "$as_me: or run \"bash.exe -l\" from a VS command prompt and then run c
+     SET_DEVELOPER_DIR=
+ 
+     if test -n "$XCODE_PATH"; then
+-      DEVELOPER_DIR="$XCODE_PATH"/Contents/Developer
++      DEVELOPER_DIR="$XCODE_PATH"/Developer
+     fi
+ 
+     # DEVELOPER_DIR could also be provided directly
+diff --git common/autoconf/toolchain.m4 common/autoconf/toolchain.m4
+index ba4798e795..353ce121e4 100644
+--- common/autoconf/toolchain.m4
++++ common/autoconf/toolchain.m4
+@@ -151,21 +151,7 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
+   VALID_TOOLCHAINS=${!toolchain_var_name}
+  
+   if test "x$OPENJDK_TARGET_OS" = xmacosx; then
+-    # On Mac OS X, default toolchain to clang after Xcode 5
+-    XCODE_VERSION_OUTPUT=`xcodebuild -version 2>&1 | $HEAD -n 1`
+-    $ECHO "$XCODE_VERSION_OUTPUT" | $GREP "Xcode " > /dev/null
+-    if test $? -ne 0; then
+-      AC_MSG_ERROR([Failed to determine Xcode version.])
+-    fi
+-    XCODE_MAJOR_VERSION=`$ECHO $XCODE_VERSION_OUTPUT | \
+-        $SED -e 's/^Xcode \(@<:@1-9@:>@@<:@0-9.@:>@*\)/\1/' | \
+-        $CUT -f 1 -d .`
+-    AC_MSG_NOTICE([Xcode major version: $XCODE_MAJOR_VERSION])
+-    if test $XCODE_MAJOR_VERSION -ge 5; then
+-        DEFAULT_TOOLCHAIN="clang"
+-    else
+-        DEFAULT_TOOLCHAIN="gcc"
+-    fi
++    DEFAULT_TOOLCHAIN="gcc"
+   else
+     # First toolchain type in the list is the default
+     DEFAULT_TOOLCHAIN=${VALID_TOOLCHAINS%% *}

--- a/java/openjdk8/files/1009-os_bsd.cpp-remove-breaking-macro-for-Apple.patch
+++ b/java/openjdk8/files/1009-os_bsd.cpp-remove-breaking-macro-for-Apple.patch
@@ -1,0 +1,32 @@
+From 00d56f059353b32a4d08d6fb5f0394db5c9c7434 Mon Sep 17 00:00:00 2001
+From: Sergey Fedorov <vital.had@gmail.com>
+Date: Tue, 16 Apr 2024 11:48:55 +0800
+Subject: [PATCH] os_bsd.cpp: remove breaking macro for Apple
+
+---
+ hotspot/src/os/bsd/vm/os_bsd.cpp | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git hotspot/src/os/bsd/vm/os_bsd.cpp hotspot/src/os/bsd/vm/os_bsd.cpp
+index 7e5e4d6db6..bb7cc5bd70 100644
+--- hotspot/src/os/bsd/vm/os_bsd.cpp
++++ hotspot/src/os/bsd/vm/os_bsd.cpp
+@@ -4853,10 +4853,6 @@ int os::fork_and_exec(char* cmd, bool use_vfork_if_available) {
+ // as libawt.so, and renamed libawt_xawt.so
+ //
+ bool os::is_headless_jre() {
+-#ifdef __APPLE__
+-    // We no longer build headless-only on Mac OS X
+-    return false;
+-#else
+     struct stat statbuf;
+     char buf[MAXPATHLEN];
+     char libmawtpath[MAXPATHLEN];
+@@ -4888,7 +4884,6 @@ bool os::is_headless_jre() {
+     if (::stat(libmawtpath, &statbuf) == 0) return false;
+ 
+     return true;
+-#endif
+ }
+ 
+ // Get the default path to the core file


### PR DESCRIPTION
#### Description

_CI failures seem irrelevant. All changes are for powerpc, and I have no intention to change anything for any other archs._

This fixes a number of errors which break the build in its early stages. I kept all patches restricted to PowerPC, so revbump should not be needed: changes for other systems are non-functional.

P. S. `PPC32` has been used since https://github.com/openjdk/jdk8u/commit/036382cefdddc53a2161ee77ddf9ab677e28c4c7 and still used in the current code https://github.com/openjdk/jdk8u/blob/6b53212ef78ad50f9eede829c5ff87cadcdb434b/hotspot/src/os_cpu/bsd_zero/vm/os_bsd_zero.hpp#L39

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
