### PR TITLE
xcode-build-server: update to 1.1.0

### DIFF
--- a/devel/xcode-build-server/Portfile
+++ b/devel/xcode-build-server/Portfile
@@ -4,8 +4,8 @@ PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           python 1.0
 
-github.setup        SolaWing xcode-build-server 1.0.1 v
-version             1.0.1
+github.setup        SolaWing xcode-build-server 1.1.0 v
+version             1.1.0
 revision            0
 platforms           {macosx any}
 license             MIT
@@ -23,9 +23,9 @@ long_description    ${name} integrates Xcode with Apple's sourcekit-lsp. \
                     server to provide sourcekit-lsp with the build \
                     information it needs for an Xcode project.
 
-checksums           rmd160  794378403a9616e785dfcdf0ed69c5bfe408a39e \
-                    sha256  11c87b7f300abc25db84eb6bddcc1a6e56c0c0a39f2547bd1c75ca2833d6073d \
-                    size    19087
+checksums           rmd160  95128d3653a1e1fc0a078e6811249169c2308e51 \
+                    sha256  99c928c2d12494bd7d0ef61feda79cf6065592b4e48e495b4704b615928d67d1 \
+                    size    20640
 
 build {}
 
@@ -37,6 +37,8 @@ post-patch {
 destroot {
     xinstall -d ${destroot}/${python.pkgd}/${name}
     xinstall -m 0755 {*}[glob ${worksrcpath}/*.py] ${destroot}/${python.pkgd}/${name}
+    xinstall -d ${destroot}/${python.pkgd}/${name}/config
+    xinstall -m 0755 {*}[glob ${worksrcpath}/config/*.py] ${destroot}/${python.pkgd}/${name}/config
     xinstall -m 0755 -W ${worksrcpath} ${name} ${destroot}/${python.pkgd}/${name}
     ln -s ${python.pkgd}/${name}/${name} ${destroot}${prefix}/bin/${name}
 }


### PR DESCRIPTION
#### Description

Update the `xcode-build-server` port to version 1.1.0

###### Type(s)

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
macOS 13.6.3 22G436 arm64
Xcode 15.2 15C500b

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
