### PR TITLE
nco: revbump because of gsl version update

### DIFF
--- a/science/nco/Portfile
+++ b/science/nco/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           github 1.0
 
 github.setup        nco nco 5.2.4
-revision            0
+revision            1
 platforms           darwin
 maintainers         {takeshi @tenomoto} \
                     {me.com:remko.scharroo @remkos} \


### PR DESCRIPTION
#### Description

Revbump needed for `nco` because `libgsl.27.dylib` became `libgsl.28.dylib` with the latest `gsl` update.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 x86_64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
