### PR TITLE
hdf5: Fix leak of internal IDs

### DIFF
--- a/science/hdf5/Portfile
+++ b/science/hdf5/Portfile
@@ -9,8 +9,8 @@ PortGroup           github 1.0
 
 github.setup        HDFGroup hdf5 1.14.4.2 hdf5_
 set distversion     1.14.4-2
-revision            1
-#set mainversion     [lrange [split ${version} -] 0 0]
+revision            2
+#set mainversion     [lindex [split ${distversion} -] 0]
 #set shortversion    [join [lrange [split ${mainversion} .] 0 1] .]
 
 categories          science
@@ -18,6 +18,7 @@ maintainers         {eborisch @eborisch} openmaintainer
 
 description         HDF5 general purpose library and file format for storing\
                     scientific data
+
 long_description    HDF5 is a data model, library, and file format for storing\
                     and managing data. It supports an unlimited variety of\
                     datatypes, and is designed for flexible and efficient I/O\
@@ -26,19 +27,10 @@ long_description    HDF5 is a data model, library, and file format for storing\
                     of HDF5. The HDF5 Technology suite includes tools and\
                     applications for managing, manipulating, viewing, and\
                     analyzing data in the HDF5 format.
+
 homepage            https://www.hdfgroup.org/solutions/hdf5/
-platforms           darwin
-
-# Looks like upstream gave up on BZ2.  Maybe they will restore it later.
-distfiles           ${name}-${distversion}.tar.gz
-#distfiles           ${name}-${version}.tar.bz2
-#use_bzip2           yes
-
-# Github download assets path is not quite right, for some unknown reason.
-master_sites        ${github.homepage}/releases/download/${git.branch}
-
-## Full target currently:
-## https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.4.2/hdf5-1.14.4-2.tar.gz
+github.tarball_from releases
+distname            ${name}-${distversion}
 
 checksums \
     rmd160  da80b0fcf47248e869da9112890edf79905bf95c \
@@ -51,6 +43,7 @@ depends_lib         port:zlib port:libaec
 use_parallel_build  yes
 
 patchfiles          patch-tools-src-misc-h5cc.in.diff
+patchfiles-append   fix-leak-of-internal-ids.patch
 
 # llvm-gcc-4.2 produced code fails type conversion tests
 # Upstream suggestion is use -O0. Clang-produced code passes all tests.

--- a/science/hdf5/files/fix-leak-of-internal-ids.patch
+++ b/science/hdf5/files/fix-leak-of-internal-ids.patch
@@ -1,0 +1,80 @@
+Fix leak of internal IDs registered during compound datatype conversion.
+
+Allegedly fixes segfault after running h5py test suite.
+
+https://github.com/h5py/h5py/issues/2419
+https://github.com/HDFGroup/hdf5/pull/4459
+--- src/H5T.c.orig	2024-04-15 14:47:31.000000000 -0500
++++ src/H5T.c	2024-05-09 00:36:32.000000000 -0500
+@@ -1643,9 +1643,8 @@
+     FUNC_ENTER_PACKAGE_NOERR
+ 
+     assert(dt);
+-    assert(dt->shared);
+ 
+-    if (H5T_STATE_IMMUTABLE == dt->shared->state) {
++    if (dt->shared && (H5T_STATE_IMMUTABLE == dt->shared->state)) {
+         dt->shared->state = H5T_STATE_RDONLY;
+         (*n)++;
+     } /* end if */
+@@ -1862,7 +1861,6 @@
+ 
+     /* Sanity check */
+     assert(dt);
+-    assert(dt->shared);
+ 
+     /* If this datatype is VOL-managed (i.e.: has a VOL object),
+      * close it through the VOL connector.
+@@ -4162,10 +4160,10 @@
+     FUNC_ENTER_NOAPI(FAIL)
+ 
+     /* Sanity check */
+-    assert(dt && dt->shared);
++    assert(dt);
+ 
+     /* Clean up resources, depending on shared state */
+-    if (dt->shared->state != H5T_STATE_OPEN) {
++    if (dt->shared && (dt->shared->state != H5T_STATE_OPEN)) {
+         if (H5T__free(dt) < 0)
+             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTFREE, FAIL, "unable to free datatype");
+ 
+@@ -4202,10 +4200,9 @@
+ 
+     /* Sanity check */
+     assert(dt);
+-    assert(dt->shared);
+ 
+     /* Named datatype cleanups */
+-    if (dt->shared->state == H5T_STATE_OPEN) {
++    if (dt->shared && (dt->shared->state == H5T_STATE_OPEN)) {
+         /* Decrement refcount count on open named datatype */
+         dt->shared->fo_count--;
+ 
+--- src/H5Tconv.c.orig	2024-04-15 14:47:31.000000000 -0500
++++ src/H5Tconv.c	2024-05-09 00:37:43.000000000 -0500
+@@ -2241,6 +2241,7 @@
+             if (need_ids) {
+                 hid_t tid;
+ 
++                if (priv->src_memb_id[i] == H5I_INVALID_HID) {
+                 if ((tid = H5I_register(H5I_DATATYPE, priv->src_memb[i], false)) < 0) {
+                     H5T__conv_struct_free(priv);
+                     cdata->priv = NULL;
+@@ -2248,7 +2249,9 @@
+                                 "can't register ID for source compound member datatype");
+                 }
+                 priv->src_memb_id[i] = tid;
++                }
+ 
++                if (priv->dst_memb_id[src2dst[i]] == H5I_INVALID_HID) {
+                 if ((tid = H5I_register(H5I_DATATYPE, priv->dst_memb[src2dst[i]], false)) < 0) {
+                     H5T__conv_struct_free(priv);
+                     cdata->priv = NULL;
+@@ -2256,6 +2259,7 @@
+                                 "can't register ID for destination compound member datatype");
+                 }
+                 priv->dst_memb_id[src2dst[i]] = tid;
++                }
+             }
+         } /* end if */
+     }     /* end for */


### PR DESCRIPTION
#### Description

See: https://trac.macports.org/ticket/69938

Also clean up fetch and extract code.


###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 21H1123 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
