### PR TITLE
perl5: add perl5.38

### DIFF
--- a/lang/perl5/Portfile
+++ b/lang/perl5/Portfile
@@ -35,6 +35,7 @@ set perl5.versions_info {
     5.32 1  3 ad9013fa389e3e73940c90b7d4ffd542a0cafc70  57cc47c735c8300a8ce2fa0643507b44c4ae59012bfdad0121313db639e02309  12610988
     5.34 3  1 092d75196ffa236528075c73bac365e1df9edb41  0b15c830a9a295c9f9439b6cda389300f0b18092686eaef47fbc9c92f5930ee1  12866356
     5.36 3  1 96c867d175fb54b631dbe9237e3d7df2c96ec8cb  45a228daef66d02fdccc820e71f87e40d8e3df1fc4431f8d4580ec08033866bd  13141248
+    5.38 2  0 febb7a0e281e16f217259441da1fa1d1b8dfe33f  d91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8  13679524
 }
 
 foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5.size} ${perl5.versions_info} {
@@ -168,6 +169,12 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
                     Configure Makefile.SH cpan/DB_File/config.in
         }
 
+        # Rather not revbump many p5 ports, so just fix it for new versions
+        set man1ext 1pm
+        if {${perl5.major} >= 5.38} {
+            set man1ext 1
+        }
+
         configure.ccache    no
         configure.distcc    no
         configure.env       LC_ALL=C
