### PR TITLE
got: update to 0.99

### DIFF
--- a/devel/got/Portfile
+++ b/devel/got/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           legacysupport 1.1
 
 name                got
-version             0.97
+version             0.99
 revision            0
 distname            ${name}-portable-${version}
 categories          devel
@@ -20,10 +20,16 @@ long_description    Game of Trees is a version control system which \
                     repository.
 homepage            https://gameoftrees.org/
 master_sites        ${homepage}releases/portable/
-checksums           rmd160 85d9802e2738f4b5dc180a3593063961bab7a644 \
-                    sha256 e07a4894a458503a32982047f064bc0c35da6349d8895be8b69064c2094e3b72 \
-                    size 1269488
+checksums           rmd160 1cd4d50d1f6c74155fb7ab7bac500772a4d33a80 \
+                    sha256 aea408353a02b2e3ad9b4d1b7607900269af97986d40998c57f10acdf0fa1e38 \
+                    size 1481387
+# There is probably a smarter way to do this, see failed attempts at
+# https://trac.macports.org/ticket/69827
+# So, if you, like me, are using LibreSSL, remove the port:libretls line
+# as that is only required for OpenSSL users to supply libtls which is
+# already included with LibreSSL.
 depends_lib         path:lib/libssl.dylib:openssl \
+                    port:libretls \
                     port:ncurses \
                     port:ossp-uuid \
                     port:libevent


### PR DESCRIPTION
* closes https://trac.macports.org/ticket/69827

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1 23E224 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
