### PR TITLE
mqttui: update to 0.21.0

### DIFF
--- a/net/mqttui/Portfile
+++ b/net/mqttui/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           cargo  1.0
 
-github.setup        EdJoPaTo mqttui 0.19.0 v
+github.setup        EdJoPaTo mqttui 0.21.0 v
 revision            0
 
 categories          net
@@ -15,179 +15,214 @@ description         Simple lightweight terminal based MQTT monitor and publisher
 long_description    {*}${description}
 
 checksums           ${distfiles} \
-                    rmd160  5a274e723ef3f90c6352f0ce87bc5eddaec43e0c \
-                    sha256  74a30d808bbdc59843515255583735c0aa73d55cf496574663cb59e3c3f0ec2a \
-                    size    191952
+                    rmd160  891c79be5f7039d8ab93402db1bb45e23ce2bf7a \
+                    sha256  a4d69271ffe3316c883f4e366b897812da594efce3756b059505766046e63a59 \
+                    size    220967
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/target/[option triplet.${muniversal.build_arch}]/release/${name} ${destroot}${prefix}/bin/
 }
 
+cargo.crates_github \
+    ratatui-binary-data-widget EdJoPaTo/ratatui-binary-data-widget main \
+    4405e4547d25917f217a810920813bf1a00de1fc \
+    1561bbbe009ad0c45aa18661bb7f87c209de147e8dcc6615ff56ebc8c08a34d6
+
 cargo.crates \
+    addr2line                       0.21.0  8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb \
+    adler                            1.0.2  f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe \
+    ahash                           0.8.11  e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011 \
+    allocator-api2                  0.2.18  5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f \
+    android-tzdata                   0.1.1  e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0 \
     android_system_properties        0.1.5  819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311 \
-    anstream                         0.3.2  0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163 \
-    anstyle                          1.0.0  41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d \
-    anstyle-parse                    0.2.0  e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee \
-    anstyle-query                    1.0.0  5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b \
-    anstyle-wincon                   1.0.1  180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188 \
-    anyhow                          1.0.71  9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8 \
-    async-tungstenite               0.16.1  5682ea0913e5c20780fe5785abacb85a411e7437bf52a1bedb93ddb3972cb8dd \
+    anstream                        0.6.13  d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb \
+    anstyle                          1.0.6  8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc \
+    anstyle-parse                    0.2.3  c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c \
+    anstyle-query                    1.0.2  e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648 \
+    anstyle-wincon                   3.0.2  1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7 \
+    anyhow                          1.0.82  f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519 \
+    async-tungstenite               0.25.1  2cca750b12e02c389c1694d35c16539f88b8bbaa5945934fdc1b41a776688589 \
     async_io_stream                  0.3.3  b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c \
-    autocfg                          1.1.0  d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa \
-    base64                          0.13.1  9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8 \
-    base64                          0.21.0  a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a \
+    autocfg                          1.2.0  f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80 \
+    backtrace                       0.3.71  26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d \
+    base64                          0.22.0  9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51 \
     bitflags                         1.3.2  bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a \
-    block-buffer                     0.9.0  4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4 \
-    bumpalo                         3.12.2  3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b \
-    byteorder                        1.4.3  14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610 \
-    bytes                            1.4.0  89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be \
+    bitflags                         2.5.0  cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1 \
+    block-buffer                    0.10.4  3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71 \
+    bumpalo                         3.16.0  79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c \
+    byteorder                        1.5.0  1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b \
+    bytes                            1.6.0  514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9 \
     cassowary                        0.3.0  df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53 \
-    cc                              1.0.79  50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f \
+    castaway                         0.2.2  8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc \
+    cc                              1.0.94  17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7 \
     cfg-if                           1.0.0  baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd \
-    chrono                          0.4.24  4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b \
-    clap                             4.2.7  34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938 \
-    clap_builder                     4.2.7  914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd \
-    clap_complete                    4.2.3  1594fe2312ec4abf402076e407628f5c313e54c32ade058521df4ee34ecac8a8 \
-    clap_derive                      4.2.0  3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4 \
-    clap_lex                         0.4.1  8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1 \
+    chrono                          0.4.38  a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401 \
+    clap                             4.5.4  90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0 \
+    clap_builder                     4.5.2  ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4 \
+    clap_complete                    4.5.2  dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e \
+    clap_derive                      4.5.4  528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64 \
+    clap_lex                         0.7.0  98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce \
+    clap_mangen                     0.2.20  e1dd95b5ebb5c1c54581dd6346f3ed6a79a3eef95dd372fc2ac13d535535300e \
     colorchoice                      1.0.0  acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7 \
