### PR TITLE
fireworkx: do not use -march=native

### DIFF
--- a/x11/fireworkx/Portfile
+++ b/x11/fireworkx/Portfile
@@ -4,9 +4,9 @@ PortSystem          1.0
 
 name                fireworkx
 version             2.2
+revision            1
 categories          x11
 license             GPL-2+
-platforms           darwin
 maintainers         nomaintainer
 description         pyrotechnic simulation eye-candy for X11
 long_description    ${description}
@@ -16,9 +16,12 @@ master_sites        http://www.ronybc.com/download
 extract.suffix      .src${extract.suffix}
 
 checksums           rmd160  ee1a8af9148421fbe4c50cbf6ad23ecfbfec48bf \
-                    sha256  fb24bd3fb103987913638fd271269e0235dc0c32e34c95652e49c0c81749a44d
+                    sha256  fb24bd3fb103987913638fd271269e0235dc0c32e34c95652e49c0c81749a44d \
+                    size    30720
 
-depends_build-append    port:pkgconfig port:cctools
+depends_build-append \
+                    port:cctools \
+                    path:bin/pkg-config:pkgconfig
 depends_lib         port:xorg-libX11
 
 use_configure       no
@@ -26,6 +29,10 @@ use_configure       no
 post-patch {
     reinplace "s|pkg-config|${prefix}/bin/pkg-config|" ${worksrcpath}/compile_x11
     reinplace "s|strip -sv|strip |" ${worksrcpath}/compile_x11
+    # We do not want these for distribution, especially -march.
+    # Also notice that gcc-4.2 does not support -mtune=native,
+    # and powerpc does not support -march=native.
+    reinplace "s|-mtune=native -march=native||g" ${worksrcpath}/compile_x11
 }
 
 destroot {


### PR DESCRIPTION
#### Description

Upbreak ppc and avoid cpu-specific optimizations generally.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
