### PR TITLE
mlt-legacy: new port

### DIFF
--- a/multimedia/mlt-legacy/Portfile
+++ b/multimedia/mlt-legacy/Portfile
@@ -1,0 +1,154 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           active_variants 1.1
+PortGroup           compiler_blacklist_versions 1.0
+PortGroup           conflicts_build 1.0
+PortGroup           github 1.0
+PortGroup           muniversal 1.0
+PortGroup           qt4 1.0
+
+name                mlt-legacy
+github.setup        mltframework mlt 6.26.1 v
+revision            0
+categories          multimedia
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+license             GPL-2+
+conflicts           mlt
+description         Open source multimedia framework – core libraries
+long_description    MLT is an open source multimedia framework, designed and developed for \
+                    television broadcasting. It provides a toolkit for broadcasters, video \
+                    editors, media players, transcoders, web streamers and many more types \
+                    of applications. The functionality of the system is provided via an assortment \
+                    of ready to use tools, xml authoring components, and an extendible plug-in \
+                    based API. \
+                    This package contains the files necessary for running applications \
+                    that use the MLT multimedia framework.
+homepage            https://www.mltframework.org
+
+checksums           rmd160  e1181cd38733c89bf7e8be386e15b61fa9700deb \
+                    sha256  8a484bbbf51f33e25312757531f3ad2ce20607149d20fcfcb40a3c1e60b20b4e \
+                    size    1366022
+github.tarball_from releases
+
+patchfiles          patch-enforce-cxx14.diff \
+                    patch-filter_rbpitch.cpp.diff \
+                    patch-numeric_limits.diff \
+                    patch-RtAudio.cpp.diff
+
+if {[string match *gcc* ${configure.compiler}]} {
+    # cc1: error: argument to '-O' should be a non-negative integer, 'g', 's', 'z' or 'fast'
+    patchfiles-append \
+                    patch-sdl2-x11.diff
+}
+
+# eigen3-devel needs C++14
+compiler.cxx_standard      2014
+configure.cxxflags-append  -std=c++14
+# fatal error: 'stdatomic.h' file not found
+compiler.blacklist-append  {clang < 700}
+
+depends_build-append \
+                    path:bin/doxygen:doxygen \
+                    port:git
+
+depends_lib-append  port:atk \
+                    path:share/pkgconfig/eigen3.pc:eigen3 \
+                    path:lib/libavcodec.dylib:ffmpeg \
+                    port:fftw-3 \
+                    port:frei0r-plugins \
+                    port:libebur128 \
+                    port:libexif \
+                    port:libsamplerate \
+                    port:libsdl2 \
+                    port:libvorbis \
+                    port:libxml2 \
+                    port:rubberband \
+                    port:sox
+
+configure.args-append \
+                    --disable-gtk2 \
+                    --disable-jackrack \
+                    --disable-mmx \
+                    --disable-opencv \
+                    --disable-sdl \
+                    --disable-swfdec \
+                    --enable-gpl \
+                    --without-kde
+
+if {[string match *clang* ${configure.cxx}] && ${configure.cxx_stdlib} ne ""} {
+    configure.ldflags-append \
+                    -stdlib=${configure.cxx_stdlib}
+}
+
+pre-configure {
+    configure.env-append \
+                    QTDIR=${qt_dir}
+    # NB: qt-includedir can and should be set to ${qt_includes_dir},
+    # not ${qt_includes_dir}/Qt !!
+    configure.args-append \
+                    --qt-libdir=${qt_frameworks_dir} \
+                    --qt-includedir=${qt_includes_dir}
+
+    configure.cflags-append  "-I${qt_includes_dir}"
+}
+
+platform darwin 10 {
+    if {${configure.build_arch} eq "x86_64"} {
+        configure.args-delete --disable-mmx
+    }
+}
+
+configure.cflags-append     "-I${prefix}/include"
+configure.ldflags-delete    "-L${prefix}/lib"
+
+# make sure the build system actually sees our settings by amending the toplevel config.mak.
+post-configure {
+    set config.mak [open ${worksrcpath}/config.mak "a"]
+    puts ${config.mak} "CC=${configure.cc}"
+    puts ${config.mak} "CXX=${configure.cxx}"
+    puts ${config.mak} "CFLAGS+=${configure.cflags} ${configure.cppflags}"
+    puts ${config.mak} "CXXFLAGS+=${configure.cxxflags} ${configure.cppflags}"
+    puts ${config.mak} "LDLAGS+=${configure.ldflags}"
+    close ${config.mak}
+}
+
+build.args-append           CC="${configure.cc}" CXX="${configure.cxx}" CPP="${configure.cpp}"
+
+if {${universal_possible} && [variant_isset universal]} {
+    foreach arch ${configure.universal_archs} {
+        lappend merger_build_env(${arch})   "CFLAGS=${configure.cflags} -arch ${arch}"
+        lappend merger_build_env(${arch})   "CXXFLAGS=${configure.cxxflags} -arch ${arch}"
+        lappend merger_build_env(${arch})   "LDFLAGS=${configure.ldflags} -L${worksrcpath}-${arch}/src/framework -L${prefix}/lib -arch ${arch}"
+    }
+} else {
+    build.env-append                        "CFLAGS=${configure.cflags} [get_canonical_archflags cc]"
+    build.env-append                        "CXXFLAGS=${configure.cxxflags} [get_canonical_archflags cxx]"
+    build.env-append                        "LDFLAGS=${configure.ldflags} -L${worksrcpath}/src/framework -L${prefix}/lib [get_canonical_archflags ld]"
+}
+
+variant gtk2 description {include the gtk2 module (for additional image and text producers)} {
+    configure.args-delete   --disable-gtk2
+    depends_lib-append      path:lib/pkgconfig/gtk+-2.0.pc:gtk2
+    require_active_variants gtk2 x11
+}
+
+variant gpl3 description {enable GPLv3 components} {
+    configure.args-append   --enable-gpl3
+    license                 GPL-3+
+}
+
+# Notice that rtaudio module requires rtaudio 5.x and fails to build with 6.x:
+# consumer_rtaudio.cpp:150:43: error: 'struct RtAudio::DeviceInfo' has no member named 'probed'
+# consumer_rtaudio.cpp:195:25: error: 'RtAudioError' does not name a type; did you mean 'RtAudioErrorType'?
+# If rtaudio port gets updated, this will break. So rather use the internal one.
+conflicts_build             rtaudio
+
+# Allow building without SDL support, useful when used in dependents that themselves
+# depend on SDL 1.2, to avoid (warnings about) runtime conflicts.
+variant disable_sdl description {disable SDL support to avoid SDL vs. SDL2 conflicts} {
+    configure.args-append   --disable-sdl2
+    configure.cppflags-append \
+                            -DMELT_NOSDL
+    depends_lib-delete      port:libsdl2
+}

