### PR TITLE
mlton: fix path pointing to C compiler

### DIFF
--- a/lang/mlton/Portfile
+++ b/lang/mlton/Portfile
@@ -8,7 +8,7 @@ PortGroup           openssl 1.0
 
 github.setup        MLton mlton 475cf2b14993869711f1a93a15a9fa854b5126ed
 version             20240519
-revision            0
+revision            1
 categories          lang ml
 maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
 license             HPND
@@ -38,10 +38,9 @@ depends_lib-append  port:gmp
 patchfiles-append   patch-settings-for-Macports.diff
 
 post-patch {
-    reinplace "s,@CC@,${configure.cc}," ${worksrcpath}/bin/mlton-script
     reinplace "s,@MLTON@,${prefix}/libexec/mlton-bootstrap/bin," ${worksrcpath}/Makefile.config
     reinplace "s,@VERSION@,${version}," ${worksrcpath}/Makefile.config
-    reinplace "s,@PREFIX@,${prefix},g" ${worksrcpath}/Makefile.config ${worksrcpath}/bin/mlbdeps ${worksrcpath}/bin/mlton-script
+    reinplace "s,@PREFIX@,${prefix},g" ${worksrcpath}/Makefile.config ${worksrcpath}/bin/mlbdeps
 }
 
 build.env-append    SH=${prefix}/bin/bash
@@ -55,6 +54,9 @@ compiler.blacklist-append {clang < 900}
 # it should be done for mlton-bootstrap and mlton together, with revbumping both.
 compiler.blacklist-append {macports-clang-1[7-9]} {macports-gcc-1[4-9]}
 
+build.args-append   CC=${configure.cc} \
+                    GMP_DIR=${prefix}
+
 platform darwin 10 {
     if {${configure.build_arch} eq "ppc"} {
         # This is only needed on Rosetta, but will not hurt native 10.6 ppc either.
@@ -67,8 +69,9 @@ platform darwin 10 {
     }
 }
 
+# https://github.com/MLton/mlton/issues/571
 post-destroot {
-    reinplace "s,${workpath}/compwrap/cc,," ${destroot}${prefix}/bin/${name}
+    reinplace "s,${workpath}/compwrap/cc,," ${destroot}${prefix}/lib/mlton/targets/self/vars
 }
 
 universal_variant   no


### PR DESCRIPTION
#### Description

The source was changed recently in a way which left out MLTon broken.
Fix that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5
Xcode 15.3

macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
