### PR TITLE
R-RcppRedis: move R-RcppMsgPack to lib deps, revbump

### DIFF
--- a/R/R-RcppRedis/Portfile
+++ b/R/R-RcppRedis/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           R 1.0
 
 R.setup             cran eddelbuettel RcppRedis 0.2.4
-revision            1
+revision            2
 categories-append   devel
 maintainers         nomaintainer
 license             GPL-2+
@@ -15,11 +15,13 @@ checksums           rmd160  f5fb4eef06fa4b79c398c92ec46a3af747932db4 \
                     sha256  c91f9c2625e48901324c93789412c4dbde12bc61f4f610ffb8a4fddeb12ee0d8 \
                     size    1067941
 
+# RcppMsgPack is optional, but desirable.
+# Configure script checks for its presence.
 depends_lib-append  port:hiredis \
                     port:R-RApiSerialize \
-                    port:R-Rcpp
+                    port:R-Rcpp \
+                    port:R-RcppMsgPack
 
-depends_test-append port:R-RcppMsgPack \
-                    port:R-tinytest
+depends_test-append port:R-tinytest
 
 test.run            yes


### PR DESCRIPTION
#### Description

While `R-RcppMsgPack` is not strictly required, it is desirable as a lib dependency, and suggested by configure.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
