### PR TITLE
google-cloud-sdk: update to 477.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             476.0.0
+version             477.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  4dbffec0718eb55f24ecc1eaa4fbb601c0d04957 \
-                    sha256  dd3d9a4049754b07b641b9c4edea646a56623119714f112104fe03112a161bfd \
-                    size    124878580
+    checksums       rmd160  5ba8a6cc794ede26dfdfffb88372a3890976af0a \
+                    sha256  f6f13f803c707094b8d8cdc19c7eebce47af352d7359d5e99ffb2f580b350713 \
+                    size    124878878
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  44ae8eaabb0ff314820c6c073fa7a46e3580b532 \
-                    sha256  4d066403c15debb61934de3a8c946691480659d94c09358e0fd7a4452d7e9bfd \
-                    size    126164859
+    checksums       rmd160  2113cbf4d634d615a3c23ade27b2e7c5b0ba1483 \
+                    sha256  c312f96ff7208152a533d0e7297efedecfa15b6c36ebb5e9ef0aa0b3a588e9c9 \
+                    size    126163652
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  2e064f2702ab816c02e3d2a3eb90d400319a07ee \
-                    sha256  6c26b5a608a6a317cda672cead7da520cdca59f758350532f8d7adca6240c677 \
-                    size    122487959
+    checksums       rmd160  5c5459bf2690a07a79a7896d5d4d53362cf72a5a \
+                    sha256  4b5b1963ca6d8b3a03783e62e9ef7ef3ede0795740bffacc6f9b22fa1a1540ab \
+                    size    122482639
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 477.0.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?