### PR TITLE
pdfjam: update to pdfjam 3.11

### DIFF
--- a/textproc/pdfjam/Portfile
+++ b/textproc/pdfjam/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            rrthomas pdfjam 3.10 v
+github.setup            rrthomas pdfjam 3.11 v
 categories              textproc pdf
 maintainers             {gmail.com:jjstickel @jjstickel} openmaintainer
 license                 GPL-2
@@ -22,9 +22,9 @@ long_description \
 
 github.tarball_from     releases
 
-checksums               rmd160  07464b84e6d2af74f0136f301b3de302ce0ca66c \
-                        sha256  a1a2e422949ece10190034283ac5267d1ec160369cbc56b4a524dfdf1adf2310 \
-                        size    121928
+checksums               rmd160  f1a2fc4482c72704c7b947b05bbce13d6cdaf36f \
+                        sha256  fcc85ec14fbb2363f02866b119aaada05b6b44af1c45224c22d407fffe0a8a2a \
+                        size    162801
 
 depends_run \
     bin:pdflatex:texlive-latex \
@@ -38,6 +38,11 @@ post-patch {
 }
 
 build {}
+
+test.run    yes
+test.cmd    bin/pdfjam
+test.target
+test.args   --version
 
 destroot {
     xinstall -m 755 ${worksrcpath}/bin/pdfjam ${destroot}${prefix}/bin/pdfjam


### PR DESCRIPTION
#### Description

Update to pdfjam 3.11.

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?