### PR TITLE
minicom: fix for old systems

### DIFF
--- a/comms/minicom/Portfile
+++ b/comms/minicom/Portfile
@@ -9,7 +9,6 @@ gitlab.setup        minicom-team minicom 2.9
 revision            0
 categories          comms
 maintainers         nomaintainer
-platforms           darwin
 license             GPL-2+
 
 description         Menu driven communications program
@@ -21,6 +20,11 @@ long_description    Minicom is a menu driven communications program. It \
 checksums           rmd160  671b178a62b62c360b053baab943fdba9bacdcd9 \
                     sha256  9efbb6458140e5a0de445613f0e76bcf12cbf7a9892b2f53e075c2e7beaba86c \
                     size    681585
+
+# cc1: error: unrecognized command line option "-Wno-format-truncation"
+# Undefined symbols: "__Static_assert"
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 
 depends_build       port:pkgconfig
 


### PR DESCRIPTION
#### Description

(I tried to patch out the flag and use gcc-4.2 initially, but then linking failed due to missing Static assert.)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
