### PR TITLE
gstreamer1-gst-plugins-base: Fix sluggishness

### DIFF
--- a/gnome/gstreamer1-gst-plugins-base/Portfile
+++ b/gnome/gstreamer1-gst-plugins-base/Portfile
@@ -11,7 +11,7 @@ name                gstreamer1-gst-plugins-base
 set my_name         gst-plugins-base
 # please only commit stable updates (even numbered releases)
 version             1.24.1
-revision            0
+revision            1
 description         This is gst-plugins, a set of plug-ins for GStreamer.
 long_description    ${description}
 maintainers         nomaintainer
@@ -63,11 +63,11 @@ configure.args-append \
                     -Dxshm=disabled \
                     -Dxvideo=disabled
 
-# gstbasetextoverlay.c:1511: error: 'for' loop initial declaration used outside C99 mode
-configure.cflags-append -std=c99
-
-# gst-libs/gst/gl/gstgldebug.h:28: error: redefinition of typedef ‘GstGLAsyncDebug’
-compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 212}
+# as of orc 0.4.34 compilation with c11 standard is required to prevent slugish behavior
+# see https://gitlab.freedesktop.org/gstreamer/orc/-/issues/47
+compiler.c_standard 2011
+configure.cflags-append \
+                    -std=c11
 
 post-patch {
     reinplace "s|/usr/bin/env python3|${python.bin}|" \


### PR DESCRIPTION
#### Description

Starting with orc 0.4.34 gstreamer1-gst-plugins-base needs to be compiled with a c11 compiler to avoid sluggish behavior. See https://gitlab.freedesktop.org/gstreamer/orc/-/issues/47

I attach two videos showing the behaviour with and without the change in this PR using the same command mentioned in the issue linked above:
```
gst-launch-1.0 -v videotestsrc pattern=ball ! autovideosink
```
This requires installing `gstreamer1-gst-plugins-good`.

Testing this requires either the use of `+x11` variants or to use the changes made in #23760 to test it with the `+quartz` variants.

**Before:**
https://github.com/macports/macports-ports/assets/59110786/d45eb94a-8677-4e90-916a-6010f108d44c

**After:**
https://github.com/macports/macports-ports/assets/59110786/f854a477-075e-4790-accb-d87f15efe5ff

I'm not sure if and which dependents of `gstreamer1-gst-plugins-base` would need a revbump. I tried upgrading `gstreamer1-gst-plugins-base` after applying this change while `gstreamer1-gst-plugins-good` was already installed and the above test case still ran smoothly; that is, without having to revbump/rebuild `gstreamer1-gst-plugins-good`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.6 22G630 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
