### PR TITLE
git: add license_noconflict openssl3

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -41,6 +41,7 @@ default_variants    +doc +pcre +credential_osxkeychain +diff_highlight
 
 categories          devel
 license             GPL-2 LGPL-2.1+
+license_noconflict  openssl3
 installs_libs       no
 
 if {${name} eq ${subport}} {


### PR DESCRIPTION
#### Description

git does not link against openssl3; this should allow distributing it.

###### Type(s)

- [x] bugfix

###### Tested on
macOS 14.4.1 23E224 x86_64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?