### PR TITLE
mingw-w64-wine-mono: New Port

### DIFF
--- a/cross/mingw-w64-wine-mono/Portfile
+++ b/cross/mingw-w64-wine-mono/Portfile
@@ -1,0 +1,125 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                mingw-w64-wine-mono
+categories          cross
+maintainers         {@Gcenx gmail.com:gcenx83}
+homepage            https://github.com/madewokherd/wine-mono
+license             GPL LGPL-2.1 MPL
+platforms           any
+supported_archs     noarch
+description         Wine's built-in replacement for Microsoft's .NET Framework
+long_description    ${subport} is a package containing Mono and other projects, \
+                    intended as a replacement for the .NET runtime and class \
+                    libraries in Wine. It works in conjunction with Wine's \
+                    builtin mscoree.dll, and it is not intended to be useful \
+                    for any other purpose.
+
+use_configure       no
+build {}
+
+if {${subport} eq ${name}} {
+    PortGroup       stub 1.0
+    version         9.1.0
+    revision        0
+    depends_run     port:mingw-w64-wine-mono-${version}
+
+    post-deactivate {
+        # When this port is deactivated, mingw-w64-wine-mono-${version} should also be.
+        if {![catch {set installed [lindex [registry_active mingw-w64-wine-mono-${version}] 0]}]} {
+            registry_deactivate_composite mingw-w64-wine-mono-${version} "" [list ports_nodepcheck 1]
+        }
+    }
+}
+
+# wine-devel (9.8)
+subport ${name}-9.1.0 {
+    version         9.1.0
+    revision        0
+    checksums       rmd160  650ab69c60a2ead85937fb32d7b62c4d779deaff \
+                    sha256  601169d0203b291fbfd946b356a9538855e01de22abd470ded73baf312c88767 \
+                    size    43820028
+    use_xz          yes
+    distname        wine-mono-${version}-x86
+}
+
+# wine-stable (9.0)
+subport ${name}-8.1.0 {
+    version         8.1.0
+    revision        0
+    checksums       rmd160  530ca1616f719c6171c55ad0fedcae4dd8c5561b \
+                    sha256  4e3e8a40729e4c9e3e9e651cebe4f1aed8f9a4d22e991e6cd24608687f0eedd4 \
+                    size    40854944
+    use_xz          yes
+    distname        wine-mono-${version}-x86
+}
+
+# game-porting-toolkit
+subport ${name}-7.4.1 {
+    version         7.4.1
+    revision        0
+    checksums       rmd160  53d7dddb324ce92f85321c54e2995121c5ed7729 \
+                    sha256  1286afc67b0a329f5e2d98d9e803ca5906a841ad5486e9b3b1fefa1124b15622 \
+                    size    44433444
+    use_xz          yes
+    distname        wine-mono-${version}-x86
+}
+
+# wine-devel-7.22
+subport ${name}-7.4.0 {
+    version         7.4.0
+    revision        0
+    checksums       rmd160  8df357ccd7e98c841b13a1eabfe8561f4a4900b8 \
+                    sha256  9249ece664bcf2fecb1308ea1d2542c72923df9fe3df891986f137b2266a9ba3 \
+                    size    45404344
+    use_xz          yes
+    distname        wine-mono-${version}-x86
+}
+
+# wine-stable-7.0.2
+subport ${name}-7.0.0 {
+    version         7.0.0
+    revision        0
+    checksums       rmd160  96f7316927cef5ea35197389e425c54b0dccc3fb \
+                    sha256  2a047893f047b4f0f5b480f1947b7dda546cee3fec080beb105bf5759c563cd3 \
+                    size    45085800
+    use_xz          yes
+    distname        wine-mono-${version}-x86
+}
+
+# wine-devel-6.8
+subport ${name}-6.1.1 {
+    version         6.1.1
+    revision        0
+    checksums       rmd160  a27137adc908a4eb1a262cc0502ef73d5a1894e2 \
+                    sha256  c3bab46c3e69ecdda61532c28c6a94a78aef9c750cc18dbb60151e0697714d6d \
+                    size    45702072
+    use_xz          yes
+    distname        wine-mono-${version}-x86
+}
+
+# wine-stable-6.0.4
+subport ${name}-5.1.1 {
+    version         5.1.1
+    revision        0
+    checksums       rmd160  9f3b7597ee1d71d9adb656033fea173b964ebd6e \
+                    sha256  b17ac815afbf5eef768c4e8d50800be02af75c8b230d668e239bad99616caa82 \
+                    size    44710604
+    use_xz          yes
+    distname        wine-mono-${version}-x86
+}
+
+set wine-mono_distfile \
+                    ${distname}${extract.suffix}
+
+master_sites        http://dl.winehq.org/wine/wine-mono/${version}/:mono \
+                    https://github.com/madewokherd/wine-mono/releases/download/wine-mono-${version}/:mono
+
+distfiles           ${wine-mono_distfile}:mono
+extract.only        ${wine-mono_distfile}
+
+destroot {
+    file mkdir  ${destroot}${prefix}/share/wine/mono
+    file copy   ${workpath}/wine-mono-${version} ${destroot}${prefix}/share/wine/mono
+}


### PR DESCRIPTION
Stub that contains multiple subports, will be used for the new `wine` portfiles.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F5074a x86_64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
