### PR TITLE
gsl-devel: New port for testing only

### DIFF
--- a/math/gsl-devel/Portfile
+++ b/math/gsl-devel/Portfile
@@ -1,0 +1,115 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           compilers 1.0
+PortGroup           gnu_info 1.0
+
+name                gsl-devel
+version             2.7.100
+revision            0
+
+checksums           rmd160  2737a999806abc5c7f3ffaa2263a5af62678942f \
+                    sha256  db158d0866cff09bb508696a32c07dd6ea09bccfdf793bd2f88587299cc16b2a \
+                    size    8997432
+
+categories          math science
+maintainers         {@Dave-Allured noaa.gov:dave.allured} \
+                    openmaintainer
+license             GPL-3+
+homepage            https://www.gnu.org/software/gsl
+
+description         This is a test port only, for the GSL numerical library.
+
+long_description    The GNU Scientific Library (GSL) is a numerical library \
+                    for C and C++ programmers.  It is free software under the \
+                    GNU General Public License. \
+                    \
+                    The library provides a wide range of mathematical routines \
+                    such as random number generators, special functions and \
+                    least-squares fitting.  There are over 1000 functions in \
+                    total.
+
+# Normal releases.
+#master_sites        gnu
+
+# Alpha releases only.
+master_sites        ftp://alpha.gnu.org/gnu/gsl
+distname            gsl-${version}
+
+patchfiles-append   patch-configure.no_fixup_chains.diff
+
+configure.args      --infodir=${prefix}/share/info \
+                    --mandir=${prefix}/share/man
+
+configure.checks.implicit_function_declaration.whitelist-append \
+                    strchr
+
+test.run            yes
+test.target         check
+
+gnu_info.name       gsl-ref
+
+compilers.choose    cc
+compilers.setup
+
+set python_version 3.9
+set python_ver_no_dot [string map {. {}} ${python_version}]
+
+variant doc description {Build documentation} {
+    depends_build   port:ghostscript \
+                    bin:latexmk:latexmk \
+                    bin:latex:texlive \
+                    port:texlive-latex-extra \
+                    port:py${python_ver_no_dot}-sphinx \
+                    port:py${python_ver_no_dot}-sphinx_rtd_theme \
+                    port:py${python_ver_no_dot}-sphinxcontrib-websupport
+
+    patchfiles-append \
+                    patch-python_version.diff
+
+    post-patch {
+        reinplace "s|__MACPORTS_SPHINX_BUILD__|sphinx-build-${python_version}|g" ${worksrcpath}/doc/Makefile.in
+    }
+
+    post-build {
+        system -W ${worksrcpath}/doc "make latexpdf"
+        system -W ${worksrcpath}/doc "make html"
+    }
+
+    post-destroot {
+        xinstall -d ${destroot}${prefix}/share/doc/${name}
+        xinstall -c -m 0644 ${worksrcpath}/doc/_build/latex/gsl-ref.pdf ${destroot}${prefix}/share/doc/${name}
+        copy ${worksrcpath}/doc/_build/html ${destroot}${prefix}/share/doc/${name}/
+    }
+}
+
+variant optimize description "Provide further optimization options (depending on compiler used)" {
+    configure.optflags-append   -O3
+}
+
+platform darwin i386 {
+    if { [variant_isset optimize] } {
+        if { [clang_variant_isset] } {
+            configure.optflags  -march=native
+        } elseif { [gcc_variant_isset] } {
+            configure.optflags  -ftree-vectorize -march=native -mno-avx
+            if { ! ([variant_isset gcc44] ||
+                    [variant_isset gcc45] ||
+                    [variant_isset gcc46]) } {
+                ## Haswell's new instruction sets need to be disabled,
+                ## because these instructions are not recognized by
+                ## cctools' assembler
+                configure.optflags-append -mno-avx2 -mno-bmi -mno-bmi2
+            }
+        } else {
+            #Default compiler. Check if the compiler supports "native" architecture
+            if { [string match "clang" ${configure.cc}] } {
+                configure.optflags  -march=native
+            }
+        }
+    }
+}
+
+livecheck.type      regex
+livecheck.url       https://ftp.gnu.org/gnu/gsl/
+livecheck.regex     ${name}-(\[\\d.\]+)${extract.suffix}

--- a/math/gsl-devel/Portfile
+++ b/math/gsl-devel/Portfile
@@ -5,12 +5,12 @@ PortGroup           compilers 1.0
 PortGroup           gnu_info 1.0
 
 name                gsl-devel
-version             2.7.100
+version             2.7.101
 revision            0
 
-checksums           rmd160  2737a999806abc5c7f3ffaa2263a5af62678942f \
-                    sha256  db158d0866cff09bb508696a32c07dd6ea09bccfdf793bd2f88587299cc16b2a \
-                    size    8997432
+checksums           rmd160  5668b5983d3efb6d8cdcb8ed71d6bc74a22b3b57 \
+                    sha256  86a7493078ca1cb24028578f1842ffb4268574acc184542330740876a0028a7b \
+                    size    8997715
 
 categories          math science
 maintainers         {@Dave-Allured noaa.gov:dave.allured} \
@@ -53,7 +53,7 @@ gnu_info.name       gsl-ref
 compilers.choose    cc
 compilers.setup
 
-set python_version 3.9
+set python_version 3.12
 set python_ver_no_dot [string map {. {}} ${python_version}]
 
 variant doc description {Build documentation} {

--- a/math/gsl-devel/Portfile
+++ b/math/gsl-devel/Portfile
@@ -42,6 +42,7 @@ configure.args      --infodir=${prefix}/share/info \
                     --mandir=${prefix}/share/man
 
 configure.checks.implicit_function_declaration.whitelist-append \
+                    finite \
                     strchr
 
 test.run            yes

--- a/math/gsl-devel/files/patch-configure.no_fixup_chains.diff
+++ b/math/gsl-devel/files/patch-configure.no_fixup_chains.diff
@@ -1,0 +1,11 @@
+--- configure.orig	2024-05-12 12:42:13.000000000 -0600
++++ configure	2024-05-12 21:54:59.000000000 -0600
+@@ -8764,7 +8764,7 @@
+         10.[012],*|,*powerpc*-darwin[5-8]*)
+           _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+         *)
+-          _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
++          _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup $wl-no_fixup_chains' ;;
+       esac
+     ;;
+   esac

--- a/math/gsl-devel/files/patch-python_version.diff
+++ b/math/gsl-devel/files/patch-python_version.diff
@@ -1,0 +1,11 @@
+--- doc/Makefile.in.orig	2024-05-12 12:42:14.000000000 -0600
++++ doc/Makefile.in	2024-05-12 23:32:01.000000000 -0600
+@@ -545,7 +545,7 @@
+ noinst_DATA = $(figures) $(rst_files) $(static_files)
+ EXTRA_DIST = $(man_MANS) $(noinst_DATA) gsl-design.texi gsl-ref.info conf.py
+ SPHINX_OPTS = 
+-SPHINX_BUILD = sphinx-build
++SPHINX_BUILD = __MACPORTS_SPHINX_BUILD__
+ SPHINX_SOURCEDIR = .
+ SPHINX_BUILDDIR = _build
+ 


### PR DESCRIPTION
#### Description

Test port for GSL releases and port development.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

###### Tested on

CI only.  Macos 11, 12, 13; x86_64. Macos 14 ;arm.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
