### PR TITLE
xscreensaver: fix build on macOS <10.13

### DIFF
--- a/x11/xscreensaver/Portfile
+++ b/x11/xscreensaver/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           active_variants 1.1
+PortGroup           compiler_blacklist_versions 1.0
 
 name                xscreensaver
 version             6.08
@@ -38,6 +39,17 @@ require_active_variants path:lib/pkgconfig/gtk+-3.0.pc:gtk3 x11
 
 # Fix "No GL visuals" when running in fullscreen
 patchfiles          patch-driver-subprocs.diff
+
+# Missing 'pthread_attr_set_qos_class_np' on macOS <10.10
+if {${os.platform} eq "darwin" && ${os.major} < 14} {
+    patchfiles-append   patch-ignore-qos.diff
+}
+
+# marbling.c:174:9: error: cannot convert between vector
+# values of different size ('v_hi' (vector of 8 'int16_t'
+# values) and 'int16_t' (aka 'short')) on macOS <10.13
+compiler.blacklist-append \
+                    {clang < 1000}
 
 configure.args      --with-app-defaults=${prefix}/share/X11/app-defaults \
                     --with-fontdir=${prefix}/share/fonts/TTF

--- a/x11/xscreensaver/files/patch-ignore-qos.diff
+++ b/x11/xscreensaver/files/patch-ignore-qos.diff
@@ -1,0 +1,15 @@
+--- utils/thread_util.c
++++ utils/thread_util.c
+@@ -718,12 +718,6 @@ void *io_thread_create(struct io_thread *self, void *parent, void *(*start_routi
+ 		pthread_attr_t attr;
+ 		pthread_attr_t *attr_ptr = NULL;
+ 
+-#   if (defined __APPLE__ && defined __MACH__)
+-		/* For Apple silicon. Requires macOS 10.10 or iOS 8.0. */
+-		attr_ptr = &attr;
+-		pthread_attr_set_qos_class_np(attr_ptr, QOS_CLASS_USER_INTERACTIVE, 0);
+-#   endif
+-
+ 		if(stacksize)
+ 		{
+ 			attr_ptr = &attr;


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