-    core-foundation                  0.9.3  194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146 \
-    core-foundation-sys              0.8.4  e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa \
-    cpufeatures                      0.2.7  3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58 \
-    crossterm                       0.25.0  e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67 \
-    crossterm_winapi                 0.9.0  2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c \
-    digest                           0.9.0  d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066 \
+    compact_str                      0.7.1  f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f \
+    core-foundation                  0.9.4  91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f \
+    core-foundation-sys              0.8.6  06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f \
+    cpufeatures                     0.2.12  53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504 \
+    crossterm                       0.27.0  f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df \
+    crossterm_winapi                 0.9.1  acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b \
+    crypto-common                    0.1.6  1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3 \
+    data-encoding                    2.5.0  7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5 \
+    digest                          0.10.7  9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292 \
     ego-tree                         0.6.2  3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591 \
-    errno                            0.3.1  4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a \
-    errno-dragonfly                  0.1.2  aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf \
-    flume                          0.10.14  1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577 \
+    either                          1.11.0  a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2 \
+    errno                            0.3.8  a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245 \
+    flume                           0.11.0  55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181 \
     fnv                              1.0.7  3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1 \
-    form_urlencoded                  1.1.0  a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8 \
-    futures                         0.3.28  23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40 \
-    futures-channel                 0.3.28  955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2 \
-    futures-core                    0.3.28  4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c \
-    futures-executor                0.3.28  ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0 \
-    futures-io                      0.3.28  4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964 \
-    futures-macro                   0.3.28  89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72 \
-    futures-sink                    0.3.28  f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e \
-    futures-task                    0.3.28  76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65 \
-    futures-util                    0.3.28  26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533 \
+    form_urlencoded                  1.2.1  e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456 \
+    futures                         0.3.30  645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0 \
+    futures-channel                 0.3.30  eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78 \
+    futures-core                    0.3.30  dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d \
+    futures-executor                0.3.30  a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d \
+    futures-io                      0.3.30  a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1 \
+    futures-macro                   0.3.30  87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac \
+    futures-sink                    0.3.30  9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5 \
+    futures-task                    0.3.30  38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004 \
+    futures-util                    0.3.30  3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48 \
     generic-array                   0.14.7  85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a \
-    getrandom                        0.2.9  c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4 \
+    getrandom                       0.2.14  94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c \
+    gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
+    hashbrown                       0.14.3  290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604 \
     heck                             0.4.1  95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8 \
-    hermit-abi                       0.3.1  fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286 \
-    http                             0.2.9  bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482 \
+    heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
+    http                             1.1.0  21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258 \
     httparse                         1.8.0  d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904 \
-    iana-time-zone                  0.1.56  0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c \
+    iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
-    idna                             0.3.0  e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6 \
-    io-lifetimes                    1.0.10  9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220 \
-    is-terminal                      0.4.7  adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f \
-    itoa                             1.0.6  453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6 \
-    js-sys                          0.3.63  2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790 \
-    json                            0.12.4  078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd \
-    libc                           0.2.144  2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1 \
-    linux-raw-sys                    0.3.7  ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f \
-    lock_api                         0.4.9  435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df \
-    log                             0.4.17  abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e \
-    memchr                           2.5.0  2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d \
-    mio                              0.8.6  5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9 \
-    nanorand                         0.7.0  6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3 \
-    num-integer                     0.1.45  225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9 \
-    num-traits                      0.2.15  578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd \
-    once_cell                       1.17.1  b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3 \
-    opaque-debug                     0.3.0  624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5 \
+    idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
+    indoc                            2.0.5  b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5 \
+    itertools                       0.12.1  ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569 \
+    itoa                            1.0.11  49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b \
+    js-sys                          0.3.69  29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d \
+    libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
+    linux-raw-sys                   0.4.13  01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c \
+    lock_api                        0.4.11  3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45 \
+    log                             0.4.21  90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c \
+    lru                             0.12.3  d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc \
+    memchr                           2.7.2  6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d \
+    miniz_oxide                      0.7.2  9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7 \
+    mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
+    num-traits                      0.2.18  da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a \
+    object                          0.32.2  a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441 \
+    once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
     parking_lot                     0.12.1  3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f \
-    parking_lot_core                 0.9.7  9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521 \
-    percent-encoding                 2.2.0  478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e \
+    parking_lot_core                 0.9.9  4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e \
+    paste                           1.0.14  de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c \
+    percent-encoding                 2.3.1  e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e \
     pharos                           0.5.3  e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414 \
-    pin-project                      1.1.0  c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead \
-    pin-project-internal             1.1.0  39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07 \
-    pin-project-lite                 0.2.9  e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116 \
+    pin-project-lite                0.2.14  bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02 \
     pin-utils                        0.1.0  8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184 \
     ppv-lite86                      0.2.17  5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de \
