### PR TITLE
LimeChat: sign app bundle on 13.0 and later

### DIFF
--- a/aqua/LimeChat/Portfile
+++ b/aqua/LimeChat/Portfile
@@ -9,6 +9,7 @@ name                    LimeChat
 if {${os.platform} eq "darwin" && ${os.major} < 11} {
     # Peg until this is addressed: https://github.com/psychs/limechat/issues/340
     github.setup        psychs limechat 2.26
+    revision            1
     checksums           sha256  fb4cb99bc2b26defb623d33ae46f500674c25e0f4bd1eda0ec44cef9e88a2e64 \
                         rmd160  3851851afa4e2b010090a2f487fcc025519450ce \
                         size    3567569
@@ -19,6 +20,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
     xcode.target        LimeChat
 } else {
     github.setup        psychs limechat 2.47
+    revision            1
     checksums           sha256  cb07c833d8bff0057b6bd1b38ee687e82a18466f8ab9e8b3c8db54ba21f48a12 \
                         rmd160  fa81e57d258280ff50d1a44e7f1759680554212e \
                         size    3540775
@@ -37,9 +39,16 @@ long_description        LimeChat is an IRC client for Mac OS X that's \
                         multiple servers and rich keyboard shortcuts \
                         for your comfortable operations.
 
-xcode.build.settings-append \
-                        CODE_SIGN_IDENTITY= \
-                        CODE_SIGNING_REQUIRED=NO
-xcode.destroot.settings-append \
-                        CODE_SIGN_IDENTITY= \
-                        CODE_SIGNING_REQUIRED=NO
+xcode.configuration     Release
+
+if {${os.major} >= 22} {
+    xcode.build.settings-append \
+        CODE_SIGN_IDENTITY=-
+} else {
+    xcode.build.settings-append \
+        CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO
+}
+
+destroot {
+    file copy ${worksrcpath}/build/${xcode.configuration}/LimeChat.app ${destroot}${applications_dir}
+}


### PR DESCRIPTION
Avoid building again in destroot

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS x.y
Xcode x.y / Command Line Tools x.y.z

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
