### PR TITLE
emacs-mac-app: Add renameapp variant

### DIFF
--- a/aqua/emacs-mac-app/Portfile
+++ b/aqua/emacs-mac-app/Portfile
@@ -8,6 +8,7 @@ set emacs_mac_ver   10.0
 
 bitbucket.setup     mituharu emacs-mac emacs-${emacs_version}-mac-${emacs_mac_ver}
 name                emacs-mac-app
+conflicts           emacs-app emacs-app-devel
 version             ${emacs_mac_ver}
 revision            1
 categories          aqua editors
@@ -35,7 +36,7 @@ depends_lib         port:ncurses \
 patchfiles          patch-src_emacs.c.diff
 
 if {${subport} eq ${name}} {
-    conflicts       emacs-mac-app-devel
+    conflicts-prepend   emacs-mac-app-devel
 }
 
 post-patch {
@@ -103,7 +104,7 @@ subport ${name}-devel {
     depends_fetch-append port:git
     git.cmd         ${prefix}/bin/git
 
-    conflicts       emacs-mac-app
+    conflicts-prepend   emacs-mac-app
 
     livecheck.version   ${git.branch}
     bitbucket.livecheck work
@@ -112,11 +113,12 @@ subport ${name}-devel {
 destroot.destdir {}
 
 post-destroot {
-    # Rename the app bundle to avoid a conflict with emacs-app
-    move ${worksrcpath}/Emacs.app ${destroot}${applications_dir}/EmacsMac.app
+    set appname [expr {[variant_isset renameapp] ? "EmacsMac" : "Emacs"}]
+
+    move ${worksrcpath}/Emacs.app ${destroot}${applications_dir}/${appname}.app
 
     # Install site-start.el
-    set site_lisp ${destroot}${applications_dir}/EmacsMac.app/Contents/Resources/site-lisp
+    set site_lisp ${destroot}${applications_dir}/${appname}.app/Contents/Resources/site-lisp
     xinstall -d ${site_lisp}
     file copy ${filespath}/site-start.el ${site_lisp}
     reinplace "s|__PREFIX__|${prefix}|g" ${site_lisp}/site-start.el
@@ -182,7 +184,11 @@ variant metal description {Enable experimental Metal support} {
     configure.args-append  --with-mac-metal
 }
 
-default_variants-append +nativecomp +treesitter
+variant renameapp description {Rename app bundle to avoid conflict with emacs-app} {
+    conflicts-delete    emacs-app emacs-app-devel
+}
+
+default_variants-append +nativecomp +treesitter +renameapp
 
 if {${subport} eq ${name}} {
     livecheck.regex     {"emacs-[0-9.]+-mac-([0-9.]+)"}


### PR DESCRIPTION
#### Description
Emacs Mac port is by default installed as `EmacsMac.app` instead of `Emacs.app` to avoid conflicting with `emacs-app`. I added the variant `renameapp` to control whether the application bundle is renamed. This way, users who install only the Mac port can choose to have it named `Emacs.app` by negating the variant. It is enabled by default, so the existing behavior of `sudo port install emacs-mac-app` is preserved.

###### Type(s)
- [x] enhancement

###### Tested on
macOS 10.15.7 19H2026 x86_64
Command Line Tools 12.4.0.0.1.1610135815

###### Verification
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