-    proc-macro2                     1.0.58  fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8 \
-    quote                           1.0.27  8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500 \
+    proc-macro2                     1.0.81  3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba \
+    quote                           1.0.36  0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \
-    redox_syscall                   0.2.16  fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a \
-    ring                           0.16.20  3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc \
-    rumqttc                         0.21.0  04483567c64bb8a9d64364a0a9437215a056a2b886140fd66e62a12394cf5998 \
+    ratatui                         0.26.2  a564a852040e82671dc50a37d88f3aa83bbc690dfc6844cfe7a2591620206a80 \
+    redox_syscall                    0.4.1  4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa \
+    ring                            0.17.8  c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d \
+    rmp                             0.8.14  228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4 \
+    rmpv                             1.0.2  e540282f11751956c82bc5529a7fb71b871b998fbf9cf06c2419b22e1b4350df \
+    roff                             0.2.1  b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316 \
+    rumqttc                         0.24.0  e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9 \
+    rustc-demangle                  0.1.23  d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76 \
     rustc_version                    0.4.0  bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366 \
-    rustix                         0.37.19  acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d \
-    rustls                          0.20.8  fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f \
-    rustls-native-certs              0.6.2  0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50 \
-    rustls-pemfile                   1.0.2  d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b \
-    schannel                        0.1.21  713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3 \
-    scopeguard                       1.1.0  d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd \
-    sct                              0.7.0  d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4 \
-    security-framework               2.9.0  ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1 \
-    security-framework-sys           2.9.0  f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7 \
-    semver                          1.0.17  bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed \
-    sha-1                            0.9.8  99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6 \
-    signal-hook                     0.3.15  732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9 \
+    rustix                         0.38.32  65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89 \
+    rustls                          0.22.3  99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c \
+    rustls-native-certs              0.7.0  8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792 \
+    rustls-pemfile                   2.1.2  29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d \
+    rustls-pki-types                 1.4.1  ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247 \
+    rustls-webpki                  0.102.2  faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610 \
+    rustversion                     1.0.15  80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47 \
+    ryu                             1.0.17  e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1 \
+    schannel                        0.1.23  fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534 \
+    scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
+    security-framework              2.10.0  770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6 \
+    security-framework-sys          2.10.0  41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef \
+    semver                          1.0.22  92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca \
+    serde                          1.0.198  9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc \
+    serde_bytes                    0.11.14  8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734 \
+    serde_derive                   1.0.198  e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9 \
+    serde_json                     1.0.116  3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813 \
+    sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
+    signal-hook                     0.3.17  8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801 \
     signal-hook-mio                  0.2.3  29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af \
     signal-hook-registry             1.4.1  d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1 \
-    slab                             0.4.8  6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d \
-    smallvec                        1.10.0  a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0 \
-    socket2                          0.4.9  64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662 \
-    spin                             0.5.2  6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d \
+    slab                             0.4.9  8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67 \
+    smallvec                        1.13.2  3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67 \
+    socket2                          0.5.6  05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871 \
     spin                             0.9.8  6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67 \
-    strsim                          0.10.0  73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623 \
-    syn                             2.0.16  a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01 \
-    terminal_size                    0.2.6  8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237 \
-    thiserror                       1.0.40  978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac \
-    thiserror-impl                  1.0.40  f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f \
+    stability                        0.2.0  2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a \
+    static_assertions                1.1.0  a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f \
+    strsim                          0.11.1  7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f \
+    strum                           0.26.2  5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29 \
+    strum_macros                    0.26.2  c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946 \
+    subtle                           2.5.0  81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc \
+    syn                             2.0.59  4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a \
+    terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
+    thiserror                       1.0.58  03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297 \
+    thiserror-impl                  1.0.58  c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7 \
     tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
-    tokio                           1.28.1  0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105 \
-    tokio-macros                     2.1.0  630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e \
-    tokio-rustls                    0.23.4  c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59 \
-    tui                             0.19.0  ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1 \
-    tui-tree-widget                 0.11.0  64cd64e2088f26dd5f7e5239cdd7ee234098d3bda4dc214e4bb58c2049ce5af3 \
-    tungstenite                     0.16.0  6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1 \
-    typenum                         1.16.0  497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba \
-    unicode-bidi                    0.3.13  92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460 \
-    unicode-ident                    1.0.8  e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4 \
-    unicode-normalization           0.1.22  5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921 \
-    unicode-segmentation            1.10.1  1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36 \
-    unicode-width                   0.1.10  c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b \
-    untrusted                        0.7.1  a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a \
-    url                              2.3.1  0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643 \
+    tokio                           1.37.0  1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787 \
+    tokio-macros                     2.2.0  5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b \
+    tokio-rustls                    0.25.0  775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f \
+    tracing                         0.1.40  c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef \
+    tracing-attributes              0.1.27  34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7 \
+    tracing-core                    0.1.32  c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54 \
+    tui-tree-widget                 0.19.0  fb0c6f924587e719c50b8f83485afbe4d4c16edca6b641d5d9a3204edeba5cf0 \
+    tungstenite                     0.21.0  9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1 \
+    typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
+    unicode-bidi                    0.3.15  08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75 \
+    unicode-ident                   1.0.12  3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b \
+    unicode-normalization           0.1.23  a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5 \
+    unicode-segmentation            1.11.0  d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202 \
+    unicode-width                   0.1.11  e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85 \
+    untrusted                        0.9.0  8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1 \
+    url                              2.5.0  31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633 \
     utf-8                            0.7.6  09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9 \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
     version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
     wasi                          0.11.0+wasi-snapshot-preview1  9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423 \
