### PR TITLE
mc: remove build workaround for macOS 10.13 (High Sierra)

### DIFF
--- a/sysutils/mc/Portfile
+++ b/sysutils/mc/Portfile
@@ -37,10 +37,6 @@ patchfiles          patch-src_subshell_common.c.diff
 
 configure.args      --without-x --enable-vfs-sftp=no
 
-if {[vercmp ${macos_version} 10.13] >= 0} {
-    configure.env-append    ac_cv_func_utimensat=no
-}
-
 post-destroot {
     set docdir ${destroot}${prefix}/share/doc/${name}
     xinstall -d ${docdir}

--- a/sysutils/mc/Portfile
+++ b/sysutils/mc/Portfile
@@ -5,7 +5,7 @@ PortGroup  legacysupport 1.0
 
 name                mc
 version             4.8.31
-revision            0
+revision            1
 
 categories          sysutils
 maintainers         nomaintainer


### PR DESCRIPTION
#### Description

This is the port of Homebrew/homebrew-core#173306 to MacPorts. I now know thanks to Homebrew CI that it at least works on all still supported macOS versions. Original description follows.

---

We introduced support for nanosecond timestamps with `utimensat` years ago and only enabled it if OS supported it.

This "worked" fine util macOS 10.13 High Sierra, when Apple introduced `utimensat` in a half-assed POSIX-incompatible way (apparently the name of the the `st` structure members were like `st_atimespec` instead of `st_atim` etc.). So the function was there, but our code couldn't use it and builds failed.

We neither had macOS, nor the kernel was published, so we couldn't fix it and the workaround here was to disable `utimensat` by force even if it was available.

I have now checked the builds on the latest version of macOS and they work, and also the nanosecond timestamps work, because apparently Apple fixed the POSIX compatibility somewhen along the way.

The current workaround is now causing data loss (file timestamps are always truncated to microseconds) for the users.

The problem is, I don't know when Apple fixed this. If the formula builds on Monterey and Ventura, then it will also work, but I don't have these systems. High Sierra is not supported for years.

Can we just remove this workaround?

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12 / 13 / 14
