### PR TITLE
keepassxc: update to 2.7.8

### DIFF
--- a/security/KeePassXC/Portfile
+++ b/security/KeePassXC/Portfile
@@ -30,8 +30,8 @@ license_noconflict      openssl openssl10 openssl11 openssl3
 
 if {${subport} eq ${name}} {
     # stable
-    github.setup        keepassxreboot keepassxc 2.7.7
-    revision            1
+    github.setup        keepassxreboot keepassxc 2.7.8
+    revision            0
     github.tarball_from releases
     distname            keepassxc-${version}-src
     use_xz              yes
@@ -42,12 +42,12 @@ if {${subport} eq ${name}} {
 
     # See keepassxc-${version}-src.tar.xz.DIGEST on upstream GitHub releases page for SHA256 sums
     checksums           ${distname}${extract.suffix} \
-                        rmd160  33170f0b573f83c3bf185f9fa5e70978704ecc93 \
-                        sha256  58fc45ae98e4b3ffb052103014f5b97a41fefd17102c7f56073934dd3a82ee67 \
-                        size    9734460 \
+                        rmd160  873c1405ad711451fdd5ac48c872c12e7a2f85f8 \
+                        sha256  87d3101712b3c8656a24b908ad5b7e2529bc01717cb4156f53ba195fb81783a3 \
+                        size    9764860 \
                         ${distname}${extract.suffix}.sig \
-                        rmd160  0a72b3b43e2892fb3aa625735dabf1cfcbbb8701 \
-                        sha256  254d8f3febf9a037dccbc3c4d34ad0a629ecb981b6ccb13509782ac04342193d \
+                        rmd160  38112c11a26f653db3d5a2a52249b286d7e108d0 \
+                        sha256  aafbc45db589e234ea0243652d49a5b6f4fd5b06431d8e8989bbdd48de48897d \
                         size    488
 
     gpg_verify.use_gpg_verification \
@@ -104,6 +104,12 @@ depends_lib-append      port:argon2 \
                         port:qrencode \
                         port:ykpers \
                         port:zlib
+
+# unknown xattrs make older BSD tar fail
+if {${os.platform} eq "darwin" && ${os.major} <= 18} {
+    depends_extract port:libarchive
+    extract.post_args | ${prefix}/bin/bsdtar -xf -
+}
 
 patchfiles-append       patch-no-deployqt.diff \
                         patch-no-findpackage-path.diff \


### PR DESCRIPTION
fix extract on older versions of os

In theory this is something that upstream could fix but since they don't seem terribly interested in issues on older versions I'm not sure they'd go for it. In the meantime this allowed me to install and confirm the app works.
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
