### PR TITLE
GPXSee: update to 13.20

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.19
+github.setup        tumic0 GPXSee 13.20
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  729c1e2b931cea4ea78d9e25cd85e6dd6a1a0e36 \
-                    sha256  e35d1bbc2b562969bb356cd6a5515f70696a870ac8255a590a55c15fc2f1f52a \
-                    size    5613645
+checksums           rmd160  23d39b0c2f688c0d04c1ae420ec8319131d588a8 \
+                    sha256  f390d0d1ea360730915a2c8526b196b56a8ec68c2f6009f50e686428cb8ebb8e \
+                    size    5621055
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
