### PR TITLE
llvm-11, clang-11-bootstrap: apply upstream patch

### DIFF
--- a/lang/clang-11-bootstrap/Portfile
+++ b/lang/clang-11-bootstrap/Portfile
@@ -8,7 +8,7 @@ PortGroup           muniversal 1.0
 name                clang-11-bootstrap
 
 version             11.1.0
-revision            5
+revision            6
 epoch               0
 
 platforms           darwin
@@ -77,6 +77,7 @@ patchfiles          0001-Define-EXC_MASK_CRASH-and-MACH_EXCEPTION_CODES-if-th.pa
                     0007-dsymutil-fix-build-on-Leopard.patch \
                     0008-lib-Support-Unix-Path.inc-define-COPYFILE_CLONE-if-n.patch \
                     0009-MacPorts-Only-Fix-name-of-scan-view-executable-insid.patch \
+                    0009-x86-pad-for-align.diff \
                     0010-default-to-libcxx-on-all-systems.patch \
                     0011-Default-to-fragile-ObjC-runtime-when-targeting-darwi.patch \
                     0012-Fixup-libstdc-header-search-paths-for-older-versions.patch \

--- a/lang/clang-11-bootstrap/files/0009-x86-pad-for-align.diff
+++ b/lang/clang-11-bootstrap/files/0009-x86-pad-for-align.diff
@@ -1,0 +1,15 @@
+See https://github.com/llvm/llvm-project/commit/a048ce13e32daa255d26533c00da8abd0b67e819
+See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
+See https://trac.macports.org/ticket/62775
+
+--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp.orig	2021-02-03 14:51:10
++++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp	2024-05-21 05:44:11
+@@ -109,7 +109,7 @@
+     cl::desc("Maximum number of prefixes to use for padding"));
+ 
+ cl::opt<bool> X86PadForAlign(
+-    "x86-pad-for-align", cl::init(true), cl::Hidden,
++    "x86-pad-for-align", cl::init(false), cl::Hidden,
+     cl::desc("Pad previous instructions to implement align directives"));
+ 
+ cl::opt<bool> X86PadForBranchAlign(

--- a/lang/llvm-11/Portfile
+++ b/lang/llvm-11/Portfile
@@ -25,7 +25,7 @@ checksums               rmd160  f566b4b75c8f30418f19069a9a84864ead766401 \
                         size    84065492
 
 name                    llvm-${llvm_version}
-revision                4
+revision                5
 subport                 clang-${llvm_version} { revision 7 }
 subport                 flang-${llvm_version} { revision 1 }
 subport                 lldb-${llvm_version} { revision 3 }
@@ -140,7 +140,8 @@ patchfiles \
     0003-MacPorts-Only-Don-t-embed-the-deployment-target-in-t.patch \
     0005-Threading-Only-call-pthread_setname_np-on-SnowLeopar.patch \
     0006-Only-call-setpriority-PRIO_DARWIN_THREAD-0-PRIO_DARW.patch \
-    0008-patch-lib-support-unix-path-copyfileclone-on-older-systems.diff
+    0008-patch-lib-support-unix-path-copyfileclone-on-older-systems.diff \
+    0009-x86-pad-for-align.diff
 
 if {${subport} eq "clang-${llvm_version}"} {
     patchfiles-append \

--- a/lang/llvm-11/files/0009-x86-pad-for-align.diff
+++ b/lang/llvm-11/files/0009-x86-pad-for-align.diff
@@ -1,0 +1,15 @@
+See https://github.com/llvm/llvm-project/commit/a048ce13e32daa255d26533c00da8abd0b67e819
+See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
+See https://trac.macports.org/ticket/62775
+
+--- llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp.orig	2021-02-03 14:51:10
++++ llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp	2024-05-21 05:44:11
+@@ -109,7 +109,7 @@
+     cl::desc("Maximum number of prefixes to use for padding"));
+ 
+ cl::opt<bool> X86PadForAlign(
+-    "x86-pad-for-align", cl::init(true), cl::Hidden,
++    "x86-pad-for-align", cl::init(false), cl::Hidden,
+     cl::desc("Pad previous instructions to implement align directives"));
+ 
+ cl::opt<bool> X86PadForBranchAlign(


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/commit/a048ce13e32daa255d26533c00da8abd0b67e819
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340
See https://trac.macports.org/ticket/62775

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
