### PR TITLE
emacs: Prevent Macports tree-sitter grammar libs from shadowing

### DIFF
--- a/editors/emacs/Portfile
+++ b/editors/emacs/Portfile
@@ -24,6 +24,8 @@ platforms       darwin freebsd
 homepage        https://www.gnu.org/software/emacs/emacs.html
 master_sites    gnu
 
+set rpaths [list]
+
 if {$subport eq $name} {
     conflicts   emacs-devel
 }
@@ -56,6 +58,12 @@ configure.args  --disable-silent-rules \
                 --with-webp \
                 --infodir ${prefix}/share/info/${name}
 
+pre-configure {
+    if {[llength $rpaths] > 0} {
+        configure.ldflags-append "-Wl,-rpath " [join $rpaths " -Wl,-rpath "]
+    }
+}
+
 depends_build-append   port:pkgconfig \
                        port:texinfo
 depends_lib-append     port:gmp \
@@ -74,11 +82,6 @@ post-destroot {
     delete ${destroot}${prefix}/share/man/man1/ctags.1.gz
 
     if {$subport eq $name || $subport eq "emacs-devel"} {
-        file copy ${filespath}/site-start.el \
-            ${destroot}${prefix}/share/emacs/site-lisp/
-        reinplace "s|__PREFIX__|${prefix}|g" \
-            ${destroot}${prefix}/share/emacs/site-lisp/site-start.el
-
         # avoid conflicts with xemacs
         move ${destroot}${prefix}/bin/etags ${destroot}${prefix}/bin/etags-emacs
         move ${destroot}${prefix}/share/man/man1/etags.1.gz ${destroot}${prefix}/share/man/man1/etags-emacs.1.gz
@@ -105,7 +108,7 @@ platform darwin {
 
 if {$subport eq $name || $subport eq "emacs-app"} {
     version         29.3
-    revision        0
+    revision        1
     checksums       rmd160  74592d7dba2f02b2d827a74b5a5aa5e2077fc73f \
                     sha256  2de8df5cab8ac697c69a1c46690772b0cf58fe7529f1d1999582c67d927d22e4 \
                     size    78508272
@@ -122,7 +125,7 @@ if {$subport eq "emacs-devel" || $subport eq "emacs-app-devel"} {
     github.setup    emacs-mirror emacs 2c887f497c723c2397888e2f406faa4de3a8208a
     epoch           5
     version         20240118
-    revision        0
+    revision        1
 
     master_sites    ${github.master_sites}
 
@@ -288,13 +291,18 @@ variant nativecomp description {Builds emacs with native compilation support} {
     configure.args-append          --with-native-compilation=aot
     compiler.cpath-prepend         ${prefix}/include/gcc${gcc_v}
     compiler.library_path-prepend  ${prefix}/lib/gcc${gcc_v}
-    configure.ldflags-append       "-Wl,-rpath ${prefix}/lib/gcc${gcc_v}"
+    lappend rpaths                 ${prefix}/lib/gcc${gcc_v}
 }
 
 variant treesitter description {Builds emacs with tree-sitter support} {
     configure.args-delete   --without-tree-sitter
     configure.args-append   --with-tree-sitter
-    depends_lib-append  port:tree-sitter
+    depends_lib-append      port:tree-sitter
+
+    if {$subport eq "emacs-app" || $subport eq "emacs-app-devel"} {
+        lappend rpaths ${prefix}/lib
+    }
+
     depends_run-append \
         port:tree-sitter-typescript \
         port:tree-sitter-javascript \
@@ -323,6 +331,12 @@ variant treesitter description {Builds emacs with tree-sitter support} {
             port:tree-sitter-elixir \
             port:tree-sitter-lua
     }
+
+    notes "
+To install tree-sitter grammar libraries not required by built-in *-ts-modes,
+please use M-x treesit-install-language-grammar.  For details, please refer to
+etc/NEWS or the Emacs Lisp reference manual.
+"
 }
 
 default_variants-append     +treesitter

--- a/editors/emacs/files/site-start-app.el
+++ b/editors/emacs/files/site-start-app.el
@@ -11,6 +11,6 @@
 ;; Info-directory-list contains ${prefix}/share/info. See #32148.
 (setq Info-default-directory-list (cons "__PREFIX__/share/info" Info-default-directory-list))
 
-;; Look in MacPorts ${prefix} for tree-sitter parser libraries
-(when (boundp 'treesit-extra-load-path)
-  (setq treesit-extra-load-path (cons "__PREFIX__/lib" treesit-extra-load-path)))
+;; Use the OS X Emoji font for Emoticons
+(when (fboundp 'set-fontset-font)
+  (set-fontset-font t 'emoji '("Apple Color Emoji" . "iso10646-1") nil 'prepend))

--- a/editors/emacs/files/site-start.el
+++ b/editors/emacs/files/site-start.el
@@ -1,3 +1,0 @@
-;; Look in MacPorts ${prefix} for tree-sitter parser libraries
-(when (boundp 'treesit-extra-load-path)
-  (setq treesit-extra-load-path (cons "__PREFIX__/lib" treesit-extra-load-path)))


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

~~The reason for this change is that the canonical way to use the new tree-sitter functionality in Emacs 29 is to either configure Emacs yourself to have it compile the libraries for you automatically or use a package like [treesit-auto](https://melpa.org/#/treesit-auto). Emacs upstream frequently assumes whatever the HEAD was in the tree-sitter grammar repo when the Elisp code was written and pays little attention to the differences between HEAD and the last released version, which frequently falls far behind HEAD by years and thus miss out on lots of the latest changes in the languages. There's also an ever increasing number of these language libraries but no reasonable Emacs users will ever require all of them. Let's make these a do-it-yourself part of Emacs as the users are so accustomed to.~~

The `treesit-extra-load-path` defined in emacs-app and emacs-app-devel are shadowing user-compiled tree-sitter grammar libraries in `user-emacs-directory`. This PR is the fix.

In addition, this PR also reverts 2416784.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5
Xcode 15.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
