### PR TITLE
turbogit: update to 5.0.0

### DIFF
--- a/devel/turbogit/Portfile
+++ b/devel/turbogit/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        b4nst turbogit 4.0.0 v
+github.setup        b4nst turbogit 5.0.0 v
 revision            0
 categories          devel
 supported_archs     x86_64 arm64
@@ -18,10 +18,6 @@ fetch.type          git
 post-fetch {
     system -W ${worksrcpath} "git submodule update --init --recursive"
 }
-
-checksums           rmd160  0a27f06aadb5d7d8f5e2ea6d5f87ea20b8b9ceca \
-                    sha256  ca96e0ee7e7e000a42fb6279268e144c3b1c248e6114a7bd8402221dfe5f07e3 \
-                    size    341809
 
 use_configure       no
 installs_libs       no


### PR DESCRIPTION
- remove checksums which aren't used because of `fetch.type git`

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
