### PR TITLE
snappy: set version of dylib to 1.2.0

### DIFF
--- a/archivers/snappy/Portfile
+++ b/archivers/snappy/Portfile
@@ -7,7 +7,7 @@ PortGroup           cmake 1.1
 PortGroup           github 1.0
 
 github.setup        google snappy 1.2.0
-revision            0
+revision            1
 categories          archivers
 maintainers         nomaintainer
 license             BSD
@@ -35,9 +35,14 @@ checksums           rmd160  35f820c4e35c8fe8ab19d88e7cdbf5860128afa3 \
 #   error: invalid output constraint '=@ccz' in asm
 compiler.blacklist-append {clang < 1200}
 
+# RTTI:
 # https://github.com/facebook/folly/issues/1583
 # https://github.com/Homebrew/homebrew-core/pull/76686#issuecomment-847527483
-patchfiles-append   patch-no-disable-rtti.diff
+# Version:
+# Upstream forgot to update version. This was done in a later PR.
+# https://github.com/google/snappy/pull/178
+patchfiles-append   patch-no-disable-rtti.diff \
+                    patch-version-number.diff
 
 # CMake Error in CMakeLists.txt:
 #  Target "snappy" requires the language dialect "CXX11" , but CMake does not

--- a/archivers/snappy/files/patch-version-number.diff
+++ b/archivers/snappy/files/patch-version-number.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 85afe58..94bbc86 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -27,7 +27,7 @@
+ # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ cmake_minimum_required(VERSION 3.1)
+-project(Snappy VERSION 1.1.10 LANGUAGES C CXX)
++project(Snappy VERSION 1.2.0 LANGUAGES C CXX)
+ 
+ # C++ standard can be overridden when this is used as a sub-project.
+ if(NOT CMAKE_CXX_STANDARD)


### PR DESCRIPTION
Apply as a patch a PR content that was merged after upstream 1.2.0 release. Fixes https://trac.macports.org/ticket/70046

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4.1 23E224 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
