### PR TITLE
g-ls: Update to 0.28.0

### DIFF
--- a/sysutils/g-ls/Portfile
+++ b/sysutils/g-ls/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/Equationzhao/g 0.27.0 v
+go.setup                github.com/Equationzhao/g 0.28.0 v
 name                    g-ls
 revision                0
 categories              sysutils
@@ -17,18 +17,28 @@ long_description        {*}${description}. Built for the modern terminal.
 
 homepage                https://g.equationzhao.space
 
-checksums               rmd160  7d3d5e402fb2ea29b8177e3b4760baede6433cbd \
-                        sha256  ec77cbb7cd98f67188f903514ebd282a3691cb0b35c9546b57207dda5529ed4b \
-                        size    401983
+checksums               rmd160  659733d7c2cbb22b2410335bb627d9546c0e5027 \
+                        sha256  a86bfa055aa783ad78be27abbb2e05393a9bede0ca5c92b649e5b6471cb7cf6e \
+                        size    410110
 
 # Vendored libraries cause failure, fetch them at build time
 go.offline_build        no
 
-build.args-append       -ldflags="-s -w"
+build.args-append       -ldflags \"-s -w\"
 
 destroot {
-    xinstall -m 0755 ${worksrcpath}/g ${destroot}${prefix}/bin/g
-    xinstall -d ${destroot}${prefix}/share/zsh/site-functions
-    xinstall -m 0644 ${worksrcpath}/completions/zsh/_g \
-        ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -m 755 ${worksrcpath}/g ${destroot}${prefix}/bin/g
+    xinstall -m 644 ${worksrcpath}/man/g.1.gz ${destroot}${prefix}/share/man/man1
+
+    set zsh_comp_path ${destroot}${prefix}/share/zsh/site-functions
+    xinstall -d ${zsh_comp_path}
+    xinstall -m 644 ${worksrcpath}/completions/zsh/_g ${zsh_comp_path}
+
+    set bash_comp_path ${destroot}${prefix}/share/bash-completion/completions
+    xinstall -d ${bash_comp_path}
+    xinstall -m 644 ${worksrcpath}/completions/bash/g-completion.bash ${bash_comp_path}/g
+
+    set fish_comp_path ${destroot}${prefix}/share/fish/vendor_completion.d
+    xinstall -d ${fish_comp_path}
+    xinstall -m 644 ${worksrcpath}/completions/fish/g.fish ${fish_comp_path}
 }


### PR DESCRIPTION
#### Description

Update `g-ls` to its latest released version, 0.28.0, while adding new completions for other terminals

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
