### PR TITLE
unrar: update to 7.0.9

### DIFF
--- a/archivers/unrar/Portfile
+++ b/archivers/unrar/Portfile
@@ -1,15 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
-PortGroup           legacysupport 1.1
 PortGroup           compiler_blacklist_versions 1.0
-
-# wcsdup function is not available in Snow Leopard
-legacysupport.newest_darwin_requires_legacy 10
 
 name                unrar
 set my_name         ${name}src
-version             7.0.8
+version             7.0.9
 categories          archivers
 maintainers         nomaintainer
 license             Restrictive/Distributable
@@ -24,9 +20,9 @@ homepage            https://www.rarlab.com/
 master_sites        ${homepage}rar/
 distname            ${my_name}-${version}
 
-checksums           rmd160  2ee2867b86492a3e4f7c8eb04bd27a0c76420fc2 \
-                    sha256  f68b6a0bb16cbc7e157652542966ee64ca66ae3958273a64128484c51f1b768d \
-                    size    258266
+checksums           rmd160  a6f75fbb962be30fe27862bede474e4a94b8e501 \
+                    sha256  505c13f9e4c54c01546f2e29b2fcc2d7fabc856a060b81e5cdfe6012a9198326 \
+                    size    258287
 
 patchfiles          patch-makefile.unix.diff
 
@@ -48,7 +44,7 @@ configure.cxxflags-append \
 
 # error: invalid cpu feature string for builtin
 # uses newer intrinsic functions
-compiler.blacklist  {clang < 900}
+compiler.blacklist  {*gcc-[3-4].*} {clang < 900}
 
 set cxx_stdlibflags {}
 if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {


### PR DESCRIPTION
* blacklist GCC 3/4
* remove redundant legacysupport portgroup

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6.8 10K549 x86_64
Xcode 3.2.6 10M2518

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
