### PR TITLE
py-qtpy: restore Qt4-compatible fallback for PowerPC systems

### DIFF
--- a/python/py-qtpy/Portfile
+++ b/python/py-qtpy/Portfile
@@ -4,9 +4,6 @@ PortSystem          1.0
 PortGroup           python 1.0
 PortGroup           github 1.0
 
-github.setup        spyder-ide qtpy 2.4.1 v
-github.tarball_from archive
-revision            0
 name                py-qtpy
 
 categories-append   devel
@@ -15,22 +12,64 @@ platforms           {darwin any}
 license             MIT
 maintainers         {reneeotten @reneeotten} openmaintainer
 
-description         Abstraction layer for PyQt5/PyQt6/PySide2/PySide6
-long_description    Provides an uniform layer to support PyQt5, PyQt6, \
+# Usage of build_arch is correct here.
+if {${build_arch} ni [list ppc ppc64]} {
+    github.setup    spyder-ide qtpy 2.4.1 v
+    revision        0
+    description     Abstraction layer for PyQt5/PyQt6/PySide2/PySide6
+    long_description \
+                    Provides an uniform layer to support PyQt5, PyQt6, \
                     PySide2, and PySide6 with a single codebase.
 
-checksums           rmd160  0789194dbee98718bd037e54525ebb12510222cc \
+    checksums       rmd160  0789194dbee98718bd037e54525ebb12510222cc \
                     sha256  e5f3ceaf3465b453f71cc0248fc85116ae5b3dfd76cbfd491409eb345a9f9df2 \
                     size    67984
 
-python.versions     38 39 310 311 312
+    python.versions 38 39 310 311 312
+
+} else {
+    github.setup    spyder-ide qtpy 1.11.3 v
+    revision        0
+    description     Abstraction layer for PyQt4/PySide
+    long_description \
+                    Provides an uniform layer to support PyQt4 \
+                    and PySide with a single codebase.
+
+    checksums       rmd160  41115ac22fbd547d86ecd37476e1be82562caaa6 \
+                    sha256  eae5c5f11acd85b0c35cd39656e093fb1c0bf20fc5176a0010d466405788c5f6 \
+                    size    39447
+
+    # At the moment py-sip4 prevents using python311+
+    python.versions 27 38 39 310
+
+    livecheck.type  none
+}
+
+github.tarball_from archive
 
 if {${name} ne ${subport}} {
-    depends_lib-append \
+    if {${configure.build_arch} ni [list ppc ppc64]} {
+        # This is for current version of py-qtpy
+        depends_lib-append \
                     port:py${python.version}-packaging
 
-    depends_test-append \
+        depends_test-append \
                     port:py${python.version}-pytest-qt
+    } else {
+        # This is for a legacy Qt4-compatible version
+        python.pep517   no
+
+        depends_build-append \
+                    port:py${python.version}-setuptools
+
+        depends_test-append \
+                    port:py${python.version}-pytest \
+                    port:py${python.version}-mock
+
+        test.cmd    py.test-${python.branch}
+        test.target
+        test.env    PYTHONPATH=${worksrcpath}/build/lib
+    }
 
     test.run        yes
 
@@ -40,16 +79,18 @@ if {${name} ne ${subport}} {
         xinstall -m 0644 -W ${worksrcpath} LICENSE.txt ${destroot}${docdir}
     }
 
-    notes "QtPy needs one of the following backends to be installed on your\
-        system: PyQt5, PyQt6, PySide2, or PySide6. If multiple backends are\
+    notes "QtPy needs one of the following backends to be installed on your system:\
+        PyQt6, PyQt5, PyQt4, PySide6, PySide2 or PySide. If multiple backends are\
         available, PyQt5 will be used unless you set the QT_API environment variable."
 
     # if no backend is installed, it is impossible to run the tests
     # also append a warning about this to the notes
-    if {[catch {set installed [lindex [registry_active py${python.version}-pyqt5] 0]}] &&
-        [catch {set installed [lindex [registry_active py${python.version}-pyqt6] 0]}] &&
+    if {[catch {set installed [lindex [registry_active py${python.version}-pyqt6] 0]}] &&
+        [catch {set installed [lindex [registry_active py${python.version}-pyqt5] 0]}] &&
+        [catch {set installed [lindex [registry_active py${python.version}-pyqt4] 0]}] &&
+        [catch {set installed [lindex [registry_active py${python.version}-pyside6] 0]}] &&
         [catch {set installed [lindex [registry_active py${python.version}-pyside2] 0]}] &&
-        [catch {set installed [lindex [registry_active py${python.version}-pyside6] 0]}]} {
+        [catch {set installed [lindex [registry_active py${python.version}-pyside] 0]}]} {
             test.run        no
             notes-append    "*** WARNING: currently none of the required backends is installed! ***"
         }


### PR DESCRIPTION
#### Description

Make the port usable on powerpc systems as well.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
