### PR TITLE
py-msgpack: fix for 32-bit

### DIFF
--- a/python/py-msgpack/Portfile
+++ b/python/py-msgpack/Portfile
@@ -27,6 +27,12 @@ if {${name} ne ${subport}} {
     depends_build-append \
                         port:py${python.version}-cython
 
+    # https://trac.macports.org/ticket/69537
+    if {${configure.build_arch} in [list i386 ppc]} {
+        patchfiles-append \
+                        patch-32-bit.diff
+    }
+
     if {${python.version} <= 37} {
         version             1.0.5
         revision            1

--- a/python/py-msgpack/files/patch-32-bit.diff
+++ b/python/py-msgpack/files/patch-32-bit.diff
@@ -1,0 +1,11 @@
+--- msgpack/pack_template.h	2022-05-23 13:55:10.000000000 +0800
++++ msgpack/pack_template.h	2024-06-08 02:53:32.000000000 +0800
+@@ -776,7 +776,7 @@
+     if ((seconds >> 34) == 0) {
+         /* seconds is unsigned and fits in 34 bits */
+         uint64_t data64 = ((uint64_t)nanoseconds << 34) | (uint64_t)seconds;
+-        if ((data64 & 0xffffffff00000000L) == 0) {
++        if ((data64 & 0xffffffff00000000ULL) == 0) {
+             /* no nanoseconds and seconds is 32bits or smaller. timestamp32. */
+             unsigned char buf[4];
+             uint32_t data32 = (uint32_t)data64;


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/69537

#### Description

@stromnov Sorry for a delay with this.
`UL` still fails, `ULL` works.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
