### PR TITLE
libass: update powerpc fix

### DIFF
--- a/multimedia/libass/Portfile
+++ b/multimedia/libass/Portfile
@@ -48,11 +48,6 @@ configure.args  --enable-fontconfig \
 # ass.h:421: error: wrong number of arguments specified for 'deprecated' attribute
 compiler.blacklist-append *gcc-3.* *gcc-4.*
 
-# https://trac.macports.org/ticket/65860
-platform darwin powerpc {
-    compiler.blacklist-append clang
-}
-
 if {${universal_possible} && [variant_isset universal]} {
     # Needed by configure to correctly set the yasm build flags.
     set merger_host(arm64)  "aarch64-apple-${os.platform}${os.major}.${os.minor}.0"
@@ -77,6 +72,13 @@ if {${universal_possible} && [variant_isset universal]} {
     }
     if {${configure.build_arch} eq "i386"} {
         configure.ldflags-append -Wl,-read_only_relocs,suppress
+    }
+    if {${configure.build_arch} eq "ppc"} {
+        # https://trac.macports.org/ticket/65860
+        compiler.blacklist-append   clang
+        # This is necessary if MacPorts itself is built for x86,
+        # but the build is for ppc via Rosetta.
+        configure.args-append       --build=powerpc-apple-${os.platform}${os.major}
     }
 }
 


### PR DESCRIPTION
#### Description

MacPorts base does not work correctly now if built for `ppc` on an Intel system. I.e., on Rosetta it has to be built for x86.
That breaks `libass`, which uses `uname`, I think, to detect the arch, and used `platform powerpc` to blacklist Xcode clang.
Fix that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 Rosetta
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
