### PR TITLE
mspdebug: add driver dependency

### DIFF
--- a/devel/mspdebug/Portfile
+++ b/devel/mspdebug/Portfile
@@ -4,8 +4,10 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        dlbeer mspdebug 0.25 v
-revision            2
-maintainers         nomaintainer
+revision            3
+maintainers         {@edilmedeiros gmail.com:jose.edil+macports} \
+                    openmaintainer
+
 categories          devel cross
 description         MSPDebug is a free debugger for use with MSP430 MCUs.
 long_description    MSPDebug is a free debugger for use with MSP430 MCUs. \
@@ -19,22 +21,26 @@ license             GPL-2+
 
 homepage            https://dlbeer.co.nz/mspdebug/
 
-checksums           rmd160  18cfcf737205ab78119a12ebad27ec051487ac5f \
+checksums           ${distname}${extract.suffix} \
+                    rmd160  18cfcf737205ab78119a12ebad27ec051487ac5f \
                     sha256  a1a3620de6a86128ad03938ef2eda6d57e7b320b2361cd35aec10ad5d3080215 \
                     size    333977
 
 depends_build       port:pkgconfig
 depends_lib         port:hidapi \
                     port:libusb-compat \
-                    port:readline
+                    port:readline \
+                    port:libmsp430
 
-patchfiles          patch-Makefile.diff
+patchfiles          patch-Makefile.diff \
+                    patch-Makefile-define_flag.diff \
+                    fix-dynlib-load.diff
 
 use_configure       no
 
 variant universal   {}
 
-build.args-append   CC="${configure.cc} [get_canonical_archflags]"
+build.args-append   CC="${configure.cc} [get_canonical_archflags]" PREFIX=${prefix}
 
 destroot.env-append PREFIX=${prefix}
 

--- a/devel/mspdebug/files/fix-dynlib-load.diff
+++ b/devel/mspdebug/files/fix-dynlib-load.diff
@@ -1,0 +1,47 @@
+--- drivers/tilib_api.c.orig	2024-06-09 00:24:35
++++ drivers/tilib_api.c	2024-06-09 00:43:06
+@@ -16,8 +16,10 @@
+  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+  */
+ 
++#include <limits.h>
+ #include <stddef.h>
+ #include <string.h>
++#include <stdio.h>
+ #include "util/output.h"
+ #include "tilib_api.h"
+ #include "dynload.h"
+@@ -28,6 +30,9 @@
+ #if defined(__Windows__) || defined(__CYGWIN__)
+ static const char tilib_filename[] = "MSP430.DLL";
+ #define TIDLL __stdcall
++#elif defined(__APPLE__)
++static const char tilib_filename[] = "libmsp430.dylib";
++#define TIDLL
+ #else
+ static const char tilib_filename[] = "libmsp430.so";
+ #define TIDLL
+@@ -757,12 +762,23 @@
+ {
+ 	int ret;
+ 
++#if defined(__MACPORTS__)
++  char libpath[PATH_MAX];
++  snprintf(libpath, sizeof(libpath), "%s/%s", MACPORTS_LIB_DIR, tilib_filename);
++  lib_handle = dynload_open(libpath);
++	if (!lib_handle) {
++		printc_err("tilib_api: can't find %s: %s\n",
++			   tilib_filename, dynload_error());
++		return -1;
++	}
++#else
+ 	lib_handle = dynload_open(tilib_filename);
+ 	if (!lib_handle) {
+ 		printc_err("tilib_api: can't find %s: %s\n",
+ 			   tilib_filename, dynload_error());
+ 		return -1;
+ 	}
++#endif
+ 
+ 	if (dynload_sym(lib_handle, "MSP430_HIL_MEMAP")) {
+ 		printc_dbg("Using new (SLAC460L+) API\n");

--- a/devel/mspdebug/files/patch-Makefile-define_flag.diff
+++ b/devel/mspdebug/files/patch-Makefile-define_flag.diff
@@ -1,0 +1,11 @@
+--- Makefile.orig	2024-06-09 00:24:35
++++ Makefile	2024-06-09 00:44:20
+@@ -90,7 +90,7 @@
+ 
+ INCLUDES = -I. -Isimio -Iformats -Itransport -Idrivers -Iutil -Iui
+ GCC_CFLAGS = -O1 -Wall -Wno-char-subscripts -ggdb
+-CONFIG_CFLAGS = -DLIB_DIR=\"$(LIBDIR)\"
++CONFIG_CFLAGS = -DLIB_DIR=\"$(LIBDIR)\" -D__APPLE__ -D__MACPORTS__ -DMACPORTS_LIB_DIR=\"$(PREFIX)/lib\"
+ 
+ MSPDEBUG_LDFLAGS = $(LDFLAGS) $(PORTS_LDFLAGS)
+ MSPDEBUG_LIBS = -L. -lusb $(READLINE_LIBS) $(OS_LIBS)


### PR DESCRIPTION
mspdebug requires the tilib driver to work properly with recent Texas Instrument's MSP430 Launchpad family ov development boards. This driver is missing in the current port. The tilib driver is provided by TI under the package MSP430 Debug Stack. #24397 introduces a port that provides the tilib driver. This enhancement:

1. add libmsp430 as a dependency (#24397)
2. provide patches so that mspdebug can find the shared library in the right place when installed through macports.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
