### PR TITLE
gtk3: Require matching x11/quartz variant of libepoxy

### DIFF
--- a/gnome/gtk3-devel/Portfile
+++ b/gnome/gtk3-devel/Portfile
@@ -274,6 +274,7 @@ variant quartz conflicts x11 {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo quartz
     require_active_variants path:lib/pkgconfig/pango.pc:pango quartz
     require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 quartz
+    require_active_variants libepoxy quartz
 
     configure.args-append \
                             -Dx11_backend=false \
@@ -285,6 +286,7 @@ variant x11 conflicts quartz {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo x11
     require_active_variants path:lib/pkgconfig/pango.pc:pango x11
     require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 x11
+    require_active_variants libepoxy x11
 
     # mesa is required to configure with +x11 due to the dependency on libepoxy
     depends_lib-append \

--- a/gnome/gtk3/Portfile
+++ b/gnome/gtk3/Portfile
@@ -274,6 +274,7 @@ variant quartz conflicts x11 {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo quartz
     require_active_variants path:lib/pkgconfig/pango.pc:pango quartz
     require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 quartz
+    require_active_variants libepoxy quartz
 
     configure.args-append \
                             -Dx11_backend=false \
@@ -285,6 +286,7 @@ variant x11 conflicts quartz {
     require_active_variants path:lib/pkgconfig/cairo.pc:cairo x11
     require_active_variants path:lib/pkgconfig/pango.pc:pango x11
     require_active_variants path:lib/pkgconfig/glib-2.0.pc:glib2 x11
+    require_active_variants libepoxy x11
 
     # mesa is required to configure with +x11 due to the dependency on libepoxy
     depends_lib-append \


### PR DESCRIPTION
#### Description

This is a followup to PR #23760, which ensures that the `x11` and `quartz` variant of `gtk3` matches the respective variant of `libepoxy`. See the discussion on [the corresponding commit](https://github.com/macports/macports-ports/commit/4fb8088b2838539db152705c8ec612d71aa4d237#commitcomment-142465364).

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.6 22G630 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
