### PR TITLE
uv: Update to 0.1.42

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.1.40
+github.setup            astral-sh uv 0.1.42
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -17,9 +17,9 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for common pip and pip-tools workflows.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  08205b8193a4ad22bd6c5e40337598c2d218737e \
-                        sha256  bb72ab10d48389ade62be703839ce3ca0c7f077057ff7a76f42c87cb036c8a49 \
-                        size    1069664
+                        rmd160  0ef58d758d5ed9f3b405456e5e6791a533b980d5 \
+                        sha256  c4b0cf67a9d4873ac7724005a43585de9b10d36a0760e3a30c9e5a70316c424e \
+                        size    1077448
 
 depends_build-append    path:bin/pkg-config:pkgconfig
 depends_lib-append      port:libgit2
@@ -84,7 +84,7 @@ cargo.crates \
     async-channel                    2.2.1  136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928 \
     async-compression                0.4.9  4e9eabd7a98fe442131a17c316bd9349c43695e49e730c3c8e12cfb5f4da2693 \
     async-trait                     0.1.80  c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca \
-    async_http_range_reader          0.7.1  8561e6613f8361df8bed11c0eef05b98384643bc81f6b753eec7c1d91f097509 \
+    async_http_range_reader          0.8.0  f1a0e0571c5d724d17fbe0b608d31a91e94938722c141877d3a2982216b084c2 \
     autocfg                          1.2.0  f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80 \
     axoasset                         0.9.1  5e05853b0d9abfab8e7532cad0d07ec396dd95c1a81926b49ab3cfa121a9d8d6 \
     axoprocess                       0.2.0  4de46920588aef95658797996130bacd542436aee090084646521260a74bda7d \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.1.42

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
