### PR TITLE
pkixssh: allow builds with gcc, move keychain in a variant

### DIFF
--- a/net/pkixssh/Portfile
+++ b/net/pkixssh/Portfile
@@ -6,9 +6,8 @@ PortGroup           compiler_blacklist_versions 1.0
 
 name                pkixssh
 version             13.4.1
-revision            1
+revision            2
 categories          net
-platforms           darwin
 maintainers         {@sstallion gmail.com:sstallion} openmaintainer
 license             BSD
 installs_libs       no
@@ -84,7 +83,8 @@ configure.cppflags-append   -D__APPLE_SANDBOX_NAMED_EXTERNAL__ \
 # Support Apple's launchd in ssh-agent
 configure.cppflags-append   -D__APPLE_LAUNCHD__
 
-configure.ldflags-append  -Wl,-search_paths_first
+configure.ldflags-append    -Wl,-search_paths_first
+
 configure.args      --with-ssl-dir=${prefix} \
                     --sysconfdir=${prefix}/etc/ssh \
                     --with-privsep-path=/var/empty \
@@ -98,27 +98,22 @@ configure.args      --with-ssl-dir=${prefix} \
                     --with-pie \
                     --without-xauth \
                     --without-ldns \
-                    --with-audit=bsm \
-                    --with-keychain=apple
+                    --with-audit=bsm
 
-use_parallel_build  yes
+compiler.blacklist-append   {clang < 421}
 
 platform macosx {
-    if {${os.major} < 10} {
-        # See: https://trac.macports.org/ticket/60385
-        configure.args-delete   --with-keychain=apple
-    } elseif {${os.major} <= 11} {
-        # clang is required to build the new Apple Keychain integration due
-        # to it using the Object Subscripting feature, c.f. #59397.
-        # We'll keep it simple and just blacklist any gcc version, cc
-        # (which could be anything), system clang versions prior to those
-        # shipped with Xcode 4.4.
-        # Regarding the macports-clang versions, any version in the
-        # MacPorts tree should suit our needs, since the clang
-        # documentation lists FOSS clang/llvm 3.1 as the first version to
-        # support Object Subscripting and the oldest version in our tree is
-        # now 3.3.
-        compiler.blacklist-append   *gcc* cc {clang < 421}
+    # See: https://trac.macports.org/ticket/60385
+    variant apple_keychain description "Enable Apple Keychain integration" {
+        configure.args-append \
+                    --with-keychain=apple
+    }
+
+    if {${os.major} > 9 && [string match *clang* ${configure.compiler}]} {
+        # At the moment this variant requires clang due
+        # to its Object Subscripting feature, c.f. #59397.
+        default_variants-append \
+                    +apple_keychain
     }
 }
 


### PR DESCRIPTION
#### Description

Make this a bit better.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
