### PR TITLE
Fix port stm32flash

### DIFF
--- a/devel/stm32flash/Portfile
+++ b/devel/stm32flash/Portfile
@@ -4,9 +4,10 @@ PortSystem          1.0
 
 name                stm32flash
 version             0.7
+revision            0
 categories          devel
-maintainers         nomaintainer
-platforms           darwin
+maintainers         {pguyot @pguyot} openmaintainer
+
 license             GPL-2
 description         Flash program for the STM32 bootloader
 long_description    Open source flash program for the STM32 ARM processors \
@@ -18,20 +19,4 @@ checksums           rmd160  f8d73e926f90ff4e5b8930710e2598805d653a92 \
                     sha256  c4c9cd8bec79da63b111d15713ef5cc2cd947deca411d35d6e3065e227dc414a \
                     size    380166
 
-worksrcdir          ${name}
-
-use_configure       no
-
-variant universal {}
-
-destroot.args PREFIX=${prefix}
-
-post-patch {
-     reinplace "s|\$\(AR\) rc|\$\(AR\) rcs|g" ${worksrcpath}/parsers/Makefile
-}
-build.env-append    "CFLAGS=${configure.cflags} [get_canonical_archflags cc]" \
-                    "LDFLAGS=${configure.ldflags} [get_canonical_archflags ld]"
-
-build.args-append   CC=${configure.cc}
-build.env-append    MAKE=${build.cmd} \
-                    INSTALL=${configure.install}
+worksrcdir          ${name}-${version}


### PR DESCRIPTION
* Fix worksrcdir
* Simplify port
* Take maintainership
* Align to current linting rules

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'echo "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion) $(uname -m)"; xcode=$(xcodebuild -version 2>/dev/null); if [ $? == 0 ]; then echo "$(echo "$xcode" | awk '\''NR==1{x=$0}END{print x" "$NF}'\'')"; else echo "Command Line Tools $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '\''/version:/ {print $2}'\'')"; fi' | tee /dev/tty | pbcopy
-->
macOS 14.5 23F79 x86_64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
