### PR TITLE
hyprlang: update to 0.5.2

### DIFF
--- a/devel/hyprlang/Portfile
+++ b/devel/hyprlang/Portfile
@@ -5,7 +5,7 @@ PortGroup           cmake 1.1
 PortGroup           compiler_blacklist_versions 1.0
 PortGroup           github 1.0
 
-github.setup        hyprwm hyprlang 0.5.1 v
+github.setup        hyprwm hyprlang 0.5.2 v
 revision            0
 categories          devel
 license             LGPL-2
@@ -15,9 +15,9 @@ description         The hypr configuration language is an extremely efficient, \
                     for applications.
 long_description    {*}${description}
 homepage            https://hyprland.org/hyprlang
-checksums           rmd160  47abca47f88f9d80d968598c445e3ef2040aa8da \
-                    sha256  7f521906d3f40b8d7b2bfcbe29a8286e9c65a7a601994344278bc16325bbd75d \
-                    size    56237
+checksums           rmd160  898d90a3bbf587a803990bd90845617d6b8ea4d3 \
+                    sha256  66a1f87634c8ecdeb67d7ccc499a3fc1c19b064a098b103be042751e7430b5cc \
+                    size    56383
 github.tarball_from archive
 
 # The port requires C++23, and builds either on macOS 13+ with clangs,


### PR DESCRIPTION
#### Description

Update

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
