### PR TITLE
util-linux: Fix 32-bit universal builds

### DIFF
--- a/devel/util-linux/Portfile
+++ b/devel/util-linux/Portfile
@@ -80,11 +80,26 @@ configure.args      --disable-agetty \
                     --without-audit \
                     --without-python
 
-if {${configure.build_arch} in [list arm i386 ppc]} {
-    # For some reason, upstream decided to break the build well in advance.
-    # configure: error: could not enable timestamps after mid-January 2038.
-    configure.args-append \
-                    --disable-year2038
+# The build procedure now includes checking related to the Y2038 problem, which
+# fails on 32-bit builds (due to the 32-bit time_t).  This check can be disabled
+# with the --disable-year2038 configure option.  Although it's probably OK
+# to set this option unconditionally, for maximum safety we only set it when
+# needed, i.e. when there's a 32-bit target.  This needs to take into account
+# all target archs in universal builds.
+#
+if {[variant_isset universal]} {
+    set target_archs ${configure.universal_archs}
+} else {
+    set target_archs ${configure.build_arch}
+}
+set have_32bit no
+foreach arch ${target_archs} {
+    if {${arch} in [list arm i386 ppc]} {
+        set have_32bit yes
+    }
+}
+if {${have_32bit}} {
+    configure.args-append --disable-year2038
 }
 
 configure.checks.implicit_function_declaration.whitelist-append strchr


### PR DESCRIPTION
The previous fix for 32-bit builds only took build_arch into account, which didn't fix, e.g., universal builds on x86_64.  This version looks at all target architectures.

Since this only affects previously broken builds, no revbump is necessary.

TESTED:
Tested on 10.4-10.5 ppc, 10.5-10.6 ppc (i386 Rosetta), 10.4-10.6 i386, 10.4-12.x x86_64, and 11.x-14.x arm64.
Builds on all tested platforms except 10.4 ppc +universal (due to broken dependency).
Passes token "port test" in all buildable cases.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
```
Mac OS X 10.4.11 8S165, PPC, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, i386, Xcode 2.5 8M2558
Mac OS X 10.4.11 8S2167, x86_64, Xcode 2.5 8M2558
Mac OS X 10.5.8 9L31a, PPC, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, i386, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, x86_64, Xcode 3.1.4 9M2809
Mac OS X 10.5.8 9L31a, PPC (i386 Rosetta), Xcode 3.1.4 9M2809
Mac OS X 10.6.8 10K549, i386, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, x86_64, Xcode 3.2.6 10M2518
Mac OS X 10.6.8 10K549, PPC (i386 Rosetta), Xcode 3.2.6 10M2518
Mac OS X 10.7.5 11G63, x86_64, Xcode 4.6.3 4H1503
OS X 10.8.5 12F2560, x86_64, Xcode 5.1.1 5B1008
OS X 10.9.5 13F1911, x86_64, Xcode 6.2 6C131e
OS X 10.10.5 14F2511, x86_64, Xcode 7.2 7C68
OS X 10.11.6 15G22010, x86_64, Xcode 8.1 8B62
macOS 10.12.6 16G2136, x86_64, Xcode 9.2 9C40b
macOS 10.13.6 17G14042, x86_64, Xcode 10.1 10B61
macOS 10.14.6 18G9323, x86_64, Xcode 11.3.1 11C505
macOS 10.15.7 19H15, x86_64, Xcode 12.4 12D4e
macOS 11.7.10 20G1427, x86_64, Xcode 13.2.1 13C100
macOS 11.7.10 20G1427, arm64, Xcode 13.2.1 13C100
macOS 12.7.4 21H1123, x86_64, Xcode 14.2 14C18
macOS 12.7.4 21H1123, arm64, Xcode 14.2 14C18
macOS 13.6.6 22G630, arm64, Xcode 15.2 15C500b
macOS 14.4.1 23E224, arm64, Xcode 15.3 15E204a
```

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [N/A] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
