### PR TITLE
lynx: update to 2.9.2

### DIFF
--- a/www/lynx/Portfile
+++ b/www/lynx/Portfile
@@ -3,12 +3,11 @@
 PortSystem          1.0
 
 name                lynx
-set milestone       2.9.0
-version             ${milestone}
+version             2.9.2
 revision            0
 categories          www
 license             {GPL-2 OpenSSLException}
-maintainers         {larryv @larryv}
+maintainers         {larryv @larryv} openmaintainer
 
 description         The text web browser
 long_description    Lynx is a fully-featured World Wide Web browser for \
@@ -30,11 +29,10 @@ depends_lib         port:brotli \
 master_sites        https://invisible-island.net/archives/lynx/tarballs \
                     https://invisible-mirror.net/archives/lynx/tarballs
 distname            [strsed ${distname} {g/-//}]
-use_bzip2           yes
 
-checksums           rmd160  fcf6cb903f25d4e26bad47f5589698d63e5669bd \
-                    sha256  5bcae5e2e6043ca7b220963a97763c49c13218d849ffda6be7739bfd5a2d36ff \
-                    size    2781819
+checksums           rmd160  6c93e18f593976d0f27d19a2b6e5d97449903a76 \
+                    sha256  99f8f28f860094c533100d1cedf058c27fb242ce25e991e2d5f30ece4457a3bf \
+                    size    3850759
 
 patchfiles          patch-LYCharSets.diff
 
@@ -65,5 +63,5 @@ variant gnutls conflicts ssl description "Enable secure connections with GnuTLS 
 
 livecheck.type      regex
 livecheck.url       [lindex ${master_sites} 0]
-livecheck.regex     [format {href="%s(\d+(?:\.\d+)*rel\.\d+)%s"} \
+livecheck.regex     [format {href="%s(\d+(?:\.\d+)*)%s"} \
                         ${name} ${extract.suffix}]


### PR DESCRIPTION
#### Description

- add openmaintainer
- fix livecheck

###### Tested on
macOS 14.4.1 23E224 x86_64
Xcode 15.4 15F31d

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?