### PR TITLE
Update: Bun 1.1.12

### DIFF
--- a/devel/bun/Portfile
+++ b/devel/bun/Portfile
@@ -1,10 +1,12 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem  1.0
-PortGroup npm 1.0
+PortSystem          1.0
+PortGroup           npm 1.0
+
+npm.nodejs_version  22
 
 name                bun
-version             1.1.10
+version             1.1.12
 maintainers         {johnlindop.com:git @JLindop} openmaintainer
 revision            0
 
@@ -18,6 +20,6 @@ categories          devel
 homepage            https://bun.sh
 license             MIT
 
-checksums           rmd160  b7c118e527f587e5832b7b096780d60d6120bfc6 \
-                    sha256  17e4deb24dc9d328c5a5b37fc1e58187e1d8587134378e9abf7e5f94379bf2f9 \
+checksums           rmd160  a5039dc5fc2010846701808523b236f0430deb76 \
+                    sha256  d4b972f9179991f01d2986a51a2fe5b503e4571be28628b6cead5fa0fb078b00 \
                     size    5455


### PR DESCRIPTION
#### Description

Update Bun port to 1.1.12
###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Command Line Tools 15.3.0.0.1.1708646388

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tested basic functionality of all binary files?
<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
