### PR TITLE
camlp5: synchronize dependencies with opam

### DIFF
--- a/lang/camlp5/Portfile
+++ b/lang/camlp5/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github 1.0
 
 github.setup        camlp5 camlp5 8.03.00
-revision            0
+revision            1
 categories          lang ocaml
 license             BSD
 maintainers         {pmetzger @pmetzger} openmaintainer
@@ -27,14 +27,15 @@ checksums           rmd160  459a703b56523f907f0c0c8b9ebf98f11edad676 \
                     sha256  c79d7e31353b5a30133ba585106cad6ad456dde0720f501ae774a95811db875a \
                     size    1284440
 
-depends_lib       port:ocaml \
+depends_build       bin:perl:perl5
+depends_lib         port:ocaml \
     port:ocaml-bos \
-    port:ocaml-re \
     port:ocaml-camlp-streams \
-    port:ocaml-ounit \
-    port:ocaml-pcre2 \
-    port:ocaml-rresult \
-    port:ocaml-fmt
+    port:ocaml-camlp5-buildscripts \
+    port:ocaml-findlib \
+    port:ocaml-fmt \
+    port:ocaml-re \
+    port:ocaml-rresult
 
 extract.suffix      .tgz
 


### PR DESCRIPTION
* Remove dependences that are only used in tests (ounit, pcre2)
* Add missing dependency declared in opam which is not strictly required but expected by other software (camlp5-buildscript)
* Add missing dependency that was installed by transitiveness (ocaml-findlib)
* add `bin:perl:perl5` as a dependency in case perl is not present
* sort dependencies in opam order

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
