### PR TITLE
GPXSee: update to 13.21

### DIFF
--- a/gis/GPXSee/Portfile
+++ b/gis/GPXSee/Portfile
@@ -4,13 +4,13 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           qmake5 1.0
 
-github.setup        tumic0 GPXSee 13.20
+github.setup        tumic0 GPXSee 13.21
 github.tarball_from archive
 revision            0
 
-checksums           rmd160  23d39b0c2f688c0d04c1ae420ec8319131d588a8 \
-                    sha256  f390d0d1ea360730915a2c8526b196b56a8ec68c2f6009f50e686428cb8ebb8e \
-                    size    5621055
+checksums           rmd160  c586cbfbf9c4249ba2115b1a3aba2bce4ee96363 \
+                    sha256  aff8d0ab876523cc157ded956362b60390a70d88436783f0cb006f41dbc9e091 \
+                    size    5624365
 
 categories          gis graphics
 license             GPL-3


### PR DESCRIPTION
#### Description
[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes)

###### Type(s)
- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 12.7 x86_64
Xcode 14.2

###### Verification
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
