### PR TITLE
rcs: use gnulib PG to fix confdir bug and fix build on Sonoma

### DIFF
--- a/devel/rcs/Portfile
+++ b/devel/rcs/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           gnulib 1.0
 
 name                rcs
 version             5.10.1

--- a/devel/rcs/Portfile
+++ b/devel/rcs/Portfile
@@ -29,6 +29,11 @@ checksums           rmd160  0adde8a075de346e4229a893366e2aa396b4e651 \
                     sha256  43ddfe10724a8b85e2468f6403b6000737186f01e60e0bd62fde69d842234cc5 \
                     size    917331
 
+if {${os.platform} eq "darwin" && ${os.major} > 22} {
+    configure.cflags-append \
+                    -Wno-error=incompatible-function-pointer-types
+}
+
 set docdir          ${prefix}/share/doc/${name}
 
 post-destroot {


### PR DESCRIPTION
#### Description

Use gnulib PG

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6*
Xcode 3.2

* gnulib PG itself needs a fix for 10.6 ppc, but once that it does, it works nicely and `rcs` installs normally.

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
