### PR TITLE
skaffold: update to 2.12.0

### DIFF
--- a/devel/skaffold/Portfile
+++ b/devel/skaffold/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        GoogleContainerTools skaffold 2.11.1 v
+github.setup        GoogleContainerTools skaffold 2.12.0 v
 revision            0
 
 categories          devel
@@ -22,9 +22,9 @@ homepage            https://skaffold.dev
 
 github.tarball_from archive
 
-checksums           rmd160  7e07e42d9e88e819a80edfaa2ddf821d1a442227 \
-                    sha256  2b0d7e3bf6b0f744ba5214b8f8d8429a207a3bfb03bf3d975dda0039813e052c \
-                    size    61134098
+checksums           rmd160  018275822dc6218873467325bbae787f7e33cda4 \
+                    sha256  3c0900ce41df0f3ec7956c15b66af73dbbf5eedd5077f7136eb69225cfa9bfa8 \
+                    size    61145914
 
 depends_build       port:go
 
@@ -32,6 +32,11 @@ use_configure       no
 
 build.env-append    VERSION=${version} LOCAL=true
 build.target
+
+test.run    yes
+test.cmd    out/${name}
+test.target
+test.args   version
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/out/${name} ${destroot}${prefix}/bin/${name}


### PR DESCRIPTION
#### Description

Update to Skaffold 2.12.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?