### PR TITLE
neofetch: update to 20211210 (master branch)

### DIFF
--- a/sysutils/neofetch/Portfile
+++ b/sysutils/neofetch/Portfile
@@ -3,11 +3,13 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dylanaraps neofetch 7.1.0
-platforms           any
+github.setup        dylanaraps neofetch ccd5d9f52609bbdcd5d8fa78c4fdb0f12954125f
+version             20211210
+revision            0
 supported_archs     noarch
 license             MIT
-maintainers         {@rangeles gmail.com:ronangeles} openmaintainer
+maintainers         {@rangeles gmail.com:ronangeles} \
+                    {@aeiouaeiouaeiouaeiouaeiouaeiou outlook.com:aeioudev} openmaintainer
 categories          sysutils
 
 description         A CLI system information tool
@@ -16,9 +18,17 @@ long_description    Neofetch is a CLI system information tool written in \
                     next to an image, your OS logo, or any ASCII file of \
                     your choice.
 
-checksums           rmd160  c9db23b6959aa7d0b8b6de68c05994f80d1e846a \
-                    sha256  c99d704d2f321d24a4655ce3fc052fd79539493dc75c025237ad78e93f9749bf \
-                    size    95403
+checksums           rmd160  c70bd266e785e8c40058465d1dcbf8079fb4732c \
+                    sha256  37501a8ffa173569266e5c255dd4823d04848285b5b6adcc7fdb2fa9614205e8 \
+                    size    104477
+
+patchfiles          patch-add-newer-codenames.diff
 
 use_configure       no
 destroot.post_args  ${destroot.destdir} PREFIX=${prefix}
+
+# This repository has been archived
+# by the owner on Apr 26, 2024.
+# However, this package is popular and
+# works, so please don't mark it obsolete
+livecheck.type      none

--- a/sysutils/neofetch/files/patch-add-newer-codenames.diff
+++ b/sysutils/neofetch/files/patch-add-newer-codenames.diff
@@ -1,0 +1,16 @@
+https://github.com/dylanaraps/neofetch/pull/2467
+--- neofetch
++++ neofetch
+@@ -1153,8 +1153,10 @@ get_distro() {
+                 10.14*) codename="macOS Mojave" ;;
+                 10.15*) codename="macOS Catalina" ;;
+                 10.16*) codename="macOS Big Sur" ;;
+-                11.*)  codename="macOS Big Sur" ;;
+-                12.*)  codename="macOS Monterey" ;;
++                11.*)   codename="macOS Big Sur" ;;
++                12.*)   codename="macOS Monterey" ;;
++                13.*)   codename="macOS Ventura" ;;
++                14.*)   codename="macOS Sonoma" ;;
+                 *)      codename=macOS ;;
+             esac
+ 


### PR DESCRIPTION
* add revision and remove platforms line
* add myself as co-maintainer
* disable livecheck

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
