### PR TITLE
pympress: new port

### DIFF
--- a/graphics/pympress/Portfile
+++ b/graphics/pympress/Portfile
@@ -1,0 +1,62 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                pympress
+version             1.8.5
+revision            0
+
+categories          graphics python
+supported_archs     noarch
+platforms           {darwin any}
+license             GPL-2
+maintainers         {@flyingsamson tuxcad.de:flyingsamson} openmaintainer
+description         PDF presentation tool
+long_description    ${name} is a {*}${description} designed for dual-screen \
+                    setups such as presentations and public talks
+
+checksums           rmd160  b464197f407c0e94044d9a4003ece90ed2f1cb65 \
+                    sha256  29bd39115d05f254da993abba42d54a0e9187f4e2ce7c363324b15136c530bf6 \
+                    size    233617
+
+python.default_version \
+                    312
+
+depends_build-append \
+                    port:py${python.version}-babel
+
+depends_run-append  path:lib/libcairo.dylib:cairo \
+                    path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
+                    path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
+                    path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
+                    port:libyaml \
+                    path:lib/pkgconfig/poppler.pc:poppler \
+                    port:py${python.version}-gobject3
+
+variant media description "Enable media playback capability" {
+    depends_run-append \
+                    port:gstreamer1 \
+                    port:gstreamer1-gst-plugins-base \
+                    port:gstreamer1-gst-plugins-good \
+                    port:gstreamer1-gst-libav
+    notes "
+The installed 'media' variant of this port installs the most common video and
+audio codecs to allow playing media contents embedded into a presentation. If
+you need further codecs, install additional gstreamer-plugin ports (e.g.,
+gstreamer1-gst-plugins-ugly or gstreamer1-gst-plugins-bad).
+"
+}
+
+if (![variant_isset media]) {
+    notes "
+The installed variant of the port does not enforce the installation of any
+video or audio codecs required to play media content embedded into a
+presentation. If you require that feature, either install the '+media' variant
+of this port, which will ensure that the most common video and audio codecs are
+installed alongside pympress, or install the gstreamer-plugin ports that
+provide the codecs that you need manually (e.g., gstreamer1-gst-plugins-good).
+"
+}
+
+default_variants    +media


### PR DESCRIPTION
#### Description

This adds the new port [`pympress`](https://github.com/Cimbali/pympress), a python viewer for presentations in pdf format (e.g., create with LaTeX beamer) that also supports showing embedded videos and audio.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 13.6.6 22G630 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
