### PR TITLE
cl-cffi-gtk: Standardize dependencies

### DIFF
--- a/lisp/cl-cffi-gtk/Portfile
+++ b/lisp/cl-cffi-gtk/Portfile
@@ -32,20 +32,17 @@ common_lisp.systems     {cairo/*.asd} \
                         {pango/*.asd}
 
 # I may split it into subports but all that dependency from one cluster
-depends_lib-append      path:lib/libcairo.dylib:cairo \
-                        path:lib/libgdk-3.dylib:gtk3 \
-                        path:lib/libgdk_pixbuf-2.0.dylib:gdk-pixbuf2 \
-                        path:lib/libgio-2.0.dylib:glib2 \
-                        path:lib/libgobject-2.0.dylib:glib2 \
-                        path:lib/libgthread-2.0.dylib:glib2 \
-                        path:lib/libglib-2.0.dylib:glib2 \
+depends_lib-append      path:lib/pkgconfig/cairo.pc:cairo \
                         port:cl-alexandria \
                         port:cl-bordeaux-threads \
                         port:cl-cffi \
                         port:cl-closer-mop \
                         port:cl-iterate \
                         port:cl-trivial-features \
-                        port:cl-trivial-garbage
+                        port:cl-trivial-garbage \
+                        path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
+                        path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                        path:lib/pkgconfig/gtk+-3.0.pc:gtk3
 
 common_lisp.ffi         yes
 common_lisp.threads     yes


### PR DESCRIPTION
#### Description

Specify the cairo, glib2, gtk3, and gdk-pixbuf2 dependencies the way other ports do, by referencing the .pc file (not by the .dylib file since that would not exist on non-macOS operating systems). Reference each port only once. Alphabetize deps by port name.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [X] bugfix
- [ ] enhancement
- [ ] security fix
