### PR TITLE
pgpointcloud: fix for older systems

### DIFF
--- a/databases/pgpointcloud/Portfile
+++ b/databases/pgpointcloud/Portfile
@@ -23,14 +23,15 @@ checksums           rmd160  54e0784994a458e9591ea416caf7ae106c0d7007 \
 
 patchfiles          01-patch-xml2-config.diff \
                     02-patch-cunit-conf.diff \
-                    03-patch-cxx.diff
+                    03-patch-cxx.diff \
+                    04-patch-pgsql.diff
 
 configure.cmd       autoupdate && ./autogen.sh && ./configure
 
 depends_build-append \
                     port:autoconf \
                     port:automake \
-                    port:pkgconfig
+                    path:bin/pkg-config:pkgconfig
 
 depends_lib-append  port:libxml2 \
                     port:zlib
@@ -39,6 +40,9 @@ configure.args-append \
                     --with-xml2config=${prefix}/bin/xml2-config \
                     --without-lazperf \
                     --without-cunit
+
+# cc1plus: error: unrecognized command line option "-std=c++11"
+compiler.cxx_standard 2011
 
 # PostgreSQL subports
 set postgresql_suffixes {12 13 14 15 16}

--- a/databases/pgpointcloud/files/04-patch-pgsql.diff
+++ b/databases/pgpointcloud/files/04-patch-pgsql.diff
@@ -1,0 +1,24 @@
+From 956881d7085884d7f985333a3658548734964250 Mon Sep 17 00:00:00 2001
+From: barracuda156 <vital.had@gmail.com>
+Date: Sat, 23 Dec 2023 05:18:34 +0800
+Subject: [PATCH] pgsql: respect compiler choice
+
+---
+ pgsql/Makefile.in | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git pgsql/Makefile.in pgsql/Makefile.in
+index 26afbcc..f22403e 100644
+--- pgsql/Makefile.in
++++ pgsql/Makefile.in
+@@ -57,6 +57,10 @@ SHLIB_LINK += ../lib/$(LIB_A) ../lib/$(LIB_A_LAZPERF) -lstdc++ $(filter -lm, $(L
+ # We are going to use PGXS for sure
+ include $(PGXS)
+ 
++# Should be here to have an effect
++CC = @CC@
++CXX = @CXX@
++
+ $(EXTENSION).control: $(EXTENSION).control.in Makefile
+ 	$(SED) -e 's/#POINTCLOUD_VERSION#/$(EXTVERSION)/' \
+          -e 's/#POINTCLOUD_VERSION_MAJOR#/$(EXTVERSION_MAJOR)/' $< > $@


### PR DESCRIPTION
#### Description

This is still broken: the port uses C++11, so it cannot possibly build with pre-C++11 compilers. Fix this finally.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
