### PR TITLE
heimdal: use heimdal fallback instead of dispatch on powerpc

### DIFF
--- a/net/heimdal/Portfile
+++ b/net/heimdal/Portfile
@@ -87,6 +87,13 @@ post-patch {
     }
 }
 
+platform darwin powerpc {
+    # heimdal has its own fallback, use it on powerpc
+    # until libdispatch is fixed and confirmed to work.
+    configure.args-append \
+                    ac_cv_prog_GCD_MIG=no
+}
+
 test.run            yes
 test.target         check
 


### PR DESCRIPTION
#### Description

Libdispatch headers may be present, but we do not want to use `libdispatch` on PowerPC, until it is fixed properly and known to work. Thankfully, Heimdal has a fallback implementation, we just need to turn off dispatch from configure.
I am not adding a variant to use `libdispatch-legacy` port on ppc, since while that may work, for now rather use the upstream code.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
