### PR TITLE
npm portgroup: use latest LTS release for default

### DIFF
--- a/_resources/port1.0/group/npm-1.0.tcl
+++ b/_resources/port1.0/group/npm-1.0.tcl
@@ -13,8 +13,8 @@ default distname        {${npm.rootname}-${version}}
 extract.suffix .tgz
 
 options npm.nodejs_version npm.version npm.add_dependencies
-default npm.nodejs_version 16
-default npm.version 8
+default npm.nodejs_version 20
+default npm.version 10
 default npm.add_dependencies yes
 
 default livecheck.type  regex

--- a/devel/bash-language-server/Portfile
+++ b/devel/bash-language-server/Portfile
@@ -5,7 +5,7 @@ PortGroup           npm 1.0
 
 name                bash-language-server
 version             5.3.1
-revision            0
+revision            1
 
 categories          devel
 license             MIT

--- a/devel/eask-cli/Portfile
+++ b/devel/eask-cli/Portfile
@@ -6,7 +6,7 @@ PortGroup           elisp 1.0
 
 name                eask-cli
 version             0.8.3
-revision            0
+revision            1
 
 npm.rootname        @emacs-eask/cli
 distname            cli-${version}

--- a/devel/pnpm/Portfile
+++ b/devel/pnpm/Portfile
@@ -5,7 +5,7 @@ PortGroup           npm 1.0
 
 name                pnpm
 version             8.15.5
-revision            0
+revision            1
 
 categories          devel
 license             MIT

--- a/devel/pyright/Portfile
+++ b/devel/pyright/Portfile
@@ -5,7 +5,7 @@ PortGroup           npm 1.0
 
 name                pyright
 version             1.1.364
-revision            0
+revision            1
 
 categories          devel
 license             MIT

--- a/devel/typescript-language-server/Portfile
+++ b/devel/typescript-language-server/Portfile
@@ -5,7 +5,7 @@ PortGroup           npm 1.0
 
 name                typescript-language-server
 version             4.3.3
-revision            0
+revision            1
 
 categories          devel
 license             Apache-2

--- a/security/bitwarden-cli/Portfile
+++ b/security/bitwarden-cli/Portfile
@@ -5,7 +5,7 @@ PortGroup           npm 1.0
 
 name                bitwarden-cli
 version             2023.12.1
-revision            0
+revision            1
 
 npm.rootname        @bitwarden/cli
 distname            cli-${version}


### PR DESCRIPTION
#### Description
Trying again with a clean slate from https://github.com/macports/macports-ports/pull/23658
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.14.6 18G9323 x86_64
Command Line Tools 10.3.0.0.1.1562985497

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
