### PR TITLE
openjdk20-openj9: obsolete, replaced by openjdk21-openj9

### DIFF
--- a/java/openjdk20-openj9/Portfile
+++ b/java/openjdk20-openj9/Portfile
@@ -1,97 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem       1.0
+PortSystem              1.0
+PortGroup               obsolete 1.0
 
-name             openjdk20-openj9
-categories       java devel
-maintainers      {breun.nl:nils @breun} openmaintainer
-platforms        {darwin any}
-# This port uses prebuilt binaries; 'NoMirror' makes sure MacPorts doesn't mirror/distribute these third-party binaries
-license          GPL-2 NoMirror
-# This port uses prebuilt binaries for a particular architecture; they are not universal binaries
-universal_variant no
+# This port can be removed on 2025-05-26.
+replaced_by             openjdk21-openj9
 
-# https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
-supported_archs  x86_64 arm64
-
-version      20.0.2
-revision     0
-
-set build    9
-set openj9_version 0.40.0
-
-description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 20
-long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
-                 built with the OpenJDK class libraries and the Eclipse OpenJ9 JVM.
-
-master_sites https://github.com/ibmruntimes/semeru20-binaries/releases/download/jdk-${version}+${build}_openj9-${openj9_version}/
-
-if {${configure.build_arch} eq "x86_64"} {
-    distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  e693d22d31b769ca19e88461beed8426610dbce3 \
-                 sha256  ece0d6e2a5cd07b2e0e05a6361026c73838cfd14556c0aeb7f9367a13d19de38 \
-                 size    218745429
-} elseif {${configure.build_arch} eq "arm64"} {
-    distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  7591a93cb06dc73b4e1c6f753d82a418171b4b24 \
-                 sha256  e9c7df3897877350b577d80a47cbc9a7b4589419ca0c2df7c185a20bca8423dd \
-                 size    212077214
-}
-
-worksrcdir   jdk-${version}+${build}
-
-homepage     https://developer.ibm.com/languages/java/semeru-runtimes/
-
-livecheck.type      regex
-livecheck.url       https://github.com/ibmruntimes/semeru20-binaries/releases/
-livecheck.regex     ibm-semeru-open-jdk_.*_mac_(20\.\[0-9\.\]+)_\[0-9\]+_openj9-\[0-9\.\]+\.tar\.gz
-
-use_configure    no
-build {}
-
-variant Applets \
-    description { Advertise the JVM capability "Applets".} {}
-
-variant BundledApp \
-    description { Advertise the JVM capability "BundledApp". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant JNI \
-    description { Advertise the JVM capability "JNI". This is required by some java-based app bundles to recognize and use the JVM.} {}
-
-variant WebStart \
-    description { Advertise the JVM capability "WebStart".} {}
-
-patch {
-    foreach var { Applets BundledApp JNI WebStart } {
-        if {[variant_isset ${var}]} {
-            reinplace -E "s|^(\[\[:space:\]\]*<string>)CommandLine(</string>)|\\1${var}\\2\\\n\\1CommandLine\\2|" ${worksrcpath}/Contents/Info.plist
-        }
-    }
-}
-
-test.run    yes
-test.cmd    Contents/Home/bin/java
-test.target
-test.args   -version
-
-# macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, which is not under ${prefix}.
-destroot.violate_mtree yes
-
-set jvms /Library/Java/JavaVirtualMachines
-set jdk ${jvms}/jdk-20-ibm-semeru.jdk
-
-destroot {
-    xinstall -m 755 -d ${destroot}${prefix}${jdk}
-    copy ${worksrcpath}/Contents ${destroot}${prefix}${jdk}
-
-    # macOS Java tools expect to find Java virtual machines under /Library/Java/JavaVirtualMachines, so let's create a symlink there
-    xinstall -m 755 -d ${destroot}${jvms}
-    ln -s ${prefix}${jdk} ${destroot}${jdk}
-}
-
-notes "
-If you have more than one JDK installed you can make ${name} the default\
-by adding the following line to your shell profile:
-
-    export JAVA_HOME=${jdk}/Contents/Home
-"
+name                    openjdk20-openj9
+version                 20.0.2
+revision                1
+categories              java devel


### PR DESCRIPTION
#### Description

Obsolete IBM Semeru 20, replaced by IBM Semeru 21.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?