### PR TITLE
libmsp430: new port

### DIFF
--- a/devel/libmsp430/Portfile
+++ b/devel/libmsp430/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8::et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libmsp430
+version             3.15.1.1
+license             BDS-3
+
+categories          devel
+platforms           darwin
+
+maintainers         {@edilmedeiros gmail.com:jose.edil+macports} \
+                    openmaintainer
+
+description         Low-level MSP430 USB drivers
+long_description    These drivers provide an interface between the host \
+                    system MSP Debug Stack library (libmsp430.dylib) and \
+                    the FET’s USB interface. This is accomplished by using \
+                    a Communication Device Class (CDC) or Virtual COM Port \
+                    (VCP) protocol.
+
+homepage            https://www.ti.com/tool/MSPDS
+master_sites        https://dr-download.ti.com/software-development/driver-or-library/MD-4vnqcP1Wk4/${version}/
+
+distfiles           MSPDebugStack_OS_Package_3_15_1_1.zip
+checksums           md5     c16ee393e6d5388e8352aed6a716b7ba \
+                    rmd160  efdad29b4f2247d92adbbe0ebc44a8e37140ca7d \
+                    sha256  e3a59a98c43de7a92e5814d8c3304026165e6d2551e60acaca1f08c6b1a4bac8 \
+                    size    2184052
+
+depends_lib         port:boost178 \
+                    port:hidapi
+
+depends_extract-append \
+                    port:zip
+
+use_zip             yes
+
+patchfiles          bsl430dll_makefile.diff \
+                    makefile.diff
+
+worksrcdir          {}
+
+use_configure       no
+
+build.args          STATIC=1 BOOST_DIR=${prefix}/libexec/boost/1.78 PREFIX=${prefix}
+
+destroot.env-append PREFIX=${prefix}

--- a/devel/libmsp430/files/bsl430dll_makefile.diff
+++ b/devel/libmsp430/files/bsl430dll_makefile.diff
@@ -1,0 +1,29 @@
+--- ThirdParty/BSL430_DLL/Makefile.orig	2019-11-18 13:16:00
++++ ThirdParty/BSL430_DLL/Makefile	2024-06-07 18:13:21
+@@ -15,13 +15,16 @@
+ MAKE_PCH := -x c++-header
+ USE_PCH := -include $(PCH_HEADER)
+ 
++export PREFIX
++
+ INCLUDES := \
+ 	-I../include \
+ 	-I./BSL430_DLL \
+ 	-I./BSL430_DLL/Utility_Classes \
+ 	-I./BSL430_DLL/Physical_Interfaces \
+ 	-I./BSL430_DLL/Packet_Handlers \
+-	-I./BSL430_DLL/Connections
++	-I./BSL430_DLL/Connections \
++        -I$(PREFIX)/include/hidapi
+ 
+ SRC := \
+ 	./BSL430_DLL/MSPBSL_Factory.cpp \
+@@ -64,7 +67,7 @@
+ 	$(CXX) -c -o $@ $< $(USE_PCH) $(CXXFLAGS) $(INCLUDES) $(DEFINES)
+ 
+ install:
+-	cp $(OUTPUT) /usr/lib/
++	cp $(OUTPUT) $(DESTDIR)/lib/
+ 
+ clean:
+ 	@for i in $(OBJS); do rm -f $$i; done

--- a/devel/libmsp430/files/makefile.diff
+++ b/devel/libmsp430/files/makefile.diff
@@ -1,0 +1,71 @@
+--- Makefile.orig	2020-06-03 16:10:18
++++ Makefile	2024-06-10 12:05:37
+@@ -1,3 +1,5 @@
++INSTALL := /usr/bin/install
++
+ CXXFLAGS := -fPIC -std=c++0x -fvisibility=hidden -fvisibility-inlines-hidden
+ 
+ PCH_HEADER := ./DLL430_v3/src/TI/DLL430/pch.h
+@@ -18,6 +20,7 @@
+ export BOOST_DIR
+ export STATIC
+ export DEBUG
++export PREFIX
+ 
+ INCLUDES := \
+ 	-I./DLL430_v3/src/TI/DLL430 \
+@@ -25,16 +28,16 @@
+ 	-I./DLL430_v3/src/TI/DLL430/EnergyTrace_TSPA \
+ 	-I./Bios/include \
+ 	-I./ThirdParty/include \
+-	-I./ThirdParty/BSL430_DLL
++	-I./ThirdParty/BSL430_DLL \
++        -I$(PREFIX)/include/hidapi
+ 
++LIBS := -L$(PREFIX)/lib
++STATIC_LIBS := -L$(PREFIX)/libmsp430/lib
+ 
+-LIBS :=
+-STATIC_LIBS :=
+-
+ ifdef STATIC
+-STATIC_LIBS += -lboost_filesystem -lboost_system -lbsl430 -lboost_date_time -lboost_chrono -lboost_thread
++STATIC_LIBS += -lboost_filesystem-mt -lboost_system-mt -lbsl430 -lboost_date_time-mt -lboost_chrono-mt -lboost_thread-mt
+ else
+-LIBS += -lboost_filesystem -lboost_system -lbsl430 -lboost_date_time -lboost_chrono -lboost_thread
++LIBS += -lboost_filesystem-mt -lboost_system-mt -lbsl430 -lboost_date_time-mt -lboost_chrono-mt -lboost_thread-mt
+ endif
+ 
+ LIBTHIRD := ./ThirdParty/lib64
+@@ -43,7 +46,7 @@
+ PLATFORM := $(shell uname -s)
+ ifeq ($(PLATFORM),Linux)
+ 	CXX:= g++
+-	
++
+ 	STATICOUTPUT := linux64
+ 
+ 	OUTPUT := libmsp430.so
+@@ -123,7 +126,7 @@
+ OBJS := $(patsubst %.cpp, %.o, $(SRC))
+ 
+ all: $(BSLLIB) $(OBJS)
+-	$(CXX) $(CXXFLAGS) -shared $(OUTNAME)$(OUTPUT) -o $(OUTPUT) $(OBJS) $(HIDOBJ) $(LIBDIRS) $(BSTATIC) $(STATIC_LIBS) $(BDYNAMIC) $(LIBS)
++	$(CXX) $(CXXFLAGS) -shared $(OUTNAME) $(OUTPUT) -o $(OUTPUT) $(OBJS) $(HIDOBJ) $(LIBDIRS) $(BSTATIC) $(STATIC_LIBS) $(BDYNAMIC) $(LIBS)
+ 	rm -f $(STATICOUTPUT).a
+ 	ar -rs $(STATICOUTPUT).a $(OBJS)
+ 
+@@ -134,10 +137,11 @@
+ 	$(CXX) -c -o $@ $< $(USE_PCH) $(CXXFLAGS) $(INCLUDES) $(DEFINES)
+ 
+ $(BSLLIB):
+-	$(MAKE) -C ./ThirdParty/BSL430_DLL
++	$(MAKE) PREFIX=$(PREFIX) -C ./ThirdParty/BSL430_DLL
+ 
+ install:
+-	cp $(OUTPUT) /usr/local/lib/
++	mkdir -p $(DESTDIR)/$(PREFIX)/lib/
++	$(INSTALL) $(OUTPUT) $(DESTDIR)/$(PREFIX)/lib/
+ 
+ clean:
+ 	$(MAKE) -C ./ThirdParty/BSL430_DLL clean


### PR DESCRIPTION
#### Description

The MSP430 opensource toolchain requires a USB driver provided by Texas Instruments under the name MSP Debug Stack. It installs a dynamic library called `libmsp430.dylib` which can be used by mspdebug and other tools.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
