### PR TITLE
mactop: write log file in $prefix/var/log

### DIFF
--- a/sysutils/mactop/Portfile
+++ b/sysutils/mactop/Portfile
@@ -6,7 +6,7 @@ PortGroup           golang 1.0
 go.setup            github.com/context-labs/mactop 0.1.8 v
 go.package          github.com/context-labs/mactop/v2
 github.tarball_from archive
-revision            0
+revision            1
 
 description         Apple Silicon Monitor Top written in pure Golang
 
@@ -22,6 +22,10 @@ license             MIT
 maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 platforms           {darwin >= 18}
+
+post-patch {
+    reinplace       "s|/var/log|${prefix}/var/log|g" ${worksrcpath}/main.go
+}
 
 build.args-append   -o ./${name}
 


### PR DESCRIPTION
The log file is currently hardcoded to /var/log [1] so change this to
$prefix/var/log.

[1] https://github.com/context-labs/mactop/commit/52b618c1cc383a81b5fa50c80853b9569b92e15b

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
