### PR TITLE
ruby-build: Upgrade to 20240517

### DIFF
--- a/ruby/ruby-build/Portfile
+++ b/ruby/ruby-build/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        rbenv ruby-build 20240501 v
+github.setup        rbenv ruby-build 20240517 v
 github.tarball_from archive
 categories          ruby
 license             MIT
@@ -17,9 +17,9 @@ maintainers         {mojca @mojca} \
 description         Compile and install Ruby
 long_description    {*}${description}
 
-checksums           rmd160  5c308b5da93dd043f2c6df346bd6d697360eb6ce \
-                    sha256  03601991e0e99ae5e75b1047e77498e329c3f8253cd3de5adabab56c05886079 \
-                    size    89667
+checksums           rmd160  88c6dd80e48e91427ba4530e9576b8e6d7dc2486 \
+                    sha256  6b4c5cc35f1049adcfb8ef3812d26df4529552cd818a58a749c98165cd7055f0 \
+                    size    89751
 
 use_configure       no
 build {}


### PR DESCRIPTION
#### Description

ruby-build: Upgrade to 20240517

##### Tested on

macOS 14.5 23F79 arm64
Xcode 15.3 15E204a

##### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
