### PR TITLE
google-cloud-sdk: update to 476.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             475.0.0
+version             476.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  3c27788325ca0ba66879a1f9aae6dbe565e5eada \
-                    sha256  857c90481f3eb819f88eb7f48720b9c1d324de73667bac216fa8419ba34439c7 \
-                    size    123658464
+    checksums       rmd160  4dbffec0718eb55f24ecc1eaa4fbb601c0d04957 \
+                    sha256  dd3d9a4049754b07b641b9c4edea646a56623119714f112104fe03112a161bfd \
+                    size    124878580
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  b31765d955f4141fa8a4125bd4cc0aeeacfc2e95 \
-                    sha256  3f608118dbb8b9c2797a2bf7e4c763432a7eff18c4f801b6292ab10be5e61c1d \
-                    size    124944507
+    checksums       rmd160  44ae8eaabb0ff314820c6c073fa7a46e3580b532 \
+                    sha256  4d066403c15debb61934de3a8c946691480659d94c09358e0fd7a4452d7e9bfd \
+                    size    126164859
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  60d8af06f0fc8d514b2c83a7e6a9caea8b615759 \
-                    sha256  24b506612beedaf01219b37de92a87461dd3c8edc8055828b765788d015e50b2 \
-                    size    122002985
+    checksums       rmd160  2e064f2702ab816c02e3d2a3eb90d400319a07ee \
+                    sha256  6c26b5a608a6a317cda672cead7da520cdca59f758350532f8d7adca6240c677 \
+                    size    122487959
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 476.0.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?