### PR TITLE
tig: Update to 2.5.10

### DIFF
--- a/devel/tig/Portfile
+++ b/devel/tig/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        jonas tig 2.5.8 tig-
+github.setup        jonas tig 2.5.10 tig-
 github.tarball_from releases
-revision            1
-checksums           rmd160  86b2c0cf87e704c7e8ff11108ce289f8138e2c71 \
-                    sha256  b70e0a42aed74a4a3990ccfe35262305917175e3164330c0889bd70580406391 \
-                    size    1179844
+revision            0
+checksums           rmd160  bee1e8579f89849499f54de952f58358f2b9d168 \
+                    sha256  f655cc1366fc10058a2bd505bb88ca78e653ff7526c1b81774c44b9d841210e3 \
+                    size    1183631
 
 categories          devel
 maintainers         {cal @neverpanic} \


### PR DESCRIPTION
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.6 22G630 x86_64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
