### PR TITLE
py-h5py: Use float16 datatype only if available

### DIFF
--- a/python/py-h5py/Portfile
+++ b/python/py-h5py/Portfile
@@ -10,7 +10,7 @@ name                    py-h5py
 
 # h5py needs to be re-built after hdf5 upgrades; it has its own version
 # check included.
-revision                1
+revision                2
 
 checksums \
     rmd160  dc509596126af570c75768e5161d8aaf1324a26e \
@@ -57,10 +57,7 @@ if {${name} ne ${subport}} {
     destroot.env-append     HDF5_DIR=${prefix}
 
     patchfiles-append       patch-oldest-supported-numpy.diff
-
-    post-patch {
-        reinplace "/=={np_min}/s/==/>=/" setup.py
-    }
+    patchfiles-append       float16.patch
 
     post-destroot {
         xinstall -d ${destroot}${prefix}/share/doc/${subport}

--- a/python/py-h5py/files/float16.patch
+++ b/python/py-h5py/files/float16.patch
@@ -1,0 +1,38 @@
+Lock native float16 dtype only if available.
+https://github.com/h5py/h5py/issues/2419
+https://github.com/h5py/h5py/pull/2422
+--- h5py/api_types_hdf5.pxd
++++ h5py/api_types_hdf5.pxd
+@@ -385,6 +385,8 @@ cdef extern from "hdf5.h":
+ 
+ # === H5I - Identifier and reflection interface ===============================
+ 
++  int H5I_INVALID_HID
++
+   IF HDF5_VERSION < VOL_MIN_HDF5_VERSION:
+     ctypedef enum H5I_type_t:
+       H5I_UNINIT       = -2,  # uninitialized Group
+--- h5py/h5i.pyx
++++ h5py/h5i.pyx
+@@ -18,6 +18,7 @@ from ._objects import phil, with_phil
+ 
+ # === Public constants and data structures ====================================
+ 
++INVALID_HID = H5I_INVALID_HID
+ BADID       = H5I_BADID
+ FILE        = H5I_FILE
+ GROUP       = H5I_GROUP
+--- h5py/h5t.pyx
++++ h5py/h5t.pyx
+@@ -232,7 +232,10 @@ LDOUBLE_BE.set_order(H5T_ORDER_BE)
+ LDOUBLE_BE.lock()
+ 
+ IF HDF5_VERSION > (1, 14, 3):
+-    NATIVE_FLOAT16 = lockid(H5T_NATIVE_FLOAT16)
++    if H5T_NATIVE_FLOAT16 != H5I_INVALID_HID:
++        NATIVE_FLOAT16 = lockid(H5T_NATIVE_FLOAT16)
++    else:
++        NATIVE_FLOAT16 = H5I_INVALID_HID
+ 
+ # Unix time types
+ UNIX_D32LE = lockid(H5T_UNIX_D32LE)


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/69938

Also remove reinplace that hasn't been needed since 3.6.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 21H1123 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
