### PR TITLE
tmate: fix build with gcc

### DIFF
--- a/sysutils/tmate/Portfile
+++ b/sysutils/tmate/Portfile
@@ -19,6 +19,14 @@ long_description    ${description}
 
 patchfiles-append   patch-configure.ac
 
+# https://github.com/tmate-io/tmate/issues/302
+if {[string match *gcc* ${configure.compiler}]} {
+    # cc1: error: unrecognized command line option "-Wno-null-pointer-arithmetic"
+    post-patch {
+        reinplace "s|-Wno-null-pointer-arithmetic||" ${worksrcpath}/Makefile.am
+    }
+}
+
 depends_build       port:pkgconfig
 
 depends_lib         port:libevent \
@@ -27,3 +35,5 @@ depends_lib         port:libevent \
                     port:libssh
 
 use_autoreconf      yes
+
+compiler.c_standard 1999


### PR DESCRIPTION
#### Description

Fix building with gcc

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8
Xcode 3.2.6

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
