### PR TITLE
libqxp, libzmf: use C++11 and Boost 1.81, revbump

### DIFF
--- a/devel/libqxp/Portfile
+++ b/devel/libqxp/Portfile
@@ -3,16 +3,20 @@
 PortSystem          1.0
 PortGroup           boost 1.0
 
+# Old Boost math has a bug which breaks it for gcc:
+# checking for boost/math/constants/constants.hpp... no
+# configure: error: Required boost headers not found.
+boost.version       1.81
+
 name                libqxp
 version             0.0.2
-revision            5
+revision            6
 
 homepage            https://wiki.documentfoundation.org/DLP/Libraries/libqxp
 master_sites        https://dev-www.libreoffice.org/src/libqxp/
 use_xz              yes
 
 categories          devel textproc
-platforms           darwin
 license             MPL-2
 maintainers         {gmail.com:audvare @Tatsh} openmaintainer
 
@@ -23,7 +27,7 @@ checksums           rmd160  3363d46e334124f454c8b928c1e91e8f138ef250 \
                     sha256  e137b6b110120a52c98edd02ebdc4095ee08d0d5295a94316a981750095a945c \
                     size    341760
 
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         path:lib/pkgconfig/icu-uc.pc:icu \
                     port:librevenge
 
@@ -31,3 +35,6 @@ configure.args      --without-docs \
                     --disable-weffc \
                     --disable-tests \
                     --disable-tools
+
+# configure: error: *** A compiler with support for C++11 language features is required
+compiler.cxx_standard   2011

--- a/devel/libzmf/Portfile
+++ b/devel/libzmf/Portfile
@@ -3,22 +3,26 @@
 PortSystem          1.0
 PortGroup           boost 1.0
 
+# Old Boost math has a bug which breaks it for gcc:
+# checking for boost/math/constants/constants.hpp... no
+# configure: error: Required boost headers not found.
+boost.version       1.81
+
 name                libzmf
 version             0.0.2
-revision            5
+revision            6
 homepage            https://wiki.documentfoundation.org/DLP/Libraries/libzmf
 master_sites        https://dev-www.libreoffice.org/src/libzmf/
 use_xz              yes
 
 categories          devel graphics
-platforms           darwin
 license             MPL-2
 maintainers         {gmail.com:audvare @Tatsh} openmaintainer
 
 description         Library for parsing Zoner Callisto/Draw documents.
 long_description    {*}${description}
 
-depends_build       port:pkgconfig
+depends_build       path:bin/pkg-config:pkgconfig
 depends_lib         path:lib/pkgconfig/icu-uc.pc:icu \
                     port:librevenge \
                     port:libpng \
@@ -33,3 +37,6 @@ configure.args      --without-docs \
                     --disable-tests \
                     --disable-tools \
                     --disable-debug
+
+# configure: error: *** A compiler with support for C++11 language features is required
+compiler.cxx_standard   2011


### PR DESCRIPTION
#### Description

Both require C++11 and need a newer Boost.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
