### PR TITLE
g-ls: Update to 0.28.2

### DIFF
--- a/sysutils/g-ls/Portfile
+++ b/sysutils/g-ls/Portfile
@@ -3,7 +3,7 @@
 PortSystem              1.0
 PortGroup               golang 1.0
 
-go.setup                github.com/Equationzhao/g 0.28.0 v
+go.setup                github.com/Equationzhao/g 0.28.2 v
 name                    g-ls
 revision                0
 categories              sysutils
@@ -17,9 +17,9 @@ long_description        {*}${description}. Built for the modern terminal.
 
 homepage                https://g.equationzhao.space
 
-checksums               rmd160  659733d7c2cbb22b2410335bb627d9546c0e5027 \
-                        sha256  a86bfa055aa783ad78be27abbb2e05393a9bede0ca5c92b649e5b6471cb7cf6e \
-                        size    410110
+checksums               rmd160  431c832037bc680acd5853004e34ed038be328ee \
+                        sha256  70c9069c5913f8f7395aa6312ff5f57f7b716b72a525e83780d1c948fdfe51dd \
+                        size    411378
 
 # Vendored libraries cause failure, fetch them at build time
 go.offline_build        no


### PR DESCRIPTION
#### Description

Update `g-ls` to its latest released version, 0.28.2

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
