### PR TITLE
zix: Avoid fdatasync on macOS

### DIFF
--- a/devel/zix/Portfile
+++ b/devel/zix/Portfile
@@ -10,7 +10,7 @@ PortGroup           meson   1.0
 legacysupport.newest_darwin_requires_legacy 15
 
 gitlab.setup        drobilla zix 0.4.2 v
-revision            0
+revision            1
 
 description         A lightweight C99 portability and data structure library
 long_description    {*}${description}
@@ -23,6 +23,8 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
 checksums           rmd160  c69eb969044123e8fe16aaa9be1a76c2335c90a0 \
                     sha256  250ad249ab080e1e45df92e8c8ea1cbcff1378c459933af5c88566480800df64 \
                     size    74432
+
+patchfiles          fdatasync.patch
 
 compiler.c_standard 1999
 # ERROR: C++ Compiler does not support -std=c++17

--- a/devel/zix/files/fdatasync.patch
+++ b/devel/zix/files/fdatasync.patch
@@ -1,0 +1,22 @@
+Avoid fdatasync() on Darwin. fsync() there doesn't actually flush writes to
+storage like it does on Linux. So, use F_FULLFSYNC which was invented as an
+alternative API to do this.
+https://gitlab.com/drobilla/zix/-/issues/3
+https://gitlab.com/drobilla/zix/-/commit/a6f804073de1f1e626464a9dd0a169fd3f69fdff
+--- src/posix/filesystem_posix.c.orig
++++ src/posix/filesystem_posix.c
+@@ -58,7 +58,13 @@ zix_get_block_size(const struct stat* const s1, const struct stat* const s2)
+ static ZixStatus
+ finish_copy(const int dst_fd, const int src_fd, const ZixStatus status)
+ {
+-  const ZixStatus st0 = zix_posix_status(dst_fd >= 0 ? fdatasync(dst_fd) : 0);
++#ifdef __APPLE__
++  const int rc = dst_fd >= 0 ? fcntl(dst_fd, F_FULLFSYNC) : 0;
++#else
++  const int rc = dst_fd >= 0 ? fdatasync(dst_fd) : 0;
++#endif
++
++  const ZixStatus st0 = zix_posix_status(rc);
+   const ZixStatus st1 = zix_system_close_fds(dst_fd, src_fd);
+ 
+   return status ? status : st0 ? st0 : st1;


### PR DESCRIPTION
#### Description

Closes: https://trac.macports.org/ticket/70070

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 21H1123 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
