### PR TITLE
py-pdal: update to 3.4.3; py-pdal-plugin: new port 1.5.0

### DIFF
--- a/python/py-pdal-plugins/Portfile
+++ b/python/py-pdal-plugins/Portfile
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+
+name                py-pdal-plugins
+version             1.5.0
+revision            0
+
+categories-append   gis
+license             BSD
+maintainers         {yahoo.com:n_larsson @nilason} openmaintainer
+
+description         PDAL Python Plugins
+long_description    {*}${description} allow you to process data with PDAL into \
+                    Numpy arrays. They support embedding Python in PDAL pipelines \
+                    with the readers.numpy and filters.python stages.
+
+homepage            https://www.pdal.io
+
+distname            [string map {- _} ${python.rootname}]-${version}
+
+checksums           rmd160  2e2d6a2b58c03c7674da251b0c4f83dd9f241647 \
+                    sha256  e4e82f14624383a63d3b669771623d5ecec161b4e38beaaff2cab740fef586a4 \
+                    size    575035
+
+python.versions     39 310 311 312
+
+patchfiles          patch_pyproject_pybind11.diff
+
+if {${name} ne ${subport}} {
+    compiler.cxx_standard \
+                    2017
+
+    depends_build-append \
+                    path:bin/cmake:cmake \
+                    port:ninja \
+                    port:py${python.version}-pybind11 \
+                    port:py${python.version}-scikit-build-core
+
+    depends_lib-append \
+                    port:pdal \
+                    port:py${python.version}-numpy \
+                    port:py${python.version}-pdal
+
+    build.env-append \
+                    pybind11_DIR=${python.pkgd}/pybind11/share/cmake/pybind11
+    
+    notes-append \
+        "Add '${python.pkgd}/pdal' to the environmental variable PDAL_DRIVER_PATH\
+        to enable PDAL to locate the plugins."
+}

--- a/python/py-pdal-plugins/files/patch_pyproject_pybind11.diff
+++ b/python/py-pdal-plugins/files/patch_pyproject_pybind11.diff
@@ -1,0 +1,11 @@
+--- pyproject.toml.orig	2022-11-09 13:37:21
++++ pyproject.toml	2024-06-06 09:27:33
+@@ -45,7 +45,7 @@
+ changelog = "https://github.com/PDAL/python-plugins/blob/main/README.rst"
+ 
+ [build-system]
+-requires = ["scikit-build-core", "numpy",  "pybind11[global]"]
++requires = ["scikit-build-core", "numpy",  "pybind11"]
+ build-backend = "scikit_build_core.build"
+ 
+ #[tool.scikit-build-core]

--- a/python/py-pdal/Portfile
+++ b/python/py-pdal/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-pdal
-version             3.3.0
-revision            2
+version             3.4.3
+revision            0
 
 categories-append   gis
 license             BSD
@@ -19,43 +19,34 @@ long_description    {*}${description} allows you to process data with PDAL\
 
 homepage            https://www.pdal.io
 
-checksums           rmd160  50fb67708b007a4276f9d35898748a0031dcd1eb \
-                    sha256  08481ced6e3d1cbdf391282b4f450b84a566cebb077e680f4658c03ccbcb24c0 \
-                    size    246265
+checksums           rmd160  1ec1dde462188413d4f59a077b7ac859b874eb8d \
+                    sha256  c7ce4e19934b19db379183e5607e1b76699e8c1fd5b956a54f28ebd2e3222ad2 \
+                    size    89462
 
-python.versions     38 39 310 311 312
-python.pep517       no
+python.versions     39 310 311 312
+
+patchfiles          patch_pyproject_pybind11.diff
 
 if {${name} ne ${subport}} {
-    PortGroup       cmake 1.1
-
     compiler.cxx_standard \
                     2017
 
     depends_build-append \
-                    port:py${python.version}-setuptools \
-                    port:py${python.version}-scikit-build \
-                    port:pybind11 \
-                    port:ninja
+                    path:bin/cmake:cmake \
+                    port:ninja \
+                    port:py${python.version}-pybind11 \
+                    port:py${python.version}-scikit-build-core
 
     depends_lib-append \
                     port:pdal \
                     port:py${python.version}-numpy
 
     depends_test-append \
-                    port:py${python.version}-meshio
+                    port:py${python.version}-meshio \
+                    port:py${python.version}-pandas
 
     build.env-append \
-                    pybind11_DIR=${prefix}/share/cmake/pybind11
-    build.dir       ${worksrcpath}
-    build.post_args
-
-    destroot.dir    ${worksrcpath}
-    destroot.target install
-
-    pre-configure {
-        file delete -force {*}[glob -nocomplain ${worksrcpath}/_skbuild/linux*]
-    }
+                    pybind11_DIR=${python.pkgd}/pybind11/share/cmake/pybind11
 
     test.run        yes
  }

--- a/python/py-pdal/files/patch_pyproject_pybind11.diff
+++ b/python/py-pdal/files/patch_pyproject_pybind11.diff
@@ -1,0 +1,11 @@
+--- pyproject.toml.orig	2022-11-09 13:37:21
++++ pyproject.toml	2024-06-05 17:17:24
+@@ -48,7 +48,7 @@
+ changelog = "https://github.com/PDAL/python/blob/main/README.rst"
+ 
+ [build-system]
+-requires = ["scikit-build-core >= 0.9", "numpy >= 1.22",  "pybind11[global]"]
++requires = ["scikit-build-core >= 0.9", "numpy >= 1.22",  "pybind11"]
+ build-backend = "scikit_build_core.build"
+ 
+ 


### PR DESCRIPTION
#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

- Update `py-pdal` to 3.4.3 and drop py38.
- New port `py-pdal-plugins` version 1.5.0.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
