### PR TITLE
d3dmetal: Don’t break everything

### DIFF
--- a/devel/d3dmetal/Portfile
+++ b/devel/d3dmetal/Portfile
@@ -10,10 +10,11 @@ maintainers         {@Gcenx gmail.com:gcenx83}
 homepage            https://developer.apple.com/games
 platforms           {darwin any >= 23}
 license             Restrictive
+# Yes this only supports x86_64 and only works on Apple Silicon
 supported_archs     x86_64
 description         Direct3D to Metal translation layer
 long_description    {*}${description}
-master_sites        https://download.developer.apple.com/Developer_Tools/Game_Porting_Toolkit_${version}/Game_Porting_Toolkit_${version}.dmg
+master_sites        https://download.developer.apple.com/Developer_Tools/Game_Porting_Toolkit_${version}
 distname            Game_Porting_Toolkit_${version}
 use_dmg             yes
 
@@ -30,7 +31,7 @@ pre-fetch {
         ui_error ""
         ui_error "Then paste this URL into your browser:"
         ui_error ""
-        ui_error "${master_sites}"
+        ui_error "${master_sites}/${distname}${extract.suffix}"
         ui_error ""
         ui_error "Place the downloaded file in this directory:"
         ui_error ""
@@ -70,8 +71,9 @@ platform darwin i386 {
     try {
         set is_rosetta2 [exec sysctl -in sysctl.proc_translated]
         if { ${is_rosetta2} != 1 } {
-            ui_error "${name} requires an Apple Silicon mac"
-            return -code error "unsupported platform"
+            # Change arch to arm64 to make it unsupported on Intel
+            # yes this is a nasty hack.
+            supported_archs arm64
         }
     }
 }


### PR DESCRIPTION
Simply force arm64 when the system isn’t running under Rosetta2

Some users might be running macports under a rosetta2 terminal session instead of arm64.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 x86_64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
