### PR TITLE
libgtksourceviewmm: fix build on older systems, restrict to Catalina and earlier

### DIFF
--- a/gnome/libgtksourceviewmm/Portfile
+++ b/gnome/libgtksourceviewmm/Portfile
@@ -27,6 +27,9 @@ depends_build	path:bin/doxygen:doxygen port:pkgconfig
 
 patchfiles	patch-glib-2.32.diff
 
+# Undefined symbols: "__Z8get_defsB5cxx11mPFbmE"
+compiler.cxx_standard 2011
+
 configure.cppflags-append "-L${prefix}/lib"
 
 livecheck.type  regex

--- a/gnome/libgtksourceviewmm/Portfile
+++ b/gnome/libgtksourceviewmm/Portfile
@@ -1,36 +1,43 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
+PortSystem      1.0
 
-name		libgtksourceviewmm
-version		0.3.1
+name            libgtksourceviewmm
+version         0.3.1
 revision        2
 license         LGPL-2+
 set branch      [join [lrange [split ${version} .] 0 1] .]
 
-description	gtksourceviewmm provides C++ wrappers for gtksourceview.
-long_description        ${description}
-maintainers	nomaintainer
+description     gtksourceviewmm provides C++ wrappers for gtksourceview.
+long_description \
+                {*}${description}
+maintainers     nomaintainer
 
-categories	gnome
-platforms	darwin
+categories      gnome
 
-homepage	https://www.gtkmm.org/
+homepage        https://www.gtkmm.org
 master_sites    gnome:sources/${name}/${branch}/
 
-use_bzip2	yes
-checksums	sha256 1084f0f826252191829097185c4f2fc88c2b3a2327054ba9056af90ff6cac2cf
+use_bzip2       yes
+checksums       sha256  1084f0f826252191829097185c4f2fc88c2b3a2327054ba9056af90ff6cac2cf \
+                rmd160  c19b99bdc7734a9b068e377dae0e4f4918b2fa3e \
+                size    382122
 
-depends_lib	port:libgnomemm port:gtksourceview \
-		port:libiconv port:gettext
-depends_build	path:bin/doxygen:doxygen port:pkgconfig
+depends_lib     port:gettext \
+                port:gtksourceview \
+                port:libgnomemm \
+                port:libiconv
+depends_build   path:bin/doxygen:doxygen \
+                port:pkgconfig
 
-patchfiles	patch-glib-2.32.diff
+patchfiles      patch-glib-2.32.diff
 
 # Undefined symbols: "__Z8get_defsB5cxx11mPFbmE"
-compiler.cxx_standard 2011
+compiler.cxx_standard \
+                2011
 
-configure.cppflags-append "-L${prefix}/lib"
+configure.cppflags-append \
+                "-L${prefix}/lib"
 
 livecheck.type  regex
 livecheck.url   http://ftp.gnome.org/pub/gnome/sources/${name}/${branch}/

--- a/gnome/libgtksourceviewmm/Portfile
+++ b/gnome/libgtksourceviewmm/Portfile
@@ -5,6 +5,8 @@ PortSystem      1.0
 name            libgtksourceviewmm
 version         0.3.1
 revision        2
+# Its dependency, gtksourceview, builds on Catalina and earlier.
+platforms       {darwin < 20}
 license         LGPL-2+
 set branch      [join [lrange [split ${version} .] 0 1] .]
 


### PR DESCRIPTION
#### Description

Fix building on older systems

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
