### PR TITLE
subprocess, git-tui, MicroTeX: fix for pre-Catalina systems with libc++

### DIFF
--- a/devel/git-tui/Portfile
+++ b/devel/git-tui/Portfile
@@ -3,8 +3,14 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+
+# filesystem
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx yes
 
 github.setup        ArthurSonzogni git-tui 1.2.0 v
+revision            1
 categories          devel sysutils
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer

--- a/devel/subprocess/Portfile
+++ b/devel/subprocess/Portfile
@@ -3,8 +3,14 @@
 PortSystem          1.0
 PortGroup           cmake 1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+
+# filesystem
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx yes
 
 github.setup        benman64 subprocess 0.4.0 v
+revision            1
 categories          devel
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer

--- a/tex/MicroTeX/Portfile
+++ b/tex/MicroTeX/Portfile
@@ -3,10 +3,16 @@
 PortSystem          1.0
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
 PortGroup           meson 1.0
+
+# filesystem
+legacysupport.newest_darwin_requires_legacy 18
+legacysupport.use_mp_libcxx yes
 
 github.setup        NanoMichael MicroTeX d87ebec8436ae01a1eb183d985c1375e39b2a542
 version             2023.05.29
+revision            1
 categories          tex
 license             MIT
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer


### PR DESCRIPTION
#### Description

A failure on < 10.15: https://build.macports.org/builders/ports-10.14_x86_64-builder/builds/209177/steps/install-port/logs/stdio

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.8.5
Xcode 5.x

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
