### PR TITLE
git: update to 2.45.2

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -10,7 +10,7 @@ legacysupport.newest_darwin_requires_legacy 10
 name                git
 # NOTE: Update the DEVEL version first before updating this RELEASE version,
 #       to verify that the intended version builds on all platforms.
-version             2.45.1
+version             2.45.2
 revision            0
 
 description         A fast version control system
@@ -58,13 +58,13 @@ if {${name} eq ${subport}} {
                     git-manpages-${version}${extract.suffix}
 
     checksums       git-${version}${extract.suffix} \
-                    rmd160  01c15b33efad6c9af6ae7945583ef72d8ced03c5 \
-                    sha256  e64d340a8e627ae22cfb8bcc651cca0b497cf1e9fdf523735544ff4a732f12bf \
-                    size    7490268 \
+                    rmd160  108f74b1214dbc98d54697e304bf9fa41b595f71 \
+                    sha256  51bfe87eb1c02fed1484051875365eeab229831d30d0cec5d89a14f9e40e9adb \
+                    size    7487680 \
                     git-manpages-${version}${extract.suffix} \
-                    rmd160  ebd5fd36a006cd52889bf0bcdfe4e699dec43ed6 \
-                    sha256  e622d7ab1114b4f67cb9d8d4ab81f6e0fcf3d1291711569befda29172315d9f0 \
-                    size    576560
+                    rmd160  d86dd6ab7125a090ee2c162b43e0e54c5f0cd898 \
+                    sha256  0938309e86537063b9d6c39b12aa4a786e16e03d02a4d12866be2f3e0db919df \
+                    size    576428
 
     extract.only    git-${version}${extract.suffix} \
                     git-manpages-${version}${extract.suffix}
@@ -273,9 +273,9 @@ variant doc description {Install HTML and plaintext documentation} {
         # RELEASE
         distfiles-append    git-htmldocs-${version}${extract.suffix}
         checksums-append    git-htmldocs-${version}${extract.suffix} \
-                            rmd160  288dd401ce1cb9c9c03e960091dd109bbc348e37 \
-                            sha256  f7095c4478028bc04afd63cd217ea5d4fa08ab819cbb66df40a1a12648edbf40 \
-                            size    1568812
+                            rmd160  83bb3ccd444ae3becb50a029cdfc129afcb3ea89 \
+                            sha256  82fdcb1bc184c34f150dd6445efcb0d75498dbec85a362e41f08c16ad8a904bb \
+                            size    1569148
 
         patchfiles-append   patch-git-subtree.html.diff
 


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
