### PR TITLE
fgsl: Update to 1.6.0

### DIFF
--- a/math/fgsl/Portfile
+++ b/math/fgsl/Portfile
@@ -3,11 +3,11 @@
 PortSystem          1.0
 PortGroup           compilers 1.0
 PortGroup           compiler_blacklist_versions 1.0
+PortGroup           github 1.0
 
-name                fgsl
-version             1.6.0
+github.setup        reinh-bader fgsl 1.6.0 v
+github.tarball_from archive
 revision            0
-
 categories          math science
 maintainers         {takeshi @tenomoto} \
                     {@Dave-Allured noaa.gov:dave.allured} \
@@ -22,16 +22,9 @@ long_description    A portable, object-based Fortran interface to the GNU scient
 
 homepage            https://doku.lrz.de/fgsl-a-fortran-interface-to-the-gnu-scientific-library-10746505.html
 
-# Switch to private repo, not github, 2024 May 26.  See home page.
-# Parts of fancy URL may be keyed for each specific release.
-# Don't know.  Don't care.  Make it work.
-
-master_sites        https://doku.lrz.de/files/10746505/611614740/5/1715160190380
-distname            ${name}-${version}
-
-checksums           rmd160  716c041b9f6cbb21369f2d038677b7d03a411b8a \
-                    sha256  00b7147755cf0558ec07fff8c26692213580d20f5a9410a8dd13a56a0c336490 \
-                    size    11111005
+checksums           rmd160  40befdf134c677e75e42e54bb68beee6a58c677b \
+                    sha256  8b6a02912b917e4544fed655b8e925c9b7160a063df57afcb35f064f351f1434 \
+                    size    10755695
 
 depends_build       port:pkgconfig
 depends_lib         port:gsl

--- a/math/fgsl/Portfile
+++ b/math/fgsl/Portfile
@@ -2,11 +2,12 @@
 
 PortSystem          1.0
 PortGroup           compilers 1.0
-PortGroup           github 1.0
+PortGroup           compiler_blacklist_versions 1.0
 
-github.setup        reinh-bader fgsl 1.5.0
-github.tarball_from archive
+name                fgsl
+version             1.6.0
 revision            0
+
 categories          math science
 maintainers         {takeshi @tenomoto} \
                     {@Dave-Allured noaa.gov:dave.allured} \
@@ -16,19 +17,32 @@ license             GPL-2
 description         Fortran interface to the GNU scientific library
 long_description    A portable, object-based Fortran interface to the GNU scientific library \
                     (GSL), a collection of numerical routines for scientific computing. \
-                    Version 1.5.x is for use with GSL versions >= 2.6. \
+                    Version 1.6.x is for use with GSL versions >= 2.7. \
                     Source: https://github.com/reinh-bader/fgsl
 
 homepage            https://doku.lrz.de/fgsl-a-fortran-interface-to-the-gnu-scientific-library-10746505.html
 
-checksums           rmd160  fec0e747a13906fdf0a9abdc43a4204769ef4a5d \
-                    sha256  5013b4e000e556daac8b3c83192adfe8f36ffdc91d1d4baf0b1cb3100260e664 \
-                    size    2945012
+# Switch to private repo, not github, 2024 May 26.  See home page.
+# Parts of fancy URL may be keyed for each specific release.
+# Don't know.  Don't care.  Make it work.
+
+master_sites        https://doku.lrz.de/files/10746505/611614740/5/1715160190380
+distname            ${name}-${version}
+
+checksums           rmd160  716c041b9f6cbb21369f2d038677b7d03a411b8a \
+                    sha256  00b7147755cf0558ec07fff8c26692213580d20f5a9410a8dd13a56a0c336490 \
+                    size    11111005
 
 depends_build       port:pkgconfig
 depends_lib         port:gsl
 use_parallel_build  no
 universal_variant   no
+
+# Fix 10.7 build.
+# Copied from https://github.com/macports/macports-ports/pull/17193
+# https://github.com/william-dawson/NTPoly/issues/192
+compiler.blacklist-append \
+                    {clang < 500}
 
 compilers.choose    fc f77 f90
 compilers.setup     require_fortran -g95


### PR DESCRIPTION
#### Description

* Update FGSL 1.5.0 --> 1.6.0.
* Version 1.6.0 is for use with GSL 2.7 and later GSL versions.
* Maybe fix 10.7 Lion build, using compiler blacklist.

###### Tested on

macOS 14.4.1 23E224 x86_64
Xcode 15.2 / Command Line Tools 15.1.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tried a full install with `port -vs install`?
- [x] tested basic functionality of all binary files?