### PR TITLE
neovim: Build and install tree-sitter parsers

### DIFF
--- a/editors/neovim/Portfile
+++ b/editors/neovim/Portfile
@@ -5,7 +5,7 @@ PortGroup               github 1.0
 PortGroup               cmake 1.1
 
 github.setup            neovim neovim 0.10.0 v
-revision                0
+revision                1
 categories              editors
 maintainers             {raimue @raimue} \
                         {l2dy @l2dy} \
@@ -45,13 +45,15 @@ depends_lib             port:gettext \
 
 cmake.build_type        Release
 
-configure.args-append   -DUSE_BUNDLED=OFF \
-                        -DLUA_PRG=${prefix}/bin/luajit
+configure.args-append   -DLUA_PRG=${prefix}/bin/luajit
+
+# Building parsers is normally an extra step, see https://github.com/neovim/neovim/issues/29042
+patchfiles              embed-parsers-build.diff
 
 subport neovim-devel {
     github.setup    neovim neovim efaf37a2b9450d56acbf48a44c3c791d00d70199
     version         20240501-[string range ${github.version} 0 6]
-    revision        0
+    revision        1
 
     github.tarball_from tarball
     checksums       rmd160  1e4dce0c64f3d793120c64555a60050daed5e504 \

--- a/editors/neovim/files/embed-parsers-build.diff
+++ b/editors/neovim/files/embed-parsers-build.diff
@@ -1,0 +1,68 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index 5ad99cbf0..3828ee192 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -98,8 +98,21 @@ else()
+ endif()
+ 
+ list(INSERT CMAKE_PREFIX_PATH 0 ${DEPS_PREFIX})
+ 
++# Reading deps.txt adapted from cmake.deps/CMakeLists.txt
++file(READ cmake.deps/deps.txt DEPENDENCIES)
++STRING(REGEX REPLACE "\n" ";" DEPENDENCIES "${DEPENDENCIES}")
++foreach(dep ${DEPENDENCIES})
++  STRING(REGEX REPLACE " " ";" dep "${dep}")
++  list(GET dep 0 name)
++  list(GET dep 1 value)
++  set(${name} ${value})
++endforeach()
++set(DEPS_IGNORE_SHA FALSE)
++list(APPEND DEPS_CMAKE_ARGS -D "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" -D "CMAKE_C_FLAGS=${CMAKE_C_FLAGS}")
++include(cmake.deps/cmake/BuildTreesitterParsers.cmake)
++
+ if(APPLE)
+   # If the macOS deployment target is not set manually (via $MACOSX_DEPLOYMENT_TARGET),
+   # fall back to local system version. Needs to be done both here and in cmake.deps.
+   if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+diff --git cmake.deps/cmake/BuildTreesitterParsers.cmake cmake.deps/cmake/BuildTreesitterParsers.cmake
+index 837d075d2..6dbd69554 100644
+--- cmake.deps/cmake/BuildTreesitterParsers.cmake
++++ cmake.deps/cmake/BuildTreesitterParsers.cmake
+@@ -20,15 +20,17 @@ function(BuildTSParser)
+   get_externalproject_options(${NAME} ${DEPS_IGNORE_SHA})
+   ExternalProject_Add(${NAME}
+     DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/${NAME}
+     PATCH_COMMAND ${CMAKE_COMMAND} -E copy
+-      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${TS_CMAKE_FILE}
++      ${CMAKE_CURRENT_LIST_DIR}/${TS_CMAKE_FILE}
+       ${DEPS_BUILD_DIR}/src/${NAME}/CMakeLists.txt
+     CMAKE_ARGS ${DEPS_CMAKE_ARGS}
+       -D PARSERLANG=${TS_LANG}
+     ${EXTERNALPROJECT_OPTIONS})
+ endfunction()
+ 
++set(ALL_BUNDLED_TS_PARSER_TARGETS c lua vim vimdoc query python bash markdown) # All parsers built in the lines directly below.
++list(TRANSFORM ALL_BUNDLED_TS_PARSER_TARGETS PREPEND treesitter_)
+ foreach(lang c lua vim vimdoc query python bash)
+   BuildTSParser(LANG ${lang})
+ endforeach()
+ BuildTSParser(LANG markdown CMAKE_FILE MarkdownParserCMakeLists.txt)
+diff --git src/nvim/CMakeLists.txt src/nvim/CMakeLists.txt
+index d9cc695c5..53bf044ba 100644
+--- src/nvim/CMakeLists.txt
++++ src/nvim/CMakeLists.txt
+@@ -767,12 +767,10 @@ if(WIN32)
+ endif()
+ 
+ file(MAKE_DIRECTORY ${BINARY_LIB_DIR})
+ 
+-# install treesitter parser if bundled
+-if(EXISTS ${DEPS_PREFIX}/lib/nvim/parser)
+-  add_custom_command(TARGET nvim_runtime_deps COMMAND ${CMAKE_COMMAND} -E ${COPY_DIRECTORY} ${DEPS_PREFIX}/lib/nvim/parser ${BINARY_LIB_DIR}/parser)
+-endif()
++add_dependencies(nvim_runtime_deps ${ALL_BUNDLED_TS_PARSER_TARGETS})
++add_custom_command(TARGET nvim_runtime_deps COMMAND ${CMAKE_COMMAND} -E ${COPY_DIRECTORY} ${DEPS_INSTALL_DIR}/lib/nvim/parser ${BINARY_LIB_DIR}/parser)
+ 
+ install(DIRECTORY ${BINARY_LIB_DIR}
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   USE_SOURCE_PERMISSIONS)


### PR DESCRIPTION
#### Description

**I consider this patch as some kind of WIP proposal. Perhaps things like the path to the cmake executable or its args should be filled dynamically from macports defaults. But I do not know the best practices for this specific case so I feel free to just push on top of this if it needs refinement.**

neovim needs a number of prebuilt parsers in <prefix>/lib/nvim/parser/ or else it will throw errors when opening e.g. ":help". USE_BUNDLED is also not a valid option for the root cmake build system anymore, but applies to the one in cmake.deps/.

Closes: https://trac.macports.org/ticket/70072

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 15.5
Xcode 15.3 / Command Line Tools 15.3.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`? (Did it without trace mode because of https://trac.macports.org/ticket/66358)
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
