### PR TITLE
libsidplayfp: Fix detection of C++11 compilers

### DIFF
--- a/audio/libsidplayfp/Portfile
+++ b/audio/libsidplayfp/Portfile
@@ -21,4 +21,6 @@ checksums           rmd160  5e5abb5847211b528d4b36c3e013a9bd0de03388 \
                     sha256  416df16c09b0ab058c21adc1792abfac8524a27b0dac0034afc040057f6346ba \
                     size    806267
 
+patchfiles          configure.patch
+
 compiler.cxx_standard   2011

--- a/audio/libsidplayfp/files/configure.patch
+++ b/audio/libsidplayfp/files/configure.patch
@@ -1,0 +1,51 @@
+Fix detection of C++11 compilers.
+https://github.com/libsidplayfp/libsidplayfp/issues/129
+--- configure.orig	2024-05-19 03:16:43.000000000 -0500
++++ configure	2024-05-21 14:26:50.000000000 -0500
+@@ -19116,7 +19231,7 @@
+     void
+     test1()
+     {
+-      auto lambda1 = (){};
++      auto lambda1 = [](){};
+       auto lambda2 = lambda1;
+       lambda1();
+       lambda2();
+@@ -19125,12 +19240,12 @@
+     int
+     test2()
+     {
+-      auto a = (int i, int j){ return i + j; }(1, 2);
+-      auto b = () -> int { return '0'; }();
+-      auto c = =(){ return a + b; }();
+-      auto d = &(){ return c; }();
+-      auto e = a, &b(int x) mutable {
+-        const auto identity = (int y){ return y; };
++      auto a = [](int i, int j){ return i + j; }(1, 2);
++      auto b = []() -> int { return '0'; }();
++      auto c = [=](){ return a + b; }();
++      auto d = [&](){ return c; }();
++      auto e = [a, &b](int x) mutable {
++        const auto identity = [](int y){ return y; };
+         for (auto i = 0; i < a; ++i)
+           a += b--;
+         return x + identity(a + b);
+@@ -19141,13 +19256,13 @@
+     int
+     test3()
+     {
+-      const auto nullary = (){ return 0; };
+-      const auto unary = (int x){ return x; };
++      const auto nullary = [](){ return 0; };
++      const auto unary = [](int x){ return x; };
+       using nullary_t = decltype(nullary);
+       using unary_t = decltype(unary);
+-      const auto higher1st = (nullary_t f){ return f(); };
+-      const auto higher2nd = unary(nullary_t f1){
+-        return unary, f1(unary_t f2){ return f2(unary(f1())); };
++      const auto higher1st = [](nullary_t f){ return f(); };
++      const auto higher2nd = [unary](nullary_t f1){
++        return [unary, f1](unary_t f2){ return f2(unary(f1())); };
+       };
+       return higher1st(nullary) + higher2nd(nullary)(unary);
+     }


### PR DESCRIPTION
#### Description

libsidplayfp: Fix detection of C++11 compilers

Should fix build on OS X 10.8 and 10.9 buildbot workers.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 10.9.5 13F1911 x86_64
Xcode 6.2 6C131e

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
