### PR TITLE
google-cloud-sdk: update to 475.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             474.0.0
+version             475.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  3435cc0770d15e7a3f1d0aa8c8cf68b35d05fb70 \
-                    sha256  774fc19c0819dd7cd822e142f9f226cb00f0efab2571eec2c53c0f801014f954 \
-                    size    123628553
+    checksums       rmd160  3c27788325ca0ba66879a1f9aae6dbe565e5eada \
+                    sha256  857c90481f3eb819f88eb7f48720b9c1d324de73667bac216fa8419ba34439c7 \
+                    size    123658464
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  1ad9df06529fb8107e77a76a8379a05b5f3c47d5 \
-                    sha256  de13df2e137cbf1f8917229a198ada67f5ce8a970c40d4e2175db5e6e3175ce5 \
-                    size    124915031
+    checksums       rmd160  b31765d955f4141fa8a4125bd4cc0aeeacfc2e95 \
+                    sha256  3f608118dbb8b9c2797a2bf7e4c763432a7eff18c4f801b6292ab10be5e61c1d \
+                    size    124944507
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  dc22a3cb1edf55b3c7fc6f293e342f9703625fe4 \
-                    sha256  937908fd50f6aab87c08c72a70fa96abef10786fc664363ee6a92a4f2a7d1c8b \
-                    size    121975066
+    checksums       rmd160  60d8af06f0fc8d514b2c83a7e6a9caea8b615759 \
+                    sha256  24b506612beedaf01219b37de92a87461dd3c8edc8055828b765788d015e50b2 \
+                    size    122002985
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 475.0.0.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?