### PR TITLE
symfony-cli: update to 5.8.19

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.17
+version             5.8.19
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  1b073ce95a80e0db82351bfea004e33904ffcf54 \
-                        sha256  4825aa3e825c4584cfa2979fc4c8b01c90886e00b91743ff60ffada2c924c9a8 \
-                        size    267082
+    checksums           rmd160  04de668569a82b67146a58b8fcca15176ef24081 \
+                        sha256  b33579bdf91eafe470c7213ffd4566a7c313419f4274d200c01f262929c2d5dc \
+                        size    267267
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  edc27cb259dc1cca12a063edbfb62d3e397b4df8 \
-                        sha256  230e348564e62780eb941933c1b4d2ba079f2f8a5e274d53988d4f41ae8c7ba9 \
-                        size    11397787
+    checksums           rmd160  0e778b3b51a270fdd4fc421831c2f0c6d16b3cdc \
+                        sha256  32f31f6e0610f4a45b9e0891aeb1d365a604b886fa70b10db97aa5e0f7ac8583 \
+                        size    11404300
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.8.19

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
