### PR TITLE
codec2: avoid old Xcode gcc, it fails to build this

### DIFF
--- a/audio/codec2/Portfile
+++ b/audio/codec2/Portfile
@@ -10,17 +10,17 @@ license             LGPL-2.1
 maintainers         {ra1nb0w @ra1nb0w} openmaintainer
 
 description         Codec 2 is an open source speech codec designed for \
-    communications quality speech between 700 and 3200 bit/s.
-long_description    Codec 2 is an open source speech codec designed for \
-    communications quality speech between 700 and 3200 bit/s. The main \
-    application is low bandwidth HF/VHF digital radio. It fills a gap in \
-    open source voice codecs beneath 5000 bit/s and is released under the \
-    GNU Lesser General Public License (LGPL). Informal listening tests \
-    indicate that Codec 2 at 700 bits/s has better speech quality than \
-    MELP and is comparable to TWELP at 600 bit/s.  The Codec 2 project \
-    also contains several modems (OFDM, FDMDV, COHPSK and mFSK) carefully \
-    designed for digital voice over HF radio.
-homepage            http://www.rowetel.com/codec2.html
+                    communications quality speech between 700 and 3200 bit/s
+long_description    {*}${description}. The main application is low-bandwidth \
+                    HF/VHF digital radio. It fills a gap in open source \
+                    voice codecs beneath 5000 bit/s and is released under \
+                    the GNU Lesser General Public License (LGPL). Informal \
+                    listening tests indicate that Codec 2 at 700 bits/s \
+                    has better speech quality than MELP and is comparable \
+                    to TWELP at 600 bit/s. The Codec 2 project also contains \
+                    several modems (OFDM, FDMDV, COHPSK and mFSK) carefully \
+                    designed for digital voice over HF radio.
+homepage            https://www.rowetel.com/codec2.html
 
 github.setup        drowe67 codec2 1.2.0
 checksums           rmd160  c752e2de46d2dc3c61c133cbdeab5184c19d0284 \
@@ -29,9 +29,8 @@ checksums           rmd160  c752e2de46d2dc3c61c133cbdeab5184c19d0284 \
 revision            0
 epoch               2
 
-depends_lib-append \
-    port:libsamplerate \
-    port:speex
+depends_lib-append  port:libsamplerate \
+                    port:speex
 
 compiler.c_standard 1999
 # error: invalid suffix "b10101010" on integer constant

--- a/audio/codec2/Portfile
+++ b/audio/codec2/Portfile
@@ -34,6 +34,9 @@ depends_lib-append \
     port:speex
 
 compiler.c_standard 1999
+# error: invalid suffix "b10101010" on integer constant
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 
 configure.args-append \
     -DCMAKE_BUILD_TYPE="Release"


### PR DESCRIPTION
#### Description

Fix for old systems, minor portfile clean-up.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
