### PR TITLE
py-mistune: restore py27 subport to unbreak dependents

### DIFF
--- a/python/py-mistune/Portfile
+++ b/python/py-mistune/Portfile
@@ -12,7 +12,7 @@ supported_archs     noarch
 platforms           {darwin any}
 license             BSD
 
-python.versions     38 39 310 311 312
+python.versions     27 38 39 310 311 312
 
 maintainers         {stromnov @stromnov} openmaintainer
 
@@ -24,3 +24,11 @@ homepage            https://github.com/lepture/mistune
 checksums           rmd160  dd076a21de07126d228f6aabe6283a3f3a7e3686 \
                     sha256  fc7f93ded930c92394ef2cb6f04a8aabab4117a91449e72dcc8dfa646a508be8 \
                     size    90840
+
+if {${name} ne ${subport}} {
+    if {${python.version} == 27} {
+        python.pep517   no
+        depends_build-append \
+                    port:py${python.version}-setuptools
+    }
+}


### PR DESCRIPTION
#### Description

Subports was deleted without checking if something depends on it. And there are several ports that do.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
