### PR TITLE
oh-my-posh: update to 19.28.0; Fix leak of Version & Date information

### DIFF
--- a/sysutils/oh-my-posh/Portfile
+++ b/sysutils/oh-my-posh/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/JanDeDobbeleer/oh-my-posh 19.27.0 v
+go.setup            github.com/JanDeDobbeleer/oh-my-posh 19.28.0 v
 github.tarball_from archive
 revision            0
 
@@ -19,16 +19,17 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     {gmail.com:acethical @acethical} \
                     openmaintainer
 
-checksums           rmd160  d9fd1093d358ef8faa2386f6d5f363d87455af2b \
-                    sha256  f531734adc7e0b4efc1b9f595c75078b11d4b25863ecadcac5d29851ab738a34 \
-                    size    6762051
+checksums           rmd160  ccf512be24c2b64f769542e996b056fdac0b62ea \
+                    sha256  e0ca6ce14f7a148f110999f13f0a82a886e3c07ef0aeaf9e5a6e0cfdb67e47c7 \
+                    size    6762209
 
 build.dir           ${worksrcpath}/src
 
 # Allow Go to fetch dependencies at build time
 go.offline_build no
 build.pre_args-append \
-    -ldflags \"-X main.Version=${version}\" -o ${name}
+    -ldflags \"-X github.com/jandedobbeleer/oh-my-posh/src/build.Version=${version} \
+    -X github.com/jandedobbeleer/oh-my-posh/src/build.Date="2024-05-10"\" -o ${name}
 
 set omp_share_path  ${prefix}/share/${name}
 


### PR DESCRIPTION
#### Description

* update to 19.28.0
* bugfix: Fix leak of Version & Date information when use `oh-my-posh version -v`
  - Version & Date were redesigned from 17.6.0, [discussion](https://github.com/JanDeDobbeleer/oh-my-posh/issues/4014)
 
By now, I haven't found a way to automatically fetch data information, so I have to hard-code it.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.3 22G436 x86_64
Command Line Tools 15.1.0.0.1.1700200546

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
