### PR TITLE
autorestic: update to 1.8.2

### DIFF
--- a/sysutils/autorestic/Portfile
+++ b/sysutils/autorestic/Portfile
@@ -3,7 +3,8 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/cupcakearmy/autorestic 1.7.9 v
+go.setup            github.com/cupcakearmy/autorestic 1.8.2 v
+go.offline_build    no
 github.tarball_from archive
 revision            0
 
@@ -11,6 +12,7 @@ categories          sysutils
 installs_libs       no
 license             Apache-2
 maintainers         {gmail.com:smanojkarthick @manojkarthick} \
+                    {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 description         High level CLI utility for restic
@@ -23,14 +25,9 @@ long_description    Autorestic is a wrapper around the amazing restic. \
 
 homepage            https://autorestic.vercel.app/
 
-checksums           rmd160  512185272f65d0a28cae7237afdec238d5a6e7a4 \
-                    sha256  e57bbc045edee4aabd850da2e61da9c18a6d12bd323866be1eb3edca4709b363 \
-                    size    173499
-
-# FIXME: This port currently can't be built without allowing go mod to fetch
-# dependencies during the build phase. See
-# https://trac.macports.org/ticket/61192
-go.offline_build no
+checksums           rmd160  68048502ce83e4ab10d1f3010b0efac7b2861abd \
+                    sha256  847a661bcf8bfdf282eca0dfd677293ad932726d357899c15a85b9238c4ea3da \
+                    size    117614
 
 depends_run         port:restic
 


### PR DESCRIPTION
###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
