### PR TITLE
gsl: drop a breaking ldflag added in 2.8 configure

### DIFF
--- a/math/gsl/Portfile
+++ b/math/gsl/Portfile
@@ -44,6 +44,11 @@ configure.checks.implicit_function_declaration.whitelist-append \
                     finite \
                     strchr
 
+# Version 2.8 added -Wl,-no_fixup_chains flag,
+# which is not universally supported. Drop it.
+# Related: https://github.com/haskell/zlib/issues/53
+patchfiles-append   patch-fix-linking.diff
+
 test.run            yes
 test.target         check
 

--- a/math/gsl/files/patch-fix-linking.diff
+++ b/math/gsl/files/patch-fix-linking.diff
@@ -1,0 +1,19 @@
+The linker may not understand this flag:
+ld: unknown option: -no_fixup_chains
+collect2: error: ld returned 1 exit status
+
+--- configure	2024-05-25 21:26:49.000000000 +0800
++++ configure	2024-05-30 14:02:19.000000000 +0800
+@@ -8761,10 +8761,11 @@
+       _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+     darwin*)
+       case $MACOSX_DEPLOYMENT_TARGET,$host in
++        # This is correct, later PowerPC uses -undefined dynamic_lookup
+         10.[012],*|,*powerpc*-darwin[5-8]*)
+           _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+         *)
+-          _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup $wl-no_fixup_chains' ;;
++          _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;
+   esac


### PR DESCRIPTION
#### Description

Fix linking

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
