### PR TITLE
ngspice, ngspice-lib: set required C++11 standard

### DIFF
--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -139,6 +139,9 @@ subport ngspice-lib {
     depends_lib-append  port:libedit \
                         port:fftw-3
 
+    # cc1plus: error: unrecognized command line option "-std=c++11"
+    compiler.cxx_standard   2011
+
     configure.args      --enable-cider \
                         --enable-pss \
                         --with-editline \

--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -27,20 +27,20 @@ set docdir      ${prefix}/share/doc/${name}
 if {${name} eq ${subport}} {
 
     # freetype2 headers are not found by default
-    # we could fix the header path in configure.ac, but then need autorecconf, etc
+    # we could fix the header path in configure.ac, but then need autorecconf, etc.
     configure.cppflags-prepend -I${prefix}/include/freetype2
 
     # TASK_BASIC_INFO_COUNT and friends were renamed in 10.8
     patchfiles-append   patch-ngspice-older-MACH-defines.diff
 
-    depends_lib-append  port:ncurses \
+    depends_lib-append  port:fftw-3
                         port:libedit \
+                        port:ncurses \
                         port:xorg-libX11 \
                         port:xorg-libXaw \
                         port:xorg-libXext \
                         port:xorg-libXmu \
-                        port:xorg-libXt \
-                        port:fftw-3
+                        port:xorg-libXt
 
     # cc1plus: error: unrecognized command line option "-std=c++11"
     compiler.cxx_standard   2011
@@ -95,8 +95,8 @@ if {${name} eq ${subport}} {
     livecheck.regex     ${name}-(\[0-9.\]+)${extract.suffix}
 
     # running the tests from MacPorts errors early, probably due to a permissions
-    # issue when calling the X11 display subsystem. Running the tests manually from the
-    # worksrcdir works fine, however
+    # issue when calling the X11 display subsystem. Running the tests manually
+    # from the worksrcdir works fine, however
     # test.run            yes
     # test.target         check
 
@@ -133,14 +133,14 @@ subport ngspice-lib {
     long_description    {*}${description}
 
     # freetype2 headers are not found by default
-    # we could fix the header path in configure.ac, but then need autorecconf, etc
+    # we could fix the header path in configure.ac, but then need autorecconf, etc.
     configure.cppflags-prepend -I${prefix}/include/freetype2
 
     # TASK_BASIC_INFO_COUNT and friends were renamed in 10.8
     patchfiles-append   patch-ngspice-older-MACH-defines.diff
 
-    depends_lib-append  port:libedit \
-                        port:fftw-3
+    depends_lib-append  port:fftw-3 \
+                        port:libedit
 
     # cc1plus: error: unrecognized command line option "-std=c++11"
     compiler.cxx_standard   2011

--- a/science/ngspice/Portfile
+++ b/science/ngspice/Portfile
@@ -42,6 +42,9 @@ if {${name} eq ${subport}} {
                         port:xorg-libXt \
                         port:fftw-3
 
+    # cc1plus: error: unrecognized command line option "-std=c++11"
+    compiler.cxx_standard   2011
+
     configure.args      --enable-cider \
                         --enable-xspice \
                         --enable-pss \


### PR DESCRIPTION
#### Description

Fix ports

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
