### PR TITLE
c3270: update to 4.3ga8

### DIFF
--- a/comms/c3270/Portfile
+++ b/comms/c3270/Portfile
@@ -1,7 +1,7 @@
 PortSystem          1.0
 
 name                c3270
-version             4.3ga4
+version             4.3ga8
 revision            0
 set branch          4.3
 categories          comms
@@ -26,9 +26,9 @@ depends_lib         path:lib/libssl.dylib:openssl  \
 
 distfiles           suite3270-${version}-src.tgz
 dist_subdir         c3270
-checksums           rmd160  23a1e80cd56ea914dc682a23dec598bcbf61a395 \
-                    sha256  3b7bf11de9a05a5f203cb845bd8e7fb805c2a06ca606ccf8cdee4ff5c80caa4b \
-                    size    13163509
+checksums           rmd160  8a1b8845fadda87f8a10e2c737851407aa2ed79f \
+                    sha256  81c0ba4447d97a7b483c40e11b39d4498bbc9af55fa4f78ccff064b3e378dc59 \
+                    size    14603479
 
 worksrcdir          suite3270-${branch}
 configure.args      --bindir=${prefix}/bin \


### PR DESCRIPTION
#### Description

Updates the port to 4.3ga8.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.6 22G630 arm64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
For some reason `port -vst install` fails on my machine.