### PR TITLE
gitu: Update to 0.20.1

### DIFF
--- a/devel/gitu/Portfile
+++ b/devel/gitu/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            altsem gitu 0.19.2 v
+github.setup            altsem gitu 0.20.1 v
 github.tarball_from     archive
 revision                0
 categories              devel
@@ -16,9 +16,9 @@ description             A TUI Git client inspired by Magit
 long_description        {*}${description}, launched straight from the terminal.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  b3f624a56469aeb63aa4568f6f817e2a5f80636a \
-                        sha256  e7d6f44410bc6cca77ee37afb00ad97c5e83018a62a9d6483ef3999b1f5d8799 \
-                        size    3910914
+                        rmd160  61d74888e8bd818f7c9d77cf0f96c6a48e72c9a0 \
+                        sha256  f36401daf3800ab1b52a0c07926262bae8e23b0e6c497a9d5077ae50022e6322 \
+                        size    3912475
 
 destroot {
     set bindir ${worksrcpath}/target/[cargo.rust_platform]/release
@@ -51,7 +51,7 @@ cargo.crates \
     castaway                         0.2.2  8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc \
     cc                              1.0.95  d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    chrono                          0.4.37  8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e \
+    chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
     ciborium                         0.2.2  42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e \
     ciborium-io                      0.2.2  05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757 \
     ciborium-ll                      0.2.2  57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9 \
@@ -81,7 +81,7 @@ cargo.crates \
     errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
     error-code                       3.2.0  a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b \
     etcetera                         0.8.0  136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943 \
-    figment                        0.10.16  fdefe49ed1057d124dc81a0681c30dd07de56ad96e32adc7b64e8f28eaab31c4 \
+    figment                        0.10.18  d032832d74006f99547004d49410a4b4218e4c33382d56ca3ff89df74f86b953 \
     form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
     gethostname                      0.4.3  0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818 \
     git-version                      0.3.9  1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19 \
@@ -136,7 +136,7 @@ cargo.crates \
     pretty_assertions                1.4.0  af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66 \
     proc-macro2                     1.0.79  e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e \
     quote                           1.0.35  291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef \
-    ratatui                         0.26.1  bcb12f8fbf6c62614b0d56eb352af54f6a22410c3b079eb53ee93c7b97dd31d8 \
+    ratatui                         0.26.2  a564a852040e82671dc50a37d88f3aa83bbc690dfc6844cfe7a2591620206a80 \
     rayon                           1.10.0  b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa \
     rayon-core                      1.12.1  1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2 \
     redox_syscall                   0.1.57  41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce \
@@ -152,8 +152,8 @@ cargo.crates \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     semver                          1.0.22  92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca \
-    serde                          1.0.197  3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2 \
-    serde_derive                   1.0.197  7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b \
+    serde                          1.0.199  0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a \
+    serde_derive                   1.0.199  11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc \
     serde_json                     1.0.115  12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd \
     serde_spanned                    0.6.5  eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1 \
     signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
@@ -162,7 +162,7 @@ cargo.crates \
     similar                          2.5.0  fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640 \
     simple-logging                   2.0.2  b00d48e85675326bb182a2286ea7c1a0b264333ae10f27a937a72be08628b542 \
     smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
-    stability                        0.1.1  ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce \
+    stability                        0.2.0  2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a \
     static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
     strsim                          0.11.0  5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01 \
     strum                           0.26.2  5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29 \
@@ -184,6 +184,7 @@ cargo.crates \
     tree-sitter-c                   0.20.8  4bbd5f3d8658c08581f8f2adac6c391c2e9fa00fe9246bf6c5f52213b9cc6b72 \
     tree-sitter-c-sharp             0.20.0  b9ab3dc608f34924fa9e10533a95f62dbc14b6de0ddd7107722eba66fe19ae31 \
     tree-sitter-cpp                 0.20.5  46b04a5ada71059afb9895966a6cc1094acc8d2ea1971006db26573e7dfebb74 \
+    tree-sitter-elixir               0.1.1  1bc0b1f3e6d9f12ca22ae5171f32fd154e3aea29dff565d05ef785c28931415b \
     tree-sitter-go                  0.20.0  1ad6d11f19441b961af2fda7f12f5d0dac325f6d6de83836a1d3750018cc5114 \
     tree-sitter-haskell             0.15.0  ac635b86d6cc127706bc0831f4b83f5503ed8ac2f8cd22831ba3e5535445b4f2 \
     tree-sitter-highlight           0.20.1  042342584c5a7a0b833d9fc4e2bdab3f9868ddc6c4b339a1e01451c6720868bc \
@@ -199,13 +200,13 @@ cargo.crates \
     tree-sitter-scala               0.20.3  44fcf4628a88a3b5cbac3ff52658b924f3e545abddfa245ab9cf683c1adda350 \
     tree-sitter-toml                0.20.0  ca517f578a98b23d20780247cc2688407fa81effad5b627a5a364ec3339b53e8 \
     tree-sitter-typescript          0.20.5  c8bc1d2c24276a48ef097a71b56888ac9db63717e8f8d0b324668a27fd619670 \
-    tui-prompts                     0.3.10  5e500909aaebfb05b51371252c7c076d92d11717eeaa6aef575c9a5db3958370 \
+    tui-prompts                     0.3.11  581e0457c7a9f81db70431d3b6c82f8589bb556a722e414ca17d55367ce77c9d \
     uncased                         0.9.10  e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697 \
     unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
     unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
     unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
     unicode-segmentation            1.11.0  d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202 \
-    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
+    unicode-width                   0.1.12  68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6 \
     url                              2.5.0  31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633 \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
     vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \


### PR DESCRIPTION
#### Description

Update `gitu` to its latest released version, 0.20.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
