### PR TITLE
superfile: new port (v1.1.2)

### DIFF
--- a/sysutils/superfile/Portfile
+++ b/sysutils/superfile/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           golang 1.0
+
+go.setup            github.com/MHNightCat/superfile 1.1.2 v
+go.offline_build    no
+github.tarball_from archive
+revision            0
+
+description         Pretty fancy and modern terminal file manager
+long_description    {*}${description}
+
+categories          sysutils
+installs_libs       no
+license             MIT
+maintainers         {gmail.com:herby.gillot @herbygillot} \
+                    openmaintainer
+
+checksums           rmd160  4f8e9da0070dedaf049d1602b8d5fac2669f3aa6 \
+                    sha256  aa4aadc54ca7b16c2715148524d241c940c4ab0b8e0610ee71ed1a8708c116d7 \
+                    size    5982048
+
+build.dir           ${worksrcpath}/src
+build.args-append   -o ../spf
+
+destroot {
+    xinstall -m 0755 ${worksrcpath}/spf ${destroot}${prefix}/bin/
+}


### PR DESCRIPTION
https://github.com/MHNightCat/superfile

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
