### PR TITLE
gk: update to v2.0.0

### DIFF
--- a/devel/gk/Portfile
+++ b/devel/gk/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               github 1.0
 
-github.setup            gitkraken gk-cli 1.6.1 v
+github.setup            gitkraken gk-cli 2.0.0 v
 name                    gk
 github.tarball_from     releases
 
@@ -25,13 +25,13 @@ long_description        ${name} is GitKraken on the command line. It makes worki
                         to visualize git information when you need it.
 
 checksums               ${name}_${version}_macOS_arm64.zip \
-                            sha256  004023ed133532f5daab8e2f5d5126f00c00b1135fa54c7dcc932faf96a476c7 \
-                            rmd160  0c139b32045161999d6784a4ca043dedc6cf10cb \
-                            size    23461717 \
+                            sha256  36be7a2e111b7ac961527fceee0857c20bb7844f7b9f4f35e2a7518a82d53840 \
+                            rmd160  92d1d21542d64a4051442d2350d4a8135cd8df96 \
+                            size    11899037 \
                         ${name}_${version}_macOS_x86_64.zip \
-                            sha256  9f23cbc098b32bdb4b916965a3a713913b4f3dfaf0a0286d6c46b67b8ad0cd73 \
-                            rmd160  7b0fd543bd474aca2e296a8c98db8c1406c022d4 \
-                            size    25405422
+                            sha256  719f87bca4448ae5dfdcd61723b6c1a5f6b0f1472a53032cc5e71f9248cdb502 \
+                            rmd160  9d7515579a49614e5b89b028f39cf5dbaf8404b5 \
+                            size    12877324
 
 extract.mkdir           yes
 


### PR DESCRIPTION
#### Description

Update to v2.0.0

###### Type(s)
- [X] update

###### Tested on
macOS 14.3.1 23D60 x86_64
Xcode 15.3 15E204a

###### Verification 
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
