### PR TITLE
d3dmetal: Only run sysctl on Sonoma and later

### DIFF
--- a/devel/d3dmetal/Portfile
+++ b/devel/d3dmetal/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  0f40a2f7c4bf6a319fff915dacbceb8e473df1b1 \
                     sha256  2a86518d7fce89c304266654a76107d395a9a7557225096b73a834893482b7f1 \
                     size    27956812
 
-pre-fetch {
+fetch {
     if {![file isfile ${distpath}/${distfiles}]} {
         ui_error "This port cannot download the needed files automatically."
         ui_error "Please log in to your Apple Developer account at:"
@@ -68,12 +68,12 @@ notes "
 "
 
 platform darwin i386 {
-    try {
-        set is_rosetta2 [exec sysctl -in sysctl.proc_translated]
-        if { ${is_rosetta2} != 1 } {
-            # Change arch to arm64 to make it unsupported on Intel
-            # yes this is a nasty hack.
-            supported_archs arm64
+    pre-fetch {
+        if {${os.major} >= 23} {
+            set is_rosetta2 [exec sysctl -in sysctl.proc_translated]
+            if { ${is_rosetta2} != 1 } {
+                error "$name does not work on Intel hardware"
+            }
         }
     }
 }


### PR DESCRIPTION
Closes https://trac.macports.org/ticket/69983

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 x86_64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
