### PR TITLE
CI: Remove macos-11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12, macos-13, macos-14]
+        os: [macos-12, macos-13, macos-14]
 
     steps:
       - name: Checkout ports


### PR DESCRIPTION
The macos-11 runner is slated for removal by the end of the month with brownouts scheduled to occur in the weeks leading up to that.