### PR TITLE
2048.c: Fix conflicts with 2048.cpp

### DIFF
--- a/games/2048.c/Portfile
+++ b/games/2048.c/Portfile
@@ -6,7 +6,7 @@ PortGroup               makefile 1.0
 
 github.setup            mevdschee 2048.c 1.0.0 v
 github.tarball_from     archive
-revision                0
+revision                1
 categories              games
 license                 MIT
 maintainers             {@TheRealKeto gmail.com:therealketo} openmaintainer
@@ -22,3 +22,12 @@ compiler.c_standard     1999
 
 test.run                yes
 test.target             test
+
+destroot {
+    xinstall -m 755 ${worksrcpath}/2048 ${destroot}${prefix}/bin/c2048
+}
+
+notes "
+${name} has been renamed to c2048 to prevent any conflicts with
+other ports that provide a 2048 binary, like ${name}pp
+"


### PR DESCRIPTION
#### Description

Fix conflicts with `2048.cpp` by renaming `2048` -> `c2048` when installing the `2048.c` port

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
