### PR TITLE
frei0r-plugins: fix build on old systems

### DIFF
--- a/multimedia/frei0r-plugins/Portfile
+++ b/multimedia/frei0r-plugins/Portfile
@@ -19,18 +19,21 @@ long_description    frei0r is a minimalistic plugin API for video sources and fi
 homepage            https://frei0r.dyne.org/
 master_sites        https://releases.dyne.org/frei0r/releases/
 
-platforms           darwin
+checksums           rmd160  5f53940b12737c9d0f7b868305396f26a34b4649 \
+                    sha256  1b1ff8f0f9bc23eed724e94e9a7c1d8f0244bfe33424bb4fe68e6460c088523a \
+                    size    1214323
 
-checksums           sha1    f56840b3d8235810ec1ce5f036c20f88ece6ddca \
-                    rmd160  5f53940b12737c9d0f7b868305396f26a34b4649 \
-                    sha256  1b1ff8f0f9bc23eed724e94e9a7c1d8f0244bfe33424bb4fe68e6460c088523a
-
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig
 
 depends_lib         path:lib/pkgconfig/cairo.pc:cairo
 
 patchfiles          patch-configure.ac.diff \
                     patch-Makefile.am.diff
+
+# cc1: error: unrecognized command line option "-Wtype-limits"
+# error: ISO C++ forbids initialization of member 'm_transformationCalculations'
+compiler.blacklist-append \
+                    *gcc-4.0 *gcc-4.2
 
 use_autoreconf      yes
 


### PR DESCRIPTION
#### Description

Xcode gcc cannot build this.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
