### PR TITLE
gcab: fix build with old Xcode gcc

### DIFF
--- a/gnome/gcab/Portfile
+++ b/gnome/gcab/Portfile
@@ -14,7 +14,6 @@ description         A tool and library mainly made to create Cabinet files
 long_description    ${description}, using GObject/GIO API, providing GIR bindings.
 maintainers         nomaintainer
 categories          gnome
-platforms           darwin
 homepage            https://wiki.gnome.org/msitools
 master_sites        gnome:sources/${name}/${branch}/
 
@@ -24,17 +23,24 @@ checksums           rmd160  c98850b41f6baec5c3997fef342ad4a42b18b8af \
                     sha256  67a5fa9be6c923fbc9197de6332f36f69a33dadc9016a2b207859246711c048f \
                     size    78240
 
-depends_build       port:pkgconfig \
+depends_build-append \
                     port:gettext \
-                    port:gtk-doc
+                    port:gtk-doc \
+                    path:bin/pkg-config:pkgconfig
 
-depends_lib         port:gettext-runtime \
+depends_lib-append  port:gettext-runtime \
                     path:lib/pkgconfig/glib-2.0.pc:glib2 \
                     path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                     path:bin/vala:vala \
                     port:zlib
 
 patchfiles          dont-use-version-script.patch
+
+# cc1: error: unrecognized command line option "-fstack-protector-strong"
+if {[string match *gcc-4.* ${configure.compiler}]} {
+    patchfiles-append \
+                    allow-xcode-gcc.patch
+}
 
 compiler.c_standard 1999
 compiler.blacklist-append {clang < 700}

--- a/gnome/gcab/files/allow-xcode-gcc.patch
+++ b/gnome/gcab/files/allow-xcode-gcc.patch
@@ -1,0 +1,13 @@
+--- meson.build	2020-01-06 19:25:54.000000000 +0800
++++ meson.build	2024-06-10 04:40:54.000000000 +0800
+@@ -73,10 +73,6 @@
+   endif
+ endforeach
+ 
+-if not meson.is_cross_build()
+-  add_project_arguments('-fstack-protector-strong', language : 'c')
+-endif
+-
+ # enable full RELRO where possible
+ # FIXME: until https://github.com/mesonbuild/meson/issues/1140 is fixed
+ global_link_args = []


### PR DESCRIPTION
#### Description

Fix for old gcc

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