@@ -183,7 +190,7 @@ foreach {perl5.v perl5.subversion perl5.revision perl5.rmd160 perl5.sha256 perl5
                             -Dusethreads \
                             -Duseshrplib \
                            {-Dcc="$CC"} \
-                            -Dman1ext=1pm \
+                            -Dman1ext=${man1ext} \
                             -Dman3ext=3pm \
                             -Dinstallstyle='lib/perl5' \
                             -Dman1dir='${prefix}/share/man/man1' \
@@ -297,7 +304,7 @@ if {$subport eq $name} {
 
     perl5.require_variant   yes
     perl5.conflict_variants yes
-    perl5.branches          5.34 5.36
+    perl5.branches          5.34 5.36 5.38
     perl5.default_branch    5.34
     perl5.create_variants   ${perl5.branches}
 

--- a/lang/perl5/files/5.38/avoid-no-cpp-precomp-PR38913.patch
+++ b/lang/perl5/files/5.38/avoid-no-cpp-precomp-PR38913.patch
@@ -1,0 +1,11 @@
+--- hints/darwin.sh.orig
++++ hints/darwin.sh
+@@ -130,7 +130,7 @@ esac
+ 
+ # Avoid Apple's cpp precompiler, better for extensions
+ if [ "X`echo | ${cc} -no-cpp-precomp -E - 2>&1 >/dev/null`" = "X" ]; then
+-    cppflags="${cppflags} -no-cpp-precomp"
++
+ 
+     # This is necessary because perl's build system doesn't
+     # apply cppflags to cc compile lines as it should.

--- a/lang/perl5/files/5.38/clean-up-paths.patch
+++ b/lang/perl5/files/5.38/clean-up-paths.patch
@@ -1,0 +1,37 @@
+--- Configure.orig
++++ Configure
+@@ -108,8 +108,8 @@ if test -d c:/. || ( uname -a | grep -i 
+ fi
+ 
+ : Proper PATH setting
+-paths='/bin /usr/bin /usr/local/bin /usr/ucb /usr/local /usr/lbin'
+-paths="$paths /opt/bin /opt/local/bin /opt/local /opt/lbin"
++paths='/bin /usr/bin /usr/ucb /usr/lbin'
++paths="$paths /opt/bin __PREFIX__/bin __PREFIX__ /opt/lbin"
+ paths="$paths /usr/5bin /etc /usr/gnu/bin /usr/new /usr/new/bin /usr/nbin"
+ paths="$paths /opt/gnu/bin /opt/new /opt/new/bin /opt/nbin"
+ paths="$paths /sys5.3/bin /sys5.3/usr/bin /bsd4.3/bin /bsd4.3/usr/ucb"
+@@ -1447,7 +1447,7 @@ archobjs=''
+ i_whoami=''
+ : Possible local include directories to search.
+ : Set locincpth to "" in a hint file to defeat local include searches.
+-locincpth="/usr/local/include /opt/local/include /usr/gnu/include"
++locincpth="__PREFIX__/include /usr/gnu/include"
+ locincpth="$locincpth /opt/gnu/include /usr/GNU/include /opt/GNU/include"
+ :
+ : no include file wanted by default
+@@ -1464,12 +1464,12 @@ libnames=''
+ : change the next line if compiling for Xenix/286 on Xenix/386
+ xlibpth='/usr/lib/386 /lib/386'
+ : Possible local library directories to search.
+-loclibpth="/usr/local/lib /opt/local/lib /usr/gnu/lib"
++loclibpth="__PREFIX__/lib /usr/gnu/lib"
+ loclibpth="$loclibpth /opt/gnu/lib /usr/GNU/lib /opt/GNU/lib"
+ 
+ : general looking path for locating libraries
+ glibpth="/lib /usr/lib $xlibpth"
+-glibpth="$glibpth /usr/ccs/lib /usr/ucblib /usr/local/lib"
++glibpth="$glibpth /usr/ccs/lib /usr/ucblib"
+ test -f /usr/shlib/libc.so && glibpth="/usr/shlib $glibpth"
+ test -f /shlib/libc.so     && glibpth="/shlib $glibpth"
+ test -d /usr/lib64         && glibpth="$glibpth /lib64 /usr/lib64 /usr/local/lib64"

--- a/lang/perl5/files/5.38/config.h.ed
+++ b/lang/perl5/files/5.38/config.h.ed
@@ -1,0 +1,157 @@
+/define[ 	]PRINTF_FORMAT_NULL_OK/c
+#ifdef __LP64__
+/*#define PRINTF_FORMAT_NULL_OK	/ **/
+#else /* !__LP64__ */
+#define PRINTF_FORMAT_NULL_OK	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]LONGSIZE/c
+#ifdef __LP64__
+#define LONGSIZE 8		/**/
+#else /* !__LP64__ */
+#define LONGSIZE 4		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]CASTI32/c
+#ifdef __ppc__
+#define CASTI32		/**/
+#else /* !__ppc__ */
+/*#define CASTI32		/ **/
+#endif /* __ppc__ */
+.
+/define[ 	]CASTNEGFLOAT/a
+.
+.,.+1c
+#ifdef __i386__
+/*#define CASTNEGFLOAT		/ **/
+#define CASTFLAGS 1		/**/
+#else
+#define CASTNEGFLOAT		/**/
+#define CASTFLAGS 0		/**/
+#endif
+.
+/define[ 	]Quad_t/a
+.
+.,.+2c
+#ifdef __LP64__
+#   define Quad_t long	/**/
+#   define Uquad_t unsigned long	/**/
+#   define QUADKIND 2	/**/
+#else /* !__LP64__ */
+#   define Quad_t long long	/**/
+#   define Uquad_t unsigned long long	/**/
+#   define QUADKIND 3	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]PTRSIZE/c
+#ifdef __LP64__
+#define PTRSIZE 8		/**/
+#else /* !__LP64__ */
+#define PTRSIZE 4		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]USE_BSD_SETPGRP/c
+#if __DARWIN_UNIX03
+/*#define USE_BSD_SETPGRP	/ **/
+#else /* !__DARWIN_UNIX03 */
+#define USE_BSD_SETPGRP	/**/
+#endif /* __DARWIN_UNIX03 */
+.
+/define[ 	]I32TYPE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	I32TYPE		int	/**/
+#define	U32TYPE		unsigned int	/**/
+#else /* !__LP64__ */
+#define	I32TYPE		long	/**/
+#define	U32TYPE		unsigned long	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]I64TYPE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	I64TYPE		long	/**/
+#define	U64TYPE		unsigned long	/**/
+#else /* !__LP64__ */
+#define	I64TYPE		long long	/**/
+#define	U64TYPE		unsigned long long	/**/
+#endif /* __LP64__ */
+.
+/define[ 	]IVSIZE/a
+.
+.,.+1c
+#ifdef __LP64__
+#define	IVSIZE		8		/**/
+#define	UVSIZE		8		/**/
+#else /* !__LP64__ */
+#define	IVSIZE		4		/**/
+#define	UVSIZE		4		/**/
+#endif /* __LP64__ */
+.
+/NV_PRESERVES_UV$/a
+.
+.,.+1c
+#ifdef __LP64__
+#undef	NV_PRESERVES_UV
+#define	NV_PRESERVES_UV_BITS	53
+#else /* !__LP64__ */
+#define	NV_PRESERVES_UV
+#define	NV_PRESERVES_UV_BITS	32
+#endif /* __LP64__ */
+.
+/define[ 	]HAS_STDIO_STREAM_ARRAY/a
+.
+.,.+3c
+#if __DARWIN_UNIX03
+/*#define	HAS_STDIO_STREAM_ARRAY	/ **/
+#define STDIO_STREAM_ARRAY	
+#else /* !__DARWIN_UNIX03 */
+#define	HAS_STDIO_STREAM_ARRAY	/**/
+#define STDIO_STREAM_ARRAY	__sF
+#endif /* __DARWIN_UNIX03 */
+.
+/define[ 	]USE_64_BIT_INT/c
+#ifdef __LP64__
+#define	USE_64_BIT_INT		/**/
+#else /* !__LP64__ */
+/*#define	USE_64_BIT_INT		/ **/
+#endif /* __LP64__ */
+.
+/define[ 	]USE_64_BIT_ALL/c
+#ifdef __LP64__
+#define	USE_64_BIT_ALL		/**/
+#else /* !__LP64__ */
+/*#define	USE_64_BIT_ALL		/ **/
+#endif /* __LP64__ */
+.
+/define[ 	]Gid_t_f/c
+#ifdef __LP64__
+#define	Gid_t_f		"u"		/**/
+#else /* !__LP64__ */
+#define	Gid_t_f		"lu"		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]Size_t_size/c
+#ifdef __LP64__
+#define Size_t_size 8		/* */
+#else /* !__LP64__ */
+#define Size_t_size 4		/* */
+#endif /* __LP64__ */
+.
+/define[ 	]Uid_t_f/c
+#ifdef __LP64__
+#define	Uid_t_f		"u"		/**/
+#else /* !__LP64__ */
+#define	Uid_t_f		"lu"		/**/
+#endif /* __LP64__ */
+.
+/define[ 	]NEED_VA_COPY/c
+#ifdef __LP64__
+#define	NEED_VA_COPY		/**/
+#else /* !__LP64__ */
+/*#define	NEED_VA_COPY		/ **/
+#endif /* __LP64__ */
+.
+w

--- a/lang/perl5/files/5.38/enable-syscall-on-sierra.patch
+++ b/lang/perl5/files/5.38/enable-syscall-on-sierra.patch
@@ -1,0 +1,34 @@
+--- hints/darwin.sh.orig
++++ hints/darwin.sh
+@@ -345,17 +345,20 @@ EOM
+     darwin_major=$(echo $osvers|awk -F. '{print $1}')
+ 
+     # macOS 10.12 (darwin 16.0.0) deprecated syscall().
+-    if [ "$darwin_major" -ge 16 ]; then
+-        d_syscall='undef'
+-        # If deploying to pre-10.12, suppress Time::HiRes's detection of the system clock_gettime()
+-        case "$MACOSX_DEPLOYMENT_TARGET" in
+-          10.[6-9]|10.10|10.11)
+-          ccflags="$ccflags -Werror=partial-availability -D_DARWIN_FEATURE_CLOCK_GETTIME=0"
+-          ;;
+-        *)
+-          ;;
+-        esac
+-    fi
++    # but it's still available on both macOS 10.12 and 10.13
++    # for compatibility with perl5.24 allow syscall() configuration on Sierra and later
++    # will auto-configure without syscall() if and when it's actually removed
++    # if [ "$darwin_major" -ge 16 ]; then
++    #     d_syscall='undef'
++    #     # If deploying to pre-10.12, suppress Time::HiRes's detection of the system clock_gettime()
++    #     case "$MACOSX_DEPLOYMENT_TARGET" in
++    #       10.[6-9]|10.10|10.11)
++    #       ccflags="$ccflags -Werror=partial-availability -D_DARWIN_FEATURE_CLOCK_GETTIME=0"
++    #       ;;
++    #     *)
++    #       ;;
++    #     esac
++    # fi
+ 
+    lddlflags="${ldflags} -bundle -undefined dynamic_lookup"
+    ;;

--- a/lang/perl5/files/5.38/fix-db_file-paths.patch
+++ b/lang/perl5/files/5.38/fix-db_file-paths.patch
@@ -1,0 +1,19 @@
+--- cpan/DB_File/config.in.orig
++++ cpan/DB_File/config.in
+@@ -9,7 +9,7 @@
+ #    Change the path below to point to the directory where db.h is
+ #    installed on your system.
+ 
+-INCLUDE	= /usr/local/BerkeleyDB/include
++INCLUDE	= __PREFIX__/include/db48
+ #INCLUDE	= /usr/local/include
+ #INCLUDE	= /usr/include
+ 
+@@ -18,7 +18,7 @@
+ #    Change the path below to point to the directory where libdb is
+ #    installed on your system.
+ 
+-LIB	= /usr/local/BerkeleyDB/lib
++LIB	= __PREFIX__/lib/db48
+ #LIB	= /usr/local/lib
+ #LIB	= /usr/lib

--- a/lang/perl5/files/5.38/fix-miniperl-linking-PR36438.patch
+++ b/lang/perl5/files/5.38/fix-miniperl-linking-PR36438.patch
@@ -1,0 +1,11 @@
+--- Makefile.SH.orig
++++ Makefile.SH
+@@ -995,7 +995,7 @@ NAMESPACEFLAGS = -force_flat_namespace
+ 		$spitshell >>$Makefile <<'!NO!SUBS!'
+ lib/buildcustomize.pl: $& $(miniperl_objs) write_buildcustomize.pl
+ 	-@rm -f miniperl.xok
+-	$(CC) $(CLDFLAGS) $(NAMESPACEFLAGS) -o $(MINIPERL_EXE) \
++	unset LIBRARY_PATH && $(CC) $(subst -L__PREFIX__/lib,,$(CLDFLAGS)) $(NAMESPACEFLAGS) -o $(MINIPERL_EXE) \
+ 	    $(miniperl_objs) $(libs)
+ 	$(LDLIBPTH) ./miniperl$(HOST_EXE_EXT) -w -Ilib -Idist/Exporter/lib -MExporter -e '<?>' || sh -c 'echo >&2 Failed to build miniperl.  Please run make minitest; exit 1'
+ 	$(MINIPERL) -f write_buildcustomize.pl

--- a/lang/perl5/files/5.38/install-under-short-version-PR43480.patch
+++ b/lang/perl5/files/5.38/install-under-short-version-PR43480.patch
@@ -1,0 +1,39 @@
+https://trac.macports.org/ticket/43480
+--- Configure.orig
++++ Configure
+@@ -7110,6 +7110,8 @@ dos|vms)
+ *)
+ 	version=`echo $revision $patchlevel $subversion | \
+ 		 $awk '{ printf "%d.%d.%d", $1, $2, $3 }'`
++	version_short=`echo $revision $patchlevel | \
++		 $awk '{ printf "%d.%d\n", $1, $2 }'`
+ 	api_versionstring=`echo $api_revision $api_version $api_subversion | \
+ 		 $awk '{ printf "%d.%d.%d", $1, $2, $3 }'`
+ 	;;
+@@ -7361,7 +7363,7 @@ esac
+ : /opt/perl/lib/perl5... would be redundant.
+ : The default "style" setting is made in installstyle.U
+ case "$installstyle" in
+-*lib/perl5*) set dflt privlib lib/$package/$version ;;
++*lib/perl5*) set dflt privlib lib/$package/$version_short ;;
+ *)	 set dflt privlib lib/$version ;;
+ esac
+ eval $prefixit
+@@ -7609,7 +7611,7 @@ siteprefixexp="$ansexp"
+ prog=`echo $package | $sed 's/-*[0-9.]*$//'`
+ case "$sitelib" in
+ '') case "$installstyle" in
+-	*lib/perl5*) dflt=$siteprefix/lib/$package/site_$prog/$version ;;
++	*lib/perl5*) dflt=$siteprefix/lib/$package/site_$prog/$version_short ;;
+ 	*)	 dflt=$siteprefix/lib/site_$prog/$version ;;
+ 	esac
+ 	;;
+@@ -8028,7 +8030,7 @@ case "$vendorprefix" in
+ 	'')
+ 		prog=`echo $package | $sed 's/-*[0-9.]*$//'`
+ 		case "$installstyle" in
+-		*lib/perl5*) dflt=$vendorprefix/lib/$package/vendor_$prog/$version ;;
++		*lib/perl5*) dflt=$vendorprefix/lib/$package/vendor_$prog/$version_short ;;
+ 		*)	     dflt=$vendorprefix/lib/vendor_$prog/$version ;;
+ 		esac
+ 		;;

