### PR TITLE
gtk3: require active variant for glib2

### DIFF
--- a/gnome/gtk3-devel/Portfile
+++ b/gnome/gtk3-devel/Portfile
@@ -279,6 +279,7 @@ variant demos description {Build demos and examples} {
 variant quartz conflicts x11 {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo quartz
     require_active_variants path:lib/pkgconfig/pango.pc:pango quartz
+    require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 quartz
 
     configure.args-append \
                             -Dx11_backend=false \
@@ -289,6 +290,7 @@ variant quartz conflicts x11 {
 variant x11 conflicts quartz {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo x11
     require_active_variants path:lib/pkgconfig/pango.pc:pango x11
+    require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 x11
 
     depends_lib-append \
                             port:at-spi2-atk \

--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -279,6 +279,7 @@ variant demos description {Build demos and examples} {
 variant quartz conflicts x11 {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo quartz
     require_active_variants path:lib/pkgconfig/pango.pc:pango quartz
+    require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 quartz
 
     configure.args-append \
                             -Dx11_backend=false \
@@ -289,6 +290,7 @@ variant quartz conflicts x11 {
 variant x11 conflicts quartz {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo x11
     require_active_variants path:lib/pkgconfig/pango.pc:pango x11
+    require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 x11
 
     depends_lib-append \
                             port:at-spi2-atk \


### PR DESCRIPTION
#### Description

Resolves "Symbol not found: _g_desktop_app_info_get_filename"

###### Type(s)

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
