### PR TITLE
saml2aws: update to 2.36.16

### DIFF
--- a/security/saml2aws/Portfile
+++ b/security/saml2aws/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/Versent/saml2aws 2.36.10 v
+go.setup            github.com/Versent/saml2aws 2.36.16 v
 go.package          github.com/versent/saml2aws
 go.offline_build    no
 github.tarball_from archive
@@ -13,6 +13,7 @@ categories          security
 platforms           darwin
 license             MIT
 maintainers         {netinertia.co.uk:jamesog @jamesog} \
+                    {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 description         Log in to AWS using a SAML IDP
@@ -21,9 +22,9 @@ long_description    CLI tool which enables you to login and retrieve AWS \
 
 homepage            https://github.com/Versent/saml2aws
 
-checksums           rmd160  57e797f570f4235e8e4a0f6a710619539352318b \
-                    sha256  5d1a9d0aa5e411ae5f890a7791db38123d9a8ecb8fed816e004ace0b21268c56 \
-                    size    266433
+checksums           rmd160  5d4fa93cda1aca9b20e7ae4bf40941291cda00e0 \
+                    sha256  a2be057a638bef4fa3c9537adcc8683493c09e45a1ce250ee964e02628535543 \
+                    size    295190
 
 if {${os.platform} eq "darwin" && ${os.major} < 13} {
     # The github.com/keybase/go-keychain dependency requires >= 10.9


### PR DESCRIPTION
- add self as co-maintaer

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with ~`sudo port -vst install`~ `sudo port -d destroot`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
