### PR TITLE
notmuch: needs C++11

### DIFF
--- a/mail/notmuch/Portfile
+++ b/mail/notmuch/Portfile
@@ -12,7 +12,6 @@ checksums           rmd160  5dec7b4dc2db2c731ad106ab1f15c6b911fb4a40 \
                     size    805416
 
 categories          mail
-platforms           darwin
 license             GPL-3+
 maintainers         {seichter.de:macports @rseichter} openmaintainer
 description         Fast, global-search and tag-based email system
@@ -61,6 +60,10 @@ configure.args      --with-docs \
 configure.cppflags-replace \
                     -I${prefix}/include \
                     -isystem${prefix}/include
+
+# Undefined symbols: "__ZN6Xapian20sortable_unserialiseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE"
+compiler.cxx_standard \
+                    2011
 
 # Ensure libraries built in the work area are found first, before those in
 # ${prefix}/lib. -L${prefix}/lib still gets added later in the build command


### PR DESCRIPTION
#### Description

Building with gcc-4.2 fails earlier for other reasons, but blacklisting does not work, since it actually also requires C++11, so just set that.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
