### PR TITLE
xdispatch2: fix build on macOS <10.11

### DIFF
--- a/devel/xdispatch2/Portfile
+++ b/devel/xdispatch2/Portfile
@@ -20,7 +20,12 @@ checksums           rmd160  84d03ffa9f18ef854943a19371644707e3b76ee6 \
 
 cmake.generator     Ninja
 
-compiler.cxx_standard   2011
+compiler.cxx_standard \
+                    2011
+# cancelable.cpp:30:8: error: thread-local storage
+# is not supported for the current target
+compiler.thread_local_storage \
+                    yes
 
 depends_build-append \
                     port:mz-cmaketools
@@ -64,7 +69,10 @@ platform darwin {
 
     # Does not yet build with libdispatch on 10.6:
     # https://github.com/emzeat/xdispatch2/issues/2
-    if {${os.major} > 10} {
+    # It also utilizes the QOS API available in macOS >10.10
+    # libdispatch_queue.cpp:139:38: error: use of undeclared
+    # identifier 'dispatch_queue_attr_make_with_qos_class'
+    if {${os.major} > 13} {
             default_variants-append \
                     +libdispatch
     }


### PR DESCRIPTION
#### Description

https://build.macports.org/builders/ports-10.10_x86_64-builder/builds/270375/steps/install-port/logs/stdio
https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/191277/steps/install-port/logs/stdio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
