### PR TITLE
miriad: fix build on older macOS

### DIFF
--- a/science/miriad/Portfile
+++ b/science/miriad/Portfile
@@ -57,10 +57,15 @@ if {[variant_isset ant256]} {
 # So we force the use of a specified MacPorts-built GCC. Some users want
 # to build with better-optimizing proprietary compilers, which we allow
 # via the gcc_select mechanism.
-
+# Xcode gcc must be blacklisted, otherwise they are being picked,
+# and it fails with the new gfortran:
+# Error: Type mismatch in argument 'pixmap' at (1); passed INTEGER(4) to INTEGER(1)
+compiler.blacklist-append \
+                     {*gcc-[34].*}
 compilers.choose     fc f77
 compilers.set_variants_conflict   gcc_select
 compilers.setup
+compilers.allow_arguments_mismatch yes
 
 variant gcc_select conflicts ${compilers.variants} description {Build with compilers chosen via gcc_select -- experts only} {
     configure.compiler  macports-gcc
@@ -95,6 +100,9 @@ worksrcdir      ${name}-${relver}
 
 patch.pre_args-replace  -p0 -p1
 patchfiles      gcc-8-fixes.patch
+
+patchfiles-append \
+                patch-fix-includes.diff
 
 # Configure settings. Keep the binaries out of ${prefix}/bin to avoid
 # possible conflicts. The automiriad scripts will deal with this correctly.

--- a/science/miriad/files/patch-fix-includes.diff
+++ b/science/miriad/files/patch-fix-includes.diff
@@ -1,0 +1,10 @@
+--- a/borrow/pgplot/sys/grtermio.c	2016-03-23 04:02:26.000000000 +0800
++++ b/borrow/pgplot/sys/grtermio.c	2024-06-10 22:59:42.000000000 +0800
+@@ -6,6 +6,7 @@
+    Fortran-callable routines: GROTER, GRCTER, GRWTER, GRPTER. */
+ 
+ #include <stdio.h>
++#include <string.h>
+ #include <termios.h>
+ 
+ #ifdef PG_PPU


### PR DESCRIPTION
#### Description

Fix the build

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 10.6
Xcode 3.2

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
