### PR TITLE
uv: Update to 0.2.6

### DIFF
--- a/devel/uv/Portfile
+++ b/devel/uv/Portfile
@@ -4,7 +4,7 @@ PortSystem              1.0
 PortGroup               cargo 1.0
 PortGroup               github 1.0
 
-github.setup            astral-sh uv 0.2.4
+github.setup            astral-sh uv 0.2.6
 github.tarball_from     archive
 revision                0
 categories              devel python
@@ -17,19 +17,15 @@ long_description        {*}${description}, written in Rust. Designed as a drop-i
                         replacement for common pip and pip-tools workflows.
 
 checksums               ${distname}${extract.suffix} \
-                        rmd160  b9e9cbfa51fb8e253ccfb6bed2a57f81ee7cec52 \
-                        sha256  67950118f8a5132f5e72bb80b1770790c12e79ace6492f379018d1d409bb9204 \
-                        size    1123813
+                        rmd160  bf1db89e731aa337395831a98aee60a97da3266e \
+                        sha256  92320fd6dd4bc8903af4ffd5b412a61125bbd4a83838c75deeaffa48e48faf7a \
+                        size    1122576
 
 depends_build-append    path:bin/pkg-config:pkgconfig
-depends_lib-append      port:libgit2
-
-openssl.branch          3
 
 # Disable --frozen to workaround dependencies from Git
 cargo.offline_cmd
 
