### PR TITLE
msp430-elf-gcc: update to version 9.3.1.2

### DIFF
--- a/cross/msp430-elf-gcc/Portfile
+++ b/cross/msp430-elf-gcc/Portfile
@@ -3,24 +3,32 @@
 PortSystem          1.0
 PortGroup           crossgcc 1.0
 
-crossgcc.setup      msp430-elf 8.3.0
+crossgcc.setup      msp430-elf 9.3.0
 crossgcc.setup_libc newlib 2.4.0
-revision            2
 
-set vers_patch      8.3.0.16
+# Align with TI's versioning
+version             9.3.1.2
+set vers_patch      9.3.1.11
 set name_patch      msp430-gcc-${vers_patch}-source-patches
 set file_patch      ${name_patch}.tar.bz2
 
-maintainers         nomaintainer
+maintainers         {@edilmedeiros gmail.com:jose.edil+macports} \
+                    openmaintainer
 
 homepage            http://www.ti.com/tool/msp430-gcc-opensource
-master_sites-append http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports/:patch
+master_sites-append https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-LlCjWuAbzH/${version}/:patch
 
 distfiles-append    ${file_patch}:patch
 checksums-append    ${file_patch} \
-                    rmd160  fa0c6ddd1d9e7a44ad470671c5c5be9a61a0051a \
-                    sha256  2732abaf76e1da9e224b25d442c2f764c487087603ae1d954d6e980e48f37af7 \
-                    size    143805
+                    md5     8f305461a3b32fc8d1155bf18685f53b \
+                    rmd160  a8e5a2ddb2adf4ed9370ec632d361b2e6b2c4613 \
+                    sha256  ec6472b034e11e8cfdeb3934b218e5bafbb7a03f3afc0e76536bd9c42653525b \
+                    size    283677
+
+# Bump back version so that newlib will compile correctly.
+pre-extract {
+    version         9.3.0
+}
 
 depends_run         port:msp430-gcc-support-files
 
@@ -31,10 +39,24 @@ post-extract {
     system -W ${workpath} "${prefix}/bin/bzip2 -dc ${distpath}/${file_patch} | /usr/bin/tar xf -"
 }
 pre-patch {
-    system -W ${worksrcpath} "/usr/bin/patch -p0 < ${workpath}/${name_patch}/gcc-8_3_0-release.patch"
+    system -W ${worksrcpath} "/usr/bin/patch -p0 < ${workpath}/${name_patch}/gcc-${version}.patch"
     system -W ${workpath}/newlib-2.4.0 "/usr/bin/patch -p0 < ${workpath}/${name_patch}/newlib-2_4_0.patch"
 }
 
+# gcc_system.diff: See https://gcc.gnu.org/bugzilla/show_bug.cgi?format=multiple&id=111632
+# gcc_config_host.diff: See https://github.com/riscv-software-src/homebrew-riscv/issues/47
+patchfiles          gcc_system.diff \
+                    gcc_config_host.diff
+
+# Use the same flags as TI's build script
 configure.args-append \
+                    --target=msp430-elf \
+                    --enable-languages=c,c++ \
+                    --disable-nls \
+                    --enable-initfini-array \
                     --enable-target-optspace \
                     --enable-newlib-nano-formatted-io
+
+# Required to build the patched newlib
+configure.cflags-append \
+                    -Wno-error=int-conversion

--- a/cross/msp430-elf-gcc/files/gcc_config_host.diff
+++ b/cross/msp430-elf-gcc/files/gcc_config_host.diff
@@ -1,0 +1,13 @@
+--- gcc/config.host.orig	2020-03-12 08:07:21
++++ gcc/config.host	2024-06-07 01:30:56
+@@ -93,8 +93,8 @@
+ case ${host} in
+   *-darwin*)
+     # Generic darwin host support.
+-    out_host_hook_obj=host-darwin.o
+-    host_xmake_file="${host_xmake_file} x-darwin"
++    # out_host_hook_obj=host-darwin.o
++    # host_xmake_file="${host_xmake_file} x-darwin"
+     ;;
+ esac
+ 

--- a/cross/msp430-elf-gcc/files/gcc_system.diff
+++ b/cross/msp430-elf-gcc/files/gcc_system.diff
@@ -1,0 +1,62 @@
+--- gcc/system.h.orig	2020-03-12 08:07:21
++++ gcc/system.h	2024-06-07 00:58:02
+@@ -194,27 +194,8 @@
+ #undef fread_unlocked
+ #undef fwrite_unlocked
+ 
+-/* Include <string> before "safe-ctype.h" to avoid GCC poisoning
+-   the ctype macros through safe-ctype.h */
+-
+-#ifdef __cplusplus
+-#ifdef INCLUDE_STRING
+-# include <string>
+-#endif
+-#endif
+-
+-/* There are an extraordinary number of issues with <ctype.h>.
+-   The last straw is that it varies with the locale.  Use libiberty's
+-   replacement instead.  */
+-#include "safe-ctype.h"
+-
+-#include <sys/types.h>
+-
+-#include <errno.h>
+-
+-#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
+-extern int errno;
+-#endif
++/* Include C++ standard headers before "safe-ctype.h" to avoid GCC
++   poisoning the ctype macros through safe-ctype.h */
+ 
+ #ifdef __cplusplus
+ #if defined (INCLUDE_ALGORITHM) || !defined (HAVE_SWAP_IN_UTILITY)
+@@ -229,6 +210,9 @@
+ #ifdef INCLUDE_SET
+ # include <set>
+ #endif
++#ifdef INCLUDE_STRING
++# include <string>
++#endif
+ #ifdef INCLUDE_VECTOR
+ # include <vector>
+ #endif
+@@ -237,6 +221,19 @@
+ # include <utility>
+ #endif
+ 
++/* There are an extraordinary number of issues with <ctype.h>.
++   The last straw is that it varies with the locale.  Use libiberty's
++   replacement instead.  */
++#include "safe-ctype.h"
++
++#include <sys/types.h>
++
++#include <errno.h>
++
++#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
++extern int errno;
++#endif
++
+ /* Some of glibc's string inlines cause warnings.  Plus we'd rather
+    rely on (and therefore test) GCC's string builtins.  */
+ #define __NO_STRING_INLINES


### PR DESCRIPTION
TI's versioning is a mess. The website reports 9.3.1.2, the release notes say 9.3.1.11 and everything is based on gcc 9.3.0. I kept the former as it is what I would expect after visiting TI's website. But that required a hack to make newlib compile.

The patches are backports of official gcc patches (see port comments with links to the issue trackers).

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.4 23E214 arm64
Xcode 15.3 15E204a

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [x] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
