### PR TITLE
zvbi: unbreak build for gcc-4.x

### DIFF
--- a/multimedia/zvbi/Portfile
+++ b/multimedia/zvbi/Portfile
@@ -1,10 +1,14 @@
 #-*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           legacysupport 1.1
+
+# sincos
+legacysupport.newest_darwin_requires_legacy 12
 
 name                zvbi
 version             0.2.35
-revision            3
+revision            4
 categories          multimedia
 maintainers         nomaintainer
 license             GPL-2+
@@ -28,9 +32,14 @@ checksums           rmd160  36749d9f11994e0ff726ac3e9d11c790c7494455 \
                     sha256  fc883c34111a487c4a783f91b1b2bb5610d8d8e58dcba80c7ab31e67e4765318 \
                     size    1047761
 
-patchfiles-append \
-                    endian.patch \
-                    patch-i386.diff
+patchfiles-append   patch-i386.diff
+
+# This patch breaks the build with Xcode gcc.
+# https://trac.macports.org/ticket/68520
+if {![string match *gcc-4.* ${configure.compiler}]} {
+    patchfiles-append \
+                    endian.patch
+}
 
 # We are patching configure.in.
 use_autoreconf      yes

--- a/multimedia/zvbi/Portfile
+++ b/multimedia/zvbi/Portfile
@@ -17,14 +17,14 @@ description         A library to capture and decode vertical blanking interval d
 
 long_description    \
         The Zapping VBI library, in short ZVBI, provides functions to capture \
-        and decode VBI data. The vertical blanking interval (VBI) is an \
-        interval in a television signal that temporarily suspends \
-        transmission of the signal before next screen field begins.  The VBI \
+        and decode VBI data. The vertical blanking interval (VBI) \
+        is an interval in a television signal that temporarily suspends \
+        transmission of the signal before next screen field begins. The VBI \
         can be used to carry data, since anything sent during the VBI would \
         naturally not be displayed. This includes Closed Captions, Teletext, \
         VPS, WSS, and XDS.
 
-homepage            http://zapping.sourceforge.net/ZVBI/
+homepage            https://zapping.sourceforge.net/ZVBI
 master_sites        sourceforge:project/zapping/${name}/${version}
 use_bzip2           yes
 


### PR DESCRIPTION
#### Description

Do not apply the patch when building with old gcc, it breaks the build unnecessarily.
Also use legacysupport for `sincos`, revbump for that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