-build.env-append        OPENSSL_NO_VENDOR=1
 build.args-append       --no-default-features
 
 post-build {
@@ -81,7 +77,7 @@ cargo.crates \
     assert_cmd                      2.0.14  ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8 \
     assert_fs                        1.1.1  2cd762e110c8ed629b11b6cde59458cc1c71de78ebbcc30099fc8e0403a2a2ec \
     async-channel                    2.3.1  89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a \
-    async-compression               0.4.10  9c90a406b4495d129f00461241616194cb8a032c8d1c53c657f0961d5f8e0498 \
+    async-compression               0.4.11  cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5 \
     async-trait                     0.1.80  c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca \
     async_http_range_reader          0.8.0  f1a0e0571c5d724d17fbe0b608d31a91e94938722c141877d3a2982216b084c2 \
     atomic-waker                     1.1.2  1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0 \
@@ -89,7 +85,7 @@ cargo.crates \
     axoasset                         0.9.3  6d492e2a60fbacf2154ee58fd4bc3dd7385a5febf10fef6145924fd3117cd920 \
     axoprocess                       0.2.0  4de46920588aef95658797996130bacd542436aee090084646521260a74bda7d \
     axotag                           0.2.0  d888fac0b73e64cbdf36a743fc5a25af5ae955c357535cb420b389bf1e1a6c54 \
-    axoupdater                       0.6.4  7d6bf8aaa32e7d33071ed9a339fc34ac30b0a5190f82069fbd12a1266bda9068 \
+    axoupdater                       0.6.5  669a5ea910fb9b97e3df709c7d0f626fc9e5e9cb83c00bd3a1b4c54835ed8b66 \
     backoff                          0.4.0  b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1 \
     backtrace                       0.3.71  26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d \
     backtrace-ext                    0.2.1  537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50 \
@@ -204,7 +200,6 @@ cargo.crates \
     getrandom                       0.2.14  94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c \
     gif                             0.12.0  80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045 \
     gimli                           0.28.1  4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253 \
-    git2                            0.18.3  232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70 \
     glob                             0.3.1  d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b \
     globset                         0.4.14  57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1 \
     globwalk                         0.9.1  0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757 \
@@ -216,7 +211,6 @@ cargo.crates \
     heck                             0.5.0  2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea \
     hermit-abi                       0.3.9  d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024 \
     hex                              0.4.3  7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70 \
-    hmac                            0.12.1  6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e \
     home                             0.5.9  e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5 \
     homedir                          0.2.1  22074da8bba2ef26fc1737ae6c777b5baab5524c2dc403b5c6a76166766ccda5 \
     html-escape                     0.2.13  6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476 \
@@ -228,7 +222,7 @@ cargo.crates \
     httpdate                         1.0.3  df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9 \
     hyper                            1.3.1  fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d \
     hyper-rustls                    0.26.0  a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c \
-    hyper-util                       0.1.3  ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa \
+    hyper-util                       0.1.5  7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56 \
     iana-time-zone                  0.1.60  e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141 \
     iana-time-zone-haiku             0.1.2  f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f \
     idna                             0.5.0  634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6 \
@@ -255,12 +249,9 @@ cargo.crates \
     kurbo                            0.9.5  bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b \
     lazy_static                      1.4.0  e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646 \
     libc                           0.2.153  9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd \
-    libgit2-sys               0.16.2+1.7.2  ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8 \
-    libmimalloc-sys                 0.1.37  81eb4061c0582dedea1cbc7aff2240300dd6982e0239d1c99e65c1dbf4a30ba7 \
+    libmimalloc-sys                 0.1.38  0e7bb23d733dfcc8af652a78b7bf232f0e967710d044732185e561e47c0336b6 \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
-    libssh2-sys                      0.3.0  2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee \
     libz-ng-sys                     1.1.15  c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5 \
-    libz-sys                        1.1.16  5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9 \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
     linux-raw-sys                   0.4.14  78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89 \
     lock_api                        0.4.12  07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17 \
@@ -275,7 +266,7 @@ cargo.crates \
     memoffset                        0.9.1  488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a \
     miette                           7.2.0  4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1 \
     miette-derive                    7.2.0  dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c \
-    mimalloc                        0.1.41  9f41a2280ded0da56c8cf898babb86e8f10651a34adcfff190ae9a1159c6908d \
+    mimalloc                        0.1.42  e9186d86b79b52f4a77af65604b51225e8db1d6ee7e3f41aec1e40829c71a176 \
     mime                            0.3.17  6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a \
     miniz_oxide                      0.7.2  9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7 \
     mio                             0.8.11  a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c \
@@ -285,7 +276,7 @@ cargo.crates \
     nix                             0.28.0  ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4 \
     normalize-line-endings           0.3.0  61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be \
     nu-ansi-term                    0.46.0  77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84 \
-    nu-ansi-term                    0.49.0  c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68 \
+    nu-ansi-term                    0.50.0  dd2800e1520bdc966782168a627aa5d1ad92e33b984bf7c7615d31280c83ff14 \
     num-traits                      0.2.19  071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841 \
     num_cpus                        1.16.0  4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43 \
     number_prefix                    0.4.0  830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3 \
@@ -293,8 +284,6 @@ cargo.crates \
     once_cell                       1.19.0  3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92 \
     oorandom                        11.1.3  0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575 \
     openssl-probe                    0.1.5  ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf \
-    openssl-src              300.2.3+3.2.1  5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843 \
-    openssl-sys                    0.9.102  c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2 \
     option-ext                       0.2.0  04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d \
     overload                         0.1.1  b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39 \
     owo-colors                       4.0.0  caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f \
@@ -387,20 +376,19 @@ cargo.crates \
     ryu                             1.0.18  f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f \
     same-file                        1.0.6  93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502 \
     schannel                        0.1.23  fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534 \
-    schemars                        0.8.20  b0218ceea14babe24a4a5836f86ade86c1effbc198164e619194cb5069187e29 \
-    schemars_derive                 0.8.20  3ed5a1ccce8ff962e31a165d41f6e2a2dd1245099dc4d594f5574a86cd90f4d3 \
+    schemars                        0.8.21  09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92 \
+    schemars_derive                 0.8.21  b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e \
     scopeguard                       1.2.0  94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49 \
     seahash                          4.1.0  1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b \
     security-framework              2.11.0  c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0 \
     security-framework-sys          2.11.0  317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7 \
     semver                          1.0.23  61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b \
-    serde                          1.0.202  226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395 \
-    serde_derive                   1.0.202  6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838 \
+    serde                          1.0.203  7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094 \
+    serde_derive                   1.0.203  500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba \
     serde_derive_internals          0.29.1  18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711 \
     serde_json                     1.0.117  455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3 \
     serde_spanned                    0.6.6  79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0 \
     serde_urlencoded                 0.7.1  d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd \
-    sha1                            0.10.6  e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba \
     sha2                            0.10.8  793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8 \
     sharded-slab                     0.1.7  f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6 \
     shell-escape                     0.1.5  45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f \
@@ -432,7 +420,6 @@ cargo.crates \
     tagu                             0.1.6  eddb6b06d20fba9ed21fca3d696ee1b6e870bca0bcf9fa2971f6ae2436de576a \
     tap                              1.0.1  55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369 \
     target-lexicon                 0.12.14  e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f \
-    temp-dir                        0.1.13  1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231 \
     temp-env                         0.3.6  96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050 \
     tempfile                        3.10.1  85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1 \
     terminal_size                    0.3.0  21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7 \
@@ -455,8 +442,8 @@ cargo.crates \
     tinyvec                          1.6.0  87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50 \
     tinyvec_macros                   0.1.1  1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20 \
     tl                               0.7.8  b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7 \
-    tokio                           1.37.0  1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787 \
-    tokio-macros                     2.2.0  5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b \
+    tokio                           1.38.0  ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a \
+    tokio-macros                     2.3.0  5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a \
     tokio-rustls                    0.25.0  775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f \
     tokio-stream                    0.1.15  267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af \
     tokio-tar                        0.3.1  9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75 \
@@ -474,7 +461,7 @@ cargo.crates \
     tracing-log                      0.2.0  ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3 \
     tracing-serde                    0.1.3  bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1 \
     tracing-subscriber              0.3.18  ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b \
-    tracing-tree                     0.3.0  65139ecd2c3f6484c3b99bc01c77afe21e95473630747c7aca525e78b0666675 \
+    tracing-tree                     0.3.1  b56c62d2c80033cb36fae448730a2f2ef99410fe3ecbffc916681a32f6807dbe \
     try-lock                         0.2.5  e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b \
     ttf-parser                      0.18.1  0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633 \
     typenum                         1.17.0  42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825 \
@@ -500,7 +487,6 @@ cargo.crates \
     utf8parse                        0.2.1  711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a \
     uuid                             1.8.0  a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0 \
     valuable                         0.1.0  830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d \
-    vcpkg                           0.2.15  accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426 \
     version_check                    0.9.4  49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f \
     wait-timeout                     0.2.0  9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6 \
     walkdir                          2.5.0  29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b \


### PR DESCRIPTION
#### Description

Update `uv` to its latest released version, 0.2.6.

`libgit2` (and thus `openssl3`) are no longer needed after this release: https://github.com/astral-sh/uv/commit/261aa2c70a93e1705f6bcea142c7cf71d7666dfa

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->

macOS 12.6 21G115 arm64
Command Line Tools 14.2.0.0.1.1668646533

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -d install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
