### PR TITLE
dmapd: fix build on old systems

### DIFF
--- a/multimedia/dmapd/Portfile
+++ b/multimedia/dmapd/Portfile
@@ -9,7 +9,6 @@ description         A server that provides DAAP and DPAP shares.
 long_description    The dmapd project provides a GObject-based, Open Source implementation of DMAP sharing.
 maintainers         {devans @dbevans} openmaintainer
 categories          multimedia
-platforms           darwin
 
 homepage            https://www.flyn.org/projects/${name}/
 master_sites        ${homepage}
@@ -36,9 +35,15 @@ depends_run         port:gstreamer1-gst-plugins-base \
 # dmapd.c:435: error: ‘for’ loop initial declaration used outside C99 mode
 compiler.c_standard 1999
 configure.cflags-append -std=c99
+# soup-message.h:18: error: redefinition of typedef ‘SoupMessage’
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 
+# Fails to build with tests:
+# dmapd-stress-test.c: error: invalid use of incomplete typedef 'SoupMessage' {aka 'struct _SoupMessage'}
 configure.args      --disable-check \
-                    --disable-silent-rules
+                    --disable-silent-rules \
+                    --disable-tests
 
 livecheck.type      regex
 livecheck.url       https://www.flyn.org/projects/${name}/


### PR DESCRIPTION
[skip ci]

#### Description

This port is broken old all new systems: https://ports.macports.org/port/dmapd/details
Therefore skipping CI.

P. S. It should be perhaps updated, but that will likely require updating its dependencies, and that is rather to be done in a separate PR. Let’s fix this first.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
