### PR TITLE
nghttp2: Remove C++20 requirement and don't autoreconf anymore

### DIFF
--- a/www/nghttp2/Portfile
+++ b/www/nghttp2/Portfile
@@ -22,7 +22,7 @@ checksums           rmd160  af8c1058f50255b0f2209ba836db9967b5cd5098 \
                     sha256  2345d4dc136fda28ce243e0bb21f2e7e8ef6293d62c799abbf6f633a6887af72 \
                     size    1606084
 
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig
 
 # See: https://trac.macports.org/ticket/57960
 # See: https://github.com/nghttp2/nghttp2/issues/1309
@@ -35,7 +35,7 @@ patchfiles-append   patch-src-shrpx_client_handler.cc.diff \
 use_autoreconf      yes
 configure.checks.implicit_function_declaration.whitelist-append strchr
 
-compiler.cxx_standard   2020
+compiler.c_standard 1999
 
 configure.args      --disable-silent-rules \
                     --disable-threads \
@@ -52,6 +52,9 @@ subport nghttp2-tools {
     description         Tools for nghttp2, an implementation of HTTP/2 in C.
     long_description    HTTP/2 client, server and proxy tools, as well as a \
                         load test and benchmarking tool for HTTP/2.
+
+    compiler.cxx_standard \
+                        2020
 
     configure.args-replace \
                         --enable-lib-only --enable-app

--- a/www/nghttp2/Portfile
+++ b/www/nghttp2/Portfile
@@ -32,7 +32,7 @@ patchfiles-append   patch-src-shrpx_client_handler.cc.diff \
                     patch-src-shrpx_downstream_connection_pool.cc.diff \
                     src-shrpx_config.diff
 
-use_autoreconf      yes
+# https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr
 configure.checks.implicit_function_declaration.whitelist-append strchr
 
 compiler.c_standard 1999


### PR DESCRIPTION
#### Description

C++20 is not required to build nghttp2. It's only required to build the nghttp2-tools subport. Removing this requirement for nghttp2 allows the port to build on Snow Leopard and earlier again and will allow the curl port to enable http2 support for all macOS versions.

Closes: https://trac.macports.org/ticket/65066
Closes: https://trac.macports.org/ticket/70027
Closes: https://trac.macports.org/ticket/70048

Running autoreconf is not needed anymore since the configure.ac patch was removed years ago.

Closes: https://trac.macports.org/ticket/70141

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [X] enhancement
- [ ] security fix

###### Tested on
macOS 12.7.4 21H1123 x86_64
Xcode 14.2 14C18

###### Verification <!-- (delete not applicable items) -->
Have you

- [X] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [X] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [X] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same chnnge?
- [X] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [X] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