--- a/multimedia/mlt-legacy/files/patch-RtAudio.cpp.diff
+++ b/multimedia/mlt-legacy/files/patch-RtAudio.cpp.diff
@@ -1,0 +1,10 @@
+--- src/modules/rtaudio/RtAudio.cpp.orig	2021-04-14 02:06:13.000000000 +0800
++++ src/modules/rtaudio/RtAudio.cpp	2024-05-29 06:10:08.000000000 +0800
+@@ -46,6 +46,7 @@
+ #include <cstring>
+ #include <climits>
+ #include <algorithm>
++#include <unistd.h>
+ 
+ // Static variable definitions.
+ const unsigned int RtApi::MAX_SAMPLE_RATES = 14;

--- a/multimedia/mlt-legacy/files/patch-enforce-cxx14.diff
+++ b/multimedia/mlt-legacy/files/patch-enforce-cxx14.diff
@@ -1,0 +1,11 @@
+--- src/modules/opengl/Makefile	2021-04-14 02:06:13.000000000 +0800
++++ src/modules/opengl/Makefile	2024-05-29 06:06:36.000000000 +0800
+@@ -35,7 +35,7 @@
+ CXXFLAGS += $(CFLAGS)
+ 
+ ifneq (, $(shell $(CXX) --version | grep -is -e g++ -e clang))
+-    CXXFLAGS += -std=c++11
++    CXXFLAGS += -std=c++14
+ endif
+ 
+ SHADERDIR = $(shell pkg-config --variable=shaderdir movit)

--- a/multimedia/mlt-legacy/files/patch-filter_rbpitch.cpp.diff
+++ b/multimedia/mlt-legacy/files/patch-filter_rbpitch.cpp.diff
@@ -1,0 +1,10 @@
+--- src/modules/rubberband/filter_rbpitch.cpp.orig	2020-12-31 11:47:05.000000000 -0800
++++ src/modules/rubberband/filter_rbpitch.cpp	2020-12-31 11:47:55.000000000 -0800
+@@ -25,6 +25,7 @@
+ #include <algorithm>
+ #include <cstring>
+ #include <math.h>
++#include <cstdlib>
+ 
+ using namespace RubberBand;
+ 

--- a/multimedia/mlt-legacy/files/patch-numeric_limits.diff
+++ b/multimedia/mlt-legacy/files/patch-numeric_limits.diff
@@ -1,0 +1,10 @@
+--- src/modules/qt/filter_qtext.cpp.orig	2021-04-14 02:06:13.000000000 +0800
++++ src/modules/qt/filter_qtext.cpp	2024-05-29 06:24:18.000000000 +0800
+@@ -18,6 +18,7 @@
+  */
+ 
+ #include "common.h"
++#include <limits>
+ #include <framework/mlt.h>
+ #include <framework/mlt_log.h>
+ #include <QPainter>

--- a/multimedia/mlt-legacy/files/patch-sdl2-x11.diff
+++ b/multimedia/mlt-legacy/files/patch-sdl2-x11.diff
@@ -1,0 +1,12 @@
+--- src/modules/sdl2/Makefile.orig	2021-04-14 02:06:13.000000000 +0800
++++ src/modules/sdl2/Makefile	2024-05-29 06:16:29.000000000 +0800
+@@ -14,8 +14,7 @@
+ 	   consumer_sdl2_audio.o
+ 
+ ifeq ($(targetos),Darwin)
+-CFLAGS += -ObjC
+-LDFLAGS += -lobjc -framework Foundation
++LDFLAGS += -lX11 -framework Foundation
+ else ifneq ($(targetos), MinGW)
+ LDFLAGS += -lX11
+ endif

--- a/multimedia/mlt/Portfile
+++ b/multimedia/mlt/Portfile
@@ -13,7 +13,7 @@ epoch               4
 categories          multimedia
 maintainers         {dennedy.org:dan @ddennedy} {gmail.com:rjvbertin @RJVB} openmaintainer
 license             GPL-2+
-
+conflicts           mlt-legacy
 description         Open source multimedia framework - core libraries
 long_description    MLT is an open source multimedia framework, designed and developed for \
                     television broadcasting. It provides a toolkit for broadcasters, video \


### PR DESCRIPTION
#### Description

I make it in a separate port, since adding a third Qt into `mlt` which uses a different build system is completely unnecessary and will be painful to maintain for `mlt` maintainers and myself alike.
Instead of restoring an outdated 6.x we had, I update it to the last release of 6.x branch.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
