### PR TITLE
yt-dlp: update to 2024.05.27

### DIFF
--- a/net/youtube-dl/Portfile
+++ b/net/youtube-dl/Portfile
@@ -37,11 +37,11 @@ if {${subport} eq ${name}} {
 }
 
 subport yt-dlp {
-    github.setup    yt-dlp ${subport} 2024.04.09
+    github.setup    yt-dlp ${subport} 2024.05.27
     revision        0
-    checksums       rmd160  b1d470b6ee5db207e3db2f165345814447acfaf1 \
-                    sha256  59d3caed5cc899e486a7b8873f6143b6a1d22c5b5c05009b709ca0104f5d9eed \
-                    size    5589808
+    checksums       rmd160  3e8c929d2c061340f443be4852811582a3952fa2 \
+                    sha256  83dbf15456490e7efe9ba839922f8221d07cf1168b29653fd476faa3cdf91235 \
+                    size    5638920
 
     dist_subdir     ${subport}/${version}
     distname        ${subport}


### PR DESCRIPTION
#### Description

yt-dlp: update to 2024.05.27

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
