### PR TITLE
primesieve: update to 12.3

### DIFF
--- a/math/primesieve/Portfile
+++ b/math/primesieve/Portfile
@@ -4,11 +4,11 @@ PortSystem                  1.0
 PortGroup                   cmake 1.1
 PortGroup                   github 1.0
 
-github.setup                kimwalisch primesieve 11.1 v
+github.setup                kimwalisch primesieve 12.3 v
 github.tarball_from         tarball
-checksums                   rmd160  ed7e991bbdf34c5bf0048b8db65ff64177fd68c1 \
-                            sha256  2a58c0aa59c1819cce3ea70407d030e9cd88c8072048c8cb427728782c0cf1a4 \
-                            size    129017
+checksums                   rmd160  d33428a65247dd40de2dc4b2ee6e809506e45c63 \
+                            sha256  f1755968774cbe89c5fc36a50cf78c4d6865eed8dbc1aa8c8c88033545fd364e \
+                            size    140737
 
 categories                  math
 maintainers                 nomaintainer
@@ -26,11 +26,6 @@ compiler.cxx_standard       2017
 configure.pre_args-replace  -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON \
                             -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 configure.args-append       -DBUILD_TESTS=ON
-
-# Until this is fixed: https://github.com/kimwalisch/primesieve/issues/141
-if {[string match *gcc* ${configure.compiler}] && ${configure.build_arch} in [list arm i386 ppc]} {
-    configure.ldflags-append    -latomic
-}
 
 test.run                    yes
 test.cmd                    ctest


### PR DESCRIPTION
no longer needs manually-added libatomic on
some gcc builds

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.13.6 17G14042 x86_64
Xcode 10.1 10B61

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
