### PR TITLE
kde4-runtime: use the right C++ standard

### DIFF
--- a/kde/kde4-runtime/Portfile
+++ b/kde/kde4-runtime/Portfile
@@ -33,8 +33,10 @@ patchfiles          patch-support-for-lldb.diff \
                     patch-phonon-cmakelists.diff \
                     patch-gpgme.diff
 
-#Blacklist gcc42 and llvm-gcc-42 (does not build with gcc, ticket #37574)
-compiler.blacklist  gcc-4.2 apple-gcc-4.2 llvm-gcc-4.2 macports-llvm-gcc-4.2
+#Needs C++11 to build.
+#Undefined symbols:
+#"__ZN5Exiv27ExifKeyC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE"
+compiler.cxx_standard   2011
 
 depends_lib-append  port:kdelibs4 \
                     port:kdepimlibs4 \

--- a/kde/kde4-runtime/Portfile
+++ b/kde/kde4-runtime/Portfile
@@ -17,7 +17,6 @@ license             GPL-2+ LGPL-2.1+
 description         Shared data needed by KDE4 programs
 long_description    Provides data which is required by KDE4 applications. \
                     e.g. icons and mimetype data.
-platforms           darwin
 homepage            https://www.kde.org
 master_sites        kde:stable/${version}/src/
 use_xz              yes
@@ -38,31 +37,34 @@ patchfiles          patch-support-for-lldb.diff \
 #"__ZN5Exiv27ExifKeyC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE"
 compiler.cxx_standard   2011
 
-depends_lib-append  port:kdelibs4 \
-                    port:kdepimlibs4 \
-                    port:kactivities \
-                    port:nepomuk-core \
-                    port:libssh \
-                    port:qimageblitz \
-                    port:oxygen-icons \
-                    port:hicolor-icon-theme \
-                    port:exiv2 \
-                    path:include/turbojpeg.h:libjpeg-turbo \
-                    port:openslp \
-                    port:redland \
-                    port:raptor2 \
-                    port:webp \
+depends_lib-append  port:attica \
                     port:bison \
-                    port:shared-mime-info \
-                    port:gpgme port:attica \
-                    port:libgcrypt port:openexr \
-                    port:xz port:zlib \
+                    port:exiv2 \
+                    port:gpgme \
+                    port:hicolor-icon-theme \
+                    port:kactivities \
+                    port:kdelibs4 \
+                    port:kdepimlibs4 \
+                    port:libgcrypt \
+                    path:include/turbojpeg.h:libjpeg-turbo \
+                    port:libssh \
+                    port:nepomuk-core \
+                    port:openexr \
+                    port:openslp \
+                    port:oxygen-icons \
+                    port:perl5 \
                     port:qca \
-                    port:perl5
+                    port:qimageblitz \
+                    port:raptor2 \
+                    port:redland \
+                    port:shared-mime-info \
+                    port:webp \
+                    port:xz \
+                    port:zlib
 
 depends_run-append  port:virtuoso
 
-#Virtuoso builds only on 64bit, but it is only a runtime dependency, 
+#Virtuoso is only a runtime dependency,
 #automatically deactivated if not available (ticket #41773)
 depends_skip_archcheck  virtuoso
 


### PR DESCRIPTION
#### Description

Port requires C++11. Drop redundant and wrong blacklist, use `cxx_standard`.
Also improve text layout.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
