### PR TITLE
gumbo-parser: update to 0.12.1

### DIFF
--- a/devel/gumbo-parser/Portfile
+++ b/devel/gumbo-parser/Portfile
@@ -1,13 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           github 1.0
+PortGroup           codeberg 1.0
 
-github.setup        google gumbo-parser 0.10.1 v
+codeberg.setup      gumbo-parser gumbo-parser 0.12.1
 revision            0
 
 categories          devel www
-platforms           darwin
 license             Apache-2
 
 maintainers         {pmetzger @pmetzger} openmaintainer
@@ -21,9 +20,9 @@ long_description    Gumbo is an implementation of the HTML5 parsing \
                     linters, validators, templating languages, and \
                     refactoring and analysis tools.
 
-checksums           rmd160  e7e8942dd17f0ace3b4626fa80acb647c27d2376 \
-                    sha256  22e57d8f0e2144198dd7d9174c44425445aa2b4b0d792f4fc99f4afc17a18f3d \
-                    size    2119366
+checksums           rmd160  2f8fa57daa353b59c5095638bf893e453fcecdd9 \
+                    sha256  c0bb5354e46539680724d638dbea07296b797229a7e965b13305c930ddc10d82 \
+                    size    2118975
 
 depends_build       port:autoconf port:automake port:libtool
 


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/69545

###### Tested on
macOS 14.4.1 23E224 x86_64
Xcode 15.4 15F31d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?