### PR TITLE
wireshark4: update to 4.2.5, new qt6 variant, http/3 support

### DIFF
--- a/net/wireshark4/Portfile
+++ b/net/wireshark4/Portfile
@@ -63,6 +63,7 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:libssh \
                     port:lz4 \
                     port:nghttp2 \
+                    port:nghttp3 \
                     port:pcre2 \
                     port:speexdsp \
                     port:zstd
@@ -79,6 +80,8 @@ configure.args-append \
                     -DENABLE_MINIZIP=OFF \
                     -DBUILD_mmdbresolve=OFF \
                     -DENABLE_NETLINK=OFF \
+                    -DENABLE_NGHTTP2=ON \
+                    -DENABLE_NGHTTP3=ON \
                     -DENABLE_SMI=OFF \
                     -DENABLE_SNAPPY=OFF \
                     -DENABLE_ZLIB=OFF \

--- a/net/wireshark4/Portfile
+++ b/net/wireshark4/Portfile
@@ -30,12 +30,12 @@ if { ${os.platform} eq "darwin" && ${os.major} < 16 } {
     }
 }
 
-version         4.2.3
+version         4.2.5
 revision        0
 
-checksums       sha256  958bd5996f543d91779b1a4e7e952dcd7b0245fe82194202c3333a8f78795811 \
-                sha1    b9d2bc4dbcf59c7295fa6cc98f5210a4e98a0b4e \
-                size    44970016
+checksums       sha256  55e793ab87a9a73aac44336235c92cb76c52180c469b362ed3a54f26fbb1261f \
+                sha1    03293699260d2492166ac805ef0c10b8a6b531e6 \
+                size    45014156
 
 livecheck.type  regex
 livecheck.url   ${homepage}download/src/

--- a/net/wireshark4/Portfile
+++ b/net/wireshark4/Portfile
@@ -84,7 +84,7 @@ configure.args-append \
                     -DENABLE_ZLIB=OFF \
                     -DBUILD_wireshark=OFF
 
-variant qt5 conflicts no_gui description {Build wireshark with a qt5 GUI} {
+variant qt5 conflicts qt6 no_gui description {Build wireshark GUI with qt5} {
     PortGroup               qt5 1.0
 
     configure.args-replace  -DENABLE_APPLICATION_BUNDLE=OFF -DENABLE_APPLICATION_BUNDLE=ON
@@ -97,23 +97,23 @@ variant qt5 conflicts no_gui description {Build wireshark with a qt5 GUI} {
                             qtmultimedia \
                             qtsvg \
                             qttranslations
-
-    post-destroot {
-        move ${destroot}${prefix}/bin/Wireshark.app ${destroot}${applications_dir}/Wireshark.app
-        ## it appears that the binaries in the Wireshark.app/Contents/MacOS directory need
-        ##  an rpath entry to "${prefix}/lib" in order for various plugins to work.
-        ## cribbed from lang/gcc10
-        set mp_extra_rpath ${prefix}/lib
-        foreach binfile [ exec find ${destroot}${applications_dir}/Wireshark.app/Contents/MacOS -type f ] {
-            ui_debug "Ensuring binary '${binfile}' has RPATH '${mp_extra_rpath}'"
-            # Note install_name_tool returns a failure if the dylib already has the entry
-            # We don't want that here so force final status to be true...
-            system "install_name_tool -add_rpath ${mp_extra_rpath} ${binfile} > /dev/null 2>&1 ; true"
-        }
-    }
 }
 
-variant no_gui conflicts qt5 description {do not build the wireshark GUI} {
+variant qt6 conflicts qt5 no_gui description {Build wireshark GUI with qt6} {
+    PortGroup               qt6 1.0
+
+    configure.args-replace  -DENABLE_APPLICATION_BUNDLE=OFF -DENABLE_APPLICATION_BUNDLE=ON
+    configure.args-replace  -DBUILD_wireshark=OFF -DBUILD_wireshark=ON
+    configure.args-append   -DUSE_qt6=ON
+    qt6.depends_build       qttools
+    qt6.depends_lib         qtbase \
+                            qtmultimedia \
+                            qtsvg \
+                            qttranslations \
+                            qt5compat
+}
+
+variant no_gui conflicts qt5 qt6 description {do not build the wireshark GUI} {
     ## initial settings (above) handle this
 }
 
@@ -194,8 +194,28 @@ if {!${python_isset}} {
 
 default_variants +zlib +libsmi +gnutls +libmaxminddb +kerberos5 +chmodbpf
 
-if {![variant_isset qt5] && ![variant_isset no_gui]} {
-    default_variants-append +qt5
+if {![variant_isset qt5] && ![variant_isset qt6] && ![variant_isset no_gui]} {
+    if {${os.major} >=20} {
+        default_variants-append +qt6
+    } else {
+        default_variants-append +qt5
+    }
+}
+
+if {[variant_isset qt5] || [variant_isset qt6]} {
+    post-destroot {
+        move ${destroot}${prefix}/bin/Wireshark.app ${destroot}${applications_dir}/Wireshark.app
+        ## it appears that the binaries in the Wireshark.app/Contents/MacOS directory need
+        ##  an rpath entry to "${prefix}/lib" in order for various plugins to work.
+        ## cribbed from lang/gcc10
+        set mp_extra_rpath ${prefix}/lib
+        foreach binfile [ exec find ${destroot}${applications_dir}/Wireshark.app/Contents/MacOS -type f ] {
+            ui_debug "Ensuring binary '${binfile}' has RPATH '${mp_extra_rpath}'"
+            # Note install_name_tool returns a failure if the dylib already has the entry
+            # We don't want that here so force final status to be true...
+            system "install_name_tool -add_rpath ${mp_extra_rpath} ${binfile} > /dev/null 2>&1 ; true"
+        }
+    }
 }
 
 post-destroot {


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
