### PR TITLE
Submission: Bun

### DIFF
--- a/devel/bun/Portfile
+++ b/devel/bun/Portfile
@@ -5,7 +5,7 @@ PortGroup npm 1.0
 
 name                bun
 version             1.1.10
-maintainers         johnlindop.com:git
+maintainers         {johnlindop.com:git @JLindop} openmaintainer
 revision            0
 
 description         JavaScript runtime built from scratch to serve the modern JavaScript ecosystem

--- a/devel/bun/bun/Portfile
+++ b/devel/bun/bun/Portfile
@@ -1,0 +1,23 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem  1.0
+PortGroup npm 1.0
+
+name                bun
+version             1.1.10
+maintainers         johnlindop.com:git
+revision            0
+
+description         JavaScript runtime built from scratch to serve the modern JavaScript ecosystem
+
+long_description    Bun is an all-in-one JavaScript runtime & toolkit designed for \
+                    speed, complete with a bundler, test runner, and Node.js-compatible \
+                    package manager
+
+categories          devel
+homepage            https://bun.sh
+license             MIT
+
+checksums           rmd160  b7c118e527f587e5832b7b096780d60d6120bfc6 \
+                    sha256  17e4deb24dc9d328c5a5b37fc1e58187e1d8587134378e9abf7e5f94379bf2f9 \
+                    size    5455


### PR DESCRIPTION
#### Description

[Bun](https://bun.sh) is a nodeJS-compatible JavaScript runtime focused on speed. This port uses the `npm` port group.

I wasn't able to build with `-t`, but this seems to be an Apple Silicon issue rather than an issue with the Portfile.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
