### PR TITLE
vips: updated to 8.15.2, added libarchive to support vips dzsave and fixed macos-14 compilation

### DIFF
--- a/graphics/vips/Portfile
+++ b/graphics/vips/Portfile
@@ -5,8 +5,8 @@ PortGroup           github 1.0
 PortGroup           gobject_introspection 1.0
 PortGroup           meson 1.0
 
-github.setup        libvips libvips 8.15.1 v
-revision            5
+github.setup        libvips libvips 8.15.2 v
+revision            0
 name                vips
 distname            vips-${version}
 description         VIPS is an image processing library.
@@ -20,9 +20,9 @@ github.tarball_from releases
 
 use_xz              yes
 
-checksums           rmd160  ecc1bb26bd15f4bd27eb528a67be66a5381fb003 \
-                    sha256  06811f5aed3e7bc03e63d05537ff4b501de5283108c8ee79396c60601a00830c \
-                    size    18648116
+checksums           rmd160  5cff05115c648f6bcafa2c90eef021cddb35232a \
+                    sha256  a2ab15946776ca7721d11cae3215f20f1f097b370ff580cd44fc0f19387aee84 \
+                    size    18653840
 
 # minor tweak to allow build with older compilers
 # StandaloneFuzzTargetMain.c:31: error: 'for' loop initial declaration used outside C99 mode
@@ -41,6 +41,7 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:ImageMagick \
                     path:include/turbojpeg.h:libjpeg-turbo \
                     port:lcms2 \
+                    port:libarchive \
                     port:libexif \
                     port:libgsf \
                     port:libjxl \
@@ -57,5 +58,15 @@ depends_lib         path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     port:webp \
                     port:zlib
 
+# meson.build: ERROR: C++ Compiler does not support -std=c++11
+compiler.cxx_standard   2011
+
 configure.post_args-append \
                    -Dintrospection=enabled
+
+if {${os.platform} eq "darwin" && ${os.major} > 22} {
+    if {[string match *clang* ${configure.compiler}]} {
+        configure.cflags-append \
+                    -Wno-error=incompatible-function-pointer-types
+    }
+}


### PR DESCRIPTION
#### Description

As suggested in https://trac.macports.org/ticket/69691 added `libarchive` to the dependencies.

Also updated vips to v8.15.2 and added `configure.cflags-append -Wno-incompatible-function-pointer-types` to allow for compilation on Macos-14.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`? (see below)
- [x] tested basic functionality of all binary files?

`sudo port -vs install vips` works as expected but `sudo port -vst install vips` fails.

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
