### PR TITLE
symfony-cli: update to 5.9.1

### DIFF
--- a/devel/symfony-cli/Portfile
+++ b/devel/symfony-cli/Portfile
@@ -2,7 +2,7 @@
 
 PortSystem          1.0
 
-version             5.8.19
+version             5.9.1
 revision            0
 
 if {${os.major} >= 17} {
@@ -44,9 +44,9 @@ if ${source_build} {
 
     use_parallel_build  no
 
-    checksums           rmd160  04de668569a82b67146a58b8fcca15176ef24081 \
-                        sha256  b33579bdf91eafe470c7213ffd4566a7c313419f4274d200c01f262929c2d5dc \
-                        size    267267
+    checksums           rmd160  8f9ecbd898bcf9aaf8444219b9f9d38169aa7fed \
+                        sha256  0a5dabe20f02e73fb8a31ff5e234e179297145785efe02b764c768a25d37a17d \
+                        size    268130
 
     github.tarball_from archive
 } else {
@@ -54,9 +54,9 @@ if ${source_build} {
 
     distname            symfony-cli_darwin_all
 
-    checksums           rmd160  0e778b3b51a270fdd4fc421831c2f0c6d16b3cdc \
-                        sha256  32f31f6e0610f4a45b9e0891aeb1d365a604b886fa70b10db97aa5e0f7ac8583 \
-                        size    11404300
+    checksums           rmd160  7de798cf8ea8a7dacac80d927a8dd3670ceb724e \
+                        sha256  98f9ef28a53c90ca55198dc3aa66defa8b30d65e5c4ce20f1a7fbe79b375f628 \
+                        size    11412604
 
     github.tarball_from releases
 


### PR DESCRIPTION
#### Description

Update to v5.9.1

###### Tested on

macOS 13.3.1 22E261 x86_64
Xcode 14.2 14C18

###### Verification

Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
