### PR TITLE
grisbi: Use files directly instead of copying them

### DIFF
--- a/gnome/grisbi/Portfile
+++ b/gnome/grisbi/Portfile
@@ -12,7 +12,6 @@ checksums           rmd160  4eca5dff3eecbe048bc679a4bc647962568ce6c7 \
                     sha256  3bc1c630a758a4b5a76116015002a9b477b495203110481ff41f3674c1df4797 \
                     size    12877828
 categories          gnome finance
-platforms           darwin
 license             GPL-2+
 maintainers         {ctreleaven @ctreleaven} openmaintainer
 installs_libs       no
@@ -32,7 +31,7 @@ use_bzip2           yes
 
 # reconfigure using autogen.sh from upstream git for intltool 0.51 compatibility
 use_autoreconf      yes
-autoreconf.cmd      ./autogen.sh
+autoreconf.cmd      ${filespath}/autogen.sh
 
 depends_build       path:bin/pkg-config:pkgconfig \
                     port:desktop-file-utils \
@@ -47,11 +46,6 @@ depends_lib-append  port:goffice \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                     port:libxml2
-
-post-patch {
-    xinstall -m 755 ${filespath}/autogen.sh ${worksrcpath}
-    xinstall -m 755 ${filespath}/Grisbi.icns ${worksrcpath}
-}
 
 configure.args      --disable-frenchdoc \
                     --disable-silent-rules \
@@ -94,7 +88,7 @@ if {![variant_isset quartz]} {
 }
 
 app.name            Grisbi
-app.icon            Grisbi.icns
+app.icon            ${filespath}/Grisbi.icns
 app.identifier      org.grisbi.Grisbi
 app.retina          yes
 


### PR DESCRIPTION
#### Description

Just a small simplification.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 21H1123 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] tried a full install with `sudo port -vst install`?
- [X] tested basic functionality of all binary files?
