### PR TITLE
google-cloud-sdk: update to 478.0.0

### DIFF
--- a/devel/google-cloud-sdk/Portfile
+++ b/devel/google-cloud-sdk/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                google-cloud-sdk
-version             477.0.0
+version             478.0.0
 revision            0
 categories          devel python
 license             Apache-2
@@ -21,19 +21,19 @@ supported_archs     i386 x86_64 arm64
 
 if { ${configure.build_arch} eq "i386" } {
     distname        ${name}-${version}-darwin-x86
-    checksums       rmd160  5ba8a6cc794ede26dfdfffb88372a3890976af0a \
-                    sha256  f6f13f803c707094b8d8cdc19c7eebce47af352d7359d5e99ffb2f580b350713 \
-                    size    124878878
+    checksums       rmd160  90e497fa1b465e4b5a673ebef73e3c96769f1a6a \
+                    sha256  da30744f5c78fe91bded55db1bdf0232df8675bb7e12c491769eb14240740fc8 \
+                    size    124954609
 } elseif { ${configure.build_arch} eq "x86_64" } {
     distname        ${name}-${version}-darwin-x86_64
-    checksums       rmd160  2113cbf4d634d615a3c23ade27b2e7c5b0ba1483 \
-                    sha256  c312f96ff7208152a533d0e7297efedecfa15b6c36ebb5e9ef0aa0b3a588e9c9 \
-                    size    126163652
+    checksums       rmd160  d2eade60d6e6684fc99f387614bc06c93bfebffd \
+                    sha256  3655177c0e208af8e0e3fd65b8e9dcf36d51a286005b00604fa32f83372c45f7 \
+                    size    126238060
 } elseif { ${configure.build_arch} eq "arm64" } {
     distname        ${name}-${version}-darwin-arm
-    checksums       rmd160  5c5459bf2690a07a79a7896d5d4d53362cf72a5a \
-                    sha256  4b5b1963ca6d8b3a03783e62e9ef7ef3ede0795740bffacc6f9b22fa1a1540ab \
-                    size    122482639
+    checksums       rmd160  a932a08e97c69d5049681851dac0518ff27df94c \
+                    sha256  adab27657b4a8cca26bd56a3a0c7e8e1f73a75bfa4dc2037f97b1db3b12ce237 \
+                    size    122564471
 }
 
 homepage            https://cloud.google.com/sdk/


### PR DESCRIPTION
#### Description

Update to Google Cloud SDK 478.0.0.

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?