### PR TITLE
tracker3: new port in gnome

### DIFF
--- a/gnome/tracker3/Portfile
+++ b/gnome/tracker3/Portfile
@@ -1,0 +1,83 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           legacysupport 1.1
+PortGroup           meson 1.0
+
+# O_CLOEXEC
+legacysupport.newest_darwin_requires_legacy 10
+
+name                tracker3
+version             3.7.3
+revision            0
+license             LGPL-2.1
+set branch          [join [lrange [split ${version} .] 0 1] .]
+description         Object database, tag/metadata database, search tool \
+                    and indexer
+long_description    {*}${description}
+
+set real_name       tracker
+maintainers         {@barracuda156 gmail.com:vital.had} openmaintainer
+categories          gnome sysutils
+homepage            https://wiki.gnome.org/Projects/Tracker
+master_sites        gnome:sources/${real_name}/${branch}/
+distname            ${real_name}-${version}
+use_xz              yes
+
+checksums           rmd160  7ce61a898bfd0830d967d4c60aab83812f90671c \
+                    sha256  ab3d4a50937e04c5ed7846f6dbb999e2909819402f389ca592ee6b77dd28d1f9 \
+                    size    1789728
+
+set py_ver          3.12
+set py_ver_nodot    [string map {. {}} ${py_ver}]
+configure.python    ${prefix}/bin/python${py_ver}
+
+patchfiles-append   patch-meson.build.diff
+
+post-patch {
+    reinplace "s|@PYTHON@|${configure.python}|" ${worksrcpath}/meson.build
+    fs-traverse f ${worksrcpath} {
+        if {[string match *.py ${f}]} {
+            ui_info "patching testpath: ${f}"
+            reinplace -q "s|/usr/bin/python3$|${configure.python}|" ${f}
+            reinplace -q "s|/usr/bin/env python3$|${configure.python}|" ${f}
+        }
+    }
+}
+
+depends_build-append \
+                    port:asciidoc \
+                    port:gettext \
+                    path:bin/pkg-config:pkgconfig \
+                    port:python${py_ver_nodot} \
+                    path:bin/vala:vala
+
+depends_lib-append  port:avahi \
+                    port:dbus \
+                    port:gettext-runtime \
+                    path:lib/pkgconfig/gdk-pixbuf-2.0.pc:gdk-pixbuf2 \
+                    path:lib/pkgconfig/glib-2.0.pc:glib2 \
+                    path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
+                    path:lib/pkgconfig/icu-uc.pc:icu \
+                    port:json-glib \
+                    path:lib/pkgconfig/libsoup-2.4.pc:libsoup \
+                    port:libxml2 \
+                    port:ossp-uuid \
+                    port:py${py_ver_nodot}-gobject3 \
+                    port:sqlite3
+
+compiler.c_standard     1999
+compiler.cxx_standard   2011
+
+configure.args-append \
+                    -Dbash_completion=false \
+                    -Ddocs=false \
+                    -Dsoup=soup2 \
+                    -Dstemmer=disabled \
+                    -Dsystemd_user_services=false
+
+# https://gitlab.gnome.org/GNOME/tracker/-/issues/443
+if {${configure.build_arch} in [list arm i386 ppc]} {
+    patchfiles-append \
+                    patch-meson.build-32.diff
+}

