### PR TITLE
bazel: upgrade to 7.1.2

### DIFF
--- a/devel/bazel/Portfile
+++ b/devel/bazel/Portfile
@@ -12,7 +12,15 @@ legacysupport.newest_darwin_requires_legacy 13
 epoch               1
 
 # List of all bazel sub-ports ( now obsolete )
-set bazel_subports {bazel-0.25 bazel-2.0 bazel-3.1 bazel-3.5 bazel-3.7}
+set bazel_subports {
+    bazel-0.25
+    bazel-2.0
+    bazel-3.1
+    bazel-3.5
+    bazel-3.7
+    bazel-6
+}
+
 set all_bazels ${bazel_subports}
 lappend all_bazels bazel
 
@@ -36,6 +44,32 @@ set min_darwin      16
 if { ${name} eq ${subport} } {
 
     # Main port
+    github.setup    bazelbuild ${name} 7.1.2
+    revision        0
+    checksums       rmd160  91c53502b2661dc2d37416dc503d304e8c1657d8 \
+                    sha256  9cf6ed2319c816919d97015eef6d0c5942cd1aed48e03c73ba0815d953ed61ab \
+                    size    168632652
+
+    set bazel_min_xcode 10.3
+    compiler.blacklist-append {clang < 1000}
+    compiler.blacklist-append {macports-clang-[5-9].0}
+
+    # fix deprectation warnings causing build failure for xcode >= 15
+    # upstream issue: https://github.com/bazelbuild/bazel/issues/20076
+    # fixed in commit  https://github.com/meteorcloudy/bazel/commit/1297bacf2f4470c23e12c3d79e5984c4d2f307ea
+    # included in bazel since 7.0.0 RC5
+    if {[vercmp ${xcodeversion} 15] >= 0} {
+        set extra_args "--copt=-Wno-deprecated-builtins --host_copt=-Wno-deprecated-builtins ${extra_args}"
+    }
+
+    # Required java version.
+    java.version    21
+    # LTS JDK port to install if required java not found
+    java.fallback   openjdk21
+
+    conflicts       bazel-6
+
+} elseif { "bazel-6" eq ${subport} } {
     github.setup    bazelbuild ${name} 6.5.0
     revision        0
     checksums       rmd160  ae91479a3518c99307029b48a8d449766dfd393e \
@@ -53,6 +87,14 @@ if { ${name} eq ${subport} } {
     if {[vercmp ${xcodeversion} 15] >= 0} {
         set extra_args "--copt=-Wno-deprecated-builtins --host_copt=-Wno-deprecated-builtins ${extra_args}"
     }
+
+    # Required java version.
+    java.version    11
+    # LTS JDK port to install if required java not found
+    java.fallback   openjdk11
+
+    conflicts       bazel
+
 } elseif { "bazel-3.7" eq ${subport} } {
     PortGroup       obsolete 1.0
 
@@ -113,10 +155,6 @@ if { ${os.platform} eq "darwin" && ${os.major} < ${min_darwin} } {
     }
 }
 
-# Required java version.
-java.version        11
-# LTS JDK port to install if required java not found
-java.fallback       openjdk11
 # JDK only needed at build time, but java PG sets lib dependency so
 # declare no conflict to allow redistribution of binaries.
 license_noconflict  ${java.fallback}
@@ -163,7 +201,7 @@ configure.sdk_version
 configure.ccache    no
 
 # Use Python 3
-set py3ver 3.11
+set py3ver 3.12
 
 depends_lib-append  port:cctools
 


### PR DESCRIPTION
- create new subport for Bazel 6
- use Python 3.12

Fixes: https://trac.macports.org/ticket/70005

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with ~`sudo port -vst install`~ `sudo port -d install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
