### PR TITLE
wxGTK-3.0: fix for a missing header bug

### DIFF
--- a/graphics/wxWidgets-3.0/Portfile
+++ b/graphics/wxWidgets-3.0/Portfile
@@ -8,7 +8,7 @@ PortGroup           wxWidgets       1.0
 
 github.setup        wxWidgets wxWidgets 3.0.5.1 v
 github.tarball_from releases
-revision            2
+revision            3
 
 name                wxWidgets-3.0
 # ugly workaround to allow some C++11-only applications to be built on < 10.9
@@ -267,6 +267,11 @@ if {${subport} eq "wxPython-3.0"} {
 
     configure.args-replace  --with-cocoa --with-gtk=3 \
                             --without-sdl --with-sdl
+}
+
+if {${subport} eq "wxgtk-3.0" || ${subport} eq "wxgtk-3.0-cxx11"} {
+    # Address this bug: https://trac.macports.org/ticket/70124
+    patchfiles-append       patch-no-osx-evtloopsrc.h.diff
 }
 
 post-destroot {

--- a/graphics/wxWidgets-3.0/files/patch-no-osx-evtloopsrc.h.diff
+++ b/graphics/wxWidgets-3.0/files/patch-no-osx-evtloopsrc.h.diff
@@ -1,0 +1,25 @@
+--- Makefile.in	2020-05-02 22:03:18.000000000 +0800
++++ Makefile.in	2024-05-31 15:29:25.000000000 +0800
+@@ -2528,7 +2528,8 @@
+ 	wx/osx/core/evtloop.h \
+ 	wx/osx/core/objcid.h \
+ 	wx/osx/core/private.h \
+-	wx/osx/core/stdpaths.h
++	wx/osx/core/stdpaths.h \
++	wx/osx/evtloopsrc.h
+ @COND_TOOLKIT_GTK@BASE_OSX_HDR = $(COND_TOOLKIT_GTK_BASE_OSX_HDR)
+ COND_TOOLKIT_X11_BASE_OSX_HDR =  \
+ 	wx/unix/app.h \
+
+
+--- include/wx/evtloopsrc.h.orig	2020-05-02 22:03:18.000000000 +0800
++++ include/wx/evtloopsrc.h	2024-05-31 15:12:57.000000000 +0800
+@@ -89,7 +89,7 @@
+     #include "wx/unix/evtloopsrc.h"
+ #endif // __UNIX__
+ 
+-#if defined(__WXGTK20__)
++#if defined(__WXGTK__)
+     #include "wx/gtk/evtloopsrc.h"
+ #endif
+ 


### PR DESCRIPTION
#### Description

Addresses a missing header issue which prevents building `wxMaxima` with GTK backend.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

macOS 14.5
Xcode 15.3

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
