### PR TITLE
textproc/jj: Add conflicts with jujutsu

### DIFF
--- a/textproc/jj/Portfile
+++ b/textproc/jj/Portfile
@@ -5,7 +5,7 @@ PortGroup           golang 1.0
 
 go.setup            github.com/tidwall/jj 1.9.2 v
 github.tarball_from archive
-revision            0
+revision            1
 
 description         JSON Stream Editor
 
@@ -21,6 +21,8 @@ installs_libs       no
 license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
+
+conflicts           jujutsu
 
 build.pre_args-append \
     -ldflags \"-X main.version=${version}\"


### PR DESCRIPTION
#### Description

The `jujutsu` port installs `jj` as does `textproc/jj`, but only `jujutsu` declares conflicts.

###### Type(s)

- [x] bugfix

###### Tested on

macOS 14.4.1 23E224 arm64
Xcode 15.3 15E204a

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tested basic functionality of all binary files?

  This is a special case where I installed `jujutsu` and then ran:

  ```console
  $ sudo port install
  --->  Computing dependencies for jj
   Error: Can't install jj because conflicting ports are active: jujutsu
  Error: Follow https://guide.macports.org/#project.tickets if you believe there is a bug.
  Error: Processing of port jj failed
  ```