--- a/lang/perl5/files/5.38/patch-Configure-remove-libs.diff
+++ b/lang/perl5/files/5.38/patch-Configure-remove-libs.diff
@@ -1,0 +1,11 @@
+--- Configure.orig	2023-11-28 15:57:27
++++ Configure	2024-05-19 17:27:30
+@@ -1511,7 +1511,7 @@
+ usereentrant='undef'
+ : List of libraries we want.
+ : If anyone needs extra -lxxx, put those in a hint file.
+-libswanted="cl pthread socket bind inet ndbm gdbm dbm db malloc dl ld"
++libswanted="pthread socket inet ndbm gdbm dbm db malloc dl ld"
+ libswanted="$libswanted sun m crypt sec util c cposix posix ucb bsd BSD"
+ : We probably want to search /usr/shlib before most other libraries.
+ : This is only used by the lib/ExtUtils/MakeMaker.pm routine extliblist.

--- a/lang/perl5/files/5.38/patch-want-implicit-errors.diff
+++ b/lang/perl5/files/5.38/patch-want-implicit-errors.diff
@@ -1,0 +1,18 @@
+Do not suppress errors for implicit function declarations
+(which was done for https://rt.cpan.org/Ticket/Display.html?id=133493)
+
+See:
+* https://trac.macports.org/ticket/61630
+* https://trac.macports.org/ticket/63022
+
+--- cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Darwin.pm.orig
++++ cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Darwin.pm
+@@ -62,7 +62,7 @@ sub cflags {
+     foreach (split /\n/, $base) {
+         /^(\S*)\s*=\s*(\S*)$/ and $self->{$1} = $2;
+     };
+-    $self->{CCFLAGS} .= " -Wno-error=implicit-function-declaration";
++
+ 
+     return $self->{CFLAGS} = qq{
+ CCFLAGS = $self->{CCFLAGS}


### PR DESCRIPTION
###### Type(s)

- [x] enhancement

###### Tested on
macOS 14.4.1 23E224 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?