-    wasm-bindgen                    0.2.86  5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73 \
-    wasm-bindgen-backend            0.2.86  19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb \
-    wasm-bindgen-macro              0.2.86  14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258 \
-    wasm-bindgen-macro-support      0.2.86  e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8 \
-    wasm-bindgen-shared             0.2.86  ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93 \
-    web-sys                         0.3.63  3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2 \
-    webpki                          0.22.0  f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd \
+    wasm-bindgen                    0.2.92  4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8 \
+    wasm-bindgen-backend            0.2.92  614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da \
+    wasm-bindgen-macro              0.2.92  a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726 \
+    wasm-bindgen-macro-support      0.2.92  e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7 \
+    wasm-bindgen-shared             0.2.92  af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96 \
     winapi                           0.3.9  5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419 \
     winapi-i686-pc-windows-gnu       0.4.0  ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6 \
     winapi-x86_64-pc-windows-gnu     0.4.0  712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f \
-    windows                         0.48.0  e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f \
-    windows-sys                     0.42.0  5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7 \
-    windows-sys                     0.45.0  75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0 \
+    windows-core                    0.52.0  33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9 \
     windows-sys                     0.48.0  677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9 \
-    windows-targets                 0.42.2  8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071 \
-    windows-targets                 0.48.0  7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5 \
-    windows_aarch64_gnullvm         0.42.2  597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8 \
-    windows_aarch64_gnullvm         0.48.0  91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc \
-    windows_aarch64_msvc            0.42.2  e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43 \
-    windows_aarch64_msvc            0.48.0  b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3 \
-    windows_i686_gnu                0.42.2  c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f \
-    windows_i686_gnu                0.48.0  622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241 \
-    windows_i686_msvc               0.42.2  44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060 \
-    windows_i686_msvc               0.48.0  4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00 \
-    windows_x86_64_gnu              0.42.2  8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36 \
-    windows_x86_64_gnu              0.48.0  ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1 \
-    windows_x86_64_gnullvm          0.42.2  26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3 \
-    windows_x86_64_gnullvm          0.48.0  7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953 \
-    windows_x86_64_msvc             0.42.2  9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0 \
-    windows_x86_64_msvc             0.48.0  1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a \
-    ws_stream_tungstenite            0.7.0  a672ec78525bf189cefa7f1b72c55f928b3edbdb967e680ca49748ab20821045
+    windows-sys                     0.52.0  282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d \
+    windows-targets                 0.48.5  9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c \
+    windows-targets                 0.52.5  6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb \
+    windows_aarch64_gnullvm         0.48.5  2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8 \
+    windows_aarch64_gnullvm         0.52.5  7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263 \
+    windows_aarch64_msvc            0.48.5  dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc \
+    windows_aarch64_msvc            0.52.5  9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6 \
+    windows_i686_gnu                0.48.5  a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e \
+    windows_i686_gnu                0.52.5  88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670 \
+    windows_i686_gnullvm            0.52.5  87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9 \
+    windows_i686_msvc               0.48.5  8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406 \
+    windows_i686_msvc               0.52.5  db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf \
+    windows_x86_64_gnu              0.48.5  53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e \
+    windows_x86_64_gnu              0.52.5  4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9 \
+    windows_x86_64_gnullvm          0.48.5  0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc \
+    windows_x86_64_gnullvm          0.52.5  852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596 \
+    windows_x86_64_msvc             0.48.5  ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538 \
+    windows_x86_64_msvc             0.52.5  bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0 \
+    ws_stream_tungstenite           0.13.0  a198f414f083fb19fcc1bffcb0fa0cf46d33ccfa229adf248cac12c180e91609 \
+    zerocopy                        0.7.32  74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be \
+    zerocopy-derive                 0.7.32  9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6 \
+    zeroize                          1.7.0  525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d


### PR DESCRIPTION
#### Description
[Changelog](https://github.com/EdJoPaTo/mqttui/releases)
https://github.com/EdJoPaTo/mqttui/compare/v0.19.0...v0.21.0

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.6.8 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
