### PR TITLE
rust PG: fix for early CLT that did not install SDKs

### DIFF
--- a/_resources/port1.0/group/rust-1.0.tcl
+++ b/_resources/port1.0/group/rust-1.0.tcl
@@ -488,13 +488,15 @@ proc rust::get_sdkroot {sdk_version} {
         return [option configure.sdkroot]
     }
 
-    if {![option use_xcode]} {
-        set sdks_dir        [option configure.developer_dir]/SDKs
+    if {![option use_xcode] && [file exists "/Library/Developer/CommandLineTools/SDKs"]} {
+        set sdks_dir        /Library/Developer/CommandLineTools/SDKs
     } else {
+        # `configure.developer_dir` is not used in case `use_xcode` is true but SDKs directory does not exist
+        # early command line tools did not install SDKs
         if {[vercmp [option xcodeversion] < 4.3]} {
-            set sdks_dir    [option configure.developer_dir]/SDKs
+            set sdks_dir    [option developer_dir]/SDKs
         } else {
-            set sdks_dir    [option configure.developer_dir]/Platforms/MacOSX.platform/Developer/SDKs
+            set sdks_dir    [option developer_dir]/Platforms/MacOSX.platform/Developer/SDKs
         }
     }
 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
