### PR TITLE
lexbor: fix build on old systems and support tests

### DIFF
--- a/net/lexbor/Portfile
+++ b/net/lexbor/Portfile
@@ -36,3 +36,22 @@ post-destroot {
         CHANGELOG.md LICENSE NOTICE README.md \
         ${destroot}${docdir}
 }
+
+variant perf description "Enable support for rdtsc" {
+    # https://github.com/lexbor/lexbor/pull/227
+    patchfiles-append \
+                    0001-perf.c-fix-for-powerpc.patch
+
+    configure.args-append \
+                    -DLEXBOR_WITH_PERF=ON
+}
+
+variant tests description "Enable testing" {
+    configure.pre_args-replace \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
+                    -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
+    configure.args-append \
+                    -DLEXBOR_BUILD_TESTS=ON
+
+    test.run        yes
+}

--- a/net/lexbor/Portfile
+++ b/net/lexbor/Portfile
@@ -12,11 +12,10 @@ checksums           rmd160  deac7830fce8949467e4063911b959d187126cb8 \
 
 description         a fast embeddable web browser engine
 
-long_description    ${name} is {*}${description} written in C with no \
-                    dependencies.
+long_description    ${name} is {*}${description} written in C \
+                    with no dependencies.
 
 categories          net www
-platforms           darwin
 maintainers         {ryandesign @ryandesign} openmaintainer
 license             Apache-2
 

--- a/net/lexbor/Portfile
+++ b/net/lexbor/Portfile
@@ -23,6 +23,9 @@ license             Apache-2
 homepage            https://lexbor.com
 github.tarball_from archive
 
+# https://github.com/lexbor/lexbor/issues/226
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 compiler.c_standard 1999
 
 set docdir          ${prefix}/share/doc/${subport}

--- a/net/lexbor/files/0001-perf.c-fix-for-powerpc.patch
+++ b/net/lexbor/files/0001-perf.c-fix-for-powerpc.patch
@@ -1,0 +1,46 @@
+From 46f0700bb0cc4216be2ec73216f85075df161e4d Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Sun, 26 May 2024 18:47:27 +0800
+Subject: [PATCH] perf.c: fix for powerpc
+
+---
+ source/lexbor/ports/posix/lexbor/core/perf.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git source/lexbor/ports/posix/lexbor/core/perf.c source/lexbor/ports/posix/lexbor/core/perf.c
+index 79b99bc..d4dbfbc 100644
+--- source/lexbor/ports/posix/lexbor/core/perf.c
++++ source/lexbor/ports/posix/lexbor/core/perf.c
+@@ -92,6 +92,24 @@ lexbor_perf_in_sec(void *perf)
+ static unsigned long long
+ lexbor_perf_clock(void)
+ {
++#if defined(__POWERPC__) || defined(__powerpc__)
++    unsigned long long int result = 0;
++    unsigned long int upper, lower, tmp;
++    __asm__ volatile (
++                      "0:\n"
++                      "\tmftbu %0\n"
++                      "\tmftb %1\n"
++                      "\tmftbu %2\n"
++                      "\tcmpw %2,%0\n"
++                      "\tbne 0b\n"
++                      : "=r"(upper), "=r"(lower), "=r"(tmp)
++                     );
++    result = upper;
++    result = result << 32;
++    result = result | lower;
++
++    return result;
++#else
+     unsigned long long x;
+ 
+      /*
+@@ -108,6 +126,7 @@ lexbor_perf_clock(void)
+                       : "rdx", "ebx", "ecx");
+ 
+     return x;
++#endif
+ }
+ 
+ static unsigned long long


### PR DESCRIPTION
#### Description

Fix build on old systems, support testing.
See: https://github.com/lexbor/lexbor/issues/226

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
