### PR TITLE
net-snmp: fix for older systems

### DIFF
--- a/net/net-snmp/Portfile
+++ b/net/net-snmp/Portfile
@@ -12,9 +12,8 @@ checksums               rmd160  f889d5aafce06974756503fe2beb109f5a2081a8 \
 
 categories              net
 license                 BSD
-platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
-homepage                http://net-snmp.sourceforge.net/
+homepage                https://net-snmp.sourceforge.net
 master_sites            sourceforge:project/${name}/${name}/${version}
 
 description             An extendable SNMP implementation
@@ -40,6 +39,8 @@ depends_lib             port:bzip2 \
 patchfiles-append       configure-frameworks.patch
 patchfiles-append       fix-order-of-L-flags.patch
 patchfiles-append       Makefile.top-libtool-tag.patch
+# https://trac.macports.org/ticket/70165
+patchfiles-append       patch-legacy-compat.diff
 
 post-patch {
     # https://github.com/net-snmp/net-snmp/issues/646

--- a/net/net-snmp/files/patch-legacy-compat.diff
+++ b/net/net-snmp/files/patch-legacy-compat.diff
@@ -1,0 +1,19 @@
+--- agent/mibgroup/mibII/kernel_sysctl.c	2023-08-16 04:32:01.000000000 +0800
++++ agent/mibgroup/mibII/kernel_sysctl.c	2024-06-08 03:50:22.000000000 +0800
+@@ -20,6 +20,16 @@
+ 
+ #include "kernel_sysctl.h"
+ 
++#ifndef MLD_LISTENER_QUERY
++#define MLD_LISTENER_QUERY MLD6_LISTENER_QUERY
++#endif
++#ifndef MLD_LISTENER_REPORT
++#define MLD_LISTENER_REPORT MLD6_LISTENER_REPORT
++#endif
++#ifndef MLD_LISTENER_DONE
++#define MLD_LISTENER_DONE MLD6_LISTENER_DONE
++#endif
++
+ #if defined(NETSNMP_CAN_USE_SYSCTL)
+ 
+ int


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/70165

#### Description

Fix

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
