### PR TITLE
abseil-dependants: revbump after c++ std change

### DIFF
--- a/devel/Bear/Portfile
+++ b/devel/Bear/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 19
 legacysupport.use_mp_libcxx                 yes
 
 github.setup        rizsotto Bear 3.1.3
-revision            3
+revision            4
 
 checksums           rmd160  909b90269b3528c4960a634c47b76a534e389a87 \
                     sha256  389a5251a835cd156fad4f4e598d0bf8c66783a0d5835eba7f113ab5f26637f5 \

--- a/devel/apache-arrow/Portfile
+++ b/devel/apache-arrow/Portfile
@@ -15,7 +15,7 @@ legacysupport.newest_darwin_requires_legacy 15
 boost.version       1.81
 
 github.setup        apache arrow 13.0.0 apache-arrow-
-revision            9
+revision            10
 name                ${github.author}-${github.project}
 
 categories          devel

--- a/devel/grpc/Portfile
+++ b/devel/grpc/Portfile
@@ -8,7 +8,7 @@ PortGroup           compiler_blacklist_versions 1.0
 
 # NOTE: Also rev-bump 'apache-arrow' when updating this port
 github.setup        grpc grpc 1.48.4 v
-revision            8
+revision            9
 categories          devel
 maintainers         nomaintainer
 license             Apache-2

--- a/devel/protobuf3-cpp-upstream/Portfile
+++ b/devel/protobuf3-cpp-upstream/Portfile
@@ -20,7 +20,7 @@ set release_version \
 name            protobuf3-cpp-upstream
 github.setup    protocolbuffers protobuf 3.${release_version} v
 git.branch      v${release_version}
-revision        3
+revision        4
 
 categories      devel
 maintainers     {mascguy @mascguy} openmaintainer

--- a/devel/re2/Portfile
+++ b/devel/re2/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport   1.1
 github.setup        google re2 2024-04-01
 github.tarball_from archive
 epoch               1
-revision            1
+revision            2
 
 checksums           rmd160 6cff98a2c0ce263f8e76127830117994ec202e11 \
                     sha256 3f6690c3393a613c3a0b566309cf04dc381d61470079b653afc47c67fb898198 \

--- a/math/s2geometry/Portfile
+++ b/math/s2geometry/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
 github.setup        google s2geometry 0.11.1 v
-revision            1
+revision            2
 categories          math science
 license             Apache-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer

--- a/net/mtxclient/Portfile
+++ b/net/mtxclient/Portfile
@@ -8,7 +8,7 @@ PortGroup           boost 1.0
 
 github.setup        Nheko-Reborn mtxclient 0.9.2 v
 epoch               2
-revision            10
+revision            11
 
 checksums           rmd160  4584fdcd4d6632a531343f235ec2258f7ba38204 \
                     sha256  14df722738830510edf8768b24648568d46f392953c9b2f8d1bf749f0c12435d \


### PR DESCRIPTION
#### Description

After the change of the c++ standard used for building abseil in f013da941ee8e69ff11d57f4a5c213ac005bf5c3, its dependants need a rev-bump.

Should fix the following track tickets:
- [69909](https://trac.macports.org/ticket/69909)
- [69932](https://trac.macports.org/ticket/69932)

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.6 22G630 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
