### PR TITLE
cdo: update to 2.4.1

### DIFF
--- a/science/cdo/Portfile
+++ b/science/cdo/Portfile
@@ -5,8 +5,8 @@ PortGroup                   mpi 1.0
 PortGroup                   legacysupport 1.0
 
 name                        cdo
-version                     2.4.0
-revision                    1
+version                     2.4.1
+revision                    0
 platforms                   darwin
 maintainers                 {takeshi @tenomoto} \
                             {me.com:remko.scharroo @remkos} \
@@ -15,11 +15,11 @@ license                     GPL-2
 categories                  science
 description                 Climate Data Operators
 homepage                    https://code.mpimet.mpg.de/projects/cdo
-master_sites                https://code.mpimet.mpg.de/attachments/download/29313
+master_sites                https://code.mpimet.mpg.de/attachments/download/29421
 
-checksums           rmd160  b70d79025fd141b93bfb733467dc36fb74b51914 \
-                    sha256  a4790fb8cc07f353b11f9bbe49218b8e4be8e5ae56aade8420bad390510b4d2c \
-                    size    13497565
+checksums           rmd160  bd6125a51dc06924801a068c570388bf7d172644 \
+                    sha256  9144d82b8ab7e73f4cb7a94cc4b884f64dff1a0455c4eb6c93ce4b568007aabf \
+                    size    13517064
 
 long_description \
     CDO is a collection of command line Operators               \
@@ -29,7 +29,11 @@ long_description \
 
 fetch.ignore_sslcert        yes
 
+# Since cdo 2.4.0, we need to select C++20 capable compilers.
+# On MacOS-13 compilation with /usr/bin/clang++ fails, so we blacklist it.
 compiler.cxx_standard       2020
+compiler.blacklist-append   clang
+
 compiler.thread_local_storage yes
 compilers.choose            cc cxx
 mpi.setup


### PR DESCRIPTION
#### Description

Simple update to upstream version 2.4.1

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