--- a/gnome/tracker3/files/patch-meson.build-32.diff
+++ b/gnome/tracker3/files/patch-meson.build-32.diff
@@ -1,0 +1,77 @@
+Reverts https://github.com/GNOME/tracker/commit/63ea8f1a2a603c356ad770ae7567246e7520f298
+
+--- meson.build	2024-05-02 21:11:35.000000000 +0800
++++ meson.build	2024-06-10 09:26:04.000000000 +0800
+@@ -207,41 +207,6 @@
+ endif
+ 
+ ##################################################################
+-# Get an appropriate 4-digit year modifier for strftime
+-##################################################################
+-result = cc.run('''
+-  #define _TIME_BITS 64
+-  #define _GNU_SOURCE
+-  #include <stdio.h>
+-  #include <string.h>
+-  #include <time.h>
+-
+-  int main (int argc, char *argv[]) {
+-    char *modifiers[] = { "%Y", "%C%y", "%4Y", "%2C%y", NULL };
+-    time_t timestamp = -58979923200; /* 0101-01-01T01:01:01Z */
+-    char buf[100];
+-    struct tm tm;
+-    int i;
+-    gmtime_r (&timestamp, &tm);
+-    for (i = 0; modifiers[i]; i++) {
+-      strftime (buf, sizeof buf, modifiers[i], &tm);
+-      if (strcmp (buf, "0101") == 0) {
+-        printf ("%s", modifiers[i]);
+-        return 0;
+-      }
+-    }
+-    return -1;
+-  }
+-  ''',
+-  name: 'strftime 4-digit year modifier')
+-
+-if not result.compiled() or result.returncode() != 0
+-  error('Libc implementation has broken 4-digit years implementation.')
+-else
+-  year_modifier = result.stdout()
+-endif
+-
+-##################################################################
+ # Check for libtracker-data and libtracker-fts: Unicode support
+ #
+ # By default, AUTO with this order of preference:
+@@ -350,7 +315,6 @@
+ conf.set('TRACKER_MICRO_VERSION', tracker_micro_version)
+ conf.set('TRACKER_INTERFACE_AGE', 0)
+ conf.set('TRACKER_BINARY_AGE', 100 * tracker_minor_version + tracker_micro_version)
+-conf.set('STRFTIME_YEAR_MODIFIER', '"@0@"'.format(year_modifier))
+ 
+ # Check for RTLD_NOLOAD
+ have_rtld_noload = cc.has_header_symbol('dlfcn.h', 'RTLD_NOLOAD')
+@@ -441,7 +405,6 @@
+   '    Debug:                                  ' + get_option('debug').to_string(),
+   '    Optimization:                           ' + get_option('optimization'),
+   '    Compiler:                               ' + cc.get_id(),
+-  '    4-digit strftime() year modifier:       ' + year_modifier,
+   '\nFeature Support:',
+   '    Unicode support library:                ' + unicode_library_name,
+   '    Build with Stemming support:            ' + have_libstemmer.to_string(),
+
+--- src/libtracker-sparql/core/tracker-db-interface-sqlite.c	2024-05-02 21:11:35.000000000 +0800
++++ src/libtracker-sparql/core/tracker-db-interface-sqlite.c	2024-06-10 09:26:57.000000000 +0800
+@@ -1542,9 +1542,9 @@
+ 				result_context_function_error (context, fn, "Invalid unix timestamp");
+ 
+ 			if (prop_type == TRACKER_PROPERTY_TYPE_DATETIME)
+-				retval = strftime ((gchar *) &buf, sizeof (buf), STRFTIME_YEAR_MODIFIER "-%m-%dT%TZ", &tm);
++				retval = strftime ((gchar *) &buf, sizeof (buf), "%2C%y-%m-%dT%TZ", &tm);
+ 			else if (prop_type == TRACKER_PROPERTY_TYPE_DATE)
+-				retval = strftime ((gchar *) &buf, sizeof (buf), STRFTIME_YEAR_MODIFIER "-%m-%d", &tm);
++				retval = strftime ((gchar *) &buf, sizeof (buf), "%2C%y-%m-%d", &tm);
+ 			else
+ 				g_assert_not_reached ();
+ 

--- a/gnome/tracker3/files/patch-meson.build.diff
+++ b/gnome/tracker3/files/patch-meson.build.diff
@@ -1,0 +1,11 @@
+--- meson.build	2023-06-01 05:18:27.000000000 +0800
++++ meson.build	2024-06-10 08:36:14.000000000 +0800
+@@ -98,7 +98,7 @@
+     py_modules += 'tap'
+   endif
+ endif
+-python = import('python').find_installation('python3', modules: py_modules)
++python = import('python').find_installation('@PYTHON@', modules: py_modules)
+ 
+ if get_option('vapi').enabled() and get_option('introspection').disabled()
+   error('Vala binding generation requires the \'introspection\' to be enabled')


### PR DESCRIPTION
#### Description

New port, a dependency for newer versions of `nautilus` and a few others.

No conflict needed, it is co-installable with `tracker`.

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
