### PR TITLE
string_theory: New port, version 3.8

### DIFF
--- a/devel/string_theory/Portfile
+++ b/devel/string_theory/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           cmake 1.1
+
+github.setup        zrax string_theory 3.8
+revision            0
+
+categories          devel
+license             MIT
+
+description         C++ string library
+long_description    Flexible modern C++ string library with type-safe formatting
+
+maintainers         {@dpogue dpogue.ca:darryl} openmaintainer
+
+checksums           rmd160  2336921819ec5617cc2eccf4121e892f3afc7971 \
+                    sha256  db8174e05a75fa0cbc0821d0ac279dcd165947d54b9280bdf4aac0054c78c22b \
+                    size    68721
+
+if {[variant_isset debug]} {
+    cmake.build_type Debug
+} else {
+    cmake.build_type RelWithDebInfo
+}
+
+compiler.cxx_standard 2011
+
+configure.args-append \
+                    -DST_BUILD_TESTS:BOOL=OFF
+
+
+variant tests description {Enable test support} {
+    fetch.type      git
+    post-fetch {
+        system -W ${worksrcpath} "git submodule update --init"
+    }
+
+    configure.args-replace \
+                    -DST_BUILD_TESTS:BOOL=OFF \
+                    -DST_BUILD_TESTS:BOOL=ON
+
+    test.run        yes
+}


### PR DESCRIPTION
#### Description

Add the [string_theory](https://github.com/zrax/string_theory) C++ string library as a port.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
