### PR TITLE
weechat: Remove extra warning flags to fix old GCC

### DIFF
--- a/irc/weechat/Portfile
+++ b/irc/weechat/Portfile
@@ -40,13 +40,12 @@ long_description    WeeChat (Wee Enhanced Environment for Chat) is \
 
 categories          irc
 maintainers         {isi.edu:calvin @cardi} openmaintainer
-platforms           darwin
 
 depends_build-append \
                     port:asciidoctor \
                     port:docbook-xsl-nons \
-                    port:pkgconfig \
-                    port:libxslt
+                    port:libxslt \
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append  port:curl \
                     port:gettext \
@@ -60,6 +59,8 @@ depends_run-append  path:etc/openssl/cert.pem:curl-ca-bundle
 depends_test-append port:cpputest
 
 license_noconflict  asciidoctor
+
+patchfiles          no-extra-gcc-warnings.patch
 
 configure.args-append \
                     -DENABLE_GUILE=OFF \
@@ -119,7 +120,7 @@ variant ruby30 description "Bindings for Ruby 3.0 plugins" conflicts ruby31 ruby
     configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
     depends_lib-append      port:ruby30
 
-    patchfiles              FindRuby.cmake.diff
+    patchfiles-append       FindRuby.cmake.diff
 }
 
 variant ruby31 description "Bindings for Ruby 3.1 plugins" conflicts ruby30 ruby32 {
@@ -127,7 +128,7 @@ variant ruby31 description "Bindings for Ruby 3.1 plugins" conflicts ruby30 ruby
     configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
     depends_lib-append      port:ruby31
 
-    patchfiles              FindRuby.cmake.diff
+    patchfiles-append       FindRuby.cmake.diff
 }
 
 variant ruby32 description "Bindings for Ruby 3.2 plugins" conflicts ruby30 ruby31 {
@@ -135,7 +136,7 @@ variant ruby32 description "Bindings for Ruby 3.2 plugins" conflicts ruby30 ruby
     configure.env-append    PKG_CONFIG_PATH=${prefix}/lib/pkgconfig
     depends_lib-append      port:ruby32
 
-    patchfiles              FindRuby.cmake.diff
+    patchfiles-append       FindRuby.cmake.diff
 }
 
 

--- a/irc/weechat/files/no-extra-gcc-warnings.patch
+++ b/irc/weechat/files/no-extra-gcc-warnings.patch
@@ -1,0 +1,13 @@
+Remove extra warning flags that are not understood by old GCC versions.
+https://github.com/weechat/weechat/issues/891#issuecomment-1693308171
+--- CMakeLists.txt.orig	2024-04-07 11:37:29.000000000 -0500
++++ CMakeLists.txt	2024-05-17 23:06:30.000000000 -0500
+@@ -33,8 +33,6 @@
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char -fms-extensions -Wall -Wextra")
+ if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+   # extra options specific to gcc/g++
+-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat-overflow=2 -Wformat-truncation=2")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat-overflow=2 -Wformat-truncation=2")
+ endif()
+ 
+ # version


### PR DESCRIPTION
#### Description

Remove extra warning flags to fix builds with gcc < 7

Closes: https://trac.macports.org/ticket/70002

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix
