### PR TITLE
Adapted glib2 to have the gio-launch-desktop back build on the generic (x11) version.

### DIFF
--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -15,7 +15,7 @@ name                        glib2
 conflicts                   glib2-devel
 set my_name                 glib
 version                     2.78.4
-revision                    0
+revision                    1
 epoch                       1
 
 checksums                   rmd160  7941be85af18c428d86f4a00e52f41542b061aa9 \

--- a/devel/glib2/files/patch-meson_build-meson_options-appinfo.diff
+++ b/devel/glib2/files/patch-meson_build-meson_options-appinfo.diff
@@ -50,9 +50,9 @@
  option('runtime_libdir',
         type : 'string',
         value : '',
---- gio/meson.build.orig	2022-03-17 23:01:31.000000000 +0800
-+++ gio/meson.build	2022-04-04 05:29:36.000000000 +0800
-@@ -380,16 +380,23 @@
+--- gio/meson.build.orig	2024-01-21 20:48:20.000000000 +0100
++++ gio/meson.build	2024-05-08 11:45:56.000000000 +0200
+@@ -389,16 +389,32 @@
      'gunixoutputstream.h',
    )
  
@@ -69,6 +69,15 @@
 +      contenttype_sources += files('gcontenttype.c')
 +      appinfo_sources += files('gdesktopappinfo.c')
 +      gio_unix_include_headers += files('gdesktopappinfo.h')
++      launch_desktop_sources = files('gio-launch-desktop.c')
++      gio_launch_desktop = executable('gio-launch-desktop', launch_desktop_sources,
++        include_directories : glibinc,
++        install : true,
++        install_dir : multiarch_libexecdir,
++        install_tag : 'bin',
++        c_args : gio_c_args,
++        # intl.lib is not compatible with SAFESEH
++        link_args : noseh_link_args)
 +    endif
      framework_dep = dependency('appleframeworks', modules : ['Foundation', 'CoreFoundation', 'AppKit'])
      platform_deps += [framework_dep]
@@ -79,8 +88,8 @@
    else
      contenttype_sources += files('gcontenttype.c')
      appinfo_sources += files('gdesktopappinfo.c')
-@@ -784,6 +791,13 @@
-   install_dir: bash_comp_inst_dir)
+@@ -828,6 +844,13 @@
+   )
  endif
  
 +appinfo_backend = get_option('appinfo_backend') 


### PR DESCRIPTION
For applications such as nautilus who require x11 the
gio-launch-desktop bin is a requirement for some functions.
By adding the patch for build quartz(native) or x11(generic)
This add was forgotten for build of x11.
With this modified patch it is back in.

the last part of patch :
devel/glib2/files/patch-meson_build-meson_options-appinfo.diff

has been modified and in section generic build this part below is added

```
      launch_desktop_sources = files('gio-launch-desktop.c')
      gio_launch_desktop = executable('gio-launch-desktop', launch_desktop_sources,
        include_directories : glibinc,
        install : true,
        install_dir : multiarch_libexecdir,
        install_tag : 'bin',
        c_args : gio_c_args,
        # intl.lib is not compatible with SAFESEH
        link_args : noseh_link_args)
```

I also included a port bump revision from 0 to 1 . Tested by me by building without -s option and yes it builded from source like it must whit a revison bump.
 