### PR TITLE
abseil-dependents: Use c++17 standard

### DIFF
--- a/devel/protobuf3-cpp-upstream/Portfile
+++ b/devel/protobuf3-cpp-upstream/Portfile
@@ -17,7 +17,7 @@ set release_version \
 name            protobuf3-cpp-upstream
 github.setup    protocolbuffers protobuf 3.${release_version} v
 git.branch      v${release_version}
-revision        0
+revision        1
 
 categories      devel
 maintainers     {mascguy @mascguy} openmaintainer
@@ -61,7 +61,7 @@ patchfiles-append cmake-zlib-include.diff
 # https://github.com/protocolbuffers/protobuf/commit/a8a9bd2e4990fd5e0f0098bdfbe62bc00783eab7
 patchfiles-append patch-unbreak-time.diff
 
-compiler.cxx_standard   2014
+compiler.cxx_standard   2017
 compiler.thread_local_storage   yes
 # error: constexpr constructor never produces a constant expression [-Winvalid-constexpr]
 compiler.blacklist {clang < 900}

--- a/devel/re2/Portfile
+++ b/devel/re2/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport   1.1
 github.setup        google re2 2024-04-01
 github.tarball_from archive
 epoch               1
-revision            3
+revision            4
 
 checksums           rmd160 6cff98a2c0ce263f8e76127830117994ec202e11 \
                     sha256 3f6690c3393a613c3a0b566309cf04dc381d61470079b653afc47c67fb898198 \
@@ -33,7 +33,7 @@ patchfiles          patch-re2pc-avoid-overlinking.diff
 legacysupport.newest_darwin_requires_legacy 15
 
 compiler.cxx_standard \
-                    2014
+                    2017
 compiler.thread_local_storage \
                     yes
 

--- a/math/s2geometry/Portfile
+++ b/math/s2geometry/Portfile
@@ -8,7 +8,7 @@ PortGroup           legacysupport 1.1
 PortGroup           openssl 1.0
 
 github.setup        google s2geometry 0.11.1 v
-revision            3
+revision            4
 categories          math science
 license             Apache-2
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
@@ -36,7 +36,8 @@ platform powerpc {
 }
 
 # C++ standard should match that of abseil port:
-compiler.cxx_standard   2014
+compiler.cxx_standard  \
+                    2017
 
 configure.args-append \
                     -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
#### Description

This PR is a followup to #23907 and updates the dependents of abseil to also use c++17 standard.

The dependents `Bear` and `apache-arrow` already use c++17 and `mtxclient` even c++20, so these were not updated.

I'm not sure if `protobuf-c` as a recursive dependent must be updated, too? 

Relevant ticket on trac: [https://trac.macports.org/ticket/69975](https://trac.macports.org/ticket/69975)

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.6 22G630 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
