### PR TITLE
2048.c: new port (1.0.0)

### DIFF
--- a/games/2048.c/Portfile
+++ b/games/2048.c/Portfile
@@ -1,0 +1,24 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               github 1.0
+PortGroup               makefile 1.0
+
+github.setup            mevdschee 2048.c 1.0.0 v
+github.tarball_from     archive
+revision                0
+categories              games
+license                 MIT
+maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
+
+description             Terminal version of 2048
+long_description        {*}${description}.
+
+checksums               rmd160  ec329c6b5676fb64566082e8e0b96380d3c8eaa0 \
+                        sha256  13d3fb3f2fd12f188d54f0a2d6809f89b5cc5e630d4f5a5b758386c0f63878ed \
+                        size    18706
+
+compiler.c_standard     1999
+
+test.run                yes
+test.target             test


### PR DESCRIPTION
#### Description

Add [`2048.c`](https://github.com/mevdschee/2048.c), a terminal version of the game 2048 written in C

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
