### PR TITLE
openmotif: unbreak after recent update

### DIFF
--- a/x11/openmotif/Portfile
+++ b/x11/openmotif/Portfile
@@ -46,12 +46,13 @@ patchfiles      wcs-functions.patch \
 # See https://trac.macports.org/ticket/42847
 if {[string match "*clang*" ${configure.compiler}]} {
     patchfiles-append clang-unsupported-cflags.patch
-}
 
-# error: incompatible function pointer types passing 'void (char *)'
-# to parameter of type 'void (*)(String) __attribute__((noreturn))'
-#     XtSetErrorHandler (WmXtErrorHandler)
-configure.cflags-append -Wno-error=incompatible-function-pointer-types
+    # error: incompatible function pointer types passing 'void (char *)'
+    # to parameter of type 'void (*)(String) __attribute__((noreturn))'
+    #     XtSetErrorHandler (WmXtErrorHandler)
+    # But adding this flag unconditionally breaks build with gcc-4.2.
+    configure.cflags-append -Wno-error=incompatible-function-pointer-types
+}
 
 configure.args  --enable-xft \
                 --enable-jpeg \


### PR DESCRIPTION
#### Description

Last update unconditionally added a flag which broken the build with gcc.
Fix that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
