### PR TITLE
update opam Portfile: add dependency on gpatch

### DIFF
--- a/ocaml/opam/Portfile
+++ b/ocaml/opam/Portfile
@@ -26,6 +26,10 @@ checksums           rmd160  734abf1551d55f29b34a97e2bf64e7cd9cc9fd8b \
                     size    11704198
 
 depends_build       port:ocaml
+# Opam upgrade uses patch to update the package repository,
+# this can silently fail with macos patch when files are
+# deleted upstream.
+depends_lib         port:gpatch
 
 # This prevents configure from trying to use a program to fetch dependencies.
 # We don't need or want one.

--- a/ocaml/opam/Portfile
+++ b/ocaml/opam/Portfile
@@ -7,7 +7,7 @@ PortGroup           github 1.0
 github.setup        ocaml opam 2.1.6
 
 name                opam
-revision            0
+revision            1
 categories          ocaml sysutils
 license             LGPL-2
 maintainers         {@pmetzger pmetzger} openmaintainer


### PR DESCRIPTION
#### Description

Updating the opam package repository can silently fail when using macos patch whenever files are removed upstream. As of opam 2.1.6 there is a warning on install to
manually install gpatch to avoid any possible issue and the corruption of the local switches. See also https://github.com/ocaml/opam-repository/issues/25961

This commit adds a dependency to gpatch to prevent any issue and avoid unnecessary manual intervention.

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
