### PR TITLE
openjdk22-openj9: new submission

### DIFF
--- a/java/openjdk22-openj9/Portfile
+++ b/java/openjdk22-openj9/Portfile
@@ -1,0 +1,97 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem       1.0
+
+name             openjdk22-openj9
+categories       java devel
+maintainers      {breun.nl:nils @breun} openmaintainer
+platforms        {darwin any}
+# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
+license          GPL-2 NoMirror
+# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
+universal_variant no
+
+# https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
+supported_archs  x86_64 arm64
+
+version      22.0.1
+revision     0
+
+set build    8
+set openj9_version 0.45.0
+
+description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 22
+long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
+                 built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
+
+master_sites https://github.com/ibmruntimes/semeru22-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
+
+if {${configure.build_arch} eq "x86_64"} {
+    distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
+    checksums    rmd160  1a286bcb9ad605a0ba38868823b4117ac012afe4 \
+                 sha256  f0e459df70b5a3c8fc0abc099d5c06a596da40b95f8226d76474516a646a3861 \
+                 size    222418946
+} elseif {${configure.build_arch} eq "arm64"} {
+    distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
+    checksums    rmd160  bc9b02fcb348782b3d0af1f0734f97ebf6e6fa98 \
+                 sha256  623cc15daa3b4c7f21d47f225c94a163e2261074cc3c11f30d2938fc249b9355 \
+                 size    215747283
+}
+
+worksrcdir   jdk-${version}+${build}
+
+homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
+
+livecheck.type      regex
+livecheck.url       https://github.com/ibmruntimes/semeru22-binaries/releases/
+livecheck.regex     ibm-semeru-open-jdk_.*_mac_(22\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
+
+use_configure    no
+build {}
+
+variant Applets \
+    description { Advertise the JVM capability "Applets".} {}
+
+variant BundledApp \
+    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant JNI \
+    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
+
+variant WebStart \
+    description { Advertise the JVM capability "WebStart".} {}
+
+patch {
+    foreach var { Applets BundledApp JNI WebStart } {
+        if {[variant_isset ${var}]} {
+            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
+        }
+    }
+}
+
+test.run    yes
+test.cmd    Contents/Home/bin/java
+test.target
+test.args   -version
+
+# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
+destroot.violate_mtree yes
+
+set jvms /Library/Java/JavaVirtualMachines
+set jdk ${jvms}/jdk-22-ibm-semeru.jdk
+
+destroot {
+    xinstall -m 755 -d ${destroot}${prefix}${jdk}
+    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
+
+    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
+    xinstall -m 755 -d ${destroot}${jvms}
+    ln -s ${prefix}${jdk} ${destroot}${jdk}
+}
+
+notes "
+If you have more than one JDK installed you can make ${name} the default\
+by adding the following line to your shell profile:
+
+    export JAVA_HOME=${jdk}/Contents/Home
+"


### PR DESCRIPTION
#### Description

New port for IBM Semeru 22.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?