### PR TITLE
openjdk21-openj9: update to 21.0.3

### DIFF
--- a/java/openjdk21-openj9/Portfile
+++ b/java/openjdk21-openj9/Portfile
@@ -14,11 +14,11 @@ universal_variant no
 # https://developer.ibm.com/languages/java/semeru-runtimes/downloads?os=macOS
 supported_archs  x86_64 arm64
 
-version      21.0.2
+version      21.0.3
 revision     0
 
-set build    13
-set openj9_version 0.43.0
+set build    9
+set openj9_version 0.44.0
 
 description  IBM Semeru with Eclipse OpenJ9 VM distribution, based on OpenJDK 21
 long_description The IBM Semeru Runtimes are free production-ready open source binaries to run your Java applications\
@@ -28,14 +28,14 @@ master_sites https://github.com/ibmruntimes/semeru21-binaries/releases/download/
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     ibm-semeru-open-jdk_x64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  fcfc7ce7d083476330636079191a6f21ada8dc86 \
-                 sha256  d4918284a06a921dcadeec700d2a22c7e3d9bf09f28b30423563daecececb8f4 \
-                 size    224362362
+    checksums    rmd160  def35b5be32a3811f5fa49d2649d8647030f13be \
+                 sha256  95640346ef677fbdbf40efa0298cc61314cffed0c43d1b3bd329b84d445db869 \
+                 size    224552939
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     ibm-semeru-open-jdk_aarch64_mac_${version}_${build}_openj9-${openj9_version}
-    checksums    rmd160  51f01ced65cca7db7282323c07a31657289ef5db \
-                 sha256  78d3e37d57f7b1ab37bba82a65a0d575939cbb06c10e0ddc6a3a1c5576d185d3 \
-                 size    217579545
+    checksums    rmd160  52da307addc619f3139edfa2d68aecb3029da0f5 \
+                 sha256  a95896a4ca7b69050a25b1557520f430abc66d098e9fd15cd394e20c4c93e5cf \
+                 size    217767190
 }
 
 worksrcdir   jdk-${version}+${build}


### PR DESCRIPTION
#### Description

Update to IBM Semeru 21.0.3.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?