### PR TITLE
rnnoise: blacklist GCC 3/4

### DIFF
--- a/audio/rnnoise/Portfile
+++ b/audio/rnnoise/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           compiler_blacklist_versions 1.0
 
 github.setup        xiph rnnoise 0.2 v
-revision            1
+revision            2
 checksums           rmd160  247533f4803d58e064037d852c1feb27bede927c \
                     sha256  90fce4b00b9ff24c08dbfe31b82ffd43bae383d85c5535676d28b0a2b11c0d37 \
                     size    2294308
@@ -29,7 +29,7 @@ patchfiles          patch-372f7b4b76cde4ca1ec4605353dd17898a99de38.diff
 
 # vec_avx.h:171:9: error: unknown type name '__m256i'
 # uses newer intrinsic functions
-compiler.blacklist  {clang < 800}
+compiler.blacklist  {*gcc-[3-4].*} {clang < 800}
 
 # FIXME: no Altivec support at the moment:
 # https://github.com/xiph/rnnoise/issues/223


### PR DESCRIPTION
#### Description

https://github.com/macports/macports-ports/pull/23833#issuecomment-2102874545
Needed for PowerPC machines, but there's no particular reason to use legacy compilers with this port anyway.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
