### PR TITLE
singular: update to 4-4-0 to fix building with new flint

### DIFF
--- a/math/singular/Portfile
+++ b/math/singular/Portfile
@@ -8,12 +8,11 @@ PortGroup           compiler_blacklist_versions 1.0
 # clock_gettime
 legacysupport.newest_darwin_requires_legacy 15
 
-github.setup        Singular Singular 4-3-2p10 Release-
+github.setup        Singular Singular 4-4-0 Release-
 name                singular
 revision            0
 version             [string map {- .} ${github.version}]
 categories          math
-platforms           darwin
 maintainers         {@catap korins.ky:kirill} openmaintainer
 license             {GPL-2 GPL-3}
 description         the Singular computer algebra system
@@ -23,9 +22,9 @@ long_description \
     geometry, and singularity theory.
 homepage            https://www.singular.uni-kl.de/
 
-checksums           rmd160  95b404d9a59a5f4ce25f07e7513b403aea48037f \
-                    sha256  2f686b9c1752999a12dddfadc3fc282cc0ac7fdafcb053ac58aa5ebe54ad327f \
-                    size    13762803
+checksums           rmd160  83126d27a2953ac7d9db7b913b731af5ebe3975a \
+                    sha256  260d9a25aecfe9971186b6fcfe6cdbe2a1f63af7915d452066323c9434f39e13 \
+                    size    13796887
 
 # clang: error: unknown argument: '-fno-delete-null-pointer-checks'
 # https://trac.macports.org/ticket/65804


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/69714

#### Description

@catap Kirill, please take a look. Trivial update, but required one.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
