### PR TITLE
msp430-elf-binutils: update to version 2.34

### DIFF
--- a/cross/msp430-elf-binutils/Portfile
+++ b/cross/msp430-elf-binutils/Portfile
@@ -3,39 +3,41 @@
 PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
-crossbinutils.setup msp430-elf 2.26
+crossbinutils.setup msp430-elf 2.34
 
-set vers_patch      8.3.0.16
+set vers_patch      9.3.1.11
 set name_patch      msp430-gcc-${vers_patch}-source-patches
 set file_patch      ${name_patch}.tar.bz2
 
-maintainers         nomaintainer
+maintainers         {@edilmedeiros gmail.com:jose.edil+macports} \
+                    openmaintainer
 
 homepage            http://www.ti.com/tool/msp430-gcc-opensource
-master_sites-append http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/:patch
+master_sites-append https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-LlCjWuAbzH/9.3.1.2/:patch
 
 distfiles-append    ${file_patch}:patch
 checksums-append    ${file_patch} \
-                    rmd160  fa0c6ddd1d9e7a44ad470671c5c5be9a61a0051a \
-                    sha256  2732abaf76e1da9e224b25d442c2f764c487087603ae1d954d6e980e48f37af7 \
-                    size    143805
+                    md5     8f305461a3b32fc8d1155bf18685f53b \
+                    rmd160  a8e5a2ddb2adf4ed9370ec632d361b2e6b2c4613 \
+                    sha256  ec6472b034e11e8cfdeb3934b218e5bafbb7a03f3afc0e76536bd9c42653525b \
+                    size    283677
 
 depends_extract-append \
-                    bin:bzip2:bzip2
+                    port:bzip2
 
 post-extract {
     system -W ${workpath} "${prefix}/bin/bzip2 -dc ${distpath}/${file_patch} | /usr/bin/tar xf -"
 }
 pre-patch {
-    system -W ${worksrcpath} "/usr/bin/patch -p0 < ${workpath}/${name_patch}/binutils-2_26.patch"
+    system -W ${worksrcpath} "/usr/bin/patch -p0 < ${workpath}/${name_patch}/binutils-2_34.patch"
 }
 
 configure.args-append \
+                    --target=msp430-elf \
+                    --enable-languages=c,c++ \
+                    --disable-nls \
+                    --enable-initfini-array \
+                    --disable-sim \
+                    --disable-gdb \
                     --disable-werror
 
-# --with-mpfr-include=${prefix}/include \
-# --with-mpfr-lib=${prefix}/lib \
-# --with-gmp-include=${prefix}/include \
-# --with-gmp-lib=${prefix}/lib \
-# --with-mpc-include=${prefix}/include \
-# --with-mpc-lib=${prefix}/lib


### PR DESCRIPTION
#### Description

Texas Instruments use a strange version system. The website says 9.3.1.2,
release notes say 9.3.1.11 but the binutils patch is based on version 2.34.
Opted for the later to follow the gnu tools versioning.

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
