### PR TITLE
ghostscript: update to 10.03.1

### DIFF
--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                ghostscript
-version             10.03.0
+version             10.03.1
 revision            0
 
 categories          print
@@ -34,9 +34,9 @@ distfiles           ${distname}.tar.gz:source \
                     ${mappingresources_commit}.zip:misc
 
 checksums           ${distname}.tar.gz \
-                    rmd160  860ee86af90acf551b31244f8adebc0e4754c258 \
-                    sha256  10849e8039d526ea490f3ead1f2aba7b2b9d5d4f13bfdfc8b9fe654948e70a44 \
-                    size    98222723 \
+                    rmd160  56619c52c32237c97739d1830b0513cd6b17d2a8 \
+                    sha256  8ea9dd8768b64576bc4ee2d79611450c9e1edeb686f7824f3bf94b92457b882a \
+                    size    98222799 \
                     ghostscript-fonts-other-6.0.tar.gz \
                     rmd160  ab60dbf71e7d91283a106c3df381cadfe173082f \
                     sha256  4fa051e341167008d37fe34c19d241060cd17b13909932cd7ca7fe759243c2de \


### PR DESCRIPTION
#### Description

Simple update to upstream version 10.03.1

This update does not remove the necessity of the last introduced patch (pdf_sec.c.diff); the developers did not yet introduce it into their version.

This update does not require revbumping any of the dependencies since the library name does not change. 

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.4.1 23E224 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
