### PR TITLE
aws-iam-authenticator: update to 0.6.20

### DIFF
--- a/sysutils/aws-iam-authenticator/Portfile
+++ b/sysutils/aws-iam-authenticator/Portfile
@@ -4,31 +4,31 @@ PortSystem          1.0
 PortGroup           golang 1.0
 
 # UPDATE THESE IN SYNC!
-set version         0.5.2
-set commit          292b9b82df69b87af962b92485b254d9f4b10f00
+set version         0.6.20
+set commit          774efb85b060370538c2d47576fb3ba3e58b2c38
 
 go.setup            github.com/kubernetes-sigs/aws-iam-authenticator ${version} v
 revision            0
 go.package          sigs.k8s.io/aws-iam-authenticator
+go.offline_build    no
 
 description         AWS IAM Authenticator for Kubernetes
 long_description    Use IAM credentials to authenticate to Kubernetes.
 
 categories          sysutils
-platforms           darwin
 license             Apache-2
 
 maintainers         @asobrien \
                     openmaintainer
 
-checksums           rmd160  0bf5bee637fe3ae2faf96d24d5b95621c8e6c00c \
-                    sha256  a24cd391de7a5f736d1a9436054188b97fd30e01c0f707afea08c31b41720653 \
-                    size    6073567
+checksums           rmd160  70d47260c91ccf6eac55bb9d9f06b18920a973bb \
+                    sha256  b902e10cbec693b38a3ed1e65ed3a75a57187782e85eee8e61c4a607cebc5e19 \
+                    size    191573
 
 
 build.args          -ldflags=\"-s -w \
-                    -X main.version=${version} \
-                    -X main.commit=${commit}\"
+                    -X ${go.package}/pkg.Version=${version} \
+                    -X ${go.package}/pkg.CommitID=${commit}\"
 build.args-append   ./cmd/${name}
 
 # Do not build on macOS 10.10 and earlier
@@ -43,5 +43,14 @@ if {${os.platform} eq "darwin" && ${os.major} < 15} {
 
 destroot {
     xinstall -m 0755 ${worksrcpath}/${name} ${destroot}${prefix}/bin/
+
+    # Install shell completions
+    set bash_completions_dir ${destroot}${prefix}/share/bash-completion/completions
+    set fish_completions_dir ${destroot}${prefix}/share/fish/vendor_completions.d
+    set zsh_completions_dir ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${bash_completions_dir} ${fish_completions_dir} ${zsh_completions_dir}
+    system "${worksrcpath}/${name} completion bash > ${bash_completions_dir}/${name}"
+    system "${worksrcpath}/${name} completion fish > ${fish_completions_dir}/${name}.fish"
+    system "${worksrcpath}/${name} completion zsh > ${zsh_completions_dir}/_${name}"
 }
 


### PR DESCRIPTION
- install shell completions

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